### PR TITLE
fix: resolve pre-existing bugs surfaced by review of #140 (concurrency, Vulkan, interpreter)

### DIFF
--- a/sarek-vulkan/Vulkan_api_base.ml
+++ b/sarek-vulkan/Vulkan_api_base.ml
@@ -50,10 +50,10 @@ let compile_glsl_to_spirv_cli ~(entry_point : string) (glsl_source : string) :
   (* Compile with glslangValidator *)
   (* NOTE: Don't use --target-env vulkan1.1 - it changes storage classes from
      Uniform to StorageBuffer which may cause issues with some drivers *)
-  let _entry_point = entry_point in
   let cmd =
     Printf.sprintf
-      "glslangValidator -V -S comp -o %s %s 2>&1"
+      "glslangValidator -V -S comp -e %s -o %s %s 2>&1"
+      entry_point
       spirv_file
       glsl_file
   in

--- a/sarek-vulkan/Vulkan_api_device.ml
+++ b/sarek-vulkan/Vulkan_api_device.ml
@@ -309,5 +309,6 @@ let set_current _dev = ()
 let synchronize dev = check "vkDeviceWaitIdle" (vkDeviceWaitIdle dev.device)
 
 let destroy dev =
+  Hashtbl.remove device_cache dev.id ;
   vkDestroyCommandPool dev.device dev.command_pool null ;
   vkDestroyDevice dev.device null

--- a/sarek-vulkan/Vulkan_api_kernel.ml
+++ b/sarek-vulkan/Vulkan_api_kernel.ml
@@ -366,24 +366,44 @@ let ensure_push_constants args =
 let set_arg_int32 args _idx n =
   let pc = ensure_push_constants args in
   let offset = args.push_constant_offset in
+  if offset + 4 > 128 then
+    Vulkan_error.raise_error
+      (Vulkan_error.context_error
+         "push constant"
+         "push constant block overflow: exceeded 128-byte limit") ;
   Bytes.set_int32_le pc offset n ;
   args.push_constant_offset <- offset + 4
 
 let set_arg_int64 args _idx n =
   let pc = ensure_push_constants args in
   let offset = args.push_constant_offset in
+  if offset + 8 > 128 then
+    Vulkan_error.raise_error
+      (Vulkan_error.context_error
+         "push constant"
+         "push constant block overflow: exceeded 128-byte limit") ;
   Bytes.set_int64_le pc offset n ;
   args.push_constant_offset <- offset + 8
 
 let set_arg_float32 args _idx f =
   let pc = ensure_push_constants args in
   let offset = args.push_constant_offset in
+  if offset + 4 > 128 then
+    Vulkan_error.raise_error
+      (Vulkan_error.context_error
+         "push constant"
+         "push constant block overflow: exceeded 128-byte limit") ;
   Bytes.set_int32_le pc offset (Int32.bits_of_float f) ;
   args.push_constant_offset <- offset + 4
 
 let set_arg_float64 args _idx f =
   let pc = ensure_push_constants args in
   let offset = args.push_constant_offset in
+  if offset + 8 > 128 then
+    Vulkan_error.raise_error
+      (Vulkan_error.context_error
+         "push constant"
+         "push constant block overflow: exceeded 128-byte limit") ;
   Bytes.set_int64_le pc offset (Int64.bits_of_float f) ;
   args.push_constant_offset <- offset + 8
 

--- a/sarek-vulkan/Vulkan_api_memory.ml
+++ b/sarek-vulkan/Vulkan_api_memory.ml
@@ -260,48 +260,61 @@ let alloc device size kind =
                      "Failed to find suitable memory type")))
   in
 
-  (* Allocate memory *)
-  let alloc_info = make vk_memory_allocate_info in
-  setf alloc_info mem_alloc_sType (u32 vk_structure_type_memory_allocate_info) ;
-  setf alloc_info mem_alloc_pNext null ;
-  setf alloc_info mem_alloc_allocationSize (getf mem_reqs mem_req_size) ;
-  setf
-    alloc_info
-    mem_alloc_memoryTypeIndex
-    (Unsigned.UInt32.of_int mem_type_idx) ;
-
-  let memory = allocate vk_device_memory vk_null_handle in
-  check
-    "vkAllocateMemory"
-    (vkAllocateMemory device.Device.device (addr alloc_info) null memory) ;
-
-  (* Bind memory to buffer *)
-  check
-    "vkBindBufferMemory"
-    (vkBindBufferMemory
-       device.Device.device
-       !@buffer
-       !@memory
-       (Unsigned.UInt64.of_int 0)) ;
-
-  (* Map memory persistently only if mappable (HOST_VISIBLE) *)
-  let mapped_ptr =
-    if is_mappable then (
-      let data_ptr = allocate (ptr void) null in
-      check
-        "vkMapMemory (persistent)"
-        (vkMapMemory
-           device.Device.device
-           !@memory
-           (Unsigned.UInt64.of_int 0)
-           vk_whole_size
-           (Unsigned.UInt32.of_int 0)
-           data_ptr) ;
-      Some !@data_ptr)
-    else None
+  (* Track allocated resources for cleanup on partial failure *)
+  let memory_ref = ref vk_null_handle in
+  let cleanup () =
+    if !memory_ref <> vk_null_handle then
+      vkFreeMemory device.Device.device !memory_ref null ;
+    vkDestroyBuffer device.Device.device !@buffer null
   in
 
