### PR TITLE
SPOC web backend: jsoo WebGPU runtime (run kernels on the GPU from OCaml)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,14 @@ lessons-gpu-test:
 	@dune build sarek/transpile/web/transpile_js.bc.js
 	@node gh-pages/learn/test/lessons_gpu_test.mjs _build/default/sarek/transpile/web/transpile_js.bc.js
 
+
+# SpocRT WebGPU runtime acceptance test: compile kernels via OCaml jsoo runtime
+# driver and run on a real GPU (Playwright + flagged Chrome -> Dawn/Vulkan).
+# Skips where playwright/chrome/WebGPU are unavailable; fails on wrong GPU result.
+webgpu-runtime-test:
+	@dune build sarek/core_js/webgpu/test/runtime_driver.bc.js
+	@node sarek/core_js/webgpu/test/webgpu_runtime_test.mjs _build/default/sarek/core_js/webgpu/test/runtime_driver.bc.js
+
 bench-update:
 	@echo "Running benchmarks and updating web data..."
 	@./benchmarks/run_all_benchmarks.sh results

--- a/sarek/core_js/webgpu/Webgpu_js.ml
+++ b/sarek/core_js/webgpu/Webgpu_js.ml
@@ -1,0 +1,88 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Low-level js_of_ocaml glue for the WebGPU runtime: promise helpers, JS
+    object/array accessors, typed-array construction, and the WebGPU global enum
+    readers. Kept separate from {!Webgpu_runtime} so each file stays within the
+    project size limits. *)
+
+open Js_of_ocaml
+
+(* jsoo 6.x: Js.to_float/Js.float exist; Js.to_int/Js.of_int/Js.of_float do not. *)
+let js_to_int x = int_of_float (Js.to_float x)
+
+let js_of_int n = Js.float (float_of_int n)
+
+let js_of_float v = Js.float v
+
+let then_ p f =
+  ignore
+    (Js.Unsafe.meth_call p "then" [|Js.Unsafe.inject (Js.wrap_callback f)|])
+
+let catch_ p f =
+  ignore
+    (Js.Unsafe.meth_call p "catch" [|Js.Unsafe.inject (Js.wrap_callback f)|])
+
+let js_global name = Js.Unsafe.get Js.Unsafe.global (Js.string name)
+
+let gpu =
+  js_global "navigator" |> fun nav -> Js.Unsafe.get nav (Js.string "gpu")
+
+let json_parse s =
+  Js.Unsafe.fun_call
+    (Js.Unsafe.get (js_global "JSON") (Js.string "parse"))
+    [|Js.Unsafe.inject (Js.string s)|]
+
+let js_get obj key = Js.Unsafe.get obj (Js.string key)
+
+let js_int obj key = js_to_int (js_get obj key)
+
+let js_str obj key = Js.to_string (js_get obj key)
+
+let js_arr_len arr = js_to_int (Js.Unsafe.get arr (Js.string "length"))
+
+let js_arr_get arr i = Js.Unsafe.get arr (js_of_int i)
+
+let js_is_null_or_undef v =
+  Js.Optdef.case
+    (Js.Optdef.return v)
+    (fun () -> true)
+    (fun v' -> Js.Opt.case (Js.Opt.return v') (fun () -> true) (fun _ -> false))
+
+let make_ta ctor (data : float array) =
+  let arr =
+    Js.Unsafe.new_obj ctor [|Js.Unsafe.inject (js_of_int (Array.length data))|]
+  in
+  Array.iteri
+    (fun i v ->
+      Js.Unsafe.set arr (js_of_int i) (Js.Unsafe.inject (js_of_float v)))
+    data ;
+  arr
+
+let typed_array et data =
+  match et with
+  | "f32" -> make_ta (js_global "Float32Array") data
+  | "i32" -> make_ta (js_global "Int32Array") data
+  | "u32" -> make_ta (js_global "Uint32Array") data
+  | _ -> failwith ("SpocRT: unknown elementType: " ^ et)
+
+let bpe = function
+  | "f32" | "i32" | "u32" -> 4
+  | et -> failwith ("SpocRT: unknown elementType: " ^ et)
+
+let usage s =
+  js_to_int (Js.Unsafe.get (js_global "GPUBufferUsage") (Js.string s))
+
+let map_read () =
+  js_to_int (Js.Unsafe.get (js_global "GPUMapMode") (Js.string "READ"))
+
+let shader_compute () =
+  js_to_int (Js.Unsafe.get (js_global "GPUShaderStage") (Js.string "COMPUTE"))
+
+let js_err err =
+  Js.Optdef.case
+    (Js.Optdef.return (js_get err "message"))
+    (fun () -> "unknown error")
+    Js.to_string

