### PR TITLE
docs(site): dropdown hover fix + documentation & UX audit

### DIFF
--- a/docs/website-audit-2026-06-02.md
+++ b/docs/website-audit-2026-06-02.md
@@ -1,0 +1,88 @@
+# Website / Documentation Audit — 2026-06-02
+
+Audit of the Sarek/SPOC site (`gh-pages/` Jekyll source → deployed on the `gh-pages`
+branch by `docs.yml` on push to `main`, `clean: true`). Two independent passes:
+deployed-docs content, and UI/UX + source structure.
+
+**Correction to an earlier assumption:** the docs ARE source-controlled (19 `.md` files
+in `gh-pages/docs/`); an earlier `ls` showing them empty was a tooling artifact. Source ↔
+deploy alignment is sound — changes to `gh-pages/` reach the live site on the next `main`
+deploy.
+
+Legend: **[H]** high / **[M]** medium / **[L]** low. ✅ = fixed in this PR. 🔧 = proposed.
+
+---
+
+## A. UI / UX
+
+| # | Finding | Sev | Status |
+|---|---|---|---|
+| A1 | Docs dropdown was unreachable by mouse — 8px `margin-top` gap dropped `:hover` mid-travel | H | ✅ CSS `::before` bridge |
+| A2 | Dropdown is hover-only: no keyboard, no touch, `<a href="#">` toggle (mobile users can't open Docs) | H | ✅ button + ARIA + JS + focus |
+| A3 | `_layouts/default.html` references missing `css/main.css` / `css/syntax.css`; dead layout that breaks if used | M | 🔧 (see note) |
+| A4 | Duplicate ~30-line nav markup in `page.html` and `index.html` (DRY) | M | 🔧 `_includes/navbar.html` (Liquid; not applied — no local Jekyll to validate) |
+| A5 | No active-nav indicator (user can't tell which page they're on) | L | 🔧 |
+| A6 | `--primary-color` `#f39c12` link contrast fails WCAG AA: ~2.2:1 on white, ~3.8:1 on dark nav | M | 🔧 (brand-color change — needs owner sign-off; report only) |
+| A7 | No mobile nav collapse (<768px links reflow/overflow); hamburger needed | M | 🔧 |
+| A8 | Copy-code button hover-only (hidden on touch); theme toggle is a 32px emoji-only tap target | L | 🔧 |
+
+**A3 note:** I did not delete `default.html` in this pass because I could not run Jekyll
+locally to confirm no page resolves `layout: default`. Safe follow-up: confirm no
+front-matter uses it, then delete (or point it at `modern.css`).
+
+## B. Missing docs
+
+| # | Finding | Sev | Status |
+|---|---|---|---|
+| B1 | No backend/device-selection guide: `SPOC_DISABLE_{GPU,CUDA,OPENCL,VULKAN,METAL}`, per-test `--vulkan/--native/--interpreter/-d`, device enumeration | H | ✅ new `docs/device_selection.md` |
+| B2 | FAQ lacks operational troubleshooting (driver faults, "context lost", ICD setup, backend disabling) | H | ✅ troubleshooting section added to `faq.md` |
+| B3 | No user-facing Sarek DSL reference (intrinsics, `[%kernel]`/`let%shared`/`let%superstep`, types). "API" nav points to low-level odoc only | M | 🔧 |
+| B4 | `CONTRIBUTING.md` and the rich `kb/` are not linked from the site | M | 🔧 |
+
+## C. Deprecated / outdated docs
+
+| # | Finding | Sev | Status |
+|---|---|---|---|
+| C1 | `getting_started.md` example uses `Device.get_default` and an `Execute.run … [Vec a;…]` form not present in the current API (e2e uses `Execute.run_vectors ~device ~ir ~args ~block ~grid`) | H | 🔧 (NOT auto-fixed — correct user-facing API must be confirmed first; fixing blindly would replace wrong docs with wrong docs) |
+| C2 | `backends.md` lists CUDA "Dynamic Parallelism" with no support in `sarek-cuda/`; Vulkan "Android" support is aspirational | M | 🔧 |
+| C3 | Clone URL drift: docs use `…/Sarek.git`, the git remote is `…/SPOC.git` (and PRs resolve under `mathiasbourgoin/Sarek`) — the canonical name needs confirming, then align everywhere | M | 🔧 |
+| C4 | `live_transpiler.md` / `live_mandelbrot.md` advertise interactive elements that are placeholders | L | 🔧 (clarify status) |
+
+## D. Inconsistent docs
+
+| # | Finding | Sev | Status |
+|---|---|---|---|
+| D1 | SPOC vs Sarek vs Spoc used interchangeably; intro pages conflate "DSL" (Sarek) and "runtime/SDK" (SPOC) | M | 🔧 (one-paragraph "Sarek = DSL, SPOC = runtime" framing on intro pages) |
+| D2 | "API" nav → odoc with no signpost ("writing kernels → Concepts; extending SPOC → API") | M | 🔧 |
+| D3 | Example code style varies (`open Sarek` vs qualified; differing `Execute` arg forms) | L | 🔧 (resolve once C1's API is confirmed) |
+
+## E. Additional docs worth adding
+
+| # | Finding | Sev | Status |
+|---|---|---|---|
+| E1 | Device-selection guide | H | ✅ (B1) |
+| E2 | Troubleshooting / known issues (incl. the Renoir+Mesa-clover OpenCL "context lost" fault → use rusticl / Vulkan / CPU) | H | ✅ (B2) |
+| E3 | "For developers" section linking `CONTRIBUTING.md`, backend READMEs, `kb/` | M | 🔧 |
+
+## F. Infrastructure / security (from KB cross-reference)
+
+| # | Finding | Sev | Status |
+|---|---|---|---|
+| F1 | `benchmark-viewer.js` writes benchmark-JSON-derived fields (descriptions, hostname, device name) via `innerHTML` → stored-XSS if untrusted data is accepted (`kb/support/docs-site.md`) | H | 🔧 (use `textContent`/escaping; separate security follow-up) |
+| F2 | `dependencies/{CL,Cuda}/LICENCE` labeled GPLv3 but are Khronos / NVIDIA terms — provenance mismatch (`kb/support/dependencies.md`) | M | 🔧 |
+| F3 | Two benchmark dashboards (`index.md` + `dashboard.md`); the older `dashboard.js` knows only 4 benchmarks — stale, should unify/deprecate | L | 🔧 |
+
+---
+
+## Implemented in this PR
+- **A1** dropdown hover bridge (CSS).
+- **A2** accessible dropdown — `<button>` toggle, `aria-expanded`/`aria-controls`, click + keyboard (Enter/Space/Esc) + outside-click close, `:focus-visible`; CSS `:hover` retained for mouse.
+- **B1/E1** new `docs/device_selection.md`.
+- **B2/E2** troubleshooting section in `docs/faq.md` (covers the real-world Renoir/clover OpenCL fault).
+
+## Deferred (proposed, not applied)
+Everything marked 🔧. The larger reasons not to auto-apply now:
+- **No local Jekyll** → Liquid-template changes (`_includes` DRY, `default.html` removal) can't be build-validated; deferred to avoid a deploy break.
+- **C1/C3/D3** require confirming the canonical user-facing API and repo name before editing, or the "fix" just substitutes one inaccuracy for another.
+- **A6** changes the brand color — owner decision.
+- **F1** is a security fix deserving its own focused, tested change.

--- a/gh-pages/_layouts/index.html
+++ b/gh-pages/_layouts/index.html
@@ -27,11 +27,12 @@
           <a href="{{ site.baseurl }}/benchmarks/">Benchmarks</a>
           <a href="{{ site.baseurl }}/examples/">Examples</a>
           <div class="nav-dropdown">
-            <a href="#" class="dropdown-toggle">Docs ▾</a>
-            <div class="dropdown-menu">
+            <button type="button" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="docs-menu">Docs ▾</button>
+            <div class="dropdown-menu" id="docs-menu">
               <a href="{{ site.baseurl }}/docs/concepts.html">Concepts</a>
               <a href="{{ site.baseurl }}/docs/architecture.html">Architecture</a>
               <a href="{{ site.baseurl }}/docs/backends.html">Backends</a>
+              <a href="{{ site.baseurl }}/docs/device_selection.html">Device Selection</a>
               <a href="{{ site.baseurl }}/docs/build_guide.html">Build Guide</a>
               <a href="{{ site.baseurl }}/docs/faq.html">FAQ</a>
               <a href="{{ site.baseurl }}/docs/publications.html">Publications</a>
@@ -88,6 +89,7 @@
     <script src="{{ site.baseurl }}/javascripts/scale.fix.js"></script>
     <script src="{{ site.baseurl }}/javascripts/copy-code.js"></script>
     <script src="{{ site.baseurl }}/javascripts/theme-toggle.js"></script>
+    <script src="{{ site.baseurl }}/javascripts/dropdown.js"></script>
     <script src="{{ site.baseurl }}/javascripts/syntax-sarek.js"></script>
     <script src="{{ site.baseurl }}/javascripts/init-mermaid.js"></script>
     <script type="module">

--- a/gh-pages/_layouts/page.html
+++ b/gh-pages/_layouts/page.html
@@ -27,11 +27,12 @@
           <a href="{{ site.baseurl }}/benchmarks/">Benchmarks</a>
           <a href="{{ site.baseurl }}/examples/">Examples</a>
           <div class="nav-dropdown">
-            <a href="#" class="dropdown-toggle">Docs ▾</a>
-            <div class="dropdown-menu">
+            <button type="button" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="docs-menu">Docs ▾</button>
+            <div class="dropdown-menu" id="docs-menu">
               <a href="{{ site.baseurl }}/docs/concepts.html">Concepts</a>
               <a href="{{ site.baseurl }}/docs/architecture.html">Architecture</a>
               <a href="{{ site.baseurl }}/docs/backends.html">Backends</a>
+              <a href="{{ site.baseurl }}/docs/device_selection.html">Device Selection</a>
               <a href="{{ site.baseurl }}/docs/build_guide.html">Build Guide</a>
               <a href="{{ site.baseurl }}/docs/faq.html">FAQ</a>
               <a href="{{ site.baseurl }}/docs/publications.html">Publications</a>
@@ -62,6 +63,7 @@
     <script src="{{ site.baseurl }}/javascripts/scale.fix.js"></script>
     <script src="{{ site.baseurl }}/javascripts/copy-code.js"></script>
     <script src="{{ site.baseurl }}/javascripts/theme-toggle.js"></script>
+    <script src="{{ site.baseurl }}/javascripts/dropdown.js"></script>
     <script src="{{ site.baseurl }}/javascripts/syntax-sarek.js"></script>
   </body>
 </html>

--- a/gh-pages/docs/device_selection.md
+++ b/gh-pages/docs/device_selection.md
@@ -1,0 +1,86 @@
+---
+layout: page
+title: Device & Backend Selection
+---
+
+# Device & Backend Selection
+
+Sarek auto-detects every available backend at startup (CUDA, OpenCL, Vulkan, Metal, plus
+the CPU **Native** and **Interpreter** backends) and exposes each physical device. This
+page explains how to list those devices and how to pick — or exclude — a specific backend
+or device.
+
+## List available devices
+
+```bash
+dune exec -- sarek-device-info
+```
+
+This prints every detected device across all backends with its framework and
+capabilities, e.g.:
+
+```
+[0] AMD Radeon RX 7900 XTX (radeonsi, navi31) (OpenCL)
+[1] AMD Radeon RX 7900 XTX (RADV NAVI31) (Vulkan)
+[2] CPU Native (Parallel, 32 cores) (Native)
+[3] CPU Interpreter (Sequential) (Interpreter)
+```
+
+The bracketed index is the device id used by `-d <id>` below. Note that the *same*
+physical GPU usually appears more than once — once per framework that can drive it (e.g.
+OpenCL and Vulkan).
+
+## Disable backends with environment variables
+
+Set any of these to `1` to keep that backend from registering at all. This is the
+simplest way to avoid a flaky or unsupported driver, or to force execution onto a
+particular backend.
+
+| Variable | Effect |
+|---|---|
+| `SPOC_DISABLE_CUDA=1` | Skip the CUDA backend |
+| `SPOC_DISABLE_OPENCL=1` | Skip the OpenCL backend |
+| `SPOC_DISABLE_VULKAN=1` | Skip the Vulkan backend |
+| `SPOC_DISABLE_METAL=1` | Skip the Metal backend |
+| `SPOC_DISABLE_GPU=1` | Skip **all** GPU backends (CUDA, OpenCL, Vulkan, Metal) |
+
+Examples:
+
+```bash
+# Run only on Vulkan (skip the OpenCL view of the same GPU)
+SPOC_DISABLE_OPENCL=1 dune exec -- sarek-device-info
+
+# Force CPU-only execution (no GPU backends register)
+SPOC_DISABLE_GPU=1 dune exec -- my_program.exe
+```
+
+## Select a device in the example / benchmark programs
+
+The bundled e2e examples and benchmarks accept backend/device flags:
+
+| Flag | Effect |
+|---|---|
+| `-d <id>` | Run on the device with this index (from `sarek-device-info`) |
+| `--vulkan` | Use the first Vulkan device |
+| `--native` | Use the CPU Native (parallel) backend |
+| `--interpreter` | Use the CPU Interpreter backend |
+| `--metal` | Use the first Metal device |
+| `--benchmark` | Run across all available devices |
+
+```bash
+# Vector-add on the Vulkan device specifically
+dune exec sarek/tests/e2e/test_vector_add.exe -- --vulkan
+
+# …on device id 2
+dune exec sarek/tests/e2e/test_vector_add.exe -- -d 2
+```
+
+> Tip: when several frameworks expose the same GPU, the *default* device is usually the
+> first GPU found (often the OpenCL view). Use `--vulkan` or `-d <id>` to target a
+> different framework for the same hardware.
+
+## See also
+
+- [Backends](backends.html) — what each backend supports.
+- [Troubleshooting](faq.html#troubleshooting) — what to do when a backend faults or a
+  device misbehaves.

--- a/gh-pages/docs/faq.md
+++ b/gh-pages/docs/faq.md
@@ -67,3 +67,60 @@ dune exec -- sarek-device-info
 ```
 
 This shows all detected devices across all backends (CUDA, OpenCL, Vulkan, Metal, Native, Interpreter) with their capabilities.
+
+## Troubleshooting
+
+### A kernel crashes with "the context is lost" / "soft recovery" (amdgpu)
+
+```
+amdgpu: The CS has cancelled because the context is lost. This context is
+guilty of a soft recovery.
+```
+
+This is a **GPU-level fault** reported by the driver, not a Sarek error — the OpenCL
+runtime submitted work the driver couldn't complete, so it reset the GPU. On integrated
+AMD GPUs (e.g. Renoir APUs) driven by Mesa's legacy **clover** OpenCL, this happens even
+for tiny workloads.
+
+What to do, in order:
+
+1. **Confirm it's the driver, not your kernel** — run on the CPU backend:
+   ```bash
+   dune exec sarek/tests/e2e/test_vector_add.exe -- --native
+   ```
+   If that passes, your kernel is fine and the OpenCL stack is the problem.
+2. **Switch OpenCL implementation** from clover to the maintained **rusticl**:
+   ```bash
+   RUSTICL_ENABLE=radeonsi dune exec -- your_program.exe
+   ```
+3. **Use the Vulkan backend instead** (more robust than clover on APUs):
+   ```bash
+   dune exec sarek/tests/e2e/test_vector_add.exe -- --vulkan
+   ```
+4. Or disable the failing backend entirely — see
+   [Device & Backend Selection](device_selection.html) (`SPOC_DISABLE_OPENCL=1`).
+
+Note: ROCm does not support most integrated APUs, so installing it will not fix this.
+
+### "No devices available" / a backend doesn't appear
+
+- Run `dune exec -- sarek-device-info` to see what is actually detected.
+- Check the backend's loader is installed (OpenCL ICD, Vulkan loader, CUDA driver).
+- Make sure you haven't left a `SPOC_DISABLE_*` variable set (see
+  [Device & Backend Selection](device_selection.html)).
+
+### A specific backend hangs or faults
+
+Isolate it with the disable variables, then run only the others:
+
+```bash
+SPOC_DISABLE_OPENCL=1 dune exec -- your_program.exe   # skip OpenCL
+SPOC_DISABLE_GPU=1     dune exec -- your_program.exe   # CPU only
+```
+
+### Results differ slightly between backends
+
+Floating-point results can differ across backends (different rounding, fused
+multiply-add, math-library implementations). The e2e tests compare against a CPU baseline
+with a tolerance rather than exact equality. If a backend's result is wildly wrong (not
+just last-bit differences), file an issue with the device, driver version, and kernel.

--- a/gh-pages/javascripts/dropdown.js
+++ b/gh-pages/javascripts/dropdown.js
@@ -1,0 +1,45 @@
+// Accessible nav dropdown: click / keyboard / touch toggle.
+// The CSS :hover rule keeps mouse behaviour; this adds the interactions hover
+// can't provide (keyboard focus, touch tap, screen-reader state) and an Escape /
+// outside-click close. Adding the `.open` class on .nav-dropdown reveals the menu
+// (see modern.css), and aria-expanded is kept in sync for assistive tech.
+(function () {
+  function setupDropdown(dd) {
+    var toggle = dd.querySelector('.dropdown-toggle');
+    var menu = dd.querySelector('.dropdown-menu');
+    if (!toggle || !menu) return;
+
+    function close() {
+      dd.classList.remove('open');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+    function open() {
+      dd.classList.add('open');
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+
+    toggle.addEventListener('click', function (e) {
+      e.preventDefault();
+      if (dd.classList.contains('open')) close();
+      else open();
+    });
+
+    // Escape closes and returns focus to the toggle.
+    dd.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' || e.key === 'Esc') {
+        close();
+        toggle.focus();
+      }
+    });
+
+    // Close when interaction leaves the dropdown.
+    document.addEventListener('click', function (e) {
+      if (!dd.contains(e.target)) close();
+    });
+    dd.addEventListener('focusout', function (e) {
+      if (!dd.contains(e.relatedTarget)) close();
+    });
+  }
+
+  document.querySelectorAll('.nav-dropdown').forEach(setupDropdown);
+})();

--- a/gh-pages/stylesheets/modern.css
+++ b/gh-pages/stylesheets/modern.css
@@ -118,6 +118,12 @@ body {
 }
 
 .nav-dropdown .dropdown-toggle {
+  /* Rendered as a <button> for keyboard/touch/ARIA support; reset native chrome
+     so it matches the surrounding nav links. */
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
   color: var(--nav-text);
   font-weight: 500;
   font-size: 0.95rem;
@@ -126,6 +132,12 @@ body {
 }
 
 .nav-dropdown .dropdown-toggle:hover {
+  color: var(--primary-color);
+}
+
+.nav-dropdown .dropdown-toggle:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 3px;
   color: var(--primary-color);
 }
 
@@ -156,7 +168,10 @@ body {
   height: 8px;
 }
 
-.nav-dropdown:hover .dropdown-menu {
+/* Mouse hover (desktop) and the JS-managed `.open` state (click / keyboard / touch)
+   both reveal the menu. */
+.nav-dropdown:hover .dropdown-menu,
+.nav-dropdown.open .dropdown-menu {
   display: block;
 }
 

--- a/gh-pages/stylesheets/modern.css
+++ b/gh-pages/stylesheets/modern.css
@@ -144,6 +144,18 @@ body {
   z-index: 1000;
 }
 
+/* Transparent bridge spanning the 8px margin gap above the menu, so the cursor
+   can travel from the toggle to the items without leaving the hover area (which
+   would hide the menu mid-move and make the subpages unreachable). */
+.dropdown-menu::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 0;
+  right: 0;
+  height: 8px;
+}
+
 .nav-dropdown:hover .dropdown-menu {
   display: block;
 }


### PR DESCRIPTION
Website / docs improvement PR, driven by a documentation + UI/UX audit. Full report: `docs/website-audit-2026-06-02.md`.

## Implemented here

**UI/UX**
- **Dropdown reachable by mouse** — added a transparent `::before` bridge over the 8px `margin-top` gap that was dropping `:hover` and hiding the submenu (the originally-reported bug).
- **Dropdown now accessible** — toggle is a real `<button>` with `aria-haspopup`/`aria-expanded`/`aria-controls`; `dropdown.js` adds click/tap toggle, Escape-to-close (restoring focus), and outside-click close; `:focus-visible` ring. Mouse `:hover` retained. Fixes keyboard + **touch/mobile** users who previously couldn't open Docs at all.

**Docs (missing/additional)**
- New **`docs/device_selection.md`** — `sarek-device-info`, `SPOC_DISABLE_{GPU,CUDA,OPENCL,VULKAN,METAL}`, and the `--vulkan/--native/--interpreter/--metal/-d` flags. Linked into the nav.
- **FAQ Troubleshooting** section — the amdgpu "context is lost" GPU fault (Mesa clover on Renoir APUs) with rusticl/Vulkan/CPU workarounds, "no devices available", isolating a faulting backend, cross-backend float differences.

## Audit (full report in `docs/website-audit-2026-06-02.md`)
Findings across UI/UX, missing/deprecated/inconsistent/additional docs, and infra/security — each with severity and status. Notable **deferred** items (with reasons, not auto-applied):
- **C1** `getting_started.md` uses an API (`Device.get_default`, `Execute.run [...]`) not in the current codebase — needs the canonical user-facing API confirmed before rewriting (won't replace wrong docs with wrong docs).
- **C3** clone-URL drift (`Sarek.git` vs `SPOC.git`) — confirm canonical repo name, then align.
- **A6** brand-orange link contrast fails WCAG AA — brand-color change needs owner sign-off.
- **F1** `benchmark-viewer.js` writes untrusted benchmark-JSON fields via `innerHTML` (stored-XSS) — deserves its own tested security fix.
- DRY nav `_includes`, `default.html` cleanup, mobile hamburger — not applied because Jekyll can't be built locally to validate Liquid changes (the PR preview build covers what's here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented dropdown menus from closing when moving the cursor between the toggle and menu items.

* **New Features**
  * Added accessible dropdown behavior with keyboard support and visible focus styling.
  * Added a “Device Selection” link to the Docs navigation.

* **Documentation**
  * New device selection guide and expanded Troubleshooting section in FAQ.
  * Added a website audit report summarizing UI/UX and doc recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->