### PR TITLE
Remove Obj usage from Sarek execution paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,19 @@
+## Unreleased
+
+### Changed
+
+- Breaking: removed first-party `Obj` escape hatches from Sarek/SPOC execution
+  paths.
+  - Kernel vector arguments now cross framework/plugin boundaries through typed
+    existential accessors and runtime type witnesses.
+  - Custom value conversion now uses typed helper lookup instead of raw runtime
+    representation casts.
+  - Native and interpreter plugin buffer copies use typed Bigarray operations.
+  - Custom shared-memory arrays are keyed by typed witnesses to reject
+    mismatched reuse.
+  - Legacy native direct execution now accepts typed `Framework_sig.exec_arg`
+    arrays.
+
 ## 2026-01
 
 ### Changed

--- a/kb/obj-usage-audit/01-native-vector-boundary.md
+++ b/kb/obj-usage-audit/01-native-vector-boundary.md
@@ -1,0 +1,25 @@
+# Native Vector Execution Boundary
+
+## Original Risk
+
+Kernel execution moved vectors through native arguments as raw runtime values.
+Backends recovered the expected vector type with representation casts, so a
+wrong descriptor or stale generated code could reinterpret a vector as another
+element type.
+
+## Implemented Alternative
+
+`Sarek_ir_types.native_arg` now carries an existential `native_vec` record with
+typed element accessors, typed scalar accessors, a vector length, an underlying
+value, and `Type_id` witnesses for both element and underlying vector type.
+
+Generated native code calls `vec_get_custom`, `vec_set_custom`, and
+`vec_as_vector` with an expected witness. The operation succeeds only when the
+witness matches.
+
+## Why This Improves The Code
+
+The dynamic boundary remains flexible, but type recovery is now guarded by a
+GADT equality proof instead of unchecked representation conversion. Scalar
+vectors use direct typed closures, which avoids extra boxing through generic
+values in the common native path.

--- a/kb/obj-usage-audit/02-custom-helper-registry.md
+++ b/kb/obj-usage-audit/02-custom-helper-registry.md
@@ -1,0 +1,19 @@
+# Custom Helper Registry
+
+## Original Risk
+
+`Sarek_type_helpers` stored custom conversion helpers behind untyped conversion
+closures. Lookup recovered the requested helper type through raw runtime
+representation casts.
+
+## Implemented Alternative
+
+Each helper module now exposes a `type_id` witness. Dynamic lookup uses
+`Sarek_ir_types.Type_id.equal` and returns a typed first-class module only when
+the witness proves equality.
+
+## Why This Improves The Code
+
+Custom record and variant conversion now fails deterministically on mismatched
+types. The registry still supports dynamic lookup, but successful lookups carry
+real type evidence.

--- a/kb/obj-usage-audit/03-interpreter-plugin-bridge.md
+++ b/kb/obj-usage-audit/03-interpreter-plugin-bridge.md
@@ -1,0 +1,22 @@
+# Interpreter Plugin Bridge
+
+## Original Risk
+
+The interpreter plugin converted framework execution arguments back into kernel
+arguments through raw representation conversion. That made interpreter execution
+depend on the hidden layout of vector and scalar wrappers.
+
+## Implemented Alternative
+
+`Sarek_ir_interp` now executes directly from `Framework_sig.exec_arg list` using
+typed conversion helpers:
+
+- scalar `typed_value` conversion for scalar arguments,
+- vector-to-array and array-to-vector writeback through typed accessors,
+- custom conversion through typed helper lookup.
+
+## Why This Improves The Code
+
+The interpreter no longer needs to reconstruct static types from opaque runtime
+objects. Writeback is explicit, and unsupported conversions are surfaced as
+normal interpreter errors.

--- a/kb/obj-usage-audit/04-plugin-buffer-copies.md
+++ b/kb/obj-usage-audit/04-plugin-buffer-copies.md
@@ -1,0 +1,20 @@
+# Plugin Buffer Copies
+
+## Original Risk
+
+Native and interpreter plugin buffer copies used representation conversion to
+copy between existential Bigarray values. This worked only if the existential
+storage and destination kind were exactly what the surrounding code assumed.
+
+## Implemented Alternative
+
+Buffer copies now use typed `Bigarray.Array1.get` and `Bigarray.Array1.set`
+inside the branch that exposes the concrete Bigarray storage. Native pointer
+copies also handle Bigarray-backed buffers by byte-copying through Ctypes
+Bigarray pointers.
+
+## Why This Improves The Code
+
+The common scalar transfer path is typed and readable. The pointer path still
+exists for generic runtime APIs and custom buffers, but it copies bytes from
+actual buffer pointers instead of rejecting native Bigarray storage.

--- a/kb/obj-usage-audit/05-custom-shared-memory-arrays.md
+++ b/kb/obj-usage-audit/05-custom-shared-memory-arrays.md
@@ -1,0 +1,17 @@
+# Custom Shared Memory Arrays
+
+## Original Risk
+
+Custom shared-memory arrays were stored in an erased slot. Reusing a name for a
+different custom type could recover the old array at the new type.
+
+## Implemented Alternative
+
+`Sarek_cpu_runtime.alloc_shared_with_key` stores each custom shared array with a
+`Type_id` witness. Reuse checks witness equality before returning the array.
+
+## Why This Improves The Code
+
+Shared memory reuse remains fast for matching calls and now rejects type
+mismatches at the allocation boundary. Unit tests cover allocation, reuse, and
+mismatch rejection.

--- a/kb/obj-usage-audit/06-native-runtime-test-vector-access.md
+++ b/kb/obj-usage-audit/06-native-runtime-test-vector-access.md
@@ -1,0 +1,19 @@
+# Native Runtime Test Vector Access
+
+## Original Risk
+
+The native runtime integration test extracted raw Bigarray vectors from
+`EXEC_VECTOR` modules through a direct object escape hatch. That test codified
+the unsafe API and prevented removing it.
+
+## Implemented Alternative
+
+The test kernel now reads and writes vector elements through `V.get` and `V.set`
+typed-value accessors. Native runtime buffers implement scalar typed-value
+access for Bigarray-backed buffers.
+
+## Why This Improves The Code
+
+The integration test now exercises the same typed public execution surface as
+native kernels receive. It also verifies that runtime `ArgBuffer` values can be
+used without accessing backend-private storage.

--- a/kb/obj-usage-audit/07-legacy-native-direct-api.md
+++ b/kb/obj-usage-audit/07-legacy-native-direct-api.md
@@ -1,0 +1,17 @@
+# Legacy Native Direct API
+
+## Original Risk
+
+`Native_plugin.run_kernel_direct` still accepted raw runtime object arrays even
+after the main native registry used typed execution arguments.
+
+## Implemented Alternative
+
+The function now accepts `Framework_sig.exec_arg array`, matching the native
+kernel registry and the runtime launch path.
+
+## Why This Improves The Code
+
+There is one native direct-call ABI instead of a safe path plus a legacy unsafe
+path. This is a breaking change, but it reduces maintenance cost and removes the
+last active raw-object API surface in the native plugin.

--- a/kb/obj-usage-audit/08-ppx-custom-descriptor-qualification.md
+++ b/kb/obj-usage-audit/08-ppx-custom-descriptor-qualification.md
@@ -1,0 +1,20 @@
+# PPX Custom Descriptor Qualification
+
+## Original Risk
+
+Removing raw casts made generated code rely on typed custom descriptors such as
+`point_custom`. Same-module generated kernels initially qualified those
+descriptors with the module currently being compiled, which is not in scope
+inside its own implementation.
+
+## Implemented Alternative
+
+Native generation now strips the current module prefix when referring to a
+custom descriptor defined in the same compilation unit. The qualified form is
+kept for external custom types.
+
+## Why This Improves The Code
+
+The typed descriptor path works for both local and external custom types. This
+keeps generated native accessors type-safe without regressing same-module PPX
+use cases.

--- a/kb/obj-usage-audit/README.md
+++ b/kb/obj-usage-audit/README.md
@@ -1,0 +1,32 @@
+# Obj Usage Audit
+
+Audit scope: first-party OCaml sources under `spoc/`, `sarek/`, backend
+packages, benchmarks, tools, and scripts. The implementation now removes active
+source hits for `Obj.magic`, `Obj.repr`, `Obj.obj`, `Obj.t`, and the old
+`internal_get_vector_obj` escape hatch.
+
+## Priority Index
+
+1. [Native vector execution boundary](01-native-vector-boundary.md)
+2. [Custom value helper registry](02-custom-helper-registry.md)
+3. [Interpreter plugin bridge](03-interpreter-plugin-bridge.md)
+4. [Plugin buffer copies](04-plugin-buffer-copies.md)
+5. [Custom shared memory arrays](05-custom-shared-memory-arrays.md)
+6. [Native runtime test direct vector access](06-native-runtime-test-vector-access.md)
+7. [Legacy native direct API](07-legacy-native-direct-api.md)
+8. [PPX custom descriptor qualification](08-ppx-custom-descriptor-qualification.md)
+
+## Implemented Direction
+
+The replacement strategy is a mix of GADT-style runtime witnesses, typed
+existentials, first-class modules, and typed Bigarray loops. This keeps values in
+their real static types across backend boundaries and turns mismatches into
+explicit errors instead of undefined representation casts.
+
+## Verification Target
+
+The source audit command used for this PR:
+
+```sh
+rg -n "Obj\.(magic|repr|obj)|Obj\.t|\bObj\b|internal_get_vector_obj|shared_key|custom_key|get_any|set_any" -S --glob '*.ml' --glob '*.mli' spoc sarek sarek-cuda sarek-opencl sarek-vulkan sarek-metal benchmarks tools scripts
+```

--- a/sarek/core/Kernel.ml
+++ b/sarek/core/Kernel.ml
@@ -7,7 +7,7 @@
  * Sarek Runtime - Kernel Execution
  *
  * Provides unified kernel compilation and execution across backends.
- * Uses first-class modules to wrap backend-specific handles - no Obj.t.
+ * Uses first-class modules to wrap backend-specific handles.
  ******************************************************************************)
 
 open Spoc_framework

--- a/sarek/core/Kernel_arg.ml
+++ b/sarek/core/Kernel_arg.ml
@@ -6,7 +6,7 @@
 (******************************************************************************
  * Kernel_arg - Type-safe kernel arguments
  *
- * Provides a GADT for kernel arguments that avoids Obj.t. Backends consume
+ * Provides a GADT for kernel arguments. Backends consume
  * these via pattern matching or the fold interface.
  ******************************************************************************)
 

--- a/sarek/core/Memory.ml
+++ b/sarek/core/Memory.ml
@@ -7,7 +7,7 @@
  * Sarek Runtime - Unified Memory Abstraction
  *
  * Provides a unified interface for GPU memory allocation and data transfer.
- * Uses first-class modules to wrap backend-specific buffers - no Obj.t.
+ * Uses first-class modules to wrap backend-specific buffers.
  ******************************************************************************)
 
 open Spoc_framework

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -9,7 +9,7 @@
  * Provides explicit and async data transfer API with stream management.
  * Phase 2 of runtime V2 feature parity roadmap.
  *
- * Uses the framework plugin system directly - no Obj.t.
+ * Uses the framework plugin system directly.
  ******************************************************************************)
 
 open Spoc_framework

--- a/sarek/core/Vector.ml
+++ b/sarek/core/Vector.ml
@@ -14,7 +14,7 @@
  * - Custom: User-defined ctypes structures with custom get/set
  *
  * Design principles:
- * - Type-safe: Uses GADTs and existentials instead of Obj.t
+ * - Type-safe: Uses GADTs and existentials
  * - Location-aware: Tracks where data resides (CPU, GPU, or both)
  * - Lazy allocation: GPU memory allocated on first device use
  * - Auto-sync: Element access triggers sync when needed

--- a/sarek/core/Vector_types.ml
+++ b/sarek/core/Vector_types.ml
@@ -244,8 +244,8 @@ let char_type_id : char Sarek_ir_types.Type_id.t =
 let complex32_type_id : Complex.t Sarek_ir_types.Type_id.t =
   Sarek_ir_types.Type_id.create ()
 
-let scalar_type_id : type a b. (a, b) scalar_kind -> a Sarek_ir_types.Type_id.t =
-  function
+let scalar_type_id : type a b. (a, b) scalar_kind -> a Sarek_ir_types.Type_id.t
+    = function
   | Float32 -> float32_type_id
   | Float64 -> float64_type_id
   | Int32 -> int32_type_id
@@ -281,8 +281,8 @@ let complex32_vector_type_id :
     (Complex.t, Bigarray.complex32_elt) t Sarek_ir_types.Type_id.t =
   Sarek_ir_types.Type_id.create ()
 
-let vector_type_id : type a b.
-    (a, b) kind -> (a, b) t Sarek_ir_types.Type_id.t = function
+let vector_type_id : type a b. (a, b) kind -> (a, b) t Sarek_ir_types.Type_id.t
+    = function
   | Scalar Float32 -> float32_vector_type_id
   | Scalar Float64 -> float64_vector_type_id
   | Scalar Int32 -> int32_vector_type_id

--- a/sarek/core/Vector_types.ml
+++ b/sarek/core/Vector_types.ml
@@ -22,12 +22,65 @@ type (_, _) scalar_kind =
   | Char : (char, Bigarray.int8_unsigned_elt) scalar_kind
   | Complex32 : (Complex.t, Bigarray.complex32_elt) scalar_kind
 
+(** {1 Location Tracking} *)
+
+(** Where the authoritative copy of data resides *)
+type location =
+  | CPU  (** Data only on host *)
+  | GPU of Device.t  (** Data only on specific device *)
+  | Both of Device.t  (** Synced on host and device *)
+  | Stale_CPU of Device.t  (** GPU is authoritative, CPU outdated *)
+  | Stale_GPU of Device.t  (** CPU is authoritative, GPU outdated *)
+
+(** {1 Device Buffer Abstraction} *)
+
+(** Device buffer reuses Memory.BUFFER module type. We use the raw module type
+    here (not the phantom-typed Memory.buffer) because the hashtable stores
+    buffers for a single vector type, and the type safety comes from the
+    Vector's ('a, 'b) t type parameter. *)
+module type DEVICE_BUFFER = Memory.BUFFER
+
+type device_buffer = (module DEVICE_BUFFER)
+
+(** Device buffer storage - maps device ID to buffer *)
+type device_buffers = (int, device_buffer) Hashtbl.t
+
 (** Custom type descriptor for ctypes-based structures *)
 type 'a custom_type = {
   elem_size : int;  (** Size of each element in bytes *)
+  type_id : 'a Sarek_ir_types.Type_id.t;  (** Runtime element type identity *)
+  vector_type_id : ('a, unit) t Sarek_ir_types.Type_id.t;
+      (** Runtime identity for the vector type carrying this element type *)
   get : unit Ctypes.ptr -> int -> 'a;  (** Read element at index *)
   set : unit Ctypes.ptr -> int -> 'a -> unit;  (** Write element at index *)
   name : string;  (** Type name for debugging *)
+}
+
+(** Unified kind type supporting both scalar and custom types *)
+and (_, _) kind =
+  | Scalar : ('a, 'b) scalar_kind -> ('a, 'b) kind
+  | Custom : 'a custom_type -> ('a, unit) kind
+
+and (_, _) host_storage =
+  | Bigarray_storage :
+      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
+      -> ('a, 'b) host_storage
+  | Custom_storage : {
+      ptr : unit Ctypes.ptr;
+      custom : 'a custom_type;
+      length : int;
+    }
+      -> ('a, unit) host_storage
+
+(** High-level vector with location tracking *)
+and ('a, 'b) t = {
+  host : ('a, 'b) host_storage;
+  device_buffers : device_buffers;
+  length : int;
+  kind : ('a, 'b) kind;
+  mutable location : location;
+  mutable auto_sync : bool;  (** Enable automatic CPU sync on get *)
+  id : int;  (** Unique vector ID for debugging *)
 }
 
 (** Helper functions for custom type implementations. These wrap Ctypes
@@ -135,11 +188,6 @@ module Custom_helpers = struct
     custom.set target_ptr 0 v
 end
 
-(** Unified kind type supporting both scalar and custom types *)
-type (_, _) kind =
-  | Scalar : ('a, 'b) scalar_kind -> ('a, 'b) kind
-  | Custom : 'a custom_type -> ('a, unit) kind
-
 (** {1 Kind Helpers} *)
 
 (** Convert scalar kind to Bigarray.kind *)
@@ -178,52 +226,67 @@ let kind_name : type a b. (a, b) kind -> string = function
   | Scalar k -> scalar_kind_name k
   | Custom c -> "Custom(" ^ c.name ^ ")"
 
-(** {1 Host Storage (GADT)} *)
+let float32_type_id : float Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
 
-(** CPU-side storage - either Bigarray or raw ctypes pointer *)
-type (_, _) host_storage =
-  | Bigarray_storage :
-      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
-      -> ('a, 'b) host_storage
-  | Custom_storage : {
-      ptr : unit Ctypes.ptr;
-      custom : 'a custom_type;
-      length : int;
-    }
-      -> ('a, unit) host_storage
+let float64_type_id : float Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
 
-(** {1 Location Tracking} *)
+let int32_type_id : int32 Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
 
-(** Where the authoritative copy of data resides *)
-type location =
-  | CPU  (** Data only on host *)
-  | GPU of Device.t  (** Data only on specific device *)
-  | Both of Device.t  (** Synced on host and device *)
-  | Stale_CPU of Device.t  (** GPU is authoritative, CPU outdated *)
-  | Stale_GPU of Device.t  (** CPU is authoritative, GPU outdated *)
+let int64_type_id : int64 Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
 
-(** {1 Device Buffer Abstraction} *)
+let char_type_id : char Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
 
-(** Device buffer reuses Memory.BUFFER module type. We use the raw module type
-    here (not the phantom-typed Memory.buffer) because the hashtable stores
-    buffers for a single vector type, and the type safety comes from the
-    Vector's ('a, 'b) t type parameter. *)
-module type DEVICE_BUFFER = Memory.BUFFER
+let complex32_type_id : Complex.t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
 
-type device_buffer = (module DEVICE_BUFFER)
+let scalar_type_id : type a b. (a, b) scalar_kind -> a Sarek_ir_types.Type_id.t =
+  function
+  | Float32 -> float32_type_id
+  | Float64 -> float64_type_id
+  | Int32 -> int32_type_id
+  | Int64 -> int64_type_id
+  | Char -> char_type_id
+  | Complex32 -> complex32_type_id
 
-(** Device buffer storage - maps device ID to buffer *)
-type device_buffers = (int, device_buffer) Hashtbl.t
+let type_id : type a b. (a, b) kind -> a Sarek_ir_types.Type_id.t = function
+  | Scalar k -> scalar_type_id k
+  | Custom c -> c.type_id
 
-(** {1 Vector Type} *)
+let float32_vector_type_id :
+    (float, Bigarray.float32_elt) t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
 
-(** High-level vector with location tracking *)
-type ('a, 'b) t = {
-  host : ('a, 'b) host_storage;
-  device_buffers : device_buffers;
-  length : int;
-  kind : ('a, 'b) kind;
-  mutable location : location;
-  mutable auto_sync : bool;  (** Enable automatic CPU sync on get *)
-  id : int;  (** Unique vector ID for debugging *)
-}
+let float64_vector_type_id :
+    (float, Bigarray.float64_elt) t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let int32_vector_type_id :
+    (int32, Bigarray.int32_elt) t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let int64_vector_type_id :
+    (int64, Bigarray.int64_elt) t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let char_vector_type_id :
+    (char, Bigarray.int8_unsigned_elt) t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let complex32_vector_type_id :
+    (Complex.t, Bigarray.complex32_elt) t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let vector_type_id : type a b.
+    (a, b) kind -> (a, b) t Sarek_ir_types.Type_id.t = function
+  | Scalar Float32 -> float32_vector_type_id
+  | Scalar Float64 -> float64_vector_type_id
+  | Scalar Int32 -> int32_vector_type_id
+  | Scalar Int64 -> int64_vector_type_id
+  | Scalar Char -> char_vector_type_id
+  | Scalar Complex32 -> complex32_vector_type_id
+  | Custom c -> c.vector_type_id

--- a/sarek/core/dune
+++ b/sarek/core/dune
@@ -7,10 +7,10 @@
  (libraries
   spoc_framework
   spoc_framework_registry
- ctypes
- unix
+  ctypes
+  unix
   sarek_ir
- sarek_registry)
+  sarek_registry)
  (modules
   Log
   Device

--- a/sarek/core/dune
+++ b/sarek/core/dune
@@ -7,9 +7,10 @@
  (libraries
   spoc_framework
   spoc_framework_registry
-  ctypes
-  unix
-  sarek_registry)
+ ctypes
+ unix
+  sarek_ir
+ sarek_registry)
  (modules
   Log
   Device

--- a/sarek/plugins/interpreter/Interpreter_plugin.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin.ml
@@ -76,26 +76,6 @@ module Backend : Framework_sig.BACKEND = struct
   let generate_source ?block:_ (_ir : Sarek_ir_types.kernel) : string option =
     None
 
-  (** Convert exec_arg array to Kernel_arg.t list for typed interpreter path *)
-  let exec_args_to_kernel_args (args : Framework_sig.exec_arg array) :
-      Spoc_core.Kernel_arg.t list =
-    Array.to_list args
-    |> List.map (fun arg ->
-        match arg with
-        | Framework_sig.EA_Int32 n -> Spoc_core.Kernel_arg.Int32 n
-        | Framework_sig.EA_Int64 n -> Spoc_core.Kernel_arg.Int64 n
-        | Framework_sig.EA_Float32 f -> Spoc_core.Kernel_arg.Float32 f
-        | Framework_sig.EA_Float64 f -> Spoc_core.Kernel_arg.Float64 f
-        | Framework_sig.EA_Vec (module V) ->
-            (* For interpreter, we need to recover the typed Vector.t.
-               Use internal_get_vector_obj which is marked for internal backend use only. *)
-            let vec_obj = V.internal_get_vector_obj () in
-            Spoc_core.Kernel_arg.Vec (Obj.magic vec_obj)
-        | Framework_sig.EA_Scalar _ | Framework_sig.EA_Composite _ ->
-            (* Custom scalars/composites not yet supported by Kernel_arg.t *)
-            Interpreter_error.(
-              raise_error (feature_not_supported "custom types in exec_arg")))
-
   (** Execute directly by interpreting the IR. Interpreter always interprets,
       ignoring native_fn (use Native backend for compiled execution). Uses
       parallel or sequential mode based on current device. *)
@@ -119,13 +99,11 @@ module Backend : Framework_sig.BACKEND = struct
     match ir with
     | Some kernel ->
         Sarek.Sarek_ir_interp.parallel_mode := use_parallel ;
-        (* Convert exec_args to Kernel_arg.t and use typed interpreter path *)
-        let kargs = exec_args_to_kernel_args args in
-        Sarek.Sarek_ir_interp.run_kernel_with_args
+        Sarek.Sarek_ir_interp.run_kernel_with_exec_args
           kernel
           ~block:(block.x, block.y, block.z)
           ~grid:(grid.x, grid.y, grid.z)
-          kargs
+          (Array.to_list args)
     | None ->
         Interpreter_error.(
           raise_error (compilation_failed "" "kernel IR required"))

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -411,12 +411,12 @@ end = struct
         src:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> dst:a buffer -> unit
         =
      fun ~src ~dst ->
-	      match dst.storage with
-	      | Bigarray_storage dst_arr ->
-	          let len = min (Bigarray.Array1.dim src) dst.size in
-	          for i = 0 to len - 1 do
-	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src i)
-	          done
+      match dst.storage with
+      | Bigarray_storage dst_arr ->
+          let len = min (Bigarray.Array1.dim src) dst.size in
+          for i = 0 to len - 1 do
+            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src i)
+          done
       | Ctypes_storage _ ->
           invalid_arg "host_to_device: destination is ctypes buffer"
 
@@ -424,12 +424,12 @@ end = struct
         src:a buffer -> dst:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> unit
         =
      fun ~src ~dst ->
-	      match src.storage with
-	      | Bigarray_storage src_arr ->
-	          let len = min src.size (Bigarray.Array1.dim dst) in
-	          for i = 0 to len - 1 do
-	            Bigarray.Array1.set dst i (Bigarray.Array1.get src_arr i)
-	          done
+      match src.storage with
+      | Bigarray_storage src_arr ->
+          let len = min src.size (Bigarray.Array1.dim dst) in
+          for i = 0 to len - 1 do
+            Bigarray.Array1.set dst i (Bigarray.Array1.get src_arr i)
+          done
       | Ctypes_storage _ ->
           invalid_arg "device_to_host: source is ctypes buffer"
 
@@ -461,12 +461,12 @@ end = struct
 
     let device_to_device : type a. src:a buffer -> dst:a buffer -> unit =
      fun ~src ~dst ->
-	      match (src.storage, dst.storage) with
-	      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
-	          let len = min src.size dst.size in
-	          for i = 0 to len - 1 do
-	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src_arr i)
-	          done
+      match (src.storage, dst.storage) with
+      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
+          let len = min src.size dst.size in
+          for i = 0 to len - 1 do
+            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src_arr i)
+          done
       | Ctypes_storage src_ptr, Ctypes_storage dst_ptr ->
           let src_char_ptr = Ctypes.from_voidp Ctypes.char src_ptr in
           let dst_char_ptr = Ctypes.from_voidp Ctypes.char dst_ptr in
