### PR TITLE
feat(web): SPOC web backend — design doc + inert WebGPU plugin skeleton

### DIFF
--- a/docs/plans/spoc-web-backend-2026-06-04.md
+++ b/docs/plans/spoc-web-backend-2026-06-04.md
@@ -1,0 +1,84 @@
+# SPOC Web Backend — pure-JS SPOC core + WebGPU backend (design / start)
+
+**Date:** 2026-06-04
+**Status:** PROPOSAL — for human review (this is the *start* of the effort; the PR is intentionally not auto-merged)
+**Relates to:** the in-browser GPU course program (`in-browser-gpu-course-program-2026-06-04.md`), Phase 5.
+
+## Goal
+
+Split SPOC so its **host-side numeric path compiles to JavaScript** (js_of_ocaml) and add an
+in-browser **WebGPU backend plugin** (`Spoc_webgpu`). This lets real SPOC host code run in the
+browser — eventually **replacing the hand-written `sarek_webgpu_runner.js`** with the actual SPOC
+runtime, and unlocking course lessons on **host-side interaction** (allocating vectors, transfers,
+reading back results) and **kernel composition** (chaining kernels, sharing buffers) that the current
+canned JS runner cannot teach.
+
+This document is the architecture + phased plan. The accompanying code is only the **first brick**
+(a registered-but-inert `Spoc_webgpu` backend skeleton that pins the interface) — deliberately small
+so the direction can be reviewed before the invasive decouple lands.
+
+## What the in-browser runner is today (and its ceiling)
+
+`gh-pages/javascripts/sarek_webgpu_runner.js` (Phase 1) is a *standalone* JS reimplementation of "bind
+buffers → dispatch → read back", driven by the ABI the transpiler emits. It is perfect for **Level 1/2**
+lessons (kernel + structured params, no `Spoc_core` in the browser). It cannot express **host logic**:
+multiple allocations with lifetimes, device→device transfers, composing several kernels over shared
+buffers, or the real SPOC `Vector`/`Execute` API. Those need actual SPOC running in the browser.
+
+## Boundary map (from the 2026-06-04 source audit — see [[webgpu-runtime-decouple-audit]])
+
+`spoc_core` (`sarek/core/`, links `ctypes` + `unix`) is **mostly Bigarray-based and jsoo-clean**. The
+non-jsoo coupling is localized:
+
+- **Custom-type only** (excludable): `Vector_types.ml` `Custom_storage`/`Custom_helpers`,
+  `Vector_storage.ml` `Ctypes.allocate_n`/`of_ctypes_ptr`/custom branches, `Vector_transfer.ml`
+  `to_ctypes_ptr`. The numeric kinds use `Bigarray_storage` (TypedArray-friendly).
+- **Backend signature** (`spoc/framework/Framework_sig.ml`): of the ~59-item `BACKEND`, only
+  `Memory.host_ptr_to_device` / `device_to_host_ptr` (l.210–215) are `Ctypes.ptr` — and only custom
+  types ever call them. The numeric path uses `host_to_device`/`device_to_host` (`Bigarray.Array1.t`).
+- **One core ctypes use:** `Memory.ml:61` `Ctypes_static.sizeof (typ_of_bigarray_kind kind)` →
+  replace with a pure `elem_size_of_kind` lookup (4/8/…).
+- **unix:** `Profiling.ml` `Unix.gettimeofday` (×2) and `Advanced.ml` `Unix.sleepf` — shim to
+  `Sys.time`/jsoo `performance.now`, and a jsoo-friendly yield.
+
+**Verdict:** a ctypes-free numeric `spoc_core` slice is achievable by isolating the custom-type branch
+behind a boundary + three small shims. Custom types in-browser are deferred (they `failwith`).
+
+## Backend plugin mechanism (to mirror)
+
+Backends implement `Framework_sig.BACKEND` and self-register on module load via
+`Framework_registry.register_backend ~priority (module Backend)` (lazy + `let () = Lazy.force …`).
+`Device.init ~frameworks:[…]` looks each up by name. The leanest existing examples to mirror are
+`sarek/plugins/interpreter/` (lightest) and `sarek/plugins/native/`. `Spoc_webgpu` will follow the same
+shape with `execution_model = JIT` and `generate_source` = the WGSL backend already in `sarek_codegen`.
+
+## Phased plan
+
+1. **(this PR — start) Interface skeleton.** `sarek/plugins/webgpu/` — `Spoc_webgpu` implementing the
+   full `Framework_sig.BACKEND` with stub bodies (`failwith "Spoc_webgpu: not yet implemented"`),
+   `is_available () = false` (so native `Device.init` never selects it), registered at priority below
+   Native. Builds in the normal toolchain. This pins the exact surface the jsoo runtime must fill and
+   proves registry integration — **no behaviour yet**.
+2. **Core decouple PR.** Isolate the custom-type/ctypes branch behind a module boundary; replace the
+   `Ctypes_static.sizeof` use and the two `Unix` uses with pure/shimmable equivalents; add an
+   **FFI-free bytecode (and jsoo) build target** for the numeric `spoc_core` slice (the regression gate,
+   mirroring the Phase-0B pure-codegen approach). Goldens / native behaviour unchanged.
+3. **jsoo WebGPU runtime PR.** Fill `Spoc_webgpu`'s `Memory`/`Kernel`/`Event`/`Stream` with real
+   js_of_ocaml ↔ WebGPU bindings (Bigarray ↔ `GPUBuffer`, WGSL `createShaderModule` + compute pass —
+   reusing the proven recipe from `sarek_webgpu_runner.js`). Build the in-browser SPOC bundle.
+4. **Migrate the playground/runner.** Route the course's "run on your GPU" through the real SPOC web
+   runtime instead of `sarek_webgpu_runner.js`; keep the JS runner as a fallback until parity.
+5. **Host-interaction & composition courses.** New `learn/` lessons that allocate vectors, transfer,
+   run multiple composed kernels over shared buffers, and read back — using the actual SPOC API in the
+   browser (impossible with the canned runner).
+
+## Risks / open questions (for the reviewer)
+
+- **WebGPU async vs SPOC's synchronous API.** WebGPU is promise-based; SPOC's `Execute.run_vectors` is
+  synchronous. The jsoo runtime must bridge this (Lwt, or a synchronous-looking façade over a
+  pre-warmed device). **This is the main design risk** and should be settled before Phase 3.
+- **Custom types in-browser:** deferred (stub `failwith`). Acceptable for courses? 
+- **Toplevel vs precompiled:** do we need `js_of_ocaml-toplevel` for learners to type host code, or do
+  we ship precompiled lesson programs and only let them edit the kernel? (Start with precompiled.)
+- **Scope of this first PR:** intentionally just the skeleton — confirm the phasing before the decouple.
+</content>

--- a/docs/plans/spoc-web-backend-2026-06-04.md
+++ b/docs/plans/spoc-web-backend-2026-06-04.md
@@ -72,13 +72,61 @@ shape with `execution_model = JIT` and `generate_source` = the WGSL backend alre
    run multiple composed kernels over shared buffers, and read back — using the actual SPOC API in the
    browser (impossible with the canned runner).
 
-## Risks / open questions (for the reviewer)
+## Risk mitigation
 
