### PR TITLE
fix: avoid side-effecting CPU barrier detection

### DIFF
--- a/sarek/sarek/Sarek_cpu_runtime.ml
+++ b/sarek/sarek/Sarek_cpu_runtime.ml
@@ -314,6 +314,15 @@ let run_block_with_barriers ~block:(bx, by, bz) ~grid:(gx, gy, gz)
   in
   let num_waiting = ref 0 in
   let num_completed = ref 0 in
+  let first_error = ref None in
+
+  let record_error tid exn =
+    if !first_error = None then first_error := Some exn ;
+    if status.(tid) <> 2 then begin
+      status.(tid) <- 2 ;
+      incr num_completed
+    end
+  in
 
   (* Pre-compute int32 values *)
   let bx32 = Int32.of_int bx in
@@ -359,9 +368,11 @@ let run_block_with_barriers ~block:(bx, by, bz) ~grid:(gx, gy, gz)
     {
       Effect.Shallow.retc =
         (fun () ->
-          status.(tid) <- 2 ;
-          incr num_completed);
-      exnc = raise;
+          if status.(tid) <> 2 then begin
+            status.(tid) <- 2 ;
+            incr num_completed
+          end);
+      exnc = (fun exn -> record_error tid exn);
       effc =
         (fun (type a) (eff : a Effect.t) ->
           match eff with
@@ -379,7 +390,9 @@ let run_block_with_barriers ~block:(bx, by, bz) ~grid:(gx, gy, gz)
   (* Create fibers for all threads *)
   let fibers =
     Array.init num_threads (fun tid ->
-        Effect.Shallow.fiber (fun () -> kernel states.(tid) shared args))
+        Effect.Shallow.fiber (fun () ->
+            try kernel states.(tid) shared args
+            with exn -> record_error tid exn))
   in
 
   (* Initial run: start all threads with shallow continue_with *)
@@ -400,7 +413,8 @@ let run_block_with_barriers ~block:(bx, by, bz) ~grid:(gx, gy, gz)
         | None -> ()
       end
     done
-  done
+  done ;
+  match !first_error with Some exn -> raise exn | None -> ()
 
 (** Global domain pool for parallel execution *)
 module DomainPool = struct
@@ -414,6 +428,7 @@ module DomainPool = struct
     mutable shutdown : bool;
     domains : unit Domain.t array;
     mutable active_tasks : int;
+    mutable first_error : exn option;
     done_cond : Condition.t;
   }
 
@@ -431,8 +446,16 @@ module DomainPool = struct
         let task = Queue.pop pool.task_queue in
         pool.active_tasks <- pool.active_tasks + 1 ;
         Mutex.unlock pool.mutex ;
-        (try task () with _ -> ()) ;
+        let task_error =
+          try
+            task () ;
+            None
+          with exn -> Some exn
+        in
         Mutex.lock pool.mutex ;
+        (match (pool.first_error, task_error) with
+        | None, Some exn -> pool.first_error <- Some exn
+        | _ -> ()) ;
         pool.active_tasks <- pool.active_tasks - 1 ;
         if pool.active_tasks = 0 && Queue.is_empty pool.task_queue then
           Condition.broadcast pool.done_cond ;
@@ -452,6 +475,7 @@ module DomainPool = struct
         shutdown = false;
         domains = [||];
         active_tasks = 0;
+        first_error = None;
         done_cond = Condition.create ();
       }
     in
@@ -471,7 +495,10 @@ module DomainPool = struct
     while pool.active_tasks > 0 || not (Queue.is_empty pool.task_queue) do
       Condition.wait pool.done_cond pool.mutex
     done ;
-    Mutex.unlock pool.mutex
+    let first_error = pool.first_error in
+    pool.first_error <- None ;
+    Mutex.unlock pool.mutex ;
+    match first_error with Some exn -> raise exn | None -> ()
 
   let shutdown pool =
     Mutex.lock pool.mutex ;
