### PR TITLE
SPOC web backend: spoc_core_js (browser numeric core + jsoo smoke)

### DIFF
--- a/sarek/core_js/Js_ops.ml
+++ b/sarek/core_js/Js_ops.ml
@@ -1,0 +1,49 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Js_ops — browser-targeted CUSTOM_OPS implementation for spoc_core_js.
+ *
+ * The pure Bigarray host path (numeric scalars) never calls any of these ops.
+ * Custom-type and device-transfer operations raise a clear message indicating
+ * they will be available once the WebGPU runtime lands.
+ *
+ * Constraints:
+ *   - NO ctypes, NO unix.
+ *   - Types are kept minimal (unit aliases) matching Stub_ops conventions.
+ ******************************************************************************)
+
+(** Opaque handle for custom storage. Unused on the pure Bigarray path. *)
+type handle = unit
+
+(** Opaque device type. WebGPU device will replace this when the runtime lands.
+*)
+type device_t = unit
+
+(** Opaque device-buffer type. WebGPU buffer will replace this. *)
+type device_buf = unit
+
+let _not_supported op =
+  failwith
+    ("spoc_core_js: " ^ op
+   ^ " not supported in the browser yet (custom types / device transfers \
+      arrive with the WebGPU runtime)")
+
+let alloc ~elem_size:_ ~length:_ = _not_supported "alloc"
+
+let free _ = _not_supported "free"
+
+let of_raw _ = _not_supported "of_raw"
+
+let to_raw _ = _not_supported "to_raw"
+
+let add_offset _ _ = _not_supported "add_offset"
+
+let copy_elems ~src:_ ~dst:_ ~elem_count:_ ~get:_ ~set:_ =
+  _not_supported "copy_elems"
+
+let bigarray_to_handle _ = _not_supported "bigarray_to_handle"
+
+let device_id _ = _not_supported "device_id"

--- a/sarek/core_js/Spoc_core_js.ml
+++ b/sarek/core_js/Spoc_core_js.ml
@@ -1,0 +1,29 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Spoc_core_js — browser instantiation of the FFI-free numeric vector core.
+ *
+ * Instantiates [Spoc_core_base.Make(Js_ops)], exposing the full browser-safe
+ * numeric Vector API: create, to_bigarray, get, set, to_array, length, kind,
+ * elem_size, kind_name, and scalar-kind convenience values.
+ *
+ * Profiling and native clock injection are skipped — they are native-only.
+ ******************************************************************************)
+
+include Spoc_core_base.Make (Js_ops)
+
+(** Convenience: get the i-th element of a scalar vector via Bigarray. *)
+let get (type a b) (vec : (a, b) t) (i : int) : a =
+  Bigarray.Array1.get (to_bigarray vec) i
+
+(** Convenience: set the i-th element of a scalar vector via Bigarray. *)
+let set (type a b) (vec : (a, b) t) (i : int) (v : a) : unit =
+  Bigarray.Array1.set (to_bigarray vec) i v
+
+(** Convert a scalar vector to an OCaml array. *)
+let to_array (type a b) (vec : (a, b) t) : a array =
+  let ba = to_bigarray vec in
+  Array.init vec.length (fun i -> Bigarray.Array1.get ba i)

--- a/sarek/core_js/Spoc_core_js.mli
+++ b/sarek/core_js/Spoc_core_js.mli
@@ -1,0 +1,32 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Spoc_core_js — public interface for the browser numeric vector core.
+ *
+ * This module is [Spoc_core_base.Make(Js_ops)] with convenience accessors
+ * added on top. It is safe to compile to JavaScript via js_of_ocaml.
+ *
+ * Custom-type and device-transfer operations are NOT available in this build;
+ * they will be filled in by the WebGPU runtime layer.
+ ******************************************************************************)
+
+(** All types, kind helpers, type-id helpers, creation, accessors, copy,
+    slicing, list/array creation, and sync-callback API from the base functor.
+    Refer to {!Spoc_core_base.Make} for full documentation. *)
+include module type of Spoc_core_base.Make (Js_ops)
+
+(** [get vec i] returns the [i]-th element of a scalar vector. Raises
+    [Invalid_argument] if [vec] uses custom storage (not reachable on the pure
+    Bigarray path). *)
+val get : ('a, 'b) t -> int -> 'a
+
+(** [set vec i v] sets the [i]-th element of a scalar vector. Raises
+    [Invalid_argument] if [vec] uses custom storage. *)
+val set : ('a, 'b) t -> int -> 'a -> unit
+
+(** [to_array vec] converts a scalar vector to an OCaml array. Raises
+    [Invalid_argument] if [vec] uses custom storage. *)
+val to_array : ('a, 'b) t -> 'a array