-  {buffer = !@buffer; memory = !@memory; size; elem_size; device; mapped_ptr}
+  try
+    (* Allocate memory *)
+    let alloc_info = make vk_memory_allocate_info in
+    setf alloc_info mem_alloc_sType (u32 vk_structure_type_memory_allocate_info) ;
+    setf alloc_info mem_alloc_pNext null ;
+    setf alloc_info mem_alloc_allocationSize (getf mem_reqs mem_req_size) ;
+    setf
+      alloc_info
+      mem_alloc_memoryTypeIndex
+      (Unsigned.UInt32.of_int mem_type_idx) ;
+
+    let memory = allocate vk_device_memory vk_null_handle in
+    check
+      "vkAllocateMemory"
+      (vkAllocateMemory device.Device.device (addr alloc_info) null memory) ;
+    memory_ref := !@memory ;
+
+    (* Bind memory to buffer *)
+    check
+      "vkBindBufferMemory"
+      (vkBindBufferMemory
+         device.Device.device
+         !@buffer
+         !@memory
+         (Unsigned.UInt64.of_int 0)) ;
+
+    (* Map memory persistently only if mappable (HOST_VISIBLE) *)
+    let mapped_ptr =
+      if is_mappable then (
+        let data_ptr = allocate (ptr void) null in
+        check
+          "vkMapMemory (persistent)"
+          (vkMapMemory
+             device.Device.device
+             !@memory
+             (Unsigned.UInt64.of_int 0)
+             vk_whole_size
+             (Unsigned.UInt32.of_int 0)
+             data_ptr) ;
+        Some !@data_ptr)
+      else None
+    in
+
+    {buffer = !@buffer; memory = !@memory; size; elem_size; device; mapped_ptr}
+  with e ->
+    cleanup () ;
+    raise e
 
 let alloc_custom device ~size ~elem_size =
   let byte_size = size * elem_size in
@@ -357,39 +370,52 @@ let alloc_custom device ~size ~elem_size =
     mem_alloc_memoryTypeIndex
     (Unsigned.UInt32.of_int mem_type_idx) ;
 
-  let memory = allocate vk_device_memory vk_null_handle in
-  check
-    "vkAllocateMemory"
-    (vkAllocateMemory device.Device.device (addr alloc_info) null memory) ;
+  (* Track allocated resources for cleanup on partial failure *)
+  let memory_ref = ref vk_null_handle in
+  let cleanup () =
+    if !memory_ref <> vk_null_handle then
+      vkFreeMemory device.Device.device !memory_ref null ;
+    vkDestroyBuffer device.Device.device !@buffer null
+  in
 
-  check
-    "vkBindBufferMemory"
-    (vkBindBufferMemory
-       device.Device.device
-       !@buffer
-       !@memory
-       (Unsigned.UInt64.of_int 0)) ;
+  try
+    let memory = allocate vk_device_memory vk_null_handle in
+    check
+      "vkAllocateMemory"
+      (vkAllocateMemory device.Device.device (addr alloc_info) null memory) ;
+    memory_ref := !@memory ;
 
-  (* Map memory persistently *)
-  let data_ptr = allocate (ptr void) null in
-  check
-    "vkMapMemory (persistent custom)"
-    (vkMapMemory
-       device.Device.device
-       !@memory
-       (Unsigned.UInt64.of_int 0)
-       vk_whole_size
-       (Unsigned.UInt32.of_int 0)
-       data_ptr) ;
+    check
+      "vkBindBufferMemory"
+      (vkBindBufferMemory
+         device.Device.device
+         !@buffer
+         !@memory
+         (Unsigned.UInt64.of_int 0)) ;
 