@@ -541,9 +541,10 @@ end = struct
               (feature_not_supported
                  "unsupported buffer kind/storage for argument"))) ;
       (* Wrap buffer in EXEC_VECTOR for exec_arg *)
-      let module EV : Typed_value.EXEC_VECTOR
-        with type elt = a
-         and type underlying = a Memory.buffer = struct
+      let module EV :
+        Typed_value.EXEC_VECTOR
+          with type elt = a
+           and type underlying = a Memory.buffer = struct
         type elt = a
 
         type underlying = a Memory.buffer
@@ -567,21 +568,30 @@ end = struct
 
         let get i =
           match (buf.Memory.kind, buf.Memory.storage) with
-          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba ->
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba
+            ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Int32_type), Bigarray.Array1.get ba i))
-          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba ->
+                (Typed_value.SV
+                   ((module Typed_value.Int32_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba
+            ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Int64_type), Bigarray.Array1.get ba i))
-          | Memory.Scalar_kind Spoc_core.Vector_types.Float32, Bigarray_storage ba ->
+                (Typed_value.SV
+                   ((module Typed_value.Int64_type), Bigarray.Array1.get ba i))
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float32,
+              Bigarray_storage ba ) ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Float32_type), Bigarray.Array1.get ba i))
-          | Memory.Scalar_kind Spoc_core.Vector_types.Float64, Bigarray_storage ba ->
+                (Typed_value.SV
+                   ((module Typed_value.Float32_type), Bigarray.Array1.get ba i))
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float64,
+              Bigarray_storage ba ) ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Float64_type), Bigarray.Array1.get ba i))
+                (Typed_value.SV
+                   ((module Typed_value.Float64_type), Bigarray.Array1.get ba i))
           | _ ->
               Interpreter_error.(
-                raise_error (feature_not_supported "buffer element get accessor"))
+                raise_error
+                  (feature_not_supported "buffer element get accessor"))
 
         let set i tv =
           match (tv, buf.Memory.kind, buf.Memory.storage) with
@@ -592,7 +602,8 @@ end = struct
               | Typed_value.PInt32 n -> Bigarray.Array1.set ba i n
               | _ ->
                   Interpreter_error.(
-                    raise_error (feature_not_supported "int32 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "int32 buffer set conversion")))
           | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
               Memory.Scalar_kind Spoc_core.Vector_types.Int64,
               Bigarray_storage ba ) -> (
@@ -600,7 +611,8 @@ end = struct
               | Typed_value.PInt64 n -> Bigarray.Array1.set ba i n
               | _ ->
                   Interpreter_error.(
-                    raise_error (feature_not_supported "int64 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "int64 buffer set conversion")))
           | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
               Memory.Scalar_kind Spoc_core.Vector_types.Float32,
               Bigarray_storage ba ) -> (
@@ -608,7 +620,8 @@ end = struct
               | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
               | _ ->
                   Interpreter_error.(
-                    raise_error (feature_not_supported "float32 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "float32 buffer set conversion")))
           | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
               Memory.Scalar_kind Spoc_core.Vector_types.Float64,
               Bigarray_storage ba ) -> (
@@ -616,10 +629,12 @@ end = struct
               | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
               | _ ->
                   Interpreter_error.(
-                    raise_error (feature_not_supported "float64 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "float64 buffer set conversion")))
           | _ ->
               Interpreter_error.(
-                raise_error (feature_not_supported "buffer element set accessor"))
+                raise_error
+                  (feature_not_supported "buffer element set accessor"))
 
         let get_typed _i =
           Interpreter_error.(

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -317,6 +317,8 @@ end = struct
       let custom =
         {
           Spoc_core.Vector_types.elem_size;
+          type_id = Sarek_ir_types.Type_id.create ();
+          vector_type_id = Sarek_ir_types.Type_id.create ();
           get =
             (fun _ _ ->
               Interpreter_error.(
@@ -533,26 +535,96 @@ end = struct
 
     let create_args () = {list = []}
 
-    let set_arg_buffer args _idx buf =
+    let set_arg_buffer : type a. args -> int -> a Memory.buffer -> unit =
+     fun args _idx buf ->
       (* Wrap buffer in EXEC_VECTOR for exec_arg *)
-      let module EV : Typed_value.EXEC_VECTOR = struct
+      let module EV : Typed_value.EXEC_VECTOR
+        with type elt = a
+         and type underlying = a Memory.buffer = struct
+        type elt = a
+
+        type underlying = a Memory.buffer
+
         let length = Memory.size buf
 
         let type_name = "buffer"
 
         let elem_size = Memory.elem_size buf.Memory.kind
 
-        let internal_get_vector_obj () = Obj.repr buf
+        let type_id =
+          match buf.Memory.kind with
+          | Memory.Scalar_kind k -> Spoc_core.Vector_types.scalar_type_id k
+          | Memory.Custom_kind c -> c.type_id
+
+        let underlying_type_id = Sarek_ir_types.Type_id.create ()
+
+        let underlying = buf
 
         let device_ptr () = Memory.device_ptr buf
 
-        let get _i =
-          Interpreter_error.(
-            raise_error (feature_not_supported "buffer element get accessor"))
+        let get i =
+          match (buf.Memory.kind, buf.Memory.storage) with
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Int32_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Int64_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Float32, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Float32_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Float64, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Float64_type), Bigarray.Array1.get ba i))
+          | _ ->
+              Interpreter_error.(
+                raise_error (feature_not_supported "buffer element get accessor"))
 
-        let set _i _v =
+        let set i tv =
+          match (tv, buf.Memory.kind, buf.Memory.storage) with
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Int32,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PInt32 n -> Bigarray.Array1.set ba i n
+              | _ ->
+                  Interpreter_error.(
+                    raise_error (feature_not_supported "int32 buffer set conversion")))
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Int64,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PInt64 n -> Bigarray.Array1.set ba i n
+              | _ ->
+                  Interpreter_error.(
+                    raise_error (feature_not_supported "int64 buffer set conversion")))
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Float32,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
+              | _ ->
+                  Interpreter_error.(
+                    raise_error (feature_not_supported "float32 buffer set conversion")))
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Float64,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
+              | _ ->
+                  Interpreter_error.(
+                    raise_error (feature_not_supported "float64 buffer set conversion")))
+          | _ ->
+              Interpreter_error.(
+                raise_error (feature_not_supported "buffer element set accessor"))
+
+        let get_typed _i =
           Interpreter_error.(
-            raise_error (feature_not_supported "buffer element set accessor"))
+            raise_error (feature_not_supported "buffer typed get accessor"))
+
+        let set_typed _i _v =
+          Interpreter_error.(
+            raise_error (feature_not_supported "buffer typed set accessor"))
       end in
       args.list <- Framework_sig.EA_Vec (module EV) :: args.list
 
@@ -584,52 +656,8 @@ end = struct
                 let name = Printf.sprintf "param%d" i in
                 match arg with
                 | Framework_sig.EA_Vec (module V) ->
-                    (* Extract buffer from EXEC_VECTOR *)
-                    let buf = Obj.obj (V.internal_get_vector_obj ()) in
-                    (* Convert bigarray to value array - detect type dynamically *)
                     let arr =
-                      Array.init (Memory.size buf) (fun j ->
-                          (* Use elem_size to detect type: 4=float32/int32, 8=float64/int64 *)
-                          if V.elem_size = 4 then begin
-                            let ba :
-                                ( float,
-                                  Bigarray.float32_elt,
-                                  Bigarray.c_layout )
-                                Bigarray.Array1.t =
-                              match (buf : _ Memory.buffer) with
-                              | {storage = Bigarray_storage arr; _} ->
-                                  (Obj.magic arr
-                                    : ( float,
-                                        Bigarray.float32_elt,
-                                        Bigarray.c_layout )
-                                      Bigarray.Array1.t)
-                              | {storage = Ctypes_storage _; _} ->
-                                  failwith
-                                    "Interpreter: Ctypes buffers not supported"
-                            in
-                            Sarek.Sarek_ir_interp.VFloat32
-                              (Bigarray.Array1.get ba j)
-                          end
-                          else begin
-                            let ba :
-                                ( float,
-                                  Bigarray.float64_elt,
-                                  Bigarray.c_layout )
-                                Bigarray.Array1.t =
-                              match (buf : _ Memory.buffer) with
-                              | {storage = Bigarray_storage arr; _} ->
-                                  (Obj.magic arr
-                                    : ( float,
-                                        Bigarray.float64_elt,
-                                        Bigarray.c_layout )
-                                      Bigarray.Array1.t)
-                              | {storage = Ctypes_storage _; _} ->
-                                  failwith
-                                    "Interpreter: Ctypes buffers not supported"
-                            in
-                            Sarek.Sarek_ir_interp.VFloat64
-                              (Bigarray.Array1.get ba j)
-                          end)
+                      Sarek.Sarek_ir_interp.exec_vector_to_array (module V)
                     in
                     (name, Sarek.Sarek_ir_interp.ArgArray arr)
                 | Framework_sig.EA_Int32 n ->

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -258,6 +258,8 @@ end = struct
       | Scalar_kind k -> Spoc_core.Vector_types.scalar_elem_size k
       | Custom_kind c -> c.elem_size
 
+    let buffer_byte_size buf = buf.size * elem_size buf.kind
+
     let alloc : type a b. Device.t -> int -> (a, b) Bigarray.kind -> a buffer =
      fun device size kind ->
       let arr = Bigarray.Array1.create kind Bigarray.c_layout size in
@@ -409,15 +411,12 @@ end = struct
         src:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> dst:a buffer -> unit
         =
      fun ~src ~dst ->
-      match dst.storage with
-      | Bigarray_storage dst_arr ->
-          let len = min (Bigarray.Array1.dim src) dst.size in
-          let dst_arr_typed =
-            (Obj.magic dst_arr : (a, b, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          Bigarray.Array1.blit
-            (Bigarray.Array1.sub src 0 len)
-            (Bigarray.Array1.sub dst_arr_typed 0 len)
+	      match dst.storage with
+	      | Bigarray_storage dst_arr ->
+	          let len = min (Bigarray.Array1.dim src) dst.size in
+	          for i = 0 to len - 1 do
+	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src i)
+	          done
       | Ctypes_storage _ ->
           invalid_arg "host_to_device: destination is ctypes buffer"
 
@@ -425,20 +424,18 @@ end = struct
         src:a buffer -> dst:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> unit
         =
      fun ~src ~dst ->
-      match src.storage with
-      | Bigarray_storage src_arr ->
-          let len = min src.size (Bigarray.Array1.dim dst) in
-          let src_arr_typed =
-            (Obj.magic src_arr : (a, b, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          Bigarray.Array1.blit
-            (Bigarray.Array1.sub src_arr_typed 0 len)
-            (Bigarray.Array1.sub dst 0 len)
+	      match src.storage with
+	      | Bigarray_storage src_arr ->
+	          let len = min src.size (Bigarray.Array1.dim dst) in
+	          for i = 0 to len - 1 do
+	            Bigarray.Array1.set dst i (Bigarray.Array1.get src_arr i)
+	          done
       | Ctypes_storage _ ->
           invalid_arg "device_to_host: source is ctypes buffer"
 
     let host_ptr_to_device ~src_ptr ~byte_size ~dst =
       let open Ctypes in
+      let byte_size = min byte_size (buffer_byte_size dst) in
       match dst.storage with
       | Ctypes_storage dst_ptr ->
           let dst_char_ptr = from_voidp char dst_ptr in
@@ -451,6 +448,7 @@ end = struct
 
     let device_to_host_ptr ~src ~dst_ptr ~byte_size =
       let open Ctypes in
+      let byte_size = min byte_size (buffer_byte_size src) in
       match src.storage with
       | Ctypes_storage src_ptr ->
           let src_char_ptr = from_voidp char src_ptr in
@@ -463,18 +461,12 @@ end = struct
 
     let device_to_device : type a. src:a buffer -> dst:a buffer -> unit =
      fun ~src ~dst ->
-      match (src.storage, dst.storage) with
-      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
-          let len = min src.size dst.size in
-          let src_typed =
-            (Obj.magic src_arr : (a, _, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          let dst_typed =
-            (Obj.magic dst_arr : (a, _, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          Bigarray.Array1.blit
-            (Bigarray.Array1.sub src_typed 0 len)
-            (Bigarray.Array1.sub dst_typed 0 len)
+	      match (src.storage, dst.storage) with
+	      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
+	          let len = min src.size dst.size in
+	          for i = 0 to len - 1 do
+	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src_arr i)
+	          done
       | Ctypes_storage src_ptr, Ctypes_storage dst_ptr ->
           let src_char_ptr = Ctypes.from_voidp Ctypes.char src_ptr in
           let dst_char_ptr = Ctypes.from_voidp Ctypes.char dst_ptr in
@@ -537,6 +529,17 @@ end = struct
 
     let set_arg_buffer : type a. args -> int -> a Memory.buffer -> unit =
      fun args _idx buf ->
+      (match (buf.Memory.kind, buf.Memory.storage) with
+      | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage _
+      | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage _
+      | Memory.Scalar_kind Spoc_core.Vector_types.Float32, Bigarray_storage _
+      | Memory.Scalar_kind Spoc_core.Vector_types.Float64, Bigarray_storage _ ->
+          ()
+      | _ ->
+          Interpreter_error.(
+            raise_error
+              (feature_not_supported
+                 "unsupported buffer kind/storage for argument"))) ;
       (* Wrap buffer in EXEC_VECTOR for exec_arg *)
       let module EV : Typed_value.EXEC_VECTOR
         with type elt = a

--- a/sarek/plugins/native/Native_plugin.ml
+++ b/sarek/plugins/native/Native_plugin.ml
@@ -266,24 +266,24 @@ module Backend : Framework_sig.BACKEND = struct
         in
         Sarek_ir_types.NA_Vec
           (Sarek_ir_types.NV
-          {
-            length = V.length;
-            elem_size = V.elem_size;
-            type_name = V.type_name;
-            type_id = V.type_id;
-            get_f32 = get_as_f32;
-            set_f32 = set_as_f32;
-            get_f64 = get_as_f64;
-            set_f64 = set_as_f64;
-            get_i32 = get_as_i32;
-            set_i32 = set_as_i32;
-            get_i64 = get_as_i64;
-            set_i64 = set_as_i64;
-            get_typed = V.get_typed;
-            set_typed = V.set_typed;
-            underlying_type_id = V.underlying_type_id;
-            underlying = V.underlying;
-          })
+             {
+               length = V.length;
+               elem_size = V.elem_size;
+               type_name = V.type_name;
+               type_id = V.type_id;
+               get_f32 = get_as_f32;
+               set_f32 = set_as_f32;
+               get_f64 = get_as_f64;
+               set_f64 = set_as_f64;
+               get_i32 = get_as_i32;
+               set_i32 = set_as_i32;
+               get_i64 = get_as_i64;
+               set_i64 = set_as_i64;
+               get_typed = V.get_typed;
+               set_typed = V.set_typed;
+               underlying_type_id = V.underlying_type_id;
+               underlying = V.underlying;
+             })
 
   (** Convert exec_arg array to native_arg array *)
   let exec_args_to_native (args : Framework_sig.exec_arg array) :

--- a/sarek/plugins/native/Native_plugin.ml
+++ b/sarek/plugins/native/Native_plugin.ml
@@ -379,9 +379,12 @@ let find_intrinsic = Native_intrinsics.find
 
 (** Execute a kernel directly with the registered function *)
 let run_kernel_direct ~name
-    ~(native_fn : Obj.t array -> int * int * int -> int * int * int -> unit)
-    ~(args : Obj.t array) ~(grid : int * int * int) ~(block : int * int * int) :
-    unit =
+    ~(native_fn :
+       Framework_sig.exec_arg array ->
+       int * int * int ->
+       int * int * int ->
+       unit) ~(args : Framework_sig.exec_arg array) ~(grid : int * int * int)
+    ~(block : int * int * int) : unit =
   (* Use the existing Native_plugin kernel registry *)
   ignore name ;
   native_fn args grid block

--- a/sarek/plugins/native/Native_plugin.ml
+++ b/sarek/plugins/native/Native_plugin.ml
@@ -186,6 +186,7 @@ module Backend : Framework_sig.BACKEND = struct
               match S.to_primitive x with
               | Typed_value.PFloat f -> f
               | Typed_value.PInt32 n -> Int32.to_float n
+              | Typed_value.PInt64 n -> Int64.to_float n
               | _ ->
                   Native_error.(
                     raise_error
@@ -205,6 +206,8 @@ module Backend : Framework_sig.BACKEND = struct
           | Typed_value.TV_Scalar (Typed_value.SV ((module S), x)) -> (
               match S.to_primitive x with
               | Typed_value.PFloat f -> f
+              | Typed_value.PInt32 n -> Int32.to_float n
+              | Typed_value.PInt64 n -> Int64.to_float n
               | _ ->
                   Native_error.(
                     raise_error
@@ -224,6 +227,7 @@ module Backend : Framework_sig.BACKEND = struct
           | Typed_value.TV_Scalar (Typed_value.SV ((module S), x)) -> (
               match S.to_primitive x with
               | Typed_value.PInt32 n -> n
+              | Typed_value.PInt64 n -> Int64.to_int32 n
               | Typed_value.PFloat f -> Int32.of_float f
               | _ ->
                   Native_error.(
@@ -245,6 +249,7 @@ module Backend : Framework_sig.BACKEND = struct
               match S.to_primitive x with
               | Typed_value.PInt64 n -> n
               | Typed_value.PInt32 n -> Int64.of_int32 n
+              | Typed_value.PFloat f -> Int64.of_float f
               | _ ->
                   Native_error.(
                     raise_error
@@ -259,21 +264,13 @@ module Backend : Framework_sig.BACKEND = struct
             (Typed_value.TV_Scalar
                (Typed_value.SV ((module Typed_value.Int64_type), n)))
         in
-        (* For custom types: use underlying Vector.t with Obj.t *)
-        let get_any i =
-          let vec = Obj.obj (V.internal_get_vector_obj ()) in
-          Obj.repr (Spoc_core.Vector.get vec i)
-        in
-        let set_any i v =
-          let vec = Obj.obj (V.internal_get_vector_obj ()) in
-          Spoc_core.Vector.kernel_set vec i (Obj.obj v)
-        in
-        let get_vec () = V.internal_get_vector_obj () in
         Sarek_ir_types.NA_Vec
+          (Sarek_ir_types.NV
           {
             length = V.length;
             elem_size = V.elem_size;
             type_name = V.type_name;
+            type_id = V.type_id;
             get_f32 = get_as_f32;
             set_f32 = set_as_f32;
             get_f64 = get_as_f64;
@@ -282,10 +279,11 @@ module Backend : Framework_sig.BACKEND = struct
             set_i32 = set_as_i32;
             get_i64 = get_as_i64;
             set_i64 = set_as_i64;
-            get_any;
-            set_any;
-            get_vec;
-          }
+            get_typed = V.get_typed;
+            set_typed = V.set_typed;
+            underlying_type_id = V.underlying_type_id;
+            underlying = V.underlying;
+          })
 
   (** Convert exec_arg array to native_arg array *)
   let exec_args_to_native (args : Framework_sig.exec_arg array) :

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -336,6 +336,8 @@ end = struct
       let custom =
         {
           Spoc_core.Vector_types.elem_size;
+          type_id = Sarek_ir_types.Type_id.create ();
+          vector_type_id = Sarek_ir_types.Type_id.create ();
           get =
             (fun _ _ ->
               Native_error.(
@@ -565,16 +567,30 @@ end = struct
 
     let create_args () = {list = []}
 
-    let set_arg_buffer args _idx buf =
+    let set_arg_buffer : type a. args -> int -> a Memory.buffer -> unit =
+     fun args _idx buf ->
       (* Wrap buffer in EXEC_VECTOR for exec_arg *)
-      let module EV : Typed_value.EXEC_VECTOR = struct
+      let module EV : Typed_value.EXEC_VECTOR
+        with type elt = a
+         and type underlying = a Memory.buffer = struct
+        type elt = a
+
+        type underlying = a Memory.buffer
+
         let length = Memory.size buf
 
         let type_name = "buffer"
 
         let elem_size = Memory.elem_size buf.Memory.kind
 
-        let internal_get_vector_obj () = Obj.repr buf
+        let type_id =
+          match buf.Memory.kind with
+          | Memory.Scalar_kind k -> Spoc_core.Vector_types.scalar_type_id k
+          | Memory.Custom_kind c -> c.type_id
+
+        let underlying_type_id = Sarek_ir_types.Type_id.create ()
+
+        let underlying = buf
 
         let device_ptr () = Memory.device_ptr buf
 
@@ -585,6 +601,14 @@ end = struct
         let set _i _v =
           Native_error.(
             raise_error (feature_not_supported "buffer element set accessor"))
+
+        let get_typed _i =
+          Native_error.(
+            raise_error (feature_not_supported "buffer typed get accessor"))
+
+        let set_typed _i _v =
+          Native_error.(
+            raise_error (feature_not_supported "buffer typed set accessor"))
       end in
       args.list <- Framework_sig.EA_Vec (module EV) :: args.list
 

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -272,6 +272,8 @@ end = struct
       | Scalar_kind k -> Spoc_core.Vector_types.scalar_elem_size k
       | Custom_kind c -> c.elem_size
 
+    let buffer_byte_size buf = buf.size * elem_size buf.kind
+
     let alloc : type a b. Device.t -> int -> (a, b) Bigarray.kind -> a buffer =
      fun device size kind ->
       let arr = Bigarray.Array1.create kind Bigarray.c_layout size in
@@ -425,16 +427,12 @@ end = struct
         src:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> dst:a buffer -> unit
         =
      fun ~src ~dst ->
-      match dst.storage with
-      | Bigarray_storage dst_arr ->
-          let len = min (Bigarray.Array1.dim src) dst.size in
-          (* SAFETY: dst_arr has existential elt type but same element type 'a as src *)
-          let dst_arr_typed =
-            (Obj.magic dst_arr : (a, b, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          Bigarray.Array1.blit
-            (Bigarray.Array1.sub src 0 len)
-            (Bigarray.Array1.sub dst_arr_typed 0 len)
+	      match dst.storage with
+	      | Bigarray_storage dst_arr ->
+	          let len = min (Bigarray.Array1.dim src) dst.size in
+	          for i = 0 to len - 1 do
+	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src i)
+	          done
       | Ctypes_storage _ ->
           invalid_arg
             "host_to_device: destination is ctypes buffer (use \
@@ -444,16 +442,12 @@ end = struct
         src:a buffer -> dst:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> unit
         =
      fun ~src ~dst ->
-      match src.storage with
-      | Bigarray_storage src_arr ->
-          let len = min src.size (Bigarray.Array1.dim dst) in
-          (* SAFETY: src_arr has existential elt type but same element type 'a as dst *)
-          let src_arr_typed =
-            (Obj.magic src_arr : (a, b, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          Bigarray.Array1.blit
-            (Bigarray.Array1.sub src_arr_typed 0 len)
-            (Bigarray.Array1.sub dst 0 len)
+	      match src.storage with
+	      | Bigarray_storage src_arr ->
+	          let len = min src.size (Bigarray.Array1.dim dst) in
+	          for i = 0 to len - 1 do
+	            Bigarray.Array1.set dst i (Bigarray.Array1.get src_arr i)
+	          done
       | Ctypes_storage _ ->
           invalid_arg
             "device_to_host: source is ctypes buffer (use device_to_host_ptr)"
@@ -462,6 +456,7 @@ end = struct
         native, this is a memcpy using ctypes. *)
     let host_ptr_to_device ~src_ptr ~byte_size ~dst =
       let open Ctypes in
+      let byte_size = min byte_size (buffer_byte_size dst) in
       match dst.storage with
       | Ctypes_storage dst_ptr ->
           let dst_char_ptr = from_voidp char dst_ptr in
@@ -469,13 +464,18 @@ end = struct
           for i = 0 to byte_size - 1 do
             dst_char_ptr +@ i <-@ !@(src_char_ptr +@ i)
           done
-      | Bigarray_storage _ ->
-          invalid_arg
-            "host_ptr_to_device: destination is bigarray (use host_to_device)"
+      | Bigarray_storage dst_arr ->
+          let dst_ptr = bigarray_start array1 dst_arr |> to_voidp in
+          let dst_char_ptr = from_voidp char dst_ptr in
+          let src_char_ptr = from_voidp char src_ptr in
+          for i = 0 to byte_size - 1 do
+            dst_char_ptr +@ i <-@ !@(src_char_ptr +@ i)
+          done
 
     (** Transfer from native buffer to raw pointer (for custom types). *)
     let device_to_host_ptr ~src ~dst_ptr ~byte_size =
       let open Ctypes in
+      let byte_size = min byte_size (buffer_byte_size src) in
       match src.storage with
       | Ctypes_storage src_ptr ->
           let src_char_ptr = from_voidp char src_ptr in
@@ -483,25 +483,22 @@ end = struct
           for i = 0 to byte_size - 1 do
             dst_char_ptr +@ i <-@ !@(src_char_ptr +@ i)
           done
-      | Bigarray_storage _ ->
-          invalid_arg
-            "device_to_host_ptr: source is bigarray (use device_to_host)"
+      | Bigarray_storage src_arr ->
+          let src_ptr = bigarray_start array1 src_arr |> to_voidp in
+          let src_char_ptr = from_voidp char src_ptr in
+          let dst_char_ptr = from_voidp char dst_ptr in
+          for i = 0 to byte_size - 1 do
+            dst_char_ptr +@ i <-@ !@(src_char_ptr +@ i)
+          done
 
     let device_to_device : type a. src:a buffer -> dst:a buffer -> unit =
      fun ~src ~dst ->
-      match (src.storage, dst.storage) with
-      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
-          let len = min src.size dst.size in
-          (* SAFETY: Both have same element type 'a, just different elt types *)
-          let src_typed =
-            (Obj.magic src_arr : (a, _, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          let dst_typed =
-            (Obj.magic dst_arr : (a, _, Bigarray.c_layout) Bigarray.Array1.t)
-          in
-          Bigarray.Array1.blit
-            (Bigarray.Array1.sub src_typed 0 len)
-            (Bigarray.Array1.sub dst_typed 0 len)
+	      match (src.storage, dst.storage) with
+	      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
+	          let len = min src.size dst.size in
+	          for i = 0 to len - 1 do
+	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src_arr i)
+	          done
       | Ctypes_storage src_ptr, Ctypes_storage dst_ptr ->
           let src_char_ptr = Ctypes.from_voidp Ctypes.char src_ptr in
           let dst_char_ptr = Ctypes.from_voidp Ctypes.char dst_ptr in
@@ -569,6 +566,18 @@ end = struct
 
     let set_arg_buffer : type a. args -> int -> a Memory.buffer -> unit =
      fun args _idx buf ->
+      (match (buf.Memory.kind, buf.Memory.storage) with
+      | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage _
+      | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage _
+      | Memory.Scalar_kind Spoc_core.Vector_types.Float32, Bigarray_storage _
+      | Memory.Scalar_kind Spoc_core.Vector_types.Float64, Bigarray_storage _
+      | Memory.Custom_kind _, Ctypes_storage _ ->
+          ()
+      | _ ->
+          Native_error.(
+            raise_error
+              (feature_not_supported
+                 "unsupported buffer kind/storage for argument"))) ;
       (* Wrap buffer in EXEC_VECTOR for exec_arg *)
       let module EV : Typed_value.EXEC_VECTOR
         with type elt = a
@@ -603,12 +612,42 @@ end = struct
             raise_error (feature_not_supported "buffer element set accessor"))
 
         let get_typed _i =
-          Native_error.(
-            raise_error (feature_not_supported "buffer typed get accessor"))
+          match (buf.Memory.kind, buf.Memory.storage) with
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba
+            ->
+              Bigarray.Array1.get ba _i
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba
+            ->
+              Bigarray.Array1.get ba _i
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float32,
+              Bigarray_storage ba ) ->
+              Bigarray.Array1.get ba _i
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float64,
+              Bigarray_storage ba ) ->
+              Bigarray.Array1.get ba _i
+          | Memory.Custom_kind c, Ctypes_storage ptr -> c.get ptr _i
+          | _ ->
+              Native_error.(
+                raise_error (feature_not_supported "buffer typed get accessor"))
 
         let set_typed _i _v =
-          Native_error.(
-            raise_error (feature_not_supported "buffer typed set accessor"))
+          match (buf.Memory.kind, buf.Memory.storage) with
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba
+            ->
+              Bigarray.Array1.set ba _i _v
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba
+            ->
+              Bigarray.Array1.set ba _i _v
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float32,
+              Bigarray_storage ba ) ->
+              Bigarray.Array1.set ba _i _v
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float64,
+              Bigarray_storage ba ) ->
+              Bigarray.Array1.set ba _i _v
+          | Memory.Custom_kind c, Ctypes_storage ptr -> c.set ptr _i _v
+          | _ ->
+              Native_error.(
+                raise_error (feature_not_supported "buffer typed set accessor"))
       end in
       args.list <- Framework_sig.EA_Vec (module EV) :: args.list
 

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -20,7 +20,7 @@ open Spoc_framework
 (** Registry for native kernel functions.
 
     Kernels are registered by name. The function signature uses exec_arg array
-    for type-safe argument passing (no Obj.t):
+    for type-safe argument passing:
     - args: Framework_sig.exec_arg array (typed kernel arguments)
     - grid: (gx, gy, gz) grid dimensions
     - block: (bx, by, bz) block dimensions
@@ -603,13 +603,61 @@ end = struct
 
         let device_ptr () = Memory.device_ptr buf
 
-        let get _i =
-          Native_error.(
-            raise_error (feature_not_supported "buffer element get accessor"))
+        let get i =
+          match (buf.Memory.kind, buf.Memory.storage) with
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Int32_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Int64_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Float32, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Float32_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Float64, Bigarray_storage ba ->
+              Typed_value.TV_Scalar
+                (Typed_value.SV ((module Typed_value.Float64_type), Bigarray.Array1.get ba i))
+          | _ ->
+              Native_error.(
+                raise_error (feature_not_supported "buffer element get accessor"))
 
-        let set _i _v =
-          Native_error.(
-            raise_error (feature_not_supported "buffer element set accessor"))
+        let set i tv =
+          match (tv, buf.Memory.kind, buf.Memory.storage) with
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Int32,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PInt32 n -> Bigarray.Array1.set ba i n
+              | _ ->
+                  Native_error.(
+                    raise_error (feature_not_supported "int32 buffer set conversion")))
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Int64,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PInt64 n -> Bigarray.Array1.set ba i n
+              | _ ->
+                  Native_error.(
+                    raise_error (feature_not_supported "int64 buffer set conversion")))
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Float32,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
+              | _ ->
+                  Native_error.(
+                    raise_error (feature_not_supported "float32 buffer set conversion")))
+          | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+              Memory.Scalar_kind Spoc_core.Vector_types.Float64,
+              Bigarray_storage ba ) -> (
+              match S.to_primitive x with
+              | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
+              | _ ->
+                  Native_error.(
+                    raise_error (feature_not_supported "float64 buffer set conversion")))
+          | _ ->
+              Native_error.(
+                raise_error (feature_not_supported "buffer element set accessor"))
 
         let get_typed _i =
           match (buf.Memory.kind, buf.Memory.storage) with
@@ -706,7 +754,7 @@ let init () = ()
     This is called by PPX-generated code at module load time to register the
     pre-compiled OCaml kernel function. The function signature matches what
     Sarek_cpu_runtime expects:
-    - args: Obj.t array of kernel arguments
+    - args: Framework_sig.exec_arg array of kernel arguments
     - grid: (gx, gy, gz) grid dimensions
     - block: (bx, by, bz) block dimensions
 

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -427,12 +427,12 @@ end = struct
         src:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> dst:a buffer -> unit
         =
      fun ~src ~dst ->
-	      match dst.storage with
-	      | Bigarray_storage dst_arr ->
-	          let len = min (Bigarray.Array1.dim src) dst.size in
-	          for i = 0 to len - 1 do
-	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src i)
-	          done
+      match dst.storage with
+      | Bigarray_storage dst_arr ->
+          let len = min (Bigarray.Array1.dim src) dst.size in
+          for i = 0 to len - 1 do
+            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src i)
+          done
       | Ctypes_storage _ ->
           invalid_arg
             "host_to_device: destination is ctypes buffer (use \
@@ -442,12 +442,12 @@ end = struct
         src:a buffer -> dst:(a, b, Bigarray.c_layout) Bigarray.Array1.t -> unit
         =
      fun ~src ~dst ->
-	      match src.storage with
-	      | Bigarray_storage src_arr ->
-	          let len = min src.size (Bigarray.Array1.dim dst) in
-	          for i = 0 to len - 1 do
-	            Bigarray.Array1.set dst i (Bigarray.Array1.get src_arr i)
-	          done
+      match src.storage with
+      | Bigarray_storage src_arr ->
+          let len = min src.size (Bigarray.Array1.dim dst) in
+          for i = 0 to len - 1 do
+            Bigarray.Array1.set dst i (Bigarray.Array1.get src_arr i)
+          done
       | Ctypes_storage _ ->
           invalid_arg
             "device_to_host: source is ctypes buffer (use device_to_host_ptr)"
@@ -493,12 +493,12 @@ end = struct
 
     let device_to_device : type a. src:a buffer -> dst:a buffer -> unit =
      fun ~src ~dst ->
-	      match (src.storage, dst.storage) with
-	      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
-	          let len = min src.size dst.size in
-	          for i = 0 to len - 1 do
-	            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src_arr i)
-	          done
+      match (src.storage, dst.storage) with
+      | Bigarray_storage src_arr, Bigarray_storage dst_arr ->
+          let len = min src.size dst.size in
+          for i = 0 to len - 1 do
+            Bigarray.Array1.set dst_arr i (Bigarray.Array1.get src_arr i)
+          done
       | Ctypes_storage src_ptr, Ctypes_storage dst_ptr ->
           let src_char_ptr = Ctypes.from_voidp Ctypes.char src_ptr in
           let dst_char_ptr = Ctypes.from_voidp Ctypes.char dst_ptr in
@@ -579,9 +579,10 @@ end = struct
               (feature_not_supported
                  "unsupported buffer kind/storage for argument"))) ;
       (* Wrap buffer in EXEC_VECTOR for exec_arg *)
-      let module EV : Typed_value.EXEC_VECTOR
-        with type elt = a
-         and type underlying = a Memory.buffer = struct
+      let module EV :
+        Typed_value.EXEC_VECTOR
+          with type elt = a
+           and type underlying = a Memory.buffer = struct
         type elt = a
 
         type underlying = a Memory.buffer
@@ -605,21 +606,30 @@ end = struct
 
         let get i =
           match (buf.Memory.kind, buf.Memory.storage) with
-          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba ->
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int32, Bigarray_storage ba
+            ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Int32_type), Bigarray.Array1.get ba i))
-          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba ->
+                (Typed_value.SV
+                   ((module Typed_value.Int32_type), Bigarray.Array1.get ba i))
+          | Memory.Scalar_kind Spoc_core.Vector_types.Int64, Bigarray_storage ba
+            ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Int64_type), Bigarray.Array1.get ba i))
-          | Memory.Scalar_kind Spoc_core.Vector_types.Float32, Bigarray_storage ba ->
+                (Typed_value.SV
+                   ((module Typed_value.Int64_type), Bigarray.Array1.get ba i))
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float32,
+              Bigarray_storage ba ) ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Float32_type), Bigarray.Array1.get ba i))
-          | Memory.Scalar_kind Spoc_core.Vector_types.Float64, Bigarray_storage ba ->
+                (Typed_value.SV
+                   ((module Typed_value.Float32_type), Bigarray.Array1.get ba i))
+          | ( Memory.Scalar_kind Spoc_core.Vector_types.Float64,
+              Bigarray_storage ba ) ->
               Typed_value.TV_Scalar