--- a/sarek/core_js/dune
+++ b/sarek/core_js/dune
@@ -1,0 +1,12 @@
+; spoc_core_js — browser-targeted instantiation of the FFI-free numeric vector core.
+; Dependencies: sarek_ir and spoc_core_base only.
+; NO ctypes, NO unix.
+
+(library
+ (name spoc_core_js)
+ (public_name sarek.core_js)
+ (libraries sarek_ir spoc_core_base)
+ (modules Js_ops Spoc_core_js)
+ (preprocess no_preprocessing)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek/core_js/test/dune
+++ b/sarek/core_js/test/dune
@@ -1,0 +1,9 @@
+; spoc_core_js smoke test — bytecode and js_of_ocaml targets.
+; No ctypes, no unix.
+
+(executable
+ (name smoke)
+ (modes byte js)
+ (modules smoke)
+ (libraries spoc_core_js)
+ (preprocess no_preprocessing))

--- a/sarek/core_js/test/smoke.ml
+++ b/sarek/core_js/test/smoke.ml
@@ -1,0 +1,87 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * smoke — spoc_core_js host Vector API smoke test.
+ *
+ * Exercises Float32, Float64, Int32, Int64 scalar vectors via the browser-safe
+ * spoc_core_js API: create, set, get, to_array, length, kind, elem_size.
+ * Prints "spoc_core_js smoke: PASS" and exits 0 on success, exits 1 on failure.
+ *
+ * Builds as:
+ *   - smoke.bc     (bytecode, native-compat test runner)
+ *   - smoke.bc.js  (js_of_ocaml, browser-path gate)
+ ******************************************************************************)
+
+module V = Spoc_core_js
+
+let check_float32 () =
+  let n = 6 in
+  let vec = V.create V.float32 n in
+  assert (vec.V.length = n) ;
+  assert (V.kind_name V.float32 = "Float32") ;
+  assert (V.elem_size V.float32 = 4) ;
+  for i = 0 to n - 1 do
+    V.set vec i (float_of_int (i * 10))
+  done ;
+  for i = 0 to n - 1 do
+    assert (V.get vec i = float_of_int (i * 10))
+  done ;
+  let arr = V.to_array vec in
+  assert (Array.length arr = n) ;
+  Array.iteri (fun i v -> assert (v = float_of_int (i * 10))) arr
+
+let check_float64 () =
+  let n = 4 in
+  let vec = V.create V.float64 n in
+  assert (vec.V.length = n) ;
+  assert (V.kind_name V.float64 = "Float64") ;
+  assert (V.elem_size V.float64 = 8) ;
+  let values = [|1.1; 2.2; 3.3; 4.4|] in
+  Array.iteri (fun i v -> V.set vec i v) values ;
+  Array.iteri (fun i v -> assert (V.get vec i = v)) values ;
+  let arr = V.to_array vec in
+  assert (Array.length arr = n) ;
+  Array.iteri (fun i v -> assert (v = values.(i))) arr
+
+let check_int32 () =
+  let n = 5 in
+  let vec = V.create V.int32 n in
+  assert (vec.V.length = n) ;
+  assert (V.kind_name V.int32 = "Int32") ;
+  assert (V.elem_size V.int32 = 4) ;
+  for i = 0 to n - 1 do
+    V.set vec i (Int32.of_int (i + 100))
+  done ;
+  for i = 0 to n - 1 do
+    assert (V.get vec i = Int32.of_int (i + 100))
+  done ;
+  let arr = V.to_array vec in
+  assert (Array.length arr = n) ;
+  Array.iteri (fun i v -> assert (v = Int32.of_int (i + 100))) arr
+
+let check_int64 () =
+  let n = 3 in
+  let vec = V.create V.int64 n in
+  assert (vec.V.length = n) ;
+  assert (V.kind_name V.int64 = "Int64") ;
+  assert (V.elem_size V.int64 = 8) ;
+  let values = [|1000L; 2000L; 3000L|] in
+  Array.iteri (fun i v -> V.set vec i v) values ;
+  Array.iteri (fun i v -> assert (V.get vec i = v)) values ;
+  let arr = V.to_array vec in
+  assert (Array.length arr = n) ;
+  Array.iteri (fun i v -> assert (v = values.(i))) arr
+
+let () =
+  try
+    check_float32 () ;
+    check_float64 () ;
+    check_int32 () ;
+    check_int64 () ;
+    Printf.printf "spoc_core_js smoke: PASS\n%!"
+  with e ->
+    Printf.eprintf "spoc_core_js smoke: FAIL — %s\n%!" (Printexc.to_string e) ;
+    exit 1


### PR DESCRIPTION
## SPOC web backend — `spoc_core_js` (browser numeric core + jsoo smoke)

Adds a browser-targeted instantiation of the now-merged FFI-free numeric vector core (`Spoc_core_base.Make(CUSTOM_OPS)`). **Additive** — no native code or golden changes.

- **`sarek/core_js/`** (new lib `spoc_core_js`, deps `sarek_ir spoc_core_base` only — **no ctypes/unix**): `Js_ops` (a `CUSTOM_OPS` whose custom-type/device ops `failwith` — provably unreachable from the pure Bigarray host path) + `Spoc_core_js = Make(Js_ops)` exposing the host `Vector` API (create/get/set/to_array/length/kind/elem_size).
- **jsoo smoke** (`test/smoke.bc.js` + `.bc`): exercises the Vector API for **Float32/Float64/Int32/Int64** with real value round-trips; runs under **`node`** → "spoc_core_js smoke: PASS".

### Pipeline
- **Fresh independent review (build-verified): VERDICT GO** — additive (diff stat: 6 new files under `core_js/`, nothing under `core/`/`core_base/`), goldens byte-identical, jsoo+bytecode smoke PASS, FFI-free confirmed (jsoo linking+running proves no C-stub closure), within code-quality limits.
- `@fmt` clean. The `Js_ops`≡`Stub_ops` duplication is a tracked cosmetic follow-up (it's replaced by real WebGPU ops in the runtime task).

The numeric SPOC host `Vector` API now runs in the browser via js_of_ocaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-compatible numeric vector library supporting Float32, Float64, Int32, and Int64 scalar vectors.
  * Introduced vector element access and array conversion utilities for scalar vectors.
  * Note: Custom storage and device-transfer operations will be available with future WebGPU runtime integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->