-- **WebGPU async vs SPOC's synchronous API.** WebGPU is promise-based; SPOC's `Execute.run_vectors` is
-  synchronous. The jsoo runtime must bridge this (Lwt, or a synchronous-looking façade over a
-  pre-warmed device). **This is the main design risk** and should be settled before Phase 3.
-- **Custom types in-browser:** deferred (stub `failwith`). Acceptable for courses? 
-- **Toplevel vs precompiled:** do we need `js_of_ocaml-toplevel` for learners to type host code, or do
-  we ship precompiled lesson programs and only let them edit the kernel? (Start with precompiled.)
-- **Scope of this first PR:** intentionally just the skeleton — confirm the phasing before the decouple.
+### Risk 1 — WebGPU async vs SPOC's synchronous API  →  **mitigated (measured)**
+
+The risk is narrower than "async vs sync". In WebGPU **almost everything is synchronous** —
+`createBuffer`/`writeBuffer`/`createShaderModule`/`createComputePipeline`/`createBindGroup`/the
+encoder/`dispatchWorkgroups`/`queue.submit` are all sync. Only **two** ops are promises:
+**device acquisition** (`requestAdapter`/`requestDevice`, one-time) and **read-back** (`buffer.mapAsync`).
+
+Mitigations, cheapest → most thorough:
+
+| | Approach | Cost |
+|---|---|---|
+| **A** | **Pre-warm the device**: acquire adapter+device once at init; the harness awaits it before enabling "Run", so in-browser `Device.init` returns the handle synchronously. Removes async (1). | trivial |
+| **B1** *(chosen)* | **Async read-back seam**: `Execute.run_vectors` stays synchronous (all sync WebGPU calls); only read-back is async in the browser — `Vector.to_array_async : 'a vector -> 'a array Lwt.t` (native keeps sync `to_array`). The one async point a lesson hits is "read results, then check". | small |
+| **C** | **Fully-synchronous façade**: jsoo in a Web Worker, GPU service on the main thread, sync RPC over `SharedArrayBuffer` + `Atomics.wait`, COOP/COEP via a coi-service-worker on GitHub Pages. SPOC's host API stays byte-identical/synchronous (needed only for a future toplevel). | heavy |
+
+Scoping the courses to **precompiled lesson programs** (the learner edits the kernel, as today) means the
+async seam is written once by the lesson author, so **A + B1 fully suffice and C is unneeded now.**
+
+### Risks 2–5 — mitigation
+
+- **Custom types (`Ctypes.ptr`):** out of v1 scope (stub `failwith`; courses use numeric vectors). Later,
+  back `Custom_storage` with an `ArrayBuffer`/`DataView` (no ctypes); `Custom_helpers.read_float32`/
+  `write_int64` map 1:1 to `DataView.getFloat32`/`setBigInt64`. The byte-identical golden gate protects
+  the numeric path during the decouple.
+- **`Ctypes_static.sizeof` + `Unix`:** fully removable — pure `elem_size_of_kind` lookup (proven by the
+  spike) and an injectable clock ref (native default / jsoo `performance.now`); the futures `Unix.sleepf`
+  is excluded from the numeric build.
+- **jsoo won't no-op ctypes-foreign:** don't compile the FFI plugins to jsoo; route through the
+  `Spoc_webgpu` BACKEND. Add a `dune` bytecode/jsoo target that builds only the numeric slice and **fails
+  the build if ctypes re-enters the link** (Phase-0B FFI-free gate) — converts the latent risk into CI.
+- **Toplevel vs precompiled:** start **precompiled** (avoids `js_of_ocaml-toplevel`, neutralizes most of Risk 1).
+
+## De-risking spikes — RESULTS (both passed; on this branch under `sarek/plugins/webgpu/spike/`)
+
+1. **jsoo ↔ WebGPU binding** (`spike/webgpu_binding/`) — an OCaml program compiled with js_of_ocaml drives a
+   full WebGPU `vector_add` **from OCaml** (`Js.Unsafe` bindings: `requestAdapter`→`requestDevice`→buffers→
+   WGSL `createShaderModule`→pipeline→dispatch→`mapAsync`), returning the result to OCaml via the **B1 async
+   callback seam**. **Verified correct for all 256 elements on the real RX 7900 XTX** (Playwright + flagged
+   Chrome). ⟹ Risk 1's chosen path is proven end-to-end.
+2. **FFI-free numeric core** (`spike/numeric_core/`) — a Bigarray-backed numeric vector (`create/get/set/
+   to_array`, `elem_size_of_kind`, injectable clock) **builds to both bytecode and js_of_ocaml with deps =
+   `bigarray` only** (no ctypes/unix); the bytecode test PASSes. The gap analysis classified every
+   `Ctypes`/`Unix` occurrence in the seven `spoc_core` numeric-path files and returned **GO**: the scalar
+   path is FFI-free once (i) `Memory.ml:61 sizeof` is shimmed, (ii) the custom-type branch is gated behind
+   a boundary, (iii) `Unix` is shimmed. One refinement over the original audit: the **FFI-transfer pointer
+   plumbing** (`Memory.ml` 130/141/172, `Vector_transfer.ml` 15–36 — `bigarray_start`/`to_voidp`) exists only
+   to feed the native FFI backends and must also be isolated for a *link-clean* build (it's never reached on
+   the WebGPU/typed-array path).
+
+## Remaining decisions (for the reviewer)
+
+- Confirm the **5-step phasing** and the **B1 (async read-back seam) + precompiled** direction before the decouple.
+- The decouple's exact module boundary: a `spoc_core_ctypes` companion lib vs a `Custom` functor for the
+  custom-type + FFI-transfer surface — to be settled at the start of the Core-decouple PR.
+- **Scope of this first PR:** still just the skeleton + these two spikes — no behaviour/decouple yet.
 </content>

--- a/docs/plans/spoc-web-backend-2026-06-04.md
+++ b/docs/plans/spoc-web-backend-2026-06-04.md
@@ -123,10 +123,30 @@ async seam is written once by the lesson author, so **A + B1 fully suffice and C
    to feed the native FFI backends and must also be isolated for a *link-clean* build (it's never reached on
    the WebGPU/typed-array path).
 
-## Remaining decisions (for the reviewer)
+## Decisions (locked 2026-06-05)
 