--- a/sarek/core_js/webgpu/Webgpu_runtime.ml
+++ b/sarek/core_js/webgpu/Webgpu_runtime.ml
@@ -1,0 +1,498 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** OCaml/js_of_ocaml WebGPU compute runtime. See {!Webgpu_runtime.mli} for full
+    API documentation. *)
+
+open Js_of_ocaml
+
+(* jsoo 6.x: Js.to_float/Js.float exist; Js.to_int/Js.of_int/Js.of_float do not. *)
+let js_to_int x = int_of_float (Js.to_float x)
+
+let js_of_int n = Js.float (float_of_int n)
+
+let js_of_float v = Js.float v
+
+let then_ p f =
+  ignore
+    (Js.Unsafe.meth_call p "then" [|Js.Unsafe.inject (Js.wrap_callback f)|])
+
+let catch_ p f =
+  ignore
+    (Js.Unsafe.meth_call p "catch" [|Js.Unsafe.inject (Js.wrap_callback f)|])
+
+let js_global name = Js.Unsafe.get Js.Unsafe.global (Js.string name)
+
+let gpu =
+  js_global "navigator" |> fun nav -> Js.Unsafe.get nav (Js.string "gpu")
+
+let json_parse s =
+  Js.Unsafe.fun_call
+    (Js.Unsafe.get (js_global "JSON") (Js.string "parse"))
+    [|Js.Unsafe.inject (Js.string s)|]
+
+let js_get obj key = Js.Unsafe.get obj (Js.string key)
+
+let js_int obj key = js_to_int (js_get obj key)
+
+let js_str obj key = Js.to_string (js_get obj key)
+
+let js_arr_len arr = js_to_int (Js.Unsafe.get arr (Js.string "length"))
+
+let js_arr_get arr i = Js.Unsafe.get arr (js_of_int i)
+
+let js_is_null_or_undef v =
+  Js.Optdef.case
+    (Js.Optdef.return v)
+    (fun () -> true)
+    (fun v' -> Js.Opt.case (Js.Opt.return v') (fun () -> true) (fun _ -> false))
+
+let make_ta ctor (data : float array) =
+  let arr =
+    Js.Unsafe.new_obj ctor [|Js.Unsafe.inject (js_of_int (Array.length data))|]
+  in
+  Array.iteri
+    (fun i v ->
+      Js.Unsafe.set arr (js_of_int i) (Js.Unsafe.inject (js_of_float v)))
+    data ;
+  arr
+
+let typed_array et data =
+  match et with
+  | "f32" -> make_ta (js_global "Float32Array") data
+  | "i32" -> make_ta (js_global "Int32Array") data
+  | "u32" -> make_ta (js_global "Uint32Array") data
+  | _ -> failwith ("SpocRT: unknown elementType: " ^ et)
+
+let bpe = function
+  | "f32" | "i32" | "u32" -> 4
+  | et -> failwith ("SpocRT: unknown elementType: " ^ et)
+
+let usage s =
+  js_to_int (Js.Unsafe.get (js_global "GPUBufferUsage") (Js.string s))
+
+let map_read () =
+  js_to_int (Js.Unsafe.get (js_global "GPUMapMode") (Js.string "READ"))
+
+let shader_compute () =
+  js_to_int (Js.Unsafe.get (js_global "GPUShaderStage") (Js.string "COMPUTE"))
+
+let js_err err =
+  Js.Optdef.case
+    (Js.Optdef.return (js_get err "message"))
+    (fun () -> "unknown error")
+    Js.to_string
+
+(** Shared context threaded through the async promise chain. *)
+type ctx = {
+  device : Js.Unsafe.any;
+  buffers_js : Js.Unsafe.any;
+  n_bufs : int;
+  params_js : Js.Unsafe.any;
+  has_params : bool;
+  workgroup_x : int;
+  wgsl : string;
+  inputs : (string * float array) list;
+  scalars : (string * float) list;
+  outputs_wanted : string list;
+  on_done : (string * float array) list -> unit;
+  on_error : string -> unit;
+}
+
+let create_buf ctx size usage =
+  Js.Unsafe.meth_call
+    ctx.device
+    "createBuffer"
+    [|
+      Js.Unsafe.inject
+        (Js.Unsafe.obj
+           [|
+             ("size", Js.Unsafe.inject (js_of_int size));
+             ("usage", Js.Unsafe.inject (js_of_int usage));
+           |]);
+    |]
+
+let queue_write ctx buf data =
+  let q = js_get ctx.device "queue" in
+  Js.Unsafe.meth_call
+    q
+    "writeBuffer"
+    [|
+      Js.Unsafe.inject buf;
+      Js.Unsafe.inject (js_of_int 0);
+      Js.Unsafe.inject data;
+    |]
+  |> ignore
+
+let destroy buf = Js.Unsafe.meth_call buf "destroy" [||] |> ignore
+
+let cleanup gbs rbs ub =
+  Hashtbl.iter (fun _ b -> destroy b) gbs ;
+  Hashtbl.iter (fun _ (b, _, _) -> destroy b) rbs ;
+  Option.iter destroy ub
+
+let build_bgl ctx =
+  let vis = shader_compute () in
+  let mk_entry binding typ =
+    Js.Unsafe.obj
+      [|
+        ("binding", Js.Unsafe.inject (js_of_int binding));
+        ("visibility", Js.Unsafe.inject (js_of_int vis));
+        ( "buffer",
+          Js.Unsafe.inject
+            (Js.Unsafe.obj [|("type", Js.Unsafe.inject (Js.string typ))|]) );
+      |]
+  in
+  let bents =
+    Array.init ctx.n_bufs (fun i ->
+        let d = js_arr_get ctx.buffers_js i in
+        let typ =
+          if String.equal (js_str d "access") "read" then "read-only-storage"
+          else "storage"
+        in
+        mk_entry (js_int d "binding") typ)
+  in
+  let ents =
+    if ctx.has_params then
+      Js.array
+        (Array.append
+           bents
+           [|mk_entry (js_int ctx.params_js "binding") "uniform"|])
+    else Js.array bents
+  in
+  Js.Unsafe.meth_call
+    ctx.device
+    "createBindGroupLayout"
+    [|Js.Unsafe.inject (Js.Unsafe.obj [|("entries", Js.Unsafe.inject ents)|])|]
+
+let alloc_storage ctx =
+  let gbs = Hashtbl.create 8 and rbs = Hashtbl.create 8 and maxn = ref 0 in
+  let stor = usage "STORAGE" lor usage "COPY_SRC" lor usage "COPY_DST" in
+  for i = 0 to ctx.n_bufs - 1 do
+    let d = js_arr_get ctx.buffers_js i in
+    let name = js_str d "name" and et = js_str d "elementType" in
+    let data =
+      match List.assoc_opt name ctx.inputs with
+      | None -> failwith ("SpocRT: missing input for buffer \"" ^ name ^ "\"")
+      | Some d -> d
+    in
+    let blen = Array.length data * bpe et in
+    let gb = create_buf ctx blen stor in
+    queue_write ctx gb (typed_array et data) ;
+    Hashtbl.replace gbs name gb ;
+    Hashtbl.replace
+      rbs
+      name
+      (create_buf ctx blen (usage "MAP_READ" lor usage "COPY_DST"), blen, et) ;
+    if Array.length data > !maxn then maxn := Array.length data
+  done ;
+  (gbs, rbs, !maxn)
+
+let pack_uniform ctx =
+  let bsz = js_int ctx.params_js "byteSize" in
+  let ab =
+    Js.Unsafe.new_obj
+      (js_global "ArrayBuffer")
+      [|Js.Unsafe.inject (js_of_int bsz)|]
+  in
+  let fields = js_get ctx.params_js "fields" in
+  for fi = 0 to js_arr_len fields - 1 do
+    let f = js_arr_get fields fi in
+    let kind = js_str f "kind"
+    and off = js_int f "offset"
+    and ftype = js_str f "type" in
+    let ctor, v =
+      if String.equal kind "length" then
+        let vn = js_str f (Js.to_string (Js.string "of")) in
+        let d =
+          match List.assoc_opt vn ctx.inputs with
+          | None ->
+              failwith
+                ("SpocRT: missing input for length field, vec \"" ^ vn ^ "\"")
+          | Some d -> d
+        in
+        ("Int32Array", float_of_int (Array.length d))
+      else
+        let fn = js_str f "name" in
+        let v =
+          match List.assoc_opt fn ctx.scalars with Some v -> v | None -> 0.0
+        in
+        ( (match ftype with
+          | "f32" -> "Float32Array"
+          | "u32" -> "Uint32Array"
+          | _ -> "Int32Array"),
+          v )
+    in
+    let view =
+      Js.Unsafe.new_obj
+        (js_global ctor)
+        [|
+          Js.Unsafe.inject ab;
+          Js.Unsafe.inject (js_of_int off);
+          Js.Unsafe.inject (js_of_int 1);
+        |]
+    in
+    Js.Unsafe.set view (js_of_int 0) (Js.Unsafe.inject (js_of_float v))
+  done ;
+  let ub = create_buf ctx bsz (usage "UNIFORM" lor usage "COPY_DST") in
+  queue_write ctx ub ab ;
+  ub
+
+let build_bg ctx bgl gbs ub =
+  let mk b r =
+    Js.Unsafe.obj
+      [|
+        ("binding", Js.Unsafe.inject (js_of_int b));
+        ("resource", Js.Unsafe.inject r);
+      |]
+  in
+  let mk_buf_res name =
+    Js.Unsafe.obj [|("buffer", Js.Unsafe.inject (Hashtbl.find gbs name))|]
+  in
+  let bents =
+    Array.init ctx.n_bufs (fun i ->
+        let d = js_arr_get ctx.buffers_js i in
+        mk (js_int d "binding") (mk_buf_res (js_str d "name")))
+  in
+  let ents =
+    match ub with
+    | None -> Js.array bents
+    | Some u ->
+        let ur = Js.Unsafe.obj [|("buffer", Js.Unsafe.inject u)|] in
+        Js.array (Array.append bents [|mk (js_int ctx.params_js "binding") ur|])
+  in
+  Js.Unsafe.meth_call
+    ctx.device
+    "createBindGroup"
+    [|
+      Js.Unsafe.inject
+        (Js.Unsafe.obj
+           [|
+             ("layout", Js.Unsafe.inject bgl); ("entries", Js.Unsafe.inject ents);
+           |]);
+    |]
+
+let encode_submit ctx pipeline bg gbs rbs dispatch =
+  let enc = Js.Unsafe.meth_call ctx.device "createCommandEncoder" [||] in
+  let pass = Js.Unsafe.meth_call enc "beginComputePass" [||] in
+  Js.Unsafe.meth_call pass "setPipeline" [|Js.Unsafe.inject pipeline|] |> ignore ;
+  Js.Unsafe.meth_call
+    pass
+    "setBindGroup"
+    [|Js.Unsafe.inject (js_of_int 0); Js.Unsafe.inject bg|]
+  |> ignore ;
+  Js.Unsafe.meth_call
+    pass
+    "dispatchWorkgroups"
+    [|Js.Unsafe.inject (js_of_int dispatch)|]
+  |> ignore ;
+  Js.Unsafe.meth_call pass "end" [||] |> ignore ;
+  for i = 0 to ctx.n_bufs - 1 do
+    let name = js_str (js_arr_get ctx.buffers_js i) "name" in
+    let rb, blen, _ = Hashtbl.find rbs name in
+    Js.Unsafe.meth_call
+      enc
+      "copyBufferToBuffer"
+      [|
+        Js.Unsafe.inject (Hashtbl.find gbs name);
+        Js.Unsafe.inject (js_of_int 0);
+        Js.Unsafe.inject rb;
+        Js.Unsafe.inject (js_of_int 0);
+        Js.Unsafe.inject (js_of_int blen);
+      |]
+    |> ignore
+  done ;
+  let q = js_get ctx.device "queue" in
+  Js.Unsafe.meth_call
+    q
+    "submit"
+    [|Js.Unsafe.inject (Js.array [|Js.Unsafe.meth_call enc "finish" [||]|])|]
+  |> ignore
+
+let on_mapped gbs rbs ub results remaining oname rb blen et ctx () =
+  let mapped = Js.Unsafe.meth_call rb "getMappedRange" [||] in
+  let ctor =
+    match et with
+    | "f32" -> "Float32Array"
+    | "i32" -> "Int32Array"
+    | _ -> "Uint32Array"
+  in
+  let view = Js.Unsafe.new_obj (js_global ctor) [|Js.Unsafe.inject mapped|] in
+  let arr =
+    Array.init
+      (blen / bpe et)
+      (fun i -> Js.to_float (Js.Unsafe.get view (js_of_int i)))
+  in
+  Js.Unsafe.meth_call rb "unmap" [||] |> ignore ;
+  results := (oname, arr) :: !results ;
+  decr remaining ;
+  if !remaining = 0 then (
+    cleanup gbs rbs ub ;
+    ctx.on_done (List.rev !results))
+
+let on_compile_info ctx bgl pipeline gbs rbs ub maxn ci =
+  let msgs = js_get ci "messages" in
+  let errors = ref [] in
+  for i = 0 to js_arr_len msgs - 1 do
+    let m = js_arr_get msgs i in
+    if String.equal (js_str m "type") "error" then
+      let line = js_to_int (js_get m "lineNum") in
+      errors := (js_str m "message" ^ " @line" ^ string_of_int line) :: !errors
+  done ;
+  if !errors <> [] then
+    ctx.on_error
+      ("SpocRT: WGSL compile errors: " ^ String.concat " | " (List.rev !errors))
+  else
+    let dispatch = (maxn + ctx.workgroup_x - 1) / ctx.workgroup_x in
+    encode_submit ctx pipeline (build_bg ctx bgl gbs ub) gbs rbs dispatch ;
+    let results = ref [] and remaining = ref (List.length ctx.outputs_wanted) in
+    if !remaining = 0 then (
+      cleanup gbs rbs ub ;
+      ctx.on_done [])
+    else
+      List.iter
+        (fun oname ->
+          match Hashtbl.find_opt rbs oname with
+          | None ->
+              decr remaining ;
+              if !remaining = 0 then (
+                cleanup gbs rbs ub ;
+                ctx.on_done (List.rev !results))
+          | Some (rb, blen, et) ->
+              let mp =
+                Js.Unsafe.meth_call
+                  rb
+                  "mapAsync"
+                  [|Js.Unsafe.inject (js_of_int (map_read ()))|]
+              in
+              catch_ mp (fun err ->
+                  cleanup gbs rbs ub ;
+                  ctx.on_error ("SpocRT: mapAsync failed: " ^ js_err err)) ;
+              then_
+                mp
+                (on_mapped gbs rbs ub results remaining oname rb blen et ctx))
+        ctx.outputs_wanted
+
+let on_device ctx device =
+  let ctx = {ctx with device} in
+  let shader_module =
+    Js.Unsafe.meth_call
+      ctx.device
+      "createShaderModule"
+      [|
+        Js.Unsafe.inject
+          (Js.Unsafe.obj [|("code", Js.Unsafe.inject (Js.string ctx.wgsl))|]);
+      |]
+  in
+  match try Ok (alloc_storage ctx) with Failure m -> Error m with
+  | Error m -> ctx.on_error m
+  | Ok (gbs, rbs, maxn) -> (
+      let ub_result =
+        if ctx.has_params then
+          try Ok (Some (pack_uniform ctx)) with Failure m -> Error m
+        else Ok None
+      in
+      match ub_result with
+      | Error m ->
+          cleanup gbs rbs None ;
+          ctx.on_error m
+      | Ok ub ->
+          let bgl = build_bgl ctx in
+          let pl =
+            Js.Unsafe.meth_call
+              ctx.device
+              "createPipelineLayout"
+              [|
+                Js.Unsafe.inject
+                  (Js.Unsafe.obj
+                     [|
+                       ("bindGroupLayouts", Js.Unsafe.inject (Js.array [|bgl|]));
+                     |]);
+              |]
+          in
+          let pipeline =
+            Js.Unsafe.meth_call
+              ctx.device
+              "createComputePipeline"
+              [|
+                Js.Unsafe.inject
+                  (Js.Unsafe.obj
+                     [|
+                       ("layout", Js.Unsafe.inject pl);
+                       ( "compute",
+                         Js.Unsafe.inject
+                           (Js.Unsafe.obj
+                              [|
+                                ("module", Js.Unsafe.inject shader_module);
+                                ( "entryPoint",
+                                  Js.Unsafe.inject (Js.string "main") );
+                              |]) );
+                     |]);
+              |]
+          in
+          let ci_p =
+            Js.Unsafe.meth_call shader_module "getCompilationInfo" [||]
+          in
+          catch_ ci_p (fun _ ->
+              cleanup gbs rbs ub ;
+              ctx.on_error "SpocRT: getCompilationInfo failed") ;
+          then_ ci_p (on_compile_info ctx bgl pipeline gbs rbs ub maxn))
+
+let request_adapter_high_perf () =
+  Js.Unsafe.fun_call
+    (Js.Unsafe.js_expr "navigator.gpu.requestAdapter.bind(navigator.gpu)")
+    [|
+      Js.Unsafe.inject
+        (Js.Unsafe.obj
+           [|
+             ("powerPreference", Js.Unsafe.inject (Js.string "high-performance"));
+           |]);
+    |]
+
+let on_adapter ctx adapter =
+  if js_is_null_or_undef adapter then
+    ctx.on_error "SpocRT: no WebGPU adapter available"
+  else
+    let dp = Js.Unsafe.meth_call adapter "requestDevice" [||] in
+    catch_ dp (fun err ->
+        ctx.on_error ("SpocRT: requestDevice failed: " ^ js_err err)) ;
+    then_ dp (on_device ctx)
+
+let run ~wgsl ~abi_json ~inputs ~scalars ~outputs_wanted ~on_done ~on_error () =
+  if js_is_null_or_undef gpu then
+    on_error "SpocRT: WebGPU not available (navigator.gpu is undefined)"
+  else
+    let abi = json_parse abi_json in
+    let wg = js_get abi "workgroupSize" in
+    let wg1 = js_to_int (js_arr_get wg 1)
+    and wg2 = js_to_int (js_arr_get wg 2) in
+    if wg1 <> 1 || wg2 <> 1 then
+      on_error
+        (Printf.sprintf
+           "SpocRT: only 1D workgroups supported (got workgroupSize[1]=%d, \
+            [2]=%d)"
+           wg1
+           wg2)
+    else
+      let ctx =
+        {
+          device = Js.Unsafe.inject Js.null;
+          buffers_js = js_get abi "buffers";
+          n_bufs = js_arr_len (js_get abi "buffers");
+          params_js = js_get abi "params";
+          has_params = not (js_is_null_or_undef (js_get abi "params"));
+          workgroup_x = js_to_int (js_arr_get wg 0);
+          wgsl;
+          inputs;
+          scalars;
+          outputs_wanted;
+          on_done;
+          on_error;
+        }
+      in
+      let ap = request_adapter_high_perf () in
+      catch_ ap (fun err ->
+          on_error ("SpocRT: requestAdapter failed: " ^ js_err err)) ;
+      then_ ap (on_adapter ctx)

