### PR TITLE
Phase 0B PR-2: pure intrinsic registry + CUDA sinf fix

### DIFF
--- a/sarek-cuda/Sarek_ir_cuda.ml
+++ b/sarek-cuda/Sarek_ir_cuda.ml
@@ -231,6 +231,30 @@ and gen_intrinsic buf path name args =
   let full_name =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
+  (* For path-qualified intrinsics, query the pure registry first.
+     This handles Float32.sin -> sinf on CUDA, sin on others, etc. *)
+  let pure_registry_hit =
+    match path with
+    | [] -> None
+    | _ ->
+        let framework = Option.value ~default:"CUDA" !current_framework in
+        (match
+           Sarek_pure_registry.fun_device_template ~module_path:path name
+         with
+        | Some f -> Some (f ~framework)
+        | None -> None)
+  in
+  match pure_registry_hit with
+  | Some device_name ->
+      Buffer.add_string buf device_name ;
+      Buffer.add_char buf '(' ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        args ;
+      Buffer.add_char buf ')'
+  | None ->
   (* Try thread intrinsics *)
   if
     List.mem

--- a/sarek-cuda/Sarek_ir_cuda.ml
+++ b/sarek-cuda/Sarek_ir_cuda.ml
@@ -236,11 +236,11 @@ and gen_intrinsic buf path name args =
   let pure_registry_hit =
     match path with
     | [] -> None
-    | _ ->
+    | _ -> (
         let framework = Option.value ~default:"CUDA" !current_framework in
-        (match
-           Sarek_pure_registry.fun_device_template ~module_path:path name
-         with
+        match
+          Sarek_pure_registry.fun_device_template ~module_path:path name
+        with
         | Some f -> Some (f ~framework)
         | None -> None)
   in
@@ -254,184 +254,198 @@ and gen_intrinsic buf path name args =
           gen_expr buf e)
         args ;
       Buffer.add_char buf ')'
