### PR TITLE
Phase 0B PR-3: split sarek_ppx_lib into pure sarek_frontend + FFI sarek_native_gen

### DIFF
--- a/briefs/pcr-pr3-frontend-split-impl.md
+++ b/briefs/pcr-pr3-frontend-split-impl.md
@@ -1,0 +1,72 @@
+# Implementation Report — Phase 0B PR-3: split sarek_ppx_lib → frontend + native_gen
+
+**Branch:** `phase0b/pr3-frontend-split`
+**Status:** COMPLETE — all hard gates pass
+
+## Commits (on branch, ordered)
+
+| Hash | Subject |
+|------|---------|
+| `e7dcf39d` | refactor(kirc_ast): retype Native variant from Device.t->string to string->string |
+| `62a53363` | refactor(ppx_registry): drop dead {ti,ii,ci}_device closure fields |
+| `f5a09404` | refactor(ppx): split sarek_ppx_lib into sarek_frontend + sarek_native_gen |
+| `3e675a58` | style: apply dune fmt to sarek/ppx/dune |
+
+## Files Modified
+
+**Step 1 — Kirc_Ast.Native retype:**
+- `sarek/ppx/Kirc_Ast.ml` line 122: `Native of (Spoc_core.Device.t -> string)` → `Native of (string -> string)`
+- `sarek/ppx/Sarek_quote.ml` line 334: `(fun _dev -> "")` → `(fun _framework -> "")`
+
+**Step 2 — Sarek_ppx_registry pure:**
+- `sarek/ppx/Sarek_ppx_registry.ml`: removed `ti_device`, `ii_device`, `ci_device` fields; removed `~device` param from `make_{type,intrinsic,const}_info` helpers
+- `sarek/ppx_intrinsic/Sarek_ppx_intrinsic.ml`: removed `~device` arg from both PPX call sites
+- `sarek/tests/unit/test_ppx_registry.ml`: removed `test_device_gen` helper and all `{ti,ii,ci}_device = ...` fields
+
+**Steps 3–5 — Library split + façade + consumer updates:**
+- `sarek/ppx/dune`: four stanzas: `sarek_frontend` (23 modules, wrapped false, `libraries ppxlib sarek_ir`), `sarek_native_gen` (9 modules, wrapped false, `libraries ppxlib spoc_core sarek_ir sarek_frontend`), `sarek_ppx_lib` (empty modules, re_export both), `sarek_ppx` (unchanged)
+- `sarek/ppx/Sarek_quote.ml`: removed 81 `Sarek_ppx_lib.` qualifications in quoted expressions
+- `sarek/ppx/Sarek_ppx.ml`: removed bare `open Sarek_ppx_lib`
+- `sarek/ppx_intrinsic/Sarek_ppx_intrinsic.ml`: removed all `Sarek_ppx_lib.` prefixes
+- `sarek/tests/common/Ir_compare.ml`, `sarek/ppx/test/` (3 files), `sarek/tests/unit/` (20+ files): removed `Sarek_ppx_lib.` prefixes and bare `open Sarek_ppx_lib` statements
+
+**Step 6 — Format:**
+- `sarek/ppx/dune`: blank line added by `dune fmt --auto-promote`
+
+## Façade Decision: FALLBACK TAKEN
+
+Dune's `(re_export)` with `(modules)` empty does NOT create `Sarek_ppx_lib.X`
+submodule aliases. Both sub-libraries use `(wrapped false)`. `sarek_ppx_lib` is
+an empty re-export façade — consumers get all modules at top level. All
+`Sarek_ppx_lib.X` qualified paths were removed from consumer source files.
+
+## sarek_frontend final dune (libraries …) line
+
+```
+(libraries ppxlib sarek_ir)
+```
+
+No `spoc_core`.
+
+## Quality Gate Results
+
+| Gate | Result |
+|------|--------|
+| `dune build @sarek/tests/runtest` — goldens byte-identical | PASS |
+| `dune build` — full build | PASS (pre-existing -lnvrtc only) |
+| `dune build @sarek-vulkan/all` | PASS |
+| `sarek_frontend (libraries ppxlib sarek_ir)` — no spoc_core | PASS |
+| `ocamlformat --check` on changed files | PASS |
+
+## Golden Diff vs pre-PR3 (94011d2e)
+
+```
+git diff 94011d2e -- sarek/tests/codegen_golden/
+(empty — byte-identical)
+```
+
+## Residual Risks
+
+- CUDA/Metal backends not available — verified OpenCL, Vulkan, and stub paths only.
+- Both sub-libs use `(wrapped false)` — all 32 modules at top-level namespace. Future name collisions possible.
+- Generated code in `Sarek_quote.ml` and `Sarek_ppx_intrinsic.ml` now references modules by short name; requires consumers to have `sarek_ppx_lib` (or the sub-libs) in their transitive deps at user-compile-time.

--- a/briefs/pcr-pr3-frontend-split-implementer.md
+++ b/briefs/pcr-pr3-frontend-split-implementer.md
@@ -1,0 +1,95 @@
+# Implementer Sub-brief — pure-codegen-rollout PR-3 (split sarek_ppx_lib → frontend + native_gen)
+
+**Status:** VALIDATED
+**Parent:** `briefs/pure-codegen-rollout-intake.md` (Phase 0B, PR-3 of 5)
+**Type:** refactor (structural; pure — NO behavior/codegen change)
+
+## Goal
+Split the mixed `sarek_ppx_lib` (`sarek/ppx/dune`, 33 modules, deps `ppxlib spoc_core`)
+into a **pure `sarek_frontend`** (deps `ppxlib` + `sarek_ir`, NO `spoc_core`/ctypes) and an
+**FFI `sarek_native_gen`** (keeps `spoc_core`), and decouple `Kirc_Ast.Native` from
+`Spoc_core.Device.t`. A re-export façade keeps all current consumers building unchanged.
+This is the structural enabler for PR-4 (`sarek_codegen`) and PR-5 (`Sarek_transpile`,
+FFI-free bytecode/jsoo).
+
+**This is a pure refactor: generated source must be BYTE-IDENTICAL.** The
+`sarek/tests/codegen_golden/` harness is the oracle. Any golden diff = a real regression → STOP.
+
+## Evidence (dependency map, already done — do NOT re-investigate)
+- The 23 pure-frontend modules have **zero** `Spoc_core` references (verified by grep).
+- The `Spoc_core` coupling lives in only: `Kirc_Ast` (the `Native` variant), the 6 native_gen
+  modules, `Sarek_quote`, and `Sarek_ppx_registry` (dead `*_device` closures).
+- `Kirc_Ast.Native of (Spoc_core.Device.t -> string)` (`Kirc_Ast.ml:122`) is **vestigial**:
+  the ONLY construction is `Sarek_quote.ml:334` `[%expr Sarek.Kirc_Ast.Native (fun _dev -> "")]`
+  (a device-ignoring no-op); it is never applied to a device. Printer `Kirc_Ast.ml:277` and
+  `Ir_compare.ml:109,185` only match `Native _`.
+- `Sarek_ppx_registry.{ti,ii,ci}_device : Spoc_core.Device.t -> string` (lines ~24/35/46) are
+  **dead** in V2 — consumers (`Sarek_env`, `Sarek_ppx`) read only metadata fields, never the
+  device closures.
+
+## Module partition (exact)
+**`sarek_frontend` (PURE — 23 modules):**
+Sarek_types, Sarek_scheme, Sarek_core_primitives, Sarek_ppx_registry, Sarek_env, Sarek_error,
+Sarek_reserved, Sarek_parse, Sarek_parse_helpers, Sarek_ast, Sarek_typed_ast, Sarek_typer,
+Sarek_convergence, Sarek_lower_ir, Sarek_quote_ir, Sarek_ir_ppx, Sarek_mono, Sarek_debug,
+Sarek_tailrec_analysis, Sarek_tailrec_elim, Sarek_tailrec_bounded, Sarek_tailrec_pragma,
+Sarek_tailrec.
+
+**`sarek_native_gen` (FFI — keeps `spoc_core`):**
+Kirc_Ast, Sarek_lower, Sarek_quote, Sarek_native_helpers, Sarek_native_intrinsics,
+Sarek_native_gen_base, Sarek_native_gen_expr, Sarek_native_gen, Sarek_native_gen_kernel.
+
+> NOTE on `Kirc_Ast`/`Sarek_lower`: after the `Native` retype (below) they no longer touch
+> `Spoc_core` directly, but they belong to the native/legacy codegen path and are consumed by
+> `Sarek_quote` → keep them in `sarek_native_gen` (do NOT force them into the pure lib; the
+> goal is a Spoc_core-free `sarek_frontend`, not minimizing native_gen). If you find a frontend
+> module (the 23) transitively needs Kirc_Ast or Sarek_lower, STOP and report — that breaks the
+> cut and the map says it won't happen.
+
+## Steps (build + goldens green after EACH; COMMIT after each step on your worktree branch)
+1. **Decouple `Kirc_Ast.Native`.** Change `Native of (Spoc_core.Device.t -> string)`
+   (`Kirc_Ast.ml:122`) → `Native of (string -> string)` (framework-string closure). Update the
+   sole constructor `Sarek_quote.ml:334` `(fun _dev -> "")` → `(fun _framework -> "")`. Confirm
+   `Kirc_Ast` has no other `Spoc_core` use; if clean, `Kirc_Ast` no longer needs `spoc_core`.
+   Build + goldens green. COMMIT.
+2. **Make `Sarek_ppx_registry` pure.** Drop the dead `ti_device/ii_device/ci_device` fields
+   (and their constructors/usages if any remain) so the registry record carries metadata only and
+   the module no longer references `Spoc_core`. If removal ripples beyond the registry, STOP and
+   report (do not leave `spoc_core` in the pure set). Build + goldens green. COMMIT.
+3. **Create `sarek_frontend`** (`sarek/ppx/frontend/` or via dune `(modules ...)` selection —
+   your call, lowest churn): `(library (name sarek_frontend) (public_name sarek.frontend)
+   (libraries ppxlib sarek_ir) (preprocess (pps ppxlib.metaquot)) (modules <the 23>))`.
+   It must build with NO `spoc_core` dependency. Build + goldens green. COMMIT.
+4. **Create `sarek_native_gen`** `(library (name sarek_native_gen) (public_name sarek.native_gen)
+   (libraries ppxlib spoc_core sarek_ir sarek_frontend) (preprocess (pps ppxlib.metaquot))
+   (modules <the 9>))`. Build + goldens green. COMMIT.
+5. **Façade.** Keep `sarek_ppx_lib` as a thin re-export so the 7 consumers below build UNCHANGED:
+   `(library (name sarek_ppx_lib) (public_name sarek.ppx.lib)
+   (libraries (re_export sarek_frontend) (re_export sarek_native_gen)) (modules))`.
+   If `(modules)` empty + `(re_export …)` does not transparently expose the modules to consumers,
+   FALL BACK to updating the 7 consumers' dune `libraries` to depend on `sarek_frontend` and/or
+   `sarek_native_gen` directly, and delete `sarek_ppx_lib` — and SAY SO in the report. Either way,
+   all 7 consumers must build. Build everything + goldens green. COMMIT.
+6. **Final gates** (below). COMMIT any format fixes.
+
+## Consumers that MUST still build (the 7)
+`sarek/ppx/dune` (sarek_ppx rewriter), `sarek/ppx_intrinsic/dune`, `sarek/ppx/test/dune`,
+`sarek/tests/common/dune`, `sarek/tests/unit/dune`, `sarek/tests/e2e/dune`, `sarek/Sarek_stdlib/dune`.
+
+## Hard constraints
+- **BYTE-IDENTICAL goldens** — `@sarek/tests/runtest` unchanged. A golden diff is a regression, STOP.
+- `sarek_frontend` MUST NOT depend on `spoc_core` (verify: its `(libraries …)` has no `spoc_core`,
+  and `dune build @sarek/tests/runtest` passes). This is the load-bearing outcome of the PR.
+- NO new `sarek_codegen` (PR-4), NO `Sarek_transpile` (PR-5), NO generator changes.
+- SPDX headers on any new files; `dune fmt` clean.
+- **COMMIT after each step** (do not leave changes uncommitted — prior PR work was lost this way).
+
+## Quality gates
+```bash
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek/tests/runtest   # goldens byte-identical
+opam exec --switch=/home/mathias/dev/SPOC -- dune build                         # all 7 consumers + libs
+opam exec --switch=/home/mathias/dev/SPOC -- dune build @sarek-vulkan/all
+opam exec --switch=/home/mathias/dev/SPOC -- dune build sarek_frontend          # must link with NO spoc_core
+/home/mathias/.opam/octez-setup/bin/ocamlformat --check <changed .ml/dune>
+```
+(`-lnvrtc` full-build link error pre-existing; CI e2e-fast matrix-mul segfault known-flaky.)