@@ -590,43 +617,15 @@ let run_parallel_with_barriers ~block:(bx, by, bz) ~grid:(gx, gy, gz)
   done ;
   DomainPool.wait_all pool
 
-(** Detect if kernel uses barriers by running one block and checking. *)
-let kernel_uses_barriers ~block:(bx, by, bz) ~grid:(gx, gy, gz)
-    (kernel : thread_state -> shared_mem -> 'a -> unit) (args : 'a) : bool =
-  let barrier_called = ref false in
-  let shared = create_shared () in
-  (* Run just one thread to detect barrier usage *)
-  let state =
-    {
-      thread_idx_x = 0l;
-      thread_idx_y = 0l;
-      thread_idx_z = 0l;
-      block_idx_x = 0l;
-      block_idx_y = 0l;
-      block_idx_z = 0l;
-      block_dim_x = Int32.of_int bx;
-      block_dim_y = Int32.of_int by;
-      block_dim_z = Int32.of_int bz;
-      grid_dim_x = Int32.of_int gx;
-      grid_dim_y = Int32.of_int gy;
-      grid_dim_z = Int32.of_int gz;
-      barrier =
-        (fun () ->
-          barrier_called := true ;
-          (* Don't actually block - just detect *)
-          ());
-    }
-  in
-  kernel state shared args ;
-  !barrier_called
-
-(** Run kernel in parallel. Auto-detects barrier usage:
-    - No barriers: uses simple work partitioning (fastest)
-    - With barriers: uses fiber-based scheduling *)
-let run_parallel ~block ~grid kernel args =
-  if kernel_uses_barriers ~block ~grid kernel args then
-    run_parallel_with_barriers ~block ~grid kernel args
-  else run_parallel_simple ~block ~grid kernel args
+(** Run kernel in parallel. Barrier metadata must come from the compiler or
+    caller; the runtime must not execute user code to discover it. When metadata
+    is unavailable, use the sequential barrier-capable path to preserve
+    correctness without broadening worker-pool exception swallowing. *)
+let run_parallel ?has_barriers ~block ~grid kernel args =
+  match has_barriers with
+  | None -> run_sequential ~block ~grid kernel args
+  | Some true -> run_parallel_with_barriers ~block ~grid kernel args
+  | Some false -> run_parallel_simple ~block ~grid kernel args
 
 (** {1 Persistent Thread Pool for Fission Mode}
 

--- a/sarek/sarek/Sarek_cpu_runtime.mli
+++ b/sarek/sarek/Sarek_cpu_runtime.mli
@@ -97,9 +97,16 @@ val run_sequential :
   unit
 
 (** Run kernel in parallel. Threads within each block run in parallel using
-    OCaml 5 Domains. Barriers properly synchronize all threads within a block
-    using Mutex/Condition. Blocks run sequentially. *)
+    OCaml 5 Domains.
+
+    @param has_barriers
+      Static barrier metadata from the compiler or caller. [true] uses the BSP
+      barrier-capable path; [false] uses the faster barrier-free path. When
+      omitted, the runtime uses the sequential barrier-capable path so barrier
+      detection never executes user kernel code before launch and worker-pool
+      exception behavior is not broadened. *)
 val run_parallel :
+  ?has_barriers:bool ->
   block:int * int * int ->
   grid:int * int * int ->
   (thread_state -> shared_mem -> 'a -> unit) ->

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -24,12 +24,15 @@
   test_mono
   test_ir_interp
   test_execute
-  test_kirc_kernel
-  test_cpu_runtime)
+  test_kirc_kernel)
  ; Link sarek_stdlib to trigger auto-registration of intrinsics
  (libraries sarek_ppx_lib sarek_stdlib sarek alcotest ppxlib str)
  (preprocess
   (pps ppxlib.metaquot)))
+
+(test
+ (name test_cpu_runtime)
+ (libraries sarek alcotest))
 
 ; Fusion tests use sarek library directly (no ppx needed)
 

