### PR TITLE
feat: Add automatic PR retargeting for merge trains

### DIFF
--- a/.github/workflows/RETARGET_PRS.md
+++ b/.github/workflows/RETARGET_PRS.md
@@ -1,0 +1,52 @@
+# Auto-Retarget PRs Workflow
+
+This workflow automatically updates the base branch of dependent PRs when their target branch is merged.
+
+## How It Works
+
+When a PR is merged, this workflow:
+
+1. **Identifies** all open PRs that were targeting the merged branch
+2. **Updates** their base to point to the branch the PR was merged into
+3. **Comments** on each updated PR to notify maintainers
+
+## Example Scenario
+
+```
+main
+ └── feature-A (PR #10) ✅ merged
+      └── feature-B (PR #11) ⏸️ open, targeting feature-A
+```
+
+**Before PR #10 merge:**
+- PR #11 targets `feature-A`
+
+**After PR #10 is merged to `main`:**
+- PR #11 automatically retargeted to `main`
+- Comment added to PR #11 explaining the change
+
+## Benefits
+
+✅ **Merge Train Support** - Enables stacked PRs without manual retargeting  
+✅ **Automatic** - No manual intervention needed  
+✅ **Transparent** - Adds comments explaining what happened  
+✅ **Safe** - Only runs on merged PRs, not closed ones
+
+## Use Cases
+
+- **Feature branches with sub-features** - Build features incrementally
+- **Breaking changes** - Isolate risky changes in a feature branch
+- **Long-running development** - Keep features organized in branches
+- **Dependency chains** - PR B depends on PR A being merged first
+
+## Permissions
+
+This workflow requires:
+- `pull-requests: write` - To update PR base branches and add comments
+- `contents: read` - To access repository information
+
+## Limitations
+
+- Only processes open PRs (closed PRs are ignored)
+- Fetches up to 100 PRs (should be sufficient for most repositories)
+- Doesn't resolve merge conflicts (maintainers need to handle those)

--- a/.github/workflows/retarget-prs.yml
+++ b/.github/workflows/retarget-prs.yml
@@ -1,0 +1,81 @@
+name: Retarget PRs After Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  retarget-dependent-prs:
+    # Only run if the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and retarget dependent PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const mergedPR = context.payload.pull_request;
+            const oldBase = mergedPR.head.ref; // The branch that was just merged
+            const newBase = mergedPR.base.ref; // The branch it was merged into (usually 'main')
+            
+            console.log(`✅ PR #${mergedPR.number} merged: ${oldBase} → ${newBase}`);
+            console.log(`🔍 Looking for PRs targeting '${oldBase}'...`);
+            
+            // Find all open PRs
+            const { data: allPRs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+            
+            // Filter PRs that target the now-merged branch
+            const dependentPRs = allPRs.filter(pr => pr.base.ref === oldBase);
+            
+            if (dependentPRs.length === 0) {
+              console.log('✨ No dependent PRs found. All done!');
+              return;
+            }
+            
+            console.log(`📋 Found ${dependentPRs.length} PR(s) to retarget:`);
+            
+            // Retarget each dependent PR
+            for (const pr of dependentPRs) {
+              try {
+                console.log(`  🔄 Retargeting PR #${pr.number}: "${pr.title}"`);
+                console.log(`     From: ${pr.base.ref} → To: ${newBase}`);
+                
+                // Update the PR base
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  base: newBase
+                });
+                
+                // Add a comment explaining the retarget
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `🤖 **Automatic Base Update**
+                  
+This PR was targeting \`${oldBase}\`, which was just merged into \`${newBase}\` via PR #${mergedPR.number}.
+
+The base branch has been automatically updated to \`${newBase}\` to maintain the merge train.
+
+Please check for any conflicts that may have appeared.`
+                });
+                
+                console.log(`     ✅ Successfully retargeted PR #${pr.number}`);
+                
+              } catch (error) {
+                console.error(`     ❌ Failed to retarget PR #${pr.number}:`, error.message);
+              }
+            }
+            
+            console.log(`\n🎉 Retargeting complete! Updated ${dependentPRs.length} PR(s).`);


### PR DESCRIPTION
## Problem

When working with stacked PRs (merge trains), if you merge a feature branch into main, any PRs targeting that feature branch become orphaned and need manual retargeting. This is tedious and error-prone.

Example scenario:
```
main
 └── feature-A (PR #10) ✅ merged to main
      └── feature-B (PR #11) ⏸️ targets feature-A (now invalid!)
```

After PR #10 merges, PR #11 still targets the now-deleted `feature-A` branch and shows conflicts.

## Solution

This PR adds a GitHub Action that **automatically retargets dependent PRs** when their base branch is merged.

### How It Works

1. **Trigger**: Runs when a PR is merged (not just closed)
2. **Discovery**: Finds all open PRs targeting the merged branch
3. **Retarget**: Updates their base to the merge destination
4. **Notify**: Comments on each PR explaining the change

### Example

**Before PR #10 merge:**
- PR #11 targets `feature-A`

**After PR #10 merges to `main`:**
- PR #11 automatically retargeted to `main`
- Comment added: "🤖 Base updated from feature-A to main"

## Benefits

✅ **Enables merge trains** - Stack PRs without manual retargeting  
✅ **Automatic** - Zero manual intervention  
✅ **Transparent** - Comments explain what happened  
✅ **Safe** - Only runs on merged PRs  
✅ **Efficient** - Supports incremental feature development

## Use Cases

- **Stacked features**: Break large features into incremental PRs
- **Breaking changes**: Isolate risky changes in feature branches
- **Long-running work**: Keep development organized
- **Dependency chains**: PR B depends on PR A

## Testing

To test:
1. Create PR A targeting main
2. Create PR B targeting PR A's branch
3. Merge PR A → PR B automatically retargets to main

## Files Changed

- `.github/workflows/retarget-prs.yml` - The workflow
- `.github/workflows/RETARGET_PRS.md` - Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for automated pull request branch management after merges.
  * Added documentation describing the auto-retarget workflow process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->