### PR TITLE
Integrate the transpiler playground into the site theme + navigation

### DIFF
--- a/gh-pages/_layouts/index.html
+++ b/gh-pages/_layouts/index.html
@@ -63,7 +63,7 @@
 
           <div class="btn-group">
             <a href="{{ site.baseurl }}/docs/getting_started.html" class="btn btn-primary">Get Started</a>
-            <a href="{{ site.baseurl }}/docs/binder.html" class="btn btn-outline">Try Online</a>
+            <a href="{{ site.baseurl }}/playground.html" class="btn btn-outline">Try Online</a>
             <a href="{{ site.baseurl }}/spoc_docs/index.html" class="btn btn-outline">API Docs</a>
           </div>
         </div>

--- a/gh-pages/_layouts/index.html
+++ b/gh-pages/_layouts/index.html
@@ -26,6 +26,7 @@
           <a href="{{ site.baseurl }}/docs/getting_started.html">Getting Started</a>
           <a href="{{ site.baseurl }}/benchmarks/">Benchmarks</a>
           <a href="{{ site.baseurl }}/examples/">Examples</a>
+          <a href="{{ site.baseurl }}/playground.html">Playground</a>
           <div class="nav-dropdown">
             <button type="button" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="docs-menu">Docs ▾</button>
             <div class="dropdown-menu" id="docs-menu">

--- a/gh-pages/_layouts/page.html
+++ b/gh-pages/_layouts/page.html
@@ -26,6 +26,7 @@
           <a href="{{ site.baseurl }}/docs/getting_started.html">Getting Started</a>
           <a href="{{ site.baseurl }}/benchmarks/">Benchmarks</a>
           <a href="{{ site.baseurl }}/examples/">Examples</a>
+          <a href="{{ site.baseurl }}/playground.html">Playground</a>
           <div class="nav-dropdown">
             <button type="button" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="docs-menu">Docs ▾</button>
             <div class="dropdown-menu" id="docs-menu">

--- a/gh-pages/playground.html
+++ b/gh-pages/playground.html
@@ -3,6 +3,17 @@ layout: page
 title: Playground
 ---
 <style>
+  :root {
+    --playground-error-color: #c0392b;
+  }
+  .dark-theme {
+    --playground-error-color: #f48771;
+  }
+  @media (prefers-color-scheme: dark) {
+    body:not(.light-theme) {
+      --playground-error-color: #f48771;
+    }
+  }
   .playground-container {
     display: flex;
     flex-direction: column;
@@ -70,7 +81,7 @@ title: Playground
     border: 1px solid var(--border-color);
   }
   pre#output-pane.error-output {
-    color: #e05252;
+    color: var(--playground-error-color);
   }
   .status-bar {
     font-size: 0.8rem;

--- a/gh-pages/playground.html
+++ b/gh-pages/playground.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: page
 title: Playground
 ---
 <style>
@@ -16,7 +16,8 @@ title: Playground
   }
   .playground-container p.subtitle {
     margin-top: 0;
-    color: #666;
+    color: var(--text-color);
+    opacity: 0.7;
   }
   .controls {
     display: flex;
@@ -29,8 +30,10 @@ title: Playground
   .controls select {
     padding: 0.3rem 0.6rem;
     font-size: 1rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
+    background: var(--card-bg);
+    color: var(--text-color);
   }
   .editor-pane {
     display: flex;
@@ -47,14 +50,16 @@ title: Playground
     font-family: monospace;
     font-size: 0.9rem;
     padding: 0.6rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     resize: vertical;
     box-sizing: border-box;
+    background: var(--code-bg);
+    color: var(--text-color);
   }
   pre#output-pane {
-    background: #1e1e1e;
-    color: #d4d4d4;
+    background: var(--code-bg);
+    color: var(--text-color);
     padding: 1rem;
     border-radius: 4px;
     font-size: 0.85rem;
@@ -62,13 +67,15 @@ title: Playground
     word-break: break-all;
     min-height: 80px;
     margin: 0;
+    border: 1px solid var(--border-color);
   }
   pre#output-pane.error-output {
-    color: #f48771;
+    color: #e05252;
   }
   .status-bar {
     font-size: 0.8rem;
-    color: #888;
+    color: var(--text-color);
+    opacity: 0.6;
     height: 1.2em;
   }
 </style>


### PR DESCRIPTION
## Integrate the playground into the rest of the website

The playground shipped (#155) on the bare `layout: default` — no navbar, no modern theme, not in the nav. This makes it a first-class page of the modern Sarek site.

### Changes
- **`gh-pages/playground.html`**: `layout: default` → **`layout: page`** (gains the navbar, `modern.css`, dark-mode, footer). Inline styles re-themed to the site CSS variables (`--text-color`/`--border-color`/`--code-bg`/`--card-bg`/…) so the editor + output panes are readable in **both light and dark mode** — replacing the previous hardcoded permanent-dark output box. JS behaviour (debounced transpile, backend select, output) unchanged; still loads `javascripts/sarek_transpile.js`.
- **Nav link**: "Playground" added to the navbar in **both** `_layouts/page.html` and `_layouts/index.html` (after Examples; identical markup).
- **Hero**: the home "Try Online" CTA now points at the playground (the real try-online experience).

### Reviewer-confirmed
Full dark/light contrast analysis — every themed surface resolves to a legible pair in both modes; bundle path resolves under the new layout (no 404); Liquid/HTML well-formed; zero JS-behavior diff; no jsoo/OCaml/workflow changes.

### Note
Jekyll toolchain isn't installed locally, so this was statically validated; the authoritative build is the `docs.yml` deploy on merge. I'll do a live smoke check (navbar renders, reachable from nav + hero) once it deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Playground" navigation link in the top navigation bar for convenient access across all pages
  * Updated the hero "Try Online" button to direct users to the Playground

* **Style**
  * Refactored Playground styling to use CSS variables, enabling seamless light and dark theme support with consistent color theming throughout the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->