-  {
-    buffer = !@buffer;
-    memory = !@memory;
-    size;
-    elem_size;
-    device;
-    mapped_ptr = Some !@data_ptr;
-  }
+    (* Map memory persistently *)
+    let data_ptr = allocate (ptr void) null in
+    check
+      "vkMapMemory (persistent custom)"
+      (vkMapMemory
+         device.Device.device
+         !@memory
+         (Unsigned.UInt64.of_int 0)
+         vk_whole_size
+         (Unsigned.UInt32.of_int 0)
+         data_ptr) ;
+
+    {
+      buffer = !@buffer;
+      memory = !@memory;
+      size;
+      elem_size;
+      device;
+      mapped_ptr = Some !@data_ptr;
+    }
+  with e ->
+    cleanup () ;
+    raise e
 
 let free buf =
   (match buf.mapped_ptr with

--- a/sarek-vulkan/Vulkan_api_stream.ml
+++ b/sarek-vulkan/Vulkan_api_stream.ml
@@ -67,7 +67,10 @@ let create device =
 
   {command_pool = !@pool; command_buffer = !@cmd_buf; fence = !@fence; device}
 
+let default_streams : (int, t) Hashtbl.t = Hashtbl.create 4
+
 let destroy stream =
+  Hashtbl.remove default_streams stream.device.Device.id ;
   vkDestroyFence stream.device.Device.device stream.fence null ;
   vkDestroyCommandPool stream.device.Device.device stream.command_pool null
 
@@ -82,8 +85,6 @@ let synchronize stream =
        vk_true
        (Unsigned.UInt64.of_int64 Int64.max_int)) ;
   ignore fence_ptr
-
-let default_streams : (int, t) Hashtbl.t = Hashtbl.create 4
 
 let default device =
   match Hashtbl.find_opt default_streams device.Device.id with

--- a/sarek/sarek/Sarek_cpu_runtime_exec.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_exec.ml
@@ -123,7 +123,7 @@ let run_block_sequential_bsp ~block:(bx, by, bz) ~grid:(gx, gy, gz)
              message =
                Printf.sprintf
                  "No progress made: %d threads waiting, %d completed (context: \
-                  run_block_parallel_bsp)"
+                  run_block_sequential_bsp)"
                  !num_waiting
                  !num_completed;
            })

--- a/sarek/sarek/Sarek_cpu_runtime_pools.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_pools.ml
@@ -102,13 +102,25 @@ end
 (** Global pool - lazily initialized *)
 let global_pool : DomainPool.t option ref = ref None
 
+let global_pool_mutex = Mutex.create ()
+
 let get_pool () =
   match !global_pool with
   | Some pool -> pool
   | None ->
-      let num_cores = try Domain.recommended_domain_count () with _ -> 4 in
-      let pool = DomainPool.create num_cores in
-      global_pool := Some pool ;
+      Mutex.lock global_pool_mutex ;
+      let pool =
+        match !global_pool with
+        | Some p -> p
+        | None ->
+            let num_cores =
+              try Domain.recommended_domain_count () with _ -> 4
+            in
+            let p = DomainPool.create num_cores in
+            global_pool := Some p ;
+            p
+      in
+      Mutex.unlock global_pool_mutex ;
       pool
 
 (** {1 Persistent Thread Pool for Fission Mode}
@@ -163,6 +175,7 @@ module ThreadPool = struct
     mutable pending_workers : int;
     mutable shutdown : bool;
     mutable generation : int; (* Incremented each kernel launch *)
+    mutable first_error : exn option; (* First error across all workers *)
   }
 
   (** Run a single block with BSP barriers using Effect.Shallow fibers *)
@@ -182,6 +195,7 @@ module ThreadPool = struct
     in
     let num_waiting = ref 0 in
     let num_completed = ref 0 in
+    let first_error = ref None in
     (* Pre-compute int32 values *)
     let bx32 = Int32.of_int bx in
     let by32 = Int32.of_int by in
