### PR TITLE
Matmul bench: relative verification tolerance (correct at large sizes)

### DIFF
--- a/benchmarks/bench_matrix_mul.ml
+++ b/benchmarks/bench_matrix_mul.ml
@@ -128,7 +128,9 @@ let benchmark_device dev size config =
 
   let verify (_va, _vb, vc) =
     let result_array = Vector.to_array vc in
-    Common.arrays_equal ~epsilon:0.001 result_array expected
+    (* Relative tolerance: float32 GPU result vs float64 reference, error grows
+       with K. See Common.arrays_close. *)
+    Common.arrays_close ~rel:1e-3 ~abs_floor:1e-3 result_array expected
   in
 
   let times, verified =

--- a/benchmarks/bench_matrix_mul_tiled.ml
+++ b/benchmarks/bench_matrix_mul_tiled.ml
@@ -190,12 +190,18 @@ let benchmark_device dev size config =
   (* Copy result back *)
   let result = Vector.to_array vc in
 
-  (* Verify correctness *)
-  let tolerance = 0.001 in
+  (* Verify correctness with a relative tolerance: the float32 GPU result is
+     compared against a float64 reference and the rounding error grows with K
+     (a fixed absolute epsilon fails at large sizes). *)
+  let rel = 1e-3 and abs_floor = 1e-3 in
   let verify_result () =
     try
       for i = 0 to (m * n) - 1 do
         let diff = abs_float (result.(i) -. expected.(i)) in
+        let tolerance =
+          (rel *. Float.max (abs_float result.(i)) (abs_float expected.(i)))
+          +. abs_floor
+        in
         if diff > tolerance then
           failwith
             (Printf.sprintf

--- a/benchmarks/common.ml
+++ b/benchmarks/common.ml
@@ -111,6 +111,29 @@ let arrays_equal ~epsilon a b =
       a ;
     !errors = 0
 
+(** Relative-tolerance comparison: element [i] passes when
+    [|a.(i) -. b.(i)| <= rel *. max |a.(i)| |b.(i)| +. abs_floor].
+
+    Use this for reductions / matrix products, where the float32 GPU result is
+    compared against a float64 reference and the absolute rounding error grows
+    with the accumulation length (≈ K·2⁻²⁴·|value| for a K-term dot product). A
+    fixed absolute epsilon cannot hold across sizes; a relative tolerance can.
+    [abs_floor] keeps near-zero entries from requiring impossible precision. *)
+let arrays_close ~rel ~abs_floor a b =
+  if Array.length a <> Array.length b then false
+  else begin
+    let ok = ref true in
+    Array.iteri
+      (fun i va ->
+        let vb = b.(i) in
+        let tol =
+          (rel *. Float.max (abs_float va) (abs_float vb)) +. abs_floor
+        in
+        if abs_float (va -. vb) > tol then ok := false)
+      a ;
+    !ok
+  end
+
 let arrays_equal_verbose ~epsilon a b =
   if Array.length a <> Array.length b then (
     Printf.printf


### PR DESCRIPTION
## Matmul bench: relative verification tolerance

Fixes the matmul benchmarks reporting `verified: false` at large sizes (e.g. `size=2048`), which made `make bench-gpu-check` (default size 2048) fail on **every** backend including the CPU device.

### Root cause
The verifiers compared the **float32** GPU result against a **float64** OCaml reference using a fixed **absolute** epsilon (`0.001`). For `C = A·B`, both the result and its float32 accumulation error grow with the contraction length `K` (≈ `K·2⁻²⁴·|C|`). With inputs in `[0, 0.9]`, `C ≈ 0.2·K`: at K=2048 the error is ≈ 0.05 (≫ 0.001) → fails; at K=256 it's ≈ 8e-4 → passes. A fixed absolute epsilon simply cannot hold across sizes.

### Fix
- `Common.arrays_close ~rel ~abs_floor`: passes when `|a-b| ≤ rel·max(|a|,|b|) + abs_floor`.
- Use it in `bench_matrix_mul` (naive) and `bench_matrix_mul_tiled` with `rel=1e-3`, `abs_floor=1e-3` (≈ 8× margin over the expected float32 matmul error; `abs_floor` covers near-zero entries).

### Verification (RX 7900 XTX + RADV + Ryzen CPU)
- Both kernels verify at **256 and 2048** on all 4 backends (16/16).
- Full `make bench-gpu-check` at the default `size=2048`: **79/79 verified ✓** (was 8 verify-fails).

Benchmark-only change; no codegen/runtime/generated-source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark verification logic for matrix multiplication to use tolerance-based floating-point comparison instead of exact element matching.
  * Enhanced floating-point array comparison utility with configurable relative and absolute tolerance thresholds for improved numerical validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->