--- a/sarek/core_js/webgpu/Webgpu_runtime.ml
+++ b/sarek/core_js/webgpu/Webgpu_runtime.ml
@@ -385,6 +385,19 @@ let on_adapter ctx adapter =
         ctx.on_error ("SpocRT: requestDevice failed: " ^ js_err err)) ;
     then_ dp (on_device ctx)
 
+(* Requested output names that are not storage buffers in the ABI. *)
+let missing_outputs buffers_js n_bufs outputs_wanted =
+  let names =
+    List.init n_bufs (fun i -> js_str (js_arr_get buffers_js i) "name")
+  in
+  List.filter (fun o -> not (List.mem o names)) outputs_wanted
+
+let start_run ctx =
+  let ap = request_adapter_high_perf () in
+  catch_ ap (fun err ->
+      ctx.on_error ("SpocRT: requestAdapter failed: " ^ js_err err)) ;
+  then_ ap (on_adapter ctx)
+
 let run ~wgsl ~abi_json ~inputs ~scalars ~outputs_wanted ~on_done ~on_error () =
   (* Guarantee on_done/on_error fire at most once, even if multiple output
      read-backs or a rejection race (relevant once multi-output is supported). *)
@@ -414,23 +427,26 @@ let run ~wgsl ~abi_json ~inputs ~scalars ~outputs_wanted ~on_done ~on_error () =
            wg1
            wg2)
     else