-                (Typed_value.SV ((module Typed_value.Float64_type), Bigarray.Array1.get ba i))
+                (Typed_value.SV
+                   ((module Typed_value.Float64_type), Bigarray.Array1.get ba i))
           | _ ->
               Native_error.(
-                raise_error (feature_not_supported "buffer element get accessor"))
+                raise_error
+                  (feature_not_supported "buffer element get accessor"))
 
         let set i tv =
           match (tv, buf.Memory.kind, buf.Memory.storage) with
@@ -630,7 +640,8 @@ end = struct
               | Typed_value.PInt32 n -> Bigarray.Array1.set ba i n
               | _ ->
                   Native_error.(
-                    raise_error (feature_not_supported "int32 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "int32 buffer set conversion")))
           | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
               Memory.Scalar_kind Spoc_core.Vector_types.Int64,
               Bigarray_storage ba ) -> (
@@ -638,7 +649,8 @@ end = struct
               | Typed_value.PInt64 n -> Bigarray.Array1.set ba i n
               | _ ->
                   Native_error.(
-                    raise_error (feature_not_supported "int64 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "int64 buffer set conversion")))
           | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
               Memory.Scalar_kind Spoc_core.Vector_types.Float32,
               Bigarray_storage ba ) -> (
@@ -646,7 +658,8 @@ end = struct
               | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
               | _ ->
                   Native_error.(
-                    raise_error (feature_not_supported "float32 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "float32 buffer set conversion")))
           | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
               Memory.Scalar_kind Spoc_core.Vector_types.Float64,
               Bigarray_storage ba ) -> (
@@ -654,10 +667,12 @@ end = struct
               | Typed_value.PFloat f -> Bigarray.Array1.set ba i f
               | _ ->
                   Native_error.(
-                    raise_error (feature_not_supported "float64 buffer set conversion")))
+                    raise_error
+                      (feature_not_supported "float64 buffer set conversion")))
           | _ ->
               Native_error.(
-                raise_error (feature_not_supported "buffer element set accessor"))
+                raise_error
+                  (feature_not_supported "buffer element set accessor"))
 
         let get_typed _i =
           match (buf.Memory.kind, buf.Memory.storage) with

--- a/sarek/ppx/Sarek_native_gen.ml
+++ b/sarek/ppx/Sarek_native_gen.ml
@@ -577,17 +577,27 @@ let gen_parallel_construct ~loc ~gen_expr (te : texpr) : expression =
                 0L]
         | TReg Char ->
             [%expr
-              Sarek.Sarek_cpu_runtime.alloc_shared
+              Sarek.Sarek_cpu_runtime.alloc_shared_with_key
                 [%e shared]
+                Spoc_core.Vector.char_type_id
                 [%e name_e]
                 [%e size_e]
                 '\000']
         | _ ->
             (* For custom types, generate proper default value *)
             let default_val = default_value_for_type ~loc elem_ty in
+            let key_expr =
+              match repr elem_ty with
+              | TRecord (type_name, _) | TVariant (type_name, _) ->
+                  [%expr
+                    [%e custom_descriptor_expr ~loc type_name]
+                      .Spoc_core.Vector.type_id]
+              | _ -> [%expr Sarek_ir_types.Type_id.create ()]
+            in
             [%expr
-              Sarek.Sarek_cpu_runtime.alloc_shared
+              Sarek.Sarek_cpu_runtime.alloc_shared_with_key
                 [%e shared]
+                [%e key_expr]
                 [%e name_e]
                 [%e size_e]
                 [%e default_val]]

--- a/sarek/ppx/Sarek_native_gen.ml
+++ b/sarek/ppx/Sarek_native_gen.ml
@@ -146,13 +146,20 @@ let gen_variable ~loc ~ctx (name : string) (id : int) : expression =
     [%expr ![%e var_e]]
   else var_e
 
-let custom_descriptor_expr ~loc type_name =
+let custom_descriptor_expr ?current_module ~loc type_name =
   let parts = String.split_on_char '.' type_name in
   match List.rev parts with
-  | name :: modules -> evar_qualified ~loc (List.rev modules) (name ^ "_custom")
+  | name :: modules ->
+      let modules = List.rev modules in
+      let modules =
+        match (current_module, modules) with
+        | Some current, [m] when String.equal current m -> []
+        | _ -> modules
+      in
+      evar_qualified ~loc modules (name ^ "_custom")
   | [] -> failwith "custom_descriptor_expr: empty type name"
 
-let vector_type_id_expr ~loc elem_ty =
+let vector_type_id_expr ?current_module ~loc elem_ty =
   match repr elem_ty with
   | TReg Float32 -> [%expr Spoc_core.Vector.float32_vector_type_id]
   | TReg Float64 -> [%expr Spoc_core.Vector.float64_vector_type_id]
@@ -161,13 +168,16 @@ let vector_type_id_expr ~loc elem_ty =
   | TReg Char -> [%expr Spoc_core.Vector.char_vector_type_id]
   | TRecord (type_name, _) | TVariant (type_name, _) ->
       [%expr
-        [%e custom_descriptor_expr ~loc type_name].Spoc_core.Vector.vector_type_id]
+        [%e custom_descriptor_expr ?current_module ~loc type_name]
+          .Spoc_core.Vector.vector_type_id]
   | _ -> [%expr Sarek_ir_types.Type_id.create ()]
 
-let custom_type_id_expr ~loc elem_ty =
+let custom_type_id_expr ?current_module ~loc elem_ty =
   match repr elem_ty with
   | TRecord (type_name, _) | TVariant (type_name, _) ->
-      [%expr [%e custom_descriptor_expr ~loc type_name].Spoc_core.Vector.type_id]
+      [%expr
+        [%e custom_descriptor_expr ?current_module ~loc type_name]
+          .Spoc_core.Vector.type_id]
   | _ -> [%expr Sarek_ir_types.Type_id.create ()]
 
 (** Generate memory access operations (vectors, arrays, record fields) *)
@@ -531,7 +541,8 @@ let gen_special_expr ~loc ~gen_expr (te : texpr) : expression =
   | _ -> failwith "gen_special_expr: not a special expression"
 
 (** Generate BSP parallel constructs (let%shared, let%superstep, let rec) *)
-let gen_parallel_construct ~loc ~gen_expr (te : texpr) : expression =
+let gen_parallel_construct ?current_module ~loc ~gen_expr (te : texpr) :
+    expression =
   match te.te with
   (* BSP let%shared - allocate shared memory using OCaml arrays *)
   | TELetShared (name, _id, elem_ty, size_opt, body) ->
@@ -590,7 +601,7 @@ let gen_parallel_construct ~loc ~gen_expr (te : texpr) : expression =
               match repr elem_ty with
               | TRecord (type_name, _) | TVariant (type_name, _) ->
                   [%expr
-                    [%e custom_descriptor_expr ~loc type_name]
+                    [%e custom_descriptor_expr ?current_module ~loc type_name]
                       .Spoc_core.Vector.type_id]
               | _ -> [%expr Sarek_ir_types.Type_id.create ()]
             in
@@ -737,7 +748,7 @@ let rec gen_expr_impl ~loc:_ ~ctx (te : texpr) : expression =
       gen_intrinsic_fun ~loc ~gen_mode:ctx.gen_mode ref args_e
   (* Parallel constructs *)
   | TELetShared _ | TESuperstep _ | TELetRec _ ->
-      gen_parallel_construct ~loc ~gen_expr te
+      gen_parallel_construct ?current_module:ctx.current_module ~loc ~gen_expr te
 
 (** Generate pattern from typed pattern. Takes context to detect same-module
     types that shouldn't be qualified. *)
@@ -1080,7 +1091,7 @@ let gen_mode_of_exec_strategy : Sarek_convergence.exec_strategy -> gen_mode =
     match on NA_Int32/NA_Float32/etc and extract the value.
 
     Uses typed native_arg for type safety. *)
-let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
+let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression =
   let arr_access =
     [%expr Array.get __args [%e Ast_builder.Default.eint ~loc idx]]
   in
@@ -1104,7 +1115,7 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1121,7 +1132,7 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1138,7 +1149,7 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1155,7 +1166,7 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1166,13 +1177,13 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
             object
               method get i =
                 Sarek_ir_types.vec_get_custom
-                  [%e custom_type_id_expr ~loc elem_ty]
+                  [%e custom_type_id_expr ?current_module ~loc elem_ty]
                   [%e vec_arg]
                   i
 
               method set i x =
                 Sarek_ir_types.vec_set_custom
-                  [%e custom_type_id_expr ~loc elem_ty]
+                  [%e custom_type_id_expr ?current_module ~loc elem_ty]
                   [%e vec_arg]
                   i
                   x
@@ -1181,7 +1192,7 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
               method underlying =
                 Sarek_ir_types.vec_as_vector
-                  [%e vector_type_id_expr ~loc elem_ty]
+                  [%e vector_type_id_expr ?current_module ~loc elem_ty]
                   [%e vec_arg]
             end])
   | TReg Float32 ->
@@ -1567,13 +1578,14 @@ let gen_cpu_kern_native_wrapper ~loc (kernel : tkernel) : expression =
   let has_barriers_expr = Ast_builder.Default.ebool ~loc has_barriers in
 
   (* Generate argument extraction bindings - use parameter names *)
+  let current_module = Some (module_name_of_sarek_loc kernel.tkern_loc) in
   let arg_bindings =
     List.mapi
       (fun i param ->
         let var_pat =
           Ast_builder.Default.ppat_var ~loc {txt = param.tparam_name; loc}
         in
-        let cast_expr = gen_arg_cast ~loc param i in
+        let cast_expr = gen_arg_cast ?current_module ~loc param i in
         (var_pat, cast_expr))
       kernel.tkern_params
   in

--- a/sarek/ppx/Sarek_native_gen.ml
+++ b/sarek/ppx/Sarek_native_gen.ml
@@ -159,26 +159,65 @@ let custom_descriptor_expr ?current_module ~loc type_name =
       evar_qualified ~loc modules (name ^ "_custom")
   | [] -> failwith "custom_descriptor_expr: empty type name"
 
