### PR TITLE
WGSL backend: Sarek IR → WebGPU compute shader (GPU-validated via Playwright)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ gh-pages/javascripts/sarek_transpile.js
 
 # Roster pipeline per-PR scaffolding — durable plans live in docs/plans/
 briefs/
+
+# Playwright MCP session artifacts
+.playwright-mcp/

--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,13 @@ bench-all:
 bench-gpu-check:
 	@SIZE=$(or $(SIZE),2048) ITERS=$(or $(ITERS),3) ./scripts/gpu-bench-check.sh
 
+# WGSL backend GPU acceptance: transpile kernels to WGSL and run them on a real
+# GPU via WebGPU (Playwright + flagged Chrome -> Dawn/Vulkan). Skips where
+# playwright/chrome/WebGPU are unavailable; fails on a wrong GPU result.
+wgsl-gpu-test:
+	@dune build sarek/transpile/web/transpile_js.bc.js
+	@node sarek/transpile/web/test/webgpu_wgsl_test.mjs _build/default/sarek/transpile/web/transpile_js.bc.js
+
 bench-update:
 	@echo "Running benchmarks and updating web data..."
 	@./benchmarks/run_all_benchmarks.sh results

--- a/gh-pages/playground.html
+++ b/gh-pages/playground.html
@@ -110,6 +110,7 @@ title: Playground
       <option value="opencl">OpenCL</option>
       <option value="metal">Metal</option>
       <option value="glsl">GLSL</option>
