### PR TITLE
Phase 3: Integrate the Learn course into the site (home + playground)

### DIFF
--- a/gh-pages/_layouts/index.html
+++ b/gh-pages/_layouts/index.html
@@ -64,7 +64,8 @@
 
           <div class="btn-group">
             <a href="{{ site.baseurl }}/docs/getting_started.html" class="btn btn-primary">Get Started</a>
-            <a href="{{ site.baseurl }}/playground.html" class="btn btn-outline">Try Online</a>
+            <a href="{{ site.baseurl }}/learn/" class="btn btn-primary">Run kernels on your GPU</a>
+            <a href="{{ site.baseurl }}/playground.html" class="btn btn-outline">Playground</a>
             <a href="{{ site.baseurl }}/spoc_docs/index.html" class="btn btn-outline">API Docs</a>
           </div>
         </div>

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -41,6 +41,8 @@ dune build
 
 Check out the [Getting Started](docs/getting_started.html) guide to write your first GPU kernel in minutes, browse the [Examples](examples/) to see common patterns, or try the [Playground](playground.html) to transpile kernels live in your browser.
 
+New to GPU programming? The interactive [**Learn** course](learn/) teaches it from scratch — you edit a Sarek kernel and **run it on your own GPU** straight from the page (via WebGPU), with automatic checking. It builds up from vector addition through generating a Mandelbrot image and writing an image filter.
+
 ## How it works
 
 Sarek allows you to express parallel logic as standard OCaml functions. These are compiled to native GPU code at runtime.
@@ -49,7 +51,7 @@ Sarek allows you to express parallel logic as standard OCaml functions. These ar
 (* A simple vector addition kernel *)
 let%kernel vector_add (a : float32 vector) (b : float32 vector) (c : float32 vector) =
   let idx = get_global_id 0 in
-  c.(idx) <- a.(idx) + b.(idx)
+  c.(idx) <- a.(idx) +. b.(idx)
 ```
 
 <hr style="margin: 50px 0; border: 0; border-top: 1px solid var(--border-color);">

--- a/gh-pages/playground.html
+++ b/gh-pages/playground.html
@@ -134,6 +134,8 @@ title: Playground
   <p class="subtitle">
     Write an OCaml kernel expression and see the GPU source output.
     The transpiler runs entirely in your browser.
+    New to this? The <a href="{{ site.baseurl }}/learn/">interactive Learn course</a>
+    walks you through writing kernels and runs them on your own GPU.
   </p>
 
   <div class="editor-pane">


### PR DESCRIPTION
## Phase 3 — Website consistency

Now that the interactive course (`learn/`) is live, integrate it into the rest of the site and fix consistency issues found while sweeping the pages.

- **Home hero**: add a **"Run kernels on your GPU"** CTA → `/learn/`; relabel the playground button "Try Online" → "Playground" so the two in-browser entry points read distinctly.
- **Home body**: add a course callout under the quick-start links.
- **Playground**: cross-link to the course (complementary — playground is free-form transpile, the course is guided + runs on your GPU).
- **Bug fix**: the home "vector addition" example wrote `a.(idx) + b.(idx)` on **float32** vectors — Sarek requires `+.` for floats (the exact rule the course teaches). `get_global_id 0` is a canonical reserved intrinsic and kept as-is.

Verified: all `learn/` lesson cross-links resolve; the "Learn" nav entry is present in both user-facing layouts (`page.html`, `index.html`).

Noted for the Phase-4 docs audit (not changed here): `_layouts/index_sample.html` is an unused layout, and the site uses two valid thread-index spellings (`get_global_id N` vs `global_thread_id`) in different places.

Docs/web only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
