### PR TITLE
refactor(codegen): decouple OpenCL/Metal/GLSL generators from Spoc_core (Phase 0B PR-1)

### DIFF
--- a/sarek-metal/Sarek_ir_metal.ml
+++ b/sarek-metal/Sarek_ir_metal.ml
@@ -17,11 +17,10 @@
  ******************************************************************************)
 
 open Sarek_ir_types
-open Spoc_core
 
-(** Current device for SNative code generation (set during generate_for_device)
-*)
-let current_device : Device.t option ref = ref None
+(** Current framework string for SNative code generation. Set by
+    [generate_for_device]; [generate] leaves this as [None]. *)
+let current_framework : string option ref = ref None
 
 (** Current kernel's variant definitions (set during generate) *)
 let current_variants : (string * (string * elttype list) list) list ref = ref []
@@ -641,9 +640,9 @@ let rec gen_stmt buf indent = function
       Buffer.add_string buf indent ;
       Buffer.add_string buf "threadgroup_barrier(mem_flags::mem_device);\n"
   | SNative {gpu; ocaml = _} -> (
-      match !current_device with
-      | Some dev ->
-          let code = gpu ~framework:dev.framework in
+      match !current_framework with
+      | Some framework ->
+          let code = gpu ~framework in
           Buffer.add_string buf indent ;
           Buffer.add_string buf code ;
           if not (String.length code > 0 && code.[String.length code - 1] = '\n')
@@ -992,11 +991,12 @@ let generate (k : kernel) : string =
 
   pretty_print_metal (Buffer.contents buf)
 
-(** Generate complete Metal source with device context for SNative *)
-let generate_for_device ~(device : Device.t) (k : kernel) : string =
-  current_device := Some device ;
+(** Generate complete Metal source with device context for SNative. Extracts
+    only the framework string from [device]. *)
+let generate_for_device ~(device : Spoc_core.Device.t) (k : kernel) : string =
+  current_framework := Some device.Spoc_core.Device.framework ;
   let result = generate k in
-  current_device := None ;
+  current_framework := None ;
   result
 
 (** Generate variant type definition for Metal *)

--- a/sarek-opencl/Sarek_ir_opencl.ml
+++ b/sarek-opencl/Sarek_ir_opencl.ml
@@ -17,7 +17,6 @@
  ******************************************************************************)
 
 open Sarek_ir_types
-open Spoc_core
 
 (** {1 Constants} *)
 
@@ -30,9 +29,9 @@ let large_buffer_size = 4096
 (** Format float with full precision (17 digits for double precision) *)
 let format_float f = Printf.sprintf "%.17g" f
 
-(** Current device for SNative code generation (set during generate_for_device)
-*)
-let current_device : Device.t option ref = ref None
+(** Current framework string for SNative code generation. Set by
+    [generate_for_device]; [generate] leaves this as [None]. *)
+let current_framework : string option ref = ref None
 
 (** Current kernel's variant definitions (set during generate) *)
 let current_variants : (string * (string * elttype list) list) list ref = ref []
@@ -528,9 +527,9 @@ let rec gen_stmt buf indent = function
       Buffer.add_string buf indent ;
       Buffer.add_string buf "mem_fence(CLK_GLOBAL_MEM_FENCE);\n"
   | SNative {gpu; ocaml = _} -> (
-      match !current_device with
-      | Some dev ->
-          let code = gpu ~framework:dev.framework in
+      match !current_framework with
+      | Some framework ->
+          let code = gpu ~framework in
           Buffer.add_string buf indent ;
           Buffer.add_string buf code ;
           if not (String.length code > 0 && code.[String.length code - 1] = '\n')
@@ -765,11 +764,12 @@ let generate (k : kernel) : string =
 
   Buffer.contents buf
 
-(** Generate complete OpenCL source with device context for SNative *)
-let generate_for_device ~(device : Device.t) (k : kernel) : string =
-  current_device := Some device ;
+(** Generate complete OpenCL source with device context for SNative. Extracts
+    only the framework string from [device]. *)
+let generate_for_device ~(device : Spoc_core.Device.t) (k : kernel) : string =
+  current_framework := Some device.Spoc_core.Device.framework ;
   let result = generate k in
-  current_device := None ;
+  current_framework := None ;
   result
 
 (** Generate variant type definition for OpenCL *)

--- a/sarek-vulkan/Sarek_ir_glsl.ml
+++ b/sarek-vulkan/Sarek_ir_glsl.ml
@@ -897,7 +897,8 @@ let gen_shared_decls buf (decls : (string * elttype * expr) list) =
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
 *)
-let generate ?block (k : kernel) : string =
+let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
+    =
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
   let buf = Buffer.create 1024 in
@@ -944,10 +945,7 @@ let generate ?block (k : kernel) : string =
   Buffer.add_string buf "}\n" ;
 
   let shader = Buffer.contents buf in
-  Spoc_core.Log.debugf
-    Spoc_core.Log.Device
-    "[GLSL] Generated shader:\n%s"
-    shader ;
+  log (Printf.sprintf "[GLSL] Generated shader:\n%s" shader) ;
   shader
 
 (** Generate GLSL record type definition - simple struct without tag *)
@@ -974,7 +972,7 @@ let gen_variant_def buf v =
 (** Generate GLSL source with custom type definitions.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
 *)
-let generate_with_types ?block
+let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
     ~(types : (string * (string * elttype) list) list) (k : kernel) : string =
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
@@ -1031,8 +1029,5 @@ let generate_with_types ?block
   Buffer.add_string buf "}\n" ;
 
   let shader = Buffer.contents buf in
-  Spoc_core.Log.debugf
-    Spoc_core.Log.Device
-    "[GLSL] Generated shader:\n%s"
-    shader ;
+  log (Printf.sprintf "[GLSL] Generated shader:\n%s" shader) ;
   shader

--- a/sarek-vulkan/Vulkan_plugin.ml
+++ b/sarek-vulkan/Vulkan_plugin.ml
@@ -188,6 +188,7 @@ module Backend : Framework_sig.BACKEND = struct
       Some
         (Sarek_ir_glsl.generate_with_types
            ?block:block_tuple
+           ~log:(fun s -> Spoc_core.Log.debugf Spoc_core.Log.Device "%s" s)
            ~types:ir.kern_types
            ir)
     with _ -> None

--- a/sarek/tests/codegen_golden/gen_metal.real.ml
+++ b/sarek/tests/codegen_golden/gen_metal.real.ml
@@ -9,7 +9,7 @@ open Sarek_ir_types
 open Sarek_metal
 
 let reset_state () =
-  Sarek_ir_metal.current_device := None ;
+  Sarek_ir_metal.current_framework := None ;
   Sarek_ir_metal.current_variants := []
 
 let generate_with_types ~types (k : kernel) =

--- a/sarek/tests/codegen_golden/gen_opencl.real.ml
+++ b/sarek/tests/codegen_golden/gen_opencl.real.ml
@@ -9,7 +9,7 @@ open Sarek_ir_types
 open Sarek_opencl
 
 let reset_state () =
-  Sarek_ir_opencl.current_device := None ;
+  Sarek_ir_opencl.current_framework := None ;
   Sarek_ir_opencl.current_variants := []
 
 let generate_with_types ~types (k : kernel) =


### PR DESCRIPTION
Phase 0B PR-1 of 5 (roadmap `docs/plans/website-overhaul-2026-06-02.md`; intake `briefs/pure-codegen-rollout-intake.md`). Mirrors the merged Phase 0A CUDA decouple onto the other three GPU generators.

- **OpenCL + Metal:** `current_device : Spoc_core.Device.t option ref` → `current_framework : string option ref`; SNative reads the framework string; `generate_for_device` extracts `device.framework`; `open Spoc_core` dropped (only the `generate_for_device` signature keeps a qualified `Spoc_core.Device.t`).
- **GLSL:** the two `Spoc_core.Log.debugf` shader dumps → injected `?log:(string->unit)` (default no-op); `Vulkan_plugin` passes the real `Spoc_core.Log` impl, preserving production logging. `Sarek_ir_glsl` now has **zero** `Spoc_core` deps.

## Verification
- Pure refactor — **all 16 codegen goldens byte-identical** (the harness from PR-0A is the oracle; reviewed: no golden regenerated to mask a diff).
- Reviewed GO — opencl/metal mirror CUDA line-for-line; GLSL logging preserved via the wired `generate_source` path.
- `@sarek-vulkan/all` builds; `@sarek/tests/runtest` green; `ocamlformat --check` clean; **Vulkan `vector_add` e2e passes on RX 7900 XTX**.

Next: PR-2 (pure registry + PPX dual-registration + the `sinf` decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced debug logging support for Vulkan shader generation with optional logging callbacks.

* **Refactor**
  * Reorganized Metal and OpenCL code generation architecture for improved framework context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->