--- a/briefs/pcr-pr3-frontend-split-reviewer.md
+++ b/briefs/pcr-pr3-frontend-split-reviewer.md
@@ -1,0 +1,43 @@
+# Reviewer Sub-brief — pure-codegen-rollout PR-3 (split sarek_ppx_lib)
+
+**Status:** VALIDATED
+**Parent:** `briefs/pure-codegen-rollout-intake.md` (Phase 0B, PR-3 of 5)
+
+## What was implemented
+`sarek_ppx_lib` (33 modules, deps `ppxlib spoc_core`) split into pure `sarek_frontend`
+(23 modules, deps `ppxlib sarek_ir`, NO spoc_core) + FFI `sarek_native_gen` (9 modules), with
+`Kirc_Ast.Native` retyped `(Device.t -> string)` → `(string -> string)` and the dead
+`Sarek_ppx_registry.*_device` closures dropped. A façade keeps consumers building.
+
+## The two load-bearing checks (GO/NO-GO hinges on these)
+1. **`sarek_frontend` is genuinely Spoc_core-free.** Read its dune `(libraries …)` — must have
+   NO `spoc_core`. Then confirm it builds standalone. If `spoc_core` leaked in (e.g. a frontend
+   module still references it, or a dep pulls it transitively), NO-GO — the entire PR's purpose
+   is this purity (it unblocks PR-5's FFI-free bytecode/jsoo compile).
+2. **Byte-identical goldens.** `git diff main -- sarek/tests/codegen_golden/` must be EMPTY. This
+   is a pure structural refactor; ANY golden change is a regression → NO-GO.
+
+## Also verify
+- **All 7 consumers build:** `sarek/ppx`, `sarek/ppx_intrinsic`, `sarek/ppx/test`,
+  `sarek/tests/common`, `sarek/tests/unit`, `sarek/tests/e2e`, `sarek/Sarek_stdlib`. Run
+  `dune build` (full) — known-pre-existing `-lnvrtc` link error is the ONLY acceptable failure.
+- **Module partition matches the brief** — the 23 named modules in `sarek_frontend`, the 9 in
+  `sarek_native_gen`, none duplicated/dropped. No module silently left in a dead `sarek_ppx_lib`.
+- **`Kirc_Ast.Native` retype is complete** — no residual `Device.t` in the variant; the sole
+  constructor (`Sarek_quote.ml:~334`) updated; printer/`Ir_compare` still compile (match `Native _`).
+- **Façade correctness** — if `sarek_ppx_lib` kept as `(re_export …)`, confirm consumers resolve
+  the modules they reference (they `open`/qualify `Sarek_typer`, `Sarek_quote`, etc.). If the
+  implementer fell back to updating consumer dunes + deleting `sarek_ppx_lib`, confirm every
+  reference site was updated and report that as the chosen approach.
+- **No scope creep** — no `sarek_codegen`, no `Sarek_transpile`, no generator edits, no behavior change.
+
+## Gates
+```bash
+dune build @sarek/tests/runtest      # goldens byte-identical
+dune build                            # all consumers (only -lnvrtc may fail, pre-existing)
+dune build @sarek-vulkan/all
+ocamlformat --check <changed>
+```
+
+Return GO/NO-GO. NO-GO if: `sarek_frontend` pulls `spoc_core`, OR any golden changed, OR a
+consumer fails to build for a non-pre-existing reason.

--- a/sarek/ppx/Kirc_Ast.ml
+++ b/sarek/ppx/Kirc_Ast.ml
@@ -119,7 +119,7 @@ type k_ext =
       (** Global float32 variable by name - for PPX quoting *)
   | GFloat64Var of string
       (** Global float64 variable by name - for PPX quoting *)
-  | Native of (Spoc_core.Device.t -> string)
+  | Native of (string -> string)
   | NativeWithFallback of {
       gpu : Ppxlib.expression;  (** fun dev -> "cuda/opencl code" *)
       ocaml : Ppxlib.expression;  (** OCaml fallback for interpreter/native *)

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -16,7 +16,6 @@
  ******************************************************************************)
 
 open Ppxlib
-open Sarek_ppx_lib
 
 (* Force stdlib module initialization to populate the PPX registry.
    This must happen before any kernel expansion uses Sarek_env.with_stdlib(). *)
@@ -1676,8 +1675,8 @@ let process_structure_for_module_items (str : structure) : structure =
         Some
           [%stri
             let () =
-              Sarek_ppx_lib.Sarek_ppx_registry.register_module_item
-                (Sarek_ppx_lib.Sarek_ppx_registry.make_module_item_info
+              Sarek_ppx_registry.register_module_item
+                (Sarek_ppx_registry.make_module_item_info
                    ~name:[%e name_str]
                    ~module_name:[%e module_name_str]
                    ~item:[%e item_expr])])

--- a/sarek/ppx/Sarek_ppx_registry.ml
+++ b/sarek/ppx/Sarek_ppx_registry.ml
@@ -21,8 +21,6 @@ open Sarek_types
 (** Type information for registered types (like float32, int64, etc.) *)
 type type_info = {
   ti_name : string;  (** Type name, e.g., "float32" *)
-  ti_device : Spoc_core.Device.t -> string;
-      (** Device type string, e.g., "float" *)
   ti_size : int;  (** Size in bytes *)
   ti_sarek_type : typ;  (** Sarek type representation *)
 }
@@ -32,9 +30,6 @@ type intrinsic_info = {
   ii_name : string;  (** Function name, e.g., "sin" *)
   ii_qualified_name : string;  (** Qualified name, e.g., "Float32.sin" *)
   ii_type : typ;  (** Type signature *)
-  ii_device : Spoc_core.Device.t -> string;
-      (** Device code generator - more generic than storing cuda/opencl
-          separately *)
   ii_module : string list;  (** Module path, e.g., ["Sarek_stdlib"; "Float32"] *)
 }
 
@@ -43,7 +38,6 @@ type const_info = {
   ci_name : string;  (** Constant name *)
   ci_qualified_name : string;  (** Qualified name *)
   ci_type : typ;  (** Type *)
-  ci_device : Spoc_core.Device.t -> string;  (** Device code generator *)
   ci_module : string list;  (** Module path *)
 }
 
@@ -191,35 +185,18 @@ let all_record_types () : record_type_info list =
     []
 
 (** Helper: create type_info for a numeric type *)
-let make_type_info ~name ~device ~size ~sarek_type : type_info =
-  {
-    ti_name = name;
-    ti_device = device;
-    ti_size = size;
-    ti_sarek_type = sarek_type;
-  }
+let make_type_info ~name ~size ~sarek_type : type_info =
+  {ti_name = name; ti_size = size; ti_sarek_type = sarek_type}
 
 (** Helper: create intrinsic_info *)
-let make_intrinsic_info ~name ~module_path ~typ ~device : intrinsic_info =
+let make_intrinsic_info ~name ~module_path ~typ : intrinsic_info =
   let qualified = String.concat "." (module_path @ [name]) in
-  {
-    ii_name = name;
-    ii_qualified_name = qualified;
-    ii_type = typ;
-    ii_device = device;
-    ii_module = module_path;
-  }
+  {ii_name = name; ii_qualified_name = qualified; ii_type = typ; ii_module = module_path}
 
 (** Helper: create const_info *)
-let make_const_info ~name ~module_path ~typ ~device : const_info =
+let make_const_info ~name ~module_path ~typ : const_info =
   let qualified = String.concat "." (module_path @ [name]) in
-  {
-    ci_name = name;
-    ci_qualified_name = qualified;
-    ci_type = typ;
-    ci_device = device;
-    ci_module = module_path;
-  }
+  {ci_name = name; ci_qualified_name = qualified; ci_type = typ; ci_module = module_path}
 
 (** Helper: create module_item_info *)
 let make_module_item_info ~name ~module_name ~item : module_item_info =

--- a/sarek/ppx/Sarek_quote.ml
+++ b/sarek/ppx/Sarek_quote.ml
@@ -695,7 +695,7 @@ let quote_kernel ~loc ?(native_kernel : tkernel option)
 let quote_sarek_loc ~loc (l : Sarek_ast.loc) : expression =
   [%expr
     {
-      Sarek_ppx_lib.Sarek_ast.loc_file = [%e quote_string ~loc l.loc_file];
+      Sarek_ast.loc_file = [%e quote_string ~loc l.loc_file];
       loc_line = [%e quote_int ~loc l.loc_line];
       loc_col = [%e quote_int ~loc l.loc_col];
       loc_end_line = [%e quote_int ~loc l.loc_end_line];
@@ -705,85 +705,85 @@ let quote_sarek_loc ~loc (l : Sarek_ast.loc) : expression =
 (** Quote a Sarek_ast.memspace *)
 let quote_sarek_memspace ~loc (m : Sarek_ast.memspace) : expression =
   match m with
-  | Sarek_ast.Local -> [%expr Sarek_ppx_lib.Sarek_ast.Local]
-  | Sarek_ast.Shared -> [%expr Sarek_ppx_lib.Sarek_ast.Shared]
-  | Sarek_ast.Global -> [%expr Sarek_ppx_lib.Sarek_ast.Global]
+  | Sarek_ast.Local -> [%expr Sarek_ast.Local]
+  | Sarek_ast.Shared -> [%expr Sarek_ast.Shared]
+  | Sarek_ast.Global -> [%expr Sarek_ast.Global]
 
 (** Quote a Sarek_ast.type_expr *)
 let rec quote_sarek_type_expr ~loc (te : Sarek_ast.type_expr) : expression =
   match te with
   | Sarek_ast.TEVar s ->
-      [%expr Sarek_ppx_lib.Sarek_ast.TEVar [%e quote_string ~loc s]]
+      [%expr Sarek_ast.TEVar [%e quote_string ~loc s]]
   | Sarek_ast.TEConstr (name, args) ->
       [%expr
-        Sarek_ppx_lib.Sarek_ast.TEConstr
+        Sarek_ast.TEConstr
           ( [%e quote_string ~loc name],
             [%e quote_list ~loc quote_sarek_type_expr args] )]
   | Sarek_ast.TEArrow (a, b) ->
       [%expr
-        Sarek_ppx_lib.Sarek_ast.TEArrow
+        Sarek_ast.TEArrow
           ([%e quote_sarek_type_expr ~loc a], [%e quote_sarek_type_expr ~loc b])]
   | Sarek_ast.TETuple ts ->
       [%expr
-        Sarek_ppx_lib.Sarek_ast.TETuple
+        Sarek_ast.TETuple
           [%e quote_list ~loc quote_sarek_type_expr ts]]
 
 (** Quote a Sarek_ast.binop *)
 let quote_sarek_binop ~loc (op : Sarek_ast.binop) : expression =
   match op with
-  | Sarek_ast.Add -> [%expr Sarek_ppx_lib.Sarek_ast.Add]
-  | Sarek_ast.Sub -> [%expr Sarek_ppx_lib.Sarek_ast.Sub]
-  | Sarek_ast.Mul -> [%expr Sarek_ppx_lib.Sarek_ast.Mul]
-  | Sarek_ast.Div -> [%expr Sarek_ppx_lib.Sarek_ast.Div]
-  | Sarek_ast.Mod -> [%expr Sarek_ppx_lib.Sarek_ast.Mod]
-  | Sarek_ast.And -> [%expr Sarek_ppx_lib.Sarek_ast.And]
-  | Sarek_ast.Or -> [%expr Sarek_ppx_lib.Sarek_ast.Or]
-  | Sarek_ast.Eq -> [%expr Sarek_ppx_lib.Sarek_ast.Eq]
-  | Sarek_ast.Ne -> [%expr Sarek_ppx_lib.Sarek_ast.Ne]
-  | Sarek_ast.Lt -> [%expr Sarek_ppx_lib.Sarek_ast.Lt]
-  | Sarek_ast.Le -> [%expr Sarek_ppx_lib.Sarek_ast.Le]
-  | Sarek_ast.Gt -> [%expr Sarek_ppx_lib.Sarek_ast.Gt]
-  | Sarek_ast.Ge -> [%expr Sarek_ppx_lib.Sarek_ast.Ge]
-  | Sarek_ast.Land -> [%expr Sarek_ppx_lib.Sarek_ast.Land]
-  | Sarek_ast.Lor -> [%expr Sarek_ppx_lib.Sarek_ast.Lor]
-  | Sarek_ast.Lxor -> [%expr Sarek_ppx_lib.Sarek_ast.Lxor]
-  | Sarek_ast.Lsl -> [%expr Sarek_ppx_lib.Sarek_ast.Lsl]
-  | Sarek_ast.Lsr -> [%expr Sarek_ppx_lib.Sarek_ast.Lsr]
-  | Sarek_ast.Asr -> [%expr Sarek_ppx_lib.Sarek_ast.Asr]
+  | Sarek_ast.Add -> [%expr Sarek_ast.Add]
+  | Sarek_ast.Sub -> [%expr Sarek_ast.Sub]
+  | Sarek_ast.Mul -> [%expr Sarek_ast.Mul]
+  | Sarek_ast.Div -> [%expr Sarek_ast.Div]
+  | Sarek_ast.Mod -> [%expr Sarek_ast.Mod]
+  | Sarek_ast.And -> [%expr Sarek_ast.And]
+  | Sarek_ast.Or -> [%expr Sarek_ast.Or]
+  | Sarek_ast.Eq -> [%expr Sarek_ast.Eq]
+  | Sarek_ast.Ne -> [%expr Sarek_ast.Ne]
+  | Sarek_ast.Lt -> [%expr Sarek_ast.Lt]
+  | Sarek_ast.Le -> [%expr Sarek_ast.Le]
+  | Sarek_ast.Gt -> [%expr Sarek_ast.Gt]
+  | Sarek_ast.Ge -> [%expr Sarek_ast.Ge]
+  | Sarek_ast.Land -> [%expr Sarek_ast.Land]
+  | Sarek_ast.Lor -> [%expr Sarek_ast.Lor]
+  | Sarek_ast.Lxor -> [%expr Sarek_ast.Lxor]
+  | Sarek_ast.Lsl -> [%expr Sarek_ast.Lsl]
+  | Sarek_ast.Lsr -> [%expr Sarek_ast.Lsr]
+  | Sarek_ast.Asr -> [%expr Sarek_ast.Asr]
 
 (** Quote a Sarek_ast.unop *)
 let quote_sarek_unop ~loc (op : Sarek_ast.unop) : expression =
   match op with
-  | Sarek_ast.Neg -> [%expr Sarek_ppx_lib.Sarek_ast.Neg]
-  | Sarek_ast.Not -> [%expr Sarek_ppx_lib.Sarek_ast.Not]
-  | Sarek_ast.Lnot -> [%expr Sarek_ppx_lib.Sarek_ast.Lnot]
+  | Sarek_ast.Neg -> [%expr Sarek_ast.Neg]
+  | Sarek_ast.Not -> [%expr Sarek_ast.Not]
+  | Sarek_ast.Lnot -> [%expr Sarek_ast.Lnot]
 
 (** Quote a Sarek_ast.for_dir *)
 let quote_sarek_for_dir ~loc (d : Sarek_ast.for_dir) : expression =
   match d with
-  | Sarek_ast.Upto -> [%expr Sarek_ppx_lib.Sarek_ast.Upto]
-  | Sarek_ast.Downto -> [%expr Sarek_ppx_lib.Sarek_ast.Downto]
+  | Sarek_ast.Upto -> [%expr Sarek_ast.Upto]
+  | Sarek_ast.Downto -> [%expr Sarek_ast.Downto]
 
 (** Quote a Sarek_ast.pattern *)
 let rec quote_sarek_pattern ~loc (p : Sarek_ast.pattern) : expression =
   let desc =
     match p.pat with
-    | Sarek_ast.PAny -> [%expr Sarek_ppx_lib.Sarek_ast.PAny]
+    | Sarek_ast.PAny -> [%expr Sarek_ast.PAny]
     | Sarek_ast.PVar s ->
-        [%expr Sarek_ppx_lib.Sarek_ast.PVar [%e quote_string ~loc s]]
+        [%expr Sarek_ast.PVar [%e quote_string ~loc s]]
     | Sarek_ast.PConstr (name, arg) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.PConstr
+          Sarek_ast.PConstr
             ( [%e quote_string ~loc name],
               [%e quote_option ~loc quote_sarek_pattern arg] )]
     | Sarek_ast.PTuple ps ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.PTuple
+          Sarek_ast.PTuple
             [%e quote_list ~loc quote_sarek_pattern ps]]
   in
   [%expr
     {
-      Sarek_ppx_lib.Sarek_ast.pat = [%e desc];
+      Sarek_ast.pat = [%e desc];
       pat_loc = [%e quote_sarek_loc ~loc p.pat_loc];
     }]
 
@@ -791,7 +791,7 @@ let rec quote_sarek_pattern ~loc (p : Sarek_ast.pattern) : expression =
 let quote_sarek_param ~loc (p : Sarek_ast.param) : expression =
   [%expr
     {
-      Sarek_ppx_lib.Sarek_ast.param_name = [%e quote_string ~loc p.param_name];
+      Sarek_ast.param_name = [%e quote_string ~loc p.param_name];
       param_type = [%e quote_sarek_type_expr ~loc p.param_type];
       param_loc = [%e quote_sarek_loc ~loc p.param_loc];
     }]
@@ -800,88 +800,88 @@ let quote_sarek_param ~loc (p : Sarek_ast.param) : expression =
 let rec quote_sarek_expr ~loc (e : Sarek_ast.expr) : expression =
   let desc =
     match e.e with
-    | Sarek_ast.EUnit -> [%expr Sarek_ppx_lib.Sarek_ast.EUnit]
+    | Sarek_ast.EUnit -> [%expr Sarek_ast.EUnit]
     | Sarek_ast.EBool b ->
-        [%expr Sarek_ppx_lib.Sarek_ast.EBool [%e quote_bool ~loc b]]
+        [%expr Sarek_ast.EBool [%e quote_bool ~loc b]]
     | Sarek_ast.EInt i ->
-        [%expr Sarek_ppx_lib.Sarek_ast.EInt [%e quote_int ~loc i]]
+        [%expr Sarek_ast.EInt [%e quote_int ~loc i]]
     | Sarek_ast.EInt32 i ->
         let i_int = Int32.to_int i in
-        [%expr Sarek_ppx_lib.Sarek_ast.EInt32 [%e quote_int32 ~loc i]]
+        [%expr Sarek_ast.EInt32 [%e quote_int32 ~loc i]]
         |> fun _ ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EInt32
+          Sarek_ast.EInt32
             (Int32.of_int [%e quote_int ~loc i_int])]
     | Sarek_ast.EInt64 i ->
         let i_int = Int64.to_int i in
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EInt64
+          Sarek_ast.EInt64
             (Int64.of_int [%e quote_int ~loc i_int])]
     | Sarek_ast.EFloat f ->
