### PR TITLE
docs(briefs): Phase 0B intake + PR-1/PR-2 sub-briefs

### DIFF
--- a/briefs/pcr-pr1-decouple-implementer.md
+++ b/briefs/pcr-pr1-decouple-implementer.md
@@ -1,0 +1,50 @@
+# Implementer Sub-brief — pure-codegen-rollout PR-1 (opencl/metal/glsl decouple)
+
+**Status:** VALIDATED
+**Parent:** `briefs/pure-codegen-rollout-intake.md` (Phase 0B, PR-1 of 5)
+
+## Goal
+Mirror the merged Phase 0A CUDA decouple onto the OpenCL and Metal generators, and decouple
+GLSL from `Spoc_core.Log`. Pure refactor — **byte-identical** generated source (the
+`sarek/tests/codegen_golden/` harness on `main` is the oracle). This removes the
+`Spoc_core.Device.t`/`Spoc_core.Log` couplings from three more generators; it does NOT yet
+extract them into a pure lib (PR-4) or touch the registry (PR-2).
+
+## Reference (already merged, reviewed GO)
+`sarek-cuda/Sarek_ir_cuda.ml` on `main`: `current_device : Device.t option ref` →
+`current_framework : string option ref`; `SNative` branch reads the framework string;
+`generate_for_device ~device` sets `current_framework := Some device.Spoc_core.Device.framework`;
+`open Spoc_core` removed. Replicate exactly.
+
+## Steps (build + goldens green after each)
+1. **OpenCL** `sarek-opencl/Sarek_ir_opencl.ml`: replace `current_device : Device.t option ref`
+   (l.~35) with `current_framework : string option ref`; the `SNative` branch (l.~531) reads
+   the framework string; `generate_for_device` (l.~770) becomes the wrapper; drop `open
+   Spoc_core` if now unused (qualify any residual refs).
+2. **Metal** `sarek-metal/Sarek_ir_metal.ml`: same (l.~24 / ~644 / ~997).
+3. **GLSL** `sarek-vulkan/Sarek_ir_glsl.ml`: replace the two `Spoc_core.Log.debugf` calls
+   (l.~947, ~1034) with an injected `?log:(string -> unit)` parameter defaulting to no-op on
+   the relevant generate entry; the Vulkan backend wrapper passes
+   `~log:(fun s -> Spoc_core.Log.debugf Spoc_core.Log.Device "%s" s)`. Remove glsl's
+   `Spoc_core` coupling if these were its only uses.
+
+## Hard constraints
+- BYTE-IDENTICAL: the opencl/metal/glsl goldens in `sarek/tests/codegen_golden/` must not
+  change. If a golden would change, STOP — that's a real output regression, not expected.
+- Do NOT touch CUDA (done), the pure registry, or the stdlib (PR-2). No lib split (PR-3/4).
+- SPDX headers preserved; `dune fmt` clean.
+
+## Quality gates
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest   # goldens byte-identical
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek-vulkan/all
+/home/mathias/.opam/octez-setup/bin/ocamlformat --check <changed .ml>
+# GPU sanity (RX 7900 XTX): dune exec sarek/tests/e2e/test_vector_add.exe -- --vulkan
+```
+(`-lnvrtc` full-build link error is pre-existing; CI e2e-fast matrix-mul segfault is known-flaky.)
+
+## Plan note
+Low risk — proven mirror of the 0A CUDA change (reviewed GO, merged). Dual-voice not
+re-spawned for this PR per that precedent. If OpenCL/Metal/GLSL diverge from the CUDA
+pattern in some way that changes output, escalate rather than force.

--- a/briefs/pcr-pr2-pure-registry-implementer.md
+++ b/briefs/pcr-pr2-pure-registry-implementer.md
@@ -1,0 +1,60 @@
+# Implementer Sub-brief — pure-codegen-rollout PR-2 (pure registry + dual-registration + sinf)
+
+**Status:** VALIDATED
+**Parent:** `briefs/pure-codegen-rollout-intake.md` (Phase 0B, PR-2 of 5)
+
+## Goal
+Make the intrinsic registry usable from the pure (no-`Device.t`) path across the whole
+stdlib, so the generators can resolve intrinsics without `Spoc_core`. Land the **`sinf`
+fix** (path-qualified `Float32` math emits the single-precision name) — a deliberate,
+intake-approved behavior change — with golden updates and GPU validation. Native/interpreter
+behaviour stays identical.
+
+## Decisions already made (do NOT re-litigate)
+- **ADOPT `sinf`** for path-qualified `Float32` math (and `cosf/sqrtf/expf/...`, plus the
+  OpenCL/Metal/GLSL equivalents). `main` wrongly emits double `sin` for a `float32` op.
+- Pure device closure type: `framework:string -> string` (no `Spoc_core.Device.t`).
+
+## Reference
+The Phase 0A spike branch `phase0a/pure-codegen-spike` holds a proven `Sarek_pure_registry.ml`
+(in `sarek_ir`, ctypes-free) + the CUDA `gen_intrinsic` pure-registry query + a
+`float32_sin_pure` golden. Get it with `git show phase0a/pure-codegen-spike:spoc/ir/Sarek_pure_registry.ml`.
+Promote and generalize it.
+
+## Steps (build + goldens green after each; COMMIT after each step on your worktree branch)
+1. **Add `Sarek_pure_registry`** to `sarek_ir` (from the spike). It maps
+   `(module-path, name) -> (framework:string -> string)` with zero `Device.t`.
+2. **Populate it for the whole stdlib** — `Float32/Float64/Int32/Int64/Math/Gpu` intrinsics,
+   types, consts. Prefer making the `%sarek_intrinsic` PPX (`sarek/ppx_intrinsic/`) emit a
+   **pure** registration (`framework:string->string`) alongside the existing FFI one — so
+   the two registries stay in sync from one definition. If PPX dual-registration proves too
+   large/risky in a bounded attempt, fall back to a build-time-generated static pure table
+   and SAY SO (escalate the scope, don't force a half-migration).
+3. **All four generators** (`Sarek_ir_{cuda,opencl,metal}.ml`, `Sarek_ir_glsl.ml`) query the
+   pure registry first for path-qualified intrinsics (`path <> []`), mirroring the spike's
+   CUDA change. Drop the dead unqualified pure-registry entries the spike reviewer flagged.
+4. **Adopt `sinf` + update goldens.** Regenerate ONLY the goldens that legitimately change
+   due to the `sin→sinf` (and siblings) fix; in the PR, the golden diff must be exactly the
+   intended `f`-suffix (and analogous) changes — no unexpected drift. Add golden kernels
+   covering path-qualified `Float32` math for all 4 backends.
+5. **GPU-validated e2e.** Add/extend an e2e that runs a `Float32.sin` (or similar) kernel and
+   checks numerical correctness; confirm it passes on the Vulkan backend (RX 7900 XTX):
+   `dune exec sarek/tests/e2e/<test>.exe -- --vulkan`.
+6. **Native/interpreter unchanged** — they keep the FFI registry/runtime; confirm their
+   tests still pass.
+
+## Hard constraints
+- Native/interpreter output identical; only the GPU path-qualified math output changes (to the `f` form), and ONLY where intended — every golden change must be an expected `sinf`-class change, justified in the report.
+- No library split (PR-3), no `sarek_codegen` extraction (PR-4), no `Sarek_transpile` (PR-5).
+- SPDX headers; `dune fmt` clean.
+- **COMMIT your work on the worktree branch after each step** (do not leave changes uncommitted).
+
+## Quality gates
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest   # goldens reflect intended sinf changes only
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek-vulkan/all
+opam exec --switch=/home/mathias/dev/SPOC -- dune exec sarek/tests/e2e/<float32-test>.exe -- --vulkan
+/home/mathias/.opam/octez-setup/bin/ocamlformat --check <changed .ml>
+```
+(`-lnvrtc` full-build error pre-existing; CI e2e-fast matrix-mul segfault known-flaky.)