-- Confirm the **5-step phasing** and the **B1 (async read-back seam) + precompiled** direction before the decouple.
-- The decouple's exact module boundary: a `spoc_core_ctypes` companion lib vs a `Custom` functor for the
-  custom-type + FFI-transfer surface — to be settled at the start of the Core-decouple PR.
-- **Scope of this first PR:** still just the skeleton + these two spikes — no behaviour/decouple yet.
+- **Phasing:** the 5-step plan above — approved.
+- **Async bridge:** **B1** (synchronous `Execute`, async read-back seam `Vector.to_array_async`) +
+  **precompiled** lessons. Option C (workers + SharedArrayBuffer) not needed now.
+- **Decouple boundary: hidden functor.** Functorise the `Vector_*` trio over a `CUSTOM_OPS` signature in a
+  new pure `spoc_core_base` (no ctypes; `type handle` replaces `unit Ctypes.ptr`; alloc/get/set/free +
+  FFI-transfer as functor params). The native `spoc_core` (same name/path) defines `Ctypes_ops` and
+  re-exports `module Vector = Spoc_core_base.Make (Ctypes_ops)` so **`Spoc_core.Vector` is byte-identical
+  for every caller/test/plugin**. The browser build (`spoc_core_js`) instantiates `Make (Stub_ops)`
+  (custom-type ops raise "not supported in browser"; DataView-backed later). **No user/test/plugin/course
+  author ever writes `Make(...)`** — only the two maintainer instantiation lines do.
+
+## Core-decouple PR — proposed build order (safe → invasive)
+
+1. **Non-boundary shims + the FFI-free gate (tiny, low risk, additive):** replace `Memory.ml:61`
+   `Ctypes_static.sizeof` with `elem_size_of_kind` (Spike 2); make `Profiling`'s clock an injectable ref;
+   exclude the futures `Unix.sleepf` from the numeric path. Add the **FFI-free bytecode/jsoo build target**
+   for the numeric slice now, so it guards the rest. Goldens/e2e unchanged.
+2. **Functorise the `Vector_*` trio** into `spoc_core_base` over `CUSTOM_OPS`; native `spoc_core`
+   re-exports `Make (Ctypes_ops)`. Move the ctypes leaf code (`Custom_helpers`, `allocate_n`,
+   `of_ctypes_ptr`, `bigarray_start`/`to_voidp` FFI-transfer) behind `Ctypes_ops`. Gate: goldens
+   byte-identical + e2e green + the FFI-free target builds `spoc_core_base` with **no ctypes in its deps**.
+3. **`spoc_core_js`** = `Make (Stub_ops)`, plus an FFI-free jsoo smoke build.
+
+(These remain on `feature/spoc-web-backend` / future PRs — none auto-merged.)
 </content>

--- a/sarek/plugins/webgpu/Webgpu_plugin.ml
+++ b/sarek/plugins/webgpu/Webgpu_plugin.ml
@@ -1,0 +1,195 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * WebGPU Plugin Backend - Inert Skeleton
+ *
+ * Implements the Framework_sig.BACKEND interface as an inert stub for the
+ * in-browser WebGPU backend.  is_available () returns false so Device.init
+ * never selects this backend during native execution.  All operations raise
+ * "Spoc_webgpu: not yet implemented" - the real in-browser WebGPU runtime
+ * is forthcoming.
+ ******************************************************************************)
+
+open Spoc_framework
+open Spoc_framework_registry
+
+let not_impl () =
+  failwith
+    "Spoc_webgpu: not yet implemented (in-browser WebGPU runtime is \
+     forthcoming)"
+
+(** Extend Framework_sig.kargs with WebGPU-specific variant *)
+type Framework_sig.kargs += Webgpu_kargs of unit
+
+(** WebGPU intrinsic registry - empty stub *)
+module Webgpu_intrinsics : Framework_sig.INTRINSIC_REGISTRY = struct
+  type intrinsic_impl = unit
+
+  let table : (string, intrinsic_impl) Hashtbl.t = Hashtbl.create 4
+
+  let register name impl = Hashtbl.replace table name impl
+
+  let find name = Hashtbl.find_opt table name
+
+  let list_all () =
+    Hashtbl.fold (fun name _ acc -> name :: acc) table [] |> List.sort compare
+end
+
+(** WebGPU Backend - inert stub implementing Framework_sig.BACKEND *)
+module Backend : Framework_sig.BACKEND = struct
+  let name = "WebGPU"
+
+  let version = (0, 1, 0)
+
+  let is_available () = false
+
+  module Device = struct
+    type t = unit
+
+    type id = int
+
+    let init () = not_impl ()
+
+    let count () = not_impl ()
+
+    let get _i = not_impl ()
+
+    let id _d = not_impl ()
+
+    let name _d = not_impl ()
+
+    let capabilities _d = not_impl ()
+
+    let set_current _d = not_impl ()
+
+    let synchronize _d = not_impl ()
+  end
+
+  module Stream = struct
+    type t = unit
+
+    let create _d = not_impl ()
+
+    let destroy _s = not_impl ()
+
+    let synchronize _s = not_impl ()
+
+    let default _d = not_impl ()
+  end
+
+  module Memory = struct
+    type 'a buffer = unit
+
+    let alloc _d _n _kind = not_impl ()
+
+    let alloc_custom _d ~size:_ ~elem_size:_ = not_impl ()
+
+    let alloc_zero_copy _d _arr _kind = not_impl ()
+
+    let free _buf = not_impl ()
+
+    let host_to_device ~src:_ ~dst:_ = not_impl ()
+
+    let device_to_host ~src:_ ~dst:_ = not_impl ()
+
+    let host_ptr_to_device ~src_ptr:_ ~byte_size:_ ~dst:_ = not_impl ()
+
+    let device_to_host_ptr ~src:_ ~dst_ptr:_ ~byte_size:_ = not_impl ()
+
+    let device_to_device ~src:_ ~dst:_ = not_impl ()
+
+    let size _buf = not_impl ()
+
+    let device_ptr _buf = not_impl ()
+
+    let is_zero_copy _buf = not_impl ()
+  end
+
+  module Event = struct
+    type t = unit
+
+    let create () = not_impl ()
+
+    let destroy _e = not_impl ()
+
+    let record _e _s = not_impl ()
+
+    let synchronize _e = not_impl ()
+
+    let elapsed ~start:_ ~stop:_ = not_impl ()
+  end
+
+  module Kernel = struct
+    type t = unit
+
+    type args = unit
+
+    let compile _d ~name:_ ~source:_ = not_impl ()
+
+    let compile_cached _d ~name:_ ~source:_ = not_impl ()
+
+    let clear_cache () = not_impl ()
+
+    let create_args () = not_impl ()
+
+    let set_arg_buffer _a _i _buf = not_impl ()
+
+    let set_arg_int32 _a _i _v = not_impl ()
+
+    let set_arg_int64 _a _i _v = not_impl ()
+
+    let set_arg_float32 _a _i _v = not_impl ()
+
+    let set_arg_float64 _a _i _v = not_impl ()
+
+    let set_arg_ptr _a _i _p = not_impl ()
+
+    let launch _k ~args:_ ~grid:_ ~block:_ ~shared_mem:_ ~stream:_ = not_impl ()
+  end
+
+  let enable_profiling () = not_impl ()
+
+  let disable_profiling () = not_impl ()
+
+  (** Execution model: JIT - WebGPU compiles WGSL shaders at runtime *)
+  let execution_model = Framework_sig.JIT
+
+  (** Generate source - WGSL codegen not yet wired; returns None *)
+  let generate_source ?block:_ (_ir : Sarek_ir_types.kernel) : string option =
+    None
+
+  (** Direct execution not applicable to JIT backend *)
+  let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_
+      (_args : Framework_sig.exec_arg array) =
+    not_impl ()
+
+  module Intrinsics = Webgpu_intrinsics
+
+  let supported_source_langs = []
+
+  let run_source ~source:_ ~lang:_ ~kernel_name:_ ~block:_ ~grid:_ ~shared_mem:_
+      (_args : Framework_sig.run_source_arg list) =
+    not_impl ()
+
+  let wrap_kargs args = Webgpu_kargs args
+
+  let unwrap_kargs = function Webgpu_kargs args -> Some args | _ -> None
+end
+
+(** Auto-register backend when module is loaded. Priority 1 - lower than Native
+    (10) and Interpreter (5). Guarded by is_available () so native Device.init
+    never selects this. *)
+let registered_backend =
+  lazy
+    (if Backend.is_available () then
+       Framework_registry.register_backend
+         ~priority:1
+         (module Backend : Framework_sig.BACKEND))
+
+let () = Lazy.force registered_backend
+
+(** Force module initialization *)
+let init () = Lazy.force registered_backend