--- a/sarek/tests/unit/test_cpu_runtime.ml
+++ b/sarek/tests/unit/test_cpu_runtime.ml
@@ -407,7 +407,7 @@ let test_run_parallel_simple () =
     let idx = Int32.to_int (global_idx_x state) in
     results.(idx) <- Int32.mul state.thread_idx_x 2l
   in
-  run_parallel ~block:(16, 1, 1) ~grid:(1, 1, 1) kernel () ;
+  run_parallel ~has_barriers:false ~block:(16, 1, 1) ~grid:(1, 1, 1) kernel () ;
   for i = 0 to size - 1 do
     check
       int32
@@ -431,7 +431,7 @@ let test_run_parallel_shared () =
     let next_tid = (tid + 1) mod size in
     results.(tid) <- arr.(next_tid)
   in
-  run_parallel ~block:(size, 1, 1) ~grid:(1, 1, 1) kernel () ;
+  run_parallel ~has_barriers:true ~block:(size, 1, 1) ~grid:(1, 1, 1) kernel () ;
   for i = 0 to size - 1 do
     let expected = ((i + 1) mod size) + 1 in
     check int (Printf.sprintf "parallel shared %d" i) expected results.(i)
@@ -498,6 +498,33 @@ let test_multiple_barriers () =
     check int (Printf.sprintf "multi-barrier %d" i) 3 results.(i)
   done
 
+(** Test barrier metadata fallback does not execute user code for detection *)
+let test_barrier_detection_non_mutating () =
+  let size = 4 in
+  let side_effects = Atomic.make 0 in
+  let results = Array.make size 0 in
+  let kernel state _shared _args =
+    let tid = Int32.to_int state.thread_idx_x in
+    let count = Atomic.fetch_and_add side_effects 1 + 1 in
+    results.(tid) <- count ;
+    state.barrier () ;
+    results.(tid) <- results.(tid) + 10
+  in
+  run_parallel ~block:(size, 1, 1) ~grid:(1, 1, 1) kernel () ;
+  check int "side effects occur once per thread" size (Atomic.get side_effects) ;
+  for i = 0 to size - 1 do
+    check bool (Printf.sprintf "thread %d ran once" i) true (results.(i) > 10)
+  done
+
+exception Test_parallel_failure
+
+let test_parallel_default_propagates_worker_exception () =
+  let kernel _state _shared _args = raise Test_parallel_failure in
+  check_raises
+    "worker exception propagates through default barrier-safe path"
+    Test_parallel_failure
+    (fun () -> run_parallel ~block:(4, 1, 1) ~grid:(1, 1, 1) kernel ())
+
 (** {1 Test Suite} *)
 
 let thread_state_tests =
@@ -550,6 +577,10 @@ let barrier_tests =
     ("sequential no-op", `Quick, test_barrier_sequential);
     ("parallel sync", `Quick, test_barrier_parallel_sync);
     ("multiple barriers", `Quick, test_multiple_barriers);
+    ("non-mutating detection", `Quick, test_barrier_detection_non_mutating);
+    ( "default exception propagation",
+      `Quick,
+      test_parallel_default_propagates_worker_exception );
   ]
 
 let () =


### PR DESCRIPTION
Fixes #128.

## Summary
- Remove the side-effecting barrier probe that executed user kernels before launch.
- Add explicit `has_barriers` metadata to the CPU runtime launch path.
- Use the sequential barrier-capable path when metadata is omitted, avoiding speculative user-code execution.
- Propagate worker failures from the parallel barrier path instead of silently swallowing them.

## Regression tests
- `test_barrier_detection_non_mutating`
- `test_parallel_default_propagates_worker_exception`

## Validation
- `opam exec --switch=/home/mathias/dev/SPOC -- dune exec sarek/tests/unit/test_cpu_runtime.exe`
- `git diff --check`
- `opam exec --switch=/home/mathias/dev/SPOC -- ocamlformat --check sarek/sarek/Sarek_cpu_runtime.ml sarek/sarek/Sarek_cpu_runtime.mli sarek/tests/unit/test_cpu_runtime.ml`