-      let ctx =
-        {
-          device = Js.Unsafe.inject Js.null;
-          buffers_js = js_get abi "buffers";
-          n_bufs = js_arr_len (js_get abi "buffers");
-          params_js = js_get abi "params";
-          has_params = not (js_is_null_or_undef (js_get abi "params"));
-          workgroup_x = js_to_int (js_arr_get wg 0);
-          wgsl;
-          inputs;
-          scalars;
-          outputs_wanted;
-          on_done;
-          on_error;
-        }
-      in
-      let ap = request_adapter_high_perf () in
-      catch_ ap (fun err ->
-          on_error ("SpocRT: requestAdapter failed: " ^ js_err err)) ;
-      then_ ap (on_adapter ctx)
+      let buffers_js = js_get abi "buffers" in
+      let n_bufs = js_arr_len buffers_js in
+      match missing_outputs buffers_js n_bufs outputs_wanted with
+      | _ :: _ as missing ->
+          on_error
+            ("SpocRT: unknown requested output(s): "
+           ^ String.concat ", " missing)
+      | [] ->
+          start_run
+            {
+              device = Js.Unsafe.inject Js.null;
+              buffers_js;
+              n_bufs;
+              params_js = js_get abi "params";
+              has_params = not (js_is_null_or_undef (js_get abi "params"));
+              workgroup_x = js_to_int (js_arr_get wg 0);
+              wgsl;
+              inputs;
+              scalars;
+              outputs_wanted;
+              on_done;
+              on_error;
+            }