--- a/sarek/plugins/webgpu/dune
+++ b/sarek/plugins/webgpu/dune
@@ -1,0 +1,13 @@
+; WebGPU Plugin - In-browser WebGPU backend (inert skeleton)
+; is_available () = false so this backend is never selected on native builds.
+
+(library
+ (name sarek_webgpu)
+ (libraries
+  ctypes
+  spoc_framework
+  spoc_framework_registry
+  sarek
+  (re_export spoc_core))
+ (modules Webgpu_plugin)
+ (preprocess no_preprocessing))

--- a/sarek/plugins/webgpu/spike/numeric_core/dune
+++ b/sarek/plugins/webgpu/spike/numeric_core/dune
@@ -1,0 +1,29 @@
+; sarek/plugins/webgpu/spike/numeric_core — FFI-free numeric vector spike
+;
+; SPIKE: de-risking proof that Bigarray-backed numeric vectors can compile
+; FFI-free to both bytecode AND js_of_ocaml.  NOT part of the regular build.
+;
+; Build targets:
+;   dune build sarek/plugins/webgpu/spike/numeric_core/
+;   dune exec sarek/plugins/webgpu/spike/numeric_core/test_numeric_spike.exe
+;   dune build sarek/plugins/webgpu/spike/numeric_core/test_numeric_spike.bc.js
+;
+; Intentionally excluded from @install and default alias.
+
+; Library: the FFI-free numeric core (stdlib + bigarray only)
+
+(library
+ (name numeric_vector_spike)
+ (modules numeric_vector_spike)
+ (libraries bigarray)
+ (preprocess no_preprocessing))
+
+; Test executable — bytecode + jsoo
+; (modes byte) produces .exe (bytecode); (modes js) produces .bc.js
+
+(executable
+ (name test_numeric_spike)
+ (modules test_numeric_spike)
+ (libraries numeric_vector_spike)
+ (modes byte js)
+ (preprocess no_preprocessing))

