### PR TITLE
docs(briefs): roster-pipeline artifacts (audit + Phase 0)

### DIFF
--- a/briefs/audit-2026-06-02.md
+++ b/briefs/audit-2026-06-02.md
@@ -1,0 +1,132 @@
+# Audit — 2026-06-02
+
+**Scope:** Full repo (sarek/, sarek-cuda/, sarek-metal/, sarek-opencl/, sarek-vulkan/, spoc/)
+**KB used:** Partial — no kb/properties.md / kb/spec.md / kb/glossary.md. Used distributed KB (kb/sarek/, kb/backends/, kb/obj-usage-audit/) + default thresholds (max fn: 50 lines, max file: 500 lines, DRY: ≥5 identical lines in 2+ files).
+
+---
+
+## Summary
+
+| Category | Findings | Actionable |
+|---|---|---|
+| File size (>500 lines) | 31 | 31 |
+| Function size (>50 lines) | 44 | 44 |
+| DRY / duplication | 10 | 5 critical |
+| Naming | PASS | 0 |
+| Obj.magic | PASS (audit clean per kb/obj-usage-audit) | 0 |
+
+---
+
+## Actionable findings
+
+### CRITICAL
+
+| File:Line | Finding |
+|---|---|
+| `sarek/ppx/Sarek_native_gen.ml:1` | 1951 lines — native code generation monolith (3.9× limit) |
+| `sarek/ppx/Sarek_ppx.ml:1` | 1864 lines — PPX entry point and orchestration (3.7×) |
+| `sarek-vulkan/Vulkan_api.ml:1` | 1756 lines — Vulkan API wrapper (3.5×) |
+| `sarek/sarek/Sarek_ir_interp.ml:1` | 1573 lines — interpreter monolith (3.1×) |
+| `sarek/sarek/Sarek_cpu_runtime.ml:1` | 1497 lines — CPU runtime monolith (3.0×) |
+| `sarek-cuda/Sarek_ir_cuda.ml:796` | `gen_variant_def` (75 lines) identical to OpenCL:778 and Metal:1005 — 96% similarity, only type-function names differ |
+| `sarek-opencl/Sarek_ir_opencl.ml:778` | same as above |
+| `sarek-metal/Sarek_ir_metal.ml:1005` | same as above |
+
+### HIGH — Function size
+
+| File:Line | Function | Lines |
+|---|---|---|
+| `sarek/ppx/Sarek_parse.ml:262` | `parse_stmt` (mutually recursive) | ~400 |
+| `sarek/ppx/Sarek_typer.ml:651` | `infer_expr` group (mutually recursive) | ~292 |
+| `sarek-metal/Sarek_ir_metal.ml:100` | codegen (mutually recursive) | ~356 |
+| `sarek-cuda/Sarek_ir_cuda.ml:80` | codegen (mutually recursive) | ~337 |
+| `sarek-opencl/Sarek_ir_opencl.ml:96` | codegen (mutually recursive) | ~331 |
+| `sarek/ppx/Sarek_native_gen.ml:1700` | `gen_cpu_kern_native_wrapper` | ~253 |
+| `sarek/ppx/Sarek_quote.ml:78` | `quote_expr` (mutually recursive) | ~284 |
+
+### HIGH — File size
+
+| File:Line | Lines |
+|---|---|
+| `sarek/sarek/Sarek_fusion.ml:1` | 1298 |
+| `sarek/tests/unit/test_fusion.ml:1` | 1188 |
+| `sarek/ppx/Sarek_typer.ml:1` | 1154 |
+| `sarek-metal/Sarek_ir_metal.ml:1` | 1153 |
+| `sarek-vulkan/Sarek_ir_glsl.ml:1` | 1102 |
+| `sarek-vulkan/Vulkan_types.ml:1` | 1065 |
+| `sarek/ppx/Sarek_quote.ml:1` | 1039 |
+
+### HIGH — DRY (backend plugin signatures)
+
+| Files | Issue |
+|---|---|
+| `sarek-cuda/Cuda_plugin_base.ml`, `sarek-opencl/Opencl_plugin_base.ml`, `sarek-metal/Metal_plugin_base.ml`, `sarek-vulkan/Vulkan_plugin_base.ml` | Plugin module signatures structurally identical; no shared functor or module type in use |
+| `sarek-cuda/Sarek_ir_cuda.ml:871`, `sarek-opencl/Sarek_ir_opencl.ml:852`, `sarek-metal/Sarek_ir_metal.ml:1079` | `generate_with_types` near-identical across 3 backends |
+
+### MEDIUM — Function size (selected)
+
+| File:Line | Function | Lines |
+|---|---|---|
+| `sarek/ppx/Sarek_native_gen.ml:1141` | `gen_arg_cast` | ~185 |
+| `sarek/ppx/Sarek_native_gen.ml:427` | `gen_data_structure` | ~119 |
+| `sarek/ppx/Sarek_native_gen.ml:583` | `gen_parallel_construct` | ~114 |
+| `sarek/ppx/Sarek_typer.ml:525` | `infer_let_binding` | ~126 |
+| `sarek/ppx/Sarek_typer.ml:943` | `infer_kernel` | ~213 |
+| `sarek/sarek/Sarek_cpu_runtime.ml:305` | `run_block_with_barriers` | ~117 |
+| `sarek/sarek/Sarek_cpu_runtime.ml:156` | `run_block_sequential_bsp` | ~115 |
+| `sarek-cuda/Sarek_ir_cuda.ml:437` | codegen helper (mutually recursive) | ~223 |
+| `sarek-opencl/Sarek_ir_opencl.ml:447` | codegen helper (mutually recursive) | ~205 |
+
+### MEDIUM — File size (selected)
+
+| File | Lines |
+|---|---|
+| `sarek-cuda/Sarek_ir_cuda.ml` | 929 |
+| `sarek-opencl/Sarek_ir_opencl.ml` | 911 |
+| `sarek/ppx/Sarek_parse.ml` | 839 |
+| `sarek/tests/unit/test_quote_ir.ml` | 836 |
+| `sarek/ppx/Sarek_core_primitives.ml` | 822 |
+| `sarek/plugins/native/Native_plugin_base.ml` | 812 |
+| `sarek/sarek/Execute.ml` | 779 |
+| `sarek-opencl/Opencl_api.ml` | 702 |
+| `sarek/ppx/Sarek_lower.ml` | 715 |
+| `sarek/ppx/Sarek_lower_ir.ml` | 710 |
+
+### LOW — Function size (at or just over limit)
+
+`sarek-vulkan/Vulkan_api.ml:52` `compile_glsl_to_spirv_cli` ~84 lines,
+`sarek/sarek/Sarek_ir_interp.ml:172` `eval_binop` ~89 lines,
+`sarek/sarek/Sarek_ir_interp.ml:397` `eval_float32_math_intrinsic` ~99 lines,
+`sarek/sarek/Sarek_cpu_runtime.ml:529` `run_parallel_simple` ~75 lines,
+`sarek/sarek/Sarek_cpu_runtime.ml:1206` `run_threadpool` ~80 lines.
+
+---
+
+## Non-actionable (for reference)
+
+- **Obj.magic** — All sites catalogued in `kb/obj-usage-audit/`; no new sites found. Existing uses are known, audited, and typed. No new violations.
+- **Naming** — Consistent use of `Sarek_value`, `Sarek_val`, plugin/backend/device terminology. No glossary violations detected.
+- **Mutually recursive `and` chains** — Long mutually recursive function groups (`parse_stmt`, `infer_expr`, `quote_expr`, IR codegen passes) cannot be trivially split without changing semantics. Extracting helpers is valid refactoring but must be done with care not to break the recursion structure.
+- **Test file sizes** — `test_fusion.ml` (1188), `test_quote_ir.ml` (836), `test_typer.ml` (732), etc. These are genuinely large but test files have lower split-priority than source files.
+
+---
+
+## Root-cause summary
+
+1. **Backend codegen is copy-pasted** — `gen_variant_def` and `generate_with_types` exist verbatim in CUDA, OpenCL, and Metal. Consolidation requires a shared module parameterised on type-function names.
+2. **PPX passes are monolithic** — `Sarek_native_gen.ml` (1951 lines) mixes memory access, control flow, type generation, and kernel wrapping in one file; splitting by pass responsibility is the fix.
+3. **Mutually recursive groups inflate function size** — the `and`-chained dispatchers in `Sarek_parse`, `Sarek_typer`, and `Sarek_quote` are structurally large by necessity; helper extraction (non-recursive subroutines) is the lever.
+4. **Plugin bases have no shared functor** — four near-identical plugin signatures could be unified into a single module type in `spoc/` or `sarek/core/`.
+
+---
+
+## Prioritised remediation
+
+| Priority | Action | Files |
+|---|---|---|
+| 1 | Extract shared `gen_variant_def` into a backend-agnostic module | `sarek-cuda`, `sarek-opencl`, `sarek-metal` |
+| 2 | Split `Sarek_native_gen.ml` by pass responsibility | `sarek/ppx/` |
+| 3 | Define shared plugin module type / functor | `sarek-*/` plugin bases |
+| 4 | Extract helpers from large mutually recursive groups | `Sarek_parse`, `Sarek_typer`, `Sarek_quote` |
+| 5 | Split `Sarek_cpu_runtime.ml` and `Sarek_ir_interp.ml` | `sarek/sarek/` |
+| 6 | Split `Vulkan_api.ml` | `sarek-vulkan/` |