-        [%expr Sarek_ppx_lib.Sarek_ast.EFloat [%e quote_float ~loc f]]
+        [%expr Sarek_ast.EFloat [%e quote_float ~loc f]]
     | Sarek_ast.EDouble f ->
-        [%expr Sarek_ppx_lib.Sarek_ast.EDouble [%e quote_float ~loc f]]
+        [%expr Sarek_ast.EDouble [%e quote_float ~loc f]]
     | Sarek_ast.EVar s ->
-        [%expr Sarek_ppx_lib.Sarek_ast.EVar [%e quote_string ~loc s]]
+        [%expr Sarek_ast.EVar [%e quote_string ~loc s]]
     | Sarek_ast.EVecGet (v, i) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EVecGet
+          Sarek_ast.EVecGet
             ([%e quote_sarek_expr ~loc v], [%e quote_sarek_expr ~loc i])]
     | Sarek_ast.EVecSet (v, i, x) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EVecSet
+          Sarek_ast.EVecSet
             ( [%e quote_sarek_expr ~loc v],
               [%e quote_sarek_expr ~loc i],
               [%e quote_sarek_expr ~loc x] )]
     | Sarek_ast.EArrGet (a, i) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EArrGet
+          Sarek_ast.EArrGet
             ([%e quote_sarek_expr ~loc a], [%e quote_sarek_expr ~loc i])]
     | Sarek_ast.EArrSet (a, i, x) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EArrSet