@@ -224,9 +238,17 @@ module ThreadPool = struct
       {
         Effect.Shallow.retc =
           (fun () ->
-            status.(tid) <- 2 ;
-            incr num_completed);
-        exnc = raise;
+            if status.(tid) <> 2 then begin
+              status.(tid) <- 2 ;
+              incr num_completed
+            end);
+        exnc =
+          (fun exn ->
+            if !first_error = None then first_error := Some exn ;
+            if status.(tid) <> 2 then begin
+              status.(tid) <- 2 ;
+              incr num_completed
+            end);
         effc =
           (fun (type a) (eff : a Effect.t) ->
             match eff with
@@ -262,7 +284,8 @@ module ThreadPool = struct
           | None -> ()
         end
       done
-    done
+    done ;
+    match !first_error with Some exn -> raise exn | None -> ()
 
   (** Run a range of global threads directly - for barrier-free kernels. More
       efficient than block distribution when no barriers are needed. *)
@@ -336,33 +359,41 @@ module ThreadPool = struct
         last_gen := pool.generation ;
         Mutex.unlock pool.mutex ;
         (* Get our work item - only signal completion if we had work *)
-        let had_work =
+        let had_work, work_error =
           match Atomic.get pool.work.(worker_id) with
-          | None -> false
+          | None -> (false, None)
           | Some w ->
-              if w.uses_barriers then begin
-                (* Block distribution - required for BSP barriers *)
-                for block_id = w.start_block to w.end_block - 1 do
-                  let block_x = block_id mod w.gx in
-                  let block_y = block_id / w.gx mod w.gy in
-                  let block_z = block_id / (w.gx * w.gy) in
-                  run_block_bsp
-                    ~block:(w.bx, w.by, w.bz)
-                    ~grid:(w.gx, w.gy, w.gz)
-                    ~block_idx:(block_x, block_y, block_z)
-                    w.kernel
-                    w.args
-                done
-              end
-              else
-                (* Thread distribution - more granular, faster *)
-                run_threads w ;
+              let err =
+                try
+                  if w.uses_barriers then begin
+                    (* Block distribution - required for BSP barriers *)
+                    for block_id = w.start_block to w.end_block - 1 do
+                      let block_x = block_id mod w.gx in
+                      let block_y = block_id / w.gx mod w.gy in
+                      let block_z = block_id / (w.gx * w.gy) in
+                      run_block_bsp
+                        ~block:(w.bx, w.by, w.bz)
+                        ~grid:(w.gx, w.gy, w.gz)
+                        ~block_idx:(block_x, block_y, block_z)
+                        w.kernel
+                        w.args
+                    done
+                  end
+                  else
+                    (* Thread distribution - more granular, faster *)
+                    run_threads w ;
+                  None
+                with exn -> Some exn
+              in
               Atomic.set pool.work.(worker_id) None ;
-              true
+              (true, err)
         in
-        (* Signal completion only if we had work *)
+        (* Signal completion only if we had work - always decrement even on error *)
         if had_work then begin
           Mutex.lock pool.mutex ;
+          (match (pool.first_error, work_error) with
+          | None, Some exn -> pool.first_error <- Some exn
+          | _ -> ()) ;
           pool.pending_workers <- pool.pending_workers - 1 ;
           if pool.pending_workers = 0 then Condition.broadcast pool.work_done ;
           Mutex.unlock pool.mutex
@@ -386,6 +417,7 @@ module ThreadPool = struct
         pending_workers = 0;
         shutdown = false;
         generation = 0;
+        first_error = None;
       }
     in
     (* Spawn workers - they all reference the same pool record *)
@@ -482,7 +514,10 @@ module ThreadPool = struct
     while pool.pending_workers > 0 do
       Condition.wait pool.work_done pool.mutex
     done ;
-    Mutex.unlock pool.mutex
+    let first_error = pool.first_error in
+    pool.first_error <- None ;
+    Mutex.unlock pool.mutex ;
+    match first_error with Some exn -> raise exn | None -> ()
 
   let shutdown pool =
     Mutex.lock pool.mutex ;

--- a/sarek/sarek/Sarek_ir_interp_eval.ml
+++ b/sarek/sarek/Sarek_ir_interp_eval.ml
@@ -69,7 +69,11 @@ and eval_array_expr state env = function
               (Not_an_array {expr = "EArrayReadExpr base"})
       in
       let i = to_int (eval_expr state env idx) in
-      a.(i)
+      if i < 0 || i >= Array.length a then
+        Interp_error.raise_error
+          (Array_bounds_error
+             {array_name = "EArrayReadExpr"; index = i; length = Array.length a})
+      else a.(i)
   | EArrayLen arr ->
       let a = get_array env arr in
       VInt32 (Int32.of_int (Array.length a))
@@ -360,7 +364,11 @@ and assign_lvalue state env lv value =
               (Not_an_array {expr = "LArrayElemExpr base"})
       in
       let i = to_int (eval_expr state env idx_expr) in
-      a.(i) <- value
+      if i < 0 || i >= Array.length a then
+        Interp_error.raise_error
+          (Array_bounds_error
+             {array_name = "LArrayElemExpr"; index = i; length = Array.length a})
+      else a.(i) <- value
   | LRecordField (base_lv, _field) ->
       (* Record field assignment is complex - simplified here *)
       ignore base_lv ;

