### PR TITLE
Phase 2: Migrate Sprint 1 benchmarks to eliminate duplicate parse_args

### DIFF
--- a/benchmarks/bench_dot_product.ml
+++ b/benchmarks/bench_dot_product.ml
@@ -10,27 +10,8 @@ open Benchmark_backends
 module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 
-type config = {
-  sizes : int list;
-  block_size : int;
-  iterations : int;
-  warmup : int;
-  output_dir : string;
-  device_filter : Device.t -> bool;
-}
-
-let default_config =
-  {
-    sizes = [1_000_000; 10_000_000; 50_000_000; 100_000_000];
-    block_size = 256;
-    iterations = 20;
-    warmup = 5;
-    output_dir = "results";
-    device_filter =
-      (fun dev ->
-        dev.Device.framework <> "Native"
-        && dev.Device.framework <> "Interpreter");
-  }
+(* Use shared config type from Benchmark_runner *)
+open Benchmark_runner
 
 let dot_product_kernel =
   [%kernel
@@ -239,40 +220,11 @@ let run_benchmark config =
       Printf.printf "Written: %s\n" filename)
     config.sizes
 
-let parse_args () =
-  let config = ref default_config in
-  let specs =
-    [
-      ( "--sizes",
-        Arg.String
-          (fun s ->
-            config :=
-              {
-                !config with
-                sizes = List.map int_of_string (String.split_on_char ',' s);
-              }),
-        "Comma-separated list of sizes (default: 1M,10M,50M,100M)" );
-      ( "--iterations",
-        Arg.Int (fun n -> config := {!config with iterations = n}),
-        "Number of benchmark iterations (default: 20)" );
-      ( "--warmup",
-        Arg.Int (fun n -> config := {!config with warmup = n}),
-        "Number of warmup iterations (default: 5)" );
-      ( "--block-size",
-        Arg.Int (fun n -> config := {!config with block_size = n}),
-        "Block size (default: 256)" );
-      ( "--output",
-        Arg.String (fun s -> config := {!config with output_dir = s}),
-        "Output directory (default: results)" );
-      ( "--all-backends",
-        Arg.Unit
-          (fun () -> config := {!config with device_filter = (fun _ -> true)}),
-        "Include all backends (Native, Interpreter)" );
-    ]
-  in
-  Arg.parse specs (fun _ -> ()) "Dot product benchmark" ;
-  !config
-
 let () =
-  let config = parse_args () in
+  let config =
+    Benchmark_runner.parse_args
+      ~benchmark_name:"dot_product"
+      ~default_sizes:[1_000_000; 10_000_000; 50_000_000; 100_000_000]
+      ()
+  in
   run_benchmark config

--- a/benchmarks/bench_reduction_max.ml
+++ b/benchmarks/bench_reduction_max.ml
@@ -11,27 +11,8 @@ module Std = Sarek_stdlib.Std
 module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 
-type config = {
-  sizes : int list;
-  block_size : int;
-  iterations : int;
-  warmup : int;
-  output_dir : string;
-  device_filter : Device.t -> bool;
-}
-
-let default_config =
-  {
-    sizes = [1_000_000; 10_000_000; 50_000_000; 100_000_000];
-    block_size = 256;
-    iterations = 20;
-    warmup = 5;
-    output_dir = "results";
-    device_filter =
-      (fun dev ->
-        dev.Device.framework <> "Native"
-        && dev.Device.framework <> "Interpreter");
-  }
+(* Use shared config type from Benchmark_runner *)
+open Benchmark_runner
 
 let reduce_max_kernel =
   [%kernel
@@ -271,40 +252,11 @@ let run_benchmark config =
       Printf.printf "Written: %s\n" filename)
     config.sizes
 
-let parse_args () =
-  let config = ref default_config in
-  let specs =
-    [
-      ( "--sizes",
-        Arg.String
-          (fun s ->
-            config :=
-              {
-                !config with
-                sizes = List.map int_of_string (String.split_on_char ',' s);
-              }),
-        "Comma-separated list of sizes (default: 1M,10M,50M,100M)" );
-      ( "--iterations",
-        Arg.Int (fun n -> config := {!config with iterations = n}),
-        "Number of benchmark iterations (default: 20)" );
-      ( "--warmup",
-        Arg.Int (fun n -> config := {!config with warmup = n}),
-        "Number of warmup iterations (default: 5)" );
-      ( "--block-size",
-        Arg.Int (fun n -> config := {!config with block_size = n}),
-        "Block size (default: 256)" );
-      ( "--output",
-        Arg.String (fun s -> config := {!config with output_dir = s}),
-        "Output directory (default: results)" );
-      ( "--all-backends",
-        Arg.Unit
-          (fun () -> config := {!config with device_filter = (fun _ -> true)}),
-        "Include all backends (Native, Interpreter)" );
-    ]
-  in
-  Arg.parse specs (fun _ -> ()) "Max reduction benchmark" ;
-  !config
-
 let () =
-  let config = parse_args () in
+  let config =
+    Benchmark_runner.parse_args
+      ~benchmark_name:"reduction_max"
+      ~default_sizes:[1_000_000; 10_000_000; 50_000_000; 100_000_000]
+      ()
+  in
   run_benchmark config

--- a/benchmarks/bench_vector_copy.ml
+++ b/benchmarks/bench_vector_copy.ml
@@ -15,28 +15,8 @@ module Std = Sarek_stdlib.Std
 module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 