+          Sarek_ast.EArrSet
             ( [%e quote_sarek_expr ~loc a],
               [%e quote_sarek_expr ~loc i],
               [%e quote_sarek_expr ~loc x] )]
     | Sarek_ast.EFieldGet (e, f) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EFieldGet
+          Sarek_ast.EFieldGet
             ([%e quote_sarek_expr ~loc e], [%e quote_string ~loc f])]
     | Sarek_ast.EFieldSet (e, f, v) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EFieldSet
+          Sarek_ast.EFieldSet
             ( [%e quote_sarek_expr ~loc e],
               [%e quote_string ~loc f],
               [%e quote_sarek_expr ~loc v] )]
     | Sarek_ast.EBinop (op, a, b) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EBinop
+          Sarek_ast.EBinop
             ( [%e quote_sarek_binop ~loc op],
               [%e quote_sarek_expr ~loc a],
               [%e quote_sarek_expr ~loc b] )]
     | Sarek_ast.EUnop (op, e) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EUnop
+          Sarek_ast.EUnop
             ([%e quote_sarek_unop ~loc op], [%e quote_sarek_expr ~loc e])]
     | Sarek_ast.EApp (f, args) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EApp
+          Sarek_ast.EApp
             ( [%e quote_sarek_expr ~loc f],
               [%e quote_list ~loc quote_sarek_expr args] )]
     | Sarek_ast.EAssign (name, e) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EAssign
+          Sarek_ast.EAssign
             ([%e quote_string ~loc name], [%e quote_sarek_expr ~loc e])]
     | Sarek_ast.ELet (name, ty, value, body) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ELet
+          Sarek_ast.ELet
             ( [%e quote_string ~loc name],
               [%e quote_option ~loc quote_sarek_type_expr ty],
               [%e quote_sarek_expr ~loc value],
               [%e quote_sarek_expr ~loc body] )]
     | Sarek_ast.ELetRec (name, params, ret_ty, fn_body, cont) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ELetRec
+          Sarek_ast.ELetRec
             ( [%e quote_string ~loc name],
               [%e quote_list ~loc quote_sarek_param params],
               [%e quote_option ~loc quote_sarek_type_expr ret_ty],
@@ -889,20 +889,20 @@ let rec quote_sarek_expr ~loc (e : Sarek_ast.expr) : expression =
               [%e quote_sarek_expr ~loc cont] )]
     | Sarek_ast.ELetMut (name, ty, value, body) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ELetMut
+          Sarek_ast.ELetMut
             ( [%e quote_string ~loc name],
               [%e quote_option ~loc quote_sarek_type_expr ty],
               [%e quote_sarek_expr ~loc value],
               [%e quote_sarek_expr ~loc body] )]
     | Sarek_ast.EIf (cond, then_e, else_e) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EIf
+          Sarek_ast.EIf
             ( [%e quote_sarek_expr ~loc cond],
               [%e quote_sarek_expr ~loc then_e],
               [%e quote_option ~loc quote_sarek_expr else_e] )]
     | Sarek_ast.EFor (var, lo, hi, dir, body) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EFor
+          Sarek_ast.EFor
             ( [%e quote_string ~loc var],
               [%e quote_sarek_expr ~loc lo],
               [%e quote_sarek_expr ~loc hi],
@@ -910,18 +910,18 @@ let rec quote_sarek_expr ~loc (e : Sarek_ast.expr) : expression =
               [%e quote_sarek_expr ~loc body] )]
     | Sarek_ast.EWhile (cond, body) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EWhile
+          Sarek_ast.EWhile
             ([%e quote_sarek_expr ~loc cond], [%e quote_sarek_expr ~loc body])]
     | Sarek_ast.ESeq (a, b) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ESeq
+          Sarek_ast.ESeq
             ([%e quote_sarek_expr ~loc a], [%e quote_sarek_expr ~loc b])]
     | Sarek_ast.EMatch (scrutinee, cases) ->
         let quote_case ~loc (p, e) =
           [%expr [%e quote_sarek_pattern ~loc p], [%e quote_sarek_expr ~loc e]]
         in
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EMatch
+          Sarek_ast.EMatch
             ( [%e quote_sarek_expr ~loc scrutinee],
               [%e quote_list ~loc quote_case cases] )]
     | Sarek_ast.ERecord (ty_name, fields) ->