--- a/briefs/backend-variant-dedup-implementer.md
+++ b/briefs/backend-variant-dedup-implementer.md
@@ -1,0 +1,184 @@
+# Implementer Brief — backend-variant-dedup
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+Extract `mangle_name` (4 identical copies) and `gen_variant_def` (3 C-style + 1 GLSL-style)
+into a new shared module `Sarek_ir_codegen` in `spoc/ir/`. All four backends then call
+the shared versions. No functional change to generated GPU code.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `spoc/ir/dune` | Add `Sarek_ir_codegen` to `(modules ...)` |
+| `spoc/ir/Sarek_ir_codegen.ml` | Create (new file) |
+| `spoc/ir/Sarek_ir_codegen.mli` | Create (new file) |
+| `sarek-cuda/Sarek_ir_cuda.ml` | Delete local `mangle_name`+`gen_variant_def`; update call sites |
+| `sarek-opencl/Sarek_ir_opencl.ml` | Delete local `mangle_name`+`gen_variant_def`; update call sites |
+| `sarek-metal/Sarek_ir_metal.ml` | Delete local `mangle_name`+`gen_variant_def`; update call sites; resolve dead-code |
+| `sarek-vulkan/Sarek_ir_glsl.ml` | Delete local `mangle_name`+`gen_variant_def`; update call sites |
+
+**Do NOT touch:** `generate_with_types`, `type_of_elttype` functions, test files
+(unless the Metal dead-code decision requires adding a call in `generate_with_types`).
+
+## Step-by-step
+
+### Step 1 — Update `spoc/ir/dune`
+
+Change:
+```
+(modules Sarek_ir_types Sarek_ir_pp Sarek_ir_analysis)
+```
+to:
+```
+(modules Sarek_ir_types Sarek_ir_pp Sarek_ir_analysis Sarek_ir_codegen)
+```
+
+### Step 2 — Create `spoc/ir/Sarek_ir_codegen.mli`
+
+```ocaml
+(* SPDX-License-Identifier: CECILL-B *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+
+val mangle_name : string -> string
+(** Replace '.' with '_' for C/GLSL identifier compatibility. *)
+
+val gen_variant_def :
+  type_of_elttype:(Sarek_ir_types.elttype -> string) ->
+  constructor_prefix:string ->
+  Buffer.t ->
+  string * (string * Sarek_ir_types.elttype list) list ->
+  unit
+(** Emit C/MSL enum + typedef struct + union + inline constructor functions.
+    Used by CUDA, OpenCL, Metal backends. *)
+
+val gen_variant_def_glsl :
+  type_of_elttype:(Sarek_ir_types.elttype -> string) ->
+  Buffer.t ->
+  string * (string * Sarek_ir_types.elttype list) list ->
+  unit
+(** Emit GLSL const-int enum + struct (flat fields, no union) + constructor functions.
+    Used by Vulkan backend. *)
+```
+
+### Step 3 — Create `spoc/ir/Sarek_ir_codegen.ml`
+
+Add SPDX header. Implement `mangle_name` as the shared one-liner.
+
+For `gen_variant_def`: copy the body verbatim from `sarek-cuda/Sarek_ir_cuda.ml:796–868`,
+replace every `cuda_type_of_elttype ty` with `type_of_elttype ty`, replace the prefix
+string literal `"__device__ __host__ inline"` with `constructor_prefix`.
+
+For `gen_variant_def_glsl`: copy the body verbatim from
+`sarek-vulkan/Sarek_ir_glsl.ml:969–1036`, replace every `glsl_type_of_elttype ty`
+with `type_of_elttype ty`. The GLSL version uses `Printf.sprintf` heavily — do not
+switch to `Buffer.add_string` style; keep it as-is.
+
+Verify: `opam exec --switch=/home/mathias/dev/SPOC -- dune build` passes.
+
+### Step 4 — Migrate CUDA (`sarek-cuda/Sarek_ir_cuda.ml`)
+
+1. Delete lines 33–34 (local `mangle_name`).
+2. Delete lines 796–868 (local `gen_variant_def`).
+3. Replace all remaining `mangle_name` call sites with `Sarek_ir_codegen.mangle_name`.
+   Call sites to update: lines 43, 44, 148, 797 (now gone), 896 in `generate_with_types`.
+   Search: `grep -n 'mangle_name' sarek-cuda/Sarek_ir_cuda.ml`
+4. Update `generate_with_types` line 881 (renumbered after deletions):
+   ```ocaml
+   List.iter
+     (Sarek_ir_codegen.gen_variant_def
+        ~type_of_elttype:cuda_type_of_elttype
+        ~constructor_prefix:"__device__ __host__ inline"
+        buf)
+     k.kern_variants ;
+   ```
+5. `opam exec --switch=/home/mathias/dev/SPOC -- dune build` — must be clean.
+
+### Step 5 — Migrate OpenCL (`sarek-opencl/Sarek_ir_opencl.ml`)
+
+Same pattern. Local `mangle_name` at line 44. Local `gen_variant_def` at line 778.
+Call site in `generate_with_types` at line 859.
+
+```ocaml
+List.iter
+  (Sarek_ir_codegen.gen_variant_def
+     ~type_of_elttype:opencl_type_of_elttype
+     ~constructor_prefix:"static inline"
+     buf)
+  k.kern_variants ;
+```
+
+`dune build` after.
+
+### Step 6 — Migrate Metal (`sarek-metal/Sarek_ir_metal.ml`)
+
+1. Delete local `mangle_name` (line 33) and `gen_variant_def` (lines 1005–1076).
+2. Update all `mangle_name` call sites to `Sarek_ir_codegen.mangle_name`.
+3. **Resolve dead-code decision:**
+   - Read `sarek-metal/test/test_sarek_ir_metal.ml` lines 199–222 (per KB).
+   - If the test exercises a kernel with a variant type and passes today:
+     the gap is intentional — do NOT add the `List.iter` call; add a comment in
+     `generate_with_types`:
+     ```ocaml
+     (* NOTE: Metal variant type codegen not yet emitted — gen_variant_def_glsl
+        equivalent lives in Sarek_ir_codegen but is not wired here. See audit
+        brief backend-variant-dedup-intake.md for context. *)
+     ```
+   - If no variant-type test exists for Metal: add the missing call after the record
+     defs block in `generate_with_types`:
+     ```ocaml
+     List.iter
+       (Sarek_ir_codegen.gen_variant_def
+          ~type_of_elttype:metal_type_of_elttype
+          ~constructor_prefix:"static inline"
+          buf)
+       k.kern_variants ;
+     ```
+4. `dune build` after.
+
+### Step 7 — Migrate Vulkan (`sarek-vulkan/Sarek_ir_glsl.ml`)
+
+1. Delete local `mangle_name` (line 33) and `gen_variant_def` (lines 969–1036).
+2. Update all `mangle_name` call sites to `Sarek_ir_codegen.mangle_name`.
+   Call sites at lines: 153, 154, 269, 279, 956 (in `gen_record_def`), 970 (now gone).
+3. Update call site in `generate_with_types` (line 1055, renumbered after deletion):
+   ```ocaml
+   List.iter
+     (Sarek_ir_codegen.gen_variant_def_glsl
+        ~type_of_elttype:glsl_type_of_elttype
+        buf)
+     k.kern_variants ;
+   ```
+4. `dune build` after.
+
+### Step 8 — Full verification
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote
+./scripts/check-license-headers.sh
+```
+
+All must pass. If `dune fmt` produces changes, stage them before the commit.
+If `check-license-headers.sh` fails, the new files are missing SPDX headers — add them.
+
+## Points of attention
+
+- **Partial application + labelled args**: `List.iter (Sarek_ir_codegen.gen_variant_def ~type_of_elttype:X ~constructor_prefix:"..." buf)` produces `string * ... -> unit` — correct for `List.iter`. Do not eta-expand unless the compiler complains.
+- **`Sarek_ir_codegen.mangle_name` inside `type_of_elttype`**: the recursive `*_type_of_elttype` functions call `mangle_name` internally (e.g. `| TRecord (name, _) -> mangle_name name`). These must be updated too — use the grep output from Step 4 as a checklist.
+- **License headers**: `Sarek_ir_codegen.ml` and `.mli` must have SPDX headers before the license check runs.
+- **Do not change generated output**: the only observable change is replacing local function definitions with calls to the shared module. If you notice any output difference in the buffer contents, stop and investigate.
+
+## Quality gates
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote
+./scripts/check-license-headers.sh
+```

--- a/briefs/backend-variant-dedup-intake.md
+++ b/briefs/backend-variant-dedup-intake.md
@@ -1,0 +1,152 @@
+# Intake Brief — backend-variant-dedup
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+`gen_variant_def` and `mangle_name` are duplicated across four backend IR modules
+(`sarek-cuda/Sarek_ir_cuda.ml`, `sarek-opencl/Sarek_ir_opencl.ml`,
+`sarek-metal/Sarek_ir_metal.ml`, `sarek-vulkan/Sarek_ir_glsl.ml`).
+
+- `mangle_name` — **identical** in all four (one-liner: replace `'.'` with `'_'`).
+- `gen_variant_def` in CUDA/OpenCL/Metal — targets C/MSL; differs only in (a) the
+  `type_of_elttype` function called and (b) the constructor inline prefix
+  (`__device__ __host__ inline` for CUDA, `static inline` for OpenCL/Metal).
+- `gen_variant_def` in Vulkan — targets GLSL; **structurally different**: uses
+  `const int` instead of `enum`, `struct` without `typedef`, flat fields instead of
+  C unions, no constructor prefix, and `r.cname_v` instead of `r.data.cname_v`.
+
+Extract into `Sarek_ir_codegen` in `spoc/ir/` with three exports:
+- `mangle_name` — shared by all four
+- `gen_variant_def` — C/MSL variant (CUDA, OpenCL, Metal), parameterised on
+  `~type_of_elttype` and `~constructor_prefix`
+- `gen_variant_def_glsl` — GLSL variant (Vulkan), parameterised on `~type_of_elttype`
+  only (no prefix)
+
+**Value:** eliminates ~320 lines of duplicated code across four backends; future
+variant-codegen fixes land in one place.
+
+## Scope Boundary
+
+Out of scope:
+- `generate_with_types` — Metal/Vulkan/OpenCL/CUDA versions all have backend-specific
+  structure. Not safely parameterisable. Deferred.
+- `type_of_elttype` functions (`cuda_type_of_elttype`, `glsl_type_of_elttype`, etc.)
+  — backend-specific, intentionally NOT shared.
+- Any other function in the four backend IR files.
+- Adding new tests for variant codegen (tracked as a follow-up gap in the KB).
+- Changes to test files unless a dune module list needs updating.
+
+**Known issue (Metal):** Metal's `gen_variant_def` is defined at line 1005 but
+`generate_with_types` never calls it — Metal kernels with variant types silently
+produce no variant typedef. This is a pre-existing bug, not introduced by this
+refactor. The implementer must confirm whether the dead definition should be deleted
+(acknowledging the gap) or whether a missing `List.iter` call should be added to
+`generate_with_types`. The decision belongs to the implementer based on reading the
+Metal test suite; it does not block extracting the shared module.
+
+## Relevant Files
+
+| File | Role | Key snippet |
+|---|---|---|
+| `spoc/ir/dune` | Library definition for `sarek_ir` | `(modules Sarek_ir_types Sarek_ir_pp Sarek_ir_analysis)` — add `Sarek_ir_codegen` |
+| `spoc/ir/Sarek_ir_types.ml` | Defines `elttype`, `kernel`, `kern_variants` | `kern_variants : (string * (string * elttype list) list) list` |
+| `sarek-cuda/Sarek_ir_cuda.ml:33` | Local `mangle_name` | `let mangle_name name = String.map …` |
+| `sarek-cuda/Sarek_ir_cuda.ml:796` | Local C `gen_variant_def` | uses `cuda_type_of_elttype`, prefix `__device__ __host__ inline` |
+| `sarek-opencl/Sarek_ir_opencl.ml:44` | Local `mangle_name` | identical to CUDA |
+| `sarek-opencl/Sarek_ir_opencl.ml:778` | Local C `gen_variant_def` | uses `opencl_type_of_elttype`, prefix `static inline` |
+| `sarek-metal/Sarek_ir_metal.ml:33` | Local `mangle_name` | identical to CUDA |
+| `sarek-metal/Sarek_ir_metal.ml:1005` | Local C `gen_variant_def` (dead — no call site in `generate_with_types`) | uses `metal_type_of_elttype`, prefix `static inline` |
+| `sarek-vulkan/Sarek_ir_glsl.ml:33` | Local `mangle_name` | identical to CUDA |
+| `sarek-vulkan/Sarek_ir_glsl.ml:969` | Local GLSL `gen_variant_def` | uses `glsl_type_of_elttype`, no prefix, flat fields (no union) |
+| `sarek-vulkan/Sarek_ir_glsl.ml:1055` | Call site | `List.iter (gen_variant_def buf) k.kern_variants` |
+
+## Architecture Notes
+
+`sarek_ir` (`spoc/ir/`) is a leaf library with no project-internal dependencies.
+All three backend libraries already declare `sarek_ir` in their `(libraries ...)`.
+Adding `Sarek_ir_codegen` to `sarek_ir` introduces no new dependency edges.
+
+New module signature (`spoc/ir/Sarek_ir_codegen.ml` + `.mli`):
+
+```ocaml
+val mangle_name : string -> string
+(** Replace '.' with '_' for C/GLSL identifier compatibility. *)
+
+val gen_variant_def :
+  type_of_elttype:(Sarek_ir_types.elttype -> string) ->
+  constructor_prefix:string ->
+  Buffer.t ->
+  string * (string * Sarek_ir_types.elttype list) list ->
+  unit
+(** Emit C enum + typedef struct + union + constructor functions for one variant type.
+    Used by CUDA, OpenCL, Metal backends. *)
+
+val gen_variant_def_glsl :
+  type_of_elttype:(Sarek_ir_types.elttype -> string) ->
+  Buffer.t ->
+  string * (string * Sarek_ir_types.elttype list) list ->
+  unit
+(** Emit GLSL const-int enum + struct (flat fields, no union) + constructor functions.
+    Used by Vulkan backend. *)
+```
+
+Call site transformations:
+
+```ocaml
+(* CUDA — generate_with_types line 881 *)
+List.iter
+  (Sarek_ir_codegen.gen_variant_def
+     ~type_of_elttype:cuda_type_of_elttype
+     ~constructor_prefix:"__device__ __host__ inline"
+     buf)
+  k.kern_variants
+
+(* OpenCL — generate_with_types line 859 *)
+List.iter
+  (Sarek_ir_codegen.gen_variant_def
+     ~type_of_elttype:opencl_type_of_elttype
+     ~constructor_prefix:"static inline"
+     buf)
+  k.kern_variants
+
+(* Metal — see Known Issue; either add this or delete the dead gen_variant_def *)
+List.iter
+  (Sarek_ir_codegen.gen_variant_def
+     ~type_of_elttype:metal_type_of_elttype
+     ~constructor_prefix:"static inline"
+     buf)
+  k.kern_variants
+
+(* Vulkan — generate_with_types line 1055 *)
+List.iter
+  (Sarek_ir_codegen.gen_variant_def_glsl
+     ~type_of_elttype:glsl_type_of_elttype
+     buf)
+  k.kern_variants
+```
+
+All four local `mangle_name` definitions are deleted. All call sites qualified as
+`Sarek_ir_codegen.mangle_name` (full qualification, no local alias).
+
+## Quality Gates
+
+```bash
+# Build (use local opam switch)
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+
+# Tests (PPX + unit; GPU not required)
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+
+# Format (ocamlformat via dune)
+opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote
+
+# License header check
+./scripts/check-license-headers.sh
+```
+
+## Open Questions
+
+_(empty — everything resolved by code reading)_