--- a/sarek/plugins/webgpu/spike/numeric_core/numeric_vector_spike.ml
+++ b/sarek/plugins/webgpu/spike/numeric_core/numeric_vector_spike.ml
@@ -1,0 +1,114 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * SPIKE: FFI-free numeric vector core — de-risking proof
+ *
+ * PURPOSE: Prove that SPOC's Bigarray-backed numeric vector core can compile
+ * FFI-free to both native/bytecode AND js_of_ocaml.  Not for production use.
+ *
+ * DEPS: stdlib only (Bigarray is in-stdlib; jsoo provides it via typed arrays).
+ * NO ctypes, NO unix, NO spoc_core.
+ *
+ * Key replacements demonstrated:
+ *   - elem_size_of_kind  : pure lookup replacing Memory.ml:61
+ *                          Ctypes_static.sizeof (typ_of_bigarray_kind kind)
+ *   - now                : injectable clock ref replacing Profiling's
+ *                          Unix.gettimeofday
+ ******************************************************************************)
+
+(** {1 Kind GADT}
+    Mirrors Vector_types.scalar_kind but references only Bigarray, no Ctypes. *)
+type (_, _) kind =
+  | Float32 : (float, Bigarray.float32_elt) kind
+  | Float64 : (float, Bigarray.float64_elt) kind
+  | Int32 : (int32, Bigarray.int32_elt) kind
+  | Int64 : (int64, Bigarray.int64_elt) kind
+  | Int8u : (int, Bigarray.int8_unsigned_elt) kind
+  | Complex32 : (Complex.t, Bigarray.complex32_elt) kind
+
+(** Convert kind to Bigarray.kind *)
+let to_bigarray_kind : type a b. (a, b) kind -> (a, b) Bigarray.kind = function
+  | Float32 -> Bigarray.Float32
+  | Float64 -> Bigarray.Float64
+  | Int32 -> Bigarray.Int32
+  | Int64 -> Bigarray.Int64
+  | Int8u -> Bigarray.Int8_unsigned
+  | Complex32 -> Bigarray.Complex32
+
+(** Pure byte-size lookup — replaces Memory.ml:61
+    [Ctypes_static.sizeof (Ctypes.typ_of_bigarray_kind kind)]. No FFI required:
+    sizes are fixed by the IEEE / ABI spec. *)
+let elem_size_of_kind : type a b. (a, b) kind -> int = function
+  | Float32 -> 4
+  | Float64 -> 8
+  | Int32 -> 4
+  | Int64 -> 8
+  | Int8u -> 1
+  | Complex32 -> 8
+
+(** {1 Injectable clock}
+    Native build leaves this as [Sys.time]; a jsoo bootstrap can swap it for
+    [Js.to_float (new%js Js.date_now)##valueOf] before the first use. *)
+let now : (unit -> float) ref = ref Sys.time
+
+(** {1 Vector type} *)
+type ('a, 'b) t = {
+  ba : ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
+  kind : ('a, 'b) kind;
+  elem_size : int;
+}
+
+(** {1 Core operations} *)
+
+(** [create kind n] allocates an uninitialised vector of [n] elements. *)
+let create : type a b. (a, b) kind -> int -> (a, b) t =
+ fun kind n ->
+  let ba = Bigarray.Array1.create (to_bigarray_kind kind) Bigarray.c_layout n in
+  {ba; kind; elem_size = elem_size_of_kind kind}
+
+(** [length v] returns the number of elements. *)
+let length (v : ('a, 'b) t) : int = Bigarray.Array1.dim v.ba
+
+(** [get v i] reads element [i]. Raises [Invalid_argument] on out-of-bounds. *)
+let get : type a b. (a, b) t -> int -> a =
+ fun v i ->
+  if i < 0 || i >= Bigarray.Array1.dim v.ba then
+    invalid_arg
+      (Printf.sprintf
+         "Numeric_vector_spike.get: index %d out of bounds [0,%d)"
+         i
+         (Bigarray.Array1.dim v.ba)) ;
+  Bigarray.Array1.get v.ba i
+
+(** [set v i x] writes [x] to element [i]. Raises [Invalid_argument] on
+    out-of-bounds. *)
+let set : type a b. (a, b) t -> int -> a -> unit =
+ fun v i x ->
+  if i < 0 || i >= Bigarray.Array1.dim v.ba then
+    invalid_arg
+      (Printf.sprintf
+         "Numeric_vector_spike.set: index %d out of bounds [0,%d)"
+         i
+         (Bigarray.Array1.dim v.ba)) ;
+  Bigarray.Array1.set v.ba i x
+
+(** [to_array v] copies the vector contents to a plain OCaml array. *)
+let to_array : type a b. (a, b) t -> a array =
+ fun v ->
+  let n = Bigarray.Array1.dim v.ba in
+  if n = 0 then [||]
+  else
+    let arr = Array.make n (Bigarray.Array1.get v.ba 0) in
+    for i = 1 to n - 1 do
+      arr.(i) <- Bigarray.Array1.get v.ba i
+    done ;
+    arr
+
+(** [kind v] returns the element kind. *)
+let kind (v : ('a, 'b) t) : ('a, 'b) kind = v.kind
+
+(** [elem_size v] returns the byte size of each element. *)
+let elem_size (v : ('a, 'b) t) : int = v.elem_size

--- a/sarek/plugins/webgpu/spike/numeric_core/test_numeric_spike.ml
+++ b/sarek/plugins/webgpu/spike/numeric_core/test_numeric_spike.ml
@@ -1,0 +1,149 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * SPIKE: test/assertion harness for numeric_vector_spike
+ *
+ * Runs under bytecode and js_of_ocaml — no Alcotest, no ctypes, no unix.
+ * Exit code 0 = PASS, non-zero = FAIL.
+ ******************************************************************************)
+
+open Numeric_vector_spike
+
+(* ------------------------------------------------------------------ helpers *)
+
+let check_bool desc b =
+  if not b then begin
+    Printf.printf "FAIL: %s\n%!" desc ;
+    exit 1
+  end
+
+let check_int desc expected actual =
+  if expected <> actual then begin
+    Printf.printf "FAIL: %s — expected %d, got %d\n%!" desc expected actual ;
+    exit 1
+  end
+
+let check_float desc expected actual =
+  let eps = 1e-6 in
+  if abs_float (expected -. actual) > eps then begin
+    Printf.printf "FAIL: %s — expected %f, got %f\n%!" desc expected actual ;
+    exit 1
+  end
+
+let check_int32 desc expected actual =
+  if Int32.compare expected actual <> 0 then begin
+    Printf.printf "FAIL: %s — expected %ld, got %ld\n%!" desc expected actual ;
+    exit 1
+  end
+
+(* ----------------------------------------------- elem_size_of_kind tests *)
+
+let test_elem_sizes () =
+  check_int "elem_size Float32" 4 (elem_size_of_kind Float32) ;
+  check_int "elem_size Float64" 8 (elem_size_of_kind Float64) ;
+  check_int "elem_size Int32" 4 (elem_size_of_kind Int32) ;
+  check_int "elem_size Int64" 8 (elem_size_of_kind Int64) ;
+  check_int "elem_size Int8u" 1 (elem_size_of_kind Int8u) ;
+  check_int "elem_size Complex32" 8 (elem_size_of_kind Complex32)
+
+(* ----------------------------------------------- Float32 vector tests *)
+
+let test_float32 () =
+  let v = create Float32 5 in
+  check_int "Float32 length" 5 (length v) ;
+  check_int "Float32 elem_size" 4 (elem_size v) ;
+  set v 0 1.0 ;
+  set v 1 2.0 ;
+  set v 2 3.0 ;
+  set v 3 4.0 ;
+  set v 4 5.0 ;
+  check_float "Float32 get 0" 1.0 (get v 0) ;
+  check_float "Float32 get 4" 5.0 (get v 4) ;
+  let arr = to_array v in
+  check_int "Float32 to_array length" 5 (Array.length arr) ;
+  check_float "Float32 to_array[2]" 3.0 arr.(2)
+
+(* ----------------------------------------------- Float64 vector tests *)
+
+let test_float64 () =
+  let v = create Float64 3 in
+  check_int "Float64 length" 3 (length v) ;
+  check_int "Float64 elem_size" 8 (elem_size v) ;
+  set v 0 1.5 ;
+  set v 1 2.5 ;
+  set v 2 3.5 ;
+  check_float "Float64 get 1" 2.5 (get v 1) ;
+  let arr = to_array v in
+  check_float "Float64 to_array[0]" 1.5 arr.(0)
+
+(* ----------------------------------------------- Int32 vector tests *)
+
+let test_int32 () =
+  let v = create Int32 4 in
+  check_int "Int32 length" 4 (length v) ;
+  check_int "Int32 elem_size" 4 (elem_size v) ;
+  set v 0 10l ;
+  set v 1 20l ;
+  set v 2 30l ;
+  set v 3 40l ;
+  check_int32 "Int32 get 0" 10l (get v 0) ;
+  check_int32 "Int32 get 3" 40l (get v 3) ;
+  let arr = to_array v in
+  check_int32 "Int32 to_array[1]" 20l arr.(1)
+
+(* ----------------------------------------------- bounds check tests *)
+
+let test_bounds () =
+  let v = create Float32 3 in
+  let got_exn = ref false in
+  (try
+     let _ = get v (-1) in
+     ()
+   with Invalid_argument _ -> got_exn := true) ;
+  check_bool "Float32 get negative index raises" !got_exn ;
+  got_exn := false ;
+  (try
+     let _ = get v 3 in
+     ()
+   with Invalid_argument _ -> got_exn := true) ;
+  check_bool "Float32 get past-end raises" !got_exn ;
+  got_exn := false ;
+  (try set v 5 99.0 with Invalid_argument _ -> got_exn := true) ;
+  check_bool "Float32 set past-end raises" !got_exn
+
+(* ----------------------------------------------- injectable clock test *)
+
+let test_injectable_clock () =
+  (* Default is Sys.time — call it and verify we get a positive float *)
+  let t0 = !now () in
+  check_bool "default clock returns positive float" (t0 >= 0.0) ;
+  (* Swap the clock for a constant stub *)
+  let stub_time = 42.0 in
+  let saved = !now in
+  (now := fun () -> stub_time) ;
+  let t1 = !now () in
+  check_float "injected clock returns stub value" stub_time t1 ;
+  now := saved
+
+(* ----------------------------------------------- empty vector *)
+
+let test_empty () =
+  let v = create Float64 0 in
+  check_int "empty length" 0 (length v) ;
+  let arr = to_array v in
+  check_int "empty to_array length" 0 (Array.length arr)
+
+(* ----------------------------------------------- run all *)
+
+let () =
+  test_elem_sizes () ;
+  test_float32 () ;
+  test_float64 () ;
+  test_int32 () ;
+  test_bounds () ;
+  test_injectable_clock () ;
+  test_empty () ;
+  print_endline "PASS"

--- a/sarek/plugins/webgpu/spike/webgpu_binding/dune
+++ b/sarek/plugins/webgpu/spike/webgpu_binding/dune
@@ -1,0 +1,18 @@
+; sarek/plugins/webgpu/spike/webgpu_binding - WebGPU jsoo spike
+;
+; SPIKE: de-risking proof that OCaml/jsoo can drive WebGPU end-to-end.
+; NOT part of the regular build; only built explicitly:
+;   dune build sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike.bc.js
+;
+; Intentionally excluded from @install and default alias.
+
+(executable
+ (name webgpu_jsoo_spike)
+ (modules webgpu_jsoo_spike)
+ (libraries js_of_ocaml)
+ (preprocess
+  (pps js_of_ocaml-ppx))
+ (js_of_ocaml
+  (flags
+   (--opt 1 --no-source-map)))
+ (modes js))

--- a/sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike.ml
+++ b/sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike.ml
@@ -37,14 +37,18 @@ let catch_ p f =
    ------------------------------------------------------------------------- *)
 
 let wgsl_source =