@@ -929,55 +929,55 @@ let rec quote_sarek_expr ~loc (e : Sarek_ast.expr) : expression =
           [%expr [%e quote_string ~loc name], [%e quote_sarek_expr ~loc e]]
         in
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ERecord
+          Sarek_ast.ERecord
             ( [%e quote_option ~loc quote_string ty_name],
               [%e quote_list ~loc quote_field fields] )]
     | Sarek_ast.EConstr (name, arg) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EConstr
+          Sarek_ast.EConstr
             ( [%e quote_string ~loc name],
               [%e quote_option ~loc quote_sarek_expr arg] )]
     | Sarek_ast.ETuple es ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ETuple
+          Sarek_ast.ETuple
             [%e quote_list ~loc quote_sarek_expr es]]
     | Sarek_ast.EReturn e ->
-        [%expr Sarek_ppx_lib.Sarek_ast.EReturn [%e quote_sarek_expr ~loc e]]
+        [%expr Sarek_ast.EReturn [%e quote_sarek_expr ~loc e]]
     | Sarek_ast.ECreateArray (size, ty, memspace) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ECreateArray
+          Sarek_ast.ECreateArray
             ( [%e quote_sarek_expr ~loc size],
               [%e quote_sarek_type_expr ~loc ty],
               [%e quote_sarek_memspace ~loc memspace] )]
     | Sarek_ast.EGlobalRef name ->
-        [%expr Sarek_ppx_lib.Sarek_ast.EGlobalRef [%e quote_string ~loc name]]
+        [%expr Sarek_ast.EGlobalRef [%e quote_string ~loc name]]
     | Sarek_ast.ENative _ ->
         (* ENative contains Ppxlib expressions which can't be quoted at runtime *)
         failwith "Cannot quote ENative expressions"
     | Sarek_ast.EPragma (hints, body) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EPragma
+          Sarek_ast.EPragma
             ( [%e quote_list ~loc quote_string hints],
               [%e quote_sarek_expr ~loc body] )]
     | Sarek_ast.ETyped (e, ty) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ETyped
+          Sarek_ast.ETyped
             ([%e quote_sarek_expr ~loc e], [%e quote_sarek_type_expr ~loc ty])]
     | Sarek_ast.EOpen (path, body) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.EOpen
+          Sarek_ast.EOpen
             ( [%e quote_list ~loc quote_string path],
               [%e quote_sarek_expr ~loc body] )]
     | Sarek_ast.ELetShared (name, ty, size, body) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ELetShared
