### PR TITLE
Fix #87: Add language tags to code blocks and convert bare URL

### DIFF
--- a/benchmarks/descriptions/reduction_max.md
+++ b/benchmarks/descriptions/reduction_max.md
@@ -12,7 +12,7 @@ Max Reduction finds the maximum value in an array using parallel tree-based redu
 
 Same tree structure as sum reduction, but with comparison instead of addition:
 
-```
+```text
 Step 1: Compare pairs (256 → 128 elements)
 Step 2: Compare pairs (128 → 64 elements)  
 ...

--- a/benchmarks/descriptions/stream_triad.md
+++ b/benchmarks/descriptions/stream_triad.md
@@ -50,7 +50,7 @@ let stream_triad_kernel =
 
 For N elements (float32):
 
-```
+```text
 Reads:  2 vectors (B, C) = 2 × N × 4 bytes = 8N bytes
 Writes: 1 vector (A)     = 1 × N × 4 bytes = 4N bytes
 Total:                                        12N bytes
@@ -77,7 +77,7 @@ Unlike burst benchmarks, STREAM measures **sustained** memory bandwidth:
 - Real-world memory access patterns
 
 ### 3. System Bottleneck Identification
-```
+```text
 if (STREAM BW < 50% of theoretical peak):
     "Memory subsystem has issues"
     "Check: memory clocks, channel config, NUMA"
@@ -86,7 +86,7 @@ else if (STREAM BW ≈ 80-90% of peak):
 ```
 
 ### 4. Power Efficiency Metric
-```
+```text
 Energy Efficiency = Bandwidth (GB/s) / Power (Watts)
                   = GB/s/W
 ```
@@ -124,7 +124,7 @@ Triad and Add have identical memory traffic, but Triad has 2× FLOPs.
 ## Running STREAM Properly
 
 ### Array Size Requirements
-```
+```text
 Minimum Size = 4 × L3 Cache Size
 ```
 
@@ -141,7 +141,7 @@ This ensures data doesn't fit in cache.
 
 ### Verification
 Always verify results:
-```
+```text
 A[i] = B[i] + C[i] × scalar
 
 With B[i] = 2.0, C[i] = 1.0, scalar = 3.0:
@@ -176,7 +176,7 @@ STREAM Triad sits at the **memory-bound region** of the Roofline:
 - Performance: Limited by memory bandwidth, not compute
 
 On a Roofline plot:
-```
+```text
           │    /  Compute Bound
  GFLOPS   │   /   (flat roof)
           │  /
@@ -194,6 +194,6 @@ On a Roofline plot:
 ## References
 
 - McCalpin, John D., "STREAM: Sustainable Memory Bandwidth in High Performance Computers" (1995-present)
-- https://www.cs.virginia.edu/stream/
+- [STREAM Benchmark Website](https://www.cs.virginia.edu/stream/)
 - Standard Performance Evaluation Corporation (SPEC), STREAM documentation
 - Top500.org - Uses STREAM for memory benchmarking

--- a/benchmarks/descriptions/vector_copy.md
+++ b/benchmarks/descriptions/vector_copy.md
@@ -20,7 +20,7 @@ Understanding pure memory bandwidth is crucial for:
 
 The kernel is trivial:
 
-```
+```text
 for each element i in parallel:
     B[i] = A[i]
 ```
@@ -73,7 +73,7 @@ Still, 80-90% is excellent for production code.
 
 For a vector copy of N elements (float32):
 
-```
+```text
 Bytes Transferred = 2 × N × 4 bytes
                   = 8N bytes
                   (1 read + 1 write, 4 bytes per float)
@@ -100,13 +100,13 @@ This shows that Vector Add is also memory-bound, not compute-bound.
 ## Use Cases
 
 ### 1. Bandwidth Measurement
-```
+```text
 Peak Bandwidth = median(Vector Copy measurements)
 Efficiency = (Actual BW) / (Theoretical Peak BW) × 100%
 ```
 
 ### 2. Identifying Bottlenecks
-```
+```text
 if (Kernel BW ≈ Vector Copy BW):
     "Your kernel is memory-bound"
 else if (Kernel BW < 50% of Vector Copy BW):

--- a/gh-pages/benchmarks/descriptions/reduction_max.md
+++ b/gh-pages/benchmarks/descriptions/reduction_max.md
@@ -12,7 +12,7 @@ Max Reduction finds the maximum value in an array using parallel tree-based redu
 
 Same tree structure as sum reduction, but with comparison instead of addition:
 
-```
+```text
 Step 1: Compare pairs (256 → 128 elements)
 Step 2: Compare pairs (128 → 64 elements)  
 ...

--- a/gh-pages/benchmarks/descriptions/stream_triad.md
+++ b/gh-pages/benchmarks/descriptions/stream_triad.md
@@ -50,7 +50,7 @@ let stream_triad_kernel =
 
 For N elements (float32):
 
-```
+```text
 Reads:  2 vectors (B, C) = 2 × N × 4 bytes = 8N bytes
 Writes: 1 vector (A)     = 1 × N × 4 bytes = 4N bytes
 Total:                                        12N bytes
@@ -77,7 +77,7 @@ Unlike burst benchmarks, STREAM measures **sustained** memory bandwidth:
 - Real-world memory access patterns
 
 ### 3. System Bottleneck Identification
-```
+```text
 if (STREAM BW < 50% of theoretical peak):
     "Memory subsystem has issues"
     "Check: memory clocks, channel config, NUMA"
@@ -86,7 +86,7 @@ else if (STREAM BW ≈ 80-90% of peak):
 ```
 
 ### 4. Power Efficiency Metric