+        <option value="wgsl">WGSL</option>
     </select>
     <span class="status-bar" id="status-bar"></span>
   </div>

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -1,0 +1,999 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek_ir_wgsl - WGSL Compute Shader Generation from Sarek IR
+ *
+ * Generates WebGPU Shading Language (WGSL) compute shader source code from
+ * Sarek_ir.kernel. The output targets WebGPU compute pipelines.
+ *
+ * Features:
+ * - Direct generation from clean IR
+ * - Storage buffer bindings for vector parameters (array<T>)
+ * - Uniform struct for scalar parameters (struct Params)
+ * - Strict type-conversion enforcement (no implicit int<->float)
+ * - Float64 / f64 unsupported — returns structured error
+ * - Workgroup size from kernel block hint
+ ******************************************************************************)
+
+open Sarek_ir_types
+
+(** Local error module — tagged as "WebGPU" in error messages. *)
+module Codegen_error = Sarek_backend_error.Backend_error.Make (struct
+  let name = "WebGPU"
+end)
+
+(** Current kernel's variant definitions (set during generate) *)
+let current_variants : (string * (string * elttype list) list) list ref = ref []
+
+(** Current framework name — mirrors the other generators so [set_framework]
+    in Sarek_transpile can set it, and the pure registry resolves Float32 math
+    with framework="WGSL" (falls through to the generic [sin] spelling). *)
+let current_framework : string option ref = ref None
+
+(** {1 Type Mapping} *)
+
+let mangle_name = Sarek_ir_codegen.mangle_name
+
+(** WGSL reserved keywords that cannot be used as identifiers *)
+let wgsl_reserved_keywords =
+  [
+    (* Types *)
+    "bool";
+    "f32";
+    "f16";
+    "i32";
+    "u32";
+    "u64";
+    "i64";
+    "vec2";
+    "vec3";
+    "vec4";
+    "mat2x2";
+    "mat3x3";
+    "mat4x4";
+    "array";
+    "atomic";
+    "ptr";
+    "sampler";
+    "texture_2d";
+    (* Storage qualifiers *)
+    "var";
+    "let";
+    "const";
+    "override";
+    (* Control flow *)
+    "if";
+    "else";
+    "for";
+    "while";
+    "loop";
+    "break";
+    "continue";
+    "return";
+    "switch";
+    "case";
+    "default";
+    "fallthrough";
+    "discard";
+    (* Functions / structure *)
+    "fn";
+    "struct";
+    "type";
+    (* Address spaces *)
+    "storage";
+    "uniform";
+    "workgroup";
+    "private";
+    "function";
+    "read";
+    "write";
+    "read_write";
+    (* Built-in decorators / attributes *)
+    "compute";
+    "vertex";
+    "fragment";
+    "builtin";
+    "location";
+    "group";
+    "binding";
+    "workgroup_size";
+    (* Built-in values *)
+    "true";
+    "false";
+    (* Entry point name — avoid shadowing *)
+    "main";
+    (* Params struct name we emit *)
+    "Params";
+    "params";
+  ]
+
+(** Escape reserved WGSL keywords by adding 'v' suffix. *)
+let escape_wgsl_name name =
+  if List.mem name wgsl_reserved_keywords then name ^ "v" else name
+
+(** Map Sarek IR element type to WGSL type string.
+    Float64 (f64) is not supported in WebGPU — callers must check for TFloat64
+    before reaching this function and raise [Codegen_error.unsupported_construct].
+*)
+let rec wgsl_type_of_elttype = function
+  | TInt32 -> "i32"
+  | TInt64 -> "i64"
+  | TFloat32 -> "f32"
+  | TFloat64 ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "f64"
+           "WGSL: f64 unsupported — WebGPU has no float64 type")
+  | TBool -> "bool"
+  | TUnit -> "/* unit */"
+  | TRecord (name, _) -> mangle_name name
+  | TVariant (name, _) -> mangle_name name
+  | TArray (elt, _) -> wgsl_type_of_elttype elt
+  | TVec elt -> wgsl_type_of_elttype elt
+
+(** Check whether an elttype (recursively) uses Float64. *)
+let rec has_float64 = function
+  | TFloat64 -> true
+  | TArray (t, _) | TVec t -> has_float64 t
+  | TRecord (_, fields) -> List.exists (fun (_, t) -> has_float64 t) fields
+  | TVariant (_, constrs) ->
+      List.exists (fun (_, ts) -> List.exists has_float64 ts) constrs
+  | TInt32 | TInt64 | TFloat32 | TBool | TUnit -> false
+
+(** {1 Thread Intrinsics}
+
+    [global_invocation_id] is [vec3<u32>], so all components need [i32(…)]
+    conversion to stay consistent with how the IR types thread ids as i32. *)
+let wgsl_thread_intrinsic = function
+  | "thread_id_x" | "thread_idx_x" -> "i32(gid.x)"
+  | "thread_id_y" | "thread_idx_y" -> "i32(gid.y)"
+  | "thread_id_z" | "thread_idx_z" -> "i32(gid.z)"
+  | "block_id_x" | "block_idx_x" -> "i32(gid.x)"
+  | "block_id_y" | "block_idx_y" -> "i32(gid.y)"
+  | "block_id_z" | "block_idx_z" -> "i32(gid.z)"
+  | "block_dim_x" -> "256i"
+  | "block_dim_y" -> "1i"
+  | "block_dim_z" -> "1i"
+  | "grid_dim_x" -> "0i"
+  | "grid_dim_y" -> "0i"
+  | "grid_dim_z" -> "0i"
+  | "global_thread_id" | "global_idx" | "global_idx_x" -> "i32(gid.x)"
+  | "global_idx_y" -> "i32(gid.y)"
+  | "global_idx_z" -> "i32(gid.z)"
+  | "global_size" -> "0i"
+  | name -> Codegen_error.raise_error (Codegen_error.unknown_intrinsic name)
+
+(** {1 Expression Generation} *)
+
+(** Names of scalar kernel params — accessed as [params.<name>] in WGSL. *)
+let scalar_param_names : string list ref = ref []
+
+let rec gen_expr buf = function
+  | EConst (CInt32 n) -> Buffer.add_string buf (Int32.to_string n ^ "i")
+  | EConst (CInt64 n) -> Buffer.add_string buf (Int64.to_string n ^ "i")
+  | EConst (CFloat32 f) ->
+      let s = Printf.sprintf "%.17g" f in
+      let s =
+        if String.contains s '.' || String.contains s 'e' then s else s ^ ".0"
+      in
+      Buffer.add_string buf (s ^ "f")
+  | EConst (CFloat64 _) ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "f64 literal"
+           "WGSL: f64 unsupported — WebGPU has no float64 type")
+  | EConst (CBool true) -> Buffer.add_string buf "true"
+  | EConst (CBool false) -> Buffer.add_string buf "false"
+  | EConst CUnit -> Buffer.add_string buf "/* unit */"
+  | EVar v ->
+      let vn = escape_wgsl_name v.var_name in
+      if List.mem v.var_name !scalar_param_names then begin
+        Buffer.add_string buf "params." ;
+        Buffer.add_string buf vn
+      end else Buffer.add_string buf vn
+  | EBinop (op, e1, e2) ->
+      Buffer.add_char buf '(' ;
+      gen_expr buf e1 ;
+      Buffer.add_string buf (gen_binop op) ;
+      gen_expr buf e2 ;
+      Buffer.add_char buf ')'
+  | EUnop (op, e) ->
+      Buffer.add_char buf '(' ;
+      Buffer.add_string buf (gen_unop op) ;
+      gen_expr buf e ;
+      Buffer.add_char buf ')'
+  | EArrayRead (arr, idx) ->
+      Buffer.add_string buf (escape_wgsl_name arr) ;
+      Buffer.add_char buf '[' ;
+      gen_expr buf idx ;
+      Buffer.add_char buf ']'
+  | EArrayReadExpr (base, idx) ->
+      Buffer.add_char buf '(' ;
+      gen_expr buf base ;
+      Buffer.add_char buf ')' ;
+      Buffer.add_char buf '[' ;
+      gen_expr buf idx ;
+      Buffer.add_char buf ']'
+  | ERecordField (e, field) ->
+      gen_expr buf e ;
+      Buffer.add_char buf '.' ;
+      Buffer.add_string buf field
+  | EIntrinsic (path, name, args) -> gen_intrinsic buf path name args
+  | ECast (ty, e) ->
+      Buffer.add_string buf (wgsl_type_of_elttype ty) ;
+      Buffer.add_char buf '(' ;
+      gen_expr buf e ;
+      Buffer.add_char buf ')'
+  | ETuple exprs ->
+      Buffer.add_string buf "{" ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        exprs ;
+      Buffer.add_string buf "}"
+  | EApp (fn, args) ->
+      gen_expr buf fn ;
+      Buffer.add_char buf '(' ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        args ;
+      Buffer.add_char buf ')'
+  | ERecord (name, fields) ->
+      Buffer.add_string buf (mangle_name name ^ "(") ;
+      List.iteri
+        (fun i (_, e) ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        fields ;
+      Buffer.add_char buf ')'
+  | EVariant (type_name, constr, args) ->
+      Buffer.add_string
+        buf
+        ("make_" ^ mangle_name type_name ^ "_" ^ constr ^ "(") ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        args ;
+      Buffer.add_char buf ')'
+  | EArrayLen arr ->
+      Buffer.add_string buf ("params.sarek_" ^ escape_wgsl_name arr ^ "_length")
+  | EArrayCreate _ ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "EArrayCreate"
+           "should be handled in gen_stmt SLet")
+  | EIf (cond, then_, else_) ->
+      Buffer.add_char buf '(' ;
+      gen_expr buf cond ;
+      Buffer.add_string buf " ? " ;
+      gen_expr buf then_ ;
+      Buffer.add_string buf " : " ;
+      gen_expr buf else_ ;
+      Buffer.add_char buf ')'
+  | EMatch (_, []) ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct "match" "empty match expression")
+  | EMatch (_, [(_, body)]) -> gen_expr buf body
+  | EMatch (e, cases) ->
+      let rec gen_cases = function
+        | [] ->
+            Codegen_error.raise_error
+              (Codegen_error.unsupported_construct "match" "empty match cases")
+        | [(_, body)] -> gen_expr buf body
+        | (pat, body) :: rest ->
+            Buffer.add_char buf '(' ;
+            (match pat with
+            | PConstr (name, _) ->
+                Buffer.add_char buf '(' ;
+                gen_expr buf e ;
+                Buffer.add_string buf (".tag == " ^ name ^ ")")
+            | PWild -> Buffer.add_string buf "true") ;
+            Buffer.add_string buf " ? " ;
+            gen_expr buf body ;
+            Buffer.add_string buf " : " ;
+            gen_cases rest ;
+            Buffer.add_char buf ')'
+      in
+      gen_cases cases
+
+and gen_binop = function
+  | Add -> " + "
+  | Sub -> " - "
+  | Mul -> " * "
+  | Div -> " / "
+  | Mod -> " % "
+  | Eq -> " == "
+  | Ne -> " != "
+  | Lt -> " < "
+  | Le -> " <= "
+  | Gt -> " > "
+  | Ge -> " >= "
+  | And -> " && "
+  | Or -> " || "
+  | Shl -> " << "
+  | Shr -> " >> "
+  | BitAnd -> " & "
+  | BitOr -> " | "
+  | BitXor -> " ^ "
+
+and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
+
+and gen_intrinsic buf path name args =
+  let full_name =
+    match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
+  in
+  let framework = Option.value ~default:"WGSL" !current_framework in
+  let pure_registry_hit =
+    match path with
+    | [] -> None
+    | _ -> (
+        match
+          Sarek_pure_registry.fun_device_template ~module_path:path name
+        with
+        | Some f -> Some (f ~framework)
+        | None -> None)
+  in
+  match pure_registry_hit with
+  | Some device_name ->
+      Buffer.add_string buf device_name ;
+      Buffer.add_char buf '(' ;
+      List.iteri
+        (fun i e ->
+          if i > 0 then Buffer.add_string buf ", " ;
+          gen_expr buf e)
+        args ;
+      Buffer.add_char buf ')'
+  | None -> (
+      if
+        List.mem
+          name
+          [
+            "thread_id_x";
+            "thread_idx_x";
+            "thread_id_y";
+            "thread_idx_y";
+            "thread_id_z";
+            "thread_idx_z";
+            "block_id_x";
+            "block_idx_x";
+            "block_id_y";
+            "block_idx_y";
+            "block_id_z";
+            "block_idx_z";
+            "block_dim_x";
+            "block_dim_y";
+            "block_dim_z";
+            "grid_dim_x";
+            "grid_dim_y";
+            "grid_dim_z";
+            "global_thread_id";
+            "global_idx";
+            "global_idx_x";
+            "global_idx_y";
+            "global_idx_z";
+            "global_size";
+          ]
+      then Buffer.add_string buf (wgsl_thread_intrinsic name)
+      else
+        match name with
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+        | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
+        | "round" | "trunc" | "abs" ->
+            Buffer.add_string buf name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "fabs" ->
+            Buffer.add_string buf "abs" ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "rsqrt" ->
+            Buffer.add_string buf "(1.0f / sqrt(" ;
+            (match args with
+            | [e] -> gen_expr buf e
+            | _ ->
+                List.iteri
+                  (fun i e ->
+                    if i > 0 then Buffer.add_string buf ", " ;
+                    gen_expr buf e)
+                  args) ;
+            Buffer.add_string buf "))"
+        | "atan2" | "pow" | "min" | "max" ->
+            Buffer.add_string buf name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "fma" ->
+            Buffer.add_string buf "fma" ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')'
+        | "block_barrier" -> Buffer.add_string buf "workgroupBarrier()"
+        | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
+            Buffer.add_string buf "atomicAdd(" ;
+            (match args with
+            | [addr; value] ->
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | [arr; idx; value] ->
+                gen_expr buf arr ;
+                Buffer.add_char buf '[' ;
+                gen_expr buf idx ;
+                Buffer.add_string buf "], " ;
+                gen_expr buf value
+            | args ->
+                Codegen_error.raise_error
+                  (Codegen_error.invalid_arg_count
+                     "atomic_add"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_min" ->
+            Buffer.add_string buf "atomicMin(" ;
+            (match args with
+            | [addr; value] ->
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | args ->
+                Codegen_error.raise_error
+                  (Codegen_error.invalid_arg_count
+                     "atomic_min"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "atomic_max" ->
+            Buffer.add_string buf "atomicMax(" ;
+            (match args with
+            | [addr; value] ->
+                gen_expr buf addr ;
+                Buffer.add_string buf ", " ;
+                gen_expr buf value
+            | args ->
+                Codegen_error.raise_error
+                  (Codegen_error.invalid_arg_count
+                     "atomic_max"
+                     2
+                     (List.length args))) ;
+            Buffer.add_char buf ')'
+        | "float" ->
+            Buffer.add_string buf "f32(" ;
+            (match args with [e] -> gen_expr buf e | _ -> ()) ;
+            Buffer.add_char buf ')'
+        | "int_of_float" ->
+            Buffer.add_string buf "i32(" ;
+            (match args with [e] -> gen_expr buf e | _ -> ()) ;
+            Buffer.add_char buf ')'
+        | _ ->
+            Buffer.add_string buf full_name ;
+            Buffer.add_char buf '(' ;
+            List.iteri
+              (fun i e ->
+                if i > 0 then Buffer.add_string buf ", " ;
+                gen_expr buf e)
+              args ;
+            Buffer.add_char buf ')')
+
+(** {1 L-value Generation} *)
+
+let rec gen_lvalue buf = function
+  | LVar v -> Buffer.add_string buf (escape_wgsl_name v.var_name)
+  | LArrayElem (arr, idx) ->
+      Buffer.add_string buf (escape_wgsl_name arr) ;
+      Buffer.add_char buf '[' ;
+      gen_expr buf idx ;
+      Buffer.add_char buf ']'
+  | LArrayElemExpr (base, idx) ->
+      Buffer.add_char buf '(' ;
+      gen_expr buf base ;
+      Buffer.add_char buf ')' ;
+      Buffer.add_char buf '[' ;
+      gen_expr buf idx ;
+      Buffer.add_char buf ']'
+  | LRecordField (lv, field) ->
+      gen_lvalue buf lv ;
+      Buffer.add_char buf '.' ;
+      Buffer.add_string buf field
+
+(** {1 Statement Generation} *)
+
+let indent_nested indent = indent ^ "  "
+
+and gen_match_pattern buf indent scrutinee cname bindings find_constr_types =
+  Buffer.add_string buf ("  case " ^ cname ^ ": {\n") ;
+  match (bindings, find_constr_types cname) with
+  | [var_name], Some [ty] ->
+      let vn = escape_wgsl_name var_name in
+      Buffer.add_string buf (indent ^ "    ") ;
+      Buffer.add_string buf "let " ;
+      Buffer.add_string buf vn ;
+      Buffer.add_string buf " : " ;
+      Buffer.add_string buf (wgsl_type_of_elttype ty) ;
+      Buffer.add_string buf " = " ;
+      Buffer.add_string buf scrutinee ;
+      Buffer.add_char buf '.' ;
+      Buffer.add_string buf cname ;
+      Buffer.add_string buf "_v;\n"
+  | vars, Some types when List.length vars = List.length types ->
+      List.iteri
+        (fun i (var_name, ty) ->
+          let vn = escape_wgsl_name var_name in
+          Buffer.add_string buf (indent ^ "    ") ;
+          Buffer.add_string buf "let " ;
+          Buffer.add_string buf vn ;
+          Buffer.add_string buf " : " ;
+          Buffer.add_string buf (wgsl_type_of_elttype ty) ;
+          Buffer.add_string buf " = " ;
+          Buffer.add_string buf scrutinee ;
+          Buffer.add_char buf '.' ;
+          Buffer.add_string buf cname ;
+          Buffer.add_string buf (Printf.sprintf "_v._%d;\n" i))
+        (List.combine vars types)
+  | [], _ | _, None | _, Some [] -> ()
+  | _ ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "pattern"
+           "mismatch between pattern bindings and constructor args")
+
+and gen_var_decl buf indent ~mutable_ v_name v_type init_expr =
+  let vn = escape_wgsl_name v_name in
+  Buffer.add_string buf indent ;
+  Buffer.add_string buf (if mutable_ then "var" else "let") ;
+  Buffer.add_char buf ' ' ;
+  Buffer.add_string buf vn ;
+  Buffer.add_string buf " : " ;
+  Buffer.add_string buf (wgsl_type_of_elttype v_type) ;
+  Buffer.add_string buf " = " ;
+  gen_expr buf init_expr ;
+  Buffer.add_string buf ";\n"
+
+let rec gen_stmt buf indent = function
+  | SEmpty -> ()
+  | SSeq stmts -> List.iter (gen_stmt buf indent) stmts
+  | SAssign (lv, e) ->
+      Buffer.add_string buf indent ;
+      gen_lvalue buf lv ;
+      Buffer.add_string buf " = " ;
+      gen_expr buf e ;
+      Buffer.add_string buf ";\n"
+  | SIf (cond, then_, else_opt) -> (
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "if (" ;
+      gen_expr buf cond ;
+      Buffer.add_string buf ") {\n" ;
+      gen_stmt buf (indent_nested indent) then_ ;
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "}" ;
+      match else_opt with
+      | None -> Buffer.add_char buf '\n'
+      | Some else_ ->
+          Buffer.add_string buf " else {\n" ;
+          gen_stmt buf (indent_nested indent) else_ ;
+          Buffer.add_string buf indent ;
+          Buffer.add_string buf "}\n")
+  | SWhile (cond, body) ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "while (" ;
+      gen_expr buf cond ;
+      Buffer.add_string buf ") {\n" ;
+      gen_stmt buf (indent_nested indent) body ;
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "}\n"
+  | SFor (v, start, stop, dir, body) ->
+      let op, step_expr =
+        match dir with
+        | Upto ->
+            ( "<=",
+              Printf.sprintf " = %s + 1i" (escape_wgsl_name v.var_name) )
+        | Downto ->
+            ( ">=",
+              Printf.sprintf " = %s - 1i" (escape_wgsl_name v.var_name) )
+      in
+      let loop_var = escape_wgsl_name v.var_name in
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "for (var " ;
+      Buffer.add_string buf loop_var ;
+      Buffer.add_string buf " : " ;
+      Buffer.add_string buf (wgsl_type_of_elttype v.var_type) ;
+      Buffer.add_string buf " = " ;
+      gen_expr buf start ;
+      Buffer.add_string buf "; " ;
+      Buffer.add_string buf loop_var ;
+      Buffer.add_string buf (" " ^ op ^ " ") ;
+      gen_expr buf stop ;
+      Buffer.add_string buf "; " ;
+      Buffer.add_string buf loop_var ;
+      Buffer.add_string buf step_expr ;
+      Buffer.add_string buf ") {\n" ;
+      gen_stmt buf (indent_nested indent) body ;
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "}\n"
+  | SMatch (e, cases) ->
+      let scrutinee_buf = Buffer.create 64 in
+      gen_expr scrutinee_buf e ;
+      let scrutinee = Buffer.contents scrutinee_buf in
+      let find_constr_types cname =
+        List.find_map
+          (fun (_vname, constrs) ->
+            List.find_map
+              (fun (cn, args) -> if cn = cname then Some args else None)
+              constrs)
+          !current_variants
+      in
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "switch (" ;
+      Buffer.add_string buf scrutinee ;
+      Buffer.add_string buf ".tag) {\n" ;
+      List.iter
+        (fun (pattern, body) ->
+          Buffer.add_string buf indent ;
+          (match pattern with
+          | PConstr (cname, bindings) ->
+              gen_match_pattern
+                buf
+                indent
+                scrutinee
+                cname
+                bindings
+                find_constr_types
+          | PWild -> Buffer.add_string buf "  default: {\n") ;
+          gen_stmt buf (indent ^ "    ") body ;
+          Buffer.add_string buf (indent ^ "  }\n"))
+        cases ;
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "}\n"
+  | SReturn e ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "return " ;
+      gen_expr buf e ;
+      Buffer.add_string buf ";\n"
+  | SBarrier ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "workgroupBarrier();\n"
+  | SWarpBarrier ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "subgroupBarrier();\n"
+  | SMemFence ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "storageBarrier();\n"
+  | SNative _ ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "/* native code not supported in WGSL */\n"
+  | SExpr e ->
+      Buffer.add_string buf indent ;
+      gen_expr buf e ;
+      Buffer.add_string buf ";\n"
+  | SLet (_v, EArrayCreate (_, _, Shared), body) ->
+      gen_stmt buf indent body
+  | SLet (v, EArrayCreate (elem_ty, size, _), body) ->
+      (* Workgroup array — emitted inline inside function scope *)
+      let vn = escape_wgsl_name v.var_name in
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "var<workgroup> " ;
+      Buffer.add_string buf vn ;
+      Buffer.add_string buf " : array<" ;
+      Buffer.add_string buf (wgsl_type_of_elttype elem_ty) ;
+      Buffer.add_string buf ", " ;
+      gen_expr buf size ;
+      Buffer.add_string buf ">;\n" ;
+      gen_stmt buf indent body
+  | SLet (v, e, body) ->
+      gen_var_decl buf indent ~mutable_:false v.var_name v.var_type e ;
+      gen_stmt buf indent body
+  | SLetMut (v, e, body) ->
+      gen_var_decl buf indent ~mutable_:true v.var_name v.var_type e ;
+      gen_stmt buf indent body
+  | SPragma (_hints, body) -> gen_stmt buf indent body
+  | SBlock body ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "{\n" ;
+      gen_stmt buf (indent_nested indent) body ;
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf "}\n"
+
+(** {1 Helper Function Generation} *)
+
+let gen_helper_func buf (hf : helper_func) =
+  let non_vec_params =
+    List.filter
+      (fun (v : var) -> match v.var_type with TVec _ -> false | _ -> true)
+      hf.hf_params
+  in
+  Buffer.add_string buf "fn " ;
+  Buffer.add_string buf hf.hf_name ;
+  Buffer.add_char buf '(' ;
+  List.iteri
+    (fun i (v : var) ->
+      if i > 0 then Buffer.add_string buf ", " ;
+      Buffer.add_string buf (escape_wgsl_name v.var_name) ;
+      Buffer.add_string buf " : " ;
+      Buffer.add_string buf (wgsl_type_of_elttype v.var_type))
+    non_vec_params ;
+  Buffer.add_string buf ") -> " ;
+  Buffer.add_string buf (wgsl_type_of_elttype hf.hf_ret_type) ;
+  Buffer.add_string buf " {\n" ;
+  gen_stmt buf "  " hf.hf_body ;
+  Buffer.add_string buf "}\n\n"
+
+(** {1 Record and Variant Type Generation} *)
+
+let gen_record_def buf (name, fields) =
+  let mangled = mangle_name name in
+  Buffer.add_string buf (Printf.sprintf "struct %s {\n" mangled) ;
+  List.iter
+    (fun (fname, ftype) ->
+      Buffer.add_string buf "  " ;
+      Buffer.add_string buf fname ;
+      Buffer.add_string buf " : " ;
+      Buffer.add_string buf (wgsl_type_of_elttype ftype) ;
+      Buffer.add_string buf ",\n")
+    fields ;
+  Buffer.add_string buf "}\n\n"
+
+(** Emit a WGSL variant type.
+    WGSL has no enums or unions. We emit:
+    - [const <CNAME> : i32 = N;] for each constructor tag
+    - a struct with [tag : i32] and flat payload fields
+    - [fn make_<Type>_<Constr>(...) -> <Type>] constructors
+*)
+let gen_variant_def buf (name, constrs) =
+  let mangled = mangle_name name in
+  List.iteri
+    (fun i (cname, _) ->
+      Buffer.add_string buf (Printf.sprintf "const %s : i32 = %di;\n" cname i))
+    constrs ;
+  Buffer.add_char buf '\n' ;
+  Buffer.add_string buf (Printf.sprintf "struct %s {\n  tag : i32,\n" mangled) ;
+  let has_payload = List.exists (fun (_, args) -> args <> []) constrs in
+  if has_payload then begin
+    List.iter
+      (fun (cname, args) ->
+        match args with
+        | [] -> ()
+        | [ty] ->
+            Buffer.add_string
+              buf
+              (Printf.sprintf "  %s_v : %s,\n" cname (wgsl_type_of_elttype ty))
+        | _ ->
+            List.iteri
+              (fun i ty ->
+                Buffer.add_string
+                  buf
+                  (Printf.sprintf
+                     "  %s_v_%d : %s,\n"
+                     cname
+                     i
+                     (wgsl_type_of_elttype ty)))
+              args)
+      constrs
+  end ;
+  Buffer.add_string buf "}\n\n" ;
+  List.iteri
+    (fun _i (cname, args) ->
+      Buffer.add_string buf (Printf.sprintf "fn make_%s_%s(" mangled cname) ;
+      (match args with
+      | [] -> ()
+      | [ty] -> Buffer.add_string buf ("v : " ^ wgsl_type_of_elttype ty)
+      | _ ->
+          List.iteri
+            (fun j ty ->
+              if j > 0 then Buffer.add_string buf ", " ;
+              Buffer.add_string
+                buf
+                (Printf.sprintf "v%d : %s" j (wgsl_type_of_elttype ty)))
+            args) ;
+      Buffer.add_string buf (Printf.sprintf ") -> %s {\n" mangled) ;
+      Buffer.add_string buf (Printf.sprintf "  var r : %s;\n" mangled) ;
+      Buffer.add_string buf (Printf.sprintf "  r.tag = %s;\n" cname) ;
+      (match args with
+      | [] -> ()
+      | [_] -> Buffer.add_string buf (Printf.sprintf "  r.%s_v = v;\n" cname)
+      | _ ->
+          List.iteri
+            (fun j _ ->
+              Buffer.add_string
+                buf
+                (Printf.sprintf "  r.%s_v_%d = v%d;\n" cname j j))
+            args) ;
+      Buffer.add_string buf "  return r;\n}\n\n")
+    constrs
+
+(** {1 Buffer / Uniform Binding Generation} *)
+
+(** Collect workgroup shared array declarations from a statement tree. *)
+let rec collect_workgroup_decls (s : stmt) : (string * elttype * expr) list =
+  match s with
+  | SLet (v, EArrayCreate (elem_ty, size, Shared), body) ->
+      (escape_wgsl_name v.var_name, elem_ty, size)
+      :: collect_workgroup_decls body
+  | SLet (_, _, body) | SLetMut (_, _, body) -> collect_workgroup_decls body
+  | SSeq stmts -> List.concat_map collect_workgroup_decls stmts
+  | SFor (_, _, _, _, body) -> collect_workgroup_decls body
+  | SWhile (_, body) -> collect_workgroup_decls body
+  | SIf (_, st, sf_opt) ->
+      let sf_decls =
+        match sf_opt with Some sf -> collect_workgroup_decls sf | None -> []
+      in
+      collect_workgroup_decls st @ sf_decls
+  | SBlock body -> collect_workgroup_decls body
+  | SPragma (_, body) -> collect_workgroup_decls body
+  | SMatch (_, cases) ->
+      List.concat_map (fun (_, body) -> collect_workgroup_decls body) cases
+  | SEmpty | SBarrier | SWarpBarrier | SMemFence | SNative _ | SExpr _
+  | SAssign _ | SReturn _ ->
+      []
+
+let gen_workgroup_module_decls buf (decls : (string * elttype * expr) list) =
+  if decls <> [] then begin
+    Buffer.add_string buf "// Workgroup shared memory\n" ;
+    List.iter
+      (fun (name, elem_ty, size) ->
+        Buffer.add_string buf "var<workgroup> " ;
+        Buffer.add_string buf name ;
+        Buffer.add_string buf " : array<" ;
+        Buffer.add_string buf (wgsl_type_of_elttype elem_ty) ;
+        Buffer.add_string buf ", " ;
+        gen_expr buf size ;
+        Buffer.add_string buf ">;\n")
+      decls ;
+    Buffer.add_char buf '\n'
+  end
+
+(** Separate kernel params into vectors (storage buffers) and scalars (uniform).
+*)
+let split_params params =
+  let vectors = ref [] in
+  let scalars = ref [] in
+  List.iter
+    (fun decl ->
+      match decl with
+      | DParam (v, _) -> (
+          match v.var_type with
+          | TVec _ -> vectors := v :: !vectors
+          | _ -> scalars := v :: !scalars)
+      | _ -> ())
+    params ;
+  (List.rev !vectors, List.rev !scalars)
+
+(** Emit storage buffer bindings and the Params uniform struct. Returns the list
+    of scalar param names (for [scalar_param_names] ref). *)
+let gen_bindings buf params =
+  let vectors, scalars = split_params params in
+  let binding_idx = ref 0 in
+  List.iter
+    (fun (v : var) ->
+      let name = escape_wgsl_name v.var_name in
+      let elem_type =
+        match v.var_type with
+        | TVec elt -> wgsl_type_of_elttype elt
+        | _ -> assert false
+      in
+      Buffer.add_string
+        buf
+        (Printf.sprintf
+           "@group(0) @binding(%d) var<storage, read_write> %s : array<%s>;\n"
+           !binding_idx
+           name
+           elem_type) ;
+      incr binding_idx)
+    vectors ;
+  if vectors <> [] || scalars <> [] then begin
+    Buffer.add_string buf "struct Params {\n" ;
+    List.iter
+      (fun (v : var) ->
+        let name = escape_wgsl_name v.var_name in
+        Buffer.add_string
+          buf
+          (Printf.sprintf "  sarek_%s_length : i32,\n" name))
+      vectors ;
+    List.iter
+      (fun (v : var) ->
+        let name = escape_wgsl_name v.var_name in
+        Buffer.add_string
+          buf
+          (Printf.sprintf
+             "  %s : %s,\n"
+             name
+             (wgsl_type_of_elttype v.var_type)))
+      scalars ;
+    Buffer.add_string buf "}\n" ;
+    Buffer.add_string
+      buf
+      (Printf.sprintf
+         "@group(0) @binding(%d) var<uniform> params : Params;\n"
+         !binding_idx)
+  end ;
+  Buffer.add_char buf '\n' ;
+  List.map (fun (v : var) -> v.var_name) scalars
+
+(** {1 Main generate functions} *)
+
+let wgsl_header ~kernel_name ?(block = (256, 1, 1)) () =
+  let bx, by, bz = block in
+  Printf.sprintf
+    "@compute @workgroup_size(%d, %d, %d)\nfn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n"
+    bx
+    by
+    bz
+  |> fun s -> Printf.sprintf "// Sarek-generated compute shader: %s\n%s" kernel_name s
+
+(** Check if any kernel param uses Float64. *)
+let params_have_float64 params =
+  List.exists
+    (fun decl ->
+      match decl with DParam (v, _) -> has_float64 v.var_type | _ -> false)
+    params
+
+(** Generate complete WGSL source for a kernel. *)
+let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
+    =
+  if params_have_float64 k.kern_params then
+    Codegen_error.raise_error
+      (Codegen_error.unsupported_construct
+         "f64 parameter"
+         "WGSL: f64 unsupported — WebGPU has no float64 type") ;
+  scalar_param_names := [] ;
+  current_variants := k.kern_variants ;
+  let buf = Buffer.create 1024 in
+  let scalars = gen_bindings buf k.kern_params in
+  scalar_param_names := scalars ;
+  let wg_decls = collect_workgroup_decls k.kern_body in
+  gen_workgroup_module_decls buf wg_decls ;
+  List.iter (gen_helper_func buf) k.kern_funcs ;
+  Buffer.add_string buf (wgsl_header ~kernel_name:k.kern_name ?block ()) ;
+  gen_stmt buf "  " k.kern_body ;
+  Buffer.add_string buf "}\n" ;
+  let shader = Buffer.contents buf in
+  log (Printf.sprintf "[WGSL] Generated shader:\n%s" shader) ;
+  shader
+
+(** Generate WGSL source with custom type definitions. *)
+let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
+    ~(types : (string * (string * elttype) list) list) (k : kernel) : string =
+  if params_have_float64 k.kern_params then
+    Codegen_error.raise_error
+      (Codegen_error.unsupported_construct
+         "f64 parameter"
+         "WGSL: f64 unsupported — WebGPU has no float64 type") ;
+  scalar_param_names := [] ;
+  current_variants := k.kern_variants ;
+  let buf = Buffer.create 1024 in
+  List.iter (gen_record_def buf) types ;
+  List.iter (gen_variant_def buf) k.kern_variants ;
+  let scalars = gen_bindings buf k.kern_params in
+  scalar_param_names := scalars ;
+  let wg_decls = collect_workgroup_decls k.kern_body in
+  gen_workgroup_module_decls buf wg_decls ;
+  List.iter (gen_helper_func buf) k.kern_funcs ;
+  Buffer.add_string buf (wgsl_header ~kernel_name:k.kern_name ?block ()) ;
+  gen_stmt buf "  " k.kern_body ;
+  Buffer.add_string buf "}\n" ;
+  let shader = Buffer.contents buf in
+  log (Printf.sprintf "[WGSL] Generated shader:\n%s" shader) ;
+  shader

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -119,7 +119,11 @@ let escape_wgsl_name name =
     function and raise [Codegen_error.unsupported_construct]. *)
 let rec wgsl_type_of_elttype = function
   | TInt32 -> "i32"
-  | TInt64 -> "i64"
+  | TInt64 ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "i64"
+           "WGSL: 64-bit integers unsupported in core WebGPU")
   | TFloat32 -> "f32"
   | TFloat64 ->
       Codegen_error.raise_error
@@ -144,21 +148,27 @@ let rec has_float64 = function
 
 (** {1 Thread Intrinsics}
 
-    [global_invocation_id] is [vec3<u32>], so all components need [i32(…)]
-    conversion to stay consistent with how the IR types thread ids as i32. *)
+    WGSL uses three distinct builtins:
+    - [local_invocation_id] (lid) — thread within workgroup
+    - [workgroup_id] (wid) — workgroup index in the dispatch grid
+    - [global_invocation_id] (gid) — globally unique thread index
+
+    All are [vec3<u32>]; we cast to i32 to match the IR's i32 type for thread
+    ids. The entry point declares all three builtins; unused ones are harmless
+    (WGSL permits unused builtin params). *)
 let wgsl_thread_intrinsic = function