--- a/sarek/core_js/webgpu/Webgpu_runtime.ml
+++ b/sarek/core_js/webgpu/Webgpu_runtime.ml
@@ -7,83 +7,7 @@
     API documentation. *)
 
 open Js_of_ocaml
-
-(* jsoo 6.x: Js.to_float/Js.float exist; Js.to_int/Js.of_int/Js.of_float do not. *)
-let js_to_int x = int_of_float (Js.to_float x)
-
-let js_of_int n = Js.float (float_of_int n)
-
-let js_of_float v = Js.float v
-
-let then_ p f =
-  ignore
-    (Js.Unsafe.meth_call p "then" [|Js.Unsafe.inject (Js.wrap_callback f)|])
-
-let catch_ p f =
-  ignore
-    (Js.Unsafe.meth_call p "catch" [|Js.Unsafe.inject (Js.wrap_callback f)|])
-
-let js_global name = Js.Unsafe.get Js.Unsafe.global (Js.string name)
-
-let gpu =
-  js_global "navigator" |> fun nav -> Js.Unsafe.get nav (Js.string "gpu")
-
-let json_parse s =
-  Js.Unsafe.fun_call
-    (Js.Unsafe.get (js_global "JSON") (Js.string "parse"))
-    [|Js.Unsafe.inject (Js.string s)|]
-
-let js_get obj key = Js.Unsafe.get obj (Js.string key)
-
-let js_int obj key = js_to_int (js_get obj key)
-
-let js_str obj key = Js.to_string (js_get obj key)
-
-let js_arr_len arr = js_to_int (Js.Unsafe.get arr (Js.string "length"))
-
-let js_arr_get arr i = Js.Unsafe.get arr (js_of_int i)
-
-let js_is_null_or_undef v =
-  Js.Optdef.case
-    (Js.Optdef.return v)
-    (fun () -> true)
-    (fun v' -> Js.Opt.case (Js.Opt.return v') (fun () -> true) (fun _ -> false))
-
-let make_ta ctor (data : float array) =
-  let arr =
-    Js.Unsafe.new_obj ctor [|Js.Unsafe.inject (js_of_int (Array.length data))|]
-  in
-  Array.iteri
-    (fun i v ->
-      Js.Unsafe.set arr (js_of_int i) (Js.Unsafe.inject (js_of_float v)))
-    data ;
-  arr
-
-let typed_array et data =
-  match et with
-  | "f32" -> make_ta (js_global "Float32Array") data
-  | "i32" -> make_ta (js_global "Int32Array") data
-  | "u32" -> make_ta (js_global "Uint32Array") data
-  | _ -> failwith ("SpocRT: unknown elementType: " ^ et)
-
-let bpe = function
-  | "f32" | "i32" | "u32" -> 4
-  | et -> failwith ("SpocRT: unknown elementType: " ^ et)
-
-let usage s =
-  js_to_int (Js.Unsafe.get (js_global "GPUBufferUsage") (Js.string s))
-
-let map_read () =
-  js_to_int (Js.Unsafe.get (js_global "GPUMapMode") (Js.string "READ"))
-
-let shader_compute () =
-  js_to_int (Js.Unsafe.get (js_global "GPUShaderStage") (Js.string "COMPUTE"))
-
-let js_err err =
-  Js.Optdef.case
-    (Js.Optdef.return (js_get err "message"))
-    (fun () -> "unknown error")
-    Js.to_string
+open Webgpu_js
 
 (** Shared context threaded through the async promise chain. *)
 type ctx = {
@@ -375,6 +299,38 @@ let on_compile_info ctx bgl pipeline gbs rbs ub maxn ci =
                 (on_mapped gbs rbs ub results remaining oname rb blen et ctx))
         ctx.outputs_wanted
 
+(* Build the compute pipeline (explicit layout from the ABI's bind-group
+   layout). Kept separate so [on_device] stays within the function-length
+   limit. *)
+let build_pipeline ctx shader_module bgl =
+  let pl =
+    Js.Unsafe.meth_call
+      ctx.device
+      "createPipelineLayout"
+      [|
+        Js.Unsafe.inject
+          (Js.Unsafe.obj
+             [|("bindGroupLayouts", Js.Unsafe.inject (Js.array [|bgl|]))|]);
+      |]
+  in
+  Js.Unsafe.meth_call
+    ctx.device
+    "createComputePipeline"
+    [|
+      Js.Unsafe.inject
+        (Js.Unsafe.obj
+           [|
+             ("layout", Js.Unsafe.inject pl);
+             ( "compute",
+               Js.Unsafe.inject
+                 (Js.Unsafe.obj
+                    [|
+                      ("module", Js.Unsafe.inject shader_module);
+                      ("entryPoint", Js.Unsafe.inject (Js.string "main"));
+                    |]) );
+           |]);
+    |]
+
 let on_device ctx device =
   let ctx = {ctx with device} in
   let shader_module =
@@ -400,38 +356,7 @@ let on_device ctx device =
           ctx.on_error m
       | Ok ub ->
           let bgl = build_bgl ctx in