-  "@group(0) @binding(0) var<storage, read>       a : array<f32>;\n\
-   @group(0) @binding(1) var<storage, read>       b : array<f32>;\n\
-   @group(0) @binding(2) var<storage, read_write> c : array<f32>;\n\n\
-   @compute @workgroup_size(64)\n\
-   fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
-   \\  let i = gid.x;\n\
-   \\  if (i < arrayLength(&c)) { c[i] = a[i] + b[i]; }\n\
-   }\n"
+  String.concat
+    "\n"
+    [
+      "@group(0) @binding(0) var<storage, read>       a : array<f32>;";
+      "@group(0) @binding(1) var<storage, read>       b : array<f32>;";
+      "@group(0) @binding(2) var<storage, read_write> c : array<f32>;";
+      "@compute @workgroup_size(64)";
+      "fn main(@builtin(global_invocation_id) gid : vec3<u32>) {";
+      "  let i = gid.x;";
+      "  if (i < arrayLength(&c)) { c[i] = a[i] + b[i]; }";
+      "}";
+    ]
 
 (* -------------------------------------------------------------------------
    GPUBufferUsage flags (WebGPU spec section 24.4).

--- a/sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike.ml
+++ b/sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike.ml
@@ -1,0 +1,324 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** SPIKE -- WebGPU js_of_ocaml end-to-end de-risking proof. NOT production
+    code. Self-contained; depends only on js_of_ocaml.
+
+    Exports [globalThis.SpocWebGpuSpike.runVectorAdd(aArray, bArray, callback)]
+    which drives a full WebGPU compute dispatch (vector add) entirely from OCaml
+    via [Js_of_ocaml.Js.Unsafe] and returns the result to OCaml via an async
+    callback after [mapAsync] resolves.
+
+    Promise chaining strategy: every [then_] call wraps an OCaml function in a
+    JS callback so control returns to OCaml at each async step; no JS blobs are
+    delegated to [eval] or external JS helpers. *)
+
+open Js_of_ocaml
+
+(* -------------------------------------------------------------------------
+   Tiny promise helpers -- the core of the async seam.
+   [then_ p f] chains [f] onto promise [p].  The returned promise is ignored
+   intentionally: this is a fire-and-forget compute chain; errors surface as
+   unhandled rejections, which is acceptable in a spike.
+   ------------------------------------------------------------------------- *)
+
+let then_ p f =
+  ignore
+    (Js.Unsafe.meth_call p "then" [|Js.Unsafe.inject (Js.wrap_callback f)|])
+
+let catch_ p f =
+  ignore
+    (Js.Unsafe.meth_call p "catch" [|Js.Unsafe.inject (Js.wrap_callback f)|])
+
+(* -------------------------------------------------------------------------
+   WGSL shader -- hardcoded; layout:'auto' so no explicit GPUBindGroupLayout.
+   ------------------------------------------------------------------------- *)
+
+let wgsl_source =
+  "@group(0) @binding(0) var<storage, read>       a : array<f32>;\n\
+   @group(0) @binding(1) var<storage, read>       b : array<f32>;\n\
+   @group(0) @binding(2) var<storage, read_write> c : array<f32>;\n\n\
+   @compute @workgroup_size(64)\n\
+   fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+   \\  let i = gid.x;\n\
+   \\  if (i < arrayLength(&c)) { c[i] = a[i] + b[i]; }\n\
+   }\n"
+
+(* -------------------------------------------------------------------------
+   GPUBufferUsage flags (WebGPU spec section 24.4).
+   ------------------------------------------------------------------------- *)
+
+let usage_storage = 0x0080
+
+let usage_copy_src = 0x0004
+
+let usage_copy_dst = 0x0008
+
+let usage_map_read = 0x0001
+
+let create_buffer device byte_length usage =
+  let desc = Js.Unsafe.obj [||] in
+  Js.Unsafe.set
+    desc
+    "size"
+    (Js.Unsafe.inject (Js.number_of_float (float_of_int byte_length))) ;
+  Js.Unsafe.set
+    desc
+    "usage"
+    (Js.Unsafe.inject (Js.number_of_float (float_of_int usage))) ;
+  Js.Unsafe.meth_call device "createBuffer" [|Js.Unsafe.inject desc|]
+
+(* -------------------------------------------------------------------------
+   Core implementation.
+
+   Called from JS as SpocWebGpuSpike.runVectorAdd(a, b, callback) where
+   [a] and [b] are JS Float32Arrays of equal length N, and [callback] is a JS
+   function called as callback(Float32Array|null, errorString|null).
+
+   The async read-back seam: mapAsync returns a Promise; its resolve handler
+   copies the mapped range into an OCaml float array, builds a JS Float32Array
+   from it, and calls the OCaml-wrapped callback -- returning GPU results to
+   OCaml via a callback after one async boundary.
+   ------------------------------------------------------------------------- *)
+
+let run_vector_add a_js b_js callback_js =
+  let gpu = Js.Unsafe.get (Js.Unsafe.get Js.Unsafe.global "navigator") "gpu" in
+  let fail msg =
+    ignore
+      (Js.Unsafe.fun_call
+         callback_js
+         [|Js.Unsafe.inject Js.null; Js.Unsafe.inject (Js.string msg)|])
+  in
+  let adapter_promise =
+    Js.Unsafe.meth_call
+      gpu
+      "requestAdapter"
+      [|Js.Unsafe.inject (Js.Unsafe.obj [||])|]
+  in
+  catch_ adapter_promise (fun err ->
+      let s = Js.to_string (Js.Unsafe.meth_call err "toString" [||]) in
+      fail ("requestAdapter rejected: " ^ s)) ;
+  then_ adapter_promise (fun adapter ->
+      if
+        Js.Unsafe.equals adapter Js.null
+        || Js.Unsafe.equals adapter Js.undefined
+      then fail "no WebGPU adapter available"
+      else
+        let device_promise =
+          Js.Unsafe.meth_call
+            adapter
+            "requestDevice"
+            [|Js.Unsafe.inject (Js.Unsafe.obj [||])|]
+        in
+        catch_ device_promise (fun err ->
+            let s = Js.to_string (Js.Unsafe.meth_call err "toString" [||]) in
+            fail ("requestDevice rejected: " ^ s)) ;
+        then_ device_promise (fun device ->
+            let n =
+              int_of_float (Js.float_of_number (Js.Unsafe.get a_js "length"))
+            in
+            let byte_len = n * 4 in
+            (* Storage buffers for a, b (read) and c (read_write + copy_src). *)
+            let buf_a =
+              create_buffer device byte_len (usage_storage lor usage_copy_dst)
+            in
+            let buf_b =
+              create_buffer device byte_len (usage_storage lor usage_copy_dst)
+            in
+            let buf_c =
+              create_buffer device byte_len (usage_storage lor usage_copy_src)
+            in
+            (* Readback buffer: MAP_READ | COPY_DST. *)
+            let buf_read =
+              create_buffer device byte_len (usage_map_read lor usage_copy_dst)
+            in
+            let queue = Js.Unsafe.get device "queue" in
+            (* Upload a and b. *)
+            Js.Unsafe.meth_call
+              queue
+              "writeBuffer"
+              [|
+                Js.Unsafe.inject buf_a;
+                Js.Unsafe.inject (Js.number_of_float 0.0);
+                Js.Unsafe.inject a_js;
+              |]
+            |> ignore ;
+            Js.Unsafe.meth_call
+              queue
+              "writeBuffer"
+              [|
+                Js.Unsafe.inject buf_b;
+                Js.Unsafe.inject (Js.number_of_float 0.0);
+                Js.Unsafe.inject b_js;
+              |]
+            |> ignore ;
+            (* Shader module. *)
+            let shader_desc = Js.Unsafe.obj [||] in
+            Js.Unsafe.set shader_desc "code" (Js.string wgsl_source) ;
+            let shader =
+              Js.Unsafe.meth_call
+                device
+                "createShaderModule"
+                [|Js.Unsafe.inject shader_desc|]
+            in
+            (* Compute pipeline with layout:'auto'. *)
+            let compute_stage = Js.Unsafe.obj [||] in
+            Js.Unsafe.set compute_stage "module" shader ;
+            Js.Unsafe.set compute_stage "entryPoint" (Js.string "main") ;
+            let pipeline_desc = Js.Unsafe.obj [||] in
+            Js.Unsafe.set pipeline_desc "layout" (Js.string "auto") ;
+            Js.Unsafe.set pipeline_desc "compute" compute_stage ;
+            let pipeline =
+              Js.Unsafe.meth_call
+                device
+                "createComputePipeline"
+                [|Js.Unsafe.inject pipeline_desc|]
+            in
+            (* Bind group entries. *)
+            let mk_entry binding buf =
+              let e = Js.Unsafe.obj [||] in
+              Js.Unsafe.set
+                e
+                "binding"
+                (Js.Unsafe.inject (Js.number_of_float (float_of_int binding))) ;
+              let res = Js.Unsafe.obj [||] in
+              Js.Unsafe.set res "buffer" buf ;
+              Js.Unsafe.set e "resource" res ;
+              e
+            in
+            let bg_desc = Js.Unsafe.obj [||] in
+            Js.Unsafe.set
+              bg_desc
+              "layout"
+              (Js.Unsafe.meth_call
+                 pipeline
+                 "getBindGroupLayout"
+                 [|Js.Unsafe.inject (Js.number_of_float 0.0)|]) ;
+            Js.Unsafe.set
+              bg_desc
+              "entries"
+              (Js.array
+                 [|mk_entry 0 buf_a; mk_entry 1 buf_b; mk_entry 2 buf_c|]) ;
+            let bind_group =
+              Js.Unsafe.meth_call
+                device
+                "createBindGroup"
+                [|Js.Unsafe.inject bg_desc|]
+            in
+            (* Command encoding. *)
+            let encoder =
+              Js.Unsafe.meth_call
+                device
+                "createCommandEncoder"
+                [|Js.Unsafe.inject (Js.Unsafe.obj [||])|]
+            in
+            let pass =
+              Js.Unsafe.meth_call
+                encoder
+                "beginComputePass"
+                [|Js.Unsafe.inject (Js.Unsafe.obj [||])|]
+            in
+            Js.Unsafe.meth_call pass "setPipeline" [|Js.Unsafe.inject pipeline|]
+            |> ignore ;
+            Js.Unsafe.meth_call
+              pass
+              "setBindGroup"
+              [|
+                Js.Unsafe.inject (Js.number_of_float 0.0);
+                Js.Unsafe.inject bind_group;
+              |]
+            |> ignore ;
+            let workgroups = (n + 63) / 64 in
+            Js.Unsafe.meth_call
+              pass
+              "dispatchWorkgroups"
+              [|
+                Js.Unsafe.inject (Js.number_of_float (float_of_int workgroups));
+              |]
+            |> ignore ;
+            Js.Unsafe.meth_call pass "end" [||] |> ignore ;
+            (* Copy c to readback buffer. *)
+            Js.Unsafe.meth_call
+              encoder
+              "copyBufferToBuffer"
+              [|
+                Js.Unsafe.inject buf_c;
+                Js.Unsafe.inject (Js.number_of_float 0.0);
+                Js.Unsafe.inject buf_read;
+                Js.Unsafe.inject (Js.number_of_float 0.0);
+                Js.Unsafe.inject (Js.number_of_float (float_of_int byte_len));
+              |]
+            |> ignore ;
+            let commands = Js.Unsafe.meth_call encoder "finish" [||] in
+            Js.Unsafe.meth_call
+              queue
+              "submit"
+              [|Js.Unsafe.inject (Js.array [|commands|])|]
+            |> ignore ;
+            (* --- ASYNC READ-BACK SEAM ---
+               GPUMapMode.READ = 1.
+               mapAsync resolves when the GPU result is ready to read from the
+               CPU.  The resolve handler runs entirely in OCaml: it reads the
+               mapped ArrayBuffer via a Float32Array view, copies values into
+               an OCaml float array, then builds a new JS Float32Array to
+               deliver to the callback.  This is the key correctness proof:
+               GPU data crosses the async boundary back into OCaml. *)
+            let map_promise =
+              Js.Unsafe.meth_call
+                buf_read
+                "mapAsync"
+                [|Js.Unsafe.inject (Js.number_of_float 1.0)|]
+            in
+            catch_ map_promise (fun err ->
+                let s =
+                  Js.to_string (Js.Unsafe.meth_call err "toString" [||])
+                in
+                fail ("mapAsync rejected: " ^ s)) ;
+            then_ map_promise (fun _unit ->
+                let ab = Js.Unsafe.meth_call buf_read "getMappedRange" [||] in
+                let f32_ctor = Js.Unsafe.get Js.Unsafe.global "Float32Array" in
+                let view = Js.Unsafe.new_obj f32_ctor [|Js.Unsafe.inject ab|] in
+                (* Copy into OCaml-side float array. *)
+                let result_arr =
+                  Array.init n (fun i ->
+                      Js.float_of_number
+                        (Js.Unsafe.get
+                           view
+                           (Js.number_of_float (float_of_int i))))
+                in
+                Js.Unsafe.meth_call buf_read "unmap" [||] |> ignore ;
+                Js.Unsafe.meth_call buf_a "destroy" [||] |> ignore ;
+                Js.Unsafe.meth_call buf_b "destroy" [||] |> ignore ;
+                Js.Unsafe.meth_call buf_c "destroy" [||] |> ignore ;
+                Js.Unsafe.meth_call buf_read "destroy" [||] |> ignore ;
+                (* Build a JS Float32Array from the OCaml result. *)
+                let out =
+                  Js.Unsafe.new_obj
+                    f32_ctor
+                    [|Js.Unsafe.inject (Js.number_of_float (float_of_int n))|]
+                in
+                Array.iteri
+                  (fun i v ->
+                    Js.Unsafe.set
+                      out
+                      (Js.number_of_float (float_of_int i))
+                      (Js.number_of_float v))
+                  result_arr ;
+                ignore
+                  (Js.Unsafe.fun_call
+                     callback_js
+                     [|Js.Unsafe.inject out; Js.Unsafe.inject Js.null|]))))
+
+(* -------------------------------------------------------------------------
+   Module registration.
+   ------------------------------------------------------------------------- *)
+
+let () =
+  let m = Js.Unsafe.obj [||] in
+  Js.Unsafe.set
+    m
+    "runVectorAdd"
+    (Js.Unsafe.callback (fun a b cb -> run_vector_add a b cb)) ;
+  Js.Unsafe.set Js.Unsafe.global "SpocWebGpuSpike" m

