### PR TITLE
fix: preserve unfused kernels in fusion pipelines

### DIFF
--- a/sarek/sarek/FUSION.md
+++ b/sarek/sarek/FUSION.md
@@ -92,9 +92,18 @@ val should_fuse : kernel -> kernel -> string -> fusion_hint
 
 (* Fusion *)
 val fuse : kernel -> kernel -> string -> kernel
+val fuse_pipeline_list : kernel list -> kernel list * string list
+val auto_fuse_pipeline_list : kernel list -> kernel list * string list * string list
+
+(* Legacy wrappers for pipelines that fully collapse to one kernel.
+   They raise Invalid_fusion if unfused stages remain. *)
 val fuse_pipeline : kernel list -> kernel * string list
 val auto_fuse_pipeline : kernel list -> kernel * string list * string list
 ```
+
+`fuse_pipeline_list` and `auto_fuse_pipeline_list` preserve every kernel in the
+input pipeline unless it is replaced by a fused kernel. The returned kernel list
+is the optimized pipeline in execution order.
 
 ## Auto-Fusion Heuristics
 
@@ -109,7 +118,8 @@ The `should_fuse` function returns a decision and reason:
 | OneToOne → Gather | DontFuse | Gather pattern - keep separate |
 | With barriers | DontFuse | Barrier prevents fusion |
 
-`auto_fuse_pipeline` only fuses when decision is `Fuse` (conservative).
+`auto_fuse_pipeline_list` only fuses when decision is `Fuse` (conservative).
+Skipped pairs remain in the returned pipeline.
 
 ## Constraints
 

--- a/sarek/sarek/Sarek_fusion.ml
+++ b/sarek/sarek/Sarek_fusion.ml
@@ -419,7 +419,8 @@ let can_fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
       ( List.assoc_opt intermediate prod_info.writes,
         List.assoc_opt intermediate cons_info.reads )
     with
-    | Some (OneToOne _), Some (OneToOne _) -> true
+    | Some (OneToOne prod_idx), Some (OneToOne cons_idx) ->
+        expr_equal prod_idx cons_idx
     | _ -> false
   in
 
@@ -548,54 +549,87 @@ let fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
 
 (** {1 High-level interface} *)
 
-(** Fuse a pipeline of kernels sequentially.
+(** Find arrays written by [producer] and read by [consumer]. *)
+let candidate_intermediates (producer : kernel) (consumer : kernel) :
+    string list =
+  let prod_info = analyze producer in
+  let cons_info = analyze consumer in
+  let prod_writes = List.map fst prod_info.writes in
+  let cons_reads = List.map fst cons_info.reads in
+  List.filter (fun arr -> List.mem arr cons_reads) prod_writes
+
+(** Fuse a pipeline of kernels sequentially, preserving unfused stages.
 
     Attempts to fuse each consecutive kernel pair, eliminating intermediate
     arrays. Processes left-to-right, greedily fusing when possible.
 
-    Algorithm: 1. Start with first kernel as current 2. For each subsequent
-    kernel:
-    - Find arrays that current writes and next reads (candidates)
-    - If fusable, inline current into next and eliminate intermediate
-    - Otherwise, advance to next kernel 3. Return final fused kernel and list of
-      eliminated arrays
+    Algorithm: 1. Start with the first kernel as the current stage. 2. For each
+    subsequent kernel:
+    - Find arrays that current writes and next reads (candidates).
+    - If fusable, replace the current stage and next stage with their fused
+      kernel.
+    - Otherwise, append the current stage to the result pipeline and continue
+      from the next kernel. 3. Append the final current stage.
+
+    Every input kernel is preserved unless it is replaced by a proven fused
+    kernel. The returned kernel list is therefore the complete optimized
+    pipeline in execution order.
 
     Note: This is greedy and may not find optimal fusion. For example, fusing
-    A→B might prevent better fusion of B→C. Use auto_fuse_pipeline for
+    A→B might prevent better fusion of B→C. Use auto_fuse_pipeline_list for
     heuristic-based fusion that considers these tradeoffs.
 
     @param kernels List of kernels to fuse (must be non-empty)
-    @return (fused_kernel, eliminated_intermediates)
+    @return (optimized_pipeline, eliminated_intermediates)
     @raise Empty_pipeline if kernel list is empty *)
-let fuse_pipeline (kernels : kernel list) : kernel * string list =
+let fuse_pipeline_list (kernels : kernel list) : kernel list * string list =
   match kernels with
   | [] ->
       Fusion_error.raise_error
-        (Fusion_error.Empty_pipeline {function_name = "fuse_pipeline"})
-  | [k] -> (k, [])
+        (Fusion_error.Empty_pipeline {function_name = "fuse_pipeline_list"})
+  | [k] -> ([k], [])
   | k1 :: rest ->
-      let rec loop current eliminated = function
-        | [] -> (current, eliminated)
+      let rec loop acc current eliminated = function
+        | [] -> (List.rev (current :: acc), List.rev eliminated)
         | k :: ks -> (
-            (* Find intermediate: array that current writes and k reads *)
-            let curr_info = analyze current in
-            let k_info = analyze k in
-            let curr_writes = List.map fst curr_info.writes in
-            let k_reads = List.map fst k_info.reads in
-            let intermediates =
-              List.filter
-                (fun arr -> List.mem arr curr_writes && List.mem arr k_reads)
-                curr_writes
-            in
+            let intermediates = candidate_intermediates current k in
             match intermediates with
             | inter :: _ when can_fuse current k inter ->
                 let fused = fuse current k inter in
-                loop fused (inter :: eliminated) ks
+                loop acc fused (inter :: eliminated) ks
             | _ ->
-                (* Can't fuse, just use k as new current *)
-                loop k eliminated ks)
+                (* Can't fuse this pair; keep the current stage. *)
+                loop (current :: acc) k eliminated ks)
       in
-      loop k1 [] rest
+      loop [] k1 [] rest
+
+(** Fuse a pipeline that is expected to collapse to one kernel.
+
+    Prefer {!fuse_pipeline_list} for general pipeline optimization. This legacy
+    wrapper returns a single kernel only when every preserved stage has fused
+    into one result. If any unfused kernel remains, it raises [Invalid_fusion]
+    instead of silently dropping stages.
+
+    @param kernels List of kernels to fuse (must be non-empty)
+    @return (fused_kernel, eliminated_intermediates)
+    @raise Empty_pipeline if kernel list is empty
+    @raise Invalid_fusion if the optimized pipeline still has multiple kernels
+*)
+let fuse_pipeline (kernels : kernel list) : kernel * string list =
+  let pipeline, eliminated = fuse_pipeline_list kernels in
+  match pipeline with
+  | [kernel] -> (kernel, eliminated)
+  | _ ->
+      Fusion_error.raise_error
+        (Fusion_error.Invalid_fusion
+           {
+             kernel = "fuse_pipeline";
+             reason =
+               Printf.sprintf
+                 "optimized pipeline contains %d kernels; use \
+                  fuse_pipeline_list to preserve unfused stages"
+                 (List.length pipeline);
+           })
 
 (** {1 Reduction Fusion}
 
@@ -1079,8 +1113,14 @@ let should_fuse (producer : kernel) (consumer : kernel) (intermediate : string)
       ( List.assoc_opt intermediate prod_info.writes,
         List.assoc_opt intermediate cons_info.reads )
     with
-    | Some (OneToOne _), Some (OneToOne _) ->
+    | Some (OneToOne prod_idx), Some (OneToOne cons_idx)
+      when expr_equal prod_idx cons_idx ->
         {decision = Fuse; reason = "Element-wise producer/consumer"}
+    | Some (OneToOne _), Some (OneToOne _) ->
+        {
+          decision = DontFuse;
+          reason = "Producer and consumer use different element indices";
+        }
     (* Rule 3: Map -> Reduction is always good *)
     | Some (OneToOne _), Some (Reduction _) ->
         {decision = Fuse; reason = "Map-reduce pattern"}
@@ -1097,21 +1137,21 @@ let should_fuse (producer : kernel) (consumer : kernel) (intermediate : string)
     | _ ->
         {decision = MaybeFuse; reason = "Unknown pattern - profile to decide"}
 
-(** Auto-fuse a pipeline using heuristics.
+(** Auto-fuse a pipeline using heuristics, preserving unfused stages.
 
-    Similar to fuse_pipeline, but uses should_fuse heuristics to decide which
-    fusions to apply. This prevents harmful fusions while still eliminating
-    obvious intermediates.
+    Similar to fuse_pipeline_list, but uses should_fuse heuristics to decide
+    which fusions to apply. This prevents harmful fusions while still
+    eliminating obvious intermediates.
 
     Decision process for each candidate fusion:
     - **Fuse**: Apply fusion, eliminate intermediate
-    - **DontFuse**: Skip this pair, keep intermediate
+    - **DontFuse**: Skip this pair and preserve both kernels
     - **MaybeFuse**: Conservative - skip (user can manually fuse if profiling
-      shows benefit)
+      shows benefit), preserving both kernels
 
     This is the recommended entry point for automatic optimization. Manual
-    fusion (via fuse_pipeline) is available for expert users who have profiled
-    specific fusion decisions.
+    fusion (via fuse_pipeline_list) is available for expert users who have
+    profiled specific fusion decisions.
 
     Example usage:
     {[
@@ -1119,50 +1159,94 @@ let should_fuse (producer : kernel) (consumer : kernel) (intermediate : string)
       let kernels = [map_kernel; filter_kernel; reduce_kernel] in
 
       (* Auto-fuse with heuristics *)
-      let fused, eliminated, skipped =
-        Sarek_fusion.auto_fuse_pipeline kernels
+      let pipeline, eliminated, skipped =
+        Sarek_fusion.auto_fuse_pipeline_list kernels
       in
 
-      (* Execute fused kernel (1 launch instead of 3) *)
-      Execute.run_vectors ~device ~ir:fused ~args ~block ~grid ()
+      (* Execute each kernel in optimized pipeline order. *)
+      List.iter
+        (fun ir -> Execute.run_vectors ~device ~ir ~args ~block ~grid ())
+        pipeline
     ]}
 
     @param kernels Pipeline to optimize (must be non-empty)
-    @return (fused_kernel, eliminated_arrays, skipped_reasons)
+    @return (optimized_pipeline, eliminated_arrays, skipped_reasons)
     @raise Empty_pipeline if kernel list is empty *)
-let auto_fuse_pipeline (kernels : kernel list) :
-    kernel * string list * string list =
+let auto_fuse_pipeline_list (kernels : kernel list) :
+    kernel list * string list * string list =
   match kernels with
   | [] ->
       Fusion_error.raise_error
-        (Fusion_error.Empty_pipeline {function_name = "auto_fuse_pipeline"})
-  | [k] -> (k, [], [])
+        (Fusion_error.Empty_pipeline {function_name = "auto_fuse_pipeline_list"})
+  | [k] -> ([k], [], [])
   | k1 :: rest ->
-      let rec loop current eliminated skipped = function
-        | [] -> (current, eliminated, skipped)
+      let rec loop acc current eliminated skipped = function
+        | [] ->
+            (List.rev (current :: acc), List.rev eliminated, List.rev skipped)
         | k :: ks -> (
-            let curr_info = analyze current in
-            let k_info = analyze k in
-            let curr_writes = List.map fst curr_info.writes in
-            let k_reads = List.map fst k_info.reads in
-            let candidates =
-              List.filter (fun arr -> List.mem arr k_reads) curr_writes
-            in
+            let candidates = candidate_intermediates current k in
             match candidates with
-            | [] -> loop k eliminated skipped ks
+            | [] -> loop (current :: acc) k eliminated skipped ks
             | inter :: _ -> (
                 let hint = should_fuse current k inter in
                 match hint.decision with
                 | Fuse -> (
                     match try_fuse current k inter with
-                    | Some fused -> loop fused (inter :: eliminated) skipped ks
-                    | None -> loop k eliminated (hint.reason :: skipped) ks)
-                | DontFuse -> loop k eliminated (hint.reason :: skipped) ks
+                    | Some fused ->
+                        loop acc fused (inter :: eliminated) skipped ks
+                    | None ->
+                        loop
+                          (current :: acc)
+                          k
+                          eliminated
+                          (hint.reason :: skipped)
+                          ks)
+                | DontFuse ->
+                    loop
+                      (current :: acc)
+                      k
+                      eliminated
+                      (hint.reason :: skipped)
+                      ks
                 | MaybeFuse ->
                     (* Conservative: don't auto-fuse uncertain cases *)
-                    loop k eliminated (hint.reason :: skipped) ks))
+                    loop
+                      (current :: acc)
+                      k
+                      eliminated
+                      (hint.reason :: skipped)
+                      ks))
       in
-      loop k1 [] [] rest
+      loop [] k1 [] [] rest
+
+(** Auto-fuse a pipeline that is expected to collapse to one kernel.
+
+    Prefer {!auto_fuse_pipeline_list} for general pipeline optimization. This
+    legacy wrapper returns a single kernel only when every preserved stage has
+    fused into one result. If any unfused kernel remains, it raises
+    [Invalid_fusion] instead of silently dropping stages.
+
+    @param kernels Pipeline to optimize (must be non-empty)
+    @return (fused_kernel, eliminated_arrays, skipped_reasons)
+    @raise Empty_pipeline if kernel list is empty
+    @raise Invalid_fusion if the optimized pipeline still has multiple kernels
+*)
+let auto_fuse_pipeline (kernels : kernel list) :
+    kernel * string list * string list =
+  let pipeline, eliminated, skipped = auto_fuse_pipeline_list kernels in
+  match pipeline with
+  | [kernel] -> (kernel, eliminated, skipped)
+  | _ ->
+      Fusion_error.raise_error
+        (Fusion_error.Invalid_fusion
+           {
+             kernel = "auto_fuse_pipeline";
+             reason =
+               Printf.sprintf
+                 "optimized pipeline contains %d kernels; use \
+                  auto_fuse_pipeline_list to preserve unfused stages"
+                 (List.length pipeline);
+           })
 
 (** Print fusion analysis for a pipeline.
 
@@ -1173,8 +1257,8 @@ let auto_fuse_pipeline (kernels : kernel list) :
     - Fusion decision and reasoning
     - Potential benefits or risks
 
-    Useful for understanding why auto_fuse_pipeline made specific decisions or
-    for identifying manual fusion opportunities.
+    Useful for understanding why auto_fuse_pipeline_list made specific decisions
+    or for identifying manual fusion opportunities.
 
     @param kernels Pipeline to analyze *)
 let analyze_pipeline (kernels : kernel list) : unit =

--- a/sarek/tests/unit/test_fusion.ml
+++ b/sarek/tests/unit/test_fusion.ml
@@ -17,6 +17,21 @@ let mk_var name id typ =
 (** Helper to create thread_idx_x intrinsic *)
 let thread_idx_x = EIntrinsic (["Gpu"], "thread_idx_x", [])
 
+(** Helper to create a minimal kernel record *)
+let mk_kernel name body =
+  {
+    kern_name = name;
+    kern_params = [];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+    kern_variants = [];
+  }
+
+let kernel_names kernels = List.map (fun k -> k.kern_name) kernels
+
 (** Test: analyze simple kernel with OneToOne access pattern *)
 let test_analyze_one_to_one () =
   (* output[thread_idx_x] = input[thread_idx_x] * 2 *)
@@ -265,6 +280,102 @@ let test_fuse_pipeline () =
   Printf.printf
     "test_fuse_pipeline: PASSED (eliminated: %s)\n"
     (String.concat ", " eliminated)
+
+(** Test: fuse_pipeline_list preserves a pipeline with no fusible pairs *)
+let test_fuse_pipeline_list_preserves_unfused () =
+  let k1 =
+    mk_kernel
+      "k1"
+      (SAssign
+         ( LArrayElem ("a", thread_idx_x),
+           EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
+         ))
+  in
+  let k2 =
+    mk_kernel
+      "k2"
+      (SAssign
+         ( LArrayElem ("b", thread_idx_x),
+           EBinop (Add, EArrayRead ("other", thread_idx_x), EConst (CInt32 1l))
+         ))
+  in
+  let k3 =
+    mk_kernel
+      "k3"
+      (SAssign
+         ( LArrayElem ("output", thread_idx_x),
+           EBinop (Mul, EArrayRead ("third", thread_idx_x), EConst (CInt32 3l))
+         ))
+  in
+  let fused, eliminated = fuse_pipeline_list [k1; k2; k3] in
+  assert (kernel_names fused = ["k1"; "k2"; "k3"]) ;
+  assert (eliminated = []) ;
+  Printf.printf "test_fuse_pipeline_list_preserves_unfused: PASSED\n"
+
+(** Test: fuse_pipeline_list preserves order around a fused pair *)
+let test_fuse_pipeline_list_mixed_order () =
+  let pre =
+    mk_kernel
+      "pre"
+      (SAssign
+         ( LArrayElem ("pre_out", thread_idx_x),
+           EArrayRead ("pre_in", thread_idx_x) ))
+  in
+  let producer =
+    mk_kernel
+      "producer"
+      (SAssign
+         ( LArrayElem ("temp", thread_idx_x),
+           EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
+         ))
+  in
+  let consumer =
+    mk_kernel
+      "consumer"
+      (SAssign
+         ( LArrayElem ("mid", thread_idx_x),
+           EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
+         ))
+  in
+  let post =
+    mk_kernel
+      "post"
+      (SAssign
+         ( LArrayElem ("output", thread_idx_x),
+           EArrayRead ("post_in", thread_idx_x) ))
+  in
+  let fused, eliminated = fuse_pipeline_list [pre; producer; consumer; post] in
+  assert (kernel_names fused = ["pre"; "consumer_fused"; "post"]) ;
+  assert (eliminated = ["temp"]) ;
+  let fused_pair = List.nth fused 1 in
+  let info = analyze fused_pair in
+  assert (List.mem_assoc "input" info.reads) ;
+  assert (not (List.mem_assoc "temp" info.reads)) ;
+  assert (List.mem_assoc "mid" info.writes) ;
+  Printf.printf "test_fuse_pipeline_list_mixed_order: PASSED\n"
+
+(** Test: fuse_pipeline_list preserves producer when indices differ *)
+let test_fuse_pipeline_list_preserves_mismatched_indices () =
+  let shifted_idx = EBinop (Add, thread_idx_x, EConst (CInt32 1l)) in
+  let producer =
+    mk_kernel
+      "producer"
+      (SAssign
+         ( LArrayElem ("temp", thread_idx_x),
+           EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
+         ))
+  in
+  let consumer =
+    mk_kernel
+      "consumer"
+      (SAssign
+         ( LArrayElem ("output", thread_idx_x),
+           EBinop (Add, EArrayRead ("temp", shifted_idx), EConst (CInt32 1l)) ))
+  in
+  let fused, eliminated = fuse_pipeline_list [producer; consumer] in
+  assert (kernel_names fused = ["producer"; "consumer"]) ;
+  assert (eliminated = []) ;
+  Printf.printf "test_fuse_pipeline_list_preserves_mismatched_indices: PASSED\n"
 
 (** Test: expr_equal *)
 let test_expr_equal () =
@@ -934,13 +1045,111 @@ let test_auto_fuse_pipeline_skip_stencil () =
       kern_variants = [];
     }
   in
-  let _fused, eliminated, skipped = auto_fuse_pipeline [k1; k2] in
+  let fused, eliminated, skipped = auto_fuse_pipeline_list [k1; k2] in
   (* Should skip because stencil is MaybeFuse *)
+  assert (kernel_names fused = ["k1"; "k2"]) ;
   assert (List.length eliminated = 0) ;
   assert (List.length skipped = 1) ;
   Printf.printf
     "test_auto_fuse_pipeline_skip_stencil: PASSED (skipped: %s)\n"
     (String.concat ", " skipped)
+
+(** Test: auto_fuse_pipeline_list preserves kernels when heuristics skip fusion
+*)
+let test_auto_fuse_pipeline_list_preserves_dont_fuse () =
+  let producer =
+    mk_kernel
+      "barrier_producer"
+      (SSeq
+         [
+           SAssign
+             ( LArrayElem ("temp", thread_idx_x),
+               EArrayRead ("input", thread_idx_x) );
+           SBarrier;
+         ])
+  in
+  let consumer =
+    mk_kernel
+      "consumer"
+      (SAssign
+         ( LArrayElem ("output", thread_idx_x),
+           EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
+         ))
+  in
+  let fused, eliminated, skipped =
+    auto_fuse_pipeline_list [producer; consumer]
+  in
+  assert (kernel_names fused = ["barrier_producer"; "consumer"]) ;
+  assert (eliminated = []) ;
+  assert (skipped = ["Barrier prevents fusion"]) ;
+  Printf.printf "test_auto_fuse_pipeline_list_preserves_dont_fuse: PASSED\n"
+
+(** Test: auto_fuse_pipeline_list preserves order around a fused pair *)
+let test_auto_fuse_pipeline_list_mixed_order () =
+  let pre =
+    mk_kernel
+      "pre"
+      (SAssign
+         ( LArrayElem ("pre_out", thread_idx_x),
+           EArrayRead ("pre_in", thread_idx_x) ))
+  in
+  let producer =
+    mk_kernel
+      "producer"
+      (SAssign
+         ( LArrayElem ("temp", thread_idx_x),
+           EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
+         ))
+  in
+  let consumer =
+    mk_kernel
+      "consumer"
+      (SAssign
+         ( LArrayElem ("mid", thread_idx_x),
+           EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
+         ))
+  in
+  let post =
+    mk_kernel
+      "post"
+      (SAssign
+         ( LArrayElem ("output", thread_idx_x),
+           EArrayRead ("post_in", thread_idx_x) ))
+  in
+  let fused, eliminated, skipped =
+    auto_fuse_pipeline_list [pre; producer; consumer; post]
+  in
+  assert (kernel_names fused = ["pre"; "consumer_fused"; "post"]) ;
+  assert (eliminated = ["temp"]) ;
+  assert (skipped = []) ;
+  Printf.printf "test_auto_fuse_pipeline_list_mixed_order: PASSED\n"
+
+(** Test: auto_fuse_pipeline_list preserves producer when indices differ *)
+let test_auto_fuse_pipeline_list_preserves_mismatched_indices () =
+  let shifted_idx = EBinop (Add, thread_idx_x, EConst (CInt32 1l)) in
+  let producer =
+    mk_kernel
+      "producer"
+      (SAssign
+         ( LArrayElem ("temp", thread_idx_x),
+           EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
+         ))
+  in
+  let consumer =
+    mk_kernel
+      "consumer"
+      (SAssign
+         ( LArrayElem ("output", thread_idx_x),
+           EBinop (Add, EArrayRead ("temp", shifted_idx), EConst (CInt32 1l)) ))
+  in
+  let fused, eliminated, skipped =
+    auto_fuse_pipeline_list [producer; consumer]
+  in
+  assert (kernel_names fused = ["producer"; "consumer"]) ;
+  assert (eliminated = []) ;
+  assert (skipped = ["Producer and consumer use different element indices"]) ;
+  Printf.printf
+    "test_auto_fuse_pipeline_list_preserves_mismatched_indices: PASSED\n"
 
 let () =
   Printf.printf "=== Fusion Unit Tests ===\n" ;
@@ -952,6 +1161,9 @@ let () =
   test_can_fuse_with_barrier () ;
   test_fuse_simple () ;
   test_fuse_pipeline () ;
+  test_fuse_pipeline_list_preserves_unfused () ;
+  test_fuse_pipeline_list_mixed_order () ;
+  test_fuse_pipeline_list_preserves_mismatched_indices () ;
   Printf.printf "\n=== Reduction Fusion Tests ===\n" ;
   test_detect_reduction_pattern () ;
   test_is_reduction_kernel () ;
@@ -970,4 +1182,7 @@ let () =
   test_should_fuse_small_stencil () ;
   test_auto_fuse_pipeline () ;
   test_auto_fuse_pipeline_skip_stencil () ;
+  test_auto_fuse_pipeline_list_preserves_dont_fuse () ;
+  test_auto_fuse_pipeline_list_mixed_order () ;
+  test_auto_fuse_pipeline_list_preserves_mismatched_indices () ;
   Printf.printf "=== All tests passed! ===\n"


### PR DESCRIPTION
Fixes #130.

## Summary
- Add list-returning fusion pipeline APIs that preserve kernels that cannot be fused.
- Keep legacy single-kernel APIs strict by raising when the optimized pipeline still contains multiple kernels.
- Reject one-to-one fusion when producer and consumer index expressions differ.
- Document the preserved-pipeline behavior in the fusion guide.

## Regression tests
- `test_fuse_pipeline_list_preserves_unfused`
- `test_fuse_pipeline_list_mixed_order`
- `test_fuse_pipeline_list_preserves_mismatched_indices`
- `test_auto_fuse_pipeline_list_preserves_dont_fuse`
- `test_auto_fuse_pipeline_list_mixed_order`
- `test_auto_fuse_pipeline_list_preserves_mismatched_indices`

## Validation
- `opam exec --switch=/home/mathias/dev/SPOC -- dune exec sarek/tests/unit/test_fusion.exe`
- `git diff --check`
- `opam exec --switch=/home/mathias/dev/SPOC -- ocamlformat --check sarek/sarek/Sarek_fusion.ml sarek/tests/unit/test_fusion.ml`