-let vector_type_id_expr ?current_module ~loc elem_ty =
+let is_inline_type inline_types type_name =
+  match inline_types with
+  | Some names -> StringSet.mem type_name names
+  | None -> false
+
+let sanitize_ident s =
+  String.map
+    (function
+      | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_') as c -> c | _ -> '_')
+    s
+
+let inline_type_id_method type_name = "type_id_" ^ sanitize_ident type_name
+
+let inline_vector_type_id_method type_name =
+  "vector_type_id_" ^ sanitize_ident type_name
+
+let inline_type_id_expr ~loc ~ids_var type_name =
+  Ast_builder.Default.pexp_send
+    ~loc
+    (evar ~loc ids_var)
+    {txt = inline_type_id_method type_name; loc}
+
+let inline_vector_type_id_expr ~loc ~ids_var type_name =
+  Ast_builder.Default.pexp_send
+    ~loc
+    (evar ~loc ids_var)
+    {txt = inline_vector_type_id_method type_name; loc}
+
+let vector_type_id_expr ?current_module ?inline_types
+    ?(inline_ids_var = types_module_var) ~loc elem_ty =
   match repr elem_ty with
   | TReg Float32 -> [%expr Spoc_core.Vector.float32_vector_type_id]
   | TReg Float64 -> [%expr Spoc_core.Vector.float64_vector_type_id]
   | TReg Int | TPrim TInt32 -> [%expr Spoc_core.Vector.int32_vector_type_id]
   | TReg Int64 -> [%expr Spoc_core.Vector.int64_vector_type_id]
   | TReg Char -> [%expr Spoc_core.Vector.char_vector_type_id]
+  | TReg (Custom "complex32") ->
+      [%expr Spoc_core.Vector.complex32_vector_type_id]
   | TRecord (type_name, _) | TVariant (type_name, _) ->
-      [%expr
-        [%e custom_descriptor_expr ?current_module ~loc type_name]
-          .Spoc_core.Vector.vector_type_id]
-  | _ -> [%expr Sarek_ir_types.Type_id.create ()]
+      if is_inline_type inline_types type_name then
+        inline_vector_type_id_expr ~loc ~ids_var:inline_ids_var type_name
+      else
+        [%expr
+          [%e custom_descriptor_expr ?current_module ~loc type_name]
+            .Spoc_core.Vector.vector_type_id]
+  | _ -> [%expr failwith "unsupported vector type identity"]
 
-let custom_type_id_expr ?current_module ~loc elem_ty =
+let custom_type_id_expr ?current_module ?inline_types
+    ?(inline_ids_var = types_module_var) ~loc elem_ty =
   match repr elem_ty with
+  | TReg (Custom "complex32") -> [%expr Spoc_core.Vector.complex32_type_id]
   | TRecord (type_name, _) | TVariant (type_name, _) ->
-      [%expr
-        [%e custom_descriptor_expr ?current_module ~loc type_name]
-          .Spoc_core.Vector.type_id]
-  | _ -> [%expr Sarek_ir_types.Type_id.create ()]
+      if is_inline_type inline_types type_name then
+        inline_type_id_expr ~loc ~ids_var:inline_ids_var type_name
+      else
+        [%expr
+          [%e custom_descriptor_expr ?current_module ~loc type_name]
+            .Spoc_core.Vector.type_id]
+  | _ -> [%expr failwith "unsupported custom type identity"]
 
 (** Generate memory access operations (vectors, arrays, record fields) *)
 let gen_memory_access ~loc ~ctx ~gen_expr (te : texpr) : expression =
@@ -541,8 +580,8 @@ let gen_special_expr ~loc ~gen_expr (te : texpr) : expression =
   | _ -> failwith "gen_special_expr: not a special expression"
 
 (** Generate BSP parallel constructs (let%shared, let%superstep, let rec) *)
-let gen_parallel_construct ?current_module ~loc ~gen_expr (te : texpr) :
-    expression =
+let gen_parallel_construct ?current_module ?inline_types ~loc ~gen_expr
+    (te : texpr) : expression =
   match te.te with
   (* BSP let%shared - allocate shared memory using OCaml arrays *)
   | TELetShared (name, _id, elem_ty, size_opt, body) ->
@@ -600,10 +639,13 @@ let gen_parallel_construct ?current_module ~loc ~gen_expr (te : texpr) :
             let key_expr =
               match repr elem_ty with
               | TRecord (type_name, _) | TVariant (type_name, _) ->
-                  [%expr
-                    [%e custom_descriptor_expr ?current_module ~loc type_name]
-                      .Spoc_core.Vector.type_id]
-              | _ -> [%expr Sarek_ir_types.Type_id.create ()]
+                  if is_inline_type inline_types type_name then
+                    inline_type_id_expr ~loc ~ids_var:types_module_var type_name
+                  else
+                    [%expr
+                      [%e custom_descriptor_expr ?current_module ~loc type_name]
+                        .Spoc_core.Vector.type_id]
+              | _ -> [%expr failwith "unsupported shared memory type identity"]
             in
             [%expr
               Sarek.Sarek_cpu_runtime.alloc_shared_with_key
@@ -750,6 +792,7 @@ let rec gen_expr_impl ~loc:_ ~ctx (te : texpr) : expression =
   | TELetShared _ | TESuperstep _ | TELetRec _ ->
       gen_parallel_construct
         ?current_module:ctx.current_module
+        ~inline_types:ctx.inline_types
         ~loc
         ~gen_expr
         te
@@ -1095,8 +1138,9 @@ let gen_mode_of_exec_strategy : Sarek_convergence.exec_strategy -> gen_mode =
     match on NA_Int32/NA_Float32/etc and extract the value.
 
     Uses typed native_arg for type safety. *)
-let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
-    =
+let gen_arg_cast ?current_module ?inline_types
+    ?(inline_ids_var = types_module_var) ~loc (param : tparam) (idx : int) :
+    expression =
   let arr_access =
     [%expr Array.get __args [%e Ast_builder.Default.eint ~loc idx]]
   in
@@ -1120,7 +1164,13 @@ let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
+                      [%e
+                        vector_type_id_expr
+                          ?current_module
+                          ?inline_types
+                          ~inline_ids_var
+                          ~loc
+                          elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1137,7 +1187,13 @@ let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
+                      [%e
+                        vector_type_id_expr
+                          ?current_module
+                          ?inline_types
+                          ~inline_ids_var
+                          ~loc
+                          elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1154,7 +1210,13 @@ let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
+                      [%e
+                        vector_type_id_expr
+                          ?current_module
+                          ?inline_types
+                          ~inline_ids_var
+                          ~loc
+                          elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1171,7 +1233,13 @@ let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
 
                   method underlying =
                     Sarek_ir_types.vec_as_vector
-                      [%e vector_type_id_expr ?current_module ~loc elem_ty]
+                      [%e
+                        vector_type_id_expr
+                          ?current_module
+                          ?inline_types
+                          ~inline_ids_var
+                          ~loc
+                          elem_ty]
                       [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
@@ -1182,13 +1250,25 @@ let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
             object
               method get i =
                 Sarek_ir_types.vec_get_custom
-                  [%e custom_type_id_expr ?current_module ~loc elem_ty]
+                  [%e
+                    custom_type_id_expr
+                      ?current_module
+                      ?inline_types
+                      ~inline_ids_var
+                      ~loc
+                      elem_ty]
                   [%e vec_arg]
                   i
 
               method set i x =
                 Sarek_ir_types.vec_set_custom
-                  [%e custom_type_id_expr ?current_module ~loc elem_ty]
+                  [%e
+                    custom_type_id_expr
+                      ?current_module
+                      ?inline_types
+                      ~inline_ids_var
+                      ~loc
+                      elem_ty]
                   [%e vec_arg]
                   i
                   x
@@ -1197,7 +1277,13 @@ let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
 
               method underlying =
                 Sarek_ir_types.vec_as_vector
-                  [%e vector_type_id_expr ?current_module ~loc elem_ty]
+                  [%e
+                    vector_type_id_expr
+                      ?current_module
+                      ?inline_types
+                      ~inline_ids_var
+                      ~loc
+                      elem_ty]
                   [%e vec_arg]
             end])
   | TReg Float32 ->
@@ -1238,101 +1324,141 @@ let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
 
     Using an object avoids needing to define a record type for the accessors. *)
 let gen_types_object ~loc (decls : ttype_decl list) : expression =
-  let methods =
+  let id_bindings =
     List.concat_map
       (fun decl ->
-        match decl with
-        | TTypeRecord {tdecl_name; tdecl_fields; _} ->
-            (* Getters *)
-            let getters =
+        let type_name =
+          match decl with
+          | TTypeRecord {tdecl_name; _} -> tdecl_name
+          | TTypeVariant {tdecl_name; _} -> tdecl_name
+        in
+        [
+          ( inline_type_id_method type_name,
+            "__" ^ inline_type_id_method type_name );
+          ( inline_vector_type_id_method type_name,
+            "__" ^ inline_vector_type_id_method type_name );
+        ])
+      decls
+  in
+  let id_methods =
+    List.map
+      (fun (method_name, binding_name) ->
+        Ast_builder.Default.pcf_method
+          ~loc
+          ( {txt = method_name; loc},
+            Public,
+            Cfk_concrete (Fresh, evar ~loc binding_name) ))
+      id_bindings
+  in
+  let methods =
+    id_methods
+    @ List.concat_map
+        (fun decl ->
+          match decl with
+          | TTypeRecord {tdecl_name; tdecl_fields; _} ->
+              (* Getters *)
+              let getters =
+                List.map
+                  (fun (fname, _fty, _is_mut) ->
+                    let fn_name = field_getter_name tdecl_name fname in
+                    let field_lid = {txt = Lident fname; loc} in
+                    let fn_expr =
+                      [%expr
+                        fun __r ->
+                          [%e
+                            Ast_builder.Default.pexp_field
+                              ~loc
+                              [%expr __r]
+                              field_lid]]
+                    in
+                    Ast_builder.Default.pcf_method
+                      ~loc
+                      ( {txt = fn_name; loc},
+                        Public,
+                        Cfk_concrete (Fresh, fn_expr) ))
+                  tdecl_fields
+              in
+              (* Maker *)
+              let maker =
+                let fn_name = record_maker_name tdecl_name in
+                let param_pats =
+                  List.map
+                    (fun (fname, _fty, _) ->
+                      ( Labelled fname,
+                        Ast_builder.Default.ppat_var ~loc {txt = fname; loc} ))
+                    tdecl_fields
+                in
+                let record_fields =
+                  List.map
+                    (fun (fname, _, _) ->
+                      ( {txt = Lident fname; loc},
+                        Ast_builder.Default.pexp_ident
+                          ~loc
+                          {txt = Lident fname; loc} ))
+                    tdecl_fields
+                in
+                let record_expr =
+                  Ast_builder.Default.pexp_record ~loc record_fields None
+                in
+                let fn_expr =
+                  List.fold_right
+                    (fun (lbl, pat) body ->
+                      Ast_builder.Default.pexp_fun ~loc lbl None pat body)
+                    param_pats
+                    record_expr
+                in
+                Ast_builder.Default.pcf_method
+                  ~loc
+                  ({txt = fn_name; loc}, Public, Cfk_concrete (Fresh, fn_expr))
+              in
+              getters @ [maker]
+          | TTypeVariant {tdecl_name; tdecl_constructors; _} ->
+              (* Constructor functions *)
               List.map
-                (fun (fname, _fty, _is_mut) ->
-                  let fn_name = field_getter_name tdecl_name fname in
-                  let field_lid = {txt = Lident fname; loc} in
+                (fun (cname, arg_opt) ->
+                  let fn_name = variant_ctor_name tdecl_name cname in
+                  let ctor_lid = {txt = Lident cname; loc} in
                   let fn_expr =
-                    [%expr
-                      fun __r ->
-                        [%e
-                          Ast_builder.Default.pexp_field
-                            ~loc
-                            [%expr __r]
-                            field_lid]]
+                    match arg_opt with
+                    | None ->
+                        [%expr
+                          fun () ->
+                            [%e
+                              Ast_builder.Default.pexp_construct
+                                ~loc
+                                ctor_lid
+                                None]]
+                    | Some _ ->
+                        [%expr
+                          fun __x ->
+                            [%e
+                              Ast_builder.Default.pexp_construct
+                                ~loc
+                                ctor_lid
+                                (Some [%expr __x])]]
                   in
                   Ast_builder.Default.pcf_method
                     ~loc
                     ({txt = fn_name; loc}, Public, Cfk_concrete (Fresh, fn_expr)))
-                tdecl_fields
-            in
-            (* Maker *)
-            let maker =
-              let fn_name = record_maker_name tdecl_name in
-              let param_pats =
-                List.map
-                  (fun (fname, _fty, _) ->
-                    ( Labelled fname,
-                      Ast_builder.Default.ppat_var ~loc {txt = fname; loc} ))
-                  tdecl_fields
-              in
-              let record_fields =
-                List.map
-                  (fun (fname, _, _) ->
-                    ( {txt = Lident fname; loc},
-                      Ast_builder.Default.pexp_ident
-                        ~loc
-                        {txt = Lident fname; loc} ))
-                  tdecl_fields
-              in
-              let record_expr =
-                Ast_builder.Default.pexp_record ~loc record_fields None
-              in
-              let fn_expr =
-                List.fold_right
-                  (fun (lbl, pat) body ->
-                    Ast_builder.Default.pexp_fun ~loc lbl None pat body)
-                  param_pats
-                  record_expr
-              in
-              Ast_builder.Default.pcf_method
-                ~loc
-                ({txt = fn_name; loc}, Public, Cfk_concrete (Fresh, fn_expr))
-            in
-            getters @ [maker]
-        | TTypeVariant {tdecl_name; tdecl_constructors; _} ->
-            (* Constructor functions *)
-            List.map
-              (fun (cname, arg_opt) ->
-                let fn_name = variant_ctor_name tdecl_name cname in
-                let ctor_lid = {txt = Lident cname; loc} in
-                let fn_expr =
-                  match arg_opt with
-                  | None ->
-                      [%expr
-                        fun () ->
-                          [%e
-                            Ast_builder.Default.pexp_construct
-                              ~loc
-                              ctor_lid
-                              None]]
-                  | Some _ ->
-                      [%expr
-                        fun __x ->
-                          [%e
-                            Ast_builder.Default.pexp_construct
-                              ~loc
-                              ctor_lid
-                              (Some [%expr __x])]]
-                in
-                Ast_builder.Default.pcf_method
-                  ~loc
-                  ({txt = fn_name; loc}, Public, Cfk_concrete (Fresh, fn_expr)))
-              tdecl_constructors)
-      decls
+                tdecl_constructors)
+        decls
   in
-  Ast_builder.Default.pexp_object
-    ~loc
-    (Ast_builder.Default.class_structure
-       ~self:(Ast_builder.Default.ppat_any ~loc)
-       ~fields:methods)
+  let object_expr =
+    Ast_builder.Default.pexp_object
+      ~loc
+      (Ast_builder.Default.class_structure
+         ~self:(Ast_builder.Default.ppat_any ~loc)
+         ~fields:methods)
+  in
+  List.fold_right
+    (fun (_method_name, binding_name) body ->
+      [%expr
+        let [%p Ast_builder.Default.pvar ~loc binding_name] =
+          Sarek_ir_types.Type_id.create ()
+        in
+        [%e body]])
+    id_bindings
+    object_expr
 
 (** Generate V2 cpu_kern - uses Spoc_core.Vector.get/set instead of Spoc.Mem.
 
@@ -1573,6 +1699,20 @@ let gen_simple_cpu_kern_native ~loc ~exec_strategy (kernel : tkernel) :
     wrapped in accessor objects with get/set/length/underlying. *)
 let gen_cpu_kern_native_wrapper ~loc (kernel : tkernel) : expression =
   let use_fcm = has_inline_types kernel in
+  let inline_type_names =
+    if use_fcm then
+      List.fold_left
+        (fun acc decl ->
+          let name =
+            match decl with
+            | TTypeRecord {tdecl_name; _} -> tdecl_name
+            | TTypeVariant {tdecl_name; _} -> tdecl_name
+          in
+          if not (String.contains name '.') then StringSet.add name acc else acc)
+        StringSet.empty
+        kernel.tkern_type_decls
+    else StringSet.empty
+  in
   let native_kern = gen_cpu_kern_native ~loc kernel in
 
   (* Detect execution strategy for optimization *)
@@ -1590,7 +1730,15 @@ let gen_cpu_kern_native_wrapper ~loc (kernel : tkernel) : expression =
         let var_pat =
           Ast_builder.Default.ppat_var ~loc {txt = param.tparam_name; loc}
         in
-        let cast_expr = gen_arg_cast ?current_module ~loc param i in
+        let cast_expr =
+          gen_arg_cast
+            ?current_module
+            ~inline_types:inline_type_names
+            ~inline_ids_var:"__types_rec"
+            ~loc
+            param
+            i
+        in
         (var_pat, cast_expr))
       kernel.tkern_params
   in

--- a/sarek/ppx/Sarek_native_gen.ml
+++ b/sarek/ppx/Sarek_native_gen.ml
@@ -146,6 +146,30 @@ let gen_variable ~loc ~ctx (name : string) (id : int) : expression =
     [%expr ![%e var_e]]
   else var_e
 
+let custom_descriptor_expr ~loc type_name =
+  let parts = String.split_on_char '.' type_name in
+  match List.rev parts with
+  | name :: modules -> evar_qualified ~loc (List.rev modules) (name ^ "_custom")
+  | [] -> failwith "custom_descriptor_expr: empty type name"
+
+let vector_type_id_expr ~loc elem_ty =
+  match repr elem_ty with
+  | TReg Float32 -> [%expr Spoc_core.Vector.float32_vector_type_id]
+  | TReg Float64 -> [%expr Spoc_core.Vector.float64_vector_type_id]
+  | TReg Int | TPrim TInt32 -> [%expr Spoc_core.Vector.int32_vector_type_id]
+  | TReg Int64 -> [%expr Spoc_core.Vector.int64_vector_type_id]
+  | TReg Char -> [%expr Spoc_core.Vector.char_vector_type_id]
+  | TRecord (type_name, _) | TVariant (type_name, _) ->
+      [%expr
+        [%e custom_descriptor_expr ~loc type_name].Spoc_core.Vector.vector_type_id]
+  | _ -> [%expr Sarek_ir_types.Type_id.create ()]
+
+let custom_type_id_expr ~loc elem_ty =
+  match repr elem_ty with
+  | TRecord (type_name, _) | TVariant (type_name, _) ->
+      [%expr [%e custom_descriptor_expr ~loc type_name].Spoc_core.Vector.type_id]
+  | _ -> [%expr Sarek_ir_types.Type_id.create ()]
+
 (** Generate memory access operations (vectors, arrays, record fields) *)
 let gen_memory_access ~loc ~ctx ~gen_expr (te : texpr) : expression =
   match te.te with
@@ -1060,7 +1084,7 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
       | TReg Float32 ->
           [%expr
             match [%e arr_access] with
-            | Sarek_ir_types.NA_Vec __v ->
+            | Sarek_ir_types.NA_Vec (Sarek_ir_types.NV __v) ->
                 object
                   method get i = __v.get_f32 i
 
@@ -1068,13 +1092,16 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method length = __v.length
 
-                  method underlying = Sarek_ir_types.vec_as_vector [%e vec_arg]
+                  method underlying =
+                    Sarek_ir_types.vec_as_vector
+                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
       | TReg Float64 ->
           [%expr
             match [%e arr_access] with
-            | Sarek_ir_types.NA_Vec __v ->
+            | Sarek_ir_types.NA_Vec (Sarek_ir_types.NV __v) ->
                 object
                   method get i = __v.get_f64 i
 
@@ -1082,13 +1109,16 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method length = __v.length
 
-                  method underlying = Sarek_ir_types.vec_as_vector [%e vec_arg]
+                  method underlying =
+                    Sarek_ir_types.vec_as_vector
+                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
       | TReg Int | TPrim TInt32 ->
           [%expr
             match [%e arr_access] with
-            | Sarek_ir_types.NA_Vec __v ->
+            | Sarek_ir_types.NA_Vec (Sarek_ir_types.NV __v) ->
                 object
                   method get i = __v.get_i32 i
 
@@ -1096,13 +1126,16 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method length = __v.length
 
-                  method underlying = Sarek_ir_types.vec_as_vector [%e vec_arg]
+                  method underlying =
+                    Sarek_ir_types.vec_as_vector
+                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
       | TReg Int64 ->
           [%expr
             match [%e arr_access] with
-            | Sarek_ir_types.NA_Vec __v ->
+            | Sarek_ir_types.NA_Vec (Sarek_ir_types.NV __v) ->
                 object
                   method get i = __v.get_i64 i
 
@@ -1110,7 +1143,10 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
 
                   method length = __v.length
 
-                  method underlying = Sarek_ir_types.vec_as_vector [%e vec_arg]
+                  method underlying =
+                    Sarek_ir_types.vec_as_vector
+                      [%e vector_type_id_expr ~loc elem_ty]
+                      [%e vec_arg]
                 end
             | _ -> failwith "Expected NA_Vec"]
       | _ ->
@@ -1118,13 +1154,25 @@ let gen_arg_cast ~loc (param : tparam) (idx : int) : expression =
               The helpers encapsulate the type conversion internally. *)
           [%expr
             object
-              method get i = Sarek_ir_types.vec_get_custom [%e vec_arg] i
+              method get i =
+                Sarek_ir_types.vec_get_custom
+                  [%e custom_type_id_expr ~loc elem_ty]
+                  [%e vec_arg]
+                  i
 
-              method set i x = Sarek_ir_types.vec_set_custom [%e vec_arg] i x
+              method set i x =
+                Sarek_ir_types.vec_set_custom
+                  [%e custom_type_id_expr ~loc elem_ty]
+                  [%e vec_arg]
+                  i
+                  x
 
               method length = Sarek_ir_types.vec_length [%e vec_arg]
 
-              method underlying = Sarek_ir_types.vec_as_vector [%e vec_arg]
+              method underlying =
+                Sarek_ir_types.vec_as_vector
+                  [%e vector_type_id_expr ~loc elem_ty]
+                  [%e vec_arg]
             end])
   | TReg Float32 ->
       [%expr

--- a/sarek/ppx/Sarek_native_gen.ml
+++ b/sarek/ppx/Sarek_native_gen.ml
@@ -748,7 +748,11 @@ let rec gen_expr_impl ~loc:_ ~ctx (te : texpr) : expression =
       gen_intrinsic_fun ~loc ~gen_mode:ctx.gen_mode ref args_e
   (* Parallel constructs *)
   | TELetShared _ | TESuperstep _ | TELetRec _ ->
-      gen_parallel_construct ?current_module:ctx.current_module ~loc ~gen_expr te
+      gen_parallel_construct
+        ?current_module:ctx.current_module
+        ~loc
+        ~gen_expr
+        te
 
 (** Generate pattern from typed pattern. Takes context to detect same-module
     types that shouldn't be qualified. *)
@@ -1091,7 +1095,8 @@ let gen_mode_of_exec_strategy : Sarek_convergence.exec_strategy -> gen_mode =
     match on NA_Int32/NA_Float32/etc and extract the value.
 
     Uses typed native_arg for type safety. *)
-let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression =
+let gen_arg_cast ?current_module ~loc (param : tparam) (idx : int) : expression
+    =
   let arr_access =
     [%expr Array.get __args [%e Ast_builder.Default.eint ~loc idx]]
   in

--- a/sarek/ppx/Sarek_native_helpers.ml
+++ b/sarek/ppx/Sarek_native_helpers.ml
@@ -53,13 +53,16 @@ let evar ~loc name =
 
 (** Helper to create a qualified identifier expression *)
 let evar_qualified ~loc path name =
-  let lid =
-    List.fold_left
-      (fun acc m -> Ldot (acc, m))
-      (Lident (List.hd path))
-      (List.tl path @ [name])
-  in
-  Ast_builder.Default.pexp_ident ~loc {txt = lid; loc}
+  match path with
+  | [] -> evar ~loc name
+  | first :: rest ->
+      let lid =
+        List.fold_left
+          (fun acc m -> Ldot (acc, m))
+          (Lident first)
+          (rest @ [name])
+      in
+      Ast_builder.Default.pexp_ident ~loc {txt = lid; loc}
 
 (** {1 Variable Naming} *)
 

--- a/sarek/ppx/Sarek_parse.ml
+++ b/sarek/ppx/Sarek_parse.ml
@@ -155,32 +155,107 @@ let parse_unop (op : string) : Sarek_ast.unop option =
   | "lnot" -> Some Sarek_ast.Lnot
   | _ -> None
 
-type fun_body =
-  | Pfunction_body of expression
-  | Pfunction_cases of case list * Location.t * attributes
+module Ast_502 = Astlib.Ast_502
+module To_502 =
+  Ppxlib_ast__Versions.Convert
+    (Ppxlib_ast__Versions.OCaml_current)
+    (Ppxlib_ast__Versions.OCaml_502)
+module From_502 =
+  Ppxlib_ast__Versions.Convert
+    (Ppxlib_ast__Versions.OCaml_502)
+    (Ppxlib_ast__Versions.OCaml_current)
 
-let pattern_of_param (p : _) : Ppxlib.pattern =
-  match p with
-  | {Parsetree.pparam_desc = Pparam_val (Nolabel, None, pat); _} -> pat
-  | {Parsetree.pparam_desc = Pparam_val (_, _, pat); _} ->
-      raise
-        (Parse_error_exn
-           ("Labelled parameters not supported in kernels", pat.ppat_loc))
-  | {Parsetree.pparam_desc = Pparam_newtype _; pparam_loc; _} ->
-      raise
-        (Parse_error_exn
-           ("Newtype parameters not supported in kernels", pparam_loc))
+let expression_to_502 expr =
+  expr |> Selected_ast.to_ocaml Expression |> To_502.copy_expression
 
-let collect_fun_params (expr : expression) : _ list * fun_body option =
-  match expr.pexp_desc with
-  | Pexp_function (params, _constraint, body) ->
-      let fb =
+let expression_of_502 expr =
+  expr |> From_502.copy_expression |> Selected_ast.of_ocaml Expression
+
+let pattern_of_502 pat =
+  pat |> From_502.copy_pattern |> Selected_ast.of_ocaml Pattern
+
+let case_of_502 case = case |> From_502.copy_case |> Selected_ast.of_ocaml Case
+
+type fun_body = Fun_body of expression | Fun_cases of case list
+
+let is_function_expression_502 expr =
+  let module P = Ast_502.Parsetree in
+  match (expression_to_502 expr).P.pexp_desc with
+  | P.Pexp_function _ -> true
+  | _ -> false
+
+let same_position (a : Lexing.position) (b : Lexing.position) =
+  String.equal a.pos_fname b.pos_fname
+  && a.pos_lnum = b.pos_lnum && a.pos_bol = b.pos_bol && a.pos_cnum = b.pos_cnum
+
+let same_location (a : Location.t) (b : Location.t) =
+  same_position a.loc_start b.loc_start && same_position a.loc_end b.loc_end
+
+let expression_at_loc (root : expression) (loc : Location.t) =
+  let found = ref None in
+  let seen_root = ref false in
+  let finder =
+    object
+      inherit Ast_traverse.iter as super
+
+      method! expression expr =
+        match !found with
+        | Some _ -> ()
+        | None ->
+            let is_root = not !seen_root in
+            seen_root := true ;
+            if (not is_root) && same_location expr.pexp_loc loc then
+              found := Some expr
+            else super#expression expr
+    end
+  in
+  finder#expression root ;
+  !found
+
+let pattern_of_param (p : Ppxlib.pattern) : Ppxlib.pattern = p
+
+let collect_fun_params (expr : expression) :
+    Ppxlib.pattern list * fun_body option =
+  let module P = Ast_502.Parsetree in
+  let module A = Ast_502.Asttypes in
+  let rec loop acc e =
+    match e.P.pexp_desc with
+    | P.Pexp_function (params, _, body) -> (
+        let collect_param acc p =
+          match p.P.pparam_desc with
+          | P.Pparam_val (A.Nolabel, None, pat) -> pat :: acc
+          | P.Pparam_val (_, _, pat) ->
+              raise
+                (Parse_error_exn
+                   ( "Labelled parameters not supported in kernels",
+                     pat.P.ppat_loc ))
+          | P.Pparam_newtype name ->
+              raise
+                (Parse_error_exn
+                   ( "Locally abstract type parameters not supported in kernels",
+                     name.loc ))
+        in
+        let acc = List.fold_left collect_param acc params in
         match body with
-        | Pfunction_body e -> Pfunction_body e
-        | Pfunction_cases (c, l, a) -> Pfunction_cases (c, l, a)
-      in
-      (params, Some fb)
-  | _ -> ([], None)
+        | P.Pfunction_body body_expr -> loop acc body_expr
+        | P.Pfunction_cases (cases, _, _) ->
+            ( List.rev_map pattern_of_502 acc,
+              Some (Fun_cases (List.map case_of_502 cases)) ))
+    | _ ->
+        if acc = [] then ([], None)
+        else
+          let body_expr =
+            match expression_at_loc expr e.P.pexp_loc with
+            | Some original when not (is_function_expression_502 original) ->
+                original
+            | None -> expression_of_502 e
+            | Some _ -> expression_of_502 e
+          in
+          (List.rev_map pattern_of_502 acc, Some (Fun_body body_expr))
+  in
+  loop [] (expression_to_502 expr)
+
+let is_function_expression = is_function_expression_502
 
 (** Parse let%shared: let%shared name : type [= size] in body Syntax: let%shared
     tile : float32 array in body let%shared tile : float32 array = 64 in body *)
@@ -423,7 +498,7 @@ and parse_expression (expr : expression) : Sarek_ast.expr =
         let fun_params, fun_body = collect_fun_params pvb_expr in
         if fun_params <> [] then
           match fun_body with
-          | Some (Pfunction_body body_expr) ->
+          | Some (Fun_body body_expr) ->
               let parsed_params =
                 List.map
                   (fun p -> extract_param_from_pattern (pattern_of_param p))
@@ -432,7 +507,7 @@ and parse_expression (expr : expression) : Sarek_ast.expr =
               let fn_body = parse_expression body_expr in
               Sarek_ast.ELetRec
                 (name, parsed_params, ty, fn_body, parse_expression body)
-          | Some (Pfunction_cases _) ->
+          | Some (Fun_cases _) ->
               raise
                 (Parse_error_exn
                    ( "Pattern-matching functions not supported in let bindings",
@@ -530,37 +605,11 @@ and parse_expression (expr : expression) : Sarek_ast.expr =
         in
         Sarek_ast.EOpen (path, parse_expression e)
     (* Lambda - for local functions in kernels *)
-    | Pexp_function (params, _, Pfunction_body body) when params <> [] ->
-        let pats = List.map pattern_of_param params in
-        let rec make_nested_lets pats body_expr =
-          match pats with
-          | [] -> parse_expression body_expr
-          | pat :: rest ->
-              let name =
-                match extract_name_from_pattern pat with
-                | Some n -> n
-                | None -> "_"
-              in
-              let ty = extract_type_from_pattern pat in
-              let inner = make_nested_lets rest body_expr in
-              {
-                Sarek_ast.e =
-                  Sarek_ast.ELet
-                    ( name,
-                      ty,
-                      inner,
-                      {
-                        Sarek_ast.e = Sarek_ast.EVar name;
-                        Sarek_ast.expr_loc = loc;
-                      } );
-                Sarek_ast.expr_loc = loc;
-              }
-        in
-        (make_nested_lets pats body).e
-    | Pexp_function (_, _, Pfunction_cases _) ->
+    | _ when is_function_expression expr ->
         raise
           (Parse_error_exn
-             ( "Pattern-matching functions not supported in kernels",
+             ( "Standalone lambda expressions are not supported in kernels; \
+                use let-bound functions",
                expr.pexp_loc ))
     (* Extension point: [%global name] - reference to OCaml value *)
     | Pexp_extension
@@ -614,11 +663,11 @@ let parse_kernel_function (expr : expression) : Sarek_ast.kernel =
   let loc = loc_of_ppxlib expr.pexp_loc in
   let params, body = collect_fun_params expr in
   match body with
-  | Some (Pfunction_cases _) ->
+  | Some (Fun_cases _) ->
       raise
         (Parse_error_exn
            ("Pattern-matching functions not supported as kernels", expr.pexp_loc))
-  | Some (Pfunction_body body_expr) ->
+  | Some (Fun_body body_expr) ->
       if params = [] then
         raise
           (Parse_error_exn
@@ -693,9 +742,9 @@ let parse_payload (payload : expression) : Sarek_ast.kernel =
                   let ty = extract_type_from_pattern vb.pvb_pat in
                   let params, body =
                     match collect_fun_params vb.pvb_expr with
-                    | params, Some (Pfunction_body fn_body) when params <> [] ->
+                    | params, Some (Fun_body fn_body) when params <> [] ->
                         (params, fn_body)
-                    | _, Some (Pfunction_cases _) ->
+                    | _, Some (Fun_cases _) ->
                         raise
                           (Parse_error_exn
                              ( "Pattern-matching functions not supported in \
@@ -755,7 +804,7 @@ let parse_payload (payload : expression) : Sarek_ast.kernel =
         let ty = extract_type_from_pattern pvb_pat in
         let module_items =
           match collect_fun_params pvb_expr with
-          | params, Some (Pfunction_body fn_body) when params <> [] ->
+          | params, Some (Fun_body fn_body) when params <> [] ->
               let parsed_params =
                 List.map
                   (fun p -> extract_param_from_pattern (pattern_of_param p))
@@ -764,7 +813,7 @@ let parse_payload (payload : expression) : Sarek_ast.kernel =
               let fn_body = parse_expression fn_body in
               Sarek_ast.MFun (name, is_recursive, parsed_params, fn_body)
               :: mods_acc
-          | _, Some (Pfunction_cases _) ->
+          | _, Some (Fun_cases _) ->
               raise
                 (Parse_error_exn
                    ( "Pattern-matching functions not supported in module items",

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -1245,18 +1245,16 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
              ~expr:
                (Ast_builder.Default.pmod_structure
                   ~loc
-	                  [
-	                    [%stri
-	                      type t =
-	                        [%t Ast_builder.Default.ptyp_constr ~loc type_lid []]];
-	                    [%stri
-	                      let type_id =
-	                        [%e
-	                          Ast_builder.Default.evar
-	                            ~loc
-	                            (type_name ^ "_custom")]
-	                          .Spoc_core.Vector.type_id];
-	                    [%stri let from_values = [%e from_values_fn]];
+                  [
+                    [%stri
+                      type t =
+                        [%t Ast_builder.Default.ptyp_constr ~loc type_lid []]];
+                    [%stri
+                      let type_id =
+                        [%e
+                          Ast_builder.Default.evar ~loc (type_name ^ "_custom")]
+                          .Spoc_core.Vector.type_id];
+                    [%stri let from_values = [%e from_values_fn]];
                     [%stri let to_values = [%e to_values_fn]];
                     [%stri let get_field = [%e get_field_fn]];
                     [%stri

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -72,6 +72,22 @@ let rec flatten_longident = function
   | Ldot (li, s) -> flatten_longident li @ [s]
   | Lapply _ -> []
 
+let custom_descriptor_expr_of_lid ~loc lid =
+  match List.rev (flatten_longident lid) with
+  | name :: modules ->
+      let modules = List.rev modules in
+      let ident =
+        match modules with
+        | [] -> Lident (name ^ "_custom")
+        | first :: rest ->
+            List.fold_left
+              (fun acc m -> Ldot (acc, m))
+              (Lident first)
+              (rest @ [name ^ "_custom"])
+      in
+      Ast_builder.Default.pexp_ident ~loc {txt = ident; loc}
+  | [] -> Ast_builder.Default.evar ~loc "unknown_custom"
+
 let rec core_type_to_sarek_type_expr ~loc (ct : core_type) =
   match ct.ptyp_desc with
   | Ptyp_constr ({txt; _}, args) ->
@@ -446,28 +462,15 @@ let gen_field_read ~loc (ftype : core_type) (byte_off_expr : expression) :
         Spoc_core.Vector.Custom_helpers.read_int
           raw_ptr
           (base_off + [%e byte_off_expr])]
-  | Ptyp_constr ({txt = Lident type_name; _}, _) ->
+  | Ptyp_constr ({txt; _}, _) ->
       (* Nested custom type - call its _custom.get directly with adjusted pointer *)
       let custom_get =
         Ast_builder.Default.pexp_field
           ~loc
-          (Ast_builder.Default.evar ~loc (type_name ^ "_custom"))
+          (custom_descriptor_expr_of_lid ~loc txt)
           {txt = Lident "get"; loc}
       in
       (* Adjust pointer to field offset, then read at index 0 *)
-      [%expr
-        let field_ptr =
-          let byte_ptr = Ctypes.from_voidp Ctypes.uint8_t raw_ptr in
-          Ctypes.to_voidp Ctypes.(byte_ptr +@ (base_off + [%e byte_off_expr]))
-        in
-        [%e custom_get] field_ptr 0]
-  | Ptyp_constr ({txt = Ldot (_, type_name); _}, _) ->
-      let custom_get =
-        Ast_builder.Default.pexp_field
-          ~loc
-          (Ast_builder.Default.evar ~loc (type_name ^ "_custom"))
-          {txt = Lident "get"; loc}
-      in
       [%expr
         let field_ptr =
           let byte_ptr = Ctypes.from_voidp Ctypes.uint8_t raw_ptr in
@@ -515,25 +518,12 @@ let gen_field_write ~loc (ftype : core_type) (byte_off_expr : expression)
           raw_ptr
           (base_off + [%e byte_off_expr])
           [%e value_expr]]
-  | Ptyp_constr ({txt = Lident type_name; _}, _) ->
+  | Ptyp_constr ({txt; _}, _) ->
       (* Nested custom type - call its _custom.set directly with adjusted pointer *)
       let custom_set =
         Ast_builder.Default.pexp_field
           ~loc
-          (Ast_builder.Default.evar ~loc (type_name ^ "_custom"))
-          {txt = Lident "set"; loc}
-      in
-      [%expr
-        let field_ptr =
-          let byte_ptr = Ctypes.from_voidp Ctypes.uint8_t raw_ptr in
-          Ctypes.to_voidp Ctypes.(byte_ptr +@ (base_off + [%e byte_off_expr]))
-        in
-        [%e custom_set] field_ptr 0 [%e value_expr]]
-  | Ptyp_constr ({txt = Ldot (_, type_name); _}, _) ->
-      let custom_set =
-        Ast_builder.Default.pexp_field
-          ~loc
-          (Ast_builder.Default.evar ~loc (type_name ^ "_custom"))
+          (custom_descriptor_expr_of_lid ~loc txt)
           {txt = Lident "set"; loc}
       in
       [%expr
@@ -591,6 +581,16 @@ let generate_custom_value ~loc (td : type_declaration) : structure_item list =
          This avoids the value restriction since it's a function definition. *)
       let make_fn_name = type_name ^ "_make_custom" in
       let make_fn_pat = Ast_builder.Default.pvar ~loc make_fn_name in
+      let type_id_name = type_name ^ "_type_id" in
+      let type_id_pat = Ast_builder.Default.pvar ~loc type_id_name in
+      let type_id_expr = Ast_builder.Default.evar ~loc type_id_name in
+      let vector_type_id_name = type_name ^ "_vector_type_id" in
+      let vector_type_id_pat =
+        Ast_builder.Default.pvar ~loc vector_type_id_name
+      in
+      let vector_type_id_expr =
+        Ast_builder.Default.evar ~loc vector_type_id_name
+      in
       let make_fn_call =
         Ast_builder.Default.eapply
           ~loc
@@ -652,12 +652,16 @@ let generate_custom_value ~loc (td : type_declaration) : structure_item list =
       in
 
       [
+        [%stri let [%p type_id_pat] = Sarek_ir_types.Type_id.create ()];
+        [%stri let [%p vector_type_id_pat] = Sarek_ir_types.Type_id.create ()];
         (* Generate: let point_make_custom = fun () -> { ... } *)
         [%stri
           let [%p make_fn_pat] =
            fun () ->
             ({
                Spoc_core.Vector.elem_size = [%e size_expr];
+               type_id = [%e type_id_expr];
+               vector_type_id = [%e vector_type_id_expr];
                name = [%e name_expr];
                get = [%e get_fn];
                set = [%e set_fn];
@@ -934,6 +938,16 @@ let generate_custom_value ~loc (td : type_declaration) : structure_item list =
 
       let make_fn_name = type_name ^ "_make_custom" in
       let make_fn_pat = Ast_builder.Default.pvar ~loc make_fn_name in
+      let type_id_name = type_name ^ "_type_id" in
+      let type_id_pat = Ast_builder.Default.pvar ~loc type_id_name in
+      let type_id_expr = Ast_builder.Default.evar ~loc type_id_name in
+      let vector_type_id_name = type_name ^ "_vector_type_id" in
+      let vector_type_id_pat =
+        Ast_builder.Default.pvar ~loc vector_type_id_name
+      in
+      let vector_type_id_expr =
+        Ast_builder.Default.evar ~loc vector_type_id_name
+      in
       let make_fn_call =
         Ast_builder.Default.eapply
           ~loc
@@ -943,11 +957,15 @@ let generate_custom_value ~loc (td : type_declaration) : structure_item list =
       let _ = type_annot in
 
       [
+        [%stri let [%p type_id_pat] = Sarek_ir_types.Type_id.create ()];
+        [%stri let [%p vector_type_id_pat] = Sarek_ir_types.Type_id.create ()];
         [%stri
           let [%p make_fn_pat] =
            fun () ->
             ({
                Spoc_core.Vector.elem_size = [%e size_expr];
+               type_id = [%e type_id_expr];
+               vector_type_id = [%e vector_type_id_expr];
                name = [%e name_expr];
                get = [%e get_fn];
                set = [%e set_fn];
@@ -1036,16 +1054,18 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
                             Ast_builder.Default.estring
                               ~loc
                               ("Field '" ^ field_name ^ "' expected bool")]]
-              | Ptyp_constr ({txt = Lident custom_type; _}, _) ->
+              | Ptyp_constr ({txt; _}, _) ->
                   (* Nested custom type - recursively call its helper *)
+                  let custom_type = String.concat "." (flatten_longident txt) in
+                  let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
                   [%expr
                     match [%e array_access] with
                     | Sarek.Sarek_value.VRecord _ as nested_vrec -> (
                         match
-                          Sarek.Sarek_type_helpers.lookup
-                            [%e Ast_builder.Default.estring ~loc custom_type]
+                          Sarek.Sarek_type_helpers.lookup_typed
+                            [%e custom_expr].Spoc_core.Vector.type_id
                         with
-                        | Some h -> h.from_value nested_vrec
+                        | Some (module H) -> H.from_value nested_vrec
                         | None ->
                             failwith
                               [%e
@@ -1100,14 +1120,18 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
                     [%expr Sarek.Sarek_value.VInt64 [%e field_access]]
                 | Ptyp_constr ({txt = Lident "bool"; _}, _) ->
                     [%expr Sarek.Sarek_value.VBool [%e field_access]]
-                | Ptyp_constr ({txt = Lident custom_type; _}, _) ->
+                | Ptyp_constr ({txt; _}, _) ->
                     (* Nested custom type - use helper to convert *)
+                    let custom_type =
+                      String.concat "." (flatten_longident txt)
+                    in
+                    let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
                     [%expr
                       match
-                        Sarek.Sarek_type_helpers.lookup
-                          [%e Ast_builder.Default.estring ~loc custom_type]
+                        Sarek.Sarek_type_helpers.lookup_typed
+                          [%e custom_expr].Spoc_core.Vector.type_id
                       with
-                      | Some h -> h.to_value [%e field_access]
+                      | Some (module H) -> H.to_value [%e field_access]
                       | None ->
                           failwith
                             [%e
@@ -1155,13 +1179,15 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
                   [%expr Sarek.Sarek_value.VInt64 [%e field_access]]
               | Ptyp_constr ({txt = Lident "bool"; _}, _) ->
                   [%expr Sarek.Sarek_value.VBool [%e field_access]]
-              | Ptyp_constr ({txt = Lident custom_type; _}, _) ->
+              | Ptyp_constr ({txt; _}, _) ->
+                  let custom_type = String.concat "." (flatten_longident txt) in
+                  let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
                   [%expr
                     match
-                      Sarek.Sarek_type_helpers.lookup
-                        [%e Ast_builder.Default.estring ~loc custom_type]
+                      Sarek.Sarek_type_helpers.lookup_typed
+                        [%e custom_expr].Spoc_core.Vector.type_id
                     with
-                    | Some h -> h.to_value [%e field_access]
+                    | Some (module H) -> H.to_value [%e field_access]
                     | None ->
                         failwith
                           [%e
@@ -1220,11 +1246,18 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
              ~expr:
                (Ast_builder.Default.pmod_structure
                   ~loc
-                  [
-                    [%stri
-                      type t =
-                        [%t Ast_builder.Default.ptyp_constr ~loc type_lid []]];
-                    [%stri let from_values = [%e from_values_fn]];
+	                  [
+	                    [%stri
+	                      type t =
+	                        [%t Ast_builder.Default.ptyp_constr ~loc type_lid []]];
+	                    [%stri
+	                      let type_id =
+	                        [%e
+	                          Ast_builder.Default.evar
+	                            ~loc
+	                            (type_name ^ "_custom")]
+	                          .Spoc_core.Vector.type_id];
+	                    [%stri let from_values = [%e from_values_fn]];
                     [%stri let to_values = [%e to_values_fn]];
                     [%stri let get_field = [%e get_field_fn]];
                     [%stri

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -271,8 +271,7 @@ let scan_file_for_sarek_types path =
                   let ty = Sarek_parse.extract_type_from_pattern vb.pvb_pat in
                   let item =
                     match Sarek_parse.collect_fun_params vb.pvb_expr with
-                    | params, Some (Pfunction_body body_expr) when params <> []
-                      ->
+                    | params, Some (Fun_body body_expr) when params <> [] ->
                         let params =
                           List.map
                             (fun p ->
@@ -282,7 +281,7 @@ let scan_file_for_sarek_types path =
                         in
                         let body = Sarek_parse.parse_expression body_expr in
                         Sarek_ast.MFun (name, is_rec, params, body)
-                    | _, Some (Pfunction_cases _) ->
+                    | _, Some (Fun_cases _) ->
                         Location.raise_errorf
                           ~loc:vb.pvb_expr.pexp_loc
                           "Pattern-matching functions are not supported for \
@@ -1641,7 +1640,7 @@ let process_structure_for_module_items (str : structure) : structure =
       let ty = Sarek_parse.extract_type_from_pattern vb.pvb_pat in
       let item =
         match Sarek_parse.collect_fun_params vb.pvb_expr with
-        | params, Some (Pfunction_body body_expr) when params <> [] ->
+        | params, Some (Fun_body body_expr) when params <> [] ->
             let params =
               List.map
                 (fun p ->
@@ -1651,7 +1650,7 @@ let process_structure_for_module_items (str : structure) : structure =
             in
             let body = Sarek_parse.parse_expression body_expr in
             Sarek_ast.MFun (name, is_rec, params, body)
-        | _, Some (Pfunction_cases _) ->
+        | _, Some (Fun_cases _) ->
             Location.raise_errorf
               ~loc:vb.pvb_expr.pexp_loc
               "Pattern-matching functions are not supported for [@sarek.module]"

--- a/sarek/ppx/Sarek_typer.ml
+++ b/sarek/ppx/Sarek_typer.ml
@@ -140,7 +140,7 @@ let rec type_of_type_expr_ctx env (ctx : tvar_ctx) te =
     Creates fresh type variables for each TEVar - use type_of_type_expr_ctx when
     type variable names need to be preserved across multiple types. *)
 let type_of_type_expr_env env te =
-  type_of_type_expr_ctx env (fresh_tvar_ctx ()) te
+  type_of_type_expr_ctx env (fresh_tvar_ctx ~level:env.current_level ()) te
 
 (** Infer type of a binary operation *)
 let infer_binop op t1 t2 loc =

--- a/sarek/sarek/Execute.ml
+++ b/sarek/sarek/Execute.ml
@@ -68,9 +68,10 @@ let custom_value_of_bytes : type a. a Vector.custom_type -> bytes -> a =
     EXEC_VECTOR wrappers for vectors. *)
 let exec_arg_of_vector : type a b. (a, b) Vector.t -> Framework_sig.exec_arg =
  fun v ->
-  let module EV : Typed_value.EXEC_VECTOR
-    with type elt = a
-     and type underlying = (a, b) Vector.t = struct
+  let module EV :
+    Typed_value.EXEC_VECTOR
+      with type elt = a
+       and type underlying = (a, b) Vector.t = struct
     type elt = a
 
     type underlying = (a, b) Vector.t
@@ -96,10 +97,12 @@ let exec_arg_of_vector : type a b. (a, b) Vector.t -> Framework_sig.exec_arg =
           | None ->
               Execute_error.raise_error
                 (Transfer_failed
-                   {vector = "unknown"; reason = "Vector has no device buffer"}))
+                   {vector = "unknown"; reason = "Vector has no device buffer"})
+          )
       | Vector.CPU | Vector.Stale_GPU _ ->
           Execute_error.raise_error
-            (Transfer_failed {vector = "unknown"; reason = "Vector not on device"})
+            (Transfer_failed
+               {vector = "unknown"; reason = "Vector not on device"})
 
     let get i =
       (* Convert element to typed_value based on vector kind *)
@@ -139,7 +142,8 @@ let exec_arg_of_vector : type a b. (a, b) Vector.t -> Framework_sig.exec_arg =
     let set i tv =
       let type_error expected actual =
         Execute_error.raise_error
-          (Type_mismatch {expected; actual; context = "vector element assignment"})
+          (Type_mismatch
+             {expected; actual; context = "vector element assignment"})
       in
       match (tv, Vector.kind v) with
       | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
@@ -182,7 +186,10 @@ let exec_arg_of_vector : type a b. (a, b) Vector.t -> Framework_sig.exec_arg =
       | _ ->
           Execute_error.raise_error
             (Unsupported_argument
-               {arg_type = "unknown combination"; context = "vector element assignment"})
+               {
+                 arg_type = "unknown combination";
+                 context = "vector element assignment";
+               })
 
     let get_typed i = Vector.get v i
 

--- a/sarek/sarek/Execute.ml
+++ b/sarek/sarek/Execute.ml
@@ -34,122 +34,168 @@ type vector_arg =
   | Float32 : float -> vector_arg  (** 32-bit float scalar *)
   | Float64 : float -> vector_arg  (** 64-bit float scalar *)
 
+let custom_value_to_bytes : type a. a Vector.custom_type -> a -> bytes =
+ fun custom value ->
+  let size = custom.Vector.elem_size in
+  let bytes = Bytes.create size in
+  let raw = Ctypes.allocate_n Ctypes.char ~count:size in
+  custom.Vector.set (Ctypes.to_voidp raw) 0 value ;
+  for i = 0 to size - 1 do
+    let cell = Ctypes.( +@ ) raw i in
+    Bytes.set bytes i Ctypes.(!@cell)
+  done ;
+  bytes
+
+let custom_value_of_bytes : type a. a Vector.custom_type -> bytes -> a =
+ fun custom bytes ->
+  let size = custom.Vector.elem_size in
+  if Bytes.length bytes < size then
+    Execute_error.raise_error
+      (Type_mismatch
+         {
+           expected = Printf.sprintf "%s bytes" custom.Vector.name;
+           actual = Printf.sprintf "%d bytes" (Bytes.length bytes);
+           context = "custom vector element assignment";
+         }) ;
+  let raw = Ctypes.allocate_n Ctypes.char ~count:size in
+  for i = 0 to size - 1 do
+    let cell = Ctypes.( +@ ) raw i in
+    Ctypes.(cell <-@ Bytes.get bytes i)
+  done ;
+  custom.Vector.get (Ctypes.to_voidp raw) 0
+
 (** Convert vector_arg list to exec_arg array (new typed interface). Creates
     EXEC_VECTOR wrappers for vectors. *)
+let exec_arg_of_vector : type a b. (a, b) Vector.t -> Framework_sig.exec_arg =
+ fun v ->
+  let module EV : Typed_value.EXEC_VECTOR
+    with type elt = a
+     and type underlying = (a, b) Vector.t = struct
+    type elt = a
+
+    type underlying = (a, b) Vector.t
+
+    let length = Vector.length v
+
+    let type_name = Vector.kind_name (Vector.kind v)
+
+    let elem_size = Vector.elem_size (Vector.kind v)
+
+    let type_id = Vector.type_id (Vector.kind v)
+
+    let underlying_type_id = Vector.vector_type_id (Vector.kind v)
+
+    let underlying = v
+
+    let device_ptr () =
+      (* Get device pointer from location-based buffer *)
+      match Vector.location v with
+      | Vector.GPU dev | Vector.Both dev | Vector.Stale_CPU dev -> (
+          match Vector.get_buffer v dev with
+          | Some (module B : Vector.DEVICE_BUFFER) -> B.device_ptr
+          | None ->
+              Execute_error.raise_error
+                (Transfer_failed
+                   {vector = "unknown"; reason = "Vector has no device buffer"}))
+      | Vector.CPU | Vector.Stale_GPU _ ->
+          Execute_error.raise_error
+            (Transfer_failed {vector = "unknown"; reason = "Vector not on device"})
+
+    let get i =
+      (* Convert element to typed_value based on vector kind *)
+      match Vector.kind v with
+      | Vector.Scalar Vector.Int32 ->
+          Typed_value.TV_Scalar
+            (Typed_value.SV ((module Typed_value.Int32_type), Vector.get v i))
+      | Vector.Scalar Vector.Int64 ->
+          Typed_value.TV_Scalar
+            (Typed_value.SV ((module Typed_value.Int64_type), Vector.get v i))
+      | Vector.Scalar Vector.Float32 ->
+          Typed_value.TV_Scalar
+            (Typed_value.SV ((module Typed_value.Float32_type), Vector.get v i))
+      | Vector.Scalar Vector.Float64 ->
+          Typed_value.TV_Scalar
+            (Typed_value.SV ((module Typed_value.Float64_type), Vector.get v i))
+      | Vector.Custom custom ->
+          let module C : Typed_value.COMPOSITE_TYPE with type t = a = struct
+            type t = a
+
+            let name = custom.Vector.name
+
+            let size = custom.Vector.elem_size
+
+            let fields = []
+
+            let to_bytes = custom_value_to_bytes custom
+
+            let of_bytes = custom_value_of_bytes custom
+          end in
+          Typed_value.TV_Composite (Typed_value.CV ((module C), Vector.get v i))
+      | Vector.Scalar (Vector.Char | Vector.Complex32) ->
+          Execute_error.raise_error
+            (Unsupported_argument
+               {arg_type = type_name; context = "vector element access"})
+
+    let set i tv =
+      let type_error expected actual =
+        Execute_error.raise_error
+          (Type_mismatch {expected; actual; context = "vector element assignment"})
+      in
+      match (tv, Vector.kind v) with
+      | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+          Vector.Scalar Vector.Int32 ) -> (
+          match S.to_primitive x with
+          | Typed_value.PInt32 n -> Vector.set v i n
+          | Typed_value.PInt64 _ -> type_error "int32" "int64"
+          | Typed_value.PFloat _ -> type_error "int32" "float"
+          | Typed_value.PBool _ -> type_error "int32" "bool"
+          | Typed_value.PBytes _ -> type_error "int32" "bytes")
+      | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+          Vector.Scalar Vector.Int64 ) -> (
+          match S.to_primitive x with
+          | Typed_value.PInt64 n -> Vector.set v i n
+          | Typed_value.PInt32 _ -> type_error "int64" "int32"
+          | Typed_value.PFloat _ -> type_error "int64" "float"
+          | Typed_value.PBool _ -> type_error "int64" "bool"
+          | Typed_value.PBytes _ -> type_error "int64" "bytes")
+      | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+          Vector.Scalar Vector.Float32 ) -> (
+          match S.to_primitive x with
+          | Typed_value.PFloat f -> Vector.set v i f
+          | Typed_value.PInt32 _ -> type_error "float" "int32"
+          | Typed_value.PInt64 _ -> type_error "float" "int64"
+          | Typed_value.PBool _ -> type_error "float" "bool"
+          | Typed_value.PBytes _ -> type_error "float" "bytes")
+      | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
+          Vector.Scalar Vector.Float64 ) -> (
+          match S.to_primitive x with
+          | Typed_value.PFloat f -> Vector.set v i f
+          | Typed_value.PInt32 _ -> type_error "float" "int32"
+          | Typed_value.PInt64 _ -> type_error "float" "int64"
+          | Typed_value.PBool _ -> type_error "float" "bool"
+          | Typed_value.PBytes _ -> type_error "float" "bytes")
+      | ( Typed_value.TV_Composite (Typed_value.CV ((module C), x)),
+          Vector.Custom custom ) ->
+          if C.name <> custom.Vector.name || C.size <> custom.Vector.elem_size
+          then type_error custom.Vector.name C.name
+          else Vector.set v i (custom_value_of_bytes custom (C.to_bytes x))
+      | _ ->
+          Execute_error.raise_error
+            (Unsupported_argument
+               {arg_type = "unknown combination"; context = "vector element assignment"})
+
+    let get_typed i = Vector.get v i
+
+    let set_typed i x = Vector.kernel_set v i x
+  end in
+  Framework_sig.EA_Vec (module EV)
+
 let vector_args_to_exec_array (args : vector_arg list) :
     Framework_sig.exec_arg array =
   Array.of_list
     (List.map
        (function
-         | Vec v ->
-             (* Create an EXEC_VECTOR module wrapping the vector *)
-             let module EV : Typed_value.EXEC_VECTOR = struct
-               let length = Vector.length v
-
-               let type_name = Vector.kind_name (Vector.kind v)
-
-               let elem_size = Vector.elem_size (Vector.kind v)
-
-               let internal_get_vector_obj () = Obj.repr v
-
-               let device_ptr () =
-                 (* Get device pointer from location-based buffer *)
-                 match Vector.location v with
-                 | Vector.GPU dev | Vector.Both dev | Vector.Stale_CPU dev -> (
-                     match Vector.get_buffer v dev with
-                     | Some (module B : Vector.DEVICE_BUFFER) -> B.device_ptr
-                     | None ->
-                         Execute_error.raise_error
-                           (Transfer_failed
-                              {
-                                vector = "unknown";
-                                reason = "Vector has no device buffer";
-                              }))
-                 | Vector.CPU | Vector.Stale_GPU _ ->
-                     Execute_error.raise_error
-                       (Transfer_failed
-                          {vector = "unknown"; reason = "Vector not on device"})
-
-               let get i =
-                 (* Convert element to typed_value based on vector kind *)
-                 match Vector.kind v with
-                 | Vector.Scalar Vector.Int32 ->
-                     Typed_value.TV_Scalar
-                       (Typed_value.SV
-                          ((module Typed_value.Int32_type), Vector.get v i))
-                 | Vector.Scalar Vector.Int64 ->
-                     Typed_value.TV_Scalar
-                       (Typed_value.SV
-                          ((module Typed_value.Int64_type), Vector.get v i))
-                 | Vector.Scalar Vector.Float32 ->
-                     Typed_value.TV_Scalar
-                       (Typed_value.SV
-                          ((module Typed_value.Float32_type), Vector.get v i))
-                 | Vector.Scalar Vector.Float64 ->
-                     Typed_value.TV_Scalar
-                       (Typed_value.SV
-                          ((module Typed_value.Float64_type), Vector.get v i))
-                 | _ ->
-                     (* Custom types: serialize to bytes *)
-                     let _bytes =
-                       Bytes.create (Vector.elem_size (Vector.kind v))
-                     in
-                     (* TODO: proper serialization for custom types *)
-                     Typed_value.TV_Scalar
-                       (Typed_value.SV ((module Typed_value.Float32_type), 0.0))
-
-               let set i tv =
-                 let type_error expected actual =
-                   Execute_error.raise_error
-                     (Type_mismatch
-                        {
-                          expected;
-                          actual;
-                          context = "vector element assignment";
-                        })
-                 in
-                 match (tv, Vector.kind v) with
-                 | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
-                     Vector.Scalar Vector.Int32 ) -> (
-                     match S.to_primitive x with
-                     | Typed_value.PInt32 n -> Vector.set v i n
-                     | Typed_value.PInt64 _ -> type_error "int32" "int64"
-                     | Typed_value.PFloat _ -> type_error "int32" "float"
-                     | Typed_value.PBool _ -> type_error "int32" "bool"
-                     | Typed_value.PBytes _ -> type_error "int32" "bytes")
-                 | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
-                     Vector.Scalar Vector.Int64 ) -> (
-                     match S.to_primitive x with
-                     | Typed_value.PInt64 n -> Vector.set v i n
-                     | Typed_value.PInt32 _ -> type_error "int64" "int32"
-                     | Typed_value.PFloat _ -> type_error "int64" "float"
-                     | Typed_value.PBool _ -> type_error "int64" "bool"
-                     | Typed_value.PBytes _ -> type_error "int64" "bytes")
-                 | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
-                     Vector.Scalar Vector.Float32 ) -> (
-                     match S.to_primitive x with
-                     | Typed_value.PFloat f -> Vector.set v i f
-                     | Typed_value.PInt32 _ -> type_error "float" "int32"
-                     | Typed_value.PInt64 _ -> type_error "float" "int64"
-                     | Typed_value.PBool _ -> type_error "float" "bool"
-                     | Typed_value.PBytes _ -> type_error "float" "bytes")
-                 | ( Typed_value.TV_Scalar (Typed_value.SV ((module S), x)),
-                     Vector.Scalar Vector.Float64 ) -> (
-                     match S.to_primitive x with
-                     | Typed_value.PFloat f -> Vector.set v i f
-                     | Typed_value.PInt32 _ -> type_error "float" "int32"
-                     | Typed_value.PInt64 _ -> type_error "float" "int64"
-                     | Typed_value.PBool _ -> type_error "float" "bool"
-                     | Typed_value.PBytes _ -> type_error "float" "bytes")
-                 | _ ->
-                     Execute_error.raise_error
-                       (Unsupported_argument
-                          {
-                            arg_type = "unknown combination";
-                            context = "vector element assignment";
-                          })
-             end in
-             Framework_sig.EA_Vec (module EV)
+         | Vec v -> exec_arg_of_vector v
          | Int n -> Framework_sig.EA_Int32 (Int32.of_int n)
          | Int32 n -> Framework_sig.EA_Int32 n
          | Int64 n -> Framework_sig.EA_Int64 n
@@ -361,11 +407,11 @@ let vector_to_interp_array : type a b.
   | Vector.Custom custom -> (
       (* Custom types: use helpers to convert to VRecord *)
       let type_name = custom.Vector.name in
-      match Sarek_type_helpers.lookup type_name with
-      | Some h ->
+      match Sarek_type_helpers.lookup_typed custom.Vector.type_id with
+      | Some (module H) ->
           Array.init len (fun i ->
               let native_record = Vector.get vec i in
-              h.to_value native_record)
+              H.to_value native_record)
       | None ->
           (* Fallback: wrap in VRecord with empty fields *)
           Array.init len (fun _i -> Sarek_ir_interp.VRecord (type_name, [||])))
@@ -406,14 +452,14 @@ let interp_array_to_vector : type a b.
       for i = 0 to len - 1 do
         Vector.set vec i (Sarek_ir_interp.to_float64 arr.(i))
       done
-  | Vector.Custom _ ->
+  | Vector.Custom custom ->
       (* Custom types: convert VRecord to native OCaml values using helpers *)
       for i = 0 to len - 1 do
         match arr.(i) with
         | Sarek_ir_interp.VRecord (type_name, _fields) as vrec -> (
-            match Sarek_type_helpers.lookup type_name with
-            | Some h ->
-                let native_record = h.from_value vrec in
+            match Sarek_type_helpers.lookup_typed custom.Vector.type_id with
+            | Some (module H) ->
+                let native_record = H.from_value vrec in
                 Vector.set vec i native_record
             | None ->
                 Execute_error.raise_error

--- a/sarek/sarek/Kirc_kernel.ml
+++ b/sarek/sarek/Kirc_kernel.ml
@@ -129,6 +129,7 @@ let exec_arg_to_native_arg (arg : Framework_sig.exec_arg) :
             match S.to_primitive x with
             | Typed_value.PFloat f -> f
             | Typed_value.PInt32 n -> Int32.to_float n
+            | Typed_value.PInt64 n -> Int64.to_float n
             | prim ->
                 Kirc_error.raise_error
                   (Kirc_error.Type_conversion_failed
@@ -159,6 +160,8 @@ let exec_arg_to_native_arg (arg : Framework_sig.exec_arg) :
         | Typed_value.TV_Scalar (Typed_value.SV ((module S), x)) -> (
             match S.to_primitive x with
             | Typed_value.PFloat f -> f
+            | Typed_value.PInt32 n -> Int32.to_float n
+            | Typed_value.PInt64 n -> Int64.to_float n
             | prim ->
                 Kirc_error.raise_error
                   (Kirc_error.Type_conversion_failed
@@ -189,6 +192,7 @@ let exec_arg_to_native_arg (arg : Framework_sig.exec_arg) :
         | Typed_value.TV_Scalar (Typed_value.SV ((module S), x)) -> (
             match S.to_primitive x with
             | Typed_value.PInt32 n -> n
+            | Typed_value.PInt64 n -> Int64.to_int32 n
             | Typed_value.PFloat f -> Int32.of_float f
             | prim ->
                 Kirc_error.raise_error
@@ -221,6 +225,7 @@ let exec_arg_to_native_arg (arg : Framework_sig.exec_arg) :
             match S.to_primitive x with
             | Typed_value.PInt64 n -> n
             | Typed_value.PInt32 n -> Int64.of_int32 n
+            | Typed_value.PFloat f -> Int64.of_float f
             | prim ->
                 Kirc_error.raise_error
                   (Kirc_error.Type_conversion_failed
@@ -246,22 +251,13 @@ let exec_arg_to_native_arg (arg : Framework_sig.exec_arg) :
           (Typed_value.TV_Scalar
              (Typed_value.SV ((module Typed_value.Int64_type), n)))
       in
-      (* For custom types: use underlying Vector.t with Obj.t *)
-      let get_any i =
-        let vec = Obj.obj (V.internal_get_vector_obj ()) in
-        Obj.repr (Vector.get vec i)
-      in
-      let set_any i v =
-        let vec = Obj.obj (V.internal_get_vector_obj ()) in
-        Vector.kernel_set vec i (Obj.obj v)
-      in
-      (* Get underlying Vector.t for passing to intrinsics/functions that expect it *)
-      let get_vec () = V.internal_get_vector_obj () in
       Sarek_ir_types.NA_Vec
+        (Sarek_ir_types.NV
         {
           length = V.length;
           elem_size = V.elem_size;
           type_name = V.type_name;
+          type_id = V.type_id;
           get_f32 = get_as_f32;
           set_f32 = set_as_f32;
           get_f64 = get_as_f64;
@@ -270,10 +266,11 @@ let exec_arg_to_native_arg (arg : Framework_sig.exec_arg) :
           set_i32 = set_as_i32;
           get_i64 = get_as_i64;
           set_i64 = set_as_i64;
-          get_any;
-          set_any;
-          get_vec;
-        }
+          get_typed = V.get_typed;
+          set_typed = V.set_typed;
+          underlying_type_id = V.underlying_type_id;
+          underlying = V.underlying;
+        })
 
 (** {1 Execution} *)
 

--- a/sarek/sarek/Kirc_kernel.ml
+++ b/sarek/sarek/Kirc_kernel.ml
@@ -253,24 +253,24 @@ let exec_arg_to_native_arg (arg : Framework_sig.exec_arg) :
       in
       Sarek_ir_types.NA_Vec
         (Sarek_ir_types.NV
-        {
-          length = V.length;
-          elem_size = V.elem_size;
-          type_name = V.type_name;
-          type_id = V.type_id;
-          get_f32 = get_as_f32;
-          set_f32 = set_as_f32;
-          get_f64 = get_as_f64;
-          set_f64 = set_as_f64;
-          get_i32 = get_as_i32;
-          set_i32 = set_as_i32;
-          get_i64 = get_as_i64;
-          set_i64 = set_as_i64;
-          get_typed = V.get_typed;
-          set_typed = V.set_typed;
-          underlying_type_id = V.underlying_type_id;
-          underlying = V.underlying;
-        })
+           {
+             length = V.length;
+             elem_size = V.elem_size;
+             type_name = V.type_name;
+             type_id = V.type_id;
+             get_f32 = get_as_f32;
+             set_f32 = set_as_f32;
+             get_f64 = get_as_f64;
+             set_f64 = set_as_f64;
+             get_i32 = get_as_i32;
+             set_i32 = set_as_i32;
+             get_i64 = get_as_i64;
+             set_i64 = set_as_i64;
+             get_typed = V.get_typed;
+             set_typed = V.set_typed;
+             underlying_type_id = V.underlying_type_id;
+             underlying = V.underlying;
+           })
 
 (** {1 Execution} *)
 

--- a/sarek/sarek/Sarek_cpu_runtime.ml
+++ b/sarek/sarek/Sarek_cpu_runtime.ml
@@ -68,8 +68,9 @@ let global_size_z st = Int32.mul st.grid_dim_z st.block_dim_z
     Implementation: We use separate hashtables for each primitive type to avoid
     boxing, and an existential wrapper for custom types. *)
 
-(** Existential wrapper for custom type arrays - type-safe alternative *)
-type any_array = AnyArray : 'a array -> any_array
+(** Existential wrapper for custom type arrays with a runtime type witness. *)
+type any_array =
+  | AnyArray : 'a Sarek_ir_types.Type_id.t * 'a array -> any_array
 
 type shared_mem = {
   int_arrays : (string, int array) Hashtbl.t;
@@ -128,15 +129,16 @@ let alloc_shared_int64 (shared : shared_mem) name size (default : int64) :
 
 (** Generic allocator for custom types. The caller must ensure they use
     consistent types for each name. *)
-let alloc_shared (type a) (shared : shared_mem) name size (default : a) :
-    a array =
+let alloc_shared_with_key (type a) (shared : shared_mem)
+    (key : a Sarek_ir_types.Type_id.t) name size (default : a) : a array =
   match Hashtbl.find_opt shared.custom_arrays name with
-  | Some (AnyArray arr) ->
-      (* Pattern match extracts the array, but we need unsafe coercion to recover type *)
-      (Obj.obj (Obj.repr arr) : a array)
+  | Some (AnyArray (stored_key, arr)) -> (
+      match Sarek_ir_types.Type_id.equal key stored_key with
+      | Some Sarek_ir_types.Type_id.Refl -> arr
+      | None -> invalid_arg ("alloc_shared: type mismatch for " ^ name))
   | None ->
       let arr = Array.make size default in
-      Hashtbl.add shared.custom_arrays name (AnyArray arr) ;
+      Hashtbl.add shared.custom_arrays name (AnyArray (key, arr)) ;
       arr
 
 (** {1 Sequential Execution}

--- a/sarek/sarek/Sarek_cpu_runtime.ml
+++ b/sarek/sarek/Sarek_cpu_runtime.ml
@@ -1439,7 +1439,7 @@ let flush_fission () =
     and just pass the global index directly.
 
     This eliminates:
-    - 6 Obj.set_field calls per element
+    - six thread-state field updates per element
     - 6 integer divisions/modulos
     - Function call overhead through thread_state
 

--- a/sarek/sarek/Sarek_cpu_runtime.mli
+++ b/sarek/sarek/Sarek_cpu_runtime.mli
@@ -181,7 +181,7 @@ val flush_fission : unit -> unit
     and just pass the global index directly.
 
     This eliminates:
-    - 6 Obj.set_field calls per element
+    - six thread-state field updates per element
     - 6 integer divisions/modulos
     - Function call overhead through thread_state
 

--- a/sarek/sarek/Sarek_cpu_runtime.mli
+++ b/sarek/sarek/Sarek_cpu_runtime.mli
@@ -81,8 +81,10 @@ val alloc_shared_int64 : shared_mem -> string -> int -> int64 -> int64 array
 
 (** {2 Generic Allocator}
 
-    For custom types not covered by typed allocators. Uses Obj.t internally. *)
-val alloc_shared : shared_mem -> string -> int -> 'a -> 'a array
+    For custom types not covered by typed allocators. *)
+
+val alloc_shared_with_key :
+  shared_mem -> 'a Sarek_ir_types.Type_id.t -> string -> int -> 'a -> 'a array
 
 (** {1 Execution Modes} *)
 

--- a/sarek/sarek/Sarek_ir_interp.ml
+++ b/sarek/sarek/Sarek_ir_interp.ml
@@ -13,6 +13,7 @@
  ******************************************************************************)
 
 open Sarek_ir_types
+open Spoc_framework.Typed_value
 module F32 = Sarek_float32
 
 (** Re-export value type from Sarek_value for convenience *)
@@ -695,8 +696,7 @@ and eval_composite_expr state env = function
       | VRecord (type_name, fields) as vrec -> (
           match Sarek_type_helpers.lookup type_name with
           | Some h ->
-              let native_record = h.from_value vrec in
-              h.get_field native_record field
+              h.get_field vrec field
           | None ->
               let field_infos = Sarek_registry.record_fields type_name in
               let rec find_idx i = function
@@ -1290,17 +1290,24 @@ let vector_to_array : type a b. (a, b) Spoc_core.Vector.t -> value array =
   | Spoc_core.Vector.Custom custom -> (
       (* Custom types: use helpers to convert to VRecord *)
       let type_name = custom.Spoc_core.Vector.name in
-      match Sarek_type_helpers.lookup type_name with
-      | Some h ->
+      match Sarek_type_helpers.lookup_typed custom.Spoc_core.Vector.type_id with
+      | Some (module H) ->
           Array.init len (fun i ->
               let native_record = Spoc_core.Vector.get vec i in
-              h.to_value native_record)
+              H.to_value native_record)
       | None ->
           (* Fallback: wrap in VRecord with empty fields - shouldn't happen *)
           Array.init len (fun _i -> VRecord (type_name, [||])))
-  | _ ->
-      (* Fallback for any other type (e.g., Char) - treat as int32 *)
-      Array.init len (fun i -> VInt32 (Obj.magic (Spoc_core.Vector.get vec i)))
+  | Spoc_core.Vector.Scalar Spoc_core.Vector.Char ->
+      Array.init len (fun i ->
+          VInt32 (Int32.of_int (Char.code (Spoc_core.Vector.get vec i))))
+  | Spoc_core.Vector.Scalar Spoc_core.Vector.Complex32 ->
+      Interp_error.raise_error
+        (Unsupported_operation
+           {
+             operation = "vector_to_array";
+             reason = "Complex32 vectors are not supported by the interpreter";
+           })
 
 (** Write interpreter value array back to V2 Vector *)
 let array_to_vector : type a b. value array -> (a, b) Spoc_core.Vector.t -> unit
@@ -1330,10 +1337,13 @@ let array_to_vector : type a b. value array -> (a, b) Spoc_core.Vector.t -> unit
         match arr.(i) with
         | VRecord (type_name, _fields) as vrec -> (
             (* All [@@sarek.type] records have helpers - this should always succeed *)
-            match Sarek_type_helpers.lookup type_name with
-            | Some h ->
+            match
+              Sarek_type_helpers.lookup_typed
+                (Spoc_core.Vector.type_id (Spoc_core.Vector.kind vec))
+            with
+            | Some (module H) ->
                 (* Use generated helper for type-safe conversion *)
-                let native_record = h.from_value vrec in
+                let native_record = H.from_value vrec in
                 Spoc_core.Vector.set vec i native_record
             | None ->
                 Interp_error.raise_error
@@ -1348,16 +1358,154 @@ let array_to_vector : type a b. value array -> (a, b) Spoc_core.Vector.t -> unit
                      }))
         | _ -> () (* Skip other values *)
       done
-  | _ ->
-      (* Fallback for any other type (e.g., Char) *)
+  | Spoc_core.Vector.Scalar Spoc_core.Vector.Char ->
       for i = 0 to len - 1 do
-        Spoc_core.Vector.set vec i (Obj.magic (to_int32 arr.(i)))
+        Spoc_core.Vector.set
+          vec
+          i
+          (Char.chr (Int32.to_int (to_int32 arr.(i))))
       done
+  | Spoc_core.Vector.Scalar Spoc_core.Vector.Complex32 ->
+      Interp_error.raise_error
+        (Unsupported_operation
+           {
+             operation = "array_to_vector";
+             reason = "Complex32 vectors are not supported by the interpreter";
+           })
 
 (** Existential wrapper to track V2 Vector + its interpreter array for writeback
 *)
 type writeback =
   | Writeback : (('a, 'b) Spoc_core.Vector.t * value array) -> writeback
+
+type exec_writeback =
+  | Exec_writeback : (module Spoc_framework.Typed_value.EXEC_VECTOR) * value array -> exec_writeback
+
+let value_of_typed_value (tv : Spoc_framework.Typed_value.typed_value) : value =
+  match tv with
+  | TV_Scalar (SV ((module S), x)) -> (
+      match S.to_primitive x with
+      | PInt32 n -> VInt32 n
+      | PInt64 n -> VInt64 n
+      | PFloat f ->
+          if S.name = "float64" then VFloat64 f else VFloat32 f
+      | PBool b -> VBool b
+      | PBytes _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "value_of_typed_value"; reason = "PBytes scalar"}))
+  | TV_Composite (CV ((module C), _x)) ->
+      VRecord (C.name, [||])
+
+let typed_value_of_value (type a)
+    (module V : Spoc_framework.Typed_value.EXEC_VECTOR with type elt = a)
+    (v : value) : Spoc_framework.Typed_value.typed_value option =
+  match v with
+  | VInt32 n ->
+      Some
+        (TV_Scalar (SV ((module Spoc_framework.Typed_value.Int32_type), n)))
+  | VInt64 n ->
+      Some
+        (TV_Scalar (SV ((module Spoc_framework.Typed_value.Int64_type), n)))
+  | VFloat32 f ->
+      Some
+        (TV_Scalar (SV ((module Spoc_framework.Typed_value.Float32_type), f)))
+  | VFloat64 f ->
+      Some
+        (TV_Scalar (SV ((module Spoc_framework.Typed_value.Float64_type), f)))
+  | VBool b ->
+      Some (TV_Scalar (SV ((module Spoc_framework.Typed_value.Bool_type), b)))
+  | VUnit | VArray _ | VRecord _ | VVariant _ -> None
+
+let exec_vector_to_array (module V : Spoc_framework.Typed_value.EXEC_VECTOR) :
+    value array =
+  Array.init V.length (fun i ->
+      match Sarek_type_helpers.lookup_typed V.type_id with
+      | Some (module H) -> H.to_value (V.get_typed i)
+      | None -> value_of_typed_value (V.get i))
+
+let array_to_exec_vector
+    (module V : Spoc_framework.Typed_value.EXEC_VECTOR)
+    (arr : value array) : unit =
+  let len = min (Array.length arr) V.length in
+  for i = 0 to len - 1 do
+    match arr.(i) with
+    | VRecord _ as vrec -> (
+        match Sarek_type_helpers.lookup_typed V.type_id with
+        | Some (module H) -> V.set_typed i (H.from_value vrec)
+        | None -> ())
+    | scalar -> (
+        match typed_value_of_value (module V) scalar with
+        | Some tv -> V.set i tv
+        | None -> ())
+  done
+
+let args_from_exec_args (k : kernel)
+    (exec_args : Spoc_framework.Framework_sig.exec_arg list) :
+    (string * arg) list * exec_writeback list =
+  let writebacks = ref [] in
+  let idx = ref 0 in
+  let arg_at i = if i >= List.length exec_args then None else Some (List.nth exec_args i) in
+  let args =
+    List.filter_map
+      (fun decl ->
+        match decl with
+        | DParam (v, Some _arr_info) -> (
+            match arg_at !idx with
+            | None -> None
+            | Some karg -> (
+                incr idx ;
+                match karg with
+                | Spoc_framework.Framework_sig.EA_Vec vec ->
+                    let arr = exec_vector_to_array vec in
+                    writebacks := Exec_writeback (vec, arr) :: !writebacks ;
+                    Some (v.var_name, ArgArray arr)
+                | _ ->
+                    Interp_error.raise_error
+                      (Type_conversion_error
+                         {
+                           from_type = "scalar";
+                           to_type = "Vec";
+                           context = "param " ^ v.var_name;
+                         })))
+        | DParam (v, None) -> (
+            match arg_at !idx with
+            | None -> None
+            | Some karg ->
+                incr idx ;
+                let value =
+                  match karg with
+                  | Spoc_framework.Framework_sig.EA_Int32 n -> VInt32 n
+                  | Spoc_framework.Framework_sig.EA_Int64 n -> VInt64 n
+                  | Spoc_framework.Framework_sig.EA_Float32 f -> VFloat32 f
+                  | Spoc_framework.Framework_sig.EA_Float64 f -> VFloat64 f
+                  | Spoc_framework.Framework_sig.EA_Scalar ((module S), x) ->
+                      value_of_typed_value (TV_Scalar (SV ((module S), x)))
+                  | Spoc_framework.Framework_sig.EA_Composite ((module C), x) ->
+                      value_of_typed_value (TV_Composite (CV ((module C), x)))
+                  | Spoc_framework.Framework_sig.EA_Vec _ ->
+                      Interp_error.raise_error
+                        (Type_conversion_error
+                           {
+                             from_type = "non-scalar";
+                             to_type = "scalar";
+                             context = "param " ^ v.var_name;
+                           })
+                in
+                Some (v.var_name, ArgScalar value))
+        | DShared _ | DLocal _ -> None)
+      k.kern_params
+  in
+  (args, List.rev !writebacks)
+
+let run_kernel_with_exec_args (k : kernel) ~(block : int * int * int)
+    ~(grid : int * int * int)
+    (exec_args : Spoc_framework.Framework_sig.exec_arg list) : unit =
+  let args, writebacks = args_from_exec_args k exec_args in
+  run_kernel k ~block ~grid args ;
+  List.iter
+    (fun (Exec_writeback (vec, arr)) -> array_to_exec_vector vec arr)
+    writebacks
 
 (** Convert Kernel_arg.t list to interpreter args, tracking vectors for
     writeback *)

--- a/sarek/sarek/Sarek_ir_interp.ml
+++ b/sarek/sarek/Sarek_ir_interp.ml
@@ -1270,7 +1270,7 @@ let run_kernel (k : kernel) ~block:(bx, by, bz) ~grid:(gx, gy, gz)
 
 (** {1 V2 Vector Support}
 
-    These functions work with typed Kernel_arg.t values instead of Obj.t. This
+    These functions work with typed Kernel_arg.t values. This
     is the preferred interface for Native/Interpreter backends. *)
 
 (** Convert V2 Vector to interpreter value array. Uses the vector's element type

--- a/sarek/sarek/Sarek_ir_interp.ml
+++ b/sarek/sarek/Sarek_ir_interp.ml
@@ -695,8 +695,7 @@ and eval_composite_expr state env = function
       match eval_expr state env e with
       | VRecord (type_name, fields) as vrec -> (
           match Sarek_type_helpers.lookup type_name with
-          | Some h ->
-              h.get_field vrec field
+          | Some h -> h.get_field vrec field
           | None ->
               let field_infos = Sarek_registry.record_fields type_name in
               let rec find_idx i = function
@@ -1270,8 +1269,8 @@ let run_kernel (k : kernel) ~block:(bx, by, bz) ~grid:(gx, gy, gz)
 
 (** {1 V2 Vector Support}
 
-    These functions work with typed Kernel_arg.t values. This
-    is the preferred interface for Native/Interpreter backends. *)
+    These functions work with typed Kernel_arg.t values. This is the preferred
+    interface for Native/Interpreter backends. *)
 
 (** Convert V2 Vector to interpreter value array. Uses the vector's element type
     to create properly typed values. *)
@@ -1360,10 +1359,7 @@ let array_to_vector : type a b. value array -> (a, b) Spoc_core.Vector.t -> unit
       done
   | Spoc_core.Vector.Scalar Spoc_core.Vector.Char ->
       for i = 0 to len - 1 do
-        Spoc_core.Vector.set
-          vec
-          i
-          (Char.chr (Int32.to_int (to_int32 arr.(i))))
+        Spoc_core.Vector.set vec i (Char.chr (Int32.to_int (to_int32 arr.(i))))
       done
   | Spoc_core.Vector.Scalar Spoc_core.Vector.Complex32 ->
       Interp_error.raise_error
@@ -1379,7 +1375,9 @@ type writeback =
   | Writeback : (('a, 'b) Spoc_core.Vector.t * value array) -> writeback
 
 type exec_writeback =
-  | Exec_writeback : (module Spoc_framework.Typed_value.EXEC_VECTOR) * value array -> exec_writeback
+  | Exec_writeback :
+      (module Spoc_framework.Typed_value.EXEC_VECTOR) * value array
+      -> exec_writeback
 
 let value_of_typed_value (tv : Spoc_framework.Typed_value.typed_value) : value =
   match tv with
@@ -1387,26 +1385,22 @@ let value_of_typed_value (tv : Spoc_framework.Typed_value.typed_value) : value =
       match S.to_primitive x with
       | PInt32 n -> VInt32 n
       | PInt64 n -> VInt64 n
-      | PFloat f ->
-          if S.name = "float64" then VFloat64 f else VFloat32 f
+      | PFloat f -> if S.name = "float64" then VFloat64 f else VFloat32 f
       | PBool b -> VBool b
       | PBytes _ ->
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "value_of_typed_value"; reason = "PBytes scalar"}))
-  | TV_Composite (CV ((module C), _x)) ->
-      VRecord (C.name, [||])
+  | TV_Composite (CV ((module C), _x)) -> VRecord (C.name, [||])
 
 let typed_value_of_value (type a)
     (module V : Spoc_framework.Typed_value.EXEC_VECTOR with type elt = a)
     (v : value) : Spoc_framework.Typed_value.typed_value option =
   match v with
   | VInt32 n ->
-      Some
-        (TV_Scalar (SV ((module Spoc_framework.Typed_value.Int32_type), n)))
+      Some (TV_Scalar (SV ((module Spoc_framework.Typed_value.Int32_type), n)))
   | VInt64 n ->
-      Some
-        (TV_Scalar (SV ((module Spoc_framework.Typed_value.Int64_type), n)))
+      Some (TV_Scalar (SV ((module Spoc_framework.Typed_value.Int64_type), n)))
   | VFloat32 f ->
       Some
         (TV_Scalar (SV ((module Spoc_framework.Typed_value.Float32_type), f)))
@@ -1424,8 +1418,7 @@ let exec_vector_to_array (module V : Spoc_framework.Typed_value.EXEC_VECTOR) :
       | Some (module H) -> H.to_value (V.get_typed i)
       | None -> value_of_typed_value (V.get i))
 
-let array_to_exec_vector
-    (module V : Spoc_framework.Typed_value.EXEC_VECTOR)
+let array_to_exec_vector (module V : Spoc_framework.Typed_value.EXEC_VECTOR)
     (arr : value array) : unit =
   let len = min (Array.length arr) V.length in
   for i = 0 to len - 1 do
@@ -1445,7 +1438,9 @@ let args_from_exec_args (k : kernel)
     (string * arg) list * exec_writeback list =
   let writebacks = ref [] in
   let idx = ref 0 in
-  let arg_at i = if i >= List.length exec_args then None else Some (List.nth exec_args i) in
+  let arg_at i =
+    if i >= List.length exec_args then None else Some (List.nth exec_args i)
+  in
   let args =
     List.filter_map
       (fun decl ->

--- a/sarek/sarek/Sarek_type_helpers.ml
+++ b/sarek/sarek/Sarek_type_helpers.ml
@@ -73,12 +73,12 @@ let lookup_typed (type a) (type_id : a Sarek_ir_types.Type_id.t) :
         | Some _ -> acc
         | None -> (
             match helpers with
-            | AnyHelpers h ->
+            | AnyHelpers h -> (
                 let (module H) = h in
                 match Sarek_ir_types.Type_id.equal type_id H.type_id with
                 | Some Sarek_ir_types.Type_id.Refl ->
-                    Some ((module H : HELPERS with type t = a))
-                | None -> None))
+                    Some (module H : HELPERS with type t = a)
+                | None -> None)))
       registry
       None
   in

--- a/sarek/sarek/Sarek_type_helpers.ml
+++ b/sarek/sarek/Sarek_type_helpers.ml
@@ -16,6 +16,8 @@ open Sarek_value
 module type HELPERS = sig
   type t
 
+  val type_id : t Sarek_ir_types.Type_id.t
+
   val from_values : value array -> t
 
   val to_values : t -> value array
@@ -46,8 +48,6 @@ type helpers = {
   from_values : value array -> value;  (** Construct VRecord from field array *)
   to_values : value -> value array;  (** Deconstruct VRecord to field array *)
   get_field : value -> string -> value;  (** Field access from VRecord *)
-  to_value : 'a. 'a -> value;  (** Convert native record to VRecord *)
-  from_value : 'a. value -> 'a;  (** Convert VRecord to native record *)
 }
 
 (** Look up helpers for a type. Returns None if not registered. *)
@@ -62,9 +62,27 @@ let lookup (type_name : string) : helpers option =
           from_values = (fun arr -> H.to_value (H.from_values arr));
           to_values = (fun v -> H.to_values (H.from_value v));
           get_field = (fun v field -> H.get_field (H.from_value v) field);
-          to_value = (fun record -> H.to_value (Obj.obj (Obj.repr record)));
-          from_value = (fun v -> Obj.obj (Obj.repr (H.from_value v)));
         }
+
+let lookup_typed (type a) (type_id : a Sarek_ir_types.Type_id.t) :
+    (module HELPERS with type t = a) option =
+  let found =
+    Hashtbl.fold
+      (fun _ helpers acc ->
+        match acc with
+        | Some _ -> acc
+        | None -> (
+            match helpers with
+            | AnyHelpers h ->
+                let (module H) = h in
+                match Sarek_ir_types.Type_id.equal type_id H.type_id with
+                | Some Sarek_ir_types.Type_id.Refl ->
+                    Some ((module H : HELPERS with type t = a))
+                | None -> None))
+      registry
+      None
+  in
+  found
 
 (** Check if a type has registered helpers *)
 let has_helpers (type_name : string) : bool = Hashtbl.mem registry type_name

--- a/sarek/sarek/test/test_sarek_type_helpers.ml
+++ b/sarek/sarek/test/test_sarek_type_helpers.ml
@@ -13,6 +13,8 @@ open Sarek_type_helpers
 module Mock_point_helpers : HELPERS with type t = float * float = struct
   type t = float * float
 
+  let type_id = Sarek_ir_types.Type_id.create ()
+
   let from_values arr =
     match arr with
     | [| VFloat64 x; VFloat64 y |] -> (x, y)

--- a/sarek/tests/new_runtime/test_native_runtime.ml
+++ b/sarek/tests/new_runtime/test_native_runtime.ml
@@ -54,33 +54,35 @@ let transform_points_kirc =
           dst.(tid) <- {x = p.x +. 1.0; y = p.y *. 2.0}]
 
 (* A simple kernel function that adds vectors: c[i] = a[i] + b[i] *)
+let get_float32_arg args arg_idx elem_idx =
+  let open Spoc_framework.Framework_sig in
+  match args.(arg_idx) with
+  | EA_Vec (module V) -> (
+      match V.get elem_idx with
+      | Spoc_framework.Typed_value.TV_Scalar
+          (Spoc_framework.Typed_value.SV ((module S), x)) -> (
+          match S.to_primitive x with
+          | Spoc_framework.Typed_value.PFloat f when S.name = "float32" -> f
+          | Spoc_framework.Typed_value.PFloat _ ->
+              failwith "Expected float32 scalar, got non-float32 float"
+          | _ -> failwith "Expected float32 scalar")
+      | _ -> failwith "Expected scalar vector element")
+  | _ -> failwith (Printf.sprintf "Expected vector for arg %d" arg_idx)
+
+let set_float32_arg args arg_idx elem_idx value =
+  let open Spoc_framework.Framework_sig in
+  match args.(arg_idx) with
+  | EA_Vec (module V) ->
+      V.set
+        elem_idx
+        (Spoc_framework.Typed_value.TV_Scalar
+           (Spoc_framework.Typed_value.SV
+              ((module Spoc_framework.Typed_value.Float32_type), value)))
+  | _ -> failwith (Printf.sprintf "Expected vector for arg %d" arg_idx)
+
 let vector_add_kernel args (gx, _gy, _gz) (bx, _by, _bz) =
   (* Extract arguments from exec_arg array *)
   let open Spoc_framework.Framework_sig in
-  let a =
-    match args.(0) with
-    | EA_Vec (module V) ->
-        let vec = Obj.obj (V.internal_get_vector_obj ()) in
-        (vec
-          : (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Array1.t)
-    | _ -> failwith "Expected vector for arg 0"
-  in
-  let b =
-    match args.(1) with
-    | EA_Vec (module V) ->
-        let vec = Obj.obj (V.internal_get_vector_obj ()) in
-        (vec
-          : (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Array1.t)
-    | _ -> failwith "Expected vector for arg 1"
-  in
-  let c =
-    match args.(2) with
-    | EA_Vec (module V) ->
-        let vec = Obj.obj (V.internal_get_vector_obj ()) in
-        (vec
-          : (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Array1.t)
-    | _ -> failwith "Expected vector for arg 2"
-  in
   let n =
     match args.(3) with
     | EA_Int32 n -> Int32.to_int n
@@ -91,10 +93,11 @@ let vector_add_kernel args (gx, _gy, _gz) (bx, _by, _bz) =
   let total_threads = gx * bx in
   for tid = 0 to total_threads - 1 do
     if tid < n then
-      Bigarray.Array1.set
-        c
+      set_float32_arg
+        args
+        2
         tid
-        (Bigarray.Array1.get a tid +. Bigarray.Array1.get b tid)
+        (get_float32_arg args 0 tid +. get_float32_arg args 1 tid)
   done
 
 (* Register the kernel *)

--- a/sarek/tests/unit/test_cpu_runtime.ml
+++ b/sarek/tests/unit/test_cpu_runtime.ml
@@ -310,15 +310,44 @@ let test_alloc_shared_multiple () =
 (** Test generic allocator for custom type *)
 type custom_record = {x : int; y : float}
 
+let custom_record_key : custom_record Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+type other_record = {z : int32} [@@warning "-69"]
+
+let other_record_key : other_record Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
 let test_alloc_shared_custom () =
   let shared = create_shared () in
   let default = {x = 0; y = 0.0} in
-  let arr = alloc_shared shared "custom" 4 default in
+  let arr = alloc_shared_with_key shared custom_record_key "custom" 4 default in
   check int "array length" 4 (Array.length arr) ;
   check int "default x" 0 arr.(0).x ;
   arr.(2) <- {x = 42; y = 3.14} ;
   check int "custom x" 42 arr.(2).x ;
   check (float 0.0001) "custom y" 3.14 arr.(2).y
+
+let test_alloc_shared_custom_reuse () =
+  let shared = create_shared () in
+  let default = {x = 0; y = 0.0} in
+  let arr1 = alloc_shared_with_key shared custom_record_key "custom" 4 default in
+  arr1.(1) <- {x = 7; y = 2.5} ;
+  let arr2 = alloc_shared_with_key shared custom_record_key "custom" 4 default in
+  check int "reused custom x" 7 arr2.(1).x ;
+  check (float 0.0001) "reused custom y" 2.5 arr2.(1).y
+
+let test_alloc_shared_custom_type_mismatch () =
+  let shared = create_shared () in
+  let _ =
+    alloc_shared_with_key shared custom_record_key "custom" 4 {x = 0; y = 0.0}
+  in
+  check_raises
+    "same shared name with different custom type"
+    (Invalid_argument "alloc_shared: type mismatch for custom")
+    (fun () ->
+      ignore
+        (alloc_shared_with_key shared other_record_key "custom" 4 {z = 0l}))
 
 (** Test shared memory isolation between blocks *)
 let test_shared_memory_isolation () =
@@ -555,6 +584,8 @@ let shared_memory_tests =
     ("reuse array", `Quick, test_alloc_shared_reuse);
     ("multiple arrays", `Quick, test_alloc_shared_multiple);
     ("custom type", `Quick, test_alloc_shared_custom);
+    ("custom reuse", `Quick, test_alloc_shared_custom_reuse);
+    ("custom mismatch", `Quick, test_alloc_shared_custom_type_mismatch);
     ("isolation", `Quick, test_shared_memory_isolation);
   ]
 

--- a/sarek/tests/unit/test_cpu_runtime.ml
+++ b/sarek/tests/unit/test_cpu_runtime.ml
@@ -331,9 +331,13 @@ let test_alloc_shared_custom () =
 let test_alloc_shared_custom_reuse () =
   let shared = create_shared () in
   let default = {x = 0; y = 0.0} in
-  let arr1 = alloc_shared_with_key shared custom_record_key "custom" 4 default in
+  let arr1 =
+    alloc_shared_with_key shared custom_record_key "custom" 4 default
+  in
   arr1.(1) <- {x = 7; y = 2.5} ;
-  let arr2 = alloc_shared_with_key shared custom_record_key "custom" 4 default in
+  let arr2 =
+    alloc_shared_with_key shared custom_record_key "custom" 4 default
+  in
   check int "reused custom x" 7 arr2.(1).x ;
   check (float 0.0001) "reused custom y" 2.5 arr2.(1).y
 
@@ -346,8 +350,7 @@ let test_alloc_shared_custom_type_mismatch () =
     "same shared name with different custom type"
     (Invalid_argument "alloc_shared: type mismatch for custom")
     (fun () ->
-      ignore
-        (alloc_shared_with_key shared other_record_key "custom" 4 {z = 0l}))
+      ignore (alloc_shared_with_key shared other_record_key "custom" 4 {z = 0l}))
 
 (** Test shared memory isolation between blocks *)
 let test_shared_memory_isolation () =

--- a/sarek/tests/unit/test_execute.ml
+++ b/sarek/tests/unit/test_execute.ml
@@ -10,6 +10,36 @@ open Spoc_core
 open Spoc_framework
 open Alcotest
 
+type point = {x : float; y : float}
+
+let point_type_id : point Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let point_vector_type_id : (point, unit) Vector.t Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let point_custom : point Vector.custom_type =
+  let get ptr i =
+    let off = i * 8 in
+    {
+      x = Vector.Custom_helpers.read_float32 ptr off;
+      y = Vector.Custom_helpers.read_float32 ptr (off + 4);
+    }
+  in
+  let set ptr i p =
+    let off = i * 8 in
+    Vector.Custom_helpers.write_float32 ptr off p.x ;
+    Vector.Custom_helpers.write_float32 ptr (off + 4) p.y
+  in
+  {
+    elem_size = 8;
+    type_id = point_type_id;
+    vector_type_id = point_vector_type_id;
+    get;
+    set;
+    name = "point";
+  }
+
 (** {1 Tests for vector argument types} *)
 
 let test_vec_arg_int () =
@@ -103,6 +133,24 @@ let test_multiple_args () =
   let args = [Vec v1; Int 42; Vec v2; Float32 3.14] in
   check int "arg list length" 4 (List.length args)
 
+let test_custom_exec_vector_get_set () =
+  let v = Vector.create_custom point_custom 2 in
+  Vector.set v 0 {x = 1.5; y = 2.5} ;
+  Vector.set v 1 {x = 0.0; y = 0.0} ;
+  match vector_args_to_exec_array [Vec v] with
+  | [|Framework_sig.EA_Vec (module V)|] -> (
+      match V.get 0 with
+      | Typed_value.TV_Composite (Typed_value.CV ((module C), p)) ->
+          check string "custom type name" "point" C.name ;
+          check int "custom byte size" 8 C.size ;
+          check int "serialized length" 8 (Bytes.length (C.to_bytes p)) ;
+          V.set 1 (Typed_value.TV_Composite (Typed_value.CV ((module C), p))) ;
+          let got = Vector.get v 1 in
+          check (float 0.001) "custom set x" 1.5 got.x ;
+          check (float 0.001) "custom set y" 2.5 got.y
+      | _ -> fail "expected composite typed value")
+  | _ -> fail "expected single exec vector"
+
 (** {1 Test suite} *)
 
 let () =
@@ -138,5 +186,9 @@ let () =
         [
           test_case "vec_wrapper" `Quick test_vec_wrapper;
           test_case "multiple_args" `Quick test_multiple_args;
+          test_case
+            "custom_exec_vector_get_set"
+            `Quick
+            test_custom_exec_vector_get_set;
         ] );
     ]

--- a/sarek/tests/unit/test_kirc_kernel.ml
+++ b/sarek/tests/unit/test_kirc_kernel.ml
@@ -53,6 +53,103 @@ let test_native_function_args () =
   fn ~block:(Framework_sig.dims_1d 1) ~grid:(Framework_sig.dims_1d 1) dummy_args ;
   check int "args passed" 2 !arg_count
 
+(** {1 Tests for exec_arg conversion} *)
+
+let int64_exec_vector value =
+  let stored = ref value in
+  let module V :
+    Typed_value.EXEC_VECTOR with type elt = int64 and type underlying = unit =
+  struct
+    type elt = int64
+
+    type underlying = unit
+
+    let length = 1
+
+    let type_name = "int64"
+
+    let elem_size = 8
+
+    let get _ =
+      Typed_value.TV_Scalar
+        (Typed_value.SV ((module Typed_value.Int64_type), !stored))
+
+    let set _ = function
+      | Typed_value.TV_Scalar (Typed_value.SV ((module S), x)) -> (
+          match S.to_primitive x with
+          | Typed_value.PInt64 n -> stored := n
+          | _ -> failwith "expected int64")
+      | _ -> failwith "expected scalar"
+
+    let get_typed _ = !stored
+
+    let set_typed _ x = stored := x
+
+    let type_id = Sarek_ir_types.Type_id.create ()
+
+    let underlying_type_id = Sarek_ir_types.Type_id.create ()
+
+    let underlying = ()
+
+    let device_ptr () = Nativeint.zero
+  end in
+  Framework_sig.EA_Vec (module V)
+
+let float32_exec_vector value =
+  let stored = ref value in
+  let module V :
+    Typed_value.EXEC_VECTOR with type elt = float and type underlying = unit =
+  struct
+    type elt = float
+
+    type underlying = unit
+
+    let length = 1
+
+    let type_name = "float32"
+
+    let elem_size = 4
+
+    let get _ =
+      Typed_value.TV_Scalar
+        (Typed_value.SV ((module Typed_value.Float32_type), !stored))
+
+    let set _ = function
+      | Typed_value.TV_Scalar (Typed_value.SV ((module S), x)) -> (
+          match S.to_primitive x with
+          | Typed_value.PFloat f -> stored := f
+          | _ -> failwith "expected float")
+      | _ -> failwith "expected scalar"
+
+    let get_typed _ = !stored
+
+    let set_typed _ x = stored := x
+
+    let type_id = Sarek_ir_types.Type_id.create ()
+
+    let underlying_type_id = Sarek_ir_types.Type_id.create ()
+
+    let underlying = ()
+
+    let device_ptr () = Nativeint.zero
+  end in
+  Framework_sig.EA_Vec (module V)
+
+let test_exec_vector_numeric_conversions () =
+  (match exec_arg_to_native_arg (int64_exec_vector 42L) with
+  | Sarek_ir_types.NA_Vec (Sarek_ir_types.NV v) ->
+      check (float 0.001) "int64 to f32" 42.0 (v.get_f32 0) ;
+      check (float 0.001) "int64 to f64" 42.0 (v.get_f64 0) ;
+      check int32 "int64 to i32" 42l (v.get_i32 0) ;
+      check int64 "int64 to i64" 42L (v.get_i64 0)
+  | _ -> fail "expected native vector") ;
+  match exec_arg_to_native_arg (float32_exec_vector 42.75) with
+  | Sarek_ir_types.NA_Vec (Sarek_ir_types.NV v) ->
+      check int32 "float to i32" 42l (v.get_i32 0) ;
+      check int64 "float to i64" 42L (v.get_i64 0) ;
+      check (float 0.001) "float to f64" 42.75 (v.get_f64 0)
+  | _ -> fail "expected native vector"
+
 (** {1 Test suite} *)
 
 let () =
@@ -70,5 +167,12 @@ let () =
         [
           test_case "call_native" `Quick test_native_function_call;
           test_case "pass_args" `Quick test_native_function_args;
+        ] );
+      ( "exec_arg_conversion",
+        [
+          test_case
+            "numeric vector conversions"
+            `Quick
+            test_exec_vector_numeric_conversions;
         ] );
     ]

--- a/sarek/tests/unit/test_parse.ml
+++ b/sarek/tests/unit/test_parse.ml
@@ -380,6 +380,19 @@ let test_parse_kernel_two_params () =
   | EUnit -> Alcotest.(check pass) "body is EUnit" () ()
   | _ -> Alcotest.fail "body should be EUnit"
 
+let test_parse_kernel_shared_body () =
+  let kernel_expr =
+    Ppxlib.Parse.expression
+      (Lexing.from_string
+         "fun (input : float32 vector) -> let%shared (tile : float32) = () in \
+          ()")
+  in
+  let kernel = parse_kernel_function kernel_expr in
+  match kernel.kern_body.e with
+  | ELetShared ("tile", TEConstr ("float32", []), None, {e = EUnit; _}) ->
+      Alcotest.(check pass) "shared body preserved" () ()
+  | _ -> Alcotest.fail "body should be ELetShared"
+
 let test_parse_kernel_no_annotation () =
   let loc = Location.none in
   let open Ppxlib.Ast_builder.Default in
@@ -496,6 +509,22 @@ let test_parse_expr_let () =
       Alcotest.(check pass) "let x = 42 in x parses" () ()
   | _ -> Alcotest.fail "let should parse correctly"
 
+let test_parse_expr_lambda_rejected () =
+  let loc = Location.none in
+  let open Ppxlib.Ast_builder.Default in
+  let param =
+    ppat_constraint
+      ~loc
+      (ppat_var ~loc {txt = "x"; loc})
+      (ptyp_constr ~loc {txt = Lident "int32"; loc} [])
+  in
+  let expr = pexp_fun ~loc Nolabel None param (evar ~loc "x") in
+  try
+    ignore (parse_expression expr) ;
+    Alcotest.fail "standalone lambda should be rejected"
+  with Parse_error_exn (msg, _) ->
+    Alcotest.(check bool) "has useful error message" true (String.length msg > 0)
+
 (* Test suite *)
 let () =
   Alcotest.run
@@ -532,6 +561,7 @@ let () =
         [
           Alcotest.test_case "simple" `Quick test_parse_kernel_simple;
           Alcotest.test_case "two params" `Quick test_parse_kernel_two_params;
+          Alcotest.test_case "shared body" `Quick test_parse_kernel_shared_body;
           Alcotest.test_case
             "no annotation"
             `Quick
@@ -560,5 +590,9 @@ let () =
           Alcotest.test_case "binop" `Quick test_parse_expr_binop;
           Alcotest.test_case "if" `Quick test_parse_expr_if;
           Alcotest.test_case "let" `Quick test_parse_expr_let;
+          Alcotest.test_case
+            "lambda rejected"
+            `Quick
+            test_parse_expr_lambda_rejected;
         ] );
     ]

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -78,7 +78,7 @@ type source_lang =
 
 (** Extensible type for backend-specific kernel arguments. Each backend extends
     this type with its own variant. This allows type-safe passing of kernel args
-    across the framework boundary without Obj.t. *)
+    across the framework boundary with typed witnesses. *)
 type kargs = ..
 
 (** Placeholder kargs for testing - not associated with any backend *)
@@ -301,7 +301,7 @@ module type BACKEND = sig
       @param ir Sarek IR kernel (for interpretation)
       @param block Block dimensions
       @param grid Grid dimensions
-      @param args Kernel arguments - fully typed, no Obj.t *)
+      @param args Kernel arguments - fully typed *)
   val execute_direct :
     native_fn:(block:dims -> grid:dims -> exec_arg array -> unit) option ->
     ir:Sarek_ir_types.kernel option ->

--- a/spoc/framework/Typed_value.ml
+++ b/spoc/framework/Typed_value.ml
@@ -106,6 +106,10 @@ type typed_value = TV_Scalar of scalar_value | TV_Composite of composite_value
     contents without depending on the full Vector module. *)
 
 module type EXEC_VECTOR = sig
+  type elt
+
+  type underlying
+
   (** Number of elements *)
   val length : int
 
@@ -118,16 +122,23 @@ module type EXEC_VECTOR = sig
   (** Set element from typed_value *)
   val set : int -> typed_value -> unit
 
+  (** Type-preserving element access for direct backends. *)
+  val get_typed : int -> elt
+
+  val set_typed : int -> elt -> unit
+
+  (** Runtime identity for element and underlying vector/buffer types. *)
+  val type_id : elt Sarek_ir_types.Type_id.t
+
+  val underlying_type_id : underlying Sarek_ir_types.Type_id.t
+
+  val underlying : underlying
+
   (** Get raw device pointer (for kernel binding) *)
   val device_ptr : unit -> nativeint
 
   (** Element size in bytes *)
   val elem_size : int
-
-  (** INTERNAL: Get underlying vector as Obj.t. Only for use by interpreter
-      backend which needs access to the typed Vector.t. This is marked internal
-      to discourage general use - prefer the typed get/set interface. *)
-  val internal_get_vector_obj : unit -> Obj.t
 end
 
 (** {1 Execution Arguments}

--- a/spoc/framework/Typed_value.ml
+++ b/spoc/framework/Typed_value.ml
@@ -6,7 +6,7 @@
 (******************************************************************************
  * Typed_value - Extensible typed value system
  *
- * Provides type-safe value representation without Obj.t for:
+ * Provides type-safe value representation for:
  * - Kernel argument passing (execute_direct)
  * - Interpreter value storage
  * - Vector element access
@@ -143,7 +143,7 @@ end
 
 (** {1 Execution Arguments}
 
-    Type-safe kernel arguments for execute_direct. No Obj.t - fully typed. *)
+    Type-safe kernel arguments for execute_direct. *)
 
 type exec_arg =
   | EA_Int32 of int32

--- a/spoc/ir/Sarek_ir_types.ml
+++ b/spoc/ir/Sarek_ir_types.ml
@@ -10,8 +10,8 @@
 
 (** Runtime type identities with equality proofs.
 
-    This uses generative extensible GADT constructors, so equality can be checked
-    without unsafe casts. *)
+    This uses generative extensible GADT constructors, so equality can be
+    checked without unsafe casts. *)
 module Type_id = struct
   type _ witness = ..
 
@@ -181,8 +181,7 @@ and helper_func = {
 }
 
 (** Native argument type for kernel execution. Typed arguments with runtime type
-    witnesses -
-    used by PPX-generated native functions. *)
+    witnesses - used by PPX-generated native functions. *)
 and native_arg =
   | NA_Int32 of int32
   | NA_Int64 of int64
@@ -190,27 +189,26 @@ and native_arg =
   | NA_Float64 of float
   | NA_Vec of native_vec
 
-and native_vec =
-  | NV : ('elt, 'underlying) native_vec_ops -> native_vec
+and native_vec = NV : ('elt, 'underlying) native_vec_ops -> native_vec
 
 and ('elt, 'underlying) native_vec_ops = {
-      length : int;
-      elem_size : int;
-      type_name : string;
-      type_id : 'elt Type_id.t;
-      get_f32 : int -> float;
-      set_f32 : int -> float -> unit;
-      get_f64 : int -> float;
-      set_f64 : int -> float -> unit;
-      get_i32 : int -> int32;
-      set_i32 : int -> int32 -> unit;
-      get_i64 : int -> int64;
-      set_i64 : int -> int64 -> unit;
-      get_typed : int -> 'elt;
-      set_typed : int -> 'elt -> unit;
-      underlying_type_id : 'underlying Type_id.t;
-      underlying : 'underlying;
-    }
+  length : int;
+  elem_size : int;
+  type_name : string;
+  type_id : 'elt Type_id.t;
+  get_f32 : int -> float;
+  set_f32 : int -> float -> unit;
+  get_f64 : int -> float;
+  set_f64 : int -> float -> unit;
+  get_i32 : int -> int32;
+  set_i32 : int -> int32 -> unit;
+  get_i64 : int -> int64;
+  set_i64 : int -> int64 -> unit;
+  get_typed : int -> 'elt;
+  set_typed : int -> 'elt -> unit;
+  underlying_type_id : 'underlying Type_id.t;
+  underlying : 'underlying;
+}
 
 and ocaml_closure = {
   run :

--- a/spoc/ir/Sarek_ir_types.ml
+++ b/spoc/ir/Sarek_ir_types.ml
@@ -180,7 +180,8 @@ and helper_func = {
   hf_body : stmt;
 }
 
-(** Native argument type for kernel execution. Typed arguments without Obj.t -
+(** Native argument type for kernel execution. Typed arguments with runtime type
+    witnesses -
     used by PPX-generated native functions. *)
 and native_arg =
   | NA_Int32 of int32

--- a/spoc/ir/Sarek_ir_types.ml
+++ b/spoc/ir/Sarek_ir_types.ml
@@ -8,6 +8,37 @@
     This module contains only type definitions with no external dependencies.
     Used by spoc_framework for typed generate_source signature. *)
 
+(** Runtime type identities with equality proofs.
+
+    This uses generative extensible GADT constructors, so equality can be checked
+    without unsafe casts. *)
+module Type_id = struct
+  type _ witness = ..
+
+  module type ID = sig
+    type t
+
+    type _ witness += Id : t witness
+  end
+
+  type 'a t = (module ID with type t = 'a)
+
+  type (_, _) eq = Refl : ('a, 'a) eq
+
+  let create (type a) () : a t =
+    let module M = struct
+      type t = a
+
+      type _ witness += Id : t witness
+    end in
+    (module M)
+
+  let equal (type a b) (id_a : a t) (id_b : b t) : (a, b) eq option =
+    let module A = (val id_a : ID with type t = a) in
+    let module B = (val id_b : ID with type t = b) in
+    match A.Id with B.Id -> Some Refl | _ -> None
+end
+
 (** Memory spaces *)
 type memspace = Global | Shared | Local
 
@@ -156,10 +187,16 @@ and native_arg =
   | NA_Int64 of int64
   | NA_Float32 of float
   | NA_Float64 of float
-  | NA_Vec of {
+  | NA_Vec of native_vec
+
+and native_vec =
+  | NV : ('elt, 'underlying) native_vec_ops -> native_vec
+
+and ('elt, 'underlying) native_vec_ops = {
       length : int;
       elem_size : int;
       type_name : string;
+      type_id : 'elt Type_id.t;
       get_f32 : int -> float;
       set_f32 : int -> float -> unit;
       get_f64 : int -> float;
@@ -168,12 +205,10 @@ and native_arg =
       set_i32 : int -> int32 -> unit;
       get_i64 : int -> int64;
       set_i64 : int -> int64 -> unit;
-      (* For custom types (records/variants): type-erased access.
-         Internal use only - callers should use vec_get_custom/vec_set_custom. *)
-      get_any : int -> Obj.t;
-      set_any : int -> Obj.t -> unit;
-      (* Get underlying Vector.t for passing to functions/intrinsics *)
-      get_vec : unit -> Obj.t;
+      get_typed : int -> 'elt;
+      set_typed : int -> 'elt -> unit;
+      underlying_type_id : 'underlying Type_id.t;
+      underlying : 'underlying;
     }
 
 and ocaml_closure = {
@@ -181,40 +216,43 @@ and ocaml_closure = {
     block:int * int * int -> grid:int * int * int -> native_arg array -> unit;
 }
 
-(** {2 Typed Helpers for Custom Types}
+(** {2 Typed Helpers for Custom Types} *)
 
-    These functions encapsulate the Obj operations so that PPX-generated code
-    doesn't need to use Obj directly. The type parameter is inferred from
-    context. *)
-
-(** Get element from NA_Vec as custom type. Type is inferred from usage. *)
-let vec_get_custom : type a. native_arg -> int -> a =
- fun arg i ->
+(** Get element from NA_Vec as a type checked custom value. *)
+let vec_get_custom : type a. a Type_id.t -> native_arg -> int -> a =
+ fun type_id arg i ->
   match arg with
-  | NA_Vec v -> Obj.magic (v.get_any i)
+  | NA_Vec (NV v) -> (
+      match Type_id.equal type_id v.type_id with
+      | Some Type_id.Refl -> v.get_typed i
+      | None -> failwith "vec_get_custom: vector element type mismatch")
   | _ -> failwith "vec_get_custom: expected NA_Vec"
 
-(** Set element in NA_Vec from custom type. Type is inferred from usage. *)
-let vec_set_custom : type a. native_arg -> int -> a -> unit =
- fun arg i x ->
+(** Set element in NA_Vec from a type checked custom value. *)
+let vec_set_custom : type a. a Type_id.t -> native_arg -> int -> a -> unit =
+ fun type_id arg i x ->
   match arg with
-  | NA_Vec v -> v.set_any i (Obj.magic x)
+  | NA_Vec (NV v) -> (
+      match Type_id.equal type_id v.type_id with
+      | Some Type_id.Refl -> v.set_typed i x
+      | None -> failwith "vec_set_custom: vector element type mismatch")
   | _ -> failwith "vec_set_custom: expected NA_Vec"
 
 (** Get length from NA_Vec *)
 let vec_length : native_arg -> int =
  fun arg ->
   match arg with
-  | NA_Vec v -> v.length
+  | NA_Vec (NV v) -> v.length
   | _ -> failwith "vec_length: expected NA_Vec"
 
-(** Get underlying vector. Used when passing vectors to functions/intrinsics
-    that need the actual Vector.t type. Returns type-erased value that the
-    caller casts to the appropriate Vector.t type. *)
-let vec_as_vector : type a. native_arg -> a =
- fun arg ->
+(** Get the checked underlying vector/buffer value. *)
+let vec_as_vector : type a. a Type_id.t -> native_arg -> a =
+ fun type_id arg ->
   match arg with
-  | NA_Vec v -> Obj.magic (v.get_vec ())
+  | NA_Vec (NV v) -> (
+      match Type_id.equal type_id v.underlying_type_id with
+      | Some Type_id.Refl -> v.underlying
+      | None -> failwith "vec_as_vector: underlying type mismatch")
   | _ -> failwith "vec_as_vector: expected NA_Vec"
 
 (** Native function type for V2 execution. Uses typed native_arg. *)

--- a/spoc/ir/test/test_sarek_ir_types.ml
+++ b/spoc/ir/test/test_sarek_ir_types.ml
@@ -419,10 +419,12 @@ let test_vec_length () =
      no-op implementations for unused fields. *)
   let na =
     NA_Vec
+      (NV
       {
         length = 1024;
         elem_size = 4;
         type_name = "float32";
+        type_id = Type_id.create ();
         get_f32 = (fun _ -> 0.0);
         set_f32 = (fun _ _ -> ());
         get_f64 = (fun _ -> 0.0);
@@ -431,13 +433,11 @@ let test_vec_length () =
         set_i32 = (fun _ _ -> ());
         get_i64 = (fun _ -> 0L);
         set_i64 = (fun _ _ -> ());
-        get_any =
-          (fun _ -> failwith "get_any should not be called in this test");
-        set_any =
-          (fun _ _ -> failwith "set_any should not be called in this test");
-        get_vec =
-          (fun () -> failwith "get_vec should not be called in this test");
-      }
+        get_typed = (fun _ -> 0.0);
+        set_typed = (fun _ _ -> ());
+        underlying_type_id = Type_id.create ();
+        underlying = ();
+      })
   in
   let len = vec_length na in
   assert (len = 1024) ;

--- a/spoc/ir/test/test_sarek_ir_types.ml
+++ b/spoc/ir/test/test_sarek_ir_types.ml
@@ -420,24 +420,24 @@ let test_vec_length () =
   let na =
     NA_Vec
       (NV
-      {
-        length = 1024;
-        elem_size = 4;
-        type_name = "float32";
-        type_id = Type_id.create ();
-        get_f32 = (fun _ -> 0.0);
-        set_f32 = (fun _ _ -> ());
-        get_f64 = (fun _ -> 0.0);
-        set_f64 = (fun _ _ -> ());
-        get_i32 = (fun _ -> 0l);
-        set_i32 = (fun _ _ -> ());
-        get_i64 = (fun _ -> 0L);
-        set_i64 = (fun _ _ -> ());
-        get_typed = (fun _ -> 0.0);
-        set_typed = (fun _ _ -> ());
-        underlying_type_id = Type_id.create ();
-        underlying = ();
-      })
+         {
+           length = 1024;
+           elem_size = 4;
+           type_name = "float32";
+           type_id = Type_id.create ();
+           get_f32 = (fun _ -> 0.0);
+           set_f32 = (fun _ _ -> ());
+           get_f64 = (fun _ -> 0.0);
+           set_f64 = (fun _ _ -> ());
+           get_i32 = (fun _ -> 0l);
+           set_i32 = (fun _ _ -> ());
+           get_i64 = (fun _ -> 0L);
+           set_i64 = (fun _ _ -> ());
+           get_typed = (fun _ -> 0.0);
+           set_typed = (fun _ _ -> ());
+           underlying_type_id = Type_id.create ();
+           underlying = ();
+         })
   in
   let len = vec_length na in
   assert (len = 1024) ;


### PR DESCRIPTION
## Summary

- remove first-party `Obj` execution escape hatches from Sarek/SPOC native, interpreter, shared-memory, and helper-registry paths
- replace raw runtime casts with typed witnesses, typed existentials, typed Bigarray copies, and checked custom helper lookup
- add KB audit notes under `kb/obj-usage-audit/` and document the breaking change
- fix PPX edge cases exposed by the typed descriptor path and current ppxlib AST

## Verification

- `rg -n "Obj\.(magic|repr|obj)|Obj\.t|\bObj\b|internal_get_vector_obj|shared_key|custom_key|get_any|set_any" -S --glob '*.ml' --glob '*.mli' spoc sarek sarek-cuda sarek-opencl sarek-vulkan sarek-metal benchmarks tools scripts`
- `dune build @fmt`
- `dune build @spoc/runtest @sarek/sarek/runtest @sarek/core/test/runtest @sarek/plugins/native/runtest @sarek/plugins/interpreter/runtest @sarek/tests/runtest`
- `dune exec sarek/tests/new_runtime/test_native_runtime.exe`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Native direct execution and kernel registration now use typed execution-argument arrays; legacy untyped object-array escape hatches removed.

* **Bug Fixes & Improvements**
  * Vector, buffer and custom-value interactions use runtime type witnesses and typed accessors; mismatches now produce explicit errors.
  * Shared-memory allocations are keyed by runtime type identity to prevent accidental reuse.

* **Documentation**
  * Added audit docs describing the new typed boundaries and conversion policies.

* **Tests**
  * New/updated tests cover typed vectors, shared-memory reuse/mismatch, and conversion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->