-          let pl =
-            Js.Unsafe.meth_call
-              ctx.device
-              "createPipelineLayout"
-              [|
-                Js.Unsafe.inject
-                  (Js.Unsafe.obj
-                     [|
-                       ("bindGroupLayouts", Js.Unsafe.inject (Js.array [|bgl|]));
-                     |]);
-              |]
-          in
-          let pipeline =
-            Js.Unsafe.meth_call
-              ctx.device
-              "createComputePipeline"
-              [|
-                Js.Unsafe.inject
-                  (Js.Unsafe.obj
-                     [|
-                       ("layout", Js.Unsafe.inject pl);
-                       ( "compute",
-                         Js.Unsafe.inject
-                           (Js.Unsafe.obj
-                              [|
-                                ("module", Js.Unsafe.inject shader_module);
-                                ( "entryPoint",
-                                  Js.Unsafe.inject (Js.string "main") );
-                              |]) );
-                     |]);
-              |]
-          in
+          let pipeline = build_pipeline ctx shader_module bgl in
           let ci_p =
             Js.Unsafe.meth_call shader_module "getCompilationInfo" [||]
           in
@@ -461,6 +386,19 @@ let on_adapter ctx adapter =
     then_ dp (on_device ctx)
 
 let run ~wgsl ~abi_json ~inputs ~scalars ~outputs_wanted ~on_done ~on_error () =
+  (* Guarantee on_done/on_error fire at most once, even if multiple output
+     read-backs or a rejection race (relevant once multi-output is supported). *)
+  let finished = ref false in
+  let on_done r =
+    if not !finished then (
+      finished := true ;
+      on_done r)
+  in
+  let on_error m =
+    if not !finished then (
+      finished := true ;
+      on_error m)
+  in
   if js_is_null_or_undef gpu then
     on_error "SpocRT: WebGPU not available (navigator.gpu is undefined)"
   else

--- a/sarek/core_js/webgpu/Webgpu_runtime.mli
+++ b/sarek/core_js/webgpu/Webgpu_runtime.mli
@@ -1,0 +1,53 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** OCaml/js_of_ocaml WebGPU compute runtime for Sarek-generated WGSL kernels.
+
+    [Webgpu_runtime] executes a transpiled WGSL kernel on the GPU using the
+    browser WebGPU API via [Js_of_ocaml.Js.Unsafe]. The module is jsoo-only: it
+    must not be linked into native executables.
+
+    Ownership and lifetime:
+    - All GPU buffers are allocated per-call and destroyed after read-back.
+    - The adapter and device are acquired fresh each call.
+    - Buffer data passed via [inputs] is uploaded; the OCaml arrays are not
+      mutated by this module.
+    - [on_done] fires exactly once after all output buffers are read back and
+      all transient GPU resources are destroyed (unmap + destroy).
+    - [on_error] fires instead of [on_done] on non-recoverable failures (no
+      WebGPU adapter, WGSL compile error, unsupported workgroup shape, missing
+      input buffer).
+
+    Explicit layout: A [GPUBindGroupLayout] is always built from the ABI rather
+    than using [layout:'auto'], ensuring the params uniform binding is present
+    even when the WGSL shader does not statically reference it. *)
+
+(** [run ~wgsl ~abi_json ~inputs ~scalars ~outputs_wanted ~on_done ~on_error ()]
+    dispatches the WGSL compute kernel and delivers results via [on_done].
+
+    - [wgsl]: WGSL source string from {!Sarek_transpile.of_source_with_abi}.
+    - [abi_json]: ABI JSON string from the same call. Schema:
+      [{workgroupSize:[x,y,z],
+       buffers:[{name,binding,elementType:"f32"|"i32"|"u32",access}],
+       params:{binding,byteSize,fields:[{name,type,offset,kind:"length"|"scalar",of?}]}|null}].
+    - [inputs]: [(buffer_name, float_array)] for every buffer in
+      [abi_json.buffers].
+    - [scalars]: [(field_name, float)] for scalar params fields.
+    - [outputs_wanted]: Names of storage buffers to include in the result.
+    - [on_done]: Receives [(name * float_array) list] on success.
+    - [on_error]: Receives an error message on failure.
+
+    Only 1D workgroups ([workgroupSize[1]=1, workgroupSize[2]=1]) are supported;
+    [on_error] fires immediately for multi-dimensional workgroups. *)
+val run :
+  wgsl:string ->
+  abi_json:string ->
+  inputs:(string * float array) list ->
+  scalars:(string * float) list ->
+  outputs_wanted:string list ->
+  on_done:((string * float array) list -> unit) ->
+  on_error:(string -> unit) ->
+  unit ->
+  unit

--- a/sarek/core_js/webgpu/dune
+++ b/sarek/core_js/webgpu/dune
@@ -10,7 +10,7 @@
  (name spoc_webgpu_runtime)
  (public_name sarek.webgpu_runtime)
  (libraries js_of_ocaml)
