### PR TITLE
Fix matrix_mul_tiled size interpretation

### DIFF
--- a/benchmarks/bench_matrix_mul_tiled.ml
+++ b/benchmarks/bench_matrix_mul_tiled.ml
@@ -103,8 +103,7 @@ let benchmark_device dev size config =
     size ;
   flush stdout ;
 
-  let dim = int_of_float (sqrt (float_of_int size)) in
-  let m, n, k = (dim, dim, dim) in
+  let m, n, k = (size, size, size) in
 
   (* Prepare host data *)
   let a = Array.init (m * k) (fun i -> float_of_int (i mod 10) /. 10.0) in


### PR DESCRIPTION
The benchmark was incorrectly interpreting the 'size' parameter as the total number of elements (area) instead of the matrix dimension (N). This caused it to run on tiny matrices (e.g., 64x64 for size=4096), making the benchmark measure kernel launch latency rather than throughput. This fixes it to use N=size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated matrix multiplication benchmark configuration to support more flexible dimension settings, enabling broader performance testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->