### PR TITLE
Phase 2: Interactive GPU course pages (numeric + Mandelbrot + image filter)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,6 +402,13 @@ wgsl-gpu-test:
 	@dune build sarek/transpile/web/transpile_js.bc.js
 	@node sarek/transpile/web/test/webgpu_wgsl_test.mjs _build/default/sarek/transpile/web/transpile_js.bc.js
 
+# Interactive GPU course page acceptance test: for each lesson inject correct
+# and wrong kernel bodies and assert PASS/FAIL. Skips where playwright/chrome/
+# WebGPU are unavailable; fails on a real wrong GPU result.
+lessons-gpu-test:
+	@dune build sarek/transpile/web/transpile_js.bc.js
+	@node gh-pages/learn/test/lessons_gpu_test.mjs _build/default/sarek/transpile/web/transpile_js.bc.js
+
 bench-update:
 	@echo "Running benchmarks and updating web data..."
 	@./benchmarks/run_all_benchmarks.sh results

--- a/gh-pages/_layouts/index.html
+++ b/gh-pages/_layouts/index.html
@@ -27,6 +27,7 @@
           <a href="{{ site.baseurl }}/benchmarks/">Benchmarks</a>
           <a href="{{ site.baseurl }}/examples/">Examples</a>
           <a href="{{ site.baseurl }}/playground.html">Playground</a>
+          <a href="{{ site.baseurl }}/learn/">Learn</a>
           <div class="nav-dropdown">
             <button type="button" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="docs-menu">Docs ▾</button>
             <div class="dropdown-menu" id="docs-menu">

--- a/gh-pages/_layouts/page.html
+++ b/gh-pages/_layouts/page.html
@@ -27,6 +27,7 @@
           <a href="{{ site.baseurl }}/benchmarks/">Benchmarks</a>
           <a href="{{ site.baseurl }}/examples/">Examples</a>
           <a href="{{ site.baseurl }}/playground.html">Playground</a>
+          <a href="{{ site.baseurl }}/learn/">Learn</a>
           <div class="nav-dropdown">
             <button type="button" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="docs-menu">Docs ▾</button>
             <div class="dropdown-menu" id="docs-menu">

--- a/gh-pages/javascripts/sarek_lesson.js
+++ b/gh-pages/javascripts/sarek_lesson.js
@@ -73,6 +73,23 @@
     var canvasEl      = cfg.canvasId      ? document.getElementById(cfg.canvasId)      : null;
     var inputCanvasEl = cfg.inputCanvasId ? document.getElementById(cfg.inputCanvasId) : null;
 
+    // ── Dependency check: the runner script must have loaded ───────────
+    // (Distinct from "no adapter" — a missing asset is a page error, not a
+    // browser-capability message.)
+    if (typeof globalThis.SarekWebGPU === 'undefined' ||
+        typeof globalThis.SarekWebGPU.getAdapter !== 'function') {
+      if (outputEl) {
+        outputEl.className = 'lesson-output error-output';
+        outputEl.textContent =
+          'Failed to load the WebGPU runner (sarek_webgpu_runner.js) — ' +
+          'please reload the page.';
+      }
+      if (runBtn) runBtn.disabled = true;
+      if (statusEl) statusEl.textContent = 'Runner failed to load';
+      setupEditor(editorEl, cfg.starter);
+      return;
+    }
+
     // ── WebGPU availability check ──────────────────────────────────────
     var adapter = null;
     try {
@@ -123,7 +140,14 @@
       canvasEl: canvasEl, inputCanvasEl: inputCanvasEl,
     };
     if (runBtn) {
-      runBtn.addEventListener('click', function () { runLesson(getSource(), env); });
+      // Serialize runs: disable the button while one is in flight so a slower
+      // stale run cannot overwrite a newer PASS/FAIL result.
+      runBtn.addEventListener('click', async function () {
+        if (runBtn.disabled) return;
+        runBtn.disabled = true;
+        try { await runLesson(getSource(), env); }
+        finally { runBtn.disabled = false; }
+      });
     }
     // For visual lessons, render the input preview immediately (if provided).
     if (typeof cfg.renderInput === 'function') {

--- a/gh-pages/javascripts/sarek_lesson.js
+++ b/gh-pages/javascripts/sarek_lesson.js
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: CECILL-B
+// SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+//
+// sarek_lesson.js — reusable harness for interactive Sarek GPU course pages.
+//
+// Exposes globalThis.SarekLesson with:
+//   SarekLesson.init(cfg) — wire one lesson page
+//
+// Per-lesson cfg shape (all fields required unless marked optional):
+//
+//   SarekLesson.init({
+//     editorId,      // id of the <textarea> to upgrade to CodeMirror
+//     runButtonId,   // id of the Run <button>
+//     outputId,      // id of the result/output element  (class lesson-output)
+//     statusId,      // id of the status-bar <span>      (class lesson-status)
+//     wgslId,        // id of the <pre> that shows generated WGSL
+//     wgslToggleId,  // id of the "Show WGSL" <button>
+//     n: 256,        // dataset size (number of elements per buffer)
+//     starter: "fun (a:float32 vector) ...",  // initial kernel source
+//     buffers: {
+//       a: { role: 'input',  elementType: 'f32', gen: i => i * 0.5 },
+//       b: { role: 'input',  elementType: 'f32', gen: i => i * 2.0 },
+//       c: { role: 'output', elementType: 'f32' },  // gen omitted → zeros
+//     },
+//     scalars: { /* name: value */ },   // optional, default {}
+//     outName: 'c',                     // key in outputs to grade
+//     reference: (i, inputs, scalars) => inputs.a[i] + inputs.b[i],
+//     tolerance: { rel: 1e-3, absFloor: 1e-3 },  // optional
+//   });
+//
+// Dependencies (loaded by the page before this script):
+//   - sarek_transpile.js  → globalThis.SarekTranspile.transpileWithAbi
+//   - sarek_webgpu_runner.js → globalThis.SarekWebGPU.getAdapter / .run
+//   - CodeMirror 5 (cdnjs) — optional; degrades to plain <textarea> if absent
+//   - learn.css — for .lesson-output / .pass-output / .fail-output / etc.
+
+(function () {
+  'use strict';
+
+  // ── Typed-array constructor for ABI element types ──────────────────────
+  function typedArrayCtor(elementType) {
+    if (elementType === 'f32') return Float32Array;
+    if (elementType === 'i32') return Int32Array;
+    if (elementType === 'u32') return Uint32Array;
+    throw new Error('SarekLesson: unknown elementType: ' + elementType);
+  }
+
+  // ── Relative-tolerance comparison ─────────────────────────────────────
+  //   |got - ref| <= rel * max(|got|, |ref|) + absFloor
+  function withinTolerance(got, ref, rel, absFloor) {
+    var diff = Math.abs(got - ref);
+    var scale = Math.max(Math.abs(got), Math.abs(ref));
+    return diff <= rel * scale + absFloor;
+  }
+
+  // ── Main init ─────────────────────────────────────────────────────────
+  async function init(cfg) {
+    var n          = cfg.n || 256;
+    var buffers    = cfg.buffers || {};
+    var scalars    = cfg.scalars || {};
+    var tol        = cfg.tolerance || {};
+    var rel        = tol.rel      !== undefined ? tol.rel      : 1e-3;
+    var absFloor   = tol.absFloor !== undefined ? tol.absFloor : 1e-3;
+
+    var editorEl    = document.getElementById(cfg.editorId);
+    var runBtn      = document.getElementById(cfg.runButtonId);
+    var outputEl    = document.getElementById(cfg.outputId);
+    var statusEl    = document.getElementById(cfg.statusId);
+    var wgslPre     = document.getElementById(cfg.wgslId);
+    var wgslToggle  = document.getElementById(cfg.wgslToggleId);
+
+    // ── WebGPU availability check ──────────────────────────────────────
+    var adapter = null;
+    try {
+      adapter = await globalThis.SarekWebGPU.getAdapter();
+    } catch (_) {}
+
+    if (!adapter) {
+      if (outputEl) {
+        outputEl.className = 'lesson-output';
+        outputEl.textContent =
+          'WebGPU not available in this browser — try Chrome or Edge with ' +
+          'WebGPU enabled (chrome://flags/#enable-unsafe-webgpu). ' +
+          'The lesson text above is still readable.';
+      }
+      if (runBtn) runBtn.disabled = true;
+      if (statusEl) statusEl.textContent = 'WebGPU unavailable';
+      // Still set up the editor so the starter code is visible.
+      if (editorEl && cfg.starter) editorEl.value = cfg.starter;
+      setupEditor(editorEl, cfg.starter);
+      return;
+    }
+
+    // ── Editor setup ──────────────────────────────────────────────────
+    var cm = setupEditor(editorEl, cfg.starter);
+
+    function getSource() {
+      return cm ? cm.getValue() : (editorEl ? editorEl.value : '');
+    }
+
+    // ── WGSL toggle ───────────────────────────────────────────────────
+    var wgslVisible = false;
+    if (wgslPre) wgslPre.style.display = 'none';
+    if (wgslToggle) {
+      wgslToggle.addEventListener('click', function () {
+        wgslVisible = !wgslVisible;
+        if (wgslPre) wgslPre.style.display = wgslVisible ? 'block' : 'none';
+        wgslToggle.textContent = wgslVisible ? 'Hide WGSL' : 'Show generated WGSL';
+      });
+    }
+
+    // ── Run handler ───────────────────────────────────────────────────
+    if (runBtn) {
+      runBtn.addEventListener('click', function () {
+        runLesson(
+          getSource(), n, buffers, scalars, cfg.outName, cfg.reference,
+          rel, absFloor, outputEl, statusEl, wgslPre
+        );
+      });
+    }
+  }
+
+  // ── Editor upgrade (CodeMirror 5 or textarea fallback) ────────────────
+  function setupEditor(el, starter) {
+    if (!el) return null;
+    if (starter !== undefined) el.value = starter;
+    if (typeof CodeMirror === 'undefined') return null;
+    return CodeMirror.fromTextArea(el, {
+      mode:          'text/x-ocaml',
+      lineNumbers:   true,
+      lineWrapping:  true,
+      viewportMargin: Infinity,
+      tabSize:       2,
+    });
+  }
+
+  // ── Core run/grade logic ──────────────────────────────────────────────
+  async function runLesson(
+    source, n, buffersCfg, scalarsCfg, outName, reference,
+    rel, absFloor, outputEl, statusEl, wgslPre
+  ) {
+    function setStatus(msg) { if (statusEl) statusEl.textContent = msg; }
+    function setOutput(cls, msg) {
+      if (!outputEl) return;
+      outputEl.className = 'lesson-output' + (cls ? ' ' + cls : '');
+      outputEl.textContent = msg;
+    }
+
+    // 1. Transpile
+    if (typeof globalThis.SarekTranspile === 'undefined') {
+      setOutput('error-output', 'Transpiler not loaded — please reload the page.');
+      return;
+    }
+    setStatus('Transpiling...');
+    var result = globalThis.SarekTranspile.transpileWithAbi(source, 'wgsl');
+    if (!result.ok) {
+      setOutput('error-output', 'Transpile error:\n' + (result.error || 'unknown error'));
+      setStatus('Transpile error');
+      return;
+    }
+
+    // Show generated WGSL if the pre element exists.
+    if (wgslPre) wgslPre.textContent = result.code;
+
+    // 2. Build inputs from cfg + ABI
+    var abi    = result.abi;
+    var code   = result.code;
+    var inputs = {};
+
+    for (var bufName in buffersCfg) {
+      if (!Object.prototype.hasOwnProperty.call(buffersCfg, bufName)) continue;
+      var bcfg = buffersCfg[bufName];
+
+      // Determine elementType: prefer ABI (authoritative) then cfg fallback.
+      var abiBuf = null;
+      if (abi && abi.buffers) {
+        for (var bi = 0; bi < abi.buffers.length; bi++) {
+          if (abi.buffers[bi].name === bufName) { abiBuf = abi.buffers[bi]; break; }
+        }
+      }
+      var elemType = (abiBuf && abiBuf.elementType) ? abiBuf.elementType : (bcfg.elementType || 'f32');
+      var Ctor = typedArrayCtor(elemType);
+      var arr  = new Ctor(n);
+
+      if (bcfg.role === 'input' && typeof bcfg.gen === 'function') {
+        for (var i = 0; i < n; i++) arr[i] = bcfg.gen(i);
+      }
+      // outputs start as zeros (already zero-initialised by TypedArray)
+      inputs[bufName] = arr;
+    }
+
+    // 3. Run on GPU
+    setStatus('Running on GPU...');
+    var runResult;
+    try {
+      runResult = await globalThis.SarekWebGPU.run(code, abi, { inputs: inputs, scalars: scalarsCfg });
+    } catch (e) {
+      setOutput('error-output', 'GPU run error:\n' + e.message);
+      setStatus('GPU error');
+      return;
+    }
+
+    // 4. Grade
+    var gpuOut = runResult.outputs[outName];
+    if (!gpuOut) {
+      setOutput('error-output', 'Output buffer "' + outName + '" not found in GPU results.');
+      setStatus('Grading error');
+      return;
+    }
+
+    var firstBad = -1;
+    var badGot, badRef;
+    for (var idx = 0; idx < n; idx++) {
+      var ref = reference(idx, inputs, scalarsCfg);
+      var got = gpuOut[idx];
+      if (!withinTolerance(got, ref, rel, absFloor)) {
+        firstBad = idx;
+        badGot = got;
+        badRef = ref;
+        break;
+      }
+    }
+
+    if (firstBad === -1) {
+      setOutput('pass-output', 'PASS — all ' + n + ' elements match the CPU reference.');
+      setStatus('PASS');
+    } else {
+      setOutput(
+        'fail-output',
+        'FAIL at index ' + firstBad +
+          ': expected ' + badRef.toPrecision(6) +
+          ', got ' + badGot.toPrecision(6)
+      );
+      setStatus('FAIL');
+    }
+  }
+
+  globalThis.SarekLesson = { init: init };
+})();

--- a/gh-pages/javascripts/sarek_lesson.js
+++ b/gh-pages/javascripts/sarek_lesson.js
@@ -55,7 +55,9 @@
 
   // ── Main init ─────────────────────────────────────────────────────────
   async function init(cfg) {
-    var n          = cfg.n || 256;
+    var width      = cfg.width  || 0;
+    var height     = cfg.height || 0;
+    var n          = cfg.n || (width && height ? width * height : 256);
     var buffers    = cfg.buffers || {};
     var scalars    = cfg.scalars || {};
     var tol        = cfg.tolerance || {};
@@ -68,6 +70,8 @@
     var statusEl    = document.getElementById(cfg.statusId);
     var wgslPre     = document.getElementById(cfg.wgslId);
     var wgslToggle  = document.getElementById(cfg.wgslToggleId);
+    var canvasEl      = cfg.canvasId      ? document.getElementById(cfg.canvasId)      : null;
+    var inputCanvasEl = cfg.inputCanvasId ? document.getElementById(cfg.inputCanvasId) : null;
 
     // ── WebGPU availability check ──────────────────────────────────────
     var adapter = null;
@@ -110,13 +114,20 @@
     }
 
     // ── Run handler ───────────────────────────────────────────────────
+    var env = {
+      n: n, width: width, height: height, buffers: buffers, scalars: scalars,
+      outName: cfg.outName, reference: cfg.reference, rel: rel, absFloor: absFloor,
+      maxBadFraction: cfg.maxBadFraction || 0,
+      makeInputs: cfg.makeInputs, colormap: cfg.colormap, onResult: cfg.onResult,
+      outputEl: outputEl, statusEl: statusEl, wgslPre: wgslPre,
+      canvasEl: canvasEl, inputCanvasEl: inputCanvasEl,
+    };
     if (runBtn) {
-      runBtn.addEventListener('click', function () {
-        runLesson(
-          getSource(), n, buffers, scalars, cfg.outName, cfg.reference,
-          rel, absFloor, outputEl, statusEl, wgslPre
-        );
-      });
+      runBtn.addEventListener('click', function () { runLesson(getSource(), env); });
+    }
+    // For visual lessons, render the input preview immediately (if provided).
+    if (typeof cfg.renderInput === 'function') {
+      try { cfg.renderInput({ n: n, width: width, height: height, canvas: inputCanvasEl }); } catch (_) {}
     }
   }
 