+          Sarek_ast.ELetShared
             ( [%e quote_string ~loc name],
               [%e quote_sarek_type_expr ~loc ty],
               [%e quote_option ~loc quote_sarek_expr size],
               [%e quote_sarek_expr ~loc body] )]
     | Sarek_ast.ESuperstep (name, divergent, step_body, cont) ->
         [%expr
-          Sarek_ppx_lib.Sarek_ast.ESuperstep
+          Sarek_ast.ESuperstep
             ( [%e quote_string ~loc name],
               [%e quote_bool ~loc divergent],
               [%e quote_sarek_expr ~loc step_body],
@@ -985,7 +985,7 @@ let rec quote_sarek_expr ~loc (e : Sarek_ast.expr) : expression =
   in
   [%expr
     {
-      Sarek_ppx_lib.Sarek_ast.e = [%e desc];
+      Sarek_ast.e = [%e desc];
       expr_loc = [%e quote_sarek_loc ~loc e.expr_loc];
     }]
 
@@ -994,13 +994,13 @@ let quote_sarek_module_item ~loc (item : Sarek_ast.module_item) : expression =
   match item with
   | Sarek_ast.MConst (name, ty, value) ->
       [%expr
-        Sarek_ppx_lib.Sarek_ast.MConst
+        Sarek_ast.MConst
           ( [%e quote_string ~loc name],
             [%e quote_sarek_type_expr ~loc ty],
             [%e quote_sarek_expr ~loc value] )]
   | Sarek_ast.MFun (name, is_rec, params, body) ->
       [%expr
-        Sarek_ppx_lib.Sarek_ast.MFun
+        Sarek_ast.MFun
           ( [%e quote_string ~loc name],
             [%e quote_bool ~loc is_rec],
             [%e quote_list ~loc quote_sarek_param params],
@@ -1017,7 +1017,7 @@ let quote_sarek_type_decl ~loc (td : Sarek_ast.type_decl) : expression =
           [%e quote_sarek_type_expr ~loc ty]]
       in
       [%expr
-        Sarek_ppx_lib.Sarek_ast.Type_record
+        Sarek_ast.Type_record
           {
             tdecl_name = [%e quote_string ~loc tdecl_name];
             tdecl_module = [%e quote_option ~loc quote_string tdecl_module];
@@ -1032,7 +1032,7 @@ let quote_sarek_type_decl ~loc (td : Sarek_ast.type_decl) : expression =
           [%e quote_option ~loc quote_sarek_type_expr ty_opt]]
       in
       [%expr
-        Sarek_ppx_lib.Sarek_ast.Type_variant
+        Sarek_ast.Type_variant
           {
             tdecl_name = [%e quote_string ~loc tdecl_name];
             tdecl_module = [%e quote_option ~loc quote_string tdecl_module];

--- a/sarek/ppx/Sarek_quote.ml
+++ b/sarek/ppx/Sarek_quote.ml
@@ -331,7 +331,7 @@ and quote_k_ext ~loc (k : Kirc_Ast.k_ext) : expression =
       [%expr Sarek.Kirc_Ast.GFloat64 (fun () -> ![%e var_expr])]
   | Kirc_Ast.Native _ ->
       (* This shouldn't be reached in PPX - we use NativeWithFallback instead *)
-      [%expr Sarek.Kirc_Ast.Native (fun _dev -> "")]
+      [%expr Sarek.Kirc_Ast.Native (fun _framework -> "")]
   | Kirc_Ast.NativeWithFallback {gpu; ocaml} ->
       (* Native code with GPU expression and OCaml fallback function.
          The GPU expression is (fun dev -> "code").

--- a/sarek/ppx/dune
+++ b/sarek/ppx/dune
@@ -1,15 +1,13 @@
 (library
- (name sarek_ppx_lib)
- (public_name sarek.ppx.lib)
- (libraries ppxlib spoc_core) ; spoc removed - V2 codegen only
+ (name sarek_frontend)
+ (public_name sarek.frontend)
+ (wrapped false)
+ (libraries ppxlib sarek_ir)
  (flags
   (:standard -w +8-4))
- ; Enable exhaustiveness warnings, disable fragile pattern
  (preprocess
   (pps ppxlib.metaquot))
  (modules
-  Kirc_Ast
-  Sarek_ast
   Sarek_types
   Sarek_scheme
   Sarek_core_primitives
@@ -17,29 +15,53 @@
   Sarek_env
   Sarek_error
   Sarek_reserved
+  Sarek_parse
+  Sarek_parse_helpers
+  Sarek_ast
   Sarek_typed_ast
   Sarek_typer
   Sarek_convergence
-  Sarek_lower
-  Sarek_ir_ppx
   Sarek_lower_ir
   Sarek_quote_ir
-  Sarek_parse_helpers
-  Sarek_parse
+  Sarek_ir_ppx
+  Sarek_mono
+  Sarek_debug
+  Sarek_tailrec_analysis
+  Sarek_tailrec_elim
+  Sarek_tailrec_bounded
+  Sarek_tailrec_pragma
+  Sarek_tailrec))
+
+(library
+ (name sarek_native_gen)
+ (public_name sarek.native_gen)
+ (wrapped false)
+ (libraries ppxlib spoc_core sarek_ir sarek_frontend)
+ (flags
+  (:standard -w +8-4))
+ (preprocess
+  (pps ppxlib.metaquot))
+ (modules
+  Kirc_Ast
+  Sarek_lower
   Sarek_quote
   Sarek_native_helpers
   Sarek_native_intrinsics
   Sarek_native_gen_base
   Sarek_native_gen_expr
   Sarek_native_gen
-  Sarek_native_gen_kernel
-  Sarek_tailrec_analysis
-  Sarek_tailrec_elim
-  Sarek_tailrec_bounded
-  Sarek_tailrec_pragma
-  Sarek_tailrec
-  Sarek_mono
-  Sarek_debug))
+  Sarek_native_gen_kernel))
+
+; Facade: re-export both sub-libraries.
+; NOTE: (modules) is empty; (wrapped true) so Sarek_ppx_lib.Foo aliases are
+; created for all re-exported modules, preserving consumer source compatibility.
+(library
+ (name sarek_ppx_lib)
+ (public_name sarek.ppx.lib)
+ (libraries
+  (re_export sarek_frontend)
+  (re_export sarek_native_gen))
+ (modules))
 
 (library
  (name sarek_ppx)

--- a/sarek/ppx/dune
+++ b/sarek/ppx/dune
@@ -55,6 +55,7 @@
 ; Facade: re-export both sub-libraries.
 ; NOTE: (modules) is empty; (wrapped true) so Sarek_ppx_lib.Foo aliases are
 ; created for all re-exported modules, preserving consumer source compatibility.
+
 (library
  (name sarek_ppx_lib)
  (public_name sarek.ppx.lib)

--- a/sarek/ppx/dune
+++ b/sarek/ppx/dune
@@ -52,9 +52,10 @@
   Sarek_native_gen
   Sarek_native_gen_kernel))
 
-; Facade: re-export both sub-libraries.
-; NOTE: (modules) is empty; (wrapped true) so Sarek_ppx_lib.Foo aliases are
-; created for all re-exported modules, preserving consumer source compatibility.
+; Facade: empty (modules), re-exports both sub-libraries. Both sub-libs are
+; (wrapped false), so their modules are exposed at top level (e.g. Sarek_typer,
+; Sarek_quote) via re_export — consumers reference them unqualified, not as
+; Sarek_ppx_lib.Foo.
 
 (library
  (name sarek_ppx_lib)

--- a/sarek/ppx/test/test_sarek_debug.ml
+++ b/sarek/ppx/test/test_sarek_debug.ml
@@ -6,7 +6,6 @@
 (** Unit tests for Sarek_debug module *)
 
 open Alcotest
-open Sarek_ppx_lib
 
 (** Test that debug functions don't crash *)
 let test_log_disabled () =

--- a/sarek/ppx/test/test_sarek_error.ml
+++ b/sarek/ppx/test/test_sarek_error.ml
@@ -6,9 +6,9 @@
 (** Unit tests for Sarek_error module *)
 
 open Alcotest
-open Sarek_ppx_lib.Sarek_ast
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_error
+open Sarek_ast
+open Sarek_types
+open Sarek_error
 
 (** Helper to create a dummy location *)
 let dummy_loc =

--- a/sarek/ppx/test/test_sarek_reserved.ml
+++ b/sarek/ppx/test/test_sarek_reserved.ml
@@ -6,7 +6,6 @@
 (** Unit tests for Sarek_reserved module *)
 
 open Alcotest
-open Sarek_ppx_lib
 
 (** Test C keywords *)
 let test_c_keyword_if () =

--- a/sarek/ppx_intrinsic/Sarek_ppx_intrinsic.ml
+++ b/sarek/ppx_intrinsic/Sarek_ppx_intrinsic.ml
@@ -12,7 +12,7 @@
  *
  * It generates both:
  * 1. Runtime registration (Sarek_registry) for JIT code generation
- * 2. PPX-time registration (Sarek_ppx_lib.Sarek_ppx_registry) for compile-time type checking
+ * 2. PPX-time registration (Sarek_ppx_registry) for compile-time type checking
  *
  * This is kept separate from the main kernel PPX to break the circular dependency:
  * - sarek_stdlib uses sarek_ppx_intrinsic (to process %sarek_intrinsic)
@@ -78,20 +78,20 @@ let module_path_of_loc loc =
 (** Convert simple type name to Sarek_types representation *)
 let sarek_type_of_simple_name ~loc (name : string) : expression =
   match name with
-  | "unit" -> [%expr Sarek_ppx_lib.Sarek_types.t_unit]
-  | "bool" -> [%expr Sarek_ppx_lib.Sarek_types.t_bool]
-  | "int" -> [%expr Sarek_ppx_lib.Sarek_types.t_int]
-  | "int32" -> [%expr Sarek_ppx_lib.Sarek_types.t_int32]
-  | "int64" -> [%expr Sarek_ppx_lib.Sarek_types.t_int64]
-  | "float32" -> [%expr Sarek_ppx_lib.Sarek_types.t_float32]
-  | "float" | "float64" -> [%expr Sarek_ppx_lib.Sarek_types.t_float64]
-  | "char" -> [%expr Sarek_ppx_lib.Sarek_types.t_char]
+  | "unit" -> [%expr Sarek_types.t_unit]
+  | "bool" -> [%expr Sarek_types.t_bool]
+  | "int" -> [%expr Sarek_types.t_int]
+  | "int32" -> [%expr Sarek_types.t_int32]
+  | "int64" -> [%expr Sarek_types.t_int64]
+  | "float32" -> [%expr Sarek_types.t_float32]
+  | "float" | "float64" -> [%expr Sarek_types.t_float64]
+  | "char" -> [%expr Sarek_types.t_char]
   | _ ->
       (* For unknown types, use TReg (Custom name) *)
       let name_expr = Ast_builder.Default.estring ~loc name in
       [%expr
-        Sarek_ppx_lib.Sarek_types.TReg
-          (Sarek_ppx_lib.Sarek_types.Custom [%e name_expr])]
+        Sarek_types.TReg
+          (Sarek_types.Custom [%e name_expr])]
 
 (** Flatten a parsed arrow type into (arg_types, return_type). E.g., PTArrow(a,
     PTArrow(b, c)) becomes ([a; b], c) *)
@@ -110,12 +110,12 @@ let rec sarek_type_of_simple_parsed ~loc (pt : parsed_type) : expression =
       let elem_expr = sarek_type_of_simple_parsed ~loc elem_type in
       (* Use Local memory space for intrinsic array args (shared memory) *)
       [%expr
-        Sarek_ppx_lib.Sarek_types.TArr
-          ([%e elem_expr], Sarek_ppx_lib.Sarek_types.Local)]
+        Sarek_types.TArr
+          ([%e elem_expr], Sarek_types.Local)]
   | PTVec elem_type ->
       let elem_expr = sarek_type_of_simple_parsed ~loc elem_type in
       (* Vector is global memory *)
-      [%expr Sarek_ppx_lib.Sarek_types.TVec [%e elem_expr]]
+      [%expr Sarek_types.TVec [%e elem_expr]]
   | PTArrow _ ->
       (* Should not happen after flattening, but handle gracefully *)
       sarek_type_of_simple_name ~loc "unknown"
@@ -132,7 +132,7 @@ let sarek_type_of_parsed ~loc (pt : parsed_type) : expression =
           (List.map (sarek_type_of_simple_parsed ~loc) args)
       in
       let ret_expr = sarek_type_of_simple_parsed ~loc ret in
-      [%expr Sarek_ppx_lib.Sarek_types.TFun ([%e arg_exprs], [%e ret_expr])]
+      [%expr Sarek_types.TFun ([%e arg_exprs], [%e ret_expr])]
   | _ -> sarek_type_of_simple_parsed ~loc pt
 
 (** Convert type name string to Sarek_types representation (for backward compat)
@@ -146,15 +146,15 @@ let sarek_type_of_name ~loc (name : string) : expression =
     let elem_name = String.sub name 0 (String.length name - 6) in
     let elem_expr = sarek_type_of_simple_name ~loc elem_name in
     [%expr
-      Sarek_ppx_lib.Sarek_types.TArr
-        ([%e elem_expr], Sarek_ppx_lib.Sarek_types.Local)]
+      Sarek_types.TArr
+        ([%e elem_expr], Sarek_types.Local)]
   else if
     String.length name > 7
     && String.sub name (String.length name - 7) 7 = " vector"
   then
     let elem_name = String.sub name 0 (String.length name - 7) in
     let elem_expr = sarek_type_of_simple_name ~loc elem_name in
-    [%expr Sarek_ppx_lib.Sarek_types.TVec [%e elem_expr]]
+    [%expr Sarek_types.TVec [%e elem_expr]]
   else sarek_type_of_simple_name ~loc name
 
 (** Build a function type from argument types and return type *)
@@ -167,7 +167,7 @@ let build_sarek_fun_type ~loc (arg_types : string list) (ret_type : string) :
         Ast_builder.Default.elist ~loc (List.map (sarek_type_of_name ~loc) args)
       in
       let ret_expr = sarek_type_of_name ~loc ret_type in
-      [%expr Sarek_ppx_lib.Sarek_types.TFun ([%e arg_exprs], [%e ret_expr])]
+      [%expr Sarek_types.TFun ([%e arg_exprs], [%e ret_expr])]
 
 (** Extension for type%sarek_intrinsic - handles type registration *)
 let expand_sarek_intrinsic_type ~ctxt payload =
@@ -233,8 +233,8 @@ let expand_sarek_intrinsic_type ~ctxt payload =
         (* PPX-time registration for compile-time type checking *)
         [%stri
           let () =
-            Sarek_ppx_lib.Sarek_ppx_registry.register_type
-              (Sarek_ppx_lib.Sarek_ppx_registry.make_type_info
+            Sarek_ppx_registry.register_type
+              (Sarek_ppx_registry.make_type_info
                  ~name:[%e type_name_str]
                  ~size:(Ctypes.sizeof [%e ctype_expr])
                  ~sarek_type:[%e sarek_type])];
@@ -369,8 +369,8 @@ let expand_sarek_intrinsic_fun ~ctxt payload =
            The ref is dereferenced at lookup time, allowing %sarek_extend to work. *)
         [%stri
           let () =
-            Sarek_ppx_lib.Sarek_ppx_registry.register_intrinsic
-              (Sarek_ppx_lib.Sarek_ppx_registry.make_intrinsic_info
+            Sarek_ppx_registry.register_intrinsic
+              (Sarek_ppx_registry.make_intrinsic_info
                  ~name:[%e fun_name_str]
                  ~module_path:[%e module_path_expr]
                  ~typ:[%e sarek_fun_type])];

--- a/sarek/ppx_intrinsic/Sarek_ppx_intrinsic.ml
+++ b/sarek/ppx_intrinsic/Sarek_ppx_intrinsic.ml
@@ -236,7 +236,6 @@ let expand_sarek_intrinsic_type ~ctxt payload =
             Sarek_ppx_lib.Sarek_ppx_registry.register_type
               (Sarek_ppx_lib.Sarek_ppx_registry.make_type_info
                  ~name:[%e type_name_str]
-                 ~device:[%e device_expr]
                  ~size:(Ctypes.sizeof [%e ctype_expr])
                  ~sarek_type:[%e sarek_type])];
       ]
@@ -374,8 +373,7 @@ let expand_sarek_intrinsic_fun ~ctxt payload =
               (Sarek_ppx_lib.Sarek_ppx_registry.make_intrinsic_info
                  ~name:[%e fun_name_str]
                  ~module_path:[%e module_path_expr]
-                 ~typ:[%e sarek_fun_type]
-                 ~device:(fun dev -> ![%e device_fun_ref_expr] dev))];
+                 ~typ:[%e sarek_fun_type])];
         (* Expose the OCaml implementation for host-side use *)
         [%stri let [%p fun_name_pat] = [%e ocaml_expr]];
       ]

--- a/sarek/tests/common/Ir_compare.ml
+++ b/sarek/tests/common/Ir_compare.ml
@@ -10,7 +10,7 @@
  * to verify that old and new implementations produce identical IR.
  ******************************************************************************)
 