-```
+```text
 Energy Efficiency = Bandwidth (GB/s) / Power (Watts)
                   = GB/s/W
 ```
@@ -124,7 +124,7 @@ Triad and Add have identical memory traffic, but Triad has 2× FLOPs.
 ## Running STREAM Properly
 
 ### Array Size Requirements
-```
+```text
 Minimum Size = 4 × L3 Cache Size
 ```
 
@@ -141,7 +141,7 @@ This ensures data doesn't fit in cache.
 
 ### Verification
 Always verify results:
-```
+```text
 A[i] = B[i] + C[i] × scalar
 
 With B[i] = 2.0, C[i] = 1.0, scalar = 3.0:
@@ -176,7 +176,7 @@ STREAM Triad sits at the **memory-bound region** of the Roofline:
 - Performance: Limited by memory bandwidth, not compute
 
 On a Roofline plot:
-```
+```text
           │    /  Compute Bound
  GFLOPS   │   /   (flat roof)
           │  /
@@ -194,6 +194,6 @@ On a Roofline plot:
 ## References
 
 - McCalpin, John D., "STREAM: Sustainable Memory Bandwidth in High Performance Computers" (1995-present)
-- https://www.cs.virginia.edu/stream/
+- [STREAM Benchmark Website](https://www.cs.virginia.edu/stream/)
 - Standard Performance Evaluation Corporation (SPEC), STREAM documentation
 - Top500.org - Uses STREAM for memory benchmarking

--- a/gh-pages/benchmarks/descriptions/vector_copy.md
+++ b/gh-pages/benchmarks/descriptions/vector_copy.md
@@ -20,7 +20,7 @@ Understanding pure memory bandwidth is crucial for:
 
 The kernel is trivial:
 
-```
+```text
 for each element i in parallel:
     B[i] = A[i]
 ```
@@ -73,7 +73,7 @@ Still, 80-90% is excellent for production code.
 
 For a vector copy of N elements (float32):
 
-```
+```text
 Bytes Transferred = 2 × N × 4 bytes
                   = 8N bytes
                   (1 read + 1 write, 4 bytes per float)
@@ -100,13 +100,13 @@ This shows that Vector Add is also memory-bound, not compute-bound.
 ## Use Cases
 
 ### 1. Bandwidth Measurement
-```
+```text
 Peak Bandwidth = median(Vector Copy measurements)
 Efficiency = (Actual BW) / (Theoretical Peak BW) × 100%
 ```
 
 ### 2. Identifying Bottlenecks
-```
+```text
 if (Kernel BW ≈ Vector Copy BW):
     "Your kernel is memory-bound"
 else if (Kernel BW < 50% of Vector Copy BW):


### PR DESCRIPTION
Fixes #87

## Changes
- Added `text` language tags to pseudocode and formula code blocks  
- Converted bare URL to proper markdown link format

## Files Updated
- **vector_copy.md**: Added `text` tags to 4 code blocks (pseudocode, formulas, conditionals)
- **stream_triad.md**: Added `text` tags to 6 code blocks + converted bare URL to `[STREAM Benchmark Website](https://www.cs.virginia.edu/stream/)`
- **reduction_max.md**: Added `text` tag to 1 code block (algorithm steps)
- Mirrored changes to corresponding files in `gh-pages/benchmarks/descriptions/`

## Before
Code blocks without language tags triggered markdown linter warnings, and bare URLs were not properly formatted.

## After  
All code blocks have appropriate language tags (`text` for pseudocode/formulas, `ocaml` for Sarek kernels, `c` for C code), and URLs are properly formatted as markdown links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced benchmark documentation with improved formatting and visual clarity
  * Added detailed step-by-step algorithm descriptions across multiple benchmarks
  * Reformatted calculation examples, verification procedures, and visual schematics for better readability
  * Updated reference links with improved labeling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->