--- a/briefs/backend-variant-dedup-plan.md
+++ b/briefs/backend-variant-dedup-plan.md
@@ -1,0 +1,102 @@
+# Plan — backend-variant-dedup
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+
+## Sequential steps
+
+1. **Add `Sarek_ir_codegen` to `spoc/ir/dune`** — one-word change to `(modules ...)`.
+   Files: `spoc/ir/dune`.
+   Completion: dune recognises the module name.
+
+2. **Create `spoc/ir/Sarek_ir_codegen.ml` and `spoc/ir/Sarek_ir_codegen.mli`** with
+   `mangle_name`, `gen_variant_def` (C/MSL), and `gen_variant_def_glsl` (GLSL).
+   Add SPDX CECILL-B license headers to both files before writing.
+   The C body is taken verbatim from `Sarek_ir_cuda.ml:796–868` with `cuda_type_of_elttype`
+   replaced by `type_of_elttype ty` and the prefix string replaced by `constructor_prefix`.
+   The GLSL body is taken verbatim from `Sarek_ir_glsl.ml:969–1036` with
+   `glsl_type_of_elttype` replaced by `type_of_elttype ty`.
+   Files: `spoc/ir/Sarek_ir_codegen.ml`, `spoc/ir/Sarek_ir_codegen.mli`.
+   Completion: `dune build` succeeds with the new module in scope.
+
+3. **Migrate CUDA** — delete local `mangle_name` (line 33) and `gen_variant_def`
+   (lines 796–868); update all `mangle_name` call sites to
+   `Sarek_ir_codegen.mangle_name`; update call site in `generate_with_types` (line 881)
+   to use `Sarek_ir_codegen.gen_variant_def ~type_of_elttype:cuda_type_of_elttype
+   ~constructor_prefix:"__device__ __host__ inline"`.
+   Files: `sarek-cuda/Sarek_ir_cuda.ml`.
+   Completion: `dune build` clean.
+
+4. **Migrate OpenCL** — same pattern; `opencl_type_of_elttype`, prefix `"static inline"`.
+   Call site: line 859.
+   Files: `sarek-opencl/Sarek_ir_opencl.ml`.
+   Completion: `dune build` clean.
+
+5. **Migrate Metal** — delete local `mangle_name` and `gen_variant_def`; update
+   `mangle_name` call sites. Then resolve the dead-code finding:
+   - Read `sarek-metal/test/test_sarek_ir_metal.ml` for any variant-type test.
+   - If a variant codegen test exists and currently passes without a `List.iter` call:
+     the gap is known and intentional — do NOT add the call; note in a code comment.
+   - If no such test exists or the gap looks like an oversight: add the missing
+     `List.iter (Sarek_ir_codegen.gen_variant_def ~type_of_elttype:metal_type_of_elttype
+     ~constructor_prefix:"static inline" buf) k.kern_variants` call to
+     `generate_with_types` after the record defs block.
+   Files: `sarek-metal/Sarek_ir_metal.ml`.
+   Completion: `dune build` clean, decision documented.
+
+6. **Migrate Vulkan** — delete local `mangle_name` and `gen_variant_def`; update call
+   site at line 1055 to `Sarek_ir_codegen.gen_variant_def_glsl
+   ~type_of_elttype:glsl_type_of_elttype`.
+   Files: `sarek-vulkan/Sarek_ir_glsl.ml`.
+   Completion: `dune build` clean.
+
+7. **Full build + tests**
+   ```bash
+   opam exec --switch=/home/mathias/dev/SPOC -- dune build
+   opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+   ```
+   Completion: all tests pass.
+
+8. **Format + license**
+   ```bash
+   opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote
+   ./scripts/check-license-headers.sh
+   ```
+   Completion: clean diff after fmt; license check exits 0.
+
+## Dependencies
+
+- Step 2 depends on step 1 (dune must list the module).
+- Steps 3–6 depend on step 2 (module must be compilable).
+- Steps 3–6 are independent of each other (different files); do sequentially with a
+  `dune build` check between each to isolate failures.
+- Steps 7–8 depend on steps 3–6.
+
+## Identified risks
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Metal dead `gen_variant_def` — decision wrong | Medium | Low | Test suite is the oracle; if no variant test exists, add a TODO comment, don't silently add a call |
+| Missed `mangle_name` call site | Low | Low (compile-time error) | OCaml catches unbound values; incremental per-file build |
+| License header check fails on new files | Low | Low | Add SPDX headers before running the check, not after |
+| Partial application type error at call site | Low | Low (compile-time error) | Labelled args + positional `buf` — verified correct for `List.iter` |
+| No variant codegen regression test | Medium | Medium | Note as gap; covered by reviewer |
+
+## Decisions made
+
+| Point | Decision | Reason |
+|---|---|---|
+| Vulkan scope | Included with `gen_variant_def_glsl` | GLSL target structurally different; needs its own function |
+| `mangle_name` style | Full qualification `Sarek_ir_codegen.mangle_name` | Explicit dependency, no hidden alias |
+| Metal dead code | Implementer decides based on test suite | Cannot determine intent without reading Metal tests |
+| `generate_with_types` | Out of scope | Backend-specific structure, not safely parameterisable |
+| `.mli` for `Sarek_ir_codegen` | Required | Public `(wrapped false)` library — explicit interface prevents accidental leakage |
+
+## Assumptions
+
+- No `.mli` files exist for the four backend IR modules (so no interface files need updating).
+- `spoc/ir/test/dune` does not need updating (no tests added in this refactor).
+- The three C-backend `gen_variant_def` bodies are byte-for-byte equivalent in generated
+  output (confirmed by reading; only `type_of_elttype` fn and prefix differ).
+- `sarek_ir` library does not transitively depend on any backend — adding `Sarek_ir_codegen`
+  introduces no circular dependency.

--- a/briefs/backend-variant-dedup-reviewer.md
+++ b/briefs/backend-variant-dedup-reviewer.md
@@ -1,0 +1,85 @@
+# Reviewer Brief — backend-variant-dedup
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## What was implemented
+
+A new shared module `Sarek_ir_codegen` was added to `spoc/ir/` (the `sarek_ir` library).
+It exports `mangle_name`, `gen_variant_def` (C/MSL), and `gen_variant_def_glsl` (GLSL).
+Four backend IR files (`Sarek_ir_cuda.ml`, `Sarek_ir_opencl.ml`, `Sarek_ir_metal.ml`,
+`Sarek_ir_glsl.ml`) had their local copies of these functions deleted and their call
+sites updated to use the shared module.
+
+This is a pure refactor — no functional change to generated GPU code is intended.
+
+## Audit checklist
+
+### 1. `spoc/ir/Sarek_ir_codegen.ml` — correctness of extracted bodies
+
+- [ ] `mangle_name` is `String.map (fun c -> if c = '.' then '_' else c) name` — identical to all four originals.
+- [ ] `gen_variant_def` body matches `Sarek_ir_cuda.ml:796–868` with `cuda_type_of_elttype` replaced by `type_of_elttype` and prefix string replaced by `constructor_prefix`. No other change.
+- [ ] `gen_variant_def_glsl` body matches `Sarek_ir_glsl.ml:969–1036` with `glsl_type_of_elttype` replaced by `type_of_elttype`. No other change.
+- [ ] Both new files carry SPDX `CECILL-B` license headers.
+
+### 2. Call sites — semantic equivalence
+
+For each backend, verify that the new call site produces identical buffer content to the original:
+
+| Backend | Original call | New call | Equivalent? |
+|---|---|---|---|
+| CUDA | `gen_variant_def buf v` (local) | `Sarek_ir_codegen.gen_variant_def ~type_of_elttype:cuda_type_of_elttype ~constructor_prefix:"__device__ __host__ inline" buf v` | ✓/✗ |
+| OpenCL | `gen_variant_def buf v` (local) | `Sarek_ir_codegen.gen_variant_def ~type_of_elttype:opencl_type_of_elttype ~constructor_prefix:"static inline" buf v` | ✓/✗ |
+| Metal | (was dead) | (either added or noted) | N/A |
+| Vulkan | `gen_variant_def buf v` (local) | `Sarek_ir_codegen.gen_variant_def_glsl ~type_of_elttype:glsl_type_of_elttype buf v` | ✓/✗ |
+
+### 3. `mangle_name` call sites — completeness
+
+For each backend, verify no remaining use of the (now-deleted) local `mangle_name`:
+
+```bash
+grep -n '\bmangle_name\b' sarek-cuda/Sarek_ir_cuda.ml sarek-opencl/Sarek_ir_opencl.ml \
+  sarek-metal/Sarek_ir_metal.ml sarek-vulkan/Sarek_ir_glsl.ml
+```
+
+Every remaining occurrence must be `Sarek_ir_codegen.mangle_name`. Zero unqualified uses allowed.
+
+### 4. Metal dead-code decision
+
+- [ ] The implementer made an explicit decision (comment or added call).
+- [ ] If a call was added: it matches the pattern for OpenCL (same `static inline` prefix, `metal_type_of_elttype`).
+- [ ] If a comment was added: it explains the gap and references the brief.
+- [ ] No silent deletion without documentation.
+
+### 5. Scope discipline
+
+- [ ] `generate_with_types` functions are unchanged (except the `gen_variant_def` call site line).
+- [ ] `*_type_of_elttype` functions are unchanged except for `mangle_name` → `Sarek_ir_codegen.mangle_name`.
+- [ ] No other functions moved or modified.
+- [ ] `spoc/ir/test/dune` unchanged (no new test dependency added).
+
+### 6. dune file
+
+- [ ] `spoc/ir/dune` has `Sarek_ir_codegen` in `(modules ...)`.
+- [ ] No new `(libraries ...)` entries in any backend dune file (no new dep edges).
+
+### 7. Quality gates passed
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build           # must pass
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest  # must pass
+opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote  # must produce no further changes
+./scripts/check-license-headers.sh                                 # must exit 0
+```
+
+## Risks to specifically check
+
+- **Vulkan `gen_variant_def_glsl` output equivalence**: the GLSL version uses `Printf.sprintf` throughout; any substitution error silently changes generated GLSL source. Compare the body character-by-character against the original if there is any doubt.
+- **`mangle_name` inside recursive `type_of_elttype`**: missed call sites inside the recursive type function bodies would cause a compile-time unbound-value error — but only if `dune build` was run after each file. Check the build logs.
+- **No variant codegen regression test**: if no test exercises a kernel with a variant type, a silent output difference would not be caught. Flag this gap in the review verdict.
+
+## Expected verdict
+
+**GO** if all checklist items pass and quality gates are clean.
+**NO-GO** if: any unqualified `mangle_name` remains, any call site is semantically different from its original, or any quality gate fails.

--- a/briefs/cpu-runtime-split-intake.md
+++ b/briefs/cpu-runtime-split-intake.md
@@ -1,0 +1,83 @@
+# Intake + Plan — cpu-runtime-split
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+`sarek/sarek/Sarek_cpu_runtime.ml` (1497 lines) splits by responsibility. PURE MOVE,
+byte-identical behavior. The module has a public `.mli` (215 lines) — the public surface
+must remain identical.
+
+## Scope Boundary
+
+OUT of scope (move verbatim, do NOT fix — each is a separate future intake):
+- Barrier-divergence deadlock (no convergence check in `run_block_with_barriers`,
+  `ThreadPool.run_block_bsp`).
+- Exception-before-decrement deadlock in `ThreadPool.worker_fn` / `ParallelPool.worker_fn`.
+- Missing grid/block dimension validation / overflow checks.
+No logic changes. The `.mli` public interface is unchanged.
+
+## Module DAG (verified by code reading)
+
+```
+types  ←  exec  ←  pools  ←  Sarek_cpu_runtime (main, keeps .mli)
+   ↖________________________/
+```
+
+1. **`Sarek_cpu_runtime_types.ml`** (leaf) — current lines ~13–154:
+   `module Float32 = Sarek_float32`, `exec_mode`, `thread_state`, `global_idx_*`,
+   `global_size_*`, `any_array`, `shared_mem`, `create_shared`, `alloc_shared_*`,
+   and `type _ Effect.t += Barrier`.
+2. **`Sarek_cpu_runtime_exec.ml`** — lines ~156–420:
+   `run_block_sequential_bsp`, `run_sequential`, `run_block_with_barriers`. Depends on
+   types. (Verified: references no pool.)
+3. **`Sarek_cpu_runtime_pools.ml`** — the internal pool machinery:
+   `DomainPool` (422–515), `ThreadPool` (644–1015), `ParallelPool` (1043–1177),
+   `LaunchQueue` (1286–1392), plus their global-ref/getter helpers
+   (`global_pool`/`get_pool`, `fission_pool`/`get_fission_pool`,
+   `parallel_pool`/`get_parallel_pool`, `fission_queues`/`get_fission_queue`).
+   Depends on types (+ exec if a pool body calls run_block_*; the implementer confirms
+   by compiler).
+4. **`Sarek_cpu_runtime.ml`** (main, KEEPS the existing `.mli`) — the public orchestrators:
+   `run_parallel_simple`, `run_parallel_with_barriers`, `run_parallel`, `run_threadpool`,
+   `enqueue_fission`, `flush_fission_queue`, `flush_fission`, `run_1d/2d/3d_threadpool`.
+   Re-exports the public types/helpers from the types module (see below).
+
+## .mli re-export requirement (the careful part)
+
+The `.mli` exposes `exec_mode`, `thread_state` (concrete records/variants), `shared_mem`
+(abstract), and the `global_*` / `create_shared` / `alloc_shared_*` helpers. After moving
+their definitions to `Sarek_cpu_runtime_types`, the main `.ml` must re-export them with
+type equality so the `.mli` still matches and external callers see identical types:
+
+```ocaml
+type exec_mode = Sarek_cpu_runtime_types.exec_mode = <constructors copied verbatim>
+type thread_state = Sarek_cpu_runtime_types.thread_state = { <fields copied verbatim> }
+type shared_mem = Sarek_cpu_runtime_types.shared_mem   (* abstract in .mli — plain alias ok *)
+let global_idx_x = Sarek_cpu_runtime_types.global_idx_x
+(* … all other public helpers re-exported … *)
+```
+
+The `.mli` file itself is NOT changed.
+
+## Quality Gates
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build sarek/sarek/
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+ocamlformat --check sarek/sarek/Sarek_cpu_runtime*.ml
+```
+
+(`@sarek/tests/runtest` includes `test_cpu_runtime.ml` — the real regression gate.
+Ignore `-lnvrtc` from a full build.)
+
+## Risks
+
+| Risk | Prob | Impact | Mitigation |
+|---|---|---|---|
+| .mli re-export type mismatch | Med | Low (compile error) | incremental build; copy constructors/fields verbatim |
+| Concurrency logic altered during move | Low | High | pure move, no edits inside bodies; test_cpu_runtime gates |
+| Accidentally fixing a documented deadlock/overflow bug | Low | High | forbidden; reviewer checks the flagged sites are verbatim |
+| Pool→exec dependency missed | Med | Low (compile error) | DAG allows pools to open exec; compiler confirms |