- (modules Webgpu_runtime)
+ (modules Webgpu_js Webgpu_runtime)
  (preprocess
   (pps js_of_ocaml-ppx))
  (instrumentation

--- a/sarek/core_js/webgpu/dune
+++ b/sarek/core_js/webgpu/dune
@@ -1,0 +1,17 @@
+; spoc_webgpu_runtime — jsoo OCaml WebGPU compute runtime for Sarek WGSL kernels.
+;
+; Depends on js_of_ocaml and sarek_transpile (for the driver). No ctypes, no unix.
+;
+; Only built explicitly; not included in @install or dune runtest by default.
+;   dune build sarek/core_js/webgpu/
+;   dune build sarek/core_js/webgpu/test/runtime_driver.bc.js
+
+(library
+ (name spoc_webgpu_runtime)
+ (public_name sarek.webgpu_runtime)
+ (libraries js_of_ocaml)
+ (modules Webgpu_runtime)
+ (preprocess
+  (pps js_of_ocaml-ppx))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek/core_js/webgpu/test/dune
+++ b/sarek/core_js/webgpu/test/dune
@@ -1,0 +1,13 @@
+; sarek/core_js/webgpu/test - browser driver for the SpocRT end-to-end test.
+;
+; SEPARATE target: not included in @install or dune runtest.
+; Build explicitly:
+;   dune build sarek/core_js/webgpu/test/runtime_driver.bc.js
+
+(executable
+ (name runtime_driver)
+ (modules runtime_driver)
+ (libraries spoc_webgpu_runtime sarek_transpile js_of_ocaml)
+ (preprocess
+  (pps js_of_ocaml-ppx))
+ (modes js))

--- a/sarek/core_js/webgpu/test/runtime_driver.ml
+++ b/sarek/core_js/webgpu/test/runtime_driver.ml
@@ -1,0 +1,110 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Browser driver for the SpocRT end-to-end test.
+
+    Exports
+    [globalThis.SpocRT.run(kernelSrc, inputsObj, scalarsObj, outName, cb)]
+    which: 1. Calls [Sarek_transpile.of_source_with_abi WGSL kernelSrc] to
+    obtain [(wgsl, abi_json)]. 2. Converts the JS [inputsObj] / [scalarsObj] to
+    the OCaml input types. 3. Calls [Webgpu_runtime.run] with the parsed data.
+    4. Delivers [outputs[outName]] as a plain JS array to [cb(null, array)] on
+    success, or [cb(errorString, null)] on failure. *)
+
+open Js_of_ocaml
+open Spoc_webgpu_runtime
+
+(* Compatibility shims for jsoo 6.x: no Js.to_int/of_int/of_float. *)
+let js_to_int x = int_of_float (Js.to_float x)
+
+let js_of_int n = Js.float (float_of_int n)
+
+let js_of_float v = Js.float v
+
+let js_get obj key = Js.Unsafe.get obj (Js.string key)
+
+let js_array_length arr = js_to_int (Js.Unsafe.get arr (Js.string "length"))
+
+(** Convert a JS object to an OCaml assoc list of (string * float array). *)
+let js_obj_to_inputs obj =
+  (* Use Object.keys to enumerate the properties. *)
+  let keys =
+    Js.Unsafe.fun_call
+      (Js.Unsafe.get
+         (Js.Unsafe.get Js.Unsafe.global (Js.string "Object"))
+         (Js.string "keys"))
+      [|Js.Unsafe.inject obj|]
+  in
+  let n = js_array_length keys in
+  List.init n (fun i ->
+      let key = Js.to_string (Js.Unsafe.get keys (js_of_int i)) in
+      let arr_js = js_get obj (Js.to_string (Js.string key)) in
+      let len = js_array_length arr_js in
+      let data =
+        Array.init len (fun j ->
+            Js.to_float (Js.Unsafe.get arr_js (js_of_int j)))
+      in
+      (key, data))
+
+(** Convert a JS object to an OCaml assoc list of (string * float). *)
+let js_obj_to_scalars obj =
+  let keys =
+    Js.Unsafe.fun_call
+      (Js.Unsafe.get
+         (Js.Unsafe.get Js.Unsafe.global (Js.string "Object"))
+         (Js.string "keys"))
+      [|Js.Unsafe.inject obj|]
+  in
+  let n = js_array_length keys in
+  List.init n (fun i ->
+      let key = Js.to_string (Js.Unsafe.get keys (js_of_int i)) in
+      let v = Js.to_float (js_get obj (Js.to_string (Js.string key))) in
+      (key, v))
+
+let run_fn kernel_src inputs_obj scalars_obj out_name cb =
+  let src = Js.to_string kernel_src in
+  let out_name_s = Js.to_string out_name in
+  match Sarek_transpile.of_source_with_abi Sarek_transpile.WGSL src with
+  | Error e ->
+      let msg = "transpile error: " ^ Sarek_transpile.string_of_error e in
+      Js.Unsafe.fun_call
+        cb
+        [|Js.Unsafe.inject (Js.string msg); Js.Unsafe.inject Js.null|]
+      |> ignore
+  | Ok (wgsl, abi_json) ->
+      let inputs = js_obj_to_inputs inputs_obj in
+      let scalars = js_obj_to_scalars scalars_obj in
+      Webgpu_runtime.run
+        ~wgsl
+        ~abi_json
+        ~inputs
+        ~scalars
+        ~outputs_wanted:[out_name_s]
+        ~on_done:(fun results ->
+          let out_arr =
+            match List.assoc_opt out_name_s results with
+            | None -> [||]
+            | Some a -> a
+          in
+          let js_arr = Js.array (Array.map js_of_float out_arr) in
+          Js.Unsafe.fun_call
+            cb
+            [|Js.Unsafe.inject Js.null; Js.Unsafe.inject js_arr|]
+          |> ignore)
+        ~on_error:(fun msg ->
+          Js.Unsafe.fun_call
+            cb
+            [|Js.Unsafe.inject (Js.string msg); Js.Unsafe.inject Js.null|]
+          |> ignore)
+        ()
+
+let () =
+  let module_obj = Js.Unsafe.obj [||] in
+  Js.Unsafe.set
+    module_obj
+    "run"
+    (Js.Unsafe.callback (fun src inputs scalars out_name cb ->
+         run_fn src inputs scalars out_name cb)) ;
+  Js.Unsafe.set Js.Unsafe.global "SpocRT" module_obj

--- a/sarek/core_js/webgpu/test/webgpu_runtime_test.mjs
+++ b/sarek/core_js/webgpu/test/webgpu_runtime_test.mjs
@@ -1,0 +1,152 @@
+// SpocRT WebGPU runtime acceptance test.
+//
+// Runs vector_add and sin kernels via SpocRT.run (the OCaml jsoo runtime driver)
+// on a real GPU. Skips gracefully where playwright/chrome/WebGPU are unavailable.
+// Only exits non-zero on a real wrong numerical result.
+//
+// Usage:
+//   node sarek/core_js/webgpu/test/webgpu_runtime_test.mjs [runtime_driver.bc.js]
+
+import http from 'http';
+import fs from 'fs';
+import { createRequire } from 'module';
+import { execSync } from 'child_process';
+
+function resolvePlaywright() {
+  const reqHere = createRequire(import.meta.url);
+  const candidates = [];
+  try { candidates.push(execSync('npm root -g').toString().trim()); } catch (_) {}
+  try {
+    candidates.push(
+      ...execSync('ls -d /home/*/.npm/_npx/*/node_modules 2>/dev/null')
+        .toString().trim().split('\n')
+    );
+  } catch (_) {}
+  for (const base of candidates.filter(Boolean)) {
+    try { return createRequire(base + '/x')('playwright'); } catch (_) {}
+  }
+  try { return reqHere('playwright'); } catch (_) {}
+  return null;
+}
+
+function skip(msg) { console.log('SKIP: ' + msg); process.exit(0); }
+
+const pw = resolvePlaywright();
+if (!pw) skip('playwright not resolvable');
+const { chromium } = pw;
+
+const DRIVER = process.argv[2] ||
+  '_build/default/sarek/core_js/webgpu/test/runtime_driver.bc.js';
+if (!fs.existsSync(DRIVER)) skip('driver not built: ' + DRIVER);
+const driverJs = fs.readFileSync(DRIVER);
+
+const html = `<!doctype html><meta charset=utf-8><title>spocrt-test</title>
+<script src="/d.js"></script>`;
+const server = http.createServer((req, res) => {
+  if (req.url === '/d.js') {
+    res.setHeader('content-type', 'text/javascript');
+    res.end(driverJs);
+  } else {
+    res.setHeader('content-type', 'text/html');
+    res.end(html);
+  }
+});
+await new Promise(r => server.listen(0, r));
+const port = server.address().port;
+
+let browser;
+try {
+  browser = await chromium.launch({
+    headless: true,
+    channel: 'chrome',
+    args: [
+      '--enable-unsafe-webgpu',
+      '--enable-features=Vulkan',
+      '--use-angle=vulkan',
+      '--use-gl=angle',
+      '--ignore-gpu-blocklist',
+      '--no-sandbox',
+    ],
+  });
+} catch (e) {
+  server.close();
+  skip('chrome launch failed: ' + e.message);
+}
+
+const page = await browser.newPage();
+await page.goto(`http://localhost:${port}/`, { waitUntil: 'load' });
+await page.waitForFunction(
+  () => typeof globalThis.SpocRT !== 'undefined',
+  { timeout: 20000 }
+);
+
+const hasAdapter = await page.evaluate(async () =>
+  !!(navigator.gpu && await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' }))
+);
+if (!hasAdapter) {
+  await browser.close();
+  server.close();
+  skip('no WebGPU adapter in this Chrome');
+}
+
+const N = 256;
+const result = await page.evaluate(async (n) => {
+  const out = [];
+  const a = new Float32Array(n);
+  const b = new Float32Array(n);
+  for (let i = 0; i < n; i++) { a[i] = i * 0.5; b[i] = i * 2.0; }
+
+  function runKernel(src, inputs, scalars, outName) {
+    return new Promise((resolve, reject) => {
+      globalThis.SpocRT.run(src, inputs, scalars, outName, (err, arr) => {
+        if (err) reject(new Error(String(err)));
+        else resolve(arr);
+      });
+    });
+  }
+
+  const cases = [
+    {
+      k: 'vector_add',
+      src: 'fun (a:float32 vector)(b:float32 vector)(c:float32 vector) -> ' +
+           'let i = global_thread_id in c.(i) <- a.(i) +. b.(i)',
+      inputs: { a: a.slice(), b: b.slice(), c: new Float32Array(n) },
+      scalars: {},
+      outName: 'c',
+      ref: (i) => a[i] + b[i],
+    },
+    {
+      k: 'sin',
+      src: 'fun (a:float32 vector)(b:float32 vector) -> ' +
+           'let i = global_thread_id in b.(i) <- Float32.sin a.(i)',
+      inputs: { a: a.slice(), b: new Float32Array(n) },
+      scalars: {},
+      outName: 'b',
+      ref: (i) => Math.sin(a[i]),
+    },
+  ];
+
+  for (const c of cases) {
+    let arr;
+    try {
+      arr = await runKernel(c.src, c.inputs, c.scalars, c.outName);
+    } catch (e) {
+      out.push({ k: c.k, ok: false, why: e.message });
+      continue;
+    }
+    let bad = 0;
+    for (let i = 0; i < n; i++) {
+      if (Math.abs(arr[i] - c.ref(i)) > 1e-4) bad++;
+    }
+    out.push({ k: c.k, ok: bad === 0, bad });
+  }
+  return out;
+}, N);
+
+console.log(JSON.stringify(result));
+await browser.close();
+server.close();
+
+const allok = Array.isArray(result) && result.length > 0 && result.every(r => r.ok);
+console.log(allok ? 'SpocRT-GPU: ALL PASS' : 'SpocRT-GPU: FAILURE');
+process.exit(allok ? 0 : 1);


### PR DESCRIPTION
## SPOC web backend — jsoo WebGPU runtime (run SPOC kernels on the GPU from OCaml)

An in-browser **OCaml/jsoo WebGPU compute runtime** — the OCaml equivalent of `sarek_webgpu_runner.js`. Given a transpiled WGSL shader + its ABI (from `Sarek_transpile.of_source_with_abi`) + input arrays, it runs the kernel on the GPU and returns results via an async callback (the B1 read-back seam). With the merged transpiler + `spoc_core_js`, SPOC now **transpiles a kernel and executes it on the GPU end-to-end, entirely in OCaml/jsoo**. ADDITIVE — no native/golden changes.

- `sarek/core_js/webgpu/Webgpu_js.ml` — low-level jsoo glue (promise/JSON/typed-array/WebGPU-enum helpers).
- `Webgpu_runtime.ml` — `run`: parses the ABI via browser JSON, builds an **explicit** bind-group/pipeline layout (not `layout:'auto'` — the known footgun), packs the params uniform, 1D dispatch (non-1D fail-fast), copy→`mapAsync`→read-back, unmap+destroy all buffers, surfaces WGSL compile errors, `on_done`/`on_error` fire at most once.
- `test/` — an OCaml driver exporting `SpocRT.run(...)` + a Playwright acceptance test; `make webgpu-runtime-test`.

### Verification
- **Playwright on the real RX 7900 XTX:** `vector_add` and `Float32.sin` (N=256) → **both correct (bad=0)** through the OCaml runtime.
- **Two fresh independent review rounds → GO.** Round 1 NO-GO'd a 64-line function → fixed via `build_pipeline` extraction + a `Webgpu_js` module split (runtime 436 lines, js 88; functions ≤50; nesting ≤4) + a `done_once` guard. Round 2: GO — rules pass, ABI/binding verified line-by-line vs the JS reference, lifecycle + FFI-free confirmed.
- Goldens byte-identical; `@fmt` clean; diff touches only `sarek/core_js/webgpu/**` + `Makefile`.

Non-blocking follow-ups (when multi-output read-back lands): guard `cleanup` with the same `finished` flag; drop a cosmetic `js_str` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebGPU compute runtime for running WGSL compute shaders in browsers, with buffer inputs, scalar params, and result callbacks.

* **Tests**
  * Acceptance test suite using Playwright/Chromium to run kernels end-to-end and validate numerical results with tolerances; exits non‑zero on real failures.

* **Chores**
  * Build/test targets and packaging updated to enable compiling and running the WebGPU runtime and its tests.

* **Documentation**
  * Added notes on runtime/test expectations and failure semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->