### PR TITLE
Fix: Markdown indentation in radix_sort.md

### DIFF
--- a/benchmarks/descriptions/radix_sort.md
+++ b/benchmarks/descriptions/radix_sort.md
@@ -12,8 +12,8 @@ Implements a single pass of radix sort using 8-bit digits (256 bins). This bench
 ## Performance Characteristics
 - **Complexity**: O(n) for a single pass.
 - **Memory Access**:
-    - Histogram: Coalesced reads, atomic updates (shared + global).
-    - Scatter: Coalesced reads, scattered writes (random access pattern depending on data distribution).
+  - Histogram: Coalesced reads, atomic updates (shared + global).
+  - Scatter: Coalesced reads, scattered writes (random access pattern depending on data distribution).
 - **Synchronization**: Requires barrier synchronization between histogram and scatter phases.
 - **Data Distribution**: Performance is sensitive to data distribution (conflicts in atomics). This benchmark uses uniform random data.
 


### PR DESCRIPTION
Fixes MD007 nitpick from CodeRabbit: use 2 spaces for nested lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor indentation adjustments to technical documentation for improved formatting consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->