--- a/briefs/ir-interp-split-intake.md
+++ b/briefs/ir-interp-split-intake.md
@@ -1,0 +1,70 @@
+# Intake + Plan — ir-interp-split
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+`sarek/sarek/Sarek_ir_interp.ml` (1573 lines) splits by responsibility. PURE MOVE,
+byte-identical behavior. NO `.mli` exists, so the whole module is public API — every
+externally-referenced name must remain reachable as `Sarek_ir_interp.<name>`.
+
+## External API that MUST stay under `Sarek_ir_interp` (verified by grep)
+
+Used by `Execute.ml`, `sarek/plugins/interpreter/*`, and e2e tests:
+- type `value` **and its constructors** (`VInt32`, `VInt64`, `VFloat32`, `VFloat64`,
+  `VRecord`, `VUnit`, …) — note `value = Sarek_value.value`
+- type `arg` (`ArgArray`, `ArgScalar`)
+- type `writeback` (`Writeback`)
+- `to_int`, `to_float32`/`to_float64` (whatever the digit-suffixed names actually are)
+- `parallel_mode`, `run_kernel`, `run_kernel_with_exec_args`, `exec_vector_to_array`
+
+Any of these that move to a sub-module MUST be re-exported from the main module with
+type equality (constructors copied verbatim for `value`), exactly like the
+`thread_state` re-export in the cpu-runtime split (Intake 4).
+
+## Module DAG
+
+```
+value  ←  intrinsics  ←  eval  ←  Sarek_ir_interp (main)
+```
+
+1. **`Sarek_ir_interp_value.ml`** (leaf) — lines ~17–314:
+   `module F32`, `type value = Sarek_value.value = <ctors>`, `Barrier` effect,
+   `thread_state`, `env`, `create_env`, `copy_env`, `bind_var`, `lookup_var`,
+   `to_int32/int64/int/float32/float64/bool`, `eval_binop`, `eval_unop`, path predicates
+   (`is_gpu_path`, `is_float32_path`, `is_float64_path`, `is_int32_path`).
+2. **`Sarek_ir_interp_intrinsics.ml`** — lines ~315–609: `eval_gpu_index_intrinsic`,
+   `eval_barrier_intrinsic`, `eval_float32_math_intrinsic`, `eval_float64_math_intrinsic`,
+   `eval_int32_math_intrinsic`, `eval_type_conversion_intrinsic`. `open …_value`.
+3. **`Sarek_ir_interp_eval.ml`** — lines ~610–1115: the `let rec eval_intrinsic … and …`
+   chain through `exec_stmt_for_return`, plus `run_block`, `run_grid_sequential`. This
+   recursive chain is ONE unit — keep it intact. `open …_value`, `open …_intrinsics`.
+4. **`Sarek_ir_interp.ml`** (main) — lines ~1116–end: `DomainPool`, `global_pool`,
+   `get_pool`, `run_grid_parallel`, `parallel_mode`, `run_grid`, type `arg`, `run_kernel`,
+   vector↔array conversions, `writeback`/`exec_writeback`, exec-args machinery,
+   `run_kernel_with_exec_args`, `run_kernel_with_args`. `open` the three sub-modules.
+   Plus RE-EXPORTS of the external-API names listed above (value+ctors, to_int,
+   to_float*, exec_vector_to_array).
+
+## Quality Gates
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build sarek/sarek/
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+ocamlformat --check sarek/sarek/Sarek_ir_interp*.ml
+```
+
+`@sarek/tests/runtest` builds `Execute.ml`, the interpreter plugin, and
+`test_polymorphism.ml` — the external callers — so it is the real gate for the
+re-exports. Ignore `-lnvrtc` from a full build.
+
+## Risks
+
+| Risk | Prob | Impact | Mitigation |
+|---|---|---|---|
+| External caller loses access to a moved name | Med | Med | re-export all listed names; runtest builds the callers |
+| `value` constructor visibility lost (abstract re-export) | Med | High | re-export `type value = …_value.value = <ctors>`; runtest gates |
+| rec eval chain split mid-way | Low | High | keep 610–1115 as one unit in eval module |
+| Logic changed during move | Low | High | pure move; runtest |

--- a/briefs/native-gen-split-intake.md
+++ b/briefs/native-gen-split-intake.md
@@ -1,0 +1,100 @@
+# Intake Brief — native-gen-split
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+`sarek/ppx/Sarek_native_gen.ml` is 1951 lines (3.9× the 500-line limit). Split it into
+cohesive modules **by responsibility**, with zero change to generated OCaml output.
+
+The file already uses an open-recursion design: the expression sub-generators
+(`gen_memory_access`, `gen_let_binding`, `gen_control_flow`, `gen_data_structure`,
+`gen_special_expr`, `gen_parallel_construct`) take the recursive `~gen_expr` as a
+parameter rather than calling it directly. This makes them liftable into a separate
+module without breaking the recursion.
+
+**Value:** four files each closer to the size limit; clear separation between context,
+expression generation, and kernel-level generation.
+
+## Scope Boundary
+
+OUT of scope — this is a **pure structural move**, not a behavior change:
+- The confirmed semantic bugs documented in `kb/sarek/ppx/native-gen.md` MUST NOT be
+  touched: `downto` bound reversal (lines ~305–343), `TECreateArray` int32/int
+  mismatch (~466–469), custom-scalar `failwith` casting (~1157–1159), mutable inline-FCM
+  rejection (~236–237). Each deserves its own intake. Moving them verbatim is required;
+  fixing them is forbidden here.
+- No change to `Sarek_native_helpers.ml` or `Sarek_native_intrinsics.ml`.
+- No change to generated AST. Output must be byte-identical.
+- No new functionality, no signature changes to the public entry points
+  (`gen_expr`, `gen_expr_with_inline_types`, `gen_cpu_kern_native`,
+  `gen_simple_cpu_kern_native`, `gen_cpu_kern_native_wrapper`, type-decl generators).
+
+## Relevant Files
+
+| File | Role |
+|---|---|
+| `sarek/ppx/Sarek_native_gen.ml` | The 1951-line monolith to split |
+| `sarek/ppx/dune` | Library module list — must list the new modules |
+| `sarek/ppx/Sarek_native_helpers.ml` | Dependency (unchanged) |
+| `sarek/ppx/Sarek_native_intrinsics.ml` | Dependency (unchanged) |
+
+## Architecture Notes
+
+Proposed 4-module decomposition (names use the `Sarek_native_gen_*` prefix so they sit
+in the existing `sarek_ppx_lib` library):
+
+1. **`Sarek_native_gen_base.ml`** (current lines ~35–220) — leaf module, no internal deps:
+   - `IntSet`, `StringSet` modules
+   - `gen_context` type + `empty_ctx`
+   - `is_same_module`, `types_module_var`
+   - FCM name helpers (`field_getter_name`, `record_maker_name`, `variant_ctor_name`)
+   - `gen_literal`, `gen_variable`
+   - `custom_descriptor_expr`, inline-type helpers, `vector_type_id_expr`,
+     `custom_type_id_expr`
+
+2. **`Sarek_native_gen_expr.ml`** (current lines ~222–695) — depends on base:
+   - the six `~gen_expr`-parameterised sub-generators
+
+3. **`Sarek_native_gen.ml`** (remaining core) — depends on base + expr:
+   - `gen_expr_impl` / `gen_pattern_impl` / `gen_binop` / `gen_unop` (the `let rec … and`)
+   - entry points `gen_expr`, `gen_expr_with_inline_types`, `module_name_of_sarek_loc`
+   - module item + type-decl generation, FCM module impl (`gen_module_fun`,
+     `gen_type_decl_*`, `gen_module_impl`, `wrap_module_items`, `has_inline_types`, …)
+
+4. **`Sarek_native_gen_kernel.ml`** (current lines ~1125–1728) — depends on base + expr + core:
+   - `gen_mode_of_exec_strategy`, `gen_arg_cast`, `gen_types_object`,
+     `gen_cpu_kern_native`, `gen_simple_cpu_kern_native`, `gen_cpu_kern_native_wrapper`
+
+Dependency DAG (no cycles): base ← expr ← core ← kernel.
+
+**Callers outside this file** reference these functions through the `Sarek_native_gen`
+module name. After the split, any function that moved to `Sarek_native_gen_kernel`
+(the public kernel builders) will have a new module path. Two options — the
+implementer chooses the lower-churn one:
+- (a) re-export from `Sarek_native_gen` via `let gen_cpu_kern_native = Sarek_native_gen_kernel.gen_cpu_kern_native` etc., OR
+- (b) update the call sites.
+Find callers first: `grep -rn 'Sarek_native_gen\.' sarek/ --include=*.ml`.
+
+No `.mli` files currently exist for `Sarek_native_gen` (verify). If none exist, none
+are required for the new modules either — but adding them is acceptable if it does not
+expand scope.
+
+## Quality Gates
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+ocamlformat --check sarek/ppx/Sarek_native_gen*.ml
+./scripts/check-license-headers.sh
+```
+
+(Full `dune build` may fail on `-lnvrtc` — pre-existing CUDA-toolkit-absent issue,
+unrelated. The `@sarek/tests/runtest` target is the real gate and includes native
+codegen tests.)
+
+## Open Questions
+
+_(empty — design resolved by code reading)_