-open Sarek_ppx_lib.Kirc_Ast
+open Kirc_Ast
 
 (** Difference found between two IR trees *)
 type ir_diff =

--- a/sarek/tests/unit/test_convergence.ml
+++ b/sarek/tests/unit/test_convergence.ml
@@ -12,7 +12,6 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib
 open Sarek_typed_ast
 
 let dummy_loc =

--- a/sarek/tests/unit/test_core_primitives.ml
+++ b/sarek/tests/unit/test_core_primitives.ml
@@ -6,7 +6,7 @@
 (** Unit tests for Sarek_core_primitives *)
 
 open Alcotest
-open Sarek_ppx_lib.Sarek_core_primitives
+open Sarek_core_primitives
 
 (* === Lookup tests === *)
 

--- a/sarek/tests/unit/test_env.ml
+++ b/sarek/tests/unit/test_env.ml
@@ -12,8 +12,8 @@
 (* Force stdlib initialization to register intrinsics *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_env
+open Sarek_types
+open Sarek_env
 
 (* Test adding and finding variables *)
 let test_add_find_var () =

--- a/sarek/tests/unit/test_error.ml
+++ b/sarek/tests/unit/test_error.ml
@@ -8,7 +8,6 @@
  * Tests error types, location extraction, formatting, and monadic operations
  ******************************************************************************)
 
-open Sarek_ppx_lib
 
 let dummy_loc =
   Sarek_ast.

--- a/sarek/tests/unit/test_lower.ml
+++ b/sarek/tests/unit/test_lower.ml
@@ -9,11 +9,11 @@
  * Tests lowering from typed AST to Kirc_Ast.
  ******************************************************************************)
 
-open Sarek_ppx_lib.Sarek_ast
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_typed_ast
-open Sarek_ppx_lib.Sarek_lower
-open Sarek_ppx_lib.Kirc_Ast
+open Sarek_ast
+open Sarek_types
+open Sarek_typed_ast
+open Sarek_lower
+open Kirc_Ast
 
 let dummy_loc =
   {
@@ -279,7 +279,7 @@ let test_lower_intrinsic_const () =
   let te =
     mk_texpr
       (TEIntrinsicConst
-         (Sarek_ppx_lib.Sarek_env.IntrinsicRef (["Gpu"], "thread_idx_x")))
+         (Sarek_env.IntrinsicRef (["Gpu"], "thread_idx_x")))
       t_int32
   in
   let state = create_state (empty_fun_map ()) in

--- a/sarek/tests/unit/test_lower_ir.ml
+++ b/sarek/tests/unit/test_lower_ir.ml
@@ -14,7 +14,6 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib
 module Ir = Sarek_ir_ppx
 
 (* Test: mangle_type_name converts dots to underscores *)

--- a/sarek/tests/unit/test_mono.ml
+++ b/sarek/tests/unit/test_mono.ml
@@ -13,8 +13,8 @@
  ******************************************************************************)
 
 open Alcotest
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_mono
+open Sarek_types
+open Sarek_mono
 
 (** Test has_type_vars on primitives *)
 let test_has_type_vars_prim () =

--- a/sarek/tests/unit/test_native_helpers.ml
+++ b/sarek/tests/unit/test_native_helpers.ml
@@ -13,10 +13,10 @@
 let () = Sarek_stdlib.force_init ()
 
 open Ppxlib
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_native_helpers
+open Sarek_types
+open Sarek_native_helpers
 
-let dummy_sarek_loc : Sarek_ppx_lib.Sarek_ast.loc =
+let dummy_sarek_loc : Sarek_ast.loc =
   {
     loc_file = "test.ml";
     loc_line = 42;

--- a/sarek/tests/unit/test_native_intrinsics.ml
+++ b/sarek/tests/unit/test_native_intrinsics.ml
@@ -13,9 +13,9 @@
 let () = Sarek_stdlib.force_init ()
 
 open Ppxlib
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_env
-open Sarek_ppx_lib.Sarek_native_intrinsics
+open Sarek_types
+open Sarek_env
+open Sarek_native_intrinsics
 
 let dummy_loc = Location.none
 

--- a/sarek/tests/unit/test_parse.ml
+++ b/sarek/tests/unit/test_parse.ml
@@ -10,8 +10,8 @@
  * Note: These tests use ppxlib's Ast_builder to create test expressions.
  ******************************************************************************)
 
-open Sarek_ppx_lib.Sarek_ast
-open Sarek_ppx_lib.Sarek_parse
+open Sarek_ast
+open Sarek_parse
 
 (* We'll test the parsing functions indirectly by checking the output AST *)
 

--- a/sarek/tests/unit/test_ppx_registry.ml
+++ b/sarek/tests/unit/test_ppx_registry.ml
@@ -25,16 +25,12 @@ let dummy_loc =
       loc_end_col = 10;
     }
 
-(* Helper: create a test device string generator *)
-let test_device_gen _dev = "test_device_code"
-
 (* Test: register and find type *)
 let test_register_find_type () =
   let type_info =
     Sarek_ppx_registry.
       {
         ti_name = "test_type";
-        ti_device = test_device_gen;
         ti_size = 4;
         ti_sarek_type = TPrim TInt32;
       }
@@ -59,7 +55,6 @@ let test_register_find_intrinsic () =
         ii_name = "test_sin";
         ii_qualified_name = "Test.sin";
         ii_type = TFun ([TReg Float32], TReg Float32);
-        ii_device = test_device_gen;
         ii_module = ["Test"];
       }
   in
@@ -78,7 +73,6 @@ let test_find_intrinsic_qualified () =
         ii_name = "test_cos";
         ii_qualified_name = "Math.Trig.cos";
         ii_type = TFun ([TReg Float32], TReg Float32);
-        ii_device = test_device_gen;
         ii_module = ["Math"; "Trig"];
       }
   in
@@ -104,7 +98,6 @@ let test_is_intrinsic () =
         ii_name = "test_sqrt";
         ii_qualified_name = "Test.sqrt";
         ii_type = TFun ([TReg Float32], TReg Float32);
-        ii_device = test_device_gen;
         ii_module = ["Test"];
       }
   in
@@ -126,7 +119,6 @@ let test_register_find_const () =
         ci_name = "test_const";
         ci_qualified_name = "Test.const";
         ci_type = TPrim TInt32;
-        ci_device = test_device_gen;
         ci_module = ["Test"];
       }
   in
@@ -147,7 +139,6 @@ let test_is_const () =
         ci_name = "test_pi";
         ci_qualified_name = "Test.pi";
         ci_type = TReg Float32;
-        ci_device = test_device_gen;
         ci_module = ["Test"];
       }
   in
@@ -271,7 +262,6 @@ let test_all_types () =
     Sarek_ppx_registry.
       {
         ti_name = "test_all_types";
-        ti_device = test_device_gen;
         ti_size = 8;
         ti_sarek_type = TReg Int64;
       }
@@ -291,7 +281,6 @@ let test_all_intrinsics_dedup () =
         ii_name = "test_dedup";
         ii_qualified_name = "Test.dedup";
         ii_type = TFun ([TPrim TInt32], TPrim TInt32);
-        ii_device = test_device_gen;
         ii_module = ["Test"];
       }
   in

--- a/sarek/tests/unit/test_ppx_registry.ml
+++ b/sarek/tests/unit/test_ppx_registry.ml
@@ -12,7 +12,6 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib
 open Sarek_types
 
 let dummy_loc =

--- a/sarek/tests/unit/test_quote.ml
+++ b/sarek/tests/unit/test_quote.ml
@@ -15,7 +15,6 @@
 let () = Sarek_stdlib.force_init ()
 
 open Ppxlib
-open Sarek_ppx_lib
 
 let dummy_loc : Location.t = Location.none
 

--- a/sarek/tests/unit/test_quote_ir.ml
+++ b/sarek/tests/unit/test_quote_ir.ml
@@ -14,7 +14,6 @@
 let () = Sarek_stdlib.force_init ()
 
 open Ppxlib