-  | None ->
-  (* Try thread intrinsics *)
-  if
-    List.mem
-      name
-      [
-        "thread_id_x";
-        "thread_idx_x";
-        "thread_id_y";
-        "thread_idx_y";
-        "thread_id_z";
-        "thread_idx_z";
-        "block_id_x";
-        "block_idx_x";
-        "block_id_y";
-        "block_idx_y";
-        "block_id_z";
-        "block_idx_z";
-        "block_dim_x";
-        "block_dim_y";
-        "block_dim_z";
-        "grid_dim_x";
-        "grid_dim_y";
-        "grid_dim_z";
-        "global_thread_id";
-        "global_idx";
-        "global_idx_x";
-        "global_idx_y";
-        "global_idx_z";
-        "global_size";
-      ]
-  then Buffer.add_string buf (cuda_thread_intrinsic name)
-  else
-    (* Standard math intrinsics *)
-    match name with
-    | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-    | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
-    | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | "atan2" | "pow" | "fma" | "min" | "max" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    (* Barrier synchronization *)
-    | "block_barrier" -> Buffer.add_string buf "__syncthreads()"
-    | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-        Buffer.add_string buf "atomicAdd(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | [arr; idx; value] ->
-            (* Array element atomic: atomicAdd(&arr[idx], value) *)
-            Buffer.add_char buf '&' ;
-            gen_expr buf arr ;
-            Buffer.add_char buf '[' ;
-            gen_expr buf idx ;
-            Buffer.add_string buf "], " ;
-            gen_expr buf value
-        | _ ->
-            Cuda_error.raise_error
-              (Cuda_error.invalid_arg_count "atomic_add" 3 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_sub" ->
-        Buffer.add_string buf "atomicSub(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | _ ->
-            Cuda_error.raise_error
-              (Cuda_error.invalid_arg_count "atomic_sub" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_min" ->
-        Buffer.add_string buf "atomicMin(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | _ ->
-            Cuda_error.raise_error
-              (Cuda_error.invalid_arg_count "atomic_min" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_max" ->
-        Buffer.add_string buf "atomicMax(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | _ ->
-            Cuda_error.raise_error
-              (Cuda_error.invalid_arg_count "atomic_max" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | _ -> (
-        (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
-        match Sarek_registry.fun_device_template ~module_path:path name with
-        | Some template ->
-            (* Generate argument strings *)
-            let arg_strs =
-              List.map
-                (fun e ->
-                  let b = Buffer.create 64 in
-                  gen_expr b e ;
-                  Buffer.contents b)
-                args
-            in
-            (* Count %s placeholders in template *)
-            let count_placeholders s =
-              let rec count i acc =
-                if i >= String.length s - 1 then acc
-                else if s.[i] = '%' && s.[i + 1] = 's' then
-                  count (i + 2) (acc + 1)
-                else count (i + 1) acc
-              in
-              count 0 0
-            in
-            let num_placeholders = count_placeholders template in
-            let result =
-              if num_placeholders = 0 then
-                (* Plain function/cast like "(float)" -> call as function *)
-                template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-              else if num_placeholders = 1 && List.length arg_strs = 1 then
-                match arg_strs with
-                | [arg] ->
-                    Printf.sprintf (Scanf.format_from_string template "%s") arg
-                | _ ->
-                    (* This should never happen due to length check above *)
-                    Cuda_error.raise_error
-                      (Cuda_error.type_error
-                         "intrinsic template"
-                         "1 placeholder, 1 argument"
-                         "unexpected list state")
-              else if num_placeholders = 2 && List.length arg_strs = 2 then
-                Printf.sprintf
-                  (Scanf.format_from_string template "%s%s")
-                  (List.nth arg_strs 0)
-                  (List.nth arg_strs 1)
-              else if num_placeholders = 3 && List.length arg_strs = 3 then
-                Printf.sprintf
-                  (Scanf.format_from_string template "%s%s%s")
-                  (List.nth arg_strs 0)
-                  (List.nth arg_strs 1)
-                  (List.nth arg_strs 2)
-              else
-                (* Fallback: treat as function call *)
-                template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-            in
-            Buffer.add_string buf result
-        | None ->
-            (* Unknown intrinsic - emit as function call *)
-            Buffer.add_string buf full_name ;
+  | None -> (
+      if
+        (* Try thread intrinsics *)
+        List.mem
+          name
+          [
+            "thread_id_x";
+            "thread_idx_x";
+            "thread_id_y";
+            "thread_idx_y";
+            "thread_id_z";
+            "thread_idx_z";
+            "block_id_x";
+            "block_idx_x";
+            "block_id_y";
+            "block_idx_y";
+            "block_id_z";
+            "block_idx_z";
+            "block_dim_x";
+            "block_dim_y";
+            "block_dim_z";
+            "grid_dim_x";
+            "grid_dim_y";
+            "grid_dim_z";
+            "global_thread_id";
+            "global_idx";
+            "global_idx_x";
+            "global_idx_y";
+            "global_idx_z";
+            "global_size";
+          ]
+      then Buffer.add_string buf (cuda_thread_intrinsic name)
+      else
+        (* Standard math intrinsics *)
+        match name with
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+        | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
+        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
+            Buffer.add_string buf name ;
             Buffer.add_char buf '(' ;
             List.iteri
               (fun i e ->
                 if i > 0 then Buffer.add_string buf ", " ;
                 gen_expr buf e)
               args ;
-            Buffer.add_char buf ')')
+            Buffer.add_char buf ')'
+        | "atan2" | "pow" | "fma" | "min" | "max" ->
+            Buffer.add_string buf name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        (* Barrier synchronization *)
+        | "block_barrier" -> Buffer.add_string buf "__syncthreads()"
+        | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
+            Buffer.add_string buf "atomicAdd(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | [arr; idx; value] ->
+                (* Array element atomic: atomicAdd(&arr[idx], value) *)
+                Buffer.add_char buf '&' ;
+                gen_expr buf arr ;
+                Buffer.add_char buf '[' ;
+                gen_expr buf idx ;
+                Buffer.add_string buf "], " ;
+                gen_expr buf value
+            | _ ->
+                Cuda_error.raise_error
+                  (Cuda_error.invalid_arg_count
+                     "atomic_add"
+                     3
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_sub" ->
+            Buffer.add_string buf "atomicSub(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | _ ->
+                Cuda_error.raise_error
+                  (Cuda_error.invalid_arg_count
+                     "atomic_sub"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_min" ->
+            Buffer.add_string buf "atomicMin(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | _ ->
+                Cuda_error.raise_error
+                  (Cuda_error.invalid_arg_count
+                     "atomic_min"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_max" ->
+            Buffer.add_string buf "atomicMax(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | _ ->
+                Cuda_error.raise_error
+                  (Cuda_error.invalid_arg_count
+                     "atomic_max"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | _ -> (
+            (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
+            match Sarek_registry.fun_device_template ~module_path:path name with
+            | Some template ->
+                (* Generate argument strings *)
+                let arg_strs =
+                  List.map
+                    (fun e ->
+                      let b = Buffer.create 64 in
+                      gen_expr b e ;
+                      Buffer.contents b)
+                    args
+                in
+                (* Count %s placeholders in template *)
+                let count_placeholders s =
+                  let rec count i acc =
+                    if i >= String.length s - 1 then acc
+                    else if s.[i] = '%' && s.[i + 1] = 's' then
+                      count (i + 2) (acc + 1)
+                    else count (i + 1) acc
+                  in
+                  count 0 0
+                in
+                let num_placeholders = count_placeholders template in
+                let result =
+                  if num_placeholders = 0 then
+                    (* Plain function/cast like "(float)" -> call as function *)
+                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                  else if num_placeholders = 1 && List.length arg_strs = 1 then
+                    match arg_strs with
+                    | [arg] ->
+                        Printf.sprintf
+                          (Scanf.format_from_string template "%s")
+                          arg
+                    | _ ->
+                        (* This should never happen due to length check above *)
+                        Cuda_error.raise_error
+                          (Cuda_error.type_error
+                             "intrinsic template"
+                             "1 placeholder, 1 argument"
+                             "unexpected list state")
+                  else if num_placeholders = 2 && List.length arg_strs = 2 then
+                    Printf.sprintf
+                      (Scanf.format_from_string template "%s%s")
+                      (List.nth arg_strs 0)
+                      (List.nth arg_strs 1)
+                  else if num_placeholders = 3 && List.length arg_strs = 3 then
+                    Printf.sprintf
+                      (Scanf.format_from_string template "%s%s%s")
+                      (List.nth arg_strs 0)
+                      (List.nth arg_strs 1)
+                      (List.nth arg_strs 2)
+                  else
+                    (* Fallback: treat as function call *)
+                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                in
+                Buffer.add_string buf result
+            | None ->
+                (* Unknown intrinsic - emit as function call *)
+                Buffer.add_string buf full_name ;
+                Buffer.add_char buf '(' ;
+                List.iteri
+                  (fun i e ->
+                    if i > 0 then Buffer.add_string buf ", " ;
+                    gen_expr buf e)
+                  args ;
+                Buffer.add_char buf ')'))
 
 (** {1 L-value Generation} *)
 

--- a/sarek-metal/Sarek_ir_metal.ml
+++ b/sarek-metal/Sarek_ir_metal.ml
@@ -255,11 +255,11 @@ and gen_intrinsic buf path name args =
   let pure_registry_hit =
     match path with
     | [] -> None
-    | _ ->
+    | _ -> (
         let framework = Option.value ~default:"Metal" !current_framework in
-        (match
-           Sarek_pure_registry.fun_device_template ~module_path:path name
-         with
+        match
+          Sarek_pure_registry.fun_device_template ~module_path:path name
+        with
         | Some f -> Some (f ~framework)
         | None -> None)
   in
@@ -273,204 +273,218 @@ and gen_intrinsic buf path name args =
           gen_expr buf e)
         args ;
       Buffer.add_char buf ')'
-  | None ->
-  (* Try thread intrinsics - support both idx and id naming *)
-  if
-    List.mem
-      name
-      [
-        "thread_id_x";
-        "thread_idx_x";
-        "thread_id_y";
-        "thread_idx_y";
-        "thread_id_z";
-        "thread_idx_z";
-        "block_id_x";
-        "block_idx_x";
-        "block_id_y";
-        "block_idx_y";
-        "block_id_z";
-        "block_idx_z";
-        "block_dim_x";
-        "block_dim_y";
-        "block_dim_z";
-        "grid_dim_x";
-        "grid_dim_y";
-        "grid_dim_z";
-        "global_thread_id";
-        "global_idx";
-        "global_idx_x";
-        "global_idx_y";
-        "global_idx_z";
-        "global_size";
-      ]
-  then Buffer.add_string buf (metal_thread_intrinsic name)
-  else
-    (* Standard math intrinsics - Metal uses same names *)
-    match name with
-    | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-    | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
-    | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | "atan2" | "pow" | "fma" | "min" | "max" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    (* Barrier synchronization *)
-    | "block_barrier" ->
-        Buffer.add_string buf "threadgroup_barrier(mem_flags::mem_threadgroup)"
-    | "atomic_add" | "atomic_add_int32" ->
-        Buffer.add_string buf "atomic_fetch_add_explicit(" ;
-        (match args with
-        | [addr; value] ->
-            (* Cast pointer to threadgroup atomic type *)
-            Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | [arr; idx; value] ->
-            (* Array element atomic with threadgroup cast *)
-            Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
-            gen_expr buf arr ;
-            Buffer.add_char buf '[' ;
-            gen_expr buf idx ;
-            Buffer.add_string buf "], " ;
-            gen_expr buf value
-        | args ->
-            Metal_error.raise_error
-              (Metal_error.invalid_arg_count "atomic_add" 2 (List.length args))) ;
-        Buffer.add_string buf ", memory_order_relaxed)"
-    | "atomic_add_global_int32" ->
-        Buffer.add_string buf "atomic_fetch_add_explicit(" ;
-        (match args with
-        | [addr; value] ->
-            (* Cast pointer to device atomic type *)
-            Buffer.add_string buf "(volatile device atomic_int*)&" ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | [arr; idx; value] ->
-            (* Array element atomic with device cast *)
-            Buffer.add_string buf "(volatile device atomic_int*)&" ;
-            gen_expr buf arr ;
-            Buffer.add_char buf '[' ;
-            gen_expr buf idx ;
-            Buffer.add_string buf "], " ;
-            gen_expr buf value
-        | args ->
-            Metal_error.raise_error
-              (Metal_error.invalid_arg_count
-                 "atomic_add_global"
-                 2
-                 (List.length args))) ;
-        (* Use relaxed memory order *)
-        Buffer.add_string buf ", memory_order_relaxed)"
-    | "atomic_sub" ->
-        Buffer.add_string buf "atomic_sub(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | args ->
-            Metal_error.raise_error
-              (Metal_error.invalid_arg_count "atomic_sub" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_min" ->
-        Buffer.add_string buf "atomic_min(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | args ->
-            Metal_error.raise_error
-              (Metal_error.invalid_arg_count "atomic_min" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_max" ->
-        Buffer.add_string buf "atomic_max(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | args ->
-            Metal_error.raise_error
-              (Metal_error.invalid_arg_count "atomic_max" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | _ -> (
-        (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
-        match Sarek_registry.fun_device_template ~module_path:path name with
-        | Some template ->
-            (* Generate argument strings *)
-            let arg_strs =
-              List.map
-                (fun e ->
-                  let b = Buffer.create 64 in
-                  gen_expr b e ;
-                  Buffer.contents b)
-                args
-            in
-            (* Count %s placeholders in template *)
-            let count_placeholders s =
-              let rec count i acc =
-                if i >= String.length s - 1 then acc
-                else if s.[i] = '%' && s.[i + 1] = 's' then
-                  count (i + 2) (acc + 1)
-                else count (i + 1) acc
-              in
-              count 0 0
-            in
-            let num_placeholders = count_placeholders template in
-            let result =
-              if num_placeholders = 0 then
-                (* Plain function/cast like "(float)" -> call as function *)
-                template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-              else if num_placeholders = 1 && List.length arg_strs = 1 then
-                Printf.sprintf
-                  (Scanf.format_from_string template "%s")
-                  (List.hd arg_strs)
-              else if num_placeholders = 2 && List.length arg_strs = 2 then
-                Printf.sprintf
-                  (Scanf.format_from_string template "%s%s")
-                  (List.nth arg_strs 0)
-                  (List.nth arg_strs 1)
-              else if num_placeholders = 3 && List.length arg_strs = 3 then
-                Printf.sprintf
-                  (Scanf.format_from_string template "%s%s%s")
-                  (List.nth arg_strs 0)
-                  (List.nth arg_strs 1)
-                  (List.nth arg_strs 2)
-              else
-                (* Fallback: treat as function call *)
-                template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-            in
-            Buffer.add_string buf result
-        | None ->
-            (* Unknown intrinsic - emit as function call *)
-            Buffer.add_string buf full_name ;
+  | None -> (
+      if
+        (* Try thread intrinsics - support both idx and id naming *)
+        List.mem
+          name
+          [
+            "thread_id_x";
+            "thread_idx_x";
+            "thread_id_y";
+            "thread_idx_y";
+            "thread_id_z";
+            "thread_idx_z";
+            "block_id_x";
+            "block_idx_x";
+            "block_id_y";
+            "block_idx_y";
+            "block_id_z";
+            "block_idx_z";
+            "block_dim_x";
+            "block_dim_y";
+            "block_dim_z";
+            "grid_dim_x";
+            "grid_dim_y";
+            "grid_dim_z";
+            "global_thread_id";
+            "global_idx";
+            "global_idx_x";
+            "global_idx_y";
+            "global_idx_z";
+            "global_size";
+          ]
+      then Buffer.add_string buf (metal_thread_intrinsic name)
+      else
+        (* Standard math intrinsics - Metal uses same names *)
+        match name with
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+        | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
+        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
+            Buffer.add_string buf name ;
             Buffer.add_char buf '(' ;
             List.iteri
               (fun i e ->
                 if i > 0 then Buffer.add_string buf ", " ;
                 gen_expr buf e)
               args ;
-            Buffer.add_char buf ')')
+            Buffer.add_char buf ')'
+        | "atan2" | "pow" | "fma" | "min" | "max" ->
+            Buffer.add_string buf name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        (* Barrier synchronization *)
+        | "block_barrier" ->
+            Buffer.add_string
+              buf
+              "threadgroup_barrier(mem_flags::mem_threadgroup)"
+        | "atomic_add" | "atomic_add_int32" ->
+            Buffer.add_string buf "atomic_fetch_add_explicit(" ;
+            (match args with
+            | [addr; value] ->
+                (* Cast pointer to threadgroup atomic type *)
+                Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | [arr; idx; value] ->
+                (* Array element atomic with threadgroup cast *)
+                Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
+                gen_expr buf arr ;
+                Buffer.add_char buf '[' ;
+                gen_expr buf idx ;
+                Buffer.add_string buf "], " ;
+                gen_expr buf value
+            | args ->
+                Metal_error.raise_error
+                  (Metal_error.invalid_arg_count
+                     "atomic_add"
+                     2
+                     (List.length args))) ;
+            Buffer.add_string buf ", memory_order_relaxed)"
+        | "atomic_add_global_int32" ->
+            Buffer.add_string buf "atomic_fetch_add_explicit(" ;
+            (match args with
+            | [addr; value] ->
+                (* Cast pointer to device atomic type *)
+                Buffer.add_string buf "(volatile device atomic_int*)&" ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | [arr; idx; value] ->
+                (* Array element atomic with device cast *)
+                Buffer.add_string buf "(volatile device atomic_int*)&" ;
+                gen_expr buf arr ;
+                Buffer.add_char buf '[' ;
+                gen_expr buf idx ;
+                Buffer.add_string buf "], " ;
+                gen_expr buf value
+            | args ->
+                Metal_error.raise_error
+                  (Metal_error.invalid_arg_count
+                     "atomic_add_global"
+                     2
+                     (List.length args))) ;
+            (* Use relaxed memory order *)
+            Buffer.add_string buf ", memory_order_relaxed)"
+        | "atomic_sub" ->
+            Buffer.add_string buf "atomic_sub(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | args ->
+                Metal_error.raise_error
+                  (Metal_error.invalid_arg_count
+                     "atomic_sub"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_min" ->
+            Buffer.add_string buf "atomic_min(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | args ->
+                Metal_error.raise_error
+                  (Metal_error.invalid_arg_count
+                     "atomic_min"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_max" ->
+            Buffer.add_string buf "atomic_max(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | args ->
+                Metal_error.raise_error
+                  (Metal_error.invalid_arg_count
+                     "atomic_max"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | _ -> (
+            (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
+            match Sarek_registry.fun_device_template ~module_path:path name with
+            | Some template ->
+                (* Generate argument strings *)
+                let arg_strs =
+                  List.map
+                    (fun e ->
+                      let b = Buffer.create 64 in
+                      gen_expr b e ;
+                      Buffer.contents b)
+                    args
+                in
+                (* Count %s placeholders in template *)
+                let count_placeholders s =
+                  let rec count i acc =
+                    if i >= String.length s - 1 then acc
+                    else if s.[i] = '%' && s.[i + 1] = 's' then
+                      count (i + 2) (acc + 1)
+                    else count (i + 1) acc
+                  in
+                  count 0 0
+                in
+                let num_placeholders = count_placeholders template in
+                let result =
+                  if num_placeholders = 0 then
+                    (* Plain function/cast like "(float)" -> call as function *)
+                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                  else if num_placeholders = 1 && List.length arg_strs = 1 then
+                    Printf.sprintf
+                      (Scanf.format_from_string template "%s")
+                      (List.hd arg_strs)
+                  else if num_placeholders = 2 && List.length arg_strs = 2 then
+                    Printf.sprintf
+                      (Scanf.format_from_string template "%s%s")
+                      (List.nth arg_strs 0)
+                      (List.nth arg_strs 1)
+                  else if num_placeholders = 3 && List.length arg_strs = 3 then
+                    Printf.sprintf
+                      (Scanf.format_from_string template "%s%s%s")
+                      (List.nth arg_strs 0)
+                      (List.nth arg_strs 1)
+                      (List.nth arg_strs 2)
+                  else
+                    (* Fallback: treat as function call *)
+                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                in
+                Buffer.add_string buf result
+            | None ->
+                (* Unknown intrinsic - emit as function call *)
+                Buffer.add_string buf full_name ;
+                Buffer.add_char buf '(' ;
+                List.iteri
+                  (fun i e ->
+                    if i > 0 then Buffer.add_string buf ", " ;
+                    gen_expr buf e)
+                  args ;
+                Buffer.add_char buf ')'))
 
 (** {1 L-value Generation} *)
 

--- a/sarek-metal/Sarek_ir_metal.ml
+++ b/sarek-metal/Sarek_ir_metal.ml
@@ -250,6 +250,30 @@ and gen_intrinsic buf path name args =
   let full_name =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
+  (* For path-qualified intrinsics, query the pure registry first.
+     Float32.sin -> sin on Metal (Metal uses un-suffixed names). *)
+  let pure_registry_hit =
+    match path with
+    | [] -> None
+    | _ ->
+        let framework = Option.value ~default:"Metal" !current_framework in
+        (match
+           Sarek_pure_registry.fun_device_template ~module_path:path name
+         with
+        | Some f -> Some (f ~framework)
+        | None -> None)
+  in
+  match pure_registry_hit with
+  | Some device_name ->
+      Buffer.add_string buf device_name ;
+      Buffer.add_char buf '(' ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        args ;
+      Buffer.add_char buf ')'
+  | None ->
   (* Try thread intrinsics - support both idx and id naming *)
   if
     List.mem

--- a/sarek-opencl/Sarek_ir_opencl.ml
+++ b/sarek-opencl/Sarek_ir_opencl.ml
@@ -253,11 +253,11 @@ and gen_intrinsic buf path name args =
   let pure_registry_hit =
     match path with
     | [] -> None
-    | _ ->
+    | _ -> (
         let framework = Option.value ~default:"OpenCL" !current_framework in
-        (match
-           Sarek_pure_registry.fun_device_template ~module_path:path name
-         with
+        match
+          Sarek_pure_registry.fun_device_template ~module_path:path name
+        with
         | Some f -> Some (f ~framework)
         | None -> None)
   in
@@ -271,177 +271,192 @@ and gen_intrinsic buf path name args =
           gen_expr buf e)
         args ;
       Buffer.add_char buf ')'
-  | None ->
-  (* Try thread intrinsics - support both idx and id naming *)
-  if
-    List.mem
-      name
-      [
-        "thread_id_x";
-        "thread_idx_x";
-        "thread_id_y";
-        "thread_idx_y";
-        "thread_id_z";
-        "thread_idx_z";
-        "block_id_x";
-        "block_idx_x";
-        "block_id_y";
-        "block_idx_y";
-        "block_id_z";
-        "block_idx_z";
-        "block_dim_x";
-        "block_dim_y";
-        "block_dim_z";
-        "grid_dim_x";
-        "grid_dim_y";
-        "grid_dim_z";
-        "global_thread_id";
-        "global_idx";
-        "global_idx_x";
-        "global_idx_y";
-        "global_idx_z";
-        "global_size";
-      ]
-  then Buffer.add_string buf (opencl_thread_intrinsic name)
-  else
-    (* Standard math intrinsics - OpenCL uses same names *)
-    match name with
-    | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-    | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
-    | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | "atan2" | "pow" | "fma" | "min" | "max" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    (* Barrier synchronization *)
-    | "block_barrier" -> Buffer.add_string buf "barrier(CLK_LOCAL_MEM_FENCE)"
-    | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-        Buffer.add_string buf "atomic_add(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | [arr; idx; value] ->
-            (* Array element atomic: atomic_add(&arr[idx], value) *)
-            Buffer.add_char buf '&' ;
-            gen_expr buf arr ;
-            Buffer.add_char buf '[' ;
-            gen_expr buf idx ;
-            Buffer.add_string buf "], " ;
-            gen_expr buf value
-        | _ ->
-            Opencl_error.raise_error
-              (Opencl_error.invalid_arg_count "atomic_add" 3 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_sub" ->
-        Buffer.add_string buf "atomic_sub(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | _ ->
-            Opencl_error.raise_error
-              (Opencl_error.invalid_arg_count "atomic_sub" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_min" ->
-        Buffer.add_string buf "atomic_min(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | _ ->
-            Opencl_error.raise_error
-              (Opencl_error.invalid_arg_count "atomic_min" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_max" ->
-        Buffer.add_string buf "atomic_max(" ;
-        (match args with
-        | [addr; value] ->
-            Buffer.add_char buf '&' ;
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | _ ->
-            Opencl_error.raise_error
-              (Opencl_error.invalid_arg_count "atomic_max" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | _ -> (
-        (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
-        match Sarek_registry.fun_device_template ~module_path:path name with
-        | Some template ->
-            (* Generate argument strings *)
-            let arg_strs =
-              List.map
-                (fun e ->
-                  let b = Buffer.create 64 in
-                  gen_expr b e ;
-                  Buffer.contents b)
-                args
-            in
-            (* Count %s placeholders in template *)
-            let count_placeholders s =
-              let rec count i acc =
-                if i >= String.length s - 1 then acc
-                else if s.[i] = '%' && s.[i + 1] = 's' then
-                  count (i + 2) (acc + 1)
-                else count (i + 1) acc
-              in
-              count 0 0
-            in
-            let num_placeholders = count_placeholders template in
-            let result =
-              if num_placeholders = 0 then
-                (* Plain function/cast like "(float)" -> call as function *)
-                template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-              else
-                match (num_placeholders, arg_strs) with
-                | 1, [arg1] ->
-                    Printf.sprintf (Scanf.format_from_string template "%s") arg1
-                | 2, [arg1; arg2] ->
-                    Printf.sprintf
-                      (Scanf.format_from_string template "%s%s")
-                      arg1
-                      arg2
-                | 3, [arg1; arg2; arg3] ->
-                    Printf.sprintf
-                      (Scanf.format_from_string template "%s%s%s")
-                      arg1
-                      arg2
-                      arg3
-                | _ ->
-                    (* Fallback: treat as function call *)
-                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-            in
-            Buffer.add_string buf result
-        | None ->
-            (* Unknown intrinsic - emit as function call *)
-            Buffer.add_string buf full_name ;
+  | None -> (
+      if
+        (* Try thread intrinsics - support both idx and id naming *)
+        List.mem
+          name
+          [
+            "thread_id_x";
+            "thread_idx_x";
+            "thread_id_y";
+            "thread_idx_y";
+            "thread_id_z";
+            "thread_idx_z";
+            "block_id_x";
+            "block_idx_x";
+            "block_id_y";
+            "block_idx_y";
+            "block_id_z";
+            "block_idx_z";
+            "block_dim_x";
+            "block_dim_y";
+            "block_dim_z";
+            "grid_dim_x";
+            "grid_dim_y";
+            "grid_dim_z";
+            "global_thread_id";
+            "global_idx";
+            "global_idx_x";
+            "global_idx_y";
+            "global_idx_z";
+            "global_size";
+          ]
+      then Buffer.add_string buf (opencl_thread_intrinsic name)
+      else
+        (* Standard math intrinsics - OpenCL uses same names *)
+        match name with
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+        | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
+        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
+            Buffer.add_string buf name ;
             Buffer.add_char buf '(' ;
             List.iteri
               (fun i e ->
                 if i > 0 then Buffer.add_string buf ", " ;
                 gen_expr buf e)
               args ;
-            Buffer.add_char buf ')')
+            Buffer.add_char buf ')'
+        | "atan2" | "pow" | "fma" | "min" | "max" ->
+            Buffer.add_string buf name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        (* Barrier synchronization *)
+        | "block_barrier" ->
+            Buffer.add_string buf "barrier(CLK_LOCAL_MEM_FENCE)"
+        | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
+            Buffer.add_string buf "atomic_add(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | [arr; idx; value] ->
+                (* Array element atomic: atomic_add(&arr[idx], value) *)
+                Buffer.add_char buf '&' ;
+                gen_expr buf arr ;
+                Buffer.add_char buf '[' ;
+                gen_expr buf idx ;
+                Buffer.add_string buf "], " ;
+                gen_expr buf value
+            | _ ->
+                Opencl_error.raise_error
+                  (Opencl_error.invalid_arg_count
+                     "atomic_add"
+                     3
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_sub" ->
+            Buffer.add_string buf "atomic_sub(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | _ ->
+                Opencl_error.raise_error
+                  (Opencl_error.invalid_arg_count
+                     "atomic_sub"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_min" ->
+            Buffer.add_string buf "atomic_min(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | _ ->
+                Opencl_error.raise_error
+                  (Opencl_error.invalid_arg_count
+                     "atomic_min"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_max" ->
+            Buffer.add_string buf "atomic_max(" ;
+            (match args with
+            | [addr; value] ->
+                Buffer.add_char buf '&' ;
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | _ ->
+                Opencl_error.raise_error
+                  (Opencl_error.invalid_arg_count
+                     "atomic_max"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | _ -> (
+            (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
+            match Sarek_registry.fun_device_template ~module_path:path name with
+            | Some template ->
+                (* Generate argument strings *)
+                let arg_strs =
+                  List.map
+                    (fun e ->
+                      let b = Buffer.create 64 in
+                      gen_expr b e ;
+                      Buffer.contents b)
+                    args
+                in
+                (* Count %s placeholders in template *)
+                let count_placeholders s =
+                  let rec count i acc =
+                    if i >= String.length s - 1 then acc
+                    else if s.[i] = '%' && s.[i + 1] = 's' then
+                      count (i + 2) (acc + 1)
+                    else count (i + 1) acc
+                  in
+                  count 0 0
+                in
+                let num_placeholders = count_placeholders template in
+                let result =
+                  if num_placeholders = 0 then
+                    (* Plain function/cast like "(float)" -> call as function *)
+                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                  else
+                    match (num_placeholders, arg_strs) with
+                    | 1, [arg1] ->
+                        Printf.sprintf
+                          (Scanf.format_from_string template "%s")
+                          arg1
+                    | 2, [arg1; arg2] ->
+                        Printf.sprintf
+                          (Scanf.format_from_string template "%s%s")
+                          arg1
+                          arg2
+                    | 3, [arg1; arg2; arg3] ->
+                        Printf.sprintf
+                          (Scanf.format_from_string template "%s%s%s")
+                          arg1
+                          arg2
+                          arg3
+                    | _ ->
+                        (* Fallback: treat as function call *)
+                        template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                in
+                Buffer.add_string buf result
+            | None ->
+                (* Unknown intrinsic - emit as function call *)
+                Buffer.add_string buf full_name ;
+                Buffer.add_char buf '(' ;
+                List.iteri
+                  (fun i e ->
+                    if i > 0 then Buffer.add_string buf ", " ;
+                    gen_expr buf e)
+                  args ;
+                Buffer.add_char buf ')'))
 
 (** {1 L-value Generation} *)
 

--- a/sarek-opencl/Sarek_ir_opencl.ml
+++ b/sarek-opencl/Sarek_ir_opencl.ml
@@ -248,6 +248,30 @@ and gen_intrinsic buf path name args =
   let full_name =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
+  (* For path-qualified intrinsics, query the pure registry first.
+     Float32.sin -> sin on OpenCL; Float64.sin -> sin on OpenCL. *)
+  let pure_registry_hit =
+    match path with
+    | [] -> None
+    | _ ->
+        let framework = Option.value ~default:"OpenCL" !current_framework in
+        (match
+           Sarek_pure_registry.fun_device_template ~module_path:path name
+         with
+        | Some f -> Some (f ~framework)
+        | None -> None)
+  in
+  match pure_registry_hit with
+  | Some device_name ->
+      Buffer.add_string buf device_name ;
+      Buffer.add_char buf '(' ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        args ;
+      Buffer.add_char buf ')'
+  | None ->
   (* Try thread intrinsics - support both idx and id naming *)
   if
     List.mem

--- a/sarek-vulkan/Sarek_ir_glsl.ml
+++ b/sarek-vulkan/Sarek_ir_glsl.ml
@@ -371,148 +371,157 @@ and gen_intrinsic buf path name args =
           gen_expr buf e)
         args ;
       Buffer.add_char buf ')'
-  | None ->
-  (* Try thread intrinsics *)
-  if
-    List.mem
-      name
-      [
-        "thread_id_x";
-        "thread_idx_x";
-        "thread_id_y";
-        "thread_idx_y";
-        "thread_id_z";
-        "thread_idx_z";
-        "block_id_x";
-        "block_idx_x";
-        "block_id_y";
-        "block_idx_y";
-        "block_id_z";
-        "block_idx_z";
-        "block_dim_x";
-        "block_dim_y";
-        "block_dim_z";
-        "grid_dim_x";
-        "grid_dim_y";
-        "grid_dim_z";
-        "global_thread_id";
-        "global_idx";
-        "global_idx_x";
-        "global_idx_y";
-        "global_idx_z";
-        "global_size";
-      ]
-  then Buffer.add_string buf (glsl_thread_intrinsic name)
-  else
-    (* Standard math intrinsics - GLSL versions *)
-    match name with
-    | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-    | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
-    | "round" | "trunc" | "abs" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | "fabs" ->
-        Buffer.add_string buf "abs" ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | "rsqrt" ->
-        Buffer.add_string buf "inversesqrt" ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | "atan2" | "pow" | "min" | "max" ->
-        Buffer.add_string buf name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | "fma" ->
-        Buffer.add_string buf "fma" ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    (* Barrier synchronization *)
-    | "block_barrier" -> Buffer.add_string buf "barrier()"
-    (* Atomic operations - GLSL uses atomicAdd etc. *)
-    | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-        Buffer.add_string buf "atomicAdd(" ;
-        (match args with
-        | [addr; value] ->
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | [arr; idx; value] ->
-            gen_expr buf arr ;
-            Buffer.add_char buf '[' ;
-            gen_expr buf idx ;
-            Buffer.add_string buf "], " ;
-            gen_expr buf value
-        | args ->
-            Vulkan_error.raise_error
-              (Vulkan_error.invalid_arg_count "atomic_add" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_min" ->
-        Buffer.add_string buf "atomicMin(" ;
-        (match args with
-        | [addr; value] ->
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | args ->
-            Vulkan_error.raise_error
-              (Vulkan_error.invalid_arg_count "atomic_min" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "atomic_max" ->
-        Buffer.add_string buf "atomicMax(" ;
-        (match args with
-        | [addr; value] ->
-            gen_expr buf addr ;
-            Buffer.add_string buf ", " ;
-            gen_expr buf value
-        | args ->
-            Vulkan_error.raise_error
-              (Vulkan_error.invalid_arg_count "atomic_max" 2 (List.length args))) ;
-        Buffer.add_char buf ')'
-    | "float" ->
-        Buffer.add_string buf "float(" ;
-        (match args with [e] -> gen_expr buf e | _ -> ()) ;
-        Buffer.add_char buf ')'
-    | "int_of_float" ->
-        Buffer.add_string buf "int(" ;
-        (match args with [e] -> gen_expr buf e | _ -> ()) ;
-        Buffer.add_char buf ')'
-    | _ ->
-        (* Unknown intrinsic - emit as function call *)
-        Buffer.add_string buf full_name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
+  | None -> (
+      if
+        (* Try thread intrinsics *)
+        List.mem
+          name
+          [
+            "thread_id_x";
+            "thread_idx_x";
+            "thread_id_y";
+            "thread_idx_y";
+            "thread_id_z";
+            "thread_idx_z";
+            "block_id_x";
+            "block_idx_x";
+            "block_id_y";
+            "block_idx_y";
+            "block_id_z";
+            "block_idx_z";
+            "block_dim_x";
+            "block_dim_y";
+            "block_dim_z";
+            "grid_dim_x";
+            "grid_dim_y";
+            "grid_dim_z";
+            "global_thread_id";
+            "global_idx";
+            "global_idx_x";
+            "global_idx_y";
+            "global_idx_z";
+            "global_size";
+          ]
+      then Buffer.add_string buf (glsl_thread_intrinsic name)
+      else
+        (* Standard math intrinsics - GLSL versions *)
+        match name with
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+        | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
+        | "round" | "trunc" | "abs" ->
+            Buffer.add_string buf name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "fabs" ->
+            Buffer.add_string buf "abs" ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "rsqrt" ->
+            Buffer.add_string buf "inversesqrt" ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "atan2" | "pow" | "min" | "max" ->
+            Buffer.add_string buf name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "fma" ->
+            Buffer.add_string buf "fma" ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        (* Barrier synchronization *)
+        | "block_barrier" -> Buffer.add_string buf "barrier()"
+        (* Atomic operations - GLSL uses atomicAdd etc. *)
+        | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
+            Buffer.add_string buf "atomicAdd(" ;
+            (match args with
+            | [addr; value] ->
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | [arr; idx; value] ->
+                gen_expr buf arr ;
+                Buffer.add_char buf '[' ;
+                gen_expr buf idx ;
+                Buffer.add_string buf "], " ;
+                gen_expr buf value
+            | args ->
+                Vulkan_error.raise_error
+                  (Vulkan_error.invalid_arg_count
+                     "atomic_add"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_min" ->
+            Buffer.add_string buf "atomicMin(" ;
+            (match args with
+            | [addr; value] ->
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | args ->
+                Vulkan_error.raise_error
+                  (Vulkan_error.invalid_arg_count
+                     "atomic_min"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_max" ->
+            Buffer.add_string buf "atomicMax(" ;
+            (match args with
+            | [addr; value] ->
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | args ->
+                Vulkan_error.raise_error
+                  (Vulkan_error.invalid_arg_count
+                     "atomic_max"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "float" ->
+            Buffer.add_string buf "float(" ;
+            (match args with [e] -> gen_expr buf e | _ -> ()) ;
+            Buffer.add_char buf ')'
+        | "int_of_float" ->
+            Buffer.add_string buf "int(" ;
+            (match args with [e] -> gen_expr buf e | _ -> ()) ;
+            Buffer.add_char buf ')'
+        | _ ->
+            (* Unknown intrinsic - emit as function call *)
+            Buffer.add_string buf full_name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')')
 
 (** {1 L-value Generation} *)
 

--- a/sarek-vulkan/Sarek_ir_glsl.ml
+++ b/sarek-vulkan/Sarek_ir_glsl.ml
@@ -349,6 +349,29 @@ and gen_intrinsic buf path name args =
   let full_name =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
+  (* For path-qualified intrinsics, query the pure registry first.
+     Float32.sin -> sin on GLSL (GLSL uses un-suffixed names). *)
+  let pure_registry_hit =
+    match path with
+    | [] -> None
+    | _ -> (
+        match
+          Sarek_pure_registry.fun_device_template ~module_path:path name
+        with
+        | Some f -> Some (f ~framework:"GLSL")
+        | None -> None)
+  in
+  match pure_registry_hit with
+  | Some device_name ->
+      Buffer.add_string buf device_name ;
+      Buffer.add_char buf '(' ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        args ;
+      Buffer.add_char buf ')'
+  | None ->
   (* Try thread intrinsics *)
   if
     List.mem

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -138,8 +138,8 @@ let variant_kernel () =
   in
   {k with kern_variants = [("Opt", opt_constrs)]}
 
-(** Kernel 4: Float32.sin intrinsic call. fun (a : float32 vec) (b : float32
-    vec) -> let idx = global_thread_id in b.[idx] <- sin a.[idx] *)
+(** Kernel 4: Float32.sin intrinsic call (unqualified path=[]).
+    fun (a : float32 vec) (b : float32 vec) -> ... b.[idx] <- sin a.[idx] *)
 let sin_kernel () =
   let a = make_var "a" (TVec TFloat32) in
   let b = make_var "b" (TVec TFloat32) in
@@ -154,6 +154,30 @@ let sin_kernel () =
   in
   empty_kernel
     "sin_kernel"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+(** Kernel 5: Float32.sin path-qualified intrinsic (path=["Float32"]).
+    CUDA must emit sinf(); OpenCL/Metal/GLSL emit sin().
+    This is the PR-2 sinf-fix test kernel. *)
+let float32_sin_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float32"], "sin", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float32_sin_path"
     [
       DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
       DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
@@ -576,6 +600,72 @@ let () =
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = sin(a[idx]);\n\
+     }\n" ;
+
+  (* ---- float32_sin_path goldens (PR-2 sinf-fix kernel) ---- *)
+  (* CUDA: sinf (f-suffix for Float32 path-qualified math) *)
+  register_golden
+    "cuda"
+    "float32_sin_path"
+    "\n\
+     extern \"C\" {\n\
+     __global__ void float32_sin_path(float* __restrict__ a, int \
+     sarek_a_length, float* __restrict__ b, int sarek_b_length) {\n\
+    \  int idx = (threadIdx.x + blockIdx.x * blockDim.x);\n\
+    \  b[idx] = sinf(a[idx]);\n\
+     }\n\
+     }\n" ;
+
+  (* OpenCL: sin (un-suffixed for Float32) *)
+  register_golden
+    "opencl"
+    "float32_sin_path"
+    "__kernel void float32_sin_path(__global float* restrict a, int \
+     sarek_a_length, __global float* restrict b, int sarek_b_length) {\n\
+    \  int idx = get_global_id(0);\n\
+    \  b[idx] = sin(a[idx]);\n\
+     }\n" ;
+
+  (* Metal: sin (un-suffixed for Float32) *)
+  register_golden
+    "metal"
+    "float32_sin_path"
+    "#include <metal_stdlib>\n\
+     using namespace metal;\n\n\
+     kernel void float32_sin_path(device float* a [[buffer(0)]], constant int \
+     &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant \
+     int &sarek_b_length [[buffer(3)]],\n\
+     uint3 __metal_gid [[thread_position_in_grid]],\n\
+     uint3 __metal_tid [[thread_position_in_threadgroup]],\n\
+     uint3 __metal_bid [[threadgroup_position_in_grid]],\n\
+     uint3 __metal_tpg [[threads_per_threadgroup]],\n\
+     uint3 __metal_num_groups [[threadgroups_per_grid]]) {\n\
+    \  int idx = __metal_gid.x;\n\
+    \  b[idx] = sin(a[idx]);\n\
+     }\n\n" ;
+
+  (* GLSL: sin (un-suffixed for Float32) *)
+  register_golden
+    "glsl"
+    "float32_sin_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_sin_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = sin(a[idx]);\n\
      }\n"
 
 (** {1 Kernel list for test iteration} *)
@@ -586,6 +676,7 @@ let test_kernels () =
     ("record_kernel", record_kernel ());
     ("variant_kernel", variant_kernel ());
     ("sin_kernel", sin_kernel ());
+    ("float32_sin_path", float32_sin_path_kernel ());
   ]
 
 (** {1 Test helpers} *)

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -138,8 +138,8 @@ let variant_kernel () =
   in
   {k with kern_variants = [("Opt", opt_constrs)]}
 
-(** Kernel 4: Float32.sin intrinsic call (unqualified path=[]).
-    fun (a : float32 vec) (b : float32 vec) -> ... b.[idx] <- sin a.[idx] *)
+(** Kernel 4: Float32.sin intrinsic call (unqualified path=[]). fun (a : float32
+    vec) (b : float32 vec) -> ... b.[idx] <- sin a.[idx] *)
 let sin_kernel () =
   let a = make_var "a" (TVec TFloat32) in
   let b = make_var "b" (TVec TFloat32) in
@@ -161,9 +161,9 @@ let sin_kernel () =
     []
     body
 
-(** Kernel 5: Float32.sin path-qualified intrinsic (path=["Float32"]).
-    CUDA must emit sinf(); OpenCL/Metal/GLSL emit sin().
-    This is the PR-2 sinf-fix test kernel. *)
+(** Kernel 5: Float32.sin path-qualified intrinsic (path=["Float32"]). CUDA must
+    emit sinf(); OpenCL/Metal/GLSL emit sin(). This is the PR-2 sinf-fix test
+    kernel. *)
 let float32_sin_path_kernel () =
   let a = make_var "a" (TVec TFloat32) in
   let b = make_var "b" (TVec TFloat32) in

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -187,6 +187,15 @@
  (preprocess
   (pps sarek_ppx)))
 
+; PR-2 Float32.sin pure-registry GPU e2e test
+; Run with: dune exec sarek/tests/e2e/test_float32_sin_pure.exe -- --vulkan
+
+(executable
+ (name test_float32_sin_pure)
+ (modules test_float32_sin_pure)
+ (libraries sarek sarek_ir spoc_core test_helpers unix)
+ (preprocess no_preprocessing))
+
 ; External kernel test - works with any available backend
 
 (executable

--- a/sarek/tests/e2e/test_float32_sin_pure.ml
+++ b/sarek/tests/e2e/test_float32_sin_pure.ml
@@ -1,0 +1,139 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * PR-2 GPU E2E test: Float32.sin via the pure registry
+ *
+ * Builds a Sarek IR kernel directly (no PPX) using
+ * EIntrinsic (["Float32"], "sin", ...) and runs it on the available GPU
+ * backend.  Verifies numerical correctness against OCaml sin.
+ *
+ * On CUDA the generator emits sinf() (f-suffix, single-precision).
+ * On Vulkan/OpenCL/Metal the generator emits sin().
+ *
+ * Run with: dune exec sarek/tests/e2e/test_float32_sin_pure.exe -- --vulkan
+ ******************************************************************************)
+
+open Sarek_ir_types
+open Sarek
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+(* Force backend registration *)
+let () = Test_helpers.Benchmarks.init_backends ()
+
+(** Build the Float32.sin kernel IR directly — no PPX dependency.
+    Equivalent to:
+      fun (a : float32 vec) (b : float32 vec) ->
+        let idx = global_thread_id in
+        b.[idx] <- Float32.sin a.[idx]   *)
+let make_float32_sin_ir () : kernel =
+  let make_var name ty =
+    {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+  in
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            (* Path-qualified: ["Float32"]."sin" -> pure registry -> sinf on
+               CUDA, sin on Vulkan/OpenCL/Metal *)
+            EIntrinsic (["Float32"], "sin", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  {
+    kern_name = "float32_sin_pure";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let n = 256
+
+let run_kernel_on_device (dev : Device.t) =
+  let ir = make_float32_sin_ir () in
+  let a_vec = Vector.create Vector.float32 n in
+  let b_vec = Vector.create Vector.float32 n in
+  (* Fill input with values in [0, 2*pi] *)
+  for i = 0 to n - 1 do
+    let x = Float.pi *. 2.0 *. (float_of_int i /. float_of_int n) in
+    Vector.set a_vec i x ;
+    Vector.set b_vec i 0.0
+  done ;
+  let block = Execute.dims1d 256 in
+  let grid = Execute.dims1d 1 in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Execute.Vec a_vec; Execute.Vec b_vec]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  (* Read back *)
+  let result = Vector.to_array b_vec in
+  result
+
+let verify_result result =
+  let errors = ref 0 in
+  for i = 0 to n - 1 do
+    let x = Float.pi *. 2.0 *. (float_of_int i /. float_of_int n) in
+    let expected = sin x in
+    let diff = abs_float (result.(i) -. expected) in
+    (* sin(float) should be accurate to ~1e-5 for float32 *)
+    if diff > 1e-4 then begin
+      if !errors < 5 then
+        Printf.printf
+          "  Mismatch at %d: x=%.4f expected=%.6f got=%.6f diff=%.2e\n"
+          i
+          x
+          expected
+          result.(i)
+          diff ;
+      incr errors
+    end
+  done ;
+  !errors = 0
+
+let () =
+  let cfg = Test_helpers.parse_args "test_float32_sin_pure" in
+  let devs = Test_helpers.init_devices cfg in
+  if Array.length devs = 0 then begin
+    print_endline "No devices found" ;
+    exit 1
+  end ;
+  Test_helpers.print_devices devs ;
+  let dev = Test_helpers.get_device cfg devs in
+  Printf.printf "Using device: %s (%s)\n%!" dev.Device.name dev.Device.framework ;
+  Printf.printf "Running Float32.sin pure-registry kernel (n=%d)...\n%!" n ;
+  (try
+     let result = run_kernel_on_device dev in
+     if verify_result result then begin
+       Printf.printf "PASSED: Float32.sin pure-registry e2e on %s\n%!"
+         dev.Device.framework
+     end else begin
+       Printf.printf "FAILED: numerical mismatch\n%!" ;
+       exit 1
+     end
+   with
+  | Spoc_framework.Backend_error.Backend_error _msg ->
+      Printf.printf "SKIPPED: backend error\n%!" ;
+      exit 0
+  | e ->
+      Printf.printf "ERROR: %s\n%!" (Printexc.to_string e) ;
+      exit 1)

--- a/sarek/tests/e2e/test_float32_sin_pure.ml
+++ b/sarek/tests/e2e/test_float32_sin_pure.ml
@@ -29,12 +29,15 @@ let () = Test_helpers.Benchmarks.init_backends ()
     fun (a : float32 vec) (b : float32 vec) -> let idx = global_thread_id in
     b.[idx] <- Float32.sin a.[idx] *)
 let make_float32_sin_ir () : kernel =
-  let make_var name ty =
-    {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+  let make_var id name ty =
+    {var_name = name; var_id = id; var_type = ty; var_mutable = false}
   in
-  let a = make_var "a" (TVec TFloat32) in
-  let b = make_var "b" (TVec TFloat32) in
-  let idx = make_var "idx" TInt32 in
+  (* Distinct var_ids: the interpreter keys env.vars by var_id and fusion
+     compares EVar by var_id, so duplicate ids are fragile even when (as here)
+     only idx is referenced via EVar. *)
+  let a = make_var 0 "a" (TVec TFloat32) in
+  let b = make_var 1 "b" (TVec TFloat32) in
+  let idx = make_var 2 "idx" TInt32 in
   let body =
     SLet
       ( idx,
@@ -92,7 +95,7 @@ let verify_result result =
     let x = Float.pi *. 2.0 *. (float_of_int i /. float_of_int n) in
     let expected = sin x in
     let diff = abs_float (result.(i) -. expected) in
-    (* sin(float) should be accurate to ~1e-5 for float32 *)
+    (* Allow 1e-4 absolute tolerance for GPU float32 sin variation *)
     if diff > 1e-4 then begin
       if !errors < 5 then
         Printf.printf
@@ -130,8 +133,10 @@ let () =
       exit 1
     end
   with
-  | Spoc_framework.Backend_error.Backend_error _msg ->
-      Printf.printf "SKIPPED: backend error\n%!" ;
+  | Spoc_framework.Backend_error.Backend_error err ->
+      Printf.printf
+        "SKIPPED: backend error: %s\n%!"
+        (Spoc_framework.Backend_error.to_string err) ;
       exit 0
   | e ->
       Printf.printf "ERROR: %s\n%!" (Printexc.to_string e) ;

--- a/sarek/tests/e2e/test_float32_sin_pure.ml
+++ b/sarek/tests/e2e/test_float32_sin_pure.ml
@@ -18,7 +18,6 @@
 
 open Sarek_ir_types
 open Sarek
-
 module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 module Transfer = Spoc_core.Transfer
@@ -26,11 +25,9 @@ module Transfer = Spoc_core.Transfer
 (* Force backend registration *)
 let () = Test_helpers.Benchmarks.init_backends ()
 
-(** Build the Float32.sin kernel IR directly — no PPX dependency.
-    Equivalent to:
-      fun (a : float32 vec) (b : float32 vec) ->
-        let idx = global_thread_id in
-        b.[idx] <- Float32.sin a.[idx]   *)
+(** Build the Float32.sin kernel IR directly — no PPX dependency. Equivalent to:
+    fun (a : float32 vec) (b : float32 vec) -> let idx = global_thread_id in
+    b.[idx] <- Float32.sin a.[idx] *)
 let make_float32_sin_ir () : kernel =
   let make_var name ty =
     {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
@@ -121,19 +118,21 @@ let () =
   let dev = Test_helpers.get_device cfg devs in
   Printf.printf "Using device: %s (%s)\n%!" dev.Device.name dev.Device.framework ;
   Printf.printf "Running Float32.sin pure-registry kernel (n=%d)...\n%!" n ;
-  (try
-     let result = run_kernel_on_device dev in
-     if verify_result result then begin
-       Printf.printf "PASSED: Float32.sin pure-registry e2e on %s\n%!"
-         dev.Device.framework
-     end else begin
-       Printf.printf "FAILED: numerical mismatch\n%!" ;
-       exit 1
-     end
-   with
+  try
+    let result = run_kernel_on_device dev in
+    if verify_result result then begin
+      Printf.printf
+        "PASSED: Float32.sin pure-registry e2e on %s\n%!"
+        dev.Device.framework
+    end
+    else begin
+      Printf.printf "FAILED: numerical mismatch\n%!" ;
+      exit 1
+    end
+  with
   | Spoc_framework.Backend_error.Backend_error _msg ->
       Printf.printf "SKIPPED: backend error\n%!" ;
       exit 0
   | e ->
       Printf.printf "ERROR: %s\n%!" (Printexc.to_string e) ;
-      exit 1)
+      exit 1

--- a/spoc/ir/Sarek_pure_registry.ml
+++ b/spoc/ir/Sarek_pure_registry.ml
@@ -171,6 +171,11 @@ let () =
   reg_math32 "fma" "fmaf" "fma" ;
   reg_math32 "min" "fminf" "min" ;
   reg_math32 "max" "fmaxf" "max" ;
+  reg_math32 "abs_float" "fabsf" "fabs" ;
+  reg_math32 "expm1" "expm1f" "expm1" ;
+  reg_math32 "log1p" "log1pf" "log1p" ;
+  reg_math32 "hypot" "hypotf" "hypot" ;
+  reg_math32 "copysign" "copysignf" "copysign" ;
   (* ---- Math.Float64 ---- *)
   let reg_math64 name =
     register_fun

--- a/spoc/ir/Sarek_pure_registry.ml
+++ b/spoc/ir/Sarek_pure_registry.ml
@@ -25,16 +25,15 @@ let fun_registry : (string list * string, framework:string -> string) Hashtbl.t
     =
   Hashtbl.create 64
 
-(** Register a pure intrinsic function.
-    [module_path] is the qualified path, e.g. [["Float32"]] for Float32.sin.
-    [name] is the unqualified function name.
+(** Register a pure intrinsic function. [module_path] is the qualified path,
+    e.g. [["Float32"]] for Float32.sin. [name] is the unqualified function name.
     [device] is a closure [~framework:string -> string] returning the
     device-code name to emit for a given backend framework string. *)
 let register_fun ?(module_path = []) name ~device =
   Hashtbl.replace fun_registry (module_path, name) device
 
-(** Look up device-code name for a path-qualified function.
-    Returns [None] if not found. *)
+(** Look up device-code name for a path-qualified function. Returns [None] if
+    not found. *)
 let fun_device_template ?(module_path = []) name =
   Hashtbl.find_opt fun_registry (module_path, name)
 
@@ -42,12 +41,12 @@ let fun_device_template ?(module_path = []) name =
  * Helpers
  ******************************************************************************)
 
-(** Build a framework-dispatching closure for float32 math functions.
-    CUDA uses the [f]-suffixed form (sinf, cosf, …);
-    OpenCL, Metal, and GLSL use the un-suffixed form. *)
+(** Build a framework-dispatching closure for float32 math functions. CUDA uses
+    the [f]-suffixed form (sinf, cosf, …); OpenCL, Metal, and GLSL use the
+    un-suffixed form. *)
 let float32_math_template ~cuda_name ~generic_name =
-  fun ~framework ->
-   match framework with "CUDA" -> cuda_name | _ -> generic_name
+ fun ~framework ->
+  match framework with "CUDA" -> cuda_name | _ -> generic_name
 
 (******************************************************************************
  * Standard stdlib registrations (static table — PR-2 design)
@@ -108,7 +107,8 @@ let () =
   reg32 "copysign" "copysignf" "copysign" ;
   (* ---- Float64 math (same name on all backends) ---- *)
   let reg64 name =
-    register_fun ~module_path:["Float64"] name ~device:(fun ~framework:_ -> name)
+    register_fun ~module_path:["Float64"] name ~device:(fun ~framework:_ ->
+        name)
   in
   reg64 "sin" ;
   reg64 "cos" ;

--- a/spoc/ir/Sarek_pure_registry.ml
+++ b/spoc/ir/Sarek_pure_registry.ml
@@ -1,0 +1,196 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek_pure_registry - Pure ctypes-free intrinsic metadata
+ *
+ * Provides a registration path for intrinsic functions whose device code
+ * generation depends only on the framework name (a string), not on any
+ * Device.t or ctypes value.
+ *
+ * This is the pure side used by GPU code generators.  The FFI registry
+ * (Sarek_registry) remains the authoritative source for native/interpreter
+ * paths; this registry serves GPU code-generation exclusively.
+ *
+ * Entry format: (module_path : string list, name : string)
+ *               -> (framework:string -> string)
+ * The returned string is the device-code function name
+ * (e.g. "sinf", "sin", "native_sin").
+ ******************************************************************************)
+
+(** Pure function registry: no Device.t, no ctypes. *)
+let fun_registry : (string list * string, framework:string -> string) Hashtbl.t
+    =
+  Hashtbl.create 64
+
+(** Register a pure intrinsic function.
+    [module_path] is the qualified path, e.g. [["Float32"]] for Float32.sin.
+    [name] is the unqualified function name.
+    [device] is a closure [~framework:string -> string] returning the
+    device-code name to emit for a given backend framework string. *)
+let register_fun ?(module_path = []) name ~device =
+  Hashtbl.replace fun_registry (module_path, name) device
+
+(** Look up device-code name for a path-qualified function.
+    Returns [None] if not found. *)
+let fun_device_template ?(module_path = []) name =
+  Hashtbl.find_opt fun_registry (module_path, name)
+
+(******************************************************************************
+ * Helpers
+ ******************************************************************************)
+
+(** Build a framework-dispatching closure for float32 math functions.
+    CUDA uses the [f]-suffixed form (sinf, cosf, …);
+    OpenCL, Metal, and GLSL use the un-suffixed form. *)
+let float32_math_template ~cuda_name ~generic_name =
+  fun ~framework ->
+   match framework with "CUDA" -> cuda_name | _ -> generic_name
+
+(******************************************************************************
+ * Standard stdlib registrations (static table — PR-2 design)
+ *
+ * PPX dual-registration was evaluated but deferred (see PR-2 report).
+ * The static table here is the fallback approach: one authoritative place
+ * for all path-qualified GPU math intrinsics.
+ *
+ * Float32 math: path ["Float32"] resolves to the `f`-suffixed CUDA form.
+ * Float64 math: path ["Float64"] resolves to the un-suffixed form everywhere.
+ * Math.Float32: path ["Math";"Float32"] (open Math.Float32 in kernels).
+ * Math.Float64: path ["Math";"Float64"].
+ *
+ * Unqualified (path = []) entries are intentionally ABSENT.
+ * Unqualified intrinsics continue to be resolved by the hardcoded match arms
+ * in each generator.  The pure registry handles path-qualified calls only.
+ ******************************************************************************)
+
+let () =
+  (* ---- Float32 math (CUDA gets sinf, others get sin) ---- *)
+  let reg32 name cuda_name generic_name =
+    register_fun
+      ~module_path:["Float32"]
+      name
+      ~device:(float32_math_template ~cuda_name ~generic_name)
+  in
+  reg32 "sin" "sinf" "sin" ;
+  reg32 "cos" "cosf" "cos" ;
+  reg32 "tan" "tanf" "tan" ;
+  reg32 "asin" "asinf" "asin" ;
+  reg32 "acos" "acosf" "acos" ;
+  reg32 "atan" "atanf" "atan" ;
+  reg32 "sinh" "sinhf" "sinh" ;
+  reg32 "cosh" "coshf" "cosh" ;
+  reg32 "tanh" "tanhf" "tanh" ;
+  reg32 "exp" "expf" "exp" ;
+  reg32 "exp2" "exp2f" "exp2" ;
+  reg32 "log" "logf" "log" ;
+  reg32 "log2" "log2f" "log2" ;
+  reg32 "log10" "log10f" "log10" ;
+  reg32 "sqrt" "sqrtf" "sqrt" ;
+  reg32 "rsqrt" "rsqrtf" "rsqrt" ;
+  reg32 "cbrt" "cbrtf" "cbrt" ;
+  reg32 "floor" "floorf" "floor" ;
+  reg32 "ceil" "ceilf" "ceil" ;
+  reg32 "round" "roundf" "round" ;
+  reg32 "trunc" "truncf" "trunc" ;
+  reg32 "fabs" "fabsf" "fabs" ;
+  reg32 "abs_float" "fabsf" "fabs" ;
+  reg32 "pow" "powf" "pow" ;
+  reg32 "atan2" "atan2f" "atan2" ;
+  reg32 "fma" "fmaf" "fma" ;
+  reg32 "min" "fminf" "min" ;
+  reg32 "max" "fmaxf" "max" ;
+  reg32 "expm1" "expm1f" "expm1" ;
+  reg32 "log1p" "log1pf" "log1p" ;
+  reg32 "hypot" "hypotf" "hypot" ;
+  reg32 "copysign" "copysignf" "copysign" ;
+  (* ---- Float64 math (same name on all backends) ---- *)
+  let reg64 name =
+    register_fun ~module_path:["Float64"] name ~device:(fun ~framework:_ -> name)
+  in
+  reg64 "sin" ;
+  reg64 "cos" ;
+  reg64 "tan" ;
+  reg64 "asin" ;
+  reg64 "acos" ;
+  reg64 "atan" ;
+  reg64 "sinh" ;
+  reg64 "cosh" ;
+  reg64 "tanh" ;
+  reg64 "exp" ;
+  reg64 "exp2" ;
+  reg64 "log" ;
+  reg64 "log2" ;
+  reg64 "log10" ;
+  reg64 "sqrt" ;
+  reg64 "rsqrt" ;
+  reg64 "cbrt" ;
+  reg64 "floor" ;
+  reg64 "ceil" ;
+  reg64 "round" ;
+  reg64 "trunc" ;
+  reg64 "fabs" ;
+  reg64 "pow" ;
+  reg64 "atan2" ;
+  reg64 "fma" ;
+  reg64 "min" ;
+  reg64 "max" ;
+  (* ---- Math.Float32 (open Math.Float32 → path ["Math";"Float32"]) ---- *)
+  let reg_math32 name cuda_name generic_name =
+    register_fun
+      ~module_path:["Math"; "Float32"]
+      name
+      ~device:(float32_math_template ~cuda_name ~generic_name)
+  in
+  reg_math32 "sin" "sinf" "sin" ;
+  reg_math32 "cos" "cosf" "cos" ;
+  reg_math32 "tan" "tanf" "tan" ;
+  reg_math32 "asin" "asinf" "asin" ;
+  reg_math32 "acos" "acosf" "acos" ;
+  reg_math32 "atan" "atanf" "atan" ;
+  reg_math32 "sinh" "sinhf" "sinh" ;
+  reg_math32 "cosh" "coshf" "cosh" ;
+  reg_math32 "tanh" "tanhf" "tanh" ;
+  reg_math32 "exp" "expf" "exp" ;
+  reg_math32 "exp2" "exp2f" "exp2" ;
+  reg_math32 "log" "logf" "log" ;
+  reg_math32 "log2" "log2f" "log2" ;
+  reg_math32 "log10" "log10f" "log10" ;
+  reg_math32 "sqrt" "sqrtf" "sqrt" ;
+  reg_math32 "rsqrt" "rsqrtf" "rsqrt" ;
+  reg_math32 "cbrt" "cbrtf" "cbrt" ;
+  reg_math32 "floor" "floorf" "floor" ;
+  reg_math32 "ceil" "ceilf" "ceil" ;
+  reg_math32 "round" "roundf" "round" ;
+  reg_math32 "trunc" "truncf" "trunc" ;
+  reg_math32 "fabs" "fabsf" "fabs" ;
+  reg_math32 "pow" "powf" "pow" ;
+  reg_math32 "atan2" "atan2f" "atan2" ;
+  reg_math32 "fma" "fmaf" "fma" ;
+  reg_math32 "min" "fminf" "min" ;
+  reg_math32 "max" "fmaxf" "max" ;
+  (* ---- Math.Float64 ---- *)
+  let reg_math64 name =
+    register_fun
+      ~module_path:["Math"; "Float64"]
+      name
+      ~device:(fun ~framework:_ -> name)
+  in
+  reg_math64 "sin" ;
+  reg_math64 "cos" ;
+  reg_math64 "tan" ;
+  reg_math64 "asin" ;
+  reg_math64 "acos" ;
+  reg_math64 "atan" ;
+  reg_math64 "sinh" ;
+  reg_math64 "cosh" ;
+  reg_math64 "tanh" ;
+  reg_math64 "exp" ;
+  reg_math64 "log" ;
+  reg_math64 "sqrt" ;
+  reg_math64 "floor" ;
+  reg_math64 "ceil" ;
+  reg_math64 "pow" ;
+  reg_math64 "atan2"

--- a/spoc/ir/dune
+++ b/spoc/ir/dune
@@ -5,7 +5,12 @@
  (name sarek_ir)
  (public_name spoc.ir)
  (wrapped false)
- (modules Sarek_ir_types Sarek_ir_pp Sarek_ir_analysis Sarek_ir_codegen Sarek_pure_registry)
+ (modules
+  Sarek_ir_types
+  Sarek_ir_pp
+  Sarek_ir_analysis
+  Sarek_ir_codegen
+  Sarek_pure_registry)
  (preprocess no_preprocessing)
  (instrumentation
   (backend bisect_ppx)))

--- a/spoc/ir/dune
+++ b/spoc/ir/dune
@@ -5,7 +5,7 @@
  (name sarek_ir)
  (public_name spoc.ir)
  (wrapped false)
- (modules Sarek_ir_types Sarek_ir_pp Sarek_ir_analysis Sarek_ir_codegen)
+ (modules Sarek_ir_types Sarek_ir_pp Sarek_ir_analysis Sarek_ir_codegen Sarek_pure_registry)
  (preprocess no_preprocessing)
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
## Phase 0B PR-2 of 5 — pure-codegen-rollout

Makes the intrinsic registry resolvable from the pure (no-`Device.t`) codegen path, and lands the intake-approved CUDA `sinf` fix.

### Changes
- **`spoc/ir/Sarek_pure_registry.ml`** (new, in `sarek_ir`, ctypes-free): maps `(module-path, name) -> (framework:string -> string)` device-name templates. Populated via a **static table** covering `Float32`/`Float64`/`Math` math intrinsics.
- **All 4 generators** (`Sarek_ir_{cuda,opencl,metal}.ml`, `Sarek_ir_glsl.ml`): for path-qualified intrinsics (`path <> []`) query the pure registry first, passing the backend framework string; otherwise fall through to the existing arms. Thread-index/atomic/barrier intrinsics remain handled by each generator's own switch.
- **`sinf` fix** (intake-approved behavior change): path-qualified `Float32.sin` now emits CUDA `sinf` (correct single-precision) instead of `main`'s erroneous double `sin`. OpenCL/Metal/GLSL keep `sin` (those languages don't suffix) — so the only behavior change is CUDA.
- **Goldens**: new `float32_sin_path` kernel across all 4 backends (CUDA `sinf`, others `sin`). Pre-existing `sin_kernel` (path=`[]`) goldens byte-unchanged.
- **e2e**: `test_float32_sin_pure.ml` (new) — builds IR directly, runs `Float32.sin` on device, numeric check vs OCaml `sin` (tol 1e-4). **PASSES on Vulkan / RX 7900 XTX.**

### Scope boundary (per brief)
No library split (PR-3), no `sarek_codegen` extraction (PR-4), no `Sarek_transpile` (PR-5). Native/interpreter behavior identical.

### Authorized escalation
The brief preferred extending the `%sarek_intrinsic` PPX to emit pure registrations alongside FFI ones (single source of truth). That proved larger than PR-2's bound, so the **static-table fallback** was used as the brief explicitly authorized. This leaves the FFI table (`Sarek_stdlib/*.ml`) and the pure table as two hand-maintained sources — **tracked follow-up: fold the pure registration into the PPX in PR-3/4 and delete the hand table.**

### Gates
- `@sarek/tests/runtest` — pass (goldens incl. unchanged `sin_kernel` on 4 backends)
- `@sarek-vulkan/all` — pass
- `test_float32_sin_pure --vulkan` — PASSED on RX 7900 XTX
- `test_math_intrinsics --native` / `--interpreter` — pass (FFI path unchanged)
- `ocamlformat --check` — clean
- (`-lnvrtc` full-build link error pre-existing; CI e2e-fast matrix-mul segfault known-flaky.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pure-registry for path-qualified intrinsics and updated intrinsic dispatch to prefer registry-resolved device names across CUDA, Metal, OpenCL, and GLSL.

* **Tests**
  * Added golden and end-to-end GPU tests validating Float32 math intrinsic codegen and runtime correctness.

* **Chores**
  * Wired the new registry into the build module list so it’s available to all backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->