--- a/sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike_test.mjs
+++ b/sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike_test.mjs
@@ -1,0 +1,154 @@
+// SPIKE: WebGPU jsoo end-to-end acceptance test.
+// Loads webgpu_jsoo_spike.bc.js, calls SpocWebGpuSpike.runVectorAdd on a
+// 256-element vector (a[i]=i*0.5, b[i]=i*2.0), and checks every element of the
+// result equals a[i]+b[i] within 1e-4.
+//
+// Mirrors the harness of sarek/transpile/web/test/webgpu_wgsl_test.mjs exactly
+// for playwright resolution, chrome launch flags, and skip/fail semantics:
+// - exit 0 on SKIP (no WebGPU adapter, playwright missing, bundle missing)
+// - exit 0 on PASS
+// - exit 1 only on a real wrong result
+//
+// Usage:
+//   node sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike_test.mjs \
+//     [path/to/webgpu_jsoo_spike.bc.js]
+//
+// The LEAD runs this on the GPU. This file is authored and syntax-checked only
+// (node --check) in CI.
+import http from 'http';
+import fs from 'fs';
+import { createRequire } from 'module';
+import { execSync } from 'child_process';
+
+function resolvePlaywright() {
+  const reqHere = createRequire(import.meta.url);
+  const candidates = [];
+  try { candidates.push(execSync('npm root -g').toString().trim()); } catch (_) {}
+  try {
+    candidates.push(
+      ...execSync('ls -d /home/*/.npm/_npx/*/node_modules 2>/dev/null')
+        .toString()
+        .trim()
+        .split('\n')
+    );
+  } catch (_) {}
+  for (const base of candidates.filter(Boolean)) {
+    try { return createRequire(base + '/x')('playwright'); } catch (_) {}
+  }
+  try { return reqHere('playwright'); } catch (_) {}
+  return null;
+}
+
+function skip(msg) { console.log('SKIP: ' + msg); process.exit(0); }
+function fail(msg) { console.log('FAIL: ' + msg); process.exit(1); }
+
+const pw = resolvePlaywright();
+if (!pw) skip('playwright not resolvable');
+const { chromium } = pw;
+
+const BUNDLE =
+  process.argv[2] ||
+  '_build/default/sarek/plugins/webgpu/spike/webgpu_binding/webgpu_jsoo_spike.bc.js';
+if (!fs.existsSync(BUNDLE)) skip('bundle not built: ' + BUNDLE);
+const bundleJs = fs.readFileSync(BUNDLE);
+
+const html =
+  '<!doctype html><meta charset=utf-8><title>spoc-webgpu-spike</title>' +
+  '<script src="/b.js"></script>';
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/b.js') {
+    res.setHeader('content-type', 'text/javascript');
+    res.end(bundleJs);
+  } else {
+    res.setHeader('content-type', 'text/html');
+    res.end(html);
+  }
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+let browser;
+try {
+  browser = await chromium.launch({
+    headless: true,
+    channel: 'chrome',
+    args: [
+      '--enable-unsafe-webgpu',
+      '--enable-features=Vulkan',
+      '--use-angle=vulkan',
+      '--use-gl=angle',
+      '--ignore-gpu-blocklist',
+      '--no-sandbox',
+    ],
+  });
+} catch (e) {
+  server.close();
+  skip('chrome launch failed: ' + e.message);
+}
+
+const page = await browser.newPage();
+await page.goto(`http://localhost:${port}/`, { waitUntil: 'load' });
+await page.waitForFunction(
+  () => typeof globalThis.SpocWebGpuSpike !== 'undefined',
+  { timeout: 20000 }
+);
+
+// Guard: skip gracefully if no WebGPU adapter is available.
+const hasAdapter = await page.evaluate(async () => {
+  if (!navigator.gpu) return false;
+  const a = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
+  return a !== null;
+});
+if (!hasAdapter) {
+  await browser.close();
+  server.close();
+  skip('no WebGPU adapter in this Chrome');
+}
+
+// Run the vector-add spike.
+const result = await page.evaluate(async () => {
+  const N = 256;
+  const a = new Float32Array(N);
+  const b = new Float32Array(N);
+  for (let i = 0; i < N; i++) {
+    a[i] = i * 0.5;
+    b[i] = i * 2.0;
+  }
+
+  // Wrap the OCaml callback-style API in a Promise so we can await it.
+  const output = await new Promise((resolve, reject) => {
+    globalThis.SpocWebGpuSpike.runVectorAdd(a, b, (result, err) => {
+      if (err !== null) reject(new Error(String(err)));
+      else resolve(result);
+    });
+  });
+
+  // Validate.
+  let badCount = 0;
+  const errors = [];
+  for (let i = 0; i < N; i++) {
+    const expected = a[i] + b[i];
+    if (Math.abs(output[i] - expected) > 1e-4) {
+      badCount++;
+      if (errors.length < 5)
+        errors.push({ i, got: output[i], expected });
+    }
+  }
+  return { ok: badCount === 0, badCount, errors, n: N };
+});
+
+await browser.close();
+server.close();
+
+if (result.ok) {
+  console.log('PASS: SpocWebGpuSpike.runVectorAdd correct for all ' + result.n + ' elements');
+  process.exit(0);
+} else {
+  fail(
+    'SpocWebGpuSpike.runVectorAdd: ' +
+      result.badCount +
+      ' wrong values; first errors: ' +
+      JSON.stringify(result.errors)
+  );
+}