-  | "thread_id_x" | "thread_idx_x" -> "i32(gid.x)"
-  | "thread_id_y" | "thread_idx_y" -> "i32(gid.y)"
-  | "thread_id_z" | "thread_idx_z" -> "i32(gid.z)"
-  | "block_id_x" | "block_idx_x" -> "i32(gid.x)"
-  | "block_id_y" | "block_idx_y" -> "i32(gid.y)"
-  | "block_id_z" | "block_idx_z" -> "i32(gid.z)"
+  | "thread_id_x" | "thread_idx_x" -> "i32(lid.x)"
+  | "thread_id_y" | "thread_idx_y" -> "i32(lid.y)"
+  | "thread_id_z" | "thread_idx_z" -> "i32(lid.z)"
+  | "block_id_x" | "block_idx_x" -> "i32(wid.x)"
+  | "block_id_y" | "block_idx_y" -> "i32(wid.y)"
+  | "block_id_z" | "block_idx_z" -> "i32(wid.z)"
   | "block_dim_x" -> "256i"
   | "block_dim_y" -> "1i"
   | "block_dim_z" -> "1i"
-  | "grid_dim_x" -> "0i"
-  | "grid_dim_y" -> "0i"
-  | "grid_dim_z" -> "0i"
+  | "grid_dim_x" -> "i32(nwg.x)"
+  | "grid_dim_y" -> "i32(nwg.y)"
+  | "grid_dim_z" -> "i32(nwg.z)"
   | "global_thread_id" | "global_idx" | "global_idx_x" -> "i32(gid.x)"
   | "global_idx_y" -> "i32(gid.y)"
   | "global_idx_z" -> "i32(gid.z)"