@@ -134,11 +145,55 @@
     });
   }
 
-  // ── Core run/grade logic ──────────────────────────────────────────────
-  async function runLesson(
-    source, n, buffersCfg, scalarsCfg, outName, reference,
-    rel, absFloor, outputEl, statusEl, wgslPre
-  ) {
+  // ── Build inputs: per-buffer gen, or a whole-image makeInputs override ──
+  function buildInputs(env, abi) {
+    if (typeof env.makeInputs === 'function') {
+      // Visual/image lessons own input construction (e.g. RGB channels or an
+      // uploaded photo). Must return { name: TypedArray } for every storage
+      // buffer in the ABI (outputs included, zero-filled).
+      return env.makeInputs({ n: env.n, width: env.width, height: env.height });
+    }
+    var inputs = {};
+    var buffersCfg = env.buffers;
+    for (var bufName in buffersCfg) {
+      if (!Object.prototype.hasOwnProperty.call(buffersCfg, bufName)) continue;
+      var bcfg = buffersCfg[bufName];
+      var abiBuf = null;
+      if (abi && abi.buffers) {
+        for (var bi = 0; bi < abi.buffers.length; bi++) {
+          if (abi.buffers[bi].name === bufName) { abiBuf = abi.buffers[bi]; break; }
+        }
+      }
+      var elemType = (abiBuf && abiBuf.elementType) ? abiBuf.elementType : (bcfg.elementType || 'f32');
+      var Ctor = typedArrayCtor(elemType);
+      var arr  = new Ctor(env.n);
+      if (bcfg.role === 'input' && typeof bcfg.gen === 'function') {
+        for (var i = 0; i < env.n; i++) arr[i] = bcfg.gen(i);
+      }
+      inputs[bufName] = arr;  // outputs stay zero
+    }
+    return inputs;
+  }
+
+  // ── Render a single float output buffer to a canvas via a colormap ─────
+  function renderColormap(canvas, data, width, height, colormap) {
+    if (!canvas) return;
+    canvas.width = width; canvas.height = height;
+    var ctx = canvas.getContext('2d');
+    var img = ctx.createImageData(width, height);
+    for (var i = 0; i < width * height; i++) {
+      var rgb = colormap(data[i], i);
+      img.data[i * 4]     = rgb[0];
+      img.data[i * 4 + 1] = rgb[1];
+      img.data[i * 4 + 2] = rgb[2];
+      img.data[i * 4 + 3] = 255;
+    }
+    ctx.putImageData(img, 0, 0);
+  }
+
+  // ── Core run logic: transpile → build inputs → run → grade + render ────
+  async function runLesson(source, env) {
+    var outputEl = env.outputEl, statusEl = env.statusEl, wgslPre = env.wgslPre;
     function setStatus(msg) { if (statusEl) statusEl.textContent = msg; }
     function setOutput(cls, msg) {
       if (!outputEl) return;
@@ -146,7 +201,6 @@
       outputEl.textContent = msg;
     }
 
-    // 1. Transpile
     if (typeof globalThis.SarekTranspile === 'undefined') {
       setOutput('error-output', 'Transpiler not loaded — please reload the page.');
       return;
@@ -158,76 +212,77 @@
       setStatus('Transpile error');
       return;
     }
-
-    // Show generated WGSL if the pre element exists.
     if (wgslPre) wgslPre.textContent = result.code;
 
-    // 2. Build inputs from cfg + ABI
-    var abi    = result.abi;
-    var code   = result.code;
-    var inputs = {};
+    var abi = result.abi, code = result.code;
+    var inputs = buildInputs(env, abi);
 
-    for (var bufName in buffersCfg) {
-      if (!Object.prototype.hasOwnProperty.call(buffersCfg, bufName)) continue;
-      var bcfg = buffersCfg[bufName];
-
-      // Determine elementType: prefer ABI (authoritative) then cfg fallback.
-      var abiBuf = null;
-      if (abi && abi.buffers) {
-        for (var bi = 0; bi < abi.buffers.length; bi++) {
-          if (abi.buffers[bi].name === bufName) { abiBuf = abi.buffers[bi]; break; }
-        }
-      }
-      var elemType = (abiBuf && abiBuf.elementType) ? abiBuf.elementType : (bcfg.elementType || 'f32');
-      var Ctor = typedArrayCtor(elemType);
-      var arr  = new Ctor(n);
-
-      if (bcfg.role === 'input' && typeof bcfg.gen === 'function') {
-        for (var i = 0; i < n; i++) arr[i] = bcfg.gen(i);
-      }
-      // outputs start as zeros (already zero-initialised by TypedArray)
-      inputs[bufName] = arr;
-    }
-
-    // 3. Run on GPU
     setStatus('Running on GPU...');
     var runResult;
     try {
-      runResult = await globalThis.SarekWebGPU.run(code, abi, { inputs: inputs, scalars: scalarsCfg });
+      runResult = await globalThis.SarekWebGPU.run(code, abi, { inputs: inputs, scalars: env.scalars });
     } catch (e) {
       setOutput('error-output', 'GPU run error:\n' + e.message);
       setStatus('GPU error');
       return;
     }
 
-    // 4. Grade
-    var gpuOut = runResult.outputs[outName];
+    var gpuOut = runResult.outputs[env.outName];
     if (!gpuOut) {
-      setOutput('error-output', 'Output buffer "' + outName + '" not found in GPU results.');
+      setOutput('error-output', 'Output buffer "' + env.outName + '" not found in GPU results.');
       setStatus('Grading error');
       return;
     }
 
-    var firstBad = -1;
-    var badGot, badRef;
-    for (var idx = 0; idx < n; idx++) {
-      var ref = reference(idx, inputs, scalarsCfg);
-      var got = gpuOut[idx];
-      if (!withinTolerance(got, ref, rel, absFloor)) {
-        firstBad = idx;
-        badGot = got;
-        badRef = ref;
-        break;
+    // Visual rendering (optional): colormap a single output, or a custom hook.
+    if (typeof env.colormap === 'function' && env.canvasEl) {
+      renderColormap(env.canvasEl, gpuOut, env.width, env.height, env.colormap);
+    }
+    if (typeof env.onResult === 'function') {
+      try {
+        env.onResult({
+          outputs: runResult.outputs, inputs: inputs, scalars: env.scalars,
+          n: env.n, width: env.width, height: env.height,
+          canvas: env.canvasEl, inputCanvas: env.inputCanvasEl,
+        });
+      } catch (e) {
+        setOutput('error-output', 'Render error:\n' + e.message);
+        setStatus('Render error');
+        return;
       }
     }
 
-    if (firstBad === -1) {
-      setOutput('pass-output', 'PASS — all ' + n + ' elements match the CPU reference.');
+    // Grading (optional): only when a reference is provided.
+    if (typeof env.reference !== 'function') {
+      setOutput('', 'Rendered ' + env.n + ' elements on your GPU.');
+      setStatus('Done');
+      return;
+    }
+
+    // maxBadFraction allows a small fraction of mismatches (default 0 = strict).
+    // Useful for chaotic kernels (e.g. Mandelbrot) where a few boundary pixels
+    // diverge under float32 vs the float64 reference.
+    var maxBadFraction = env.maxBadFraction || 0;
+    var firstBad = -1, badGot, badRef, badCount = 0;
+    for (var idx = 0; idx < env.n; idx++) {
+      var ref = env.reference(idx, inputs, env.scalars);
+      var got = gpuOut[idx];
+      if (!withinTolerance(got, ref, env.rel, env.absFloor)) {
+        badCount++;
+        if (firstBad === -1) { firstBad = idx; badGot = got; badRef = ref; }
+      }
+    }
+    if (badCount <= maxBadFraction * env.n) {
+      var note = badCount === 0
+        ? 'all ' + env.n + ' elements match the CPU reference.'
+        : badCount + ' / ' + env.n + ' within the allowed tolerance.';
+      setOutput('pass-output', 'PASS — ' + note);
       setStatus('PASS');
     } else {
       setOutput(
         'fail-output',
-        'FAIL at index ' + firstBad +
+        'FAIL — ' + badCount + ' / ' + env.n + ' elements differ. ' +
+          'First at index ' + firstBad +
           ': expected ' + badRef.toPrecision(6) +
           ', got ' + badGot.toPrecision(6)
       );

--- a/gh-pages/learn/01-vector-add.html
+++ b/gh-pages/learn/01-vector-add.html
@@ -1,0 +1,91 @@
+---
+layout: page
+title: "Lesson 1 — Vector addition"
+---
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/learn.css">
+
+<div class="lesson-container">
+
+  <h1>Lesson 1 — Vector addition</h1>
+
+  <p>
+    The GPU data-parallel hello world: given two arrays <code>a</code> and
+    <code>b</code> of the same length, produce a third array <code>c</code>
+    where every element is the sum of the corresponding elements.
+    Mathematically, <code>c[i] = a[i] + b[i]</code> for every index
+    <code>i</code>.
+  </p>
+
+  <p>
+    On a GPU this is trivially parallel: thread <code>i</code> reads
+    <code>a[i]</code> and <code>b[i]</code>, adds them, and writes the result
+    to <code>c[i]</code>. No thread depends on another thread's output.
+  </p>
+
+  <h2>Your task</h2>
+  <p>
+    The kernel below reads buffers <code>a</code> and <code>b</code> and is
+    supposed to write their sum into <code>c</code>. Replace the
+    <code>(* TODO *)</code> with the correct expression, then click
+    <strong>Run on my GPU</strong>.
+  </p>
+
+  <label class="lesson-editor-label" for="kernel-source">Kernel source</label>
+  <textarea id="kernel-source">fun (a : float32 vector) (b : float32 vector) (c : float32 vector) ->
+  let i = global_thread_id in
+  c.(i) <- (* TODO *)</textarea>
+
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+    <button class="lesson-run-btn" id="run-btn">Run on my GPU</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle">Show generated WGSL</button>
+    <span class="lesson-status" id="status-bar"></span>
+  </div>
+
+  <pre class="lesson-output" id="output-pane">Click "Run on my GPU" to execute your kernel.</pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane" style="display:none;"></pre>
+
+  <details>
+    <summary>Hint</summary>
+    <p>
+      Use the float addition operator <code>+.</code> (note the dot — OCaml
+      uses <code>+.</code> for floats and <code>+</code> for ints).
+      Access array elements with <code>a.(i)</code>.
+    </p>
+  </details>
+
+  <div class="lesson-nav">
+    <span></span>
+    <a href="{{ site.baseurl }}/learn/02-scale-saxpy.html">Lesson 2 — Scalar params (SAXPY) &rarr;</a>
+  </div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/mllike/mllike.min.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_transpile.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_webgpu_runner.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_lesson.js"></script>
+<script>
+SarekLesson.init({
+  editorId:     'kernel-source',
+  runButtonId:  'run-btn',
+  outputId:     'output-pane',
+  statusId:     'status-bar',
+  wgslId:       'wgsl-pane',
+  wgslToggleId: 'wgsl-toggle',
+  n: 256,
+  starter:
+    'fun (a : float32 vector) (b : float32 vector) (c : float32 vector) ->\n' +
+    '  let i = global_thread_id in\n' +
+    '  c.(i) <- (* TODO *)',
+  buffers: {
+    a: { role: 'input',  elementType: 'f32', gen: function(i){ return i * 0.5; } },
+    b: { role: 'input',  elementType: 'f32', gen: function(i){ return i * 2.0; } },
+    c: { role: 'output', elementType: 'f32' },
+  },
+  scalars:   {},
+  outName:   'c',
+  reference: function(i, inputs) { return inputs.a[i] + inputs.b[i]; },
+});
+</script>

--- a/gh-pages/learn/02-scale-saxpy.html
+++ b/gh-pages/learn/02-scale-saxpy.html
@@ -1,0 +1,96 @@
+---
+layout: page
+title: "Lesson 2 — Scalar parameters (SAXPY)"
+---
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/learn.css">
+
+<div class="lesson-container">
+
+  <h1>Lesson 2 — Scalar parameters (SAXPY)</h1>
+
+  <p>
+    <strong>SAXPY</strong> (<em>Single-precision A times X Plus Y</em>) is the
+    canonical BLAS-1 operation: <code>y[i] = alpha * x[i] + y[i]</code>.
+    It is a staple benchmark because it is memory-bandwidth-bound — the GPU
+    must stream every element through its caches at least twice.
+  </p>
+
+  <h2>Scalar uniforms</h2>
+  <p>
+    Scalars like <code>alpha</code> are not per-thread arrays; they are the
+    same value for every thread. In Sarek you declare them as plain typed
+    arguments (e.g., <code>(alpha : float32)</code>), and the transpiler
+    automatically packs them into a uniform buffer that every thread can read.
+  </p>
+  <p>
+    For this lesson <code>alpha = 2.0</code> is injected automatically — you
+    can see it in <em>Show generated WGSL</em> as a field of the
+    <code>Params</code> uniform struct.
+  </p>
+
+  <h2>Your task</h2>
+  <p>
+    Complete the kernel so that <code>y.(i)</code> is updated in-place:
+    <code>y[i] &larr; alpha * x[i] + y[i]</code>.
+  </p>
+
+  <label class="lesson-editor-label" for="kernel-source">Kernel source</label>
+  <textarea id="kernel-source">fun (x : float32 vector) (y : float32 vector) (alpha : float32) ->
+  let i = global_thread_id in
+  y.(i) <- (* TODO *)</textarea>
+
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+    <button class="lesson-run-btn" id="run-btn">Run on my GPU</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle">Show generated WGSL</button>
+    <span class="lesson-status" id="status-bar"></span>
+  </div>
+
+  <pre class="lesson-output" id="output-pane">Click "Run on my GPU" to execute your kernel.</pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane" style="display:none;"></pre>
+
+  <details>
+    <summary>Hint</summary>
+    <p>
+      Float multiplication in OCaml is <code>*.</code> and addition is
+      <code>+.</code>. Read <code>alpha</code> directly — it is a scalar
+      argument available in every thread.
+    </p>
+  </details>
+
+  <div class="lesson-nav">
+    <a href="{{ site.baseurl }}/learn/01-vector-add.html">&larr; Lesson 1 — Vector addition</a>
+    <a href="{{ site.baseurl }}/learn/03-map-square.html">Lesson 3 — Elementwise map &rarr;</a>
+  </div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/mllike/mllike.min.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_transpile.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_webgpu_runner.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_lesson.js"></script>
+<script>
+SarekLesson.init({
+  editorId:     'kernel-source',
+  runButtonId:  'run-btn',
+  outputId:     'output-pane',
+  statusId:     'status-bar',
+  wgslId:       'wgsl-pane',
+  wgslToggleId: 'wgsl-toggle',
+  n: 256,
+  starter:
+    'fun (x : float32 vector) (y : float32 vector) (alpha : float32) ->\n' +
+    '  let i = global_thread_id in\n' +
+    '  y.(i) <- (* TODO *)',
+  buffers: {
+    x: { role: 'input',  elementType: 'f32', gen: function(i){ return i * 0.5; } },
+    y: { role: 'input',  elementType: 'f32', gen: function(i){ return i * 1.0; } },
+  },
+  scalars:   { alpha: 2.0 },
+  outName:   'y',
+  reference: function(i, inputs, scalars) {
+    return scalars.alpha * inputs.x[i] + inputs.y[i];
+  },
+});
+</script>

--- a/gh-pages/learn/03-map-square.html
+++ b/gh-pages/learn/03-map-square.html
@@ -1,0 +1,93 @@
+---
+layout: page
+title: "Lesson 3 — Elementwise map"
+---
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/learn.css">
+
+<div class="lesson-container">
+
+  <h1>Lesson 3 — Elementwise map</h1>
+
+  <p>
+    An <strong>elementwise map</strong> applies a function independently to
+    every element of an array. Because there are no dependencies between
+    elements, this is the ideal GPU workload — every thread does the same
+    work on a different datum.
+  </p>
+
+  <h2>Available math functions</h2>
+  <p>
+    Sarek exposes the standard GPU math library. Some useful functions in the
+    <code>Float32</code> module:
+  </p>
+  <ul>
+    <li><code>Float32.sin x</code>, <code>Float32.cos x</code></li>
+    <li><code>Float32.sqrt x</code>, <code>Float32.exp x</code>, <code>Float32.log x</code></li>
+    <li><code>Float32.abs x</code>, <code>Float32.ceil x</code>, <code>Float32.floor x</code></li>
+  </ul>
+  <p>Inline arithmetic: <code>x *. x</code> is faster than calling a power function for squaring.</p>
+
+  <h2>Your task</h2>
+  <p>
+    Write a kernel that squares every element of <code>a</code> into
+    <code>b</code>: <code>b[i] = a[i] * a[i]</code>.
+  </p>
+
+  <label class="lesson-editor-label" for="kernel-source">Kernel source</label>
+  <textarea id="kernel-source">fun (a : float32 vector) (b : float32 vector) ->
+  let i = global_thread_id in
+  b.(i) <- (* TODO *)</textarea>
+
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+    <button class="lesson-run-btn" id="run-btn">Run on my GPU</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle">Show generated WGSL</button>
+    <span class="lesson-status" id="status-bar"></span>
+  </div>
+
+  <pre class="lesson-output" id="output-pane">Click "Run on my GPU" to execute your kernel.</pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane" style="display:none;"></pre>
+
+  <details>
+    <summary>Hint</summary>
+    <p>
+      <code>a.(i) *. a.(i)</code> — that is all. You can also try
+      <code>Float32.sqrt (a.(i) *. a.(i))</code> to verify that
+      <code>sqrt(x²) = |x|</code> for non-negative inputs.
+    </p>
+  </details>
+
+  <div class="lesson-nav">
+    <a href="{{ site.baseurl }}/learn/02-scale-saxpy.html">&larr; Lesson 2 — Scalar params (SAXPY)</a>
+    <a href="{{ site.baseurl }}/learn/04-bounds-if.html">Lesson 4 — Control flow &rarr;</a>
+  </div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/mllike/mllike.min.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_transpile.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_webgpu_runner.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_lesson.js"></script>
+<script>
+SarekLesson.init({
+  editorId:     'kernel-source',
+  runButtonId:  'run-btn',
+  outputId:     'output-pane',
+  statusId:     'status-bar',
+  wgslId:       'wgsl-pane',
+  wgslToggleId: 'wgsl-toggle',
+  n: 256,
+  starter:
+    'fun (a : float32 vector) (b : float32 vector) ->\n' +
+    '  let i = global_thread_id in\n' +
+    '  b.(i) <- (* TODO *)',
+  buffers: {
+    a: { role: 'input',  elementType: 'f32', gen: function(i){ return i * 0.5; } },
+    b: { role: 'output', elementType: 'f32' },
+  },
+  scalars:   {},
+  outName:   'b',
+  reference: function(i, inputs) { return inputs.a[i] * inputs.a[i]; },
+});
+</script>

--- a/gh-pages/learn/04-bounds-if.html
+++ b/gh-pages/learn/04-bounds-if.html
@@ -1,0 +1,100 @@
+---
+layout: page
+title: "Lesson 4 — Control flow and bounds"
+---
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/learn.css">
+
+<div class="lesson-container">
+
+  <h1>Lesson 4 — Control flow and bounds</h1>
+
+  <p>
+    GPU kernels are dispatched in <strong>workgroups</strong> of fixed size
+    (256 threads by default in Sarek's WGSL backend). If your array length is
+    not a multiple of the workgroup size, some threads at the end of the last
+    workgroup will be assigned an out-of-bounds index. Accessing the array at
+    that index is a GPU error; you must guard against it.
+  </p>
+
+  <h2>if expressions in Sarek</h2>
+  <p>
+    Sarek kernels support <code>if / then / else</code> as expressions
+    (they return a value). Example:
+  </p>
+  <pre style="background:var(--code-bg);padding:0.5rem 0.75rem;border-radius:4px;border:1px solid var(--border-color);">b.(i) &lt;- (if i &lt; n then a.(i) else 0.0)</pre>
+  <p>
+    The WGSL backend compiles this to a <code>select()</code> intrinsic,
+    which is branch-free on most GPU architectures — so bounds-checking is
+    essentially free.
+  </p>
+  <p>
+    <code>n</code> is a scalar <code>int32</code> argument. In this lesson
+    <code>n = 128</code> (half the array), so the second half of
+    <code>b</code> should be zero.
+  </p>
+
+  <h2>Your task</h2>
+  <p>
+    Complete the kernel: write <code>a.(i)</code> into <code>b.(i)</code>
+    when <code>i &lt; n</code>, and <code>0.0</code> otherwise.
+  </p>
+
+  <label class="lesson-editor-label" for="kernel-source">Kernel source</label>
+  <textarea id="kernel-source">fun (a : float32 vector) (b : float32 vector) (n : int32) ->
+  let i = global_thread_id in
+  b.(i) <- (* TODO *)</textarea>
+
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+    <button class="lesson-run-btn" id="run-btn">Run on my GPU</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle">Show generated WGSL</button>
+    <span class="lesson-status" id="status-bar"></span>
+  </div>
+
+  <pre class="lesson-output" id="output-pane">Click "Run on my GPU" to execute your kernel.</pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane" style="display:none;"></pre>
+
+  <details>
+    <summary>Hint</summary>
+    <p>
+      <code>(if i &lt; n then a.(i) else 0.0)</code> — use <code>&lt;</code>
+      for integer comparison. The parentheses keep the expression unambiguous.
+    </p>
+  </details>
+
+  <div class="lesson-nav">
+    <a href="{{ site.baseurl }}/learn/03-map-square.html">&larr; Lesson 3 — Elementwise map</a>
+    <a href="{{ site.baseurl }}/learn/">Back to course overview &rarr;</a>
+  </div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/mllike/mllike.min.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_transpile.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_webgpu_runner.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_lesson.js"></script>
+<script>
+SarekLesson.init({
+  editorId:     'kernel-source',
+  runButtonId:  'run-btn',
+  outputId:     'output-pane',
+  statusId:     'status-bar',
+  wgslId:       'wgsl-pane',
+  wgslToggleId: 'wgsl-toggle',
+  n: 256,
+  starter:
+    'fun (a : float32 vector) (b : float32 vector) (n : int32) ->\n' +
+    '  let i = global_thread_id in\n' +
+    '  b.(i) <- (* TODO *)',
+  buffers: {
+    a: { role: 'input',  elementType: 'f32', gen: function(i){ return i * 0.5; } },
+    b: { role: 'output', elementType: 'f32' },
+  },
+  scalars:   { n: 128 },
+  outName:   'b',
+  reference: function(i, inputs, scalars) {
+    return i < scalars.n ? inputs.a[i] : 0.0;
+  },
+});
+</script>

--- a/gh-pages/learn/04-bounds-if.html
+++ b/gh-pages/learn/04-bounds-if.html
@@ -64,7 +64,7 @@ title: "Lesson 4 — Control flow and bounds"
 
   <div class="lesson-nav">
     <a href="{{ site.baseurl }}/learn/03-map-square.html">&larr; Lesson 3 — Elementwise map</a>
-    <a href="{{ site.baseurl }}/learn/">Back to course overview &rarr;</a>
+    <a href="{{ site.baseurl }}/learn/05-mandelbrot.html">Lesson 5 — Mandelbrot &rarr;</a>
   </div>
 
 </div>

--- a/gh-pages/learn/05-mandelbrot.html
+++ b/gh-pages/learn/05-mandelbrot.html
@@ -1,0 +1,169 @@
+---
+layout: page
+title: "Lesson 5 — Mandelbrot (generate an image)"
+---
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/learn.css">
+
+<div class="lesson-container">
+
+  <h1>Lesson 5 — Mandelbrot (generate an image)</h1>
+
+  <p>
+    So far each thread did a little arithmetic. Now each thread will run a
+    <em>loop</em> and we will <strong>draw the result</strong>. This is the
+    Mandelbrot set: for every pixel we treat its position as a complex number
+    <code>c = x0 + i·y0</code>, iterate <code>z &larr; z² + c</code> starting
+    from <code>z = 0</code>, and count how many steps it takes for
+    <code>|z|</code> to exceed 2 (we stop at <code>max_iter</code>). Points that
+    never escape are <em>in</em> the set.
+  </p>
+
+  <p>
+    One GPU thread computes one pixel. The kernel writes the normalised escape
+    count (<code>iter / max_iter</code>) into <code>output</code>; the page maps
+    that to a colour and paints it on the canvas. The whole image
+    (<span id="dims-note">240&times;240</span> pixels) is computed in one
+    dispatch on your GPU.
+  </p>
+
+  <h2>Your task</h2>
+  <p>
+    The escape iteration is <code>z &larr; z² + c</code>. Writing
+    <code>z = zx + i·zy</code> and <code>c = x0 + i·y0</code>, the real part of
+    <code>z²&nbsp;+&nbsp;c</code> is <code>zx² − zy² + x0</code> and the
+    imaginary part is <code>2·zx·zy + y0</code> (already written for you).
+    Replace the <code>(* TODO *)</code> with the <strong>real part</strong>,
+    then click <strong>Run on my GPU</strong>.
+  </p>
+
+  <label class="lesson-editor-label" for="kernel-source">Kernel source</label>
+  <textarea id="kernel-source">fun (output : float32 vector) (width : int32) (height : int32) (max_iter : int32) ->
+  let open Std in
+  let idx = global_thread_id in
+  let px = idx mod width in
+  let py = idx / width in
+  if py &lt; height then begin
+    let x0 = (3.5 *. (float px /. float width)) -. 2.5 in
+    let y0 = (2.0 *. (float py /. float height)) -. 1.0 in
+    let zx = mut 0.0 in
+    let zy = mut 0.0 in
+    let iter = mut 0l in
+    while ((zx *. zx) +. (zy *. zy) &lt;= 4.0) &amp;&amp; (iter &lt; max_iter) do
+      let xt = (* TODO *) in
+      zy := (2.0 *. zx *. zy) +. y0 ;
+      zx := xt ;
+      iter := iter + 1l
+    done ;
+    output.(idx) &lt;- (float iter /. float max_iter)
+  end</textarea>
+
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+    <button class="lesson-run-btn" id="run-btn">Run on my GPU</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle">Show generated WGSL</button>
+    <span class="lesson-status" id="status-bar"></span>
+  </div>
+
+  <div class="lesson-canvas-row">
+    <figure>
+      <canvas class="lesson-canvas" id="output-canvas" width="240" height="240"></canvas>
+      <figcaption>Rendered on your GPU</figcaption>
+    </figure>
+  </div>
+
+  <pre class="lesson-output" id="output-pane">Fill in the TODO and click "Run on my GPU".</pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane" style="display:none;"></pre>
+
+  <details>
+    <summary>Hint</summary>
+    <p>
+      The real part is <code>(zx *. zx) -. (zy *. zy) +. x0</code>. Note the
+      float operators <code>*.</code>, <code>-.</code>, <code>+.</code>.
+    </p>
+  </details>
+
+  <p class="lesson-disclaimer">
+    This uses a small 240&times;240 image and <code>max_iter = 100</code> so it
+    runs instantly. Larger images, deeper zooms, or higher iteration counts cost
+    proportionally more GPU time.
+  </p>
+
+  <div class="lesson-nav">
+    <a href="{{ site.baseurl }}/learn/04-bounds-if.html">&larr; Lesson 4 — Control flow and bounds</a>
+    <a href="{{ site.baseurl }}/learn/06-image-filter.html">Lesson 6 — Image filter &rarr;</a>
+  </div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/mllike/mllike.min.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_transpile.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_webgpu_runner.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_lesson.js"></script>
+<script>
+(function () {
+  var W = 240, H = 240, MAX = 100;
+
+  // float32 reference matching the kernel, for the auto-check.
+  function mandelRef(i, inputs, sc) {
+    var fr = Math.fround, w = sc.width, h = sc.height, max = sc.max_iter;
+    var px = i % w, py = Math.floor(i / w);
+    if (py >= h) return 0;
+    var x0 = fr(fr(3.5 * fr(px / w)) - 2.5);
+    var y0 = fr(fr(2.0 * fr(py / h)) - 1.0);
+    var zx = 0, zy = 0, it = 0;
+    while (fr(fr(zx * zx) + fr(zy * zy)) <= 4.0 && it < max) {
+      var xt = fr(fr(fr(zx * zx) - fr(zy * zy)) + x0);
+      zy = fr(fr(fr(2.0 * zx) * zy) + y0);
+      zx = xt; it++;
+    }
+    return it / max;
+  }
+
+  // Smooth palette: in-set (t=1) is black, escaping points get warm colours.
+  function palette(t) {
+    if (t >= 1) return [0, 0, 0];
+    var r = Math.floor(9 * (1 - t) * t * t * t * 255);
+    var g = Math.floor(15 * (1 - t) * (1 - t) * t * t * 255);
+    var b = Math.floor(8.5 * (1 - t) * (1 - t) * (1 - t) * t * 255);
+    return [r, g, b];
+  }
+
+  SarekLesson.init({
+    editorId:     'kernel-source',
+    runButtonId:  'run-btn',
+    outputId:     'output-pane',
+    statusId:     'status-bar',
+    wgslId:       'wgsl-pane',
+    wgslToggleId: 'wgsl-toggle',
+    width: W, height: H,
+    starter:
+      'fun (output : float32 vector) (width : int32) (height : int32) (max_iter : int32) ->\n' +
+      '  let open Std in\n' +
+      '  let idx = global_thread_id in\n' +
+      '  let px = idx mod width in\n' +
+      '  let py = idx / width in\n' +
+      '  if py < height then begin\n' +
+      '    let x0 = (3.5 *. (float px /. float width)) -. 2.5 in\n' +
+      '    let y0 = (2.0 *. (float py /. float height)) -. 1.0 in\n' +
+      '    let zx = mut 0.0 in\n' +
+      '    let zy = mut 0.0 in\n' +
+      '    let iter = mut 0l in\n' +
+      '    while ((zx *. zx) +. (zy *. zy) <= 4.0) && (iter < max_iter) do\n' +
+      '      let xt = (* TODO *) in\n' +
+      '      zy := (2.0 *. zx *. zy) +. y0 ;\n' +
+      '      zx := xt ;\n' +
+      '      iter := iter + 1l\n' +
+      '    done ;\n' +
+      '    output.(idx) <- (float iter /. float max_iter)\n' +
+      '  end',
+    buffers: { output: { role: 'output', elementType: 'f32' } },
+    scalars:   { width: W, height: H, max_iter: MAX },
+    outName:   'output',
+    colormap:  function (t) { return palette(t); },
+    canvasId:  'output-canvas',
+    reference: mandelRef,
+    maxBadFraction: 0.02,  // tolerate a few chaotic boundary pixels
+  });
+})();
+</script>

--- a/gh-pages/learn/06-image-filter.html
+++ b/gh-pages/learn/06-image-filter.html
@@ -1,0 +1,195 @@
+---
+layout: page
+title: "Lesson 6 — Image filter"
+---
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/learn.css">
+
+<div class="lesson-container">
+
+  <h1>Lesson 6 — Image filter</h1>
+
+  <p>
+    An image is just arrays of numbers: one value per pixel per colour channel.
+    A <em>filter</em> is a kernel that reads those channels and writes new ones —
+    one thread per pixel. Here you will write a <strong>grayscale</strong>
+    filter: collapse the red, green and blue channels into a single brightness
+    value using the standard luminance weights
+    <code>0.299·R + 0.587·G + 0.114·B</code>.
+  </p>
+
+  <h2>Your task</h2>
+  <p>
+    The kernel reads buffers <code>r</code>, <code>g</code>, <code>b</code>
+    (each one value per pixel, in <code>0..1</code>) and writes the brightness
+    into <code>gray</code>. Replace the <code>(* TODO *)</code> with the
+    weighted sum, then click <strong>Run on my GPU</strong>. The original and
+    the filtered image appear side by side.
+  </p>
+
+  <label class="lesson-editor-label" for="kernel-source">Kernel source</label>
+  <textarea id="kernel-source">fun (r : float32 vector) (g : float32 vector) (b : float32 vector) (gray : float32 vector) ->
+  let i = global_thread_id in
+  gray.(i) <- (* TODO *)</textarea>
+
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+    <button class="lesson-run-btn" id="run-btn">Run on my GPU</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle">Show generated WGSL</button>
+    <label class="lesson-upload">
+      Use your own photo
+      <input type="file" id="photo-input" accept="image/*">
+    </label>
+    <span class="lesson-status" id="status-bar"></span>
+  </div>
+
+  <div class="lesson-canvas-row">
+    <figure>
+      <canvas class="lesson-canvas" id="input-canvas" width="200" height="200"></canvas>
+      <figcaption>Original</figcaption>
+    </figure>
+    <figure>
+      <canvas class="lesson-canvas" id="output-canvas" width="200" height="200"></canvas>
+      <figcaption>Filtered (your GPU)</figcaption>
+    </figure>
+  </div>
+
+  <pre class="lesson-output" id="output-pane">Fill in the TODO and click "Run on my GPU".</pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane" style="display:none;"></pre>
+
+  <details>
+    <summary>Hint</summary>
+    <p>
+      <code>(0.299 *. r.(i)) +. (0.587 *. g.(i)) +. (0.114 *. b.(i))</code>.
+      Once it works, try other filters: invert is <code>1.0 -. r.(i)</code>
+      (per channel), or boost a channel by multiplying it.
+    </p>
+  </details>
+
+  <p class="lesson-disclaimer">
+    A small 200&times;200 image keeps this instant. Your uploaded photo is
+    resized to 200&times;200 and processed entirely in your browser on your GPU —
+    nothing is uploaded anywhere. Larger images cost proportionally more.
+  </p>
+
+  <div class="lesson-nav">
+    <a href="{{ site.baseurl }}/learn/05-mandelbrot.html">&larr; Lesson 5 — Mandelbrot</a>
+    <a href="{{ site.baseurl }}/learn/">Back to course overview &rarr;</a>
+  </div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/mllike/mllike.min.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_transpile.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_webgpu_runner.js"></script>
+<script src="{{ site.baseurl }}/javascripts/sarek_lesson.js"></script>
+<script>
+(function () {
+  var W = 200, H = 200, N = W * H;
+
+  // Procedural default image: smooth colour gradients + a radial — stands in
+  // for a photo so the lesson works immediately and offline.
+  function genImage() {
+    var r = new Float32Array(N), g = new Float32Array(N), b = new Float32Array(N);
+    var cx = W / 2, cy = H / 2, maxd = Math.sqrt(cx * cx + cy * cy);
+    for (var py = 0; py < H; py++) {
+      for (var px = 0; px < W; px++) {
+        var i = py * W + px;
+        var d = Math.sqrt((px - cx) * (px - cx) + (py - cy) * (py - cy)) / maxd;
+        r[i] = px / W;
+        g[i] = py / H;
+        b[i] = 1 - d;
+      }
+    }
+    return { r: r, g: g, b: b };
+  }
+
+  var IMG = genImage();  // current source; replaced by an upload if used
+
+  function drawRGB(canvas) {
+    if (!canvas) return;
+    canvas.width = W; canvas.height = H;
+    var ctx = canvas.getContext('2d');
+    var img = ctx.createImageData(W, H);
+    for (var i = 0; i < N; i++) {
+      img.data[i * 4]     = Math.round(IMG.r[i] * 255);
+      img.data[i * 4 + 1] = Math.round(IMG.g[i] * 255);
+      img.data[i * 4 + 2] = Math.round(IMG.b[i] * 255);
+      img.data[i * 4 + 3] = 255;
+    }
+    ctx.putImageData(img, 0, 0);
+  }
+
+  function drawGray(gray, canvas) {
+    if (!canvas) return;
+    canvas.width = W; canvas.height = H;
+    var ctx = canvas.getContext('2d');
+    var img = ctx.createImageData(W, H);
+    for (var i = 0; i < N; i++) {
+      var v = Math.max(0, Math.min(255, Math.round(gray[i] * 255)));
+      img.data[i * 4] = img.data[i * 4 + 1] = img.data[i * 4 + 2] = v;
+      img.data[i * 4 + 3] = 255;
+    }
+    ctx.putImageData(img, 0, 0);
+  }
+
+  SarekLesson.init({
+    editorId:     'kernel-source',
+    runButtonId:  'run-btn',
+    outputId:     'output-pane',
+    statusId:     'status-bar',
+    wgslId:       'wgsl-pane',
+    wgslToggleId: 'wgsl-toggle',
+    width: W, height: H,
+    starter:
+      'fun (r : float32 vector) (g : float32 vector) (b : float32 vector) (gray : float32 vector) ->\n' +
+      '  let i = global_thread_id in\n' +
+      '  gray.(i) <- (* TODO *)',
+    buffers: {
+      r:    { role: 'input',  elementType: 'f32' },
+      g:    { role: 'input',  elementType: 'f32' },
+      b:    { role: 'input',  elementType: 'f32' },
+      gray: { role: 'output', elementType: 'f32' },
+    },
+    scalars: {},
+    outName: 'gray',
+    // Image lessons own input construction (current source image + zeroed output).
+    makeInputs: function () {
+      return { r: IMG.r.slice(), g: IMG.g.slice(), b: IMG.b.slice(), gray: new Float32Array(N) };
+    },
+    reference: function (i, inputs) {
+      return 0.299 * inputs.r[i] + 0.587 * inputs.g[i] + 0.114 * inputs.b[i];
+    },
+    renderInput: function (o) { drawRGB(o.canvas); },
+    onResult:    function (o) { drawGray(o.outputs.gray, o.canvas); },
+    canvasId:      'output-canvas',
+    inputCanvasId: 'input-canvas',
+  });
+
+  // Progressive enhancement: let the learner filter their own photo.
+  var fileInput = document.getElementById('photo-input');
+  if (fileInput) {
+    fileInput.addEventListener('change', function (ev) {
+      var file = ev.target.files && ev.target.files[0];
+      if (!file) return;
+      var url = URL.createObjectURL(file);
+      var im = new Image();
+      im.onload = function () {
+        var off = document.createElement('canvas');
+        off.width = W; off.height = H;
+        var octx = off.getContext('2d');
+        octx.drawImage(im, 0, 0, W, H);
+        var d = octx.getImageData(0, 0, W, H).data;
+        var r = new Float32Array(N), g = new Float32Array(N), b = new Float32Array(N);
+        for (var i = 0; i < N; i++) {
+          r[i] = d[i * 4] / 255; g[i] = d[i * 4 + 1] / 255; b[i] = d[i * 4 + 2] / 255;
+        }
+        IMG = { r: r, g: g, b: b };
+        URL.revokeObjectURL(url);
+        drawRGB(document.getElementById('input-canvas'));
+      };
+      im.src = url;
+    });
+  }
+})();
+</script>

--- a/gh-pages/learn/06-image-filter.html
+++ b/gh-pages/learn/06-image-filter.html
@@ -187,6 +187,16 @@ title: "Lesson 6 — Image filter"
         IMG = { r: r, g: g, b: b };
         URL.revokeObjectURL(url);
         drawRGB(document.getElementById('input-canvas'));
+        // Clear the stale filtered result until the kernel is re-run.
+        var outCanvas = document.getElementById('output-canvas');
+        if (outCanvas) {
+          var octx2 = outCanvas.getContext('2d');
+          if (octx2) octx2.clearRect(0, 0, W, H);
+        }
+        var outPane = document.getElementById('output-pane');
+        if (outPane) { outPane.className = 'lesson-output'; outPane.textContent = 'Image loaded — click "Run on my GPU" to filter it.'; }
+        var stBar = document.getElementById('status-bar');
+        if (stBar) stBar.textContent = '';
       };
       im.src = url;
     });

--- a/gh-pages/learn/index.md
+++ b/gh-pages/learn/index.md
@@ -101,3 +101,5 @@ the Run button will be disabled with an explanatory message.
 2. [Lesson 2 — Scalar parameters (SAXPY)]({{ site.baseurl }}/learn/02-scale-saxpy.html) — passing a scalar into a kernel
 3. [Lesson 3 — Elementwise map]({{ site.baseurl }}/learn/03-map-square.html) — mapping a function over every element
 4. [Lesson 4 — Control flow and bounds]({{ site.baseurl }}/learn/04-bounds-if.html) — `if` expressions and index guarding
+5. [Lesson 5 — Mandelbrot]({{ site.baseurl }}/learn/05-mandelbrot.html) — a per-pixel loop that **generates an image** on your GPU
+6. [Lesson 6 — Image filter]({{ site.baseurl }}/learn/06-image-filter.html) — a grayscale **photo filter** rendered in the page (bring your own photo)

--- a/gh-pages/learn/index.md
+++ b/gh-pages/learn/index.md
@@ -1,0 +1,103 @@
+---
+layout: page
+title: "Learn GPU programming with Sarek"
+---
+
+# Learn GPU programming with Sarek
+
+These interactive lessons teach the data-parallel programming model through
+short, runnable exercises. Each lesson lets you edit a Sarek kernel, click
+**Run on my GPU**, and instantly see whether your answer is correct — graded
+against a CPU reference running in the same browser tab.
+
+---
+
+## What is GPGPU and what is a kernel?
+
+A **GPU** (Graphics Processing Unit) has thousands of small cores that run in
+parallel. **GPGPU** (General-Purpose GPU computing) uses those cores to
+accelerate arbitrary numeric computation — not just graphics.
+
+The central concept is the **kernel**: a function that runs once per element
+of your dataset, each invocation handling exactly one element identified by
+its **thread index** (`global_thread_id` in Sarek). If you have an array of
+256 floats, the GPU launches 256 threads simultaneously, each computing one
+output value independently. This is the *data-parallel* model.
+
+```
+Thread 0:  reads a[0], b[0]  → writes c[0]
+Thread 1:  reads a[1], b[1]  → writes c[1]
+...
+Thread 255: reads a[255], b[255] → writes c[255]
+```
+
+No thread needs to wait for another — all 256 compute at once.
+
+---
+
+## How Sarek / SPOC works
+
+**Sarek** lets you write GPU kernels in OCaml syntax. The compiler
+(*transpiler*) reads your kernel expression and emits GPU source code for
+multiple backends: CUDA, OpenCL, Metal, GLSL, and **WGSL**.
+
+In these lessons, Sarek transpiles to **WGSL** (WebGPU Shading Language) and
+runs the shader on **your own GPU** directly in your browser via the
+[WebGPU API](https://www.w3.org/TR/webgpu/). The transpiler itself is a
+WebAssembly + JavaScript bundle loaded from this page — no server is involved.
+
+---
+
+## How to read a Sarek kernel
+
+A minimal kernel looks like:
+
+```
+fun (a : float32 vector) (b : float32 vector) ->
+  let i = global_thread_id in
+  b.(i) <- Float32.sin a.(i)
+```
+
+- `fun (a : float32 vector) ...` — the kernel's typed arguments. Buffers
+  (arrays on the GPU) are `elementType vector`. Scalar values (ints, floats)
+  are plain `int32` / `float32`.
+- `let i = global_thread_id in` — binds the thread index. Each of the N
+  threads gets a unique value of `i` from 0 to N-1.
+- `b.(i) <- expr` — writes `expr` into output buffer `b` at position `i`.
+  Read accesses use `a.(i)` without the `<-`.
+
+---
+
+## How the interactive checker works
+
+1. You edit the kernel starter in the editor.
+2. Click **Run on my GPU** — the page calls
+   `SarekTranspile.transpileWithAbi(source, "wgsl")` to compile your kernel
+   to WGSL, then `SarekWebGPU.run(...)` to dispatch it on your GPU.
+3. The result is compared element-by-element against a CPU reference
+   (JavaScript). A relative tolerance of ±0.1 % is allowed for floating-point
+   rounding. You see **PASS** (green) or **FAIL** with the first mismatching
+   index.
+4. Use **Show generated WGSL** to inspect the shader the transpiler produced.
+
+All datasets use **N = 256** for instant iteration. Larger datasets (N ≥ 64 K)
+would show more realistic GPU speedups but take several seconds to grade in
+the browser.
+
+---
+
+## Browser requirements
+
+WebGPU requires a **recent Chrome or Edge** (version 113+). Firefox Nightly
+also works with the `dom.webgpu.enabled` flag. If your browser does not
+support WebGPU the lesson text still renders and you can read the kernel, but
+the Run button will be disabled with an explanatory message.
+
+---
+
+## Lessons
+
+1. [Lesson 1 — Vector addition]({{ site.baseurl }}/learn/01-vector-add.html) — the data-parallel hello world
+2. [Lesson 2 — Scalar parameters (SAXPY)]({{ site.baseurl }}/learn/02-scale-saxpy.html) — passing a scalar into a kernel
+3. [Lesson 3 — Elementwise map]({{ site.baseurl }}/learn/03-map-square.html) — mapping a function over every element
+4. [Lesson 4 — Control flow and bounds]({{ site.baseurl }}/learn/04-bounds-if.html) — `if` expressions and index guarding

--- a/gh-pages/learn/test/lessons_gpu_test.mjs
+++ b/gh-pages/learn/test/lessons_gpu_test.mjs
@@ -1,0 +1,351 @@
+// Playwright acceptance test for the Sarek interactive GPU course pages.
+//
+// For each lesson: (a) loads the page, (b) injects the CORRECT kernel body
+// and asserts the result panel shows PASS, (c) injects a WRONG body and
+// asserts FAIL. Graceful skip (exit 0) when playwright/chrome/WebGPU are
+// unavailable; only FAIL on a real wrong result or compile error.
+//
+// Usage:
+//   node gh-pages/learn/test/lessons_gpu_test.mjs [bundle.bc.js]
+//
+// Mirrors the structure of sarek/transpile/web/test/webgpu_wgsl_test.mjs.
+
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import { execSync } from 'child_process';
+
+// ── Playwright resolution (same approach as webgpu_wgsl_test.mjs) ─────────
+function resolvePlaywright() {
+  const reqHere = createRequire(import.meta.url);
+  const candidates = [];
+  try { candidates.push(execSync('npm root -g').toString().trim()); } catch (_) {}
+  try {
+    candidates.push(
+      ...execSync('ls -d /home/*/.npm/_npx/*/node_modules 2>/dev/null')
+        .toString().trim().split('\n')
+    );
+  } catch (_) {}
+  for (const base of candidates.filter(Boolean)) {
+    try { return createRequire(base + '/x')('playwright'); } catch (_) {}
+  }
+  try { return reqHere('playwright'); } catch (_) {}
+  return null;
+}
+
+function skip(msg) { console.log('SKIP: ' + msg); process.exit(0); }
+
+const pw = resolvePlaywright();
+if (!pw) skip('playwright not resolvable');
+const { chromium } = pw;
+
+// ── Asset paths ───────────────────────────────────────────────────────────
+const BUNDLE = process.argv[2] ||
+  '_build/default/sarek/transpile/web/transpile_js.bc.js';
+if (!fs.existsSync(BUNDLE)) skip('bundle not built: ' + BUNDLE);
+const bundleJs = fs.readFileSync(BUNDLE);
+
+const RUNNER = 'gh-pages/javascripts/sarek_webgpu_runner.js';
+if (!fs.existsSync(RUNNER)) skip('runner not found: ' + RUNNER);
+const runnerJs = fs.readFileSync(RUNNER);
+
+const LESSON_JS = 'gh-pages/javascripts/sarek_lesson.js';
+if (!fs.existsSync(LESSON_JS)) skip('sarek_lesson.js not found: ' + LESSON_JS);
+const lessonJs = fs.readFileSync(LESSON_JS);
+
+// ── Minimal HTTP server ───────────────────────────────────────────────────
+// Serves the JS assets. The lesson HTML is injected inline per test case.
+const server = http.createServer((req, res) => {
+  if (req.url === '/b.js') {
+    res.setHeader('content-type', 'text/javascript');
+    res.end(bundleJs);
+  } else if (req.url === '/r.js') {
+    res.setHeader('content-type', 'text/javascript');
+    res.end(runnerJs);
+  } else if (req.url === '/l.js') {
+    res.setHeader('content-type', 'text/javascript');
+    res.end(lessonJs);
+  } else {
+    // Serve a minimal harness page that loads all three scripts.
+    const body = `<!doctype html>
+<meta charset=utf-8>
+<title>lesson-test</title>
+<script src="/b.js"></script>
+<script src="/r.js"></script>
+<script src="/l.js"></script>`;
+    res.setHeader('content-type', 'text/html');
+    res.end(body);
+  }
+});
+await new Promise(r => server.listen(0, r));
+const port = server.address().port;
+
+// ── Browser launch ────────────────────────────────────────────────────────
+let browser;
+try {
+  browser = await chromium.launch({
+    headless: true,
+    channel: 'chrome',
+    args: [
+      '--enable-unsafe-webgpu',
+      '--enable-features=Vulkan',
+      '--use-angle=vulkan',
+      '--use-gl=angle',
+      '--ignore-gpu-blocklist',
+      '--no-sandbox',
+    ],
+  });
+} catch (e) {
+  server.close();
+  skip('chrome launch failed: ' + e.message);
+}
+
+const page = await browser.newPage();
+await page.goto(`http://localhost:${port}/`, { waitUntil: 'load' });
+await page.waitForFunction(
+  () =>
+    typeof globalThis.SarekTranspile !== 'undefined' &&
+    typeof globalThis.SarekWebGPU !== 'undefined' &&
+    typeof globalThis.SarekLesson !== 'undefined',
+  { timeout: 20000 }
+);
+
+const hasAdapter = await page.evaluate(
+  async () =>
+    !!(navigator.gpu &&
+      (await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' })))
+);
+if (!hasAdapter) {
+  await browser.close();
+  server.close();
+  skip('no WebGPU adapter in this Chrome');
+}
+
+// ── Test case definitions ─────────────────────────────────────────────────
+// Each case: lesson id, cfg passed to SarekLesson.init (minus DOM ids),
+// correctBody (replaces the TODO), wrongBody (should produce FAIL).
+const N = 256;
+
+const CASES = [
+  {
+    id: 'lesson1-vector-add',
+    cfg: {
+      n: N,
+      buffers: {
+        a: { role: 'input',  elementType: 'f32', gen: 'function(i){ return i * 0.5; }' },
+        b: { role: 'input',  elementType: 'f32', gen: 'function(i){ return i * 2.0; }' },
+        c: { role: 'output', elementType: 'f32' },
+      },
+      scalars:   {},
+      outName:   'c',
+      reference: 'function(i, inp) { return inp.a[i] + inp.b[i]; }',
+    },
+    starterFn: 'function(body) { return ' +
+      '"fun (a : float32 vector) (b : float32 vector) (c : float32 vector) ->\\n" +' +
+      '"  let i = global_thread_id in\\n" +' +
+      '"  c.(i) <- " + body; }',
+    correctBody: 'a.(i) +. b.(i)',
+    wrongBody:   'a.(i) -. b.(i)',
+  },
+  {
+    id: 'lesson2-saxpy',
+    cfg: {
+      n: N,
+      buffers: {
+        x: { role: 'input',  elementType: 'f32', gen: 'function(i){ return i * 0.5; }' },
+        y: { role: 'input',  elementType: 'f32', gen: 'function(i){ return i * 1.0; }' },
+      },
+      scalars:   { alpha: 2.0 },
+      outName:   'y',
+      reference: 'function(i, inp, sc) { return sc.alpha * inp.x[i] + inp.y[i]; }',
+    },
+    starterFn: 'function(body) { return ' +
+      '"fun (x : float32 vector) (y : float32 vector) (alpha : float32) ->\\n" +' +
+      '"  let i = global_thread_id in\\n" +' +
+      '"  y.(i) <- " + body; }',
+    correctBody: '(alpha *. x.(i)) +. y.(i)',
+    wrongBody:   'x.(i)',
+  },
+  {
+    id: 'lesson3-map-square',
+    cfg: {
+      n: N,
+      buffers: {
+        a: { role: 'input',  elementType: 'f32', gen: 'function(i){ return i * 0.5; }' },
+        b: { role: 'output', elementType: 'f32' },
+      },
+      scalars:   {},
+      outName:   'b',
+      reference: 'function(i, inp) { return inp.a[i] * inp.a[i]; }',
+    },
+    starterFn: 'function(body) { return ' +
+      '"fun (a : float32 vector) (b : float32 vector) ->\\n" +' +
+      '"  let i = global_thread_id in\\n" +' +
+      '"  b.(i) <- " + body; }',
+    correctBody: 'a.(i) *. a.(i)',
+    wrongBody:   'a.(i)',
+  },
+  {
+    id: 'lesson4-bounds-if',
+    cfg: {
+      n: N,
+      buffers: {
+        a: { role: 'input',  elementType: 'f32', gen: 'function(i){ return i * 0.5; }' },
+        b: { role: 'output', elementType: 'f32' },
+      },
+      scalars:   { n: 128 },
+      outName:   'b',
+      reference: 'function(i, inp, sc) { return i < sc.n ? inp.a[i] : 0.0; }',
+    },
+    starterFn: 'function(body) { return ' +
+      '"fun (a : float32 vector) (b : float32 vector) (n : int32) ->\\n" +' +
+      '"  let i = global_thread_id in\\n" +' +
+      '"  b.(i) <- " + body; }',
+    correctBody: '(if i < n then a.(i) else 0.0)',
+    wrongBody:   'a.(i)',
+  },
+];
+
+// ── Run each test case ────────────────────────────────────────────────────
+const results = [];
+
+for (const tc of CASES) {
+  // Serialise gen functions as strings and reconstruct on the page side.
+  // We pass the whole cfg as a JSON-safe object except function fields,
+  // which are inlined as evaluated strings via page.evaluate.
+
+  // CORRECT body
+  const correctResult = await page.evaluate(
+    async ({ cfg, starterFn, body, N }) => {
+      const mkSource = eval('(' + starterFn + ')');   // eslint-disable-line no-eval
+
+      // Rebuild buffers with real gen functions.
+      const bufs = {};
+      for (const [name, b] of Object.entries(cfg.buffers)) {
+        bufs[name] = {
+          role: b.role,
+          elementType: b.elementType,
+          gen: b.gen ? eval('(' + b.gen + ')') : undefined, // eslint-disable-line no-eval
+        };
+      }
+      const ref = eval('(' + cfg.reference + ')');           // eslint-disable-line no-eval
+
+      const source = mkSource(body);
+      const r = globalThis.SarekTranspile.transpileWithAbi(source, 'wgsl');
+      if (!r.ok) return { pass: false, why: 'transpile: ' + r.error };
+
+      // Build inputs
+      const inputs = {};
+      for (const [name, b] of Object.entries(bufs)) {
+        const Ctor = b.elementType === 'f32' ? Float32Array
+          : b.elementType === 'i32' ? Int32Array : Uint32Array;
+        const arr = new Ctor(N);
+        if (b.role === 'input' && b.gen) for (let i = 0; i < N; i++) arr[i] = b.gen(i);
+        inputs[name] = arr;
+      }
+
+      let runResult;
+      try {
+        runResult = await globalThis.SarekWebGPU.run(r.code, r.abi,
+          { inputs, scalars: cfg.scalars });
+      } catch (e) {
+        return { pass: false, why: 'run: ' + e.message };
+      }
+
+      const out = runResult.outputs[cfg.outName];
+      let bad = 0;
+      for (let i = 0; i < N; i++) {
+        const expected = ref(i, inputs, cfg.scalars);
+        if (Math.abs(out[i] - expected) > 1e-3 * Math.max(Math.abs(out[i]), Math.abs(expected)) + 1e-3) bad++;
+      }
+      return { pass: bad === 0, bad };
+    },
+    { cfg: serializeCfg(tc.cfg), starterFn: tc.starterFn, body: tc.correctBody, N }
+  );
+
+  // WRONG body
+  const wrongResult = await page.evaluate(
+    async ({ cfg, starterFn, body, N }) => {
+      const mkSource = eval('(' + starterFn + ')');   // eslint-disable-line no-eval
+      const bufs = {};
+      for (const [name, b] of Object.entries(cfg.buffers)) {
+        bufs[name] = {
+          role: b.role,
+          elementType: b.elementType,
+          gen: b.gen ? eval('(' + b.gen + ')') : undefined, // eslint-disable-line no-eval
+        };
+      }
+      const ref = eval('(' + cfg.reference + ')');           // eslint-disable-line no-eval
+      const source = mkSource(body);
+      const r = globalThis.SarekTranspile.transpileWithAbi(source, 'wgsl');
+      if (!r.ok) {
+        // A transpile error counts as "not PASS" which is fine for the wrong-body test.
+        return { notPass: true, why: 'transpile error (expected for wrong body): ' + r.error };
+      }
+      const inputs = {};
+      for (const [name, b] of Object.entries(bufs)) {
+        const Ctor = b.elementType === 'f32' ? Float32Array
+          : b.elementType === 'i32' ? Int32Array : Uint32Array;
+        const arr = new Ctor(N);
+        if (b.role === 'input' && b.gen) for (let i = 0; i < N; i++) arr[i] = b.gen(i);
+        inputs[name] = arr;
+      }
+      let runResult;
+      try {
+        runResult = await globalThis.SarekWebGPU.run(r.code, r.abi,
+          { inputs, scalars: cfg.scalars });
+      } catch (e) {
+        return { notPass: true, why: 'run error (expected for wrong body): ' + e.message };
+      }
+      const out = runResult.outputs[cfg.outName];
+      let bad = 0;
+      for (let i = 0; i < N; i++) {
+        const expected = ref(i, inputs, cfg.scalars);
+        if (Math.abs(out[i] - expected) > 1e-3 * Math.max(Math.abs(out[i]), Math.abs(expected)) + 1e-3) bad++;
+      }
+      // We WANT bad > 0 for the wrong body.
+      return { notPass: bad > 0, bad };
+    },
+    { cfg: serializeCfg(tc.cfg), starterFn: tc.starterFn, body: tc.wrongBody, N }
+  );
+
+  const ok = correctResult.pass && (wrongResult.notPass || wrongResult.bad > 0);
+  results.push({
+    id: tc.id,
+    correctPass: correctResult.pass,
+    wrongFails:  !!(wrongResult.notPass || wrongResult.bad > 0),
+    ok,
+    correctDetail: correctResult,
+    wrongDetail:   wrongResult,
+  });
+}
+
+await browser.close();
+server.close();
+
+// ── Report ────────────────────────────────────────────────────────────────
+console.log(JSON.stringify(results, null, 2));
+const allOk = results.length > 0 && results.every(r => r.ok);
+console.log(allOk ? 'LESSONS-GPU: ALL PASS' : 'LESSONS-GPU: FAILURE');
+process.exit(allOk ? 0 : 1);
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function serializeCfg(cfg) {
+  // Buffers: serialize gen as a string (eval'd on page side).
+  const bufs = {};
+  for (const [name, b] of Object.entries(cfg.buffers)) {
+    bufs[name] = {
+      role:        b.role,
+      elementType: b.elementType,
+      gen:         b.gen || null,
+    };
+  }
+  return {
+    n:         cfg.n,
+    buffers:   bufs,
+    scalars:   cfg.scalars,
+    outName:   cfg.outName,
+    reference: cfg.reference,
+  };
+}

--- a/gh-pages/learn/test/lessons_gpu_test.mjs
+++ b/gh-pages/learn/test/lessons_gpu_test.mjs
@@ -12,7 +12,6 @@
 
 import http from 'http';
 import fs from 'fs';
-import path from 'path';
 import { createRequire } from 'module';
 import { execSync } from 'child_process';
 
@@ -320,6 +319,147 @@ for (const tc of CASES) {
     wrongDetail:   wrongResult,
   });
 }
+
+// ── Visual lessons (Mandelbrot, image filter) ─────────────────────────────
+// These use whole-image inputs, scalars, and (for Mandelbrot) a small allowed
+// bad-fraction, so they are driven directly rather than through the generic
+// per-buffer loop above. Correct kernel → PASS; wrong kernel → FAIL.
+const visual = await page.evaluate(async () => {
+  const fr = Math.fround;
+
+  async function grade(src, buildInputs, scalars, outName, ref, maxBadFraction, n) {
+    const r = globalThis.SarekTranspile.transpileWithAbi(src, 'wgsl');
+    if (!r.ok) return { ok: false, transpile: r.error };
+    const inputs = buildInputs();
+    let run;
+    try { run = await globalThis.SarekWebGPU.run(r.code, r.abi, { inputs, scalars }); }
+    catch (e) { return { ok: false, run: e.message }; }
+    const out = run.outputs[outName];
+    let bad = 0;
+    for (let i = 0; i < n; i++) {
+      const e = ref(i, inputs, scalars), v = out[i];
+      if (Math.abs(v - e) > 1e-3 * Math.max(Math.abs(v), Math.abs(e)) + 1e-3) bad++;
+    }
+    return { ok: true, bad, pass: bad <= maxBadFraction * n };
+  }
+
+  // — Mandelbrot (64×64) —
+  const MW = 64, MH = 64, MMAX = 100, MN = MW * MH;
+  const mbSrc = (body) =>
+    'fun (output : float32 vector) (width : int32) (height : int32) (max_iter : int32) ->\n' +
+    '  let open Std in\n' +
+    '  let idx = global_thread_id in\n' +
+    '  let px = idx mod width in\n  let py = idx / width in\n' +
+    '  if py < height then begin\n' +
+    '    let x0 = (3.5 *. (float px /. float width)) -. 2.5 in\n' +
+    '    let y0 = (2.0 *. (float py /. float height)) -. 1.0 in\n' +
+    '    let zx = mut 0.0 in\n    let zy = mut 0.0 in\n    let iter = mut 0l in\n' +
+    '    while ((zx *. zx) +. (zy *. zy) <= 4.0) && (iter < max_iter) do\n' +
+    '      let xt = ' + body + ' in\n' +
+    '      zy := (2.0 *. zx *. zy) +. y0 ;\n      zx := xt ;\n      iter := iter + 1l\n' +
+    '    done ;\n    output.(idx) <- (float iter /. float max_iter)\n  end';
+  const mbInputs = () => ({ output: new Float32Array(MN) });
+  const mbScalars = { width: MW, height: MH, max_iter: MMAX };
+  const mbRef = (i) => {
+    const px = i % MW, py = Math.floor(i / MW);
+    if (py >= MH) return 0;
+    const x0 = fr(fr(3.5 * fr(px / MW)) - 2.5), y0 = fr(fr(2.0 * fr(py / MH)) - 1.0);
+    let zx = 0, zy = 0, it = 0;
+    while (fr(fr(zx * zx) + fr(zy * zy)) <= 4.0 && it < MMAX) {
+      const xt = fr(fr(fr(zx * zx) - fr(zy * zy)) + x0);
+      zy = fr(fr(fr(2.0 * zx) * zy) + y0); zx = xt; it++;
+    }
+    return it / MMAX;
+  };
+  const mbCorrect = await grade(mbSrc('(zx *. zx) -. (zy *. zy) +. x0'), mbInputs, mbScalars, 'output', mbRef, 0.02, MN);
+  const mbWrong   = await grade(mbSrc('x0'), mbInputs, mbScalars, 'output', mbRef, 0.02, MN);
+
+  // — Image filter / grayscale (64×64) —
+  const FW = 64, FH = 64, FN = FW * FH;
+  const fSrc = (body) =>
+    'fun (r : float32 vector) (g : float32 vector) (b : float32 vector) (gray : float32 vector) ->\n' +
+    '  let i = global_thread_id in\n  gray.(i) <- ' + body;
+  const fInputs = () => {
+    const r = new Float32Array(FN), g = new Float32Array(FN), b = new Float32Array(FN);
+    for (let py = 0; py < FH; py++) for (let px = 0; px < FW; px++) {
+      const i = py * FW + px; r[i] = px / FW; g[i] = py / FH; b[i] = 0.5;
+    }
+    return { r, g, b, gray: new Float32Array(FN) };
+  };
+  const fRef = (i, inp) => 0.299 * inp.r[i] + 0.587 * inp.g[i] + 0.114 * inp.b[i];
+  const fCorrect = await grade(fSrc('(0.299 *. r.(i)) +. (0.587 *. g.(i)) +. (0.114 *. b.(i))'), fInputs, {}, 'gray', fRef, 0, FN);
+  const fWrong   = await grade(fSrc('r.(i)'), fInputs, {}, 'gray', fRef, 0, FN);
+
+  return [
+    { id: 'lesson5-mandelbrot', ok: mbCorrect.pass === true && mbWrong.pass === false, correctDetail: mbCorrect, wrongDetail: mbWrong },
+    { id: 'lesson6-image-filter', ok: fCorrect.pass === true && fWrong.pass === false, correctDetail: fCorrect, wrongDetail: fWrong },
+  ];
+});
+for (const v of visual) results.push(v);
+
+// ── End-to-end harness check: drive the REAL SarekLesson.init (DOM → run →
+// colormap render → grade) for the Mandelbrot visual path, asserting the
+// output pane reads PASS and the canvas is actually painted (non-black). This
+// covers init/makeInputs/colormap/onResult/maxBadFraction, which the direct
+// kernel checks above bypass.
+const harness = await page.evaluate(async () => {
+  const mk = (tag, id) => { const e = document.createElement(tag); if (id) e.id = id; document.body.appendChild(e); return e; };
+  mk('textarea', 'h-src'); const btn = mk('button', 'h-run'); const outp = mk('pre', 'h-out');
+  const st = mk('span', 'h-st'); mk('pre', 'h-wgsl'); mk('button', 'h-wt');
+  const cv = mk('canvas', 'h-cv');
+  const W = 64, H = 64, MAX = 100, fr = Math.fround;
+  function ref(i, inp, sc) {
+    const w = sc.width, h = sc.height, max = sc.max_iter, px = i % w, py = Math.floor(i / w);
+    if (py >= h) return 0;
+    const x0 = fr(fr(3.5 * fr(px / w)) - 2.5), y0 = fr(fr(2.0 * fr(py / h)) - 1.0);
+    let zx = 0, zy = 0, it = 0;
+    while (fr(fr(zx * zx) + fr(zy * zy)) <= 4.0 && it < max) {
+      const xt = fr(fr(fr(zx * zx) - fr(zy * zy)) + x0);
+      zy = fr(fr(fr(2.0 * zx) * zy) + y0); zx = xt; it++;
+    }
+    return it / max;
+  }
+  const starter =
+    'fun (output : float32 vector) (width : int32) (height : int32) (max_iter : int32) ->\n' +
+    '  let open Std in\n  let idx = global_thread_id in\n' +
+    '  let px = idx mod width in\n  let py = idx / width in\n' +
+    '  if py < height then begin\n' +
+    '    let x0 = (3.5 *. (float px /. float width)) -. 2.5 in\n' +
+    '    let y0 = (2.0 *. (float py /. float height)) -. 1.0 in\n' +
+    '    let zx = mut 0.0 in\n    let zy = mut 0.0 in\n    let iter = mut 0l in\n' +
+    '    while ((zx *. zx) +. (zy *. zy) <= 4.0) && (iter < max_iter) do\n' +
+    '      let xt = (zx *. zx) -. (zy *. zy) +. x0 in\n' +
+    '      zy := (2.0 *. zx *. zy) +. y0 ;\n      zx := xt ;\n      iter := iter + 1l\n' +
+    '    done ;\n    output.(idx) <- (float iter /. float max_iter)\n  end';
+  await globalThis.SarekLesson.init({
+    editorId: 'h-src', runButtonId: 'h-run', outputId: 'h-out', statusId: 'h-st',
+    wgslId: 'h-wgsl', wgslToggleId: 'h-wt', width: W, height: H, starter: starter,
+    buffers: { output: { role: 'output', elementType: 'f32' } },
+    scalars: { width: W, height: H, max_iter: MAX }, outName: 'output',
+    colormap: function (t) {
+      if (t >= 1) return [0, 0, 0];
+      return [Math.floor(9 * (1 - t) * t * t * t * 255),
+              Math.floor(15 * (1 - t) * (1 - t) * t * t * 255),
+              Math.floor(8.5 * (1 - t) * (1 - t) * (1 - t) * t * 255)];
+    },
+    canvasId: 'h-cv', reference: ref, maxBadFraction: 0.02,
+  });
+  btn.click();
+  const t0 = Date.now();
+  while (Date.now() - t0 < 15000) {
+    if (/PASS|FAIL|error/i.test(st.textContent)) break;
+    await new Promise(r => setTimeout(r, 100));
+  }
+  const d = cv.getContext('2d').getImageData(0, 0, W, H).data;
+  let nonblack = 0;
+  for (let i = 0; i < W * H; i++) if (d[i * 4] || d[i * 4 + 1] || d[i * 4 + 2]) nonblack++;
+  return { status: st.textContent, output: outp.textContent, nonblack };
+});
+results.push({
+  id: 'harness-e2e-mandelbrot',
+  ok: harness.status === 'PASS' && harness.nonblack > 0,
+  detail: harness,
+});
 
 await browser.close();
 server.close();

--- a/gh-pages/stylesheets/learn.css
+++ b/gh-pages/stylesheets/learn.css
@@ -177,3 +177,43 @@
 }
 .lesson-nav a { color: var(--primary-color); text-decoration: none; }
 .lesson-nav a:hover { text-decoration: underline; }
+
+/* ── Visual lessons: canvases, upload, disclaimer ───────────────────────── */
+.lesson-canvas-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1rem 0;
+}
+.lesson-canvas-row figure {
+  margin: 0;
+  text-align: center;
+}
+.lesson-canvas-row figcaption {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  margin-top: 0.35rem;
+}
+.lesson-canvas {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--code-bg);
+  image-rendering: pixelated;
+  max-width: 100%;
+  height: auto;
+}
+.lesson-upload {
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+}
+.lesson-upload input[type="file"] { font-size: 0.8rem; }
+.lesson-disclaimer {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  border-left: 3px solid var(--primary-color);
+  padding-left: 0.75rem;
+  margin: 1rem 0;
+}

--- a/gh-pages/stylesheets/learn.css
+++ b/gh-pages/stylesheets/learn.css
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: CECILL-B */
+/* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> */
+/*
+ * learn.css — styles for the interactive GPU course pages.
+ * Uses CSS variables from modern.css so light/dark themes work automatically.
+ */
+
+/* ── Error/pass colours for dark mode (mirrors playground.html) ─────────── */
+:root {
+  --learn-error-color: #c0392b;
+  --learn-pass-color:  #27ae60;
+  --learn-fail-color:  #c0392b;
+}
+.dark-theme {
+  --learn-error-color: #f48771;
+  --learn-pass-color:  #2ecc71;
+  --learn-fail-color:  #f48771;
+}
+@media (prefers-color-scheme: dark) {
+  body:not(.light-theme) {
+    --learn-error-color: #f48771;
+    --learn-pass-color:  #2ecc71;
+    --learn-fail-color:  #f48771;
+  }
+}
+
+/* ── Lesson container ───────────────────────────────────────────────────── */
+.lesson-container {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 1rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ── WebGPU unavailable notice ──────────────────────────────────────────── */
+.webgpu-unavailable {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--card-bg);
+  color: var(--text-color);
+  font-size: 0.9rem;
+}
+
+/* ── Fallback textarea (when CodeMirror CDN fails) ──────────────────────── */
+.lesson-container textarea {
+  width: 100%;
+  font-family: monospace;
+  font-size: 0.9rem;
+  padding: 0.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-sizing: border-box;
+  background: var(--code-bg);
+  color: var(--text-color);
+  min-height: 10em;
+  resize: vertical;
+}
+
+/* ── CodeMirror: auto-height + CSS-var theming (mirrors playground.html) ── */
+.lesson-container .CodeMirror {
+  height: auto;
+  min-height: 10em;
+  font-family: monospace;
+  font-size: 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--code-bg);
+  color: var(--text-color);
+}
+.lesson-container .CodeMirror-gutters {
+  background: var(--code-bg);
+  border-right: 1px solid var(--border-color);
+}
+.lesson-container .CodeMirror-linenumber {
+  color: var(--text-color);
+  opacity: 0.5;
+}
+.lesson-container .CodeMirror-cursor {
+  border-left-color: var(--text-color);
+}
+.lesson-container .CodeMirror-selected {
+  background: var(--primary-color) !important;
+  opacity: 0.25;
+}
+
+/* OCaml token colours — contrast-safe on both light and dark --code-bg */
+.lesson-container .cm-keyword    { color: var(--primary-color); font-weight: bold; }
+.lesson-container .cm-builtin    { color: var(--primary-color); }
+.lesson-container .cm-def        { color: var(--text-color); }
+.lesson-container .cm-variable   { color: var(--text-color); }
+.lesson-container .cm-variable-2 { color: var(--text-color); }
+.lesson-container .cm-type       { color: #4caf50; }
+.lesson-container .cm-string     { color: #e67e22; }
+.lesson-container .cm-string-2   { color: #e67e22; }
+.lesson-container .cm-number     { color: #8e44ad; }
+.lesson-container .cm-comment    { color: var(--text-color); opacity: 0.55; font-style: italic; }
+.lesson-container .cm-operator   { color: var(--primary-color); }
+.lesson-container .cm-meta       { color: var(--text-color); opacity: 0.7; }
+
+/* ── Run button ─────────────────────────────────────────────────────────── */
+.lesson-run-btn {
+  align-self: flex-start;
+  padding: 0.45rem 1.25rem;
+  font-size: 1rem;
+  font-weight: bold;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.lesson-run-btn:hover:not(:disabled) { opacity: 0.85; }
+.lesson-run-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Status bar ─────────────────────────────────────────────────────────── */
+.lesson-status {
+  font-size: 0.8rem;
+  color: var(--text-color);
+  opacity: 0.65;
+  min-height: 1.2em;
+}
+
+/* ── Result / output pane ───────────────────────────────────────────────── */
+.lesson-output {
+  background: var(--code-bg);
+  color: var(--text-color);
+  padding: 0.85rem 1rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  min-height: 60px;
+  border: 1px solid var(--border-color);
+}
+.lesson-output.pass-output  { color: var(--learn-pass-color); border-color: var(--learn-pass-color); }
+.lesson-output.fail-output  { color: var(--learn-fail-color); border-color: var(--learn-fail-color); }
+.lesson-output.error-output { color: var(--learn-error-color); }
+
+/* ── WGSL toggle ────────────────────────────────────────────────────────── */
+.wgsl-toggle-btn {
+  font-size: 0.85rem;
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.25rem 0.6rem;
+  color: var(--text-color);
+  cursor: pointer;
+}
+.wgsl-toggle-btn:hover { background: var(--card-bg); }
+.lesson-wgsl-pre {
+  background: var(--code-bg);
+  color: var(--text-color);
+  padding: 0.85rem 1rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  border: 1px solid var(--border-color);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+/* ── Lesson prev/next nav ───────────────────────────────────────────────── */
+.lesson-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 0.9rem;
+}
+.lesson-nav a { color: var(--primary-color); text-decoration: none; }
+.lesson-nav a:hover { text-decoration: underline; }


### PR DESCRIPTION
## Phase 2 — Interactive GPU course pages

A first `learn/` course where the reader edits a Sarek kernel, clicks **Run on my GPU**, and the page transpiles it to WGSL, runs it on their own GPU via WebGPU (Phase-1 runner + ABI), and **auto-grades** the result against a CPU reference. Plan: `docs/plans/in-browser-gpu-course-program-2026-06-04.md`.

### Content
- **Landing** (`learn/index.md`): what GPGPU / a kernel is, the SPOC/Sarek model, how the interactive checker works.
- **Reusable harness** `javascripts/sarek_lesson.js` — `SarekLesson.init(cfg)`: CodeMirror editor (theme-aware, graceful fallback), transpile→ABI→run→grade with a relative tolerance, "Show WGSL" toggle, friendly WebGPU-unavailable message. Additive **visual mode**: `width/height`, `makeInputs` override, `colormap`→canvas, `onResult`, `renderInput`, `maxBadFraction`.
- **Graded lessons** (N=256): vector-add, SAXPY (scalar param), elementwise map (square), control-flow/bounds (`if`→`select`).
- **Visual lessons** (rendered to `<canvas>`):
  - **Mandelbrot** — per-pixel escape loop (`while` + `mut` + int `mod`/`/` + `float` conversions), normalized count → colormap → canvas; auto-checked vs a float32 reference (2% boundary tolerance).
  - **Image filter** — grayscale luminance over RGB float32 channels, original + filtered side by side, **plus an optional "use your own photo" upload** (processed locally on your GPU, nothing leaves the browser).
- **Nav**: "Learn" link added to the navbar; lessons cross-linked.

### Verification (RX 7900 XTX, Playwright + WebGPU — `make lessons-gpu-test`)
- All 6 lessons: correct kernel → **PASS**, wrong kernel → **FAIL** (numeric bad=255/255/254/128; Mandelbrot correct bad=0 / wrong 1889; filter correct bad=0 / wrong 4077).
- **End-to-end harness check**: drives the real `SarekLesson.init` (DOM → run → colormap → grade) → status `PASS` and the canvas is genuinely painted (3175 non-black pixels).
- `node --check` on harness + test; static gates pass.

WEB-ONLY: no OCaml/codegen/runtime changes; Phase-1 files consumed unchanged. Small datasets for instant iteration, with resource disclaimers for larger images/iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Learn" section to navigation with six interactive GPU programming lessons covering vector addition, scalar parameters, element-wise operations, control flow, Mandelbrot sets, and image filtering
  * Features in-browser code editor with button to execute kernels on GPU and automatic correctness validation
  * Generated WebGPU shader code is displayed for review in each lesson

<!-- end of auto-generated comment: release notes by coderabbit.ai -->