### PR TITLE
Fixed a couple of typos and compatibility with some 64bit architectures 

### DIFF
--- a/Spoc/Mem_c.c
+++ b/Spoc/Mem_c.c
@@ -306,9 +306,9 @@ extern "C" {
     cuv = (cu_vector*)Field(dev_vec, 1);
     d_A = cuv->cu_vector;
     size = Int_val(Field(vector, 4))-seek;
-	
+
     CUDA_GET_CONTEXT;
-	
+
     CUDA_CHECK_CALL(cuDeviceGet(&dev, Int_val(nb_device)));
 
     h_A = (void*)Data_bigarray_val(bigArray);
@@ -356,8 +356,8 @@ extern "C" {
 
     CAMLreturn(Val_unit);
   }
-  
-  
+
+
   CAMLprim value spoc_cuda_alloc_vector(value vector, value nb_device, value gi, int custom){
     CAMLparam3(vector, nb_device, gi);
     CAMLlocal3(bigArray,  dev_vec_array, dev_vec);
@@ -377,7 +377,7 @@ extern "C" {
 	cuMemFree(cuv->cu_vector);
       free(cuv);
     }
-    cuv = (cu_vector*)malloc(sizeof(cu_vector*));
+    cuv = (cu_vector*)malloc(sizeof(cu_vector));
 
     size = Int_val(Field(vector, 4));
     cuv->cu_size = size;
@@ -606,7 +606,7 @@ extern "C" {
 
     OPENCL_CHECK_CALL1(
 		       opencl_error, clEnqueueWriteBuffer
-		       (queue[Int_val(queue_id)], d_A, CL_FALSE, 
+		       (queue[Int_val(queue_id)], d_A, CL_FALSE,
 			0, size*type_size, h_A, 0, NULL, NULL));
     OPENCL_RESTORE_CONTEXT;
 
@@ -1173,4 +1173,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-

--- a/Spoc/Spoc_cu.c
+++ b/Spoc/Spoc_cu.c
@@ -47,7 +47,7 @@ extern "C" {
 #include <math.h>
 #include "cuda_drvapi_dynlink_cuda.h"
 #include "Spoc.h"
-  
+
   value spoc_cuInit() {
 
     CAMLparam0();
@@ -72,7 +72,7 @@ extern "C" {
 
   dev_vectors *usefull_vectors;
   dev_vectors *useless_vectors;
-  
+
   void add_usefull_vector (spoc_vector v, void* dev) {
     dev_vectors *vecs = usefull_vectors;
     while (vecs)
@@ -168,7 +168,7 @@ extern "C" {
     int infoInt;
     size_t infoUInt;
     int major, minor;
-    enum cudaError_enum cuda_error; 
+    enum cudaError_enum cuda_error;
 
 
     cuDeviceGetCount (&nb_devices);
@@ -198,7 +198,7 @@ extern "C" {
     CUDA_CHECK_CALL(cuCtxCreate	(&ctx,
 				 CU_CTX_SCHED_BLOCKING_SYNC | CU_CTX_MAP_HOST,
 				 dev));
-    spoc_ctx = malloc(sizeof(spoc_cl_context));
+    spoc_ctx = malloc(sizeof(spoc_cu_context));
     spoc_ctx->ctx = ctx;
     CUDA_CHECK_CALL(cuStreamCreate(&queue[0], 0));
     CUDA_CHECK_CALL(cuStreamCreate(&queue[1], 0));

--- a/Spoc/cuda_drvapi_dynlink_cuda.h
+++ b/Spoc/cuda_drvapi_dynlink_cuda.h
@@ -51,7 +51,7 @@ extern "C" {
      */
 #if __CUDA_API_VERSION >= 3020
 
-#if defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
+#if defined(_WIN64) || defined(__LP64__)
     typedef unsigned long long CUdeviceptr;
 #else
     typedef unsigned int CUdeviceptr;


### PR DESCRIPTION
Fixed a typo in a malloc of a cu_vector in Mem_c.c

Fix in Spoc_cu.c in which a spoc_cl_context was allocated instead of a
spoc_cu_context

Updated cuda_drvapi_dynlink_cuda.h to make SPOC work on ppc64le