### PR TITLE
docs: consolidated roadmap (transpiler, playground, WebGPU levels)

### DIFF
--- a/docs/plans/roadmap-2026-06-03.md
+++ b/docs/plans/roadmap-2026-06-03.md
@@ -1,0 +1,93 @@
+# Sarek / SPOC Roadmap — in-browser GPU transpiler & runtime
+
+**Date:** 2026-06-03
+**Status:** living document
+**Supersedes (consolidates):** `docs/plans/website-overhaul-2026-06-02.md`,
+`docs/plans/phase2-playground-mvp-2026-06-03.md`
+
+This roadmap consolidates the pure-codegen extraction, the in-browser transpiler, and the
+architectural direction for running Sarek kernels on a user's GPU from the browser via WebGPU.
+
+## North star
+Two goals, in priority order:
+1. **A tutorial/course series on the website where users run Sarek kernels on their own GPU,
+   in-browser** (the immediate priority).
+2. **Develop WebGPU webapps with SPOC** — full OCaml SPOC programs running in the browser (ultimate).
+
+---
+
+## ✅ Done
+
+### Phase 0B — pure, FFI-free transpiler (PRs #146–#154)
+A ctypes/`spoc_core`-free pipeline `OCaml kernel source → Sarek IR → backend source`:
+- Generators decoupled from `Spoc_core.Device.t` → framework string (CUDA/OpenCL/Metal/GLSL).
+- `Sarek_pure_registry` + CUDA `sinf` fix; `sarek_ppx_lib` split into pure `sarek_frontend` + FFI
+  `sarek_native_gen`; `sarek_registry` made ctypes-free; 4 generators extracted into pure
+  `sarek_codegen`; pure `sarek_stdlib_meta` (FFI-free intrinsic registry).
+- `Sarek_transpile.of_source : backend -> string -> (string, error) result`, proven to compile
+  **FFI-free to bytecode** and transpile a `Float32.sin` kernel to all 4 backends.
+
+### Phase 2 MVP — in-browser playground, LIVE (PRs #155, #156)
+- jsoo shim `sarek/transpile/web/transpile_js.ml` → `globalThis.SarekTranspile.transpile`.
+- **Live**: http://mathiasbourgoin.github.io/Sarek/playground.html — client-side, type a kernel,
+  see CUDA/OpenCL/Metal/GLSL. Integrated into the site theme + nav (navbar, dark-mode, hero CTA).
+- **CI jsoo-compat gate**: CI builds the jsoo bundle, so any future FFI/jsoo regression fails CI.
+- Bundle (~21 MB; ~3–5 MB gzipped) built in CI on deploy, never committed.
+
+---
+
+## ▶ Next — Level 2: interactive GPU tutorial (PRIORITY)
+
+Goal: course pages where a learner edits a kernel, tweaks **structured** inputs (data, sizes,
+grid/block, iterations), and **runs it on their own GPU** — results/timings shown live. **No
+`Spoc_core` in the browser**; the "host" is a fixed JS runner.
+
+Execution levels (see `[[webgpu-runtime-decouple-audit]]`):
+- **L1** kernel-only (canned runner) · **L2** kernel + structured host params (runner interprets).
+  Both need only WGSL codegen + a JS WebGPU runner. **L2 is the target.**
+
+Decomposition:
+1. **WGSL backend** — a 5th generator in `sarek_codegen` (`Sarek IR → WGSL` compute: `@group/@binding`,
+   `@compute @workgroup_size`, WGSL types/builtins) + golden tests. Pure, no runtime.
+2. **ABI descriptor** — the transpiler emits, alongside WGSL, a small JSON describing params
+   (buffer vs scalar, binding indices, element types, lengths, workgroup) so the runner can wire
+   bind groups. Extend the jsoo shim with a `transpileWGSL`/`compile` entry returning WGSL + ABI.
+3. **JS WebGPU runner** — `navigator.gpu` → buffers from TypedArrays → compute pipeline → dispatch →
+   `mapAsync` readback. Feature-detect; degrade to transpile-only without WebGPU.
+4. **Tutorial/course pages** — progressive lessons (vector add → map → reduce → stencil …), each an
+   editable kernel + input controls + "Run on your GPU" + results/visualization. New Jekyll section,
+   linked from the nav.
+
+Why WebGPU (not OpenCL/Vulkan): WebCL is dead; Vulkan doesn't run in-browser. WebGPU is the browser
+compute API (Chrome/Edge/Firefox/Safari), with compute shaders, abstracting Vulkan/Metal/D3D12.
+
+---
+
+## ◻ Later — Level 3: WebGPU webapps with SPOC (ultimate)
+
+Run full OCaml SPOC programs (host orchestration + kernels) in the browser. Needs:
+- **Decouple the custom-type ctypes seam** from the Bigarray numeric core of `spoc_core` — audited
+  as **localized and Phase-0B-shaped, not a rewrite** (`[[webgpu-runtime-decouple-audit]]`): the
+  numeric vector path is already `Bigarray` (jsoo-clean); ctypes is confined to `Custom_storage`/
+  `*_ptr_*` transfers + `Typed_value.ctype`.
+- **jsoo `Spoc_webgpu`** implementing `Framework_sig.BACKEND` (Bigarray ↔ `GPUBuffer` + dispatch).
+- (optional) in-browser OCaml toplevel (`js_of_ocaml-toplevel`) for free-form host code.
+Rough size: "one decouple PR + one WebGPU-backend PR" (+ toplevel if free-form host is wanted).
+
+---
+
+## ◻ Tracked follow-ups (non-blocking)
+- **Float64 FFI-free**: `Float64` lives in FFI-bearing `Sarek_float64`; needs a `sarek_float64_meta`
+  analog for FFI-free `Float64.*` transpile.
+- **Reject unknown path-qualified intrinsics** in `of_source` (currently emits a bogus name).
+- **`b.[i]` parse**: standalone-expr limit in OCaml 5.4 — kernels use `b.(i)`.
+- **Bundle size**: 21 MB (gzip helps); a smaller parse path is a later option.
+- **jsoo error strings**: `Syntaxerr.Error(_)` leaks into user-facing messages — polish.
+- **`Gpu.spoc_powint`** native impl loops on negative exponents (pre-existing; fix both stdlib copies).
+- **Single-source registry**: `sarek_stdlib` still re-registers what `sarek_stdlib_meta` does (benign).
+
+---
+
+## Earlier roadmap (docs/site, still open)
+The website-overhaul plan's Phase 1 (docs-from-tested-examples + compatibility matrix) and Phase 3
+(Sarek Book + benchmarks portal) remain — see `docs/plans/website-overhaul-2026-06-02.md`.


### PR DESCRIPTION
Consolidates the project direction into one durable roadmap: Phase 0B (done), the live in-browser playground (done), the Level-2 interactive GPU tutorial (priority — WGSL backend + JS WebGPU runner + course pages), Level-3 WebGPU-SPOC (the bounded `spoc_core` custom-type decouple), and tracked follow-ups. Supersedes/links the website-overhaul and phase2-playground plan docs.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)