--- a/briefs/native-gen-split-plan.md
+++ b/briefs/native-gen-split-plan.md
@@ -1,0 +1,55 @@
+# Plan — native-gen-split
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+
+## Sequential steps
+
+1. **Create `Sarek_native_gen_base.ml`** with lines ~35–220 content (context, sets, name
+   helpers, `gen_literal`, `gen_variable`, type-id helpers). SPDX header + `open` the same
+   modules the original opens (check lines 19–31). Build `sarek/ppx/` — expect the original
+   to now have duplicate defs; that's fixed in step 5.
+2. **Create `Sarek_native_gen_expr.ml`** with the six sub-generators (lines ~222–695),
+   `open Sarek_native_gen_base` (or qualify). SPDX header.
+3. **Create `Sarek_native_gen_kernel.ml`** with lines ~1125–1728 (arg cast, types object,
+   CPU kernel builders). Depends on base + expr + core entry points. SPDX header.
+4. **Add the three new modules to `sarek/ppx/dune`** `(modules …)` list.
+5. **Reduce `Sarek_native_gen.ml`** to the core: delete the moved sections; keep
+   `gen_expr_impl`/`gen_pattern_impl`/`gen_binop`/`gen_unop`, entry points, and
+   module/type-decl generation. Add `open` / qualification for base + expr. The recursive
+   core calls the sub-generators as `Sarek_native_gen_expr.gen_memory_access …`.
+6. **Update the single external caller** `sarek/ppx/Sarek_quote.ml:664`:
+   `Sarek_native_gen.gen_cpu_kern_native_wrapper` →
+   `Sarek_native_gen_kernel.gen_cpu_kern_native_wrapper`.
+7. **Build + test + format + license** (gates below). Iterate until green.
+
+## Dependencies
+
+base ← expr ← core (`Sarek_native_gen`) ← kernel. No cycle. Build after each module to
+isolate failures. The compiler is the oracle for completeness of the move.
+
+## Identified risks
+
+| Risk | Prob | Impact | Mitigation |
+|---|---|---|---|
+| Subtle output change during move | Low | High (PPX compiles all kernels) | Pure copy; `@sarek/tests/runtest` native codegen tests gate it; no logic edits |
+| Accidentally "fixing" a documented bug | Low | High | Brief forbids it; reviewer checks the four bug sites are moved verbatim |
+| Missed reference / forward dep | Med | Low (compile error) | Incremental per-module build |
+| Shared helper used by both expr and kernel placed in wrong module | Med | Low (compile error) | base holds all shared leaf helpers |
+
+## Decisions made
+
+| Point | Decision | Reason |
+|---|---|---|
+| Single caller fix | Update `Sarek_quote.ml` call site (not re-export) | Re-export from core would create core→kernel cycle |
+| Dual-voice planning | Skipped | Design fully determined by code reading; no scope ambiguity |
+| Documented bugs | Move verbatim, do NOT fix | Each deserves its own intake; mixing is untestable |
+| `.mli` files | None (match existing) | No `.mli` exists for the original; not required |
+
+## Assumptions
+
+- Only one external caller exists (`Sarek_quote.ml:664`) — confirmed by grep.
+- All sub-generators are `~gen_expr`-parameterised (confirmed: no direct `gen_expr_impl`
+  call inside them).
+- Native codegen is exercised by `@sarek/tests/runtest` (per `kb/sarek/ppx/native-gen.md`
+  related tests).

--- a/briefs/parse-split-intake.md
+++ b/briefs/parse-split-intake.md
@@ -1,0 +1,61 @@
+# Intake + Plan — parse-split (Intake 6, two steps)
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+`sarek/ppx/Sarek_parse.ml` (839 lines, no `.mli`). Two steps:
+- **6a (this brief):** pure-move split — extract leaf helpers into
+  `Sarek_parse_helpers.ml`. Mechanical, byte-identical, test-gated.
+- **6b (separate):** decompose the 316-line `parse_expression` (47 match arms) into
+  category sub-parsers via open recursion. Logic refactor, test-gated + reviewed.
+
+## External API (must stay reachable as `Sarek_parse.<name>`)
+
+Used outside the module: `Parse_error_exn`, `extract_name_from_pattern`,
+`extract_param_from_pattern`, `extract_type_from_pattern`, `collect_fun_params`,
+`pattern_of_param`, `parse_expression`, `parse_payload`.
+
+## Step 6a — module DAG: helpers ← Sarek_parse (main)
+
+**`Sarek_parse_helpers.ml`** (leaf) — move lines ~15–258:
+`loc_of_ppxlib`, `exception Parse_error_exn`, `loc_to_sloc`, `parse_type`,
+`parse_record_fields`, `parse_variant_constructors`, `extract_type_from_pattern`,
+`extract_name_from_pattern`, `extract_param_from_pattern`, `parse_pattern`,
+`parse_binop`, `parse_unop`, the `Ast_502`/`To_502`/`From_502` compat block +
+`expression_to_502`/`expression_of_502`/`pattern_of_502`/`case_of_502`,
+`type fun_body`, `is_function_expression_502`, `same_position`, `same_location`,
+`expression_at_loc`, `pattern_of_param`, `collect_fun_params`, `is_function_expression`.
+(`Parse_error_exn` MUST be here — the helpers raise it.)
+
+**`Sarek_parse.ml`** (main) — keep lines ~262–end: the `let rec parse_let_shared …
+and parse_superstep … and parse_expression … and is_array_access` chain,
+`parse_kernel_function`, `parse_payload`. `open Sarek_parse_helpers`. Re-export the
+external-API helpers:
+```ocaml
+exception Parse_error_exn = Sarek_parse_helpers.Parse_error_exn
+let extract_name_from_pattern = Sarek_parse_helpers.extract_name_from_pattern
+let extract_param_from_pattern = Sarek_parse_helpers.extract_param_from_pattern
+let extract_type_from_pattern  = Sarek_parse_helpers.extract_type_from_pattern
+let collect_fun_params         = Sarek_parse_helpers.collect_fun_params
+let pattern_of_param           = Sarek_parse_helpers.pattern_of_param
+```
+
+## Quality Gates
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build sarek/ppx/
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+ocamlformat --check sarek/ppx/Sarek_parse.ml sarek/ppx/Sarek_parse_helpers.ml
+```
+`@sarek/tests/runtest` builds the PPX and its consumers — the gate for the re-exports.
+
+## Risks (6a)
+
+| Risk | Prob | Impact | Mitigation |
+|---|---|---|---|
+| External caller loses a helper | Med | Med | re-export the 6 listed names; runtest builds callers |
+| Parse_error_exn identity split (two distinct exns) | Med | High | define ONCE in helpers; main re-exports via `exception … = …` (same identity) |
+| Pure move alters logic | Low | High | verbatim move; runtest |

--- a/briefs/plugin-base-sig-intake.md
+++ b/briefs/plugin-base-sig-intake.md
@@ -1,0 +1,84 @@
+# Intake + Plan — plugin-base-sig
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+CUDA, OpenCL, and Metal plugin-base modules each carry a ~130-line inline module
+signature (`module Xxx : sig … end = struct …`) that is structurally identical across
+the three. Extract it into a single shared `module type PLUGIN_BASE` in
+`spoc/framework/Framework_sig.ml`, and annotate each backend module with it.
+
+**Value:** removes ~260 lines of duplicated signature; one place to evolve the
+low-level backend interface.
+
+## Scope correction (audit was partly wrong)
+
+- The audit said "4 backends, shared functor." Reality: **3 backends** (CUDA/OpenCL/Metal).
+  Vulkan's `Vulkan_plugin_base.ml` has NO inline signature and a different submodule
+  order — explicitly OUT of scope.
+- It is a shared **module type**, not a functor. Implementations differ (each wraps a
+  distinct FFI api) and are NOT shared.
+- No file is oversized (max OpenCL 469 < 500). This is pure DRY, not a size fix.
+
+## Scope Boundary
+
+OUT of scope:
+- Vulkan plugin base (no inline sig).
+- The implementations (`struct … end` bodies) — unchanged.
+- `Framework_sig.BACKEND` — NOT refactored. PLUGIN_BASE is standalone, because
+  PLUGIN_BASE.Device has `get_current_device` which BACKEND.Device lacks (they are not
+  subset-compatible). Making BACKEND include PLUGIN_BASE is a separate, larger change.
+- The `*_plugin.ml` consumers — unchanged (verified they use `Kernel.args` only as an
+  abstract variant payload).
+
+## Key design facts (verified by code reading)
+
+- The 3 inline sigs differ in exactly two ways: `is_zero_copy` value ordering (irrelevant
+  — OCaml signature matching is order-independent), and CUDA exposes
+  `type args = Cuda_api.Kernel.arg list ref` concretely while OpenCL/Metal keep `type args`
+  abstract.
+- PLUGIN_BASE will declare `type args` **abstract**. Sealing CUDA with it hides the
+  concrete `args`. Verified safe: the only consumer, `Cuda_plugin.ml:25`
+  (`type Framework_sig.kargs += Cuda_kargs of Cuda_base.Kernel.args`) uses it purely as an
+  abstract variant payload, as do OpenCL/Metal equivalents.
+- `Framework_sig` already depends on `ctypes` and references `Ctypes.ptr`, so PLUGIN_BASE's
+  `host_ptr_to_device` / `device_to_host_ptr` introduce no new dependency.
+
+## PLUGIN_BASE shape
+
+Exactly the current CUDA inline sig (`Cuda_plugin_base.ml:15–145`) with `type args`
+abstract. Members: `name`, `version`, `module Device` (with `get_current_device`),
+`module Memory` (incl. `alloc_zero_copy`, `is_zero_copy`, ptr transfers, `device_ptr`),
+`module Stream`, `module Event`, `module Kernel`, `enable_profiling`,
+`disable_profiling`, `is_available`.
+
+## Steps
+
+1. Add `module type PLUGIN_BASE = sig … end` to `Framework_sig.ml` (after `BACKEND` or
+   near it). Use abstract `type args`. Internal cross-refs (`Device.t`, `Memory.buffer`,
+   `Stream.t`) resolve within the module type. Use unqualified `capabilities`/`dims`
+   (we are inside Framework_sig).
+2. `sarek-cuda/Cuda_plugin_base.ml`: replace the inline `: sig … end` (lines 15–145) with
+   `: Framework_sig.PLUGIN_BASE`. Keep the `struct … end` body verbatim.
+3. Same for `sarek-opencl/Opencl_plugin_base.ml` and `sarek-metal/Metal_plugin_base.ml`.
+4. Build each backend + framework; build tests; format; license.
+
+## Quality Gates
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build spoc/framework/ sarek-cuda/ sarek-opencl/ sarek-metal/
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+ocamlformat --check spoc/framework/Framework_sig.ml sarek-cuda/Cuda_plugin_base.ml sarek-opencl/Opencl_plugin_base.ml sarek-metal/Metal_plugin_base.ml
+./scripts/check-license-headers.sh
+```
+
+## Risks
+
+| Risk | Prob | Impact | Mitigation |
+|---|---|---|---|
+| A backend struct lacks a PLUGIN_BASE member → seal fails | Low | Low (compile error) | normalized diff showed identical member sets; build is the oracle |
+| Abstracting CUDA `args` breaks a consumer | Low | Med | verified only abstract-payload use; build gates |
+| `get_current_device` missing in some backend struct | Low | Low (compile error) | present in all 3 inline sigs per diff |