-open Sarek_ppx_lib
 module Ir = Sarek_ir_ppx
 
 let dummy_loc : Location.t = Location.none

--- a/sarek/tests/unit/test_reserved.ml
+++ b/sarek/tests/unit/test_reserved.ml
@@ -14,7 +14,6 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib
 
 let dummy_loc =
   Sarek_ast.

--- a/sarek/tests/unit/test_scheme.ml
+++ b/sarek/tests/unit/test_scheme.ml
@@ -13,8 +13,8 @@
  ******************************************************************************)
 
 open Alcotest
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_scheme
+open Sarek_types
+open Sarek_scheme
 
 (** Helper to create a fresh type variable at a given level *)
 let fresh_at level =

--- a/sarek/tests/unit/test_tailrec.ml
+++ b/sarek/tests/unit/test_tailrec.ml
@@ -14,10 +14,10 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib.Sarek_ast
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_typed_ast
-open Sarek_ppx_lib.Sarek_tailrec
+open Sarek_ast
+open Sarek_types
+open Sarek_typed_ast
+open Sarek_tailrec
 
 let dummy_loc =
   {

--- a/sarek/tests/unit/test_tailrec_analysis.ml
+++ b/sarek/tests/unit/test_tailrec_analysis.ml
@@ -14,13 +14,13 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib.Sarek_ast
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_typed_ast
-open Sarek_ppx_lib.Sarek_tailrec_analysis
+open Sarek_ast
+open Sarek_types
+open Sarek_typed_ast
+open Sarek_tailrec_analysis
 
 (* Import for_dir type without shadowing other types *)
-type for_dir = Sarek_ppx_lib.Sarek_ir_ppx.for_dir = Upto | Downto
+type for_dir = Sarek_ir_ppx.for_dir = Upto | Downto
 
 let dummy_loc =
   {

--- a/sarek/tests/unit/test_tailrec_bounded.ml
+++ b/sarek/tests/unit/test_tailrec_bounded.ml
@@ -12,7 +12,6 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib
 
 let dummy_loc =
   Sarek_ast.

--- a/sarek/tests/unit/test_tailrec_elim.ml
+++ b/sarek/tests/unit/test_tailrec_elim.ml
@@ -12,10 +12,10 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib.Sarek_ast
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_typed_ast
-open Sarek_ppx_lib.Sarek_tailrec_elim
+open Sarek_ast
+open Sarek_types
+open Sarek_typed_ast
+open Sarek_tailrec_elim
 
 let dummy_loc =
   {

--- a/sarek/tests/unit/test_tailrec_pragma.ml
+++ b/sarek/tests/unit/test_tailrec_pragma.ml
@@ -12,7 +12,6 @@
 (* Force stdlib initialization *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib
 open Sarek_typed_ast
 
 let dummy_loc =

--- a/sarek/tests/unit/test_typer.ml
+++ b/sarek/tests/unit/test_typer.ml
@@ -12,11 +12,11 @@
 (* Force stdlib initialization to register intrinsics *)
 let () = Sarek_stdlib.force_init ()
 
-open Sarek_ppx_lib.Sarek_ast
-open Sarek_ppx_lib.Sarek_types
-open Sarek_ppx_lib.Sarek_env
-open Sarek_ppx_lib.Sarek_typer
-open Sarek_ppx_lib.Sarek_typed_ast
+open Sarek_ast
+open Sarek_types
+open Sarek_env
+open Sarek_typer
+open Sarek_typed_ast
 
 let dummy_loc =
   {
@@ -86,7 +86,7 @@ let check_infer_ok msg env expr expected_typ =
         msg
         (String.concat
            ", "
-           (List.map Sarek_ppx_lib.Sarek_error.error_to_string errors))
+           (List.map Sarek_error.error_to_string errors))
 
 let check_infer_error msg env expr =
   reset_tvar_counter () ;
@@ -165,7 +165,7 @@ let test_kernel_module_const () =
         "kernel with module const failed: %s"
         (String.concat
            ", "
-           (List.map Sarek_ppx_lib.Sarek_error.error_to_string errs))
+           (List.map Sarek_error.error_to_string errs))
 
 let test_kernel_module_fun () =
   reset_tvar_counter () ;
@@ -224,7 +224,7 @@ let test_kernel_module_fun () =
         "kernel with module fun failed: %s"
         (String.concat
            ", "
-           (List.map Sarek_ppx_lib.Sarek_error.error_to_string errs))
+           (List.map Sarek_error.error_to_string errs))
 
 let test_kernel_module_fun_with_variant () =
   reset_tvar_counter () ;
@@ -325,7 +325,7 @@ let test_kernel_module_fun_with_variant () =
         "kernel with variant helper failed: %s"
         (String.concat
            ", "
-           (List.map Sarek_ppx_lib.Sarek_error.error_to_string errs))
+           (List.map Sarek_error.error_to_string errs))
 
 let test_kernel_module_fun_with_record () =
   reset_tvar_counter () ;
@@ -408,7 +408,7 @@ let test_kernel_module_fun_with_record () =
         "kernel with record helper failed: %s"
         (String.concat
            ", "
-           (List.map Sarek_ppx_lib.Sarek_error.error_to_string errs))
+           (List.map Sarek_error.error_to_string errs))
 
 let test_kernel_type_decl_record () =
   reset_tvar_counter () ;
@@ -463,7 +463,7 @@ let test_kernel_type_decl_record () =
         "kernel with type decl failed: %s"
         (String.concat
            ", "
-           (List.map Sarek_ppx_lib.Sarek_error.error_to_string errs))
+           (List.map Sarek_error.error_to_string errs))
 
 (* Test variable type inference *)
 let test_var_lookup () =
@@ -582,13 +582,13 @@ let test_let_simple () =
 
 let test_let_with_annotation () =
   let env = with_stdlib empty in
-  let ty_annot = Sarek_ppx_lib.Sarek_ast.TEConstr ("int32", []) in
+  let ty_annot = Sarek_ast.TEConstr ("int32", []) in
   let expr = let_expr "x" (Some ty_annot) (int_expr 42) (var_expr "x") in
   check_infer_ok "let x : int32 = 42 in x" env expr t_int32
 
 let test_let_annotation_mismatch () =
   let env = with_stdlib empty in
-  let ty_annot = Sarek_ppx_lib.Sarek_ast.TEConstr ("float32", []) in
+  let ty_annot = Sarek_ast.TEConstr ("float32", []) in
   let expr = let_expr "x" (Some ty_annot) (int_expr 42) (var_expr "x") in
   check_infer_error "let x : float32 = 42 should fail" env expr
 

--- a/sarek/tests/unit/test_types.ml
+++ b/sarek/tests/unit/test_types.ml
@@ -9,7 +9,7 @@
  * Tests type representation and unification.
  ******************************************************************************)
 
-open Sarek_ppx_lib.Sarek_types
+open Sarek_types
 
 (* Test helpers *)
 let check_ok msg = function Ok () -> () | Error _ -> Alcotest.fail msg


### PR DESCRIPTION
## Phase 0B PR-3 of 5 — pure-codegen-rollout

Splits the mixed `sarek_ppx_lib` into a **pure `sarek_frontend`** (no `Spoc_core`/ctypes) and an FFI `sarek_native_gen`, the structural enabler for PR-4 (`sarek_codegen`) and PR-5 (FFI-free bytecode/jsoo transpile). **Pure structural refactor — generated source is byte-identical.**

### Changes
- **`sarek_frontend`** (new lib, `(libraries ppxlib sarek_ir)` — verified Spoc_core-free): 23 pure modules (parse/type/convergence/mono/tailrec/lower-IR + AST/env/registry).
- **`sarek_native_gen`** (new lib, keeps `spoc_core`): 9 modules (Kirc_Ast, Sarek_lower, Sarek_quote, the native-gen cluster).
- **`Kirc_Ast.Native`** retyped `(Spoc_core.Device.t -> string)` → `(string -> string)` (framework). The variant was vestigial — only ever constructed as a device-ignoring no-op (`Sarek_quote.ml`), never invoked.
- **`Sarek_ppx_registry`** dead `{ti,ii,ci}_device` closures dropped → metadata-only, Spoc_core-free.
- **Façade**: `sarek_ppx_lib` kept as an empty `(re_export sarek_frontend) (re_export sarek_native_gen)`. Both sub-libs are `(wrapped false)` (matching the existing `sarek_ir` precedent), so the now-invalid `Sarek_ppx_lib.` qualifiers were removed from 26 consumer files — purely mechanical (reviewer spot-checked; corroborated by byte-identical goldens).

### Scope boundary
No `sarek_codegen` (PR-4), no `Sarek_transpile` (PR-5), no generator/behavior change.

### Tracked follow-up (non-blocking)
`(wrapped false)` puts 32 modules at top level. No collision exists today; a later PR may re-wrap with a prefix or document the shared flat namespace as an invariant.

### Gates
- `git diff main -- sarek/tests/codegen_golden/` — **empty** (byte-identical)
- `@sarek/tests/runtest` — pass (51 math + 42 quote + 35 parse + 20 goldens)
- full `dune build` — pass except pre-existing `-lnvrtc` link error
- `@sarek-vulkan/all` — pass
- `sarek_frontend` `(libraries ppxlib sarek_ir)` — no spoc_core
- e2e `test_float32_sin_pure --vulkan` PASSED (RX 7900 XTX); `test_math_intrinsics --interpreter` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)