@@ -172,7 +182,11 @@ let scalar_param_names : string list ref = ref []
 
 let rec gen_expr buf = function
   | EConst (CInt32 n) -> Buffer.add_string buf (Int32.to_string n ^ "i")
-  | EConst (CInt64 n) -> Buffer.add_string buf (Int64.to_string n ^ "i")
+  | EConst (CInt64 _) ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "i64 literal"
+           "WGSL: 64-bit integers unsupported in core WebGPU")
   | EConst (CFloat32 f) ->
       let s = Printf.sprintf "%.17g" f in
       let s =
@@ -270,36 +284,61 @@ let rec gen_expr buf = function
            "EArrayCreate"
            "should be handled in gen_stmt SLet")
   | EIf (cond, then_, else_) ->
-      Buffer.add_char buf '(' ;
-      gen_expr buf cond ;
-      Buffer.add_string buf " ? " ;
-      gen_expr buf then_ ;
-      Buffer.add_string buf " : " ;
+      (* WGSL has no ternary operator — use select(false_val, true_val, cond) *)
+      Buffer.add_string buf "select(" ;
       gen_expr buf else_ ;
+      Buffer.add_string buf ", " ;
+      gen_expr buf then_ ;
+      Buffer.add_string buf ", " ;
+      gen_expr buf cond ;
       Buffer.add_char buf ')'
   | EMatch (_, []) ->
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct "match" "empty match expression")
   | EMatch (_, [(_, body)]) -> gen_expr buf body
   | EMatch (e, cases) ->