--- a/briefs/pure-codegen-extraction-impl.md
+++ b/briefs/pure-codegen-extraction-impl.md
@@ -1,0 +1,49 @@
+# Implementation Brief — pure-codegen-extraction · Phase 0A (spike)
+
+**Date:** 2026-06-02
+**Mode:** full (gated spike)
+**Status:** COMPLETED — all 5 steps; GO on the riskiest (Step 4) and Step 5.
+
+## Modified / added files
+
+| File | Change | Reason |
+|---|---|---|
+| `spoc/framework_error/{dune,Backend_error.ml}` | new pure lib `sarek_backend_error` (no ctypes) | Step 2 — extract error layer |
+| `spoc/framework/Backend_error.ml` + `dune` | re-export stub → `Sarek_backend_error` | preserve compat |
+| `sarek-{cuda,opencl,metal,vulkan}/{*_error.ml,dune}` | repoint to `Sarek_backend_error` | Step 2 |
+| `sarek-cuda/Sarek_ir_cuda.ml` + `dune` | `current_device:Device.t` → `current_framework:string`; `generate_for_device` wrapper; drop `open Spoc_core` | Step 3 |
+| `spoc/ir/Sarek_pure_registry.ml` + `dune` | new pure intrinsic registry (`framework:string->string`, no Device.t) | Step 4 |
+| `sarek/tests/codegen_golden/*` (9 files) + `sarek/tests/dune` | golden-snapshot harness, 5 kernels × 4 backends = 20 byte-exact tests | Step 1 |
+| `tools/transpile_smoke/*` (2 files) | `(modes byte)` FFI-free target: `sarek_ir + sarek_backend_error` only | Step 5 |
+
+## Decisions / deviations
+- Pure registry runs **in parallel** to the FFI registry (path-qualified intrinsics query it first) — minimal, non-breaking; full PPX dual-registration is 0B.
+- Step 5 FFI-free surface proven = generator-emit logic against `sarek_ir + sarek_backend_error`; the CUDA *module* still lives in `sarek_cuda` (ctypes) — full generator extraction is 0B (documented).
+- Golden capture mode via `GOLDEN_CAPTURE=1`; metal/cuda goldens captured locally, CI uses stub variants (determinism still exercised).
+
+## Quality gates
+- [x] `dune build @sarek/tests/runtest` ✅ (20 golden + all unit/e2e)
+- [x] `dune build @sarek-vulkan/all` ✅
+- [x] `dune build` ✅ (except pre-existing `new_runtime` `-lnvrtc` link — CUDA toolkit absent)
+- [x] `ocamlformat --check` changed files ✅
+- [x] `tools/transpile_smoke` links FFI-free + runs PASS ✅
+- [x] Golden perturbation test (1-char change fails, revert restores) ✅
+
+## GO/NO-GO verdict (the spike's purpose)
+- **Step 4 (registry/stdlib decouple): GO** — a `Device.t`-free pure registry resolves
+  `Float32.sin` and the CUDA generator emits byte-identical output via it.
+- **Step 5 (FFI-free compile): GO** — the pure slice links with no ctypes/spoc_core.
+- ⇒ Phase 0B (full rollout) is **feasible**.
+
+## Points of attention for review
+- Goldens must be genuinely byte-exact + deterministic (mutable refs reset).
+- `Backend_error` extraction: pure lib ctypes-free; the exception identity preserved across
+  the re-export stub (existing `Spoc_framework.Backend_error.Backend_error` catchers).
+- CUDA `generate_for_device` wrapper must keep `SNative` output byte-identical.
+- Confirm nothing outside 0A scope changed (no stdlib conversion, no lib split, no
+  `Sarek_transpile`).
+
+## Out-of-scope (0B, documented)
+Full generator extraction to a pure lib; PPX dual-registration of intrinsics;
+`Kirc_Ast.Native` decouple; opencl/metal/glsl `current_device` decouple; `sarek_ppx_lib`
+split; `Sarek_transpile.of_source`.