-(** Configuration *)
-type config = {
-  sizes : int list;
-  block_size : int;
-  iterations : int;
-  warmup : int;
-  output_dir : string;
-  device_filter : Device.t -> bool;
-}
-
-let default_config =
-  {
-    sizes = [1_000_000; 10_000_000; 50_000_000; 100_000_000; 500_000_000];
-    block_size = 256;
-    iterations = 20;
-    warmup = 5;
-    output_dir = "results";
-    device_filter =
-      (fun dev ->
-        dev.Device.framework <> "Native"
-        && dev.Device.framework <> "Interpreter");
-  }
+(* Use shared config type from Benchmark_runner *)
+open Benchmark_runner
 
 (** Vector copy kernel *)
 let vector_copy_kernel =
@@ -289,43 +269,13 @@ let run_benchmark config =
 
   Printf.printf "\nBenchmark complete!\n"
 
-(** Parse command line arguments *)
-let parse_args () =
-  let config = ref default_config in
-
-  let specs =
-    [
-      ( "--sizes",
-        Arg.String
-          (fun s ->
-            config :=
-              {
-                !config with
-                sizes = List.map int_of_string (String.split_on_char ',' s);
-              }),
-        "Comma-separated list of sizes (default: 1M,10M,50M,100M,500M)" );
-      ( "--iterations",
-        Arg.Int (fun n -> config := {!config with iterations = n}),
-        "Number of benchmark iterations (default: 20)" );
-      ( "--warmup",
-        Arg.Int (fun n -> config := {!config with warmup = n}),
-        "Number of warmup iterations (default: 5)" );
-      ( "--block-size",
-        Arg.Int (fun n -> config := {!config with block_size = n}),
-        "Block size (default: 256)" );
-      ( "--output",
-        Arg.String (fun s -> config := {!config with output_dir = s}),
-        "Output directory (default: results)" );
-      ( "--all-backends",
-        Arg.Unit
-          (fun () -> config := {!config with device_filter = (fun _ -> true)}),
-        "Include all backends (Native, Interpreter)" );
-    ]
-  in
-  Arg.parse specs (fun _ -> ()) "Vector copy benchmark" ;
-  !config
-
 (** Entry point *)
 let () =
-  let config = parse_args () in
+  let config =
+    Benchmark_runner.parse_args
+      ~benchmark_name:"vector_copy"
+      ~default_sizes:
+        [1_000_000; 10_000_000; 50_000_000; 100_000_000; 500_000_000]
+      ()
+  in
   run_benchmark config


### PR DESCRIPTION
## Phase 2: Sprint 1 Benchmarks Migration

This PR eliminates duplicate `parse_args` code across Sprint 1 benchmarks by migrating them to use the shared `Benchmark_runner.parse_args` function.

### Changes

Migrated benchmarks (4 out of 5):
- ✅ `bench_vector_copy.ml` - Removed 38 lines of duplicate code
- ✅ `bench_reduction_max.ml` - Removed 35 lines of duplicate code
- ✅ `bench_dot_product.ml` - Removed 35 lines of duplicate code  
- ✅ `bench_stream_triad.ml` - Removed 35 lines of duplicate code
- ⏭️ `bench_matrix_mul_tiled.ml` - **Not migrated** (uses `tile_size` field instead of `block_size`, requires separate handling)

### Implementation Details

For each migrated benchmark:
- Removed local `type config` definition
- Removed local `default_config` definition  
- Removed local `parse_args()` function (~35 lines each)
- Added `open Benchmark_runner` to access shared config type
- Replaced `parse_args()` call with `Benchmark_runner.parse_args ~benchmark_name:"..." ~default_sizes:[...] ()`

### Benefits

- **196 lines of code removed** (+34, -230)
- Single source of truth for CLI parsing
- Easier maintenance (changes to CLI only need to be made in one place)
- Consistent behavior across all benchmarks
- All existing functionality preserved

### CLI Support (Unchanged)

All migrated benchmarks still support the same CLI options:
```bash
--sizes SIZES          Comma-separated list of sizes
--iterations N         Number of benchmark iterations (default: 20)
--warmup N             Number of warmup iterations (default: 5)
--block-size N         Block size (default: 256)
--output DIR           Output directory (default: results)
--all-backends         Include all backends (Native, Interpreter)
```

### Testing

All 4 benchmarks build successfully:
```bash
dune build benchmarks/bench_vector_copy.exe
dune build benchmarks/bench_reduction_max.exe
dune build benchmarks/bench_dot_product.exe
dune build benchmarks/bench_stream_triad.ml
```

### Note on bench_matrix_mul_tiled.ml

This benchmark was intentionally not migrated because it uses a `tile_size` field in its config instead of the standard `block_size`. The `tile_size` is used for:
1. Configuring 2D grid dimensions
2. Setting the block_size in output metadata

Since it has different semantics than `block_size`, it requires a separate migration approach or extending `Benchmark_runner.config` to support both fields. This can be addressed in a future PR if needed.

### Related

- Part of #93 (Phase 2)
- Follows Phase 1 (#94) which migrated Sprint 2 benchmarks

### Next Steps

After this PR, Phase 3 will add full infrastructure integration to Sprint 2 benchmarks (JSON output, multiple sizes, descriptions, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated benchmark configuration handling across multiple benchmark modules by centralizing command-line argument parsing to a shared utility module, reducing code duplication and improving maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->