+      (* Nest select() calls: select(else_result, then_result, condition) *)
       let rec gen_cases = function
         | [] ->
             Codegen_error.raise_error
               (Codegen_error.unsupported_construct "match" "empty match cases")
         | [(_, body)] -> gen_expr buf body
         | (pat, body) :: rest ->
-            Buffer.add_char buf '(' ;
+            Buffer.add_string buf "select(" ;
+            (* false branch comes first in select() *)
+            let rest_buf = Buffer.create 64 in
+            gen_cases_into rest_buf rest ;
+            Buffer.add_buffer buf rest_buf ;
+            Buffer.add_string buf ", " ;
+            gen_expr buf body ;
+            Buffer.add_string buf ", " ;
             (match pat with
             | PConstr (name, _) ->
                 Buffer.add_char buf '(' ;
                 gen_expr buf e ;
                 Buffer.add_string buf (".tag == " ^ name ^ ")")
             | PWild -> Buffer.add_string buf "true") ;
-            Buffer.add_string buf " ? " ;
-            gen_expr buf body ;
-            Buffer.add_string buf " : " ;
-            gen_cases rest ;
             Buffer.add_char buf ')'
+      and gen_cases_into buf2 = function
+        | [] ->
+            Codegen_error.raise_error
+              (Codegen_error.unsupported_construct "match" "empty match cases")
+        | [(_, body)] -> gen_expr buf2 body
+        | (pat, body) :: rest ->
+            Buffer.add_string buf2 "select(" ;
+            let rest_buf = Buffer.create 64 in
+            gen_cases_into rest_buf rest ;
+            Buffer.add_buffer buf2 rest_buf ;
+            Buffer.add_string buf2 ", " ;
+            gen_expr buf2 body ;
+            Buffer.add_string buf2 ", " ;
+            (match pat with
+            | PConstr (name, _) ->
+                Buffer.add_char buf2 '(' ;
+                gen_expr buf2 e ;
+                Buffer.add_string buf2 (".tag == " ^ name ^ ")")
+            | PWild -> Buffer.add_string buf2 "true") ;
+            Buffer.add_char buf2 ')'
       in
       gen_cases cases
 
@@ -687,19 +726,23 @@ let rec gen_stmt buf indent = function
       Buffer.add_string buf indent ;
       gen_expr buf e ;
       Buffer.add_string buf ";\n"
-  | SLet (_v, EArrayCreate (_, _, Shared), body) -> gen_stmt buf indent body
-  | SLet (v, EArrayCreate (elem_ty, size, _), body) ->
-      (* Workgroup array — emitted inline inside function scope *)
-      let vn = escape_wgsl_name v.var_name in
-      Buffer.add_string buf indent ;
-      Buffer.add_string buf "var<workgroup> " ;
-      Buffer.add_string buf vn ;
-      Buffer.add_string buf " : array<" ;
-      Buffer.add_string buf (wgsl_type_of_elttype elem_ty) ;
-      Buffer.add_string buf ", " ;
-      gen_expr buf size ;
-      Buffer.add_string buf ">;\n" ;
+  | SLet (_v, EArrayCreate (_, _, Shared), body) ->
+      (* Shared arrays are hoisted to module scope by collect_workgroup_decls;
+         only the body continuation needs to be emitted here. *)
       gen_stmt buf indent body
+  | SLet (_v, EArrayCreate (_, _, Local), _) ->
+      (* WGSL has no function-local dynamic arrays. Raise rather than emit
+         invalid WGSL. Use Shared memspace for workgroup-scoped arrays. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "EArrayCreate(Local)"
+           "WGSL: local dynamic arrays unsupported; use Shared for workgroup \
+            arrays")
+  | SLet (_v, EArrayCreate (_, _, Global), _) ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "EArrayCreate(Global)"
+           "WGSL: global dynamic array creation not supported in kernel body")
   | SLet (v, e, body) ->
       gen_var_decl buf indent ~mutable_:false v.var_name v.var_type e ;
       gen_stmt buf indent body
@@ -928,7 +971,12 @@ let wgsl_header ~kernel_name ?(block = (256, 1, 1)) () =
   let bx, by, bz = block in
   Printf.sprintf
     "@compute @workgroup_size(%d, %d, %d)\n\
-     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n"
+     fn main(\n\
+    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+     ) {\n"
     bx
     by
     bz

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -28,9 +28,9 @@ end)
 (** Current kernel's variant definitions (set during generate) *)
 let current_variants : (string * (string * elttype list) list) list ref = ref []
 
-(** Current framework name — mirrors the other generators so [set_framework]
-    in Sarek_transpile can set it, and the pure registry resolves Float32 math
-    with framework="WGSL" (falls through to the generic [sin] spelling). *)
+(** Current framework name — mirrors the other generators so [set_framework] in
+    Sarek_transpile can set it, and the pure registry resolves Float32 math with
+    framework="WGSL" (falls through to the generic [sin] spelling). *)
 let current_framework : string option ref = ref None
 
 (** {1 Type Mapping} *)
@@ -114,10 +114,9 @@ let wgsl_reserved_keywords =
 let escape_wgsl_name name =
   if List.mem name wgsl_reserved_keywords then name ^ "v" else name
 
-(** Map Sarek IR element type to WGSL type string.
-    Float64 (f64) is not supported in WebGPU — callers must check for TFloat64
-    before reaching this function and raise [Codegen_error.unsupported_construct].
-*)
+(** Map Sarek IR element type to WGSL type string. Float64 (f64) is not
+    supported in WebGPU — callers must check for TFloat64 before reaching this
+    function and raise [Codegen_error.unsupported_construct]. *)
 let rec wgsl_type_of_elttype = function
   | TInt32 -> "i32"
   | TInt64 -> "i64"
@@ -193,7 +192,8 @@ let rec gen_expr buf = function
       if List.mem v.var_name !scalar_param_names then begin
         Buffer.add_string buf "params." ;
         Buffer.add_string buf vn
-      end else Buffer.add_string buf vn
+      end
+      else Buffer.add_string buf vn
   | EBinop (op, e1, e2) ->
       Buffer.add_char buf '(' ;
       gen_expr buf e1 ;
@@ -609,11 +609,9 @@ let rec gen_stmt buf indent = function
       let op, step_expr =
         match dir with
         | Upto ->
-            ( "<=",
-              Printf.sprintf " = %s + 1i" (escape_wgsl_name v.var_name) )
+            ("<=", Printf.sprintf " = %s + 1i" (escape_wgsl_name v.var_name))
         | Downto ->
-            ( ">=",
-              Printf.sprintf " = %s - 1i" (escape_wgsl_name v.var_name) )
+            (">=", Printf.sprintf " = %s - 1i" (escape_wgsl_name v.var_name))
       in
       let loop_var = escape_wgsl_name v.var_name in
       Buffer.add_string buf indent ;
@@ -689,8 +687,7 @@ let rec gen_stmt buf indent = function
       Buffer.add_string buf indent ;
       gen_expr buf e ;
       Buffer.add_string buf ";\n"
-  | SLet (_v, EArrayCreate (_, _, Shared), body) ->
-      gen_stmt buf indent body
+  | SLet (_v, EArrayCreate (_, _, Shared), body) -> gen_stmt buf indent body
   | SLet (v, EArrayCreate (elem_ty, size, _), body) ->
       (* Workgroup array — emitted inline inside function scope *)
       let vn = escape_wgsl_name v.var_name in
@@ -756,12 +753,10 @@ let gen_record_def buf (name, fields) =
     fields ;
   Buffer.add_string buf "}\n\n"
 
-(** Emit a WGSL variant type.
-    WGSL has no enums or unions. We emit:
+(** Emit a WGSL variant type. WGSL has no enums or unions. We emit:
     - [const <CNAME> : i32 = N;] for each constructor tag
     - a struct with [tag : i32] and flat payload fields
-    - [fn make_<Type>_<Constr>(...) -> <Type>] constructors
-*)
+    - [fn make_<Type>_<Constr>(...) -> <Type>] constructors *)
 let gen_variant_def buf (name, constrs) =
   let mangled = mangle_name name in
   List.iteri
@@ -908,19 +903,14 @@ let gen_bindings buf params =
     List.iter
       (fun (v : var) ->
         let name = escape_wgsl_name v.var_name in
-        Buffer.add_string
-          buf
-          (Printf.sprintf "  sarek_%s_length : i32,\n" name))
+        Buffer.add_string buf (Printf.sprintf "  sarek_%s_length : i32,\n" name))
       vectors ;
     List.iter
       (fun (v : var) ->
         let name = escape_wgsl_name v.var_name in
         Buffer.add_string
           buf
-          (Printf.sprintf
-             "  %s : %s,\n"
-             name
-             (wgsl_type_of_elttype v.var_type)))
+          (Printf.sprintf "  %s : %s,\n" name (wgsl_type_of_elttype v.var_type)))
       scalars ;
     Buffer.add_string buf "}\n" ;
     Buffer.add_string
@@ -937,11 +927,13 @@ let gen_bindings buf params =
 let wgsl_header ~kernel_name ?(block = (256, 1, 1)) () =
   let bx, by, bz = block in
   Printf.sprintf
-    "@compute @workgroup_size(%d, %d, %d)\nfn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n"
+    "@compute @workgroup_size(%d, %d, %d)\n\
+     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n"
     bx
     by
     bz
-  |> fun s -> Printf.sprintf "// Sarek-generated compute shader: %s\n%s" kernel_name s
+  |> fun s ->
+  Printf.sprintf "// Sarek-generated compute shader: %s\n%s" kernel_name s
 
 (** Check if any kernel param uses Float64. *)
 let params_have_float64 params =

--- a/sarek/codegen/dune
+++ b/sarek/codegen/dune
@@ -8,7 +8,12 @@
  (name sarek_codegen)
  (public_name sarek.codegen)
  (libraries sarek_ir sarek_registry sarek_backend_error)
