### PR TITLE
Add matrix_mul_naive to benchmark suite

### DIFF
--- a/benchmarks/run_all_benchmarks.sh
+++ b/benchmarks/run_all_benchmarks.sh
@@ -66,6 +66,7 @@ mkdir -p "${RUN_DIR}"
 
 echo "Building all benchmarks..."
 dune build \
+  benchmarks/bench_matrix_mul.exe \
   benchmarks/bench_matrix_mul_tiled.exe \
   benchmarks/bench_vector_add.exe \
   benchmarks/bench_vector_copy.exe \
@@ -115,6 +116,7 @@ run_benchmark() {
 }
 
 # Run all benchmarks
+run_benchmark "Matrix Multiplication (naive)" "bench_matrix_mul"
 run_benchmark "Matrix Multiplication (tiled)" "bench_matrix_mul_tiled"
 run_benchmark "Vector Addition" "bench_vector_add"
 run_benchmark "Vector Copy" "bench_vector_copy"


### PR DESCRIPTION
## Problem

The automated benchmark script (`run_all_benchmarks.sh`) only ran the tiled (optimized) matrix multiplication, not the naive version. This meant:
- New benchmark runs (like ladon.local) were missing naive results
- No comparison baseline to show tiling optimization impact
- Inconsistent with cachyos which has naive results (run manually)

## Solution

Add `bench_matrix_mul.exe` (naive version) to the build and run lists in `run_all_benchmarks.sh`.

## Changes

- Added to build list (line 69)
- Added to run list before tiled version (line 118)
- Naive runs first, then tiled for logical ordering

## Impact

✅ Future `make benchmarks` runs will include naive baseline  
✅ Enables naive vs tiled comparisons in viewer  
✅ Shows optimization impact (speedup from tiling)  
✅ Consistency across all systems

## Testing

After merge, when benchmarks are re-run on ladon.local:
- Will generate 4 new files: `ladon.local_matrix_mul_naive_*.json`
- Viewer will show data on default page load
- Comparison view can show naive vs tiled speedup

## Related

- Addresses issue discovered while investigating benchmark coverage
- Complements PR #108 (macOS metadata fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added naive Matrix Multiplication benchmark to the benchmark suite, expanding the range of performance tests executed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->