--- a/briefs/pure-codegen-rollout-intake.md
+++ b/briefs/pure-codegen-rollout-intake.md
@@ -1,0 +1,94 @@
+# Intake Brief — pure-codegen-rollout (Phase 0B)
+
+**Date:** 2026-06-02
+**Status:** VALIDATED
+**Type:** refactor
+
+## Goal
+
+Complete the pure-codegen carve-out begun in Phase 0A (golden harness, `sarek_backend_error`,
+CUDA decouple — all merged to `main`). End state: a pure, FFI-free
+`OCaml source → IR → per-backend GPU source` pipeline exposed as
+`Sarek_transpile.of_source : string -> (backend, string) result`, compilable to bytecode
+(and ultimately js_of_ocaml for the Phase 2 playground), with GPU backend *runtimes*
+unchanged. The Phase 0A golden harness on `main` is the byte-identical regression gate
+throughout.
+
+**This is large — to be delivered as 5 sequential PRs, each its own roster cycle** (see
+"PR split"). This brief covers the whole Phase 0B; each PR gets a focused implementer
+sub-brief at its own plan stage.
+
+## Scope Boundary (OUT)
+- Phase 2 playground UI / the actual jsoo web bundle (a bytecode FFI-free compile is the 0B
+  acceptance proof; a jsoo smoke is a stretch goal, not required).
+- Backend runtime behaviour (memory/launch/device mgmt) — unchanged.
+- The native-CPU generator (`Sarek_native_gen_*`) — stays FFI-linked; native/interpreter
+  output must remain identical.
+- `[%native]` in `of_source` — excluded (ENative carries unevaluated `Ppxlib.expression`);
+  returns a structured error.
+
+## Decisions (resolved at intake)
+- **`sinf` (path-qualified `Float32` math): ADOPT.** `main` emits `sin` for
+  `EIntrinsic(["Float32"],"sin")` (fell through to the unqualified branch) — wrong for a
+  `float32` op. The pure registry's `sinf` is correct single-precision. 0B adopts it as a
+  deliberate fix, updating the affected goldens and adding a **GPU-validated** `Float32.sin`
+  e2e (RX 7900 XTX available) to confirm numerically. Mirror for `cos/sqrt/exp/...` and the
+  OpenCL/Metal/GLSL equivalents.
+- Device decouple mechanism: `current_framework : string option ref` (same as CUDA 0A).
+- GLSL logging: injected `?log` no-op hook.
+- Parser: ppxlib parse + `Ppxlib_ast.Selected_ast.of_ocaml` migration.
+
+## PR split (proposed)
+1. **opencl+metal+glsl decouple** (plan steps 6–7). Mirror CUDA `current_device`→
+   `current_framework` in OpenCL + Metal; GLSL `?log` hook. Byte-identical; low risk.
+2. **pure registry + PPX dual-registration + `sinf`** (step 8). Promote `Sarek_pure_registry`
+   from the spike; make `%sarek_intrinsic` emit pure (`framework:string->string`) entries
+   alongside the FFI ones across `Float32/Float64/Int32/Int64/Math/Gpu`; adopt `sinf` with
+   golden updates + GPU e2e. Behaviour-affecting; medium risk.
+3. **split `sarek_ppx_lib`** (step 9) → `sarek_frontend` (pure) + `sarek_native_gen` (FFI) +
+   re-export façade; decouple `Kirc_Ast.Native (Spoc_core.Device.t -> string)` → framework.
+   Structural; medium-high risk (wrapped-lib paths).
+4. **create `sarek_codegen`** (step 10): extract the 4 device-decoupled generators +
+   `sarek_backend_error` into a pure lib (deps `sarek_ir` only); backends re-export
+   `Sarek_ir_<b>` under their wrapped namespace.
+5. **`Sarek_transpile.of_source` + FFI-free proof** (steps 11–12): the orchestrator; final
+   gates incl. all goldens byte-identical and a bytecode FFI-free compile of
+   `sarek_frontend + sarek_codegen + Sarek_transpile`.
+
+## Relevant Files
+| File | Role | Fact |
+|---|---|---|
+| `sarek-opencl/Sarek_ir_opencl.ml` | OpenCL gen | `current_device:Device.t option ref` (l.35, used l.531, set l.770) — mirror CUDA |
+| `sarek-metal/Sarek_ir_metal.ml` | Metal gen | same pattern (l.24/644/997) |
+| `sarek-vulkan/Sarek_ir_glsl.ml` | GLSL gen | `Spoc_core.Log.debugf` ×2 (l.947, l.1034) — inject `?log` |
+| `spoc/ir/Sarek_pure_registry.ml` (spike branch) | pure registry | proven; promote + extend |
+| `sarek/ppx/Sarek_ppx_registry.ml` | FFI registry | `*_device : Spoc_core.Device.t -> string` |
+| `sarek/Sarek_stdlib/*.ml`, `sarek/ppx_intrinsic/` | `%sarek_intrinsic` defs + PPX | source of dual-registration |
+| `sarek/ppx/Sarek_lower_ir.ml` | typed AST → IR | `IntrinsicRef(path,name)→EIntrinsic(path,name,..)` (l.383–390) — path-qualified intrinsics reach codegen |
+| `sarek/ppx/dune` (`sarek_ppx_lib`) | mixed lib | split into frontend/native-gen |
+| `sarek/ppx/Kirc_Ast.ml` | legacy AST | `Native of (Spoc_core.Device.t -> string)` (l.122) — decouple |
+| `sarek/tests/codegen_golden/` (main) | golden harness | the byte-identical gate; extend with stdlib-math goldens |
+| `sarek-*/Cuda|Opencl|Metal|Vulkan_plugin.ml` | consumers | reference `Sarek_ir_<b>` unqualified (wrapped) — re-export must preserve |
+
+## Quality Gates
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest   # goldens byte-identical
+opam exec --switch=/home/mathias/dev/SPOC -- dune build
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek-vulkan/all
+opam exec --switch=/home/mathias/dev/SPOC -- dune fmt --auto-promote
+# PR2: GPU e2e for Float32 math — dune exec sarek/tests/e2e/test_*.exe -- --vulkan (RX 7900 XTX)
+# PR5: bytecode FFI-free compile of sarek_frontend + sarek_codegen + Sarek_transpile
+```
+(`-lnvrtc` full-build link error is pre-existing; CI `build` e2e-fast matrix-mul segfault is known-flaky OpenCL-CPU — re-run, don't treat a lone hit as regression.)
+
+## Open Questions
+- [ ] **PR2 numerical validation:** adopting `sinf` changes CUDA/OpenCL output for
+  `Float32` math. Beyond byte-identical goldens (which we deliberately update), confirm a
+  `Float32.sin` kernel produces correct results on the Vulkan/OpenCL GPU before merging PR2.
+  (Resolve in PR2's QA, not assumed.)
+- [ ] **PR3 façade completeness:** after splitting `sarek_ppx_lib`, must `sarek_ppx_lib`
+  re-export everything its current external consumers use? Enumerate consumers at PR3 plan
+  time (grep `Sarek_ppx_lib`/the modules) — the brief flags it; the PR3 plan resolves it.
+- [ ] **jsoo stretch:** is a real `js_of_ocaml` compile (not just bytecode) required for 0B
+  acceptance, or deferred to Phase 2? (Default: bytecode FFI-free proof suffices for 0B;
+  jsoo is Phase 2.)


### PR DESCRIPTION
Pipeline artifacts for Phase 0B (intake + PR-1/PR-2 implementer briefs). Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added implementation briefs documenting planned refactoring phases for code generation architecture, including decoupling strategies for GPU backends and registry consolidation efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->