- (modules Sarek_ir_cuda Sarek_ir_opencl Sarek_ir_metal Sarek_ir_glsl Sarek_ir_wgsl)
+ (modules
+  Sarek_ir_cuda
+  Sarek_ir_opencl
+  Sarek_ir_metal
+  Sarek_ir_glsl
+  Sarek_ir_wgsl)
  (preprocess no_preprocessing)
  (instrumentation
   (backend bisect_ppx)))

--- a/sarek/codegen/dune
+++ b/sarek/codegen/dune
@@ -8,7 +8,7 @@
  (name sarek_codegen)
  (public_name sarek.codegen)
  (libraries sarek_ir sarek_registry sarek_backend_error)
- (modules Sarek_ir_cuda Sarek_ir_opencl Sarek_ir_metal Sarek_ir_glsl)
+ (modules Sarek_ir_cuda Sarek_ir_opencl Sarek_ir_metal Sarek_ir_glsl Sarek_ir_wgsl)
  (preprocess no_preprocessing)
  (instrumentation
   (backend bisect_ppx)))

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -6,7 +6,7 @@
 (library
  (name codegen_golden_backends)
  (wrapped false)
- (modules gen_cuda gen_opencl gen_metal gen_glsl)
+ (modules gen_cuda gen_opencl gen_metal gen_glsl gen_wgsl)
  (libraries sarek_ir sarek_codegen))
 
 (rule
@@ -24,6 +24,10 @@
 (rule
  (action
   (copy gen_glsl.real.ml gen_glsl.ml)))
+
+(rule
+ (action
+  (copy gen_wgsl.real.ml gen_wgsl.ml)))
 
 (test
  (name test_codegen_golden)

--- a/sarek/tests/codegen_golden/gen_wgsl.real.ml
+++ b/sarek/tests/codegen_golden/gen_wgsl.real.ml
@@ -1,0 +1,14 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Thin adapter for WGSL generator in golden tests — uses pure sarek_codegen *)
+
+open Sarek_ir_types
+open Sarek_codegen
+
+let reset_state () = Sarek_ir_wgsl.current_variants := []
+
+let generate_with_types ~types (k : kernel) =
+  Sarek_ir_wgsl.generate_with_types ~types k

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -185,6 +185,36 @@ let float32_sin_path_kernel () =
     []
     body
 
+(** Kernel 6: bounds-check with if-expression. WGSL-specific: exercises EIf
+    which must emit [select(else, then, cond)] (no ternary in WGSL). fun (a :
+    float32 vec) (b : float32 vec) (n : int32) -> let i = global_thread_id in
+    b.(i) <- if i < n then a.(i) else 0.0 *)
+let bounds_check_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let n = make_var "n" TInt32 in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIf
+              ( EBinop (Lt, EVar idx, EVar n),
+                EArrayRead ("a", EVar idx),
+                EConst (CFloat32 0.0) ) ) )
+  in
+  empty_kernel
+    "bounds_check"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (n, None);
+    ]
+    []
+    body
+
 (** {1 Backend Adapter Type} *)
 
 type backend = {
@@ -691,7 +721,12 @@ let () =
      @group(0) @binding(3) var<uniform> params : Params;\n\n\
      // Sarek-generated compute shader: scalar_vec_add\n\
      @compute @workgroup_size(256, 1, 1)\n\
-     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+     fn main(\n\
+    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+     ) {\n\
     \  let idx : i32 = i32(gid.x);\n\
     \  c[idx] = (a[idx] + b[idx]);\n\
      }\n" ;
@@ -710,7 +745,12 @@ let () =
      @group(0) @binding(1) var<uniform> params : Params;\n\n\
      // Sarek-generated compute shader: record_kernel\n\
      @compute @workgroup_size(256, 1, 1)\n\
-     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+     fn main(\n\
+    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+     ) {\n\
     \  let idx : i32 = i32(gid.x);\n\
     \  let p : Point2 = pts[idx];\n\
     \  pts[idx] = Point2((p.x * 2.0f), (p.y * 2.0f));\n\
@@ -745,7 +785,12 @@ let () =
      @group(0) @binding(2) var<uniform> params : Params;\n\n\
      // Sarek-generated compute shader: variant_kernel\n\
      @compute @workgroup_size(256, 1, 1)\n\
-     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+     fn main(\n\
+    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+     ) {\n\
     \  let idx : i32 = i32(gid.x);\n\
     \  let flag : i32 = flags[idx];\n\
     \  if ((flag != 0i)) {\n\
@@ -767,7 +812,12 @@ let () =
      @group(0) @binding(2) var<uniform> params : Params;\n\n\
      // Sarek-generated compute shader: sin_kernel\n\
      @compute @workgroup_size(256, 1, 1)\n\
-     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+     fn main(\n\
+    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+     ) {\n\
     \  let idx : i32 = i32(gid.x);\n\
     \  b[idx] = sin(a[idx]);\n\
      }\n" ;
@@ -785,7 +835,12 @@ let () =
      @group(0) @binding(2) var<uniform> params : Params;\n\n\
      // Sarek-generated compute shader: float32_sin_path\n\
      @compute @workgroup_size(256, 1, 1)\n\
-     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+     fn main(\n\
+    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+     ) {\n\
     \  let idx : i32 = i32(gid.x);\n\
     \  b[idx] = sin(a[idx]);\n\
      }\n"
@@ -861,5 +916,55 @@ let make_backend_tests backend =
   in
   (backend.name, tests)
 
+(** {1 WGSL-only golden tests}
+
+    These kernels exercise WGSL-specific correctness fixes (select, thread ids,
+    etc.) that are not applicable or observable on other backends. They are
+    tested only against the wgsl backend to keep the cross-backend loop clean.
+*)
+
 let () =
-  Alcotest.run "codegen_golden" (List.map make_backend_tests all_backends)
+  (* WGSL bounds_check: EIf must emit select(else, then, cond) — no ternary in
+     WGSL. This golden is WGSL-only because other backends do support ternary. *)
+  register_golden
+    "wgsl"
+    "bounds_check"
+    "@group(0) @binding(0) var<storage, read_write> a : array<f32>;\n\
+     @group(0) @binding(1) var<storage, read_write> b : array<f32>;\n\
+     struct Params {\n\
+    \  sarek_a_length : i32,\n\
+    \  sarek_b_length : i32,\n\
+    \  n : i32,\n\
+     }\n\
+     @group(0) @binding(2) var<uniform> params : Params;\n\n\
+     // Sarek-generated compute shader: bounds_check\n\
+     @compute @workgroup_size(256, 1, 1)\n\
+     fn main(\n\
+    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+     ) {\n\
+    \  let idx : i32 = i32(gid.x);\n\
+    \  b[idx] = select(0.0f, a[idx], (idx < params.n));\n\
+     }\n"
+
+let wgsl_only_kernels () = [("bounds_check", bounds_check_kernel ())]
+
+let wgsl_only_tests () =
+  List.map
+    (fun (kernel_name, k) ->
+      Alcotest.test_case
+        (Printf.sprintf "wgsl/%s" kernel_name)
+        `Quick
+        (fun () ->
+          Gen_wgsl.reset_state () ;
+          let actual = Gen_wgsl.generate_with_types ~types:[] k in
+          check_golden "wgsl" kernel_name actual))
+    (wgsl_only_kernels ())
+
+let () =
+  Alcotest.run
+    "codegen_golden"
+    (List.map make_backend_tests all_backends
+    @ [("wgsl_only", wgsl_only_tests ())])

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -221,7 +221,15 @@ let glsl_backend =
     generate = Gen_glsl.generate_with_types;
   }
 
-let all_backends = [cuda_backend; opencl_backend; metal_backend; glsl_backend]
+let wgsl_backend =
+  {
+    name = "wgsl";
+    reset = Gen_wgsl.reset_state;
+    generate = Gen_wgsl.generate_with_types;
+  }
+
+let all_backends =
+  [cuda_backend; opencl_backend; metal_backend; glsl_backend; wgsl_backend]
 
 (** {1 Golden Registry} *)
 
@@ -665,6 +673,120 @@ let () =
      #define b_len pc.b_len\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = sin(a[idx]);\n\
+     }\n" ;
+
+  (* ---- WGSL goldens ---- *)
+  register_golden
+    "wgsl"
+    "scalar_vec_add"
+    "@group(0) @binding(0) var<storage, read_write> a : array<f32>;\n\
+     @group(0) @binding(1) var<storage, read_write> b : array<f32>;\n\
+     @group(0) @binding(2) var<storage, read_write> c : array<f32>;\n\
+     struct Params {\n\
+    \  sarek_a_length : i32,\n\
+    \  sarek_b_length : i32,\n\
+    \  sarek_c_length : i32,\n\
+     }\n\
+     @group(0) @binding(3) var<uniform> params : Params;\n\n\
+     // Sarek-generated compute shader: scalar_vec_add\n\
+     @compute @workgroup_size(256, 1, 1)\n\
+     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+    \  let idx : i32 = i32(gid.x);\n\
+    \  c[idx] = (a[idx] + b[idx]);\n\
+     }\n" ;
+
+  register_golden
+    "wgsl"
+    "record_kernel"
+    "struct Point2 {\n\
+    \  x : f32,\n\
+    \  y : f32,\n\
+     }\n\n\
+     @group(0) @binding(0) var<storage, read_write> pts : array<Point2>;\n\
+     struct Params {\n\
+    \  sarek_pts_length : i32,\n\
+     }\n\
+     @group(0) @binding(1) var<uniform> params : Params;\n\n\
+     // Sarek-generated compute shader: record_kernel\n\
+     @compute @workgroup_size(256, 1, 1)\n\
+     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+    \  let idx : i32 = i32(gid.x);\n\
+    \  let p : Point2 = pts[idx];\n\
+    \  pts[idx] = Point2((p.x * 2.0f), (p.y * 2.0f));\n\
+     }\n" ;
+
+  register_golden
+    "wgsl"
+    "variant_kernel"
+    "const OptNone : i32 = 0i;\n\
+     const OptSome : i32 = 1i;\n\n\
+     struct Opt {\n\
+    \  tag : i32,\n\
+    \  OptSome_v : f32,\n\
+     }\n\n\
+     fn make_Opt_OptNone() -> Opt {\n\
+    \  var r : Opt;\n\
+    \  r.tag = OptNone;\n\
+    \  return r;\n\
+     }\n\n\
+     fn make_Opt_OptSome(v : f32) -> Opt {\n\
+    \  var r : Opt;\n\
+    \  r.tag = OptSome;\n\
+    \  r.OptSome_v = v;\n\
+    \  return r;\n\
+     }\n\n\
+     @group(0) @binding(0) var<storage, read_write> flags : array<i32>;\n\
+     @group(0) @binding(1) var<storage, read_write> out : array<Opt>;\n\
+     struct Params {\n\
+    \  sarek_flags_length : i32,\n\
+    \  sarek_out_length : i32,\n\
+     }\n\
+     @group(0) @binding(2) var<uniform> params : Params;\n\n\
+     // Sarek-generated compute shader: variant_kernel\n\
+     @compute @workgroup_size(256, 1, 1)\n\
+     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+    \  let idx : i32 = i32(gid.x);\n\
+    \  let flag : i32 = flags[idx];\n\
+    \  if ((flag != 0i)) {\n\
+    \    out[idx] = make_Opt_OptSome(1.0f);\n\
+    \  } else {\n\
+    \    out[idx] = make_Opt_OptNone();\n\
+    \  }\n\
+     }\n" ;
+
+  register_golden
+    "wgsl"
+    "sin_kernel"
+    "@group(0) @binding(0) var<storage, read_write> a : array<f32>;\n\
+     @group(0) @binding(1) var<storage, read_write> b : array<f32>;\n\
+     struct Params {\n\
+    \  sarek_a_length : i32,\n\
+    \  sarek_b_length : i32,\n\
+     }\n\
+     @group(0) @binding(2) var<uniform> params : Params;\n\n\
+     // Sarek-generated compute shader: sin_kernel\n\
+     @compute @workgroup_size(256, 1, 1)\n\
+     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+    \  let idx : i32 = i32(gid.x);\n\
+    \  b[idx] = sin(a[idx]);\n\
+     }\n" ;
+
+  (* WGSL: sin (un-suffixed for Float32, matching GLSL/OpenCL/Metal) *)
+  register_golden
+    "wgsl"
+    "float32_sin_path"
+    "@group(0) @binding(0) var<storage, read_write> a : array<f32>;\n\
+     @group(0) @binding(1) var<storage, read_write> b : array<f32>;\n\
+     struct Params {\n\
+    \  sarek_a_length : i32,\n\
+    \  sarek_b_length : i32,\n\
+     }\n\
+     @group(0) @binding(2) var<uniform> params : Params;\n\n\
+     // Sarek-generated compute shader: float32_sin_path\n\
+     @compute @workgroup_size(256, 1, 1)\n\
+     fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+    \  let idx : i32 = i32(gid.x);\n\
     \  b[idx] = sin(a[idx]);\n\
      }\n"
 

--- a/sarek/transpile/Sarek_transpile.ml
+++ b/sarek/transpile/Sarek_transpile.ml
@@ -13,7 +13,7 @@
  ******************************************************************************)
 
 (** GPU backend selector *)
-type backend = CUDA | OpenCL | Metal | GLSL
+type backend = CUDA | OpenCL | Metal | GLSL | WGSL
 
 (** Structured error: every frontend failure is converted here — no exception
     escapes [of_source]. *)
@@ -222,10 +222,12 @@ let set_framework backend =
     | OpenCL -> "OpenCL"
     | Metal -> "Metal"
     | GLSL -> "GLSL"
+    | WGSL -> "WGSL"
   in
   Sarek_ir_cuda.current_framework := Some name ;
   Sarek_ir_opencl.current_framework := Some name ;
-  Sarek_ir_metal.current_framework := Some name
+  Sarek_ir_metal.current_framework := Some name ;
+  Sarek_ir_wgsl.current_framework := Some name
 
 let emit_backend backend (k : Sarek_ir_ppx.kernel) =
   let k_types = Sarek_ir_conv.conv_kernel k in
@@ -234,6 +236,7 @@ let emit_backend backend (k : Sarek_ir_ppx.kernel) =
   | OpenCL -> Sarek_ir_opencl.generate k_types
   | Metal -> Sarek_ir_metal.generate k_types
   | GLSL -> Sarek_ir_glsl.generate k_types
+  | WGSL -> Sarek_ir_wgsl.generate k_types
 
 (******************************************************************************)
 (* Main pipeline                                                              *)

--- a/sarek/transpile/Sarek_transpile.mli
+++ b/sarek/transpile/Sarek_transpile.mli
@@ -14,7 +14,7 @@
 *)
 
 (** GPU backend selector. *)
-type backend = CUDA | OpenCL | Metal | GLSL
+type backend = CUDA | OpenCL | Metal | GLSL | WGSL
 
 (** Structured error type. Every frontend failure is converted to one of these
     variants; no exception escapes {!of_source}. *)

--- a/sarek/transpile/web/test/webgpu_wgsl_test.mjs
+++ b/sarek/transpile/web/test/webgpu_wgsl_test.mjs
@@ -54,6 +54,8 @@ if (!hasAdapter) { await browser.close(); server.close(); skip('no WebGPU adapte
 
 const result = await page.evaluate(async () => {
   const N=256;
+  // Run a WGSL kernel. bufs entries: {name, binding, data (TypedArray), out?, uniform?}
+  // uniform:true → GPUBufferUsage.UNIFORM (no STORAGE); used for Params struct.
   async function runWGSL(wgsl, bufs){
     const ad=await navigator.gpu.requestAdapter({powerPreference:'high-performance'});
     const dev=await ad.requestDevice();
@@ -63,7 +65,14 @@ const result = await page.evaluate(async () => {
     if(es.length) return {err:'compile: '+es.map(e=>e.message+' @line'+e.lineNum).join(' | ')};
     const pipe=dev.createComputePipeline({layout:'auto',compute:{module:mod,entryPoint:'main'}});
     const gb={}, rb={};
-    for(const b of bufs){ gb[b.binding]=dev.createBuffer({size:b.data.byteLength,usage:GPUBufferUsage.STORAGE|GPUBufferUsage.COPY_DST|GPUBufferUsage.COPY_SRC}); dev.queue.writeBuffer(gb[b.binding],0,b.data); if(b.out) rb[b.binding]=dev.createBuffer({size:b.data.byteLength,usage:GPUBufferUsage.COPY_DST|GPUBufferUsage.MAP_READ}); }
+    for(const b of bufs){
+      const usage = b.uniform
+        ? GPUBufferUsage.UNIFORM|GPUBufferUsage.COPY_DST
+        : GPUBufferUsage.STORAGE|GPUBufferUsage.COPY_DST|GPUBufferUsage.COPY_SRC;
+      gb[b.binding]=dev.createBuffer({size:b.data.byteLength,usage});
+      dev.queue.writeBuffer(gb[b.binding],0,b.data);
+      if(b.out) rb[b.binding]=dev.createBuffer({size:b.data.byteLength,usage:GPUBufferUsage.COPY_DST|GPUBufferUsage.MAP_READ});
+    }
     const bg=dev.createBindGroup({layout:pipe.getBindGroupLayout(0),entries:bufs.map(b=>({binding:b.binding,resource:{buffer:gb[b.binding]}}))});
     const enc=dev.createCommandEncoder(); const p=enc.beginComputePass(); p.setPipeline(pipe); p.setBindGroup(0,bg); p.dispatchWorkgroups(1); p.end();
     for(const b of bufs) if(b.out) enc.copyBufferToBuffer(gb[b.binding],0,rb[b.binding],0,b.data.byteLength);
@@ -75,11 +84,25 @@ const result = await page.evaluate(async () => {
   const a=new Float32Array(N), b=new Float32Array(N);
   for(let i=0;i<N;i++){a[i]=i*0.5; b[i]=i*2.0;}
   const out=[];
+  // Set up scalar uniform data for bounds_check (Params struct: 3 × i32)
+  // Layout: sarek_a_length, sarek_b_length, n  (each i32 = 4 bytes = 12 bytes total)
+  const BC_N = N/2; // half array in-bounds
+  const paramsBC = new Int32Array([N, N, BC_N]); // a_len=N, b_len=N, n=BC_N
   const cases=[
     {k:'vector_add', src:"fun (a:float32 vector)(b:float32 vector)(c:float32 vector) -> let i = global_thread_id in c.(i) <- a.(i) +. b.(i)",
      bufs:[{name:'a',binding:0,data:a.slice()},{name:'b',binding:1,data:b.slice()},{name:'c',binding:2,data:new Float32Array(N),out:true}], ref:i=>a[i]+b[i], outName:'c'},
     {k:'sin', src:"fun (a:float32 vector)(b:float32 vector) -> let i = global_thread_id in b.(i) <- Float32.sin a.(i)",
      bufs:[{name:'a',binding:0,data:a.slice()},{name:'b',binding:1,data:new Float32Array(N),out:true}], ref:i=>Math.sin(a[i]), outName:'b'},
+    // bounds_check: exercises EIf → select(else,then,cond) fix.
+    // Kernel: b.(i) <- if i < n then a.(i) else 0.0
+    // Expected: b[i] = a[i] for i < BC_N, else 0.0
+    {k:'bounds_check',
+     src:"fun (a:float32 vector)(b:float32 vector)(n:int32) -> let i = global_thread_id in b.(i) <- (if i < n then a.(i) else 0.0)",
+     bufs:[
+       {name:'a',binding:0,data:a.slice()},
+       {name:'b',binding:1,data:new Float32Array(N),out:true},
+       {name:'params',binding:2,data:paramsBC,uniform:true}
+     ], ref:i=>(i<BC_N?a[i]:0.0), outName:'b'},
   ];
   for(const c of cases){
     const r=T(c.src,"wgsl");

--- a/sarek/transpile/web/test/webgpu_wgsl_test.mjs
+++ b/sarek/transpile/web/test/webgpu_wgsl_test.mjs
@@ -1,0 +1,98 @@
+// WGSL backend acceptance test: transpile kernels to WGSL and run them on a
+// real GPU via WebGPU in a Playwright-driven Chrome (Dawn/Vulkan). Validates
+// that the generated WGSL compiles AND computes correctly against a CPU
+// reference. Skips gracefully (exit 0) where playwright/chrome/WebGPU are
+// unavailable; only FAILS on a real wrong result or compile error.
+//
+// Usage: node sarek/transpile/web/test/webgpu_wgsl_test.mjs [bundle.bc.js]
+import http from 'http';
+import fs from 'fs';
+import { createRequire } from 'module';
+import { execSync } from 'child_process';
+
+function resolvePlaywright() {
+  const reqHere = createRequire(import.meta.url);
+  const candidates = [];
+  try { candidates.push(execSync('npm root -g').toString().trim()); } catch {}
+  try { candidates.push(...execSync('ls -d /home/*/.npm/_npx/*/node_modules 2>/dev/null').toString().trim().split('\n')); } catch {}
+  for (const base of candidates.filter(Boolean)) {
+    try { return createRequire(base + '/x')('playwright'); } catch {}
+  }
+  try { return reqHere('playwright'); } catch {}
+  return null;
+}
+function skip(msg){ console.log('SKIP: ' + msg); process.exit(0); }
+
+const pw = resolvePlaywright();
+if (!pw) skip('playwright not resolvable');
+const { chromium } = pw;
+
+const BUNDLE = process.argv[2] || '_build/default/sarek/transpile/web/transpile_js.bc.js';
+if (!fs.existsSync(BUNDLE)) skip('bundle not built: ' + BUNDLE);
+const bundleJs = fs.readFileSync(BUNDLE);
+
+const html = `<!doctype html><meta charset=utf-8><title>wgsl-test</title><script src="/b.js"></script>`;
+const server = http.createServer((req,res)=>{
+  if (req.url==='/b.js'){res.setHeader('content-type','text/javascript');res.end(bundleJs);}
+  else {res.setHeader('content-type','text/html');res.end(html);}
+});
+await new Promise(r=>server.listen(0,r));
+const port = server.address().port;
+
+let browser;
+try {
+  browser = await chromium.launch({ headless:true, channel:'chrome',
+    args:['--enable-unsafe-webgpu','--enable-features=Vulkan','--use-angle=vulkan','--use-gl=angle','--ignore-gpu-blocklist','--no-sandbox'] });
+} catch (e) { server.close(); skip('chrome launch failed: ' + e.message); }
+
+const page = await browser.newPage();
+await page.goto(`http://localhost:${port}/`, {waitUntil:'load'});
+await page.waitForFunction(()=>typeof globalThis.SarekTranspile!=='undefined', {timeout:20000});
+
+const hasAdapter = await page.evaluate(async()=> !!(navigator.gpu && await navigator.gpu.requestAdapter({powerPreference:'high-performance'})));
+if (!hasAdapter) { await browser.close(); server.close(); skip('no WebGPU adapter in this Chrome'); }
+
+const result = await page.evaluate(async () => {
+  const N=256;
+  async function runWGSL(wgsl, bufs){
+    const ad=await navigator.gpu.requestAdapter({powerPreference:'high-performance'});
+    const dev=await ad.requestDevice();
+    const mod=dev.createShaderModule({code:wgsl});
+    const ci=await mod.getCompilationInfo();
+    const es=ci.messages.filter(m=>m.type==='error');
+    if(es.length) return {err:'compile: '+es.map(e=>e.message+' @line'+e.lineNum).join(' | ')};
+    const pipe=dev.createComputePipeline({layout:'auto',compute:{module:mod,entryPoint:'main'}});
+    const gb={}, rb={};
+    for(const b of bufs){ gb[b.binding]=dev.createBuffer({size:b.data.byteLength,usage:GPUBufferUsage.STORAGE|GPUBufferUsage.COPY_DST|GPUBufferUsage.COPY_SRC}); dev.queue.writeBuffer(gb[b.binding],0,b.data); if(b.out) rb[b.binding]=dev.createBuffer({size:b.data.byteLength,usage:GPUBufferUsage.COPY_DST|GPUBufferUsage.MAP_READ}); }
+    const bg=dev.createBindGroup({layout:pipe.getBindGroupLayout(0),entries:bufs.map(b=>({binding:b.binding,resource:{buffer:gb[b.binding]}}))});
+    const enc=dev.createCommandEncoder(); const p=enc.beginComputePass(); p.setPipeline(pipe); p.setBindGroup(0,bg); p.dispatchWorkgroups(1); p.end();
+    for(const b of bufs) if(b.out) enc.copyBufferToBuffer(gb[b.binding],0,rb[b.binding],0,b.data.byteLength);
+    dev.queue.submit([enc.finish()]);
+    const o={}; for(const b of bufs) if(b.out){ await rb[b.binding].mapAsync(GPUMapMode.READ); o[b.name]=Array.from(new Float32Array(rb[b.binding].getMappedRange().slice(0))); }
+    return {o};
+  }
+  const T=globalThis.SarekTranspile.transpile;
+  const a=new Float32Array(N), b=new Float32Array(N);
+  for(let i=0;i<N;i++){a[i]=i*0.5; b[i]=i*2.0;}
+  const out=[];
+  const cases=[
+    {k:'vector_add', src:"fun (a:float32 vector)(b:float32 vector)(c:float32 vector) -> let i = global_thread_id in c.(i) <- a.(i) +. b.(i)",
+     bufs:[{name:'a',binding:0,data:a.slice()},{name:'b',binding:1,data:b.slice()},{name:'c',binding:2,data:new Float32Array(N),out:true}], ref:i=>a[i]+b[i], outName:'c'},
+    {k:'sin', src:"fun (a:float32 vector)(b:float32 vector) -> let i = global_thread_id in b.(i) <- Float32.sin a.(i)",
+     bufs:[{name:'a',binding:0,data:a.slice()},{name:'b',binding:1,data:new Float32Array(N),out:true}], ref:i=>Math.sin(a[i]), outName:'b'},
+  ];
+  for(const c of cases){
+    const r=T(c.src,"wgsl");
+    if(!r.ok){ out.push({k:c.k,ok:false,why:'transpile: '+r.error}); continue; }
+    const run=await runWGSL(r.code,c.bufs);
+    if(run.err){ out.push({k:c.k,ok:false,why:run.err}); continue; }
+    let bad=0; for(let i=0;i<N;i++) if(Math.abs(run.o[c.outName][i]-c.ref(i))>1e-4) bad++;
+    out.push({k:c.k,ok:bad===0,bad});
+  }
+  return out;
+});
+console.log(JSON.stringify(result));
+await browser.close(); server.close();
+const allok = Array.isArray(result) && result.length>0 && result.every(r=>r.ok);
+console.log(allok ? 'WGSL-GPU: ALL PASS ✓' : 'WGSL-GPU: FAILURE ✗');
+process.exit(allok?0:1);

--- a/sarek/transpile/web/transpile_js.ml
+++ b/sarek/transpile/web/transpile_js.ml
@@ -17,6 +17,7 @@ let backend_of_string s =
   | "opencl" -> Some Sarek_transpile.OpenCL
   | "metal" -> Some Sarek_transpile.Metal
   | "glsl" -> Some Sarek_transpile.GLSL
+  | "wgsl" -> Some Sarek_transpile.WGSL
   | _ -> None
 
 let transpile source backend_str =
@@ -33,7 +34,7 @@ let transpile source backend_str =
         (Js.some
            (Js.string
               (Printf.sprintf
-                 "unknown backend %S; expected cuda|opencl|metal|glsl"
+                 "unknown backend %S; expected cuda|opencl|metal|glsl|wgsl"
                  backend_str)))
   | Some backend -> (
       match Sarek_transpile.of_source backend source with
@@ -65,5 +66,6 @@ let () =
          Js.string "opencl";
          Js.string "metal";
          Js.string "glsl";
+         Js.string "wgsl";
        |]) ;
   Js.Unsafe.set Js.Unsafe.global "SarekTranspile" module_obj


### PR DESCRIPTION
## WGSL backend — the Level-2 (in-browser GPU) cornerstone

Adds a 5th codegen backend, **WGSL** (WebGPU Shading Language), to the pure FFI-free `sarek_codegen`, so the transpiler can emit compute shaders that run in the browser via WebGPU. Roadmap: `docs/plans/roadmap-2026-06-03.md`.

### Changes
- **`sarek/codegen/Sarek_ir_wgsl.ml`** (new, mirrors the GLSL generator) — IR → WGSL compute shader. Strict-typing handled: explicit `f32()`/`i32()` conversions, `vec3<u32>` `global_invocation_id` → `i32` thread ids, scalar params packed into a `uniform struct Params`, storage buffers `@group(0) @binding(N) var<storage,read_write> … : array<T>`, `@compute @workgroup_size(...)`. **Float64 → structured "unsupported" error** (WebGPU has no f64) — never invalid WGSL.
- Wired into `Sarek_transpile` (`backend … | WGSL`), the jsoo shim (`"wgsl"`), and the playground backend dropdown.
- **Goldens**: `gen_wgsl.real.ml` + a WGSL column → 25 tests (5 backends × 5 kernels). The existing CUDA/OpenCL/Metal/GLSL goldens are **byte-identical** (additive only); `sarek_codegen` stays FFI-free.

### GPU acceptance via Playwright (`make wgsl-gpu-test`)
`sarek/transpile/web/test/webgpu_wgsl_test.mjs` launches Chrome with WebGPU/Vulkan flags (Dawn → **RX 7900 XTX**), loads the jsoo bundle, transpiles `vector_add` + `Float32.sin` to WGSL, runs them through WebGPU, and verifies the GPU output vs a CPU reference. **Both PASS** (256 elements, exact). Skips gracefully where playwright/Chrome/WebGPU are unavailable.

### Gates
- `@sarek/tests/runtest` — 25/25 goldens; existing 4 backends byte-identical
- `make wgsl-gpu-test` — vector_add + sin verified on the real GPU (Playwright/WebGPU)
- `test_transpile_proof` pass; `transpile_js.bc.js` builds with WGSL; `@fmt` clean
- GPU benchmark regression check — 80/80 verified (existing backends unaffected)

### Known follow-ups (non-blocking)
- `block_dim_*`/`grid_dim_*` intrinsics emit constants (WGSL has no equivalent builtins) — kernels depending on dynamic grid dims need the ABI/runner to pass them; `SWarpBarrier` → `subgroupBarrier()` needs the subgroups feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WGSL backend now available in the transpiler.
  * Playground supports WGSL as a selectable backend.

* **Tests**
  * Added golden snapshot coverage for WGSL output.
  * Added an end-to-end WebGPU GPU execution acceptance test.

* **Chores**
  * Added a Makefile target to run the WGSL GPU acceptance test.
  * Updated .gitignore for scaffolding and session artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->