### PR TITLE
Fix #85: Add pretty-printing for Metal backend generated code

### DIFF
--- a/benchmarks/descriptions/generated/dot_product_generated.md
+++ b/benchmarks/descriptions/generated/dot_product_generated.md
@@ -246,12 +246,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* output [[buffer(4)]], constant int &sarek_output_length [[buffer(5)]], constant int &n [[buffer(6)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* output [[buffer(4)]], constant int &sarek_output_length [[buffer(5)]], constant int &n [[buffer(6)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   threadgroup float sdata[256];
   int tid = __metal_tid.x;
   int gid = (__metal_tid.x + (__metal_tpg.x * __metal_bid.x));
@@ -315,5 +315,6 @@ kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_leng
     output[__metal_bid.x] = sdata[0];
   }
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/mandelbrot_generated.md
+++ b/benchmarks/descriptions/generated/mandelbrot_generated.md
@@ -100,12 +100,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device int* output [[buffer(0)]], constant int &sarek_output_length [[buffer(1)]], constant int &width [[buffer(2)]], constant int &height [[buffer(3)]], constant int &max_iter [[buffer(4)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device int* output [[buffer(0)]], constant int &sarek_output_length [[buffer(1)]], constant int &width [[buffer(2)]], constant int &height [[buffer(3)]], constant int &max_iter [[buffer(4)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int px = __metal_gid.x;
   int py = __metal_gid.y;
   if (((px < width) && (py < height))) {
@@ -123,5 +123,6 @@ kernel void sarek_kern(device int* output [[buffer(0)]], constant int &sarek_out
     output[((py * width) + px)] = iter;
   }
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/matrix_mul_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_generated.md
@@ -92,12 +92,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &m [[buffer(6)]], constant int &n [[buffer(7)]], constant int &k [[buffer(8)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &m [[buffer(6)]], constant int &n [[buffer(7)]], constant int &k [[buffer(8)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int tid = __metal_gid.x;
   int row = (tid / n);
   int col = (tid % n);
@@ -109,5 +109,6 @@ kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_leng
     c[((row * n) + col)] = sum;
   }
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
@@ -178,12 +178,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &m [[buffer(6)]], constant int &n [[buffer(7)]], constant int &k [[buffer(8)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &m [[buffer(6)]], constant int &n [[buffer(7)]], constant int &k [[buffer(8)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   threadgroup float tile_a[256];
   threadgroup float tile_b[256];
   int tx = __metal_tid.x;
@@ -223,5 +223,6 @@ kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_leng
     c[((row * n) + col)] = sum;
   }
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/reduction_generated.md
+++ b/benchmarks/descriptions/generated/reduction_generated.md
@@ -250,12 +250,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &n [[buffer(4)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &n [[buffer(4)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   threadgroup float sdata[256];
   int tid = __metal_tid.x;
   int gid = (__metal_tid.x + (__metal_tpg.x * __metal_bid.x));
@@ -322,5 +322,6 @@ kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_in
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/reduction_max_generated.md
+++ b/benchmarks/descriptions/generated/reduction_max_generated.md
@@ -346,12 +346,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &n [[buffer(4)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &n [[buffer(4)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   threadgroup float sdata[256];
   int tid = __metal_tid.x;
   int gid = (__metal_tid.x + (__metal_tpg.x * __metal_bid.x));
@@ -450,5 +450,6 @@ kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_in
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/stream_triad_generated.md
+++ b/benchmarks/descriptions/generated/stream_triad_generated.md
@@ -72,16 +72,17 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant float &scalar [[buffer(6)]], constant int &n [[buffer(7)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant float &scalar [[buffer(6)]], constant int &n [[buffer(7)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int tid = __metal_gid.x;
   if ((tid < n)) {
     a[tid] = (b[tid] + (c[tid] * scalar));
   }
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/transpose_naive_generated.md
+++ b/benchmarks/descriptions/generated/transpose_naive_generated.md
@@ -82,12 +82,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &width [[buffer(4)]], constant int &height [[buffer(5)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &width [[buffer(4)]], constant int &height [[buffer(5)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int tid = __metal_gid.x;
   int n = (width * height);
   if ((tid < n)) {
@@ -98,5 +98,6 @@ kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_in
     output[out_idx] = input[in_idx];
   }
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/transpose_tiled_generated.md
+++ b/benchmarks/descriptions/generated/transpose_tiled_generated.md
@@ -135,12 +135,12 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &width [[buffer(4)]], constant int &height [[buffer(5)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &width [[buffer(4)]], constant int &height [[buffer(5)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   threadgroup float tile[272];
   int tile_size = 16;
   int tx = __metal_tid.x;
@@ -168,5 +168,6 @@ kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_in
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/vector_add_generated.md
+++ b/benchmarks/descriptions/generated/vector_add_generated.md
@@ -70,16 +70,17 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &n [[buffer(6)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &n [[buffer(6)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int tid = __metal_gid.x;
   if ((tid < n)) {
     c[tid] = (a[tid] + b[tid]);
   }
 }
+
 ```
 

--- a/benchmarks/descriptions/generated/vector_copy_generated.md
+++ b/benchmarks/descriptions/generated/vector_copy_generated.md
@@ -65,16 +65,17 @@ void main() {
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], constant int &n [[buffer(4)]], 
-  uint3 __metal_gid [[thread_position_in_grid]],
-  uint3 __metal_tid [[thread_position_in_threadgroup]],
-  uint3 __metal_bid [[threadgroup_position_in_grid]],
-  uint3 __metal_tpg [[threads_per_threadgroup]],
-  uint3 __metal_num_groups [[threadgroups_per_grid]]) {
+kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], constant int &n [[buffer(4)]],
+uint3 __metal_gid [[thread_position_in_grid]],
+uint3 __metal_tid [[thread_position_in_threadgroup]],
+uint3 __metal_bid [[threadgroup_position_in_grid]],
+uint3 __metal_tpg [[threads_per_threadgroup]],
+uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int tid = __metal_gid.x;
   if ((tid < n)) {
     b[tid] = a[tid];
   }
 }
+
 ```
 


### PR DESCRIPTION
Fixes #85

## Changes
- Implemented `pretty_print_metal` function with brace-based indentation
- Applied pretty-printing to both `generate` and `generate_with_types` functions  
- Regenerated all benchmark Metal code with proper formatting

## Before
Metal kernel parameters were rendered on a single long line, making the code hard to read on the website.

## After
Metal code is now properly indented with 2-space indentation levels based on brace nesting, matching the formatting of other backend code generators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated Metal code is now automatically formatted with proper indentation and whitespace management for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->