--- a/briefs/pure-codegen-extraction-implementer.md
+++ b/briefs/pure-codegen-extraction-implementer.md
@@ -1,0 +1,58 @@
+# Implementer Sub-brief — pure-codegen-extraction · Phase 0A (spike)
+
+**Status:** VALIDATED
+**Scope:** Phase 0A ONLY (the de-risking spike). Phase 0B is gated behind the 0A
+go/no-go and gets its own implementer brief after the gate.
+
+## Goal
+Cheaply prove the Phase 0 carve-out is feasible before the full rollout: a real
+byte-identical gate, `Backend_error` extraction, a minimal Device.t→framework decouple,
+a minimal registry/stdlib pure-metadata proof, and an FFI-free bytecode compile.
+
+## Steps (do in order; build + goldens green after each)
+
+1. **Golden harness.** Add `sarek/tests/e2e/` (or unit) golden snapshots: pick a small
+   kernel set covering scalars, records, variants, and a stdlib call (`Float32.sin`), for
+   each of cuda/opencl/metal/glsl. Capture byte-exact generated source to committed golden
+   files; reset `current_variants`/`current_device` between captures; double-capture to
+   assert determinism. Wire into `@sarek/tests/runtest`.
+   - Verify a deliberate 1-char change to a generator makes it fail.
+2. **Extract `Backend_error`.** New pure lib (no ctypes), e.g. `spoc/framework_error/` →
+   `sarek_backend_error`. Move `Backend_error.ml` verbatim. Repoint `Cuda_error`/
+   `Opencl_error`/`Metal_error`/`Vulkan_error` to it. `Framework_sig`/`Device_type`/
+   `Typed_value` stay in `spoc_framework`.
+3. **CUDA device-decouple.** In `sarek-cuda/Sarek_ir_cuda.ml` replace
+   `current_device : Device.t option ref` → `current_framework : string option ref`; the
+   `SNative` branch reads the string; `generate_for_device ~device` becomes a backend-side
+   wrapper setting `current_framework := Some device.framework`. CUDA goldens must be
+   byte-identical.
+4. **Minimal registry/stdlib proof (Float32.sin).** Introduce a pure intrinsic-metadata
+   form with `device : framework:string -> string` (no `Spoc_core.Device.t`); register
+   `Float32.sin` via a jsoo-clean path; confirm the typer resolves it and CUDA emits the
+   same bytes for a `Float32.sin` kernel. Do NOT yet convert the whole stdlib.
+5. **FFI-free bytecode proof.** Define a throwaway dune target that compiles the minimal
+   pure slice (frontend subset + a `sarek_codegen` skeleton holding the decoupled CUDA
+   generator + `Backend_error`) with NO `ctypes`/`spoc_core` in `(libraries …)`. It must
+   link. (Bytecode is enough; jsoo is Phase 2.)
+
+## Hard constraints
+- Generated GPU source BYTE-IDENTICAL throughout (the goldens are the oracle).
+- Native/interpreter behaviour unchanged; do NOT touch `Sarek_native_gen_*`/`Kirc_Ast.Native`
+  in 0A beyond what Step 4 minimally needs (do not convert the whole stdlib).
+- No new public API surfaced yet (`Sarek_transpile` is 0B).
+- SPDX headers on new files; `dune fmt` clean.
+
+## Quality gates
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest   # incl. new goldens
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek-vulkan/all
+opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote
+# FFI-free proof target builds (Step 5)
+```
+
+## Points of attention (from dual-voice)
+- The registry/stdlib coupling (Step 4) is the riskiest unknown — if it can't be done
+  without rewriting the stdlib, STOP and report for the go/no-go, do not force it.
+- Mutable global refs in generators → goldens must reset them or determinism is fake.
+- `generate_for_device` wrapper must keep SNative output identical.

--- a/briefs/pure-codegen-extraction-intake.md
+++ b/briefs/pure-codegen-extraction-intake.md
@@ -1,0 +1,137 @@
+# Intake Brief — pure-codegen-extraction (v2, corrected scope)
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+> v2 supersedes the v1 brief. Dual-voice planning (architect + skeptic) showed v1
+> materially under-scoped the FFI coupling and the test situation; code-verified
+> corrections are folded in below. Decisions made during planning are recorded under
+> **Decisions**; genuinely-open high risks remain under **Open Questions**.
+
+## Goal
+
+Phase 0 of the website overhaul (`docs/plans/website-overhaul-2026-06-02.md`). Carve a
+**pure, FFI-free** path `OCaml source → ppxlib AST → typed AST → IR → per-backend GPU
+source` out of the FFI-linked packages, and expose
+`Sarek_transpile.of_source : string -> (backend, string) result` so the Phase 2 in-browser
+playground can transpile client-side (no GPU/runtime). GPU backend *runtimes*
+(ctypes/CUDA/Vulkan/Metal) stay unchanged.
+
+This is **multi-library architectural surgery**, not a file move — see Architecture.
+
+## Scope Boundary
+
+OUT of scope:
+- js_of_ocaml target / playground UI (Phase 2). *But:* a bytecode (or jsoo) compile of the
+  pure libraries is the only real proof the carve-out worked — see Open Q5.
+- Backend runtime behaviour (memory, launch, device mgmt) — unchanged.
+- The native-CPU generator (`Sarek_native_gen_*`) and `Kirc_Ast.Native` — legitimately
+  FFI-coupled; stay in the FFI-linked library.
+- **`[%native]` kernels in `of_source`.** `Sarek_ast.ENative` carries
+  `gpu/ocaml : Ppxlib.expression` (unevaluated AST); `Sarek_quote` itself `failwith`s on
+  quoting ENative. A runtime string transpiler cannot evaluate them. `of_source` returns a
+  structured error for sources using `[%native]` — explicitly unsupported.
+- Any change to generated GPU source bytes — must stay byte-identical (gated by a NEW
+  golden harness, see below).
+
+## Relevant Files
+
+| File | Role | Verified fact |
+|---|---|---|
+| `spoc/ir/Sarek_ir_types.ml` (`sarek_ir`, pure) | IR types | FFI-clean leaf |
+| `sarek/ppx/Sarek_parse.ml` | source AST → Sarek AST | `open Ppxlib`; consumes **ppxlib** `expression` (not compiler-libs Parsetree) |
+| `sarek/ppx/Sarek_ast.ml` | Sarek AST | `ENative {gpu:Ppxlib.expression; ocaml:Ppxlib.expression}` — unevaluated nodes |
+| `sarek/ppx/{Sarek_typer,Sarek_convergence,Sarek_mono,Sarek_tailrec,Sarek_lower,Sarek_lower_ir}.ml` | type→convergence→mono→tailrec→lower→IR | 0 *direct* FFI refs, BUT `Sarek_lower` produces `Kirc_Ast.k_ext` |
+| `sarek/ppx/Kirc_Ast.ml` | legacy AST on the lower path | `Native of (Spoc_core.Device.t -> string)` → **transitive FFI dep** |
+| `sarek/ppx/Sarek_ppx_registry.ml` + `Sarek_core_primitives.ml` | intrinsic registry consulted by the typer | `all_intrinsics()` reads a **mutable global** populated at module-init by FFI `sarek_stdlib`/`sarek_float64` |
+| `sarek/ppx/dune` (`sarek_ppx_lib`) | one lib mixing pure frontend + FFI native-gen | `(libraries ppxlib spoc_core)` — must be **split** |
+| `sarek-cuda/Sarek_ir_cuda.ml`, `sarek-opencl/…opencl.ml`, `sarek-metal/…metal.ml` | IR→source | `current_device:Device.t option ref` used only in `SNative` (reads `dev.framework`); **25/23/27 `*_error.*` calls** |
+| `sarek-vulkan/Sarek_ir_glsl.ml` | IR→GLSL | no current_device; `Spoc_core.Log.debugf` ×2; 16 `Vulkan_error.*` calls |
+| `sarek-*/{Cuda,Opencl,Metal,Vulkan}_error.ml` | error helpers | `include Spoc_framework.Backend_error.Make(...)` |
+| `spoc/framework/{Backend_error,Device_type,Framework_sig,Typed_value}.ml` (`spoc_framework`) | error/device substrate | `spoc_framework` **links ctypes**; `Framework_sig`/`Typed_value` use it; `Backend_error`/`Device_type` purity is UNPROVEN (Open Q1) |
+| `sarek-*/test/test_sarek_ir_*.ml` | the ONLY codegen tests | fragment asserts (`String.contains`), **no golden/byte-exact snapshots** |
+| `sarek-{cuda,opencl,metal,vulkan}/dune` | backend pkgs (`wrapped` default true) | host the generators today; reference `Sarek_ir_<b>` **unqualified** as siblings |
+
+## Architecture Notes
+
+**Corrected FFI coupling (all on the transpile path):**
+1. `Device.t` in cuda/opencl/metal — only `SNative` via `dev.framework` (a string).
+2. `Spoc_core.Log` in glsl — 2 debug calls.
+3. `*_error` modules → `Spoc_framework.Backend_error` → `spoc_framework` (**ctypes**).
+4. `Kirc_Ast.Native (Spoc_core.Device.t -> string)` on the `Sarek_lower` path → spoc_core.
+5. Intrinsic registry: typing reads a mutable global filled by FFI `sarek_stdlib` at init.
+
+**Target library graph (to finalize in re-plan):**
+- `sarek_ir` (pure, existing) + a pure `Backend_error` lib. **Verified:** `Backend_error.ml`
+  is ctypes-free and self-contained; the `*_error` modules only `include
+  Backend_error.Make(...)`. Extract `Backend_error` into a pure leaf lib; the ctypes users
+  (`Framework_sig`/`Device_type`/`Typed_value`) stay in `spoc_framework`. (Resolves Q1.)
+- `sarek_frontend` (pure: parse, typer, convergence, mono, tailrec, lower, lower_ir, env,
+  registry, core_primitives; deps `ppxlib`+`sarek_ir`) — split out of `sarek_ppx_lib`.
+- `sarek_codegen` (the 4 device-decoupled generators + error substrate; deps `sarek_ir`).
+- `sarek_native_gen` (Kirc_Ast, Sarek_native_gen_*; keeps spoc_core).
+- `sarek_ppx_lib` kept as a **façade** re-exporting the above so existing consumers/tests
+  don't break; backend packages re-export `Sarek_ir_<b>` under their wrapped namespace.
+- `Sarek_transpile` depends on `sarek_frontend` + `sarek_codegen`.
+
+**Pipeline order (must match for byte-identical):** parse → typer → **convergence → mono →
+tailrec** → lower_ir → `Sarek_ir_types.kernel` → per-backend `generate_with_types
+~types:kern.kern_types`. (`Sarek_ppx.ml`'s `Unix.gettimeofday` is driver-only; omit.)
+
+**`of_source`:** parse the string via ppxlib's parser (compiler-libs `Parse.expression`
+then `Ppxlib_ast.Selected_ast.of_ocaml` migration to the pinned AST — Decision below),
+require a bare `fun … -> …` (no `[%kernel]` wrapper), run the pipeline, emit
+`(backend,string) result` with structured location/message errors. `backend` is a new
+variant `Cuda|Opencl|Metal|Glsl` the transpiler defines.
+
+## Decisions (resolved during planning)
+
+| Point | Decision |
+|---|---|
+| Device decoupling | (a) replace `current_device:Device.t option ref` with `current_framework:string option ref`; `generate_for_device` becomes a 2-line backend-side wrapper. Minimal diff, lowest byte-identical-regression risk. |
+| GLSL logging | inject `?log:(string->unit)` defaulting to no-op; backend wrapper passes the `Spoc_core.Log` impl. |
+| `sarek_ppx_lib` | split is **mandatory** (frontend vs native-gen) with a re-export façade. |
+| Parser | ppxlib parse + `Selected_ast.of_ocaml` migration (robust to ocaml↔ppxlib version skew); verify the exact bridge in implementation. |
+| `[%native]` | excluded from `of_source` (structured error). |
+| Golden harness | build FIRST, before any decoupling, as the regression gate (see gates). |
+
+## Quality Gates
+
+```bash
+# 0. NEW prerequisite — golden-snapshot harness (must exist before refactor)
+#    Capture current byte-exact generated source for representative kernels across
+#    cuda/opencl/metal/glsl; reset mutable codegen refs (current_variants/current_device)
+#    between captures to ensure determinism. This is the real byte-identical detector.
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek-vulkan/all
+opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote
+# Acceptance proof: pure libs compile FFI-free (bytecode at minimum) — Open Q5
+```
+
+## Open Questions
+
+- [x] **Q1 (RESOLVED) — `Backend_error` is ctypes-free.** Verified: 0 ctypes/Framework_sig/
+  Typed_value refs; the `*_error` modules only `include Backend_error.Make(...)`. Extract
+  `Backend_error` to a pure leaf lib; `Framework_sig`/`Device_type`/`Typed_value` (ctypes
+  users) stay in `spoc_framework`. Carve-out feasible.
+- [~] **Q2 (RESOLVED — scope expands).** Investigated: the registry is itself FFI-coupled.
+  `intrinsic_info`/`type_info`/`const_info` carry `*_device : Spoc_core.Device.t -> string`
+  device-codegen closures (`Sarek_ppx_registry.ml:24,35,46`), and every `let%sarek_intrinsic`
+  in `sarek_stdlib` builds one. Two consequences for the pure path:
+  (a) **Type decoupling:** extend the framework-name decision to the registry — change
+  `*_device : Spoc_core.Device.t -> string` to `framework:string -> string` (or a pure
+  device descriptor), touching the registry type AND every stdlib intrinsic `device`
+  closure. Same root cause as the generators' `current_device`, but a wider surface.
+  (b) **Population:** the registry is filled by FFI `sarek_stdlib` module-init (its runtime
+  bodies use `Spoc_core.Vector`). The pure path needs a **pure intrinsic-metadata split**
+  (name/type/device-codegen) separable from the FFI runtime bodies — or a build-time static
+  metadata table. The plan must validate this on a minimal case (one `Float32` intrinsic)
+  in its de-risking spike before the full rollout.
+- [ ] **Q3 — regression fixtures.** The only codegen tests are fragment asserts. Do we add
+  golden fixtures covering SNative and stdlib-heavy kernels BEFORE the device/Log refactor
+  (Steps that change those paths)? (Strongly implied yes by both voices.)
+- [ ] **Q5 — acceptance proof.** Does a bytecode/jsoo compile of `sarek_frontend` +
+  `sarek_codegen` gate Phase 0 "done"? (Without it, "compiles to jsoo" is asserted, not
+  verified.)

--- a/briefs/pure-codegen-extraction-plan.md
+++ b/briefs/pure-codegen-extraction-plan.md
@@ -1,0 +1,103 @@
+# Plan — pure-codegen-extraction (Phase 0)
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Source brief:** `briefs/pure-codegen-extraction-intake.md` (v2, VALIDATED)
+
+Dual-voice analysis (architect + skeptic) was performed on v1 and folded into the v2 brief;
+not re-spawned. Q1 resolved (Backend_error is ctypes-free → extractable). Q2 resolved with
+expanded scope (the registry + every stdlib intrinsic carry `Spoc_core.Device.t` device
+closures; population is FFI-coupled). The plan front-loads a **spike (0A)** to validate the
+riskiest unknowns cheaply, with a **go/no-go** before the full rollout **(0B)**.
+
+## Strategy
+
+The whole carve-out hinges on removing `Spoc_core.Device.t` from the compile path
+(generators + registry + stdlib intrinsic defs) and on having a real byte-identical gate.
+Prove both on a *minimal slice* before touching the full surface.
+
+## Phase 0A — De-risking spike (small, gated)
+
+1. **Golden-snapshot harness.** Add a test that captures byte-exact generated source for a
+   representative kernel set across cuda/opencl/metal/glsl, resetting the mutable codegen
+   refs (`current_variants`, `current_device`) between captures. This is the regression
+   detector that does not exist today. Establishes the baseline goldens on current `main`.
+   *Completion:* goldens committed; a deliberate whitespace change makes the test fail.
+2. **Extract `Backend_error` to a pure leaf lib** (`sarek_backend_error`, no ctypes).
+   Repoint the four `*_error` modules to it. *Completion:* `@sarek/tests/runtest` +
+   `@sarek-vulkan/all` green; goldens unchanged.
+3. **Minimal device-decouple proof.** In ONE generator (CUDA) replace
+   `current_device : Device.t option ref` → `current_framework : string option ref`;
+   `generate_for_device` becomes a backend-side wrapper. *Completion:* CUDA goldens
+   byte-identical; build green.
+4. **Minimal registry/stdlib-split proof.** For ONE intrinsic (`Float32.sin`): introduce a
+   pure intrinsic-metadata representation with `device : framework:string -> string` (no
+   `Device.t`), register it via a jsoo-clean path, and confirm the typer resolves it and the
+   CUDA generator emits the same bytes. Proves Q2(a)+(b) tractable. *Completion:* goldens
+   byte-identical for a `Float32.sin` kernel.
+5. **Bytecode FFI-free proof.** Compile the minimal pure slice (frontend subset +
+   `sarek_codegen` skeleton + `Backend_error`) with no ctypes/spoc_core link (bytecode is
+   sufficient; jsoo target is Phase 2). *Completion:* it links FFI-free.
+
+   **GO/NO-GO gate (human):** if 0A succeeds, proceed to 0B. If Step 4 or 5 reveals the
+   registry/stdlib decoupling is intractable without rewriting the stdlib, STOP and
+   re-decide scope (the spike has then cheaply saved the full rollout).
+
+## Phase 0B — Full rollout (after GO)
+
+6. Apply the device→framework decouple to **opencl + metal** generators (mirror Step 3).
+7. Apply the GLSL `?log` no-op hook (decouple `Spoc_core.Log`).
+8. Extend the registry `*_device` decouple + pure-metadata registration to **all** stdlib
+   intrinsics/types/consts (mirror Step 4 across `Float32/Float64/Int32/Int64/Math/Gpu`),
+   splitting pure metadata from FFI runtime bodies. Keep native/interpreter behaviour
+   identical (their runtime path still links the FFI stdlib).
+9. **Split `sarek_ppx_lib`** → `sarek_frontend` (pure: parse/typer/convergence/mono/tailrec/
+   lower/lower_ir/env/registry/core_primitives; deps `ppxlib`+`sarek_ir`) and
+   `sarek_native_gen` (Kirc_Ast, Sarek_native_gen_*; keeps spoc_core). Keep `sarek_ppx_lib`
+   as a re-export façade. Decouple `Kirc_Ast.Native (Spoc_core.Device.t -> string)` →
+   framework-name (so `Sarek_lower`'s path is pure).
+10. **Create `sarek_codegen`** = the 4 device-decoupled generators + `Backend_error`; deps
+    `sarek_ir` only. Backend packages re-export `Sarek_ir_<b>` under their wrapped namespace
+    (preserve unqualified call sites in `*_plugin.ml`).
+11. **Write `Sarek_transpile.of_source`** — ppxlib parse (compiler-libs `Parse.expression` +
+    `Ppxlib_ast.Selected_ast.of_ocaml` migration) → pipeline (parse→type→convergence→mono→
+    tailrec→lower_ir) → per-backend `generate_with_types`. Returns `(backend, string) result`;
+    `[%native]` → structured error.
+12. **Final gates:** full `dune build`; `@sarek/tests/runtest`; `@sarek-vulkan/all`; all
+    goldens byte-identical; `dune fmt`; bytecode FFI-free compile of `sarek_frontend` +
+    `sarek_codegen` + `Sarek_transpile`.
+
+## Dependencies
+
+1 (goldens) precedes everything (it's the gate). 2 unblocks 10. 3 precedes 6. 4 precedes 8.
+5 gates 0B. 9 depends on 8 (Kirc_Ast decouple). 10 depends on 2,6,7,9. 11 depends on 9,10.
+
+## Identified risks
+
+| Risk | Prob | Impact | Mitigation |
+|---|---|---|---|
+| Registry/stdlib decouple intractable without stdlib rewrite | Med | High | Spike Step 4 proves it on one intrinsic before the full surface; GO/NO-GO gate |
+| Golden gate misses non-determinism (mutable refs) | Med | High | Step 1 resets refs between captures; assert determinism by double-capture |
+| `Selected_ast` migration / version pinning (ocaml 5.x ↔ ppxlib) | Med | Med | Validate the parse bridge in spike (fold into Step 5 if `of_source` skeleton is touched) |
+| Wrapped-lib re-export breaks unqualified `Sarek_ir_<b>` call sites | Med | Low (compile error) | re-export module named exactly `Sarek_ir_<b>` per backend |
+| Native/interpreter output changes when stdlib is split | Low | High | their runtime path keeps the FFI stdlib; goldens + runtest gate |
+| Scope/effort overrun (pervasive Device.t threading) | High | Med | spike-first + go/no-go; 0B only after cheap proof |
+
+## Decisions made
+
+| Point | Decision | Reason |
+|---|---|---|
+| Device decouple | `current_framework : string option ref` (generators) + `framework:string->string` (registry/stdlib closures) | minimal-diff, lowest byte-identical risk; only `dev.framework` is read |
+| GLSL logging | inject `?log` no-op hook | preserves bytes; no return value used |
+| Parser | ppxlib parse + `Selected_ast.of_ocaml` migration | robust to version skew (skeptic) |
+| `[%native]` | excluded from `of_source` (structured error) | ENative carries unevaluated AST |
+| Lib split | mandatory: `sarek_frontend` / `sarek_native_gen` + façade | single lib mixes pure+FFI |
+| Sequencing | spike (0A) + go/no-go before full rollout (0B) | scope grew at every layer; de-risk cheaply |
+
+## Assumptions
+
+- The device closures (`*_device`, generators' SNative) read only `dev.framework` — verified
+  for generators; to re-verify across stdlib defs in Step 8.
+- `kern.kern_types` is the correct `~types` source (all plugins pass it).
+- Native/interpreter execution is out of scope and keeps the FFI stdlib.
+- Byte-identical is judged by the new goldens (Step 1), not the existing fragment asserts.

--- a/briefs/pure-codegen-extraction-qa-scope.md
+++ b/briefs/pure-codegen-extraction-qa-scope.md
@@ -1,0 +1,30 @@
+# QA Scope — pure-codegen-extraction · Phase 0A (spike)
+
+**Status:** VALIDATED
+
+## Gates (all must pass)
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek-vulkan/all
+/home/mathias/.opam/octez-setup/bin/ocamlformat --check <changed .ml files>
+# FFI-free proof target builds (no ctypes/spoc_core)
+```
+(`-lnvrtc` link error in a full `dune build` is a pre-existing CUDA-absent issue. The CI
+`build` job's `e2e-fast` matrix-mul segfault is a known flaky OpenCL-CPU failure — re-run
+to confirm, don't treat a lone occurrence as a regression.)
+
+## Behaviours to validate
+- **Goldens:** the new snapshot test passes AND is byte-exact (introduce a temp 1-char
+  change to a generator → it must fail; revert). Run the suite twice → identical (determinism).
+- **No regression:** existing `test_sarek_ir_{cuda,opencl,metal,glsl}` fragment tests still pass.
+- **GPU runtime sanity (hardware available — RX 7900 XTX):** the Vulkan e2e still passes,
+  proving the GLSL `?log` decouple and any glsl touch didn't change runtime behaviour:
+  `dune exec sarek/tests/e2e/test_vector_add.exe -- --vulkan`
+  (and `test_klet_variant --vulkan` for variant codegen).
+- **FFI-free proof:** the Step-5 target compiles without ctypes/spoc_core in its libraries.
+
+## Out of scope for 0A QA
+- `Sarek_transpile.of_source` (0B).
+- jsoo bundle (Phase 2).
+- Full-stdlib conversion (only Float32.sin in 0A).

--- a/briefs/pure-codegen-extraction-reviewer.md
+++ b/briefs/pure-codegen-extraction-reviewer.md
@@ -1,0 +1,31 @@
+# Reviewer Sub-brief — pure-codegen-extraction · Phase 0A (spike)
+
+**Status:** VALIDATED
+
+## What was implemented (0A)
+A de-risking spike: a golden-snapshot harness, `Backend_error` extracted to a pure lib,
+CUDA generator device→framework decouple, a minimal `Float32.sin` registry/stdlib
+pure-metadata proof, and an FFI-free bytecode compile of a minimal pure slice.
+
+## Audit first
+- The new golden harness: does it capture **byte-exact** output (not fragment asserts), for
+  cuda/opencl/metal/glsl, and reset `current_variants`/`current_device` between captures?
+  Confirm a deliberate generator tweak fails it (ask the implementer for evidence, or test).
+- `Backend_error` extraction: pure lib has no ctypes; the four `*_error` modules repoint
+  cleanly; `Framework_sig`/`Device_type`/`Typed_value` stayed in `spoc_framework`.
+- CUDA decouple: `current_device:Device.t` → `current_framework:string`; `generate_for_device`
+  wrapper preserves SNative output; **CUDA goldens byte-identical**.
+- Float32.sin proof: the pure metadata form drops `Spoc_core.Device.t`; the typer still
+  resolves the intrinsic; the emitted bytes match the golden.
+- FFI-free target: `(libraries …)` contains no `ctypes`/`spoc_core`; it links.
+
+## Risks to verify
+- **Determinism:** are the goldens stable across repeated runs (mutable global refs)?
+- **Scope creep:** confirm the whole stdlib was NOT converted in 0A (only Float32.sin); and
+  native/interpreter paths untouched.
+- **Byte-identical:** every backend's goldens unchanged vs the baseline captured in Step 1.
+
+## Expected verdict
+GO if: goldens are real byte-exact + deterministic, Backend_error is genuinely ctypes-free,
+CUDA + Float32.sin goldens are byte-identical, and the FFI-free target links. Otherwise
+NO-GO with the specific blocker (this feeds the 0A go/no-go decision).

--- a/briefs/vulkan-api-split-intake.md
+++ b/briefs/vulkan-api-split-intake.md
@@ -1,0 +1,88 @@
+# Intake + Plan — vulkan-api-split (Intake 7)
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+`sarek-vulkan/Vulkan_api.ml` (1756 lines, no `.mli`) splits along its existing submodule
+boundaries (Device, Memory, Stream, Event, Kernel) into one file each, plus a base for
+shared helpers. PURE MOVE, byte-identical. The `Vulkan_api.Device.t` / `Memory.buffer` /
+`Kernel.args` / etc. access paths used by `Vulkan_plugin_base.ml` must be preserved via
+re-export.
+
+## External API (must stay reachable as `Vulkan_api.<path>`)
+
+`Vulkan_plugin_base.ml` uses: `compile_glsl_to_spirv`, `glslang_available`,
+`is_available`, and the full `Device.*`, `Memory.*`, `Stream.*`, `Event.*`, `Kernel.*`
+submodule surfaces (`.t`, `.buffer`, `.args`, and all their functions).
+
+## Module DAG (verified)
+
+```
+base + device  ←  {memory, stream, event}  ←  kernel  ←  Vulkan_api (main, re-exports)
+```
+Device has no sibling refs. Memory/Stream/Event each reference Device only. Kernel
+references Device, Memory, Stream.
+
+## Plan
+
+Each submodule's `struct … end` body becomes the top-level of its own file (so the file
+IS the module). All files open the same prelude the original opens: `open Ctypes`,
+`open Vulkan_types`, `open Vulkan_bindings`, `open Spoc_framework_registry` (drop any the
+compiler flags unused), plus `open Vulkan_api_base` and the sibling-module aliases needed.
+
+1. **`Vulkan_api_base.ml`** (leaf) — lines ~21–167: `memcpy`, `u32`,
+   `exception Vk_result_error`, `check`, `compile_glsl_to_spirv_cli`,
+   `compile_glsl_to_spirv`, `glslang_available`.
+2. **`Vulkan_api_device.ml`** — body of `module Device` (lines ~169–490). `open …_base`.
+3. **`Vulkan_api_memory.ml`** — body of `module Memory` (~492–1048). Add
+   `module Device = Vulkan_api_device`. `open …_base`.
+4. **`Vulkan_api_stream.ml`** — body of `module Stream` (~1050–1136). `module Device = …`.
+5. **`Vulkan_api_event.ml`** — body of `module Event` (~1138–1174). `module Device = …`.
+6. **`Vulkan_api_kernel.ml`** — body of `module Kernel` (~1176–1737). `module Device = …`,
+   `module Memory = Vulkan_api_memory`, `module Stream = Vulkan_api_stream`. `open …_base`.
+7. **`Vulkan_api.ml`** (main) — re-export:
+   ```ocaml
+   exception Vk_result_error = Vulkan_api_base.Vk_result_error
+   let compile_glsl_to_spirv = Vulkan_api_base.compile_glsl_to_spirv
+   let glslang_available = Vulkan_api_base.glslang_available
+   module Device = Vulkan_api_device
+   module Memory = Vulkan_api_memory
+   module Stream = Vulkan_api_stream
+   module Event = Vulkan_api_event
+   module Kernel = Vulkan_api_kernel
+   let vulkan_version () = …   (* keep verbatim, lines ~1738–1743 *)
+   let is_available () = …     (* keep verbatim, lines ~1744–end *)
+   ```
+   (also re-export `compile_glsl_to_spirv_cli` and `check`/`memcpy`/`u32` only if an
+   external caller needs them — the compiler/runtest will tell you; the external list
+   above suggests only compile_glsl_to_spirv/glslang_available/is_available + the 5
+   submodules.)
+
+## dune
+
+Add `Vulkan_api_base`, `Vulkan_api_device`, `Vulkan_api_memory`, `Vulkan_api_stream`,
+`Vulkan_api_event`, `Vulkan_api_kernel` to `(modules …)` in `sarek-vulkan/dune` (before
+`Vulkan_api`).
+
+## Quality Gates
+
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build sarek-vulkan/
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest
+ocamlformat --check sarek-vulkan/Vulkan_api*.ml
+```
+`sarek-vulkan` is `(optional)` — it builds only if Vulkan deps are present. Confirm it
+actually compiles in this env (it has FFI bindings; if dune skips it as optional, say so).
+Ignore `-lnvrtc`.
+
+## Risks
+
+| Risk | Prob | Impact | Mitigation |
+|---|---|---|---|
+| External `Vulkan_api.X.y` path breaks | Med | Med | re-export all 5 submodules + 3 top helpers; build Vulkan_plugin_base |
+| Sibling-module alias missing in a file | Med | Low (compile error) | add `module Device/Memory/Stream = …` per DAG |
+| Vulkan lib absent → backend not built → split unverified | Med | Med | report whether sarek-vulkan actually compiled; rely on build of the lib |
+| Logic changed in move | Low | High | verbatim move |


### PR DESCRIPTION
Persists the intake/plan/review/impl briefs from this session's roster-pipeline work (code-quality audit + website-overhaul Phase 0). Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive code audit report with analysis findings and prioritized remediation recommendations.
  * Added intake and planning briefs for multiple refactoring initiatives to improve code organization and reduce duplication across runtime, parsing, code generation, and API structure.
  * Added implementation guides, reviewer checklists, and QA scope documentation to track and validate planned architectural improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->