--- a/sarek/tests/unit/test_cpu_runtime.ml
+++ b/sarek/tests/unit/test_cpu_runtime.ml
@@ -557,6 +557,25 @@ let test_parallel_default_propagates_worker_exception () =
     Test_parallel_failure
     (fun () -> run_parallel ~block:(4, 1, 1) ~grid:(1, 1, 1) kernel ())
 
+(** Test that a BSP barrier kernel which raises propagates the exception and
+    does not hang (regression for run_block_bsp exnc=raise bug). run_threadpool
+    with has_barriers=true exercises run_block_bsp via the fission ThreadPool.
+*)
+exception Test_bsp_failure
+
+let test_bsp_worker_exception_propagates () =
+  let kernel _state _shared _args = raise Test_bsp_failure in
+  check_raises
+    "BSP worker exception propagates through run_block_bsp"
+    Test_bsp_failure
+    (fun () ->
+      run_threadpool
+        ~has_barriers:true
+        ~block:(4, 1, 1)
+        ~grid:(1, 1, 1)
+        kernel
+        ())
+
 (** {1 Test Suite} *)
 
 let thread_state_tests =
@@ -615,6 +634,7 @@ let barrier_tests =
     ( "default exception propagation",
       `Quick,
       test_parallel_default_propagates_worker_exception );
+    ("bsp exception propagation", `Quick, test_bsp_worker_exception_propagates);
   ]
 
 let () =

--- a/scripts/add-license-headers.sh
+++ b/scripts/add-license-headers.sh
@@ -3,7 +3,8 @@
 # SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 #
 # Automatically add or update SPDX license headers in source files
-# Uses git history to determine copyright years and contributors
+# Uses git history to determine copyright years
+# Uses a canonical maintainer identity (MAINTAINER) for contributor attribution
 
 set -e
 


### PR DESCRIPTION
Fixes the verified pre-existing bugs that CodeRabbit surfaced on #140 (the module-split refactor). Each was confirmed present in the pre-refactor baseline `10e380c8` and is fixed here **with the change reviewed and validated**, not in the structural PR.

## Fixes

**Runtime (cpu)** — `282377d3`
- 🔴 **Critical:** `ThreadPool.run_block_bsp` used `exnc = raise` → a kernel exception crashed the worker Domain and left `pending_workers` un-decremented → `run_kernel` hung forever. Now captures the first error and re-raises after all workers finish; `pending_workers` always decremented. **Regression test added** (`bsp exception propagation`).
- 🟠 **Major:** `get_pool` lazy init had no mutex (race → orphan domains). Now double-checked-locked like the other pool getters.
- 🟡 error-string typo `run_block_parallel_bsp` → `run_block_sequential_bsp`.

**Interpreter** — `2d9d39af`
- 🟡 `EArrayReadExpr` / `LArrayElemExpr` now bounds-check (structured `Array_bounds_error`) like their non-`Expr` siblings.

**Vulkan** — `49ec5f75`
- 🟠 `Device.destroy` / `Stream.destroy` now evict their cache entries (were returning destroyed handles → use-after-free).
- 🟠 `set_arg_*` now guard the 128-byte push-constant block (was overflowing).
- 🟠 `alloc` / `alloc_custom` now clean up on partial failure (were leaking buffer/memory).
- 🟡 `compile_glsl_to_spirv_cli` now passes `-e <entry_point>` (was ignored).

**Scripts** — `8a9ee88f`: banner comment corrected after the maintainer-identity pin.

## Validation (full roster pipeline: implement → review → QA)
- Reviewed in depth — the Critical concurrency fix verified against the correct `run_block_with_barriers` pattern (no lost exception, no double-decrement, no new deadlock).
- `@sarek/tests/runtest`: green, incl. the new regression test.
- `@sarek-vulkan/all`: compiles.
- **Vulkan runtime on RX 7900 XTX (RADV):** `vector_add`, `klet_variant`, `ktype_helper` e2e all pass — exercises the alloc/push-constant/device-cache paths.

Skipped CodeRabbit's 4 pure nitpicks (helper extraction, Int64 literal style, FFI hoist) as out-of-scope refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device cache cleanup on destruction.
  * Improved error handling in memory allocation with proper resource cleanup on failures.
  * Fixed exception propagation in parallel execution contexts.
  * Added array bounds checking for expression-based operations.
  * Fixed stream entry cleanup from cache.

* **New Features**
  * Enforced 128-byte limit validation for push constants.
  * Improved thread-safe initialization of thread pools.

* **Chores**
  * Updated error messaging in sequential execution contexts.
  * Refreshed script documentation headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->