### PR DESCRIPTION
## SPOC web backend — START (design + inert skeleton) — ⚠️ please review, do NOT auto-merge

This is the **beginning** of splitting SPOC so its host-side numeric path compiles to JS and runs in the browser via a real **WebGPU backend**, eventually replacing the hand-written `sarek_webgpu_runner.js` and enabling **host-interaction / kernel-composition** course lessons. Opened for your review of the *direction* before the invasive work lands — **not for merge yet**.

### What's here (intentionally minimal)
- **Design doc** `docs/plans/spoc-web-backend-2026-06-04.md` — architecture, the verified ctypes/unix boundary, the backend-plugin mechanism to mirror, a 5-step phased plan, and the open design risks (notably WebGPU's async API vs SPOC's synchronous `Execute`).
- **Inert backend skeleton** `sarek/plugins/webgpu/` (`Spoc_webgpu`) — implements the full `Framework_sig.BACKEND` (59 items; 52 stubbed with `failwith "not yet implemented"`), `is_available () = false` so `Device.init` never selects it, registered below Native. It **pins the exact interface** the future jsoo WebGPU runtime must fill and proves registry integration — **no behaviour yet**.

### Verified
- `dune build sarek/plugins/webgpu/` ✓ and `@fmt` ✓.
- Additive only: no changes to existing plugins / `Framework_sig` / `spoc_core`; not added to any default framework list.
- The full-build `-lnvrtc` error is pre-existing (CUDA not installed locally) — identical on `main`; unrelated to this PR (CI builds without that link step).

### Next (in the design doc — NOT in this PR)
1. Core decouple: isolate the custom-type/ctypes branch + shim `Ctypes_static.sizeof`/`Unix`; add an FFI-free bytecode/jsoo build of the numeric `spoc_core`.
2. jsoo WebGPU runtime: fill `Spoc_webgpu`'s Memory/Kernel/Event with real WebGPU bindings.
3. Migrate the course's "run on your GPU" onto the real SPOC web runtime.
4. Host-interaction & composition lessons.

**Decision needed:** does the phasing + the async-bridge approach look right before I start the decouple?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed design proposal and 5-step roadmap for a browser-based WebGPU backend.

* **New Features**
  * Introduced an inert WebGPU backend plugin (marked unavailable).
  * Added an FFI-free numeric-core proof-of-concept for browser numeric operations.
  * Added a WebGPU binding spike demonstrating async GPU compute and readback.

* **Tests**
  * Added unit tests for the numeric core and an end-to-end WebGPU acceptance test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->