### PR TITLE
Course: kernel-composition lesson on the OCaml WebGPU runtime

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,8 @@ jobs:
         run: |
           opam exec -- dune build sarek/transpile/web/transpile_js.bc.js
           cp _build/default/sarek/transpile/web/transpile_js.bc.js gh-pages/javascripts/sarek_transpile.js
+          opam exec -- dune build sarek/core_js/webgpu/lessons/compose_driver.bc.js
+          cp _build/default/sarek/core_js/webgpu/lessons/compose_driver.bc.js gh-pages/javascripts/spoc_compose.js
 
       - name: Build Jekyll site
         run: |

--- a/Makefile
+++ b/Makefile
@@ -417,6 +417,14 @@ webgpu-runtime-test:
 	@dune build sarek/core_js/webgpu/test/runtime_driver.bc.js
 	@node sarek/core_js/webgpu/test/webgpu_runtime_test.mjs _build/default/sarek/core_js/webgpu/test/runtime_driver.bc.js
 
+# Kernel-composition course lesson GPU acceptance test: run two chained kernels
+# via the OCaml jsoo compose driver on a real GPU (Playwright + flagged Chrome).
+# Skips where playwright/chrome/WebGPU are unavailable; fails on wrong GPU result.
+compose-gpu-test:
+	@dune build sarek/core_js/webgpu/lessons/compose_driver.bc.js
+	@node gh-pages/learn/test/compose_gpu_test.mjs _build/default/sarek/core_js/webgpu/lessons/compose_driver.bc.js
+
+
 bench-update:
 	@echo "Running benchmarks and updating web data..."
 	@./benchmarks/run_all_benchmarks.sh results

--- a/gh-pages/learn/07-compose.html
+++ b/gh-pages/learn/07-compose.html
@@ -1,0 +1,250 @@
+---
+layout: page
+title: "Lesson 7 — Composing kernels"
+---
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/learn.css">
+
+<div class="lesson-container">
+
+  <h1>Lesson 7 — Composing kernels</h1>
+
+  <p>
+    A single kernel maps over one array at a time, but many algorithms are
+    naturally expressed as a <strong>pipeline</strong> of kernels: the output of
+    one kernel becomes the input of the next. This lesson shows how to chain two
+    kernels — <em>square</em> and <em>add</em> — to compute
+    <code>out[i] = a[i]² + b[i]</code> in two GPU passes.
+  </p>
+
+  <p>
+    What makes this different from the earlier lessons: there is now an OCaml
+    <strong>host program</strong> (compiled to JavaScript with
+    <a href="https://ocsigen.org/js_of_ocaml/">js_of_ocaml</a>) that
+    orchestrates the two GPU dispatches. The host transpiles each kernel source,
+    runs Kernel A to produce a temporary buffer <code>tmp</code>, then runs
+    Kernel B with <code>tmp</code> and <code>b</code> to produce the final
+    result.
+  </p>
+
+  <h2>Host orchestration (OCaml)</h2>
+  <pre class="lesson-output" style="margin-bottom:1rem;">
+(* Host program (runs in the browser via js_of_ocaml) *)
+let run kA_src kB_src ~a ~b ~cb =
+  match of_source_with_abi WGSL kA_src with
+  | Error e -> cb_err cb e
+  | Ok (wgslA, abiA) ->
+    Webgpu_runtime.run ~wgsl:wgslA ~abi_json:abiA
+      ~inputs:[("a", a); ("tmp", zeros)]
+      ~outputs_wanted:["tmp"]
+      ~on_done:(fun [{tmp}] ->
+        match of_source_with_abi WGSL kB_src with
+        | Error e -> cb_err cb e
+        | Ok (wgslB, abiB) ->
+          Webgpu_runtime.run ~wgsl:wgslB ~abi_json:abiB
+            ~inputs:[("tmp", tmp); ("b", b); ("out", zeros)]
+            ~outputs_wanted:["out"]
+            ~on_done:(fun [{out}] -> cb_ok cb out) ())
+      ()</pre>
+
+  <p>
+    <em>Note:</em> the two kernels currently round-trip through the host between
+    stages (tmp is read back from the GPU before being re-uploaded for Kernel B).
+    True GPU-side buffer persistence — avoiding the round-trip — is a planned
+    runtime enhancement.
+  </p>
+
+  <h2>Your task</h2>
+  <p>
+    Fill in the two kernels below and click <strong>Run on my GPU</strong>.
+    Both editors use the same OCaml kernel syntax you have seen in earlier
+    lessons. The host program above glues them together automatically.
+  </p>
+
+  <label class="lesson-editor-label" for="kernel-a-source">Kernel A — square (writes <code>tmp[i] = a[i] * a[i]</code>)</label>
+  <textarea id="kernel-a-source">fun (a : float32 vector) (tmp : float32 vector) ->
+  let i = global_thread_id in
+  tmp.(i) <- (* TODO: a[i] squared *)</textarea>
+
+  <label class="lesson-editor-label" for="kernel-b-source" style="margin-top:1rem;display:block;">Kernel B — add (writes <code>out[i] = tmp[i] + b[i]</code>)</label>
+  <textarea id="kernel-b-source">fun (tmp : float32 vector) (b : float32 vector) (out : float32 vector) ->
+  let i = global_thread_id in
+  out.(i) <- (* TODO: tmp[i] + b[i] *)</textarea>
+
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-top:1rem;">
+    <button class="lesson-run-btn" id="run-btn">Run on my GPU</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle-a">Show WGSL (Kernel A)</button>
+    <button class="wgsl-toggle-btn" id="wgsl-toggle-b">Show WGSL (Kernel B)</button>
+    <span class="lesson-status" id="status-bar"></span>
+  </div>
+
+  <pre class="lesson-output" id="output-pane">Fill in the TODOs and click "Run on my GPU".</pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane-a" style="display:none;"></pre>
+  <pre class="lesson-wgsl-pre" id="wgsl-pane-b" style="display:none;"></pre>
+
+  <details>
+    <summary>Hint</summary>
+    <p>
+      Kernel A: <code>a.(i) *. a.(i)</code> (OCaml uses <code>*.</code> for
+      float multiplication). Kernel B: <code>tmp.(i) +. b.(i)</code>.
+    </p>
+  </details>
+
+  <div class="lesson-nav">
+    <a href="{{ site.baseurl }}/learn/06-image-filter.html">&larr; Lesson 6 — Image filter</a>
+    <a href="{{ site.baseurl }}/learn/">Back to course overview &rarr;</a>
+  </div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/mllike/mllike.min.js"></script>
+<script src="{{ site.baseurl }}/javascripts/spoc_compose.js"></script>
+<script>
+(function () {
+  'use strict';
+
+  var N = 256;
+
+  // Default kernel sources shown in the editors.
+  var STARTER_A =
+    'fun (a : float32 vector) (tmp : float32 vector) ->\n' +
+    '  let i = global_thread_id in\n' +
+    '  tmp.(i) <- (* TODO: a[i] squared *)';
+
+  var STARTER_B =
+    'fun (tmp : float32 vector) (b : float32 vector) (out : float32 vector) ->\n' +
+    '  let i = global_thread_id in\n' +
+    '  out.(i) <- (* TODO: tmp[i] + b[i] *)';
+
+  // CodeMirror editors.
+  var editorA = CodeMirror.fromTextArea(
+    document.getElementById('kernel-a-source'),
+    { mode: 'mllike', lineNumbers: true, theme: 'default' }
+  );
+  editorA.setValue(STARTER_A);
+
+  var editorB = CodeMirror.fromTextArea(
+    document.getElementById('kernel-b-source'),
+    { mode: 'mllike', lineNumbers: true, theme: 'default' }
+  );
+  editorB.setValue(STARTER_B);
+
+  // DOM references.
+  var runBtn    = document.getElementById('run-btn');
+  var statusBar = document.getElementById('status-bar');
+  var outputPane = document.getElementById('output-pane');
+  var wgslPaneA  = document.getElementById('wgsl-pane-a');
+  var wgslPaneB  = document.getElementById('wgsl-pane-b');
+  var wgslToggleA = document.getElementById('wgsl-toggle-a');
+  var wgslToggleB = document.getElementById('wgsl-toggle-b');
+
+  // WGSL toggle buttons.
+  wgslToggleA.addEventListener('click', function () {
+    var hidden = wgslPaneA.style.display === 'none';
+    wgslPaneA.style.display = hidden ? 'block' : 'none';
+    wgslToggleA.textContent = hidden ? 'Hide WGSL (Kernel A)' : 'Show WGSL (Kernel A)';
+  });
+  wgslToggleB.addEventListener('click', function () {
+    var hidden = wgslPaneB.style.display === 'none';
+    wgslPaneB.style.display = hidden ? 'block' : 'none';
+    wgslToggleB.textContent = hidden ? 'Hide WGSL (Kernel B)' : 'Show WGSL (Kernel B)';
+  });
+
+  // Build input data: a[i] = i * 0.5, b[i] = i * 2.0.
+  function buildInputs() {
+    var a = new Float32Array(N);
+    var b = new Float32Array(N);
+    for (var i = 0; i < N; i++) {
+      a[i] = i * 0.5;
+      b[i] = i * 2.0;
+    }
+    return { a: a, b: b };
+  }
+
+  // Check result against reference: out[i] == a[i]^2 + b[i] within 1e-3.
+  function checkResult(out, inputs) {
+    var bad = [];
+    for (var i = 0; i < N; i++) {
+      var expected = inputs.a[i] * inputs.a[i] + inputs.b[i];
+      if (Math.abs(out[i] - expected) > 1e-3) {
+        bad.push({ i: i, got: out[i], expected: expected });
+      }
+    }
+    return bad;
+  }
+
+  function setStatus(msg) { statusBar.textContent = msg; }
+
+  function showPass(msg) {
+    outputPane.className = 'lesson-output pass-output';
+    outputPane.textContent = msg;
+    setStatus('PASS');
+  }
+
+  function showFail(msg) {
+    outputPane.className = 'lesson-output fail-output';
+    outputPane.textContent = msg;
+    setStatus('FAIL');
+  }
+
+  function showError(msg) {
+    outputPane.className = 'lesson-output fail-output';
+    outputPane.textContent = msg;
+    setStatus('error');
+  }
+
+  // Check WebGPU availability before running.
+  function checkWebGPU(cb) {
+    if (!navigator.gpu) {
+      showError('WebGPU is not available in this browser.\n' +
+        'Try Chrome 113+ or Edge 113+ with WebGPU enabled.');
+      return;
+    }
+    navigator.gpu.requestAdapter().then(function (adapter) {
+      if (!adapter) {
+        showError('No WebGPU adapter found.\n' +
+          'Your GPU may not support WebGPU or the driver is missing.');
+        return;
+      }
+      cb();
+    });
+  }
+
+  runBtn.addEventListener('click', function () {
+    var srcA = editorA.getValue();
+    var srcB = editorB.getValue();
+    var inputs = buildInputs();
+
+    setStatus('running...');
+    outputPane.className = 'lesson-output';
+    outputPane.textContent = 'Running on your GPU...';
+
+    checkWebGPU(function () {
+      SpocCompose.run(srcA, srcB, { a: inputs.a, b: inputs.b },
+        function (result, err) {
+          if (err) {
+            showError('Error: ' + err);
+            return;
+          }
+
+          // Populate WGSL panes if available via SpocCompose internals.
+          // (The driver does not expose WGSL; panes stay empty unless filled.)
+
+          var bad = checkResult(Array.from(result), inputs);
+          if (bad.length === 0) {
+            showPass('PASS — all ' + N + ' elements correct.\n' +
+              'out[i] = a[i]² + b[i] for every i.');
+          } else {
+            var first = bad[0];
+            showFail('FAIL — ' + bad.length + ' mismatches.\n' +
+              'First mismatch at i=' + first.i +
+              ': got ' + first.got.toFixed(6) +
+              ', expected ' + first.expected.toFixed(6));
+          }
+        }
+      );
+    });
+  });
+})();
+</script>

--- a/gh-pages/learn/index.md
+++ b/gh-pages/learn/index.md
@@ -103,3 +103,4 @@ the Run button will be disabled with an explanatory message.
 4. [Lesson 4 — Control flow and bounds]({{ site.baseurl }}/learn/04-bounds-if.html) — `if` expressions and index guarding
 5. [Lesson 5 — Mandelbrot]({{ site.baseurl }}/learn/05-mandelbrot.html) — a per-pixel loop that **generates an image** on your GPU
 6. [Lesson 6 — Image filter]({{ site.baseurl }}/learn/06-image-filter.html) — a grayscale **photo filter** rendered in the page (bring your own photo)
+7. [Lesson 7 — Composing kernels]({{ site.baseurl }}/learn/07-compose.html) — chain two kernels with an OCaml host: square then add, in two GPU passes

--- a/gh-pages/learn/test/compose_gpu_test.mjs
+++ b/gh-pages/learn/test/compose_gpu_test.mjs
@@ -1,0 +1,186 @@
+// Playwright acceptance test for the "Composing kernels" lesson driver.
+//
+// Tests SpocCompose.run with:
+//   (a) correct kernel A + correct kernel B -> out == a²+b (within 1e-4)
+//   (b) wrong kernel A (identity instead of square) -> mismatch detected
+//
+// Graceful skip (exit 0) when playwright / chrome / WebGPU are unavailable.
+// Only fails on a real wrong GPU result or an unexpected error.
+//
+// Usage:
+//   node gh-pages/learn/test/compose_gpu_test.mjs [compose_driver.bc.js]
+
+import http from 'http';
+import fs from 'fs';
+import { createRequire } from 'module';
+import { execSync } from 'child_process';
+
+// ── Playwright resolution (mirrors lessons_gpu_test.mjs) ─────────────────
+function resolvePlaywright() {
+  const reqHere = createRequire(import.meta.url);
+  const candidates = [];
+  try { candidates.push(execSync('npm root -g').toString().trim()); } catch (_) {}
+  try {
+    candidates.push(
+      ...execSync('ls -d /home/*/.npm/_npx/*/node_modules 2>/dev/null')
+        .toString().trim().split('\n')
+    );
+  } catch (_) {}
+  for (const base of candidates.filter(Boolean)) {
+    try { return createRequire(base + '/x')('playwright'); } catch (_) {}
+  }
+  try { return reqHere('playwright'); } catch (_) {}
+  return null;
+}
+
+function skip(msg) { console.log('SKIP: ' + msg); process.exit(0); }
+
+const pw = resolvePlaywright();
+if (!pw) skip('playwright not resolvable');
+const { chromium } = pw;
+
+// ── Asset path ────────────────────────────────────────────────────────────
+const BUNDLE = process.argv[2] ||
+  '_build/default/sarek/core_js/webgpu/lessons/compose_driver.bc.js';
+if (!fs.existsSync(BUNDLE)) skip('compose bundle not built: ' + BUNDLE);
+const bundleJs = fs.readFileSync(BUNDLE);
+
+// ── Minimal HTTP server ───────────────────────────────────────────────────
+const server = http.createServer((req, res) => {
+  if (req.url === '/compose.js') {
+    res.setHeader('content-type', 'text/javascript');
+    res.end(bundleJs);
+  } else {
+    const body = `<!doctype html>
+<meta charset=utf-8>
+<title>compose-test</title>
+<script src="/compose.js"></script>`;
+    res.setHeader('content-type', 'text/html');
+    res.end(body);
+  }
+});
+await new Promise(r => server.listen(0, r));
+const port = server.address().port;
+
+// ── Browser launch ────────────────────────────────────────────────────────
+let browser;
+try {
+  browser = await chromium.launch({
+    headless: true,
+    channel: 'chrome',
+    args: [
+      '--enable-unsafe-webgpu',
+      '--enable-features=Vulkan',
+      '--use-angle=vulkan',
+      '--use-gl=angle',
+      '--ignore-gpu-blocklist',
+      '--no-sandbox',
+    ],
+  });
+} catch (e) {
+  server.close();
+  skip('chrome launch failed: ' + e.message);
+}
+
+const page = await browser.newPage();
+await page.goto(`http://localhost:${port}/`, { waitUntil: 'load' });
+await page.waitForFunction(
+  () => typeof globalThis.SpocCompose !== 'undefined',
+  { timeout: 20000 }
+);
+
+const hasAdapter = await page.evaluate(
+  async () =>
+    !!(navigator.gpu &&
+      (await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' })))
+);
+if (!hasAdapter) {
+  await browser.close();
+  server.close();
+  skip('no WebGPU adapter in this Chrome');
+}
+
+// ── Kernel sources ────────────────────────────────────────────────────────
+const KERNEL_A_CORRECT =
+  'fun (a : float32 vector) (tmp : float32 vector) ->\n' +
+  '  let i = global_thread_id in\n' +
+  '  tmp.(i) <- a.(i) *. a.(i)';
+
+const KERNEL_A_WRONG =
+  'fun (a : float32 vector) (tmp : float32 vector) ->\n' +
+  '  let i = global_thread_id in\n' +
+  '  tmp.(i) <- a.(i)';
+
+const KERNEL_B =
+  'fun (tmp : float32 vector) (b : float32 vector) (out : float32 vector) ->\n' +
+  '  let i = global_thread_id in\n' +
+  '  out.(i) <- tmp.(i) +. b.(i)';
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+function makeInputs(N) {
+  const a = new Array(N), b = new Array(N);
+  for (let i = 0; i < N; i++) { a[i] = i * 0.5; b[i] = i * 2.0; }
+  return { a, b };
+}
+
+function referenceOut(inputs) {
+  return inputs.a.map((ai, i) => ai * ai + inputs.b[i]);
+}
+
+// ── Run a single compose case on the page ─────────────────────────────────
+async function runCompose(kA, kB, inputs) {
+  return page.evaluate(
+    async ({ kA, kB, inputs }) => {
+      return new Promise((resolve) => {
+        SpocCompose.run(kA, kB, { a: inputs.a, b: inputs.b },
+          function (result, err) {
+            if (err) { resolve({ ok: false, error: err }); return; }
+            resolve({ ok: true, result: Array.from(result) });
+          }
+        );
+      });
+    },
+    { kA, kB, inputs }
+  );
+}
+
+// ── Test execution ────────────────────────────────────────────────────────
+const N = 256;
+const inputs = makeInputs(N);
+const ref = referenceOut(inputs);
+const results = [];
+
+// Case 1: correct kernels -> out == a²+b within 1e-4
+const correctRun = await runCompose(KERNEL_A_CORRECT, KERNEL_B, inputs);
+if (!correctRun.ok) {
+  results.push({ id: 'correct-kernels', ok: false, detail: correctRun.error });
+} else {
+  let bad = 0;
+  for (let i = 0; i < N; i++) {
+    if (Math.abs(correctRun.result[i] - ref[i]) > 1e-4) bad++;
+  }
+  results.push({ id: 'correct-kernels', ok: bad === 0, bad });
+}
+
+// Case 2: wrong kernel A -> result should not match a²+b
+const wrongRun = await runCompose(KERNEL_A_WRONG, KERNEL_B, inputs);
+if (!wrongRun.ok) {
+  // A transpile/runtime error from wrong kernel still counts as "not PASS".
+  results.push({ id: 'wrong-kernel-a', ok: true, detail: 'error as expected: ' + wrongRun.error });
+} else {
+  let bad = 0;
+  for (let i = 0; i < N; i++) {
+    if (Math.abs(wrongRun.result[i] - ref[i]) > 1e-4) bad++;
+  }
+  // We want mismatches (bad > 0) to confirm wrong kernel is detected.
+  results.push({ id: 'wrong-kernel-a', ok: bad > 0, bad });
+}
+
+// ── Teardown and report ───────────────────────────────────────────────────
+await browser.close();
+server.close();
+
+console.log(JSON.stringify(results, null, 2));
+const allOk = results.length > 0 && results.every(r => r.ok);
+console.log(allOk ? 'COMPOSE-GPU: ALL PASS' : 'COMPOSE-GPU: FAILURE');
+process.exit(allOk ? 0 : 1);

--- a/sarek/core_js/webgpu/lessons/compose_driver.ml
+++ b/sarek/core_js/webgpu/lessons/compose_driver.ml
@@ -1,0 +1,141 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Browser driver: kernel-composition course lesson.
+
+    Exports
+    [globalThis.SpocCompose.run(kernelA_src, kernelB_src, inputsObj, cb)] where
+    [inputsObj] is a JS object [{ a: Array, b: Array }] and
+    [cb(resultArray, errorStringOrNull)].
+
+    Composition: [out = a^2 + b], implemented as two kernels run in sequence.
+    - Kernel A (square): reads [a], writes [tmp].
+    - Kernel B (add): reads [tmp] and [b], writes [out].
+
+    Buffer ownership: all GPU buffers are allocated per-call and destroyed after
+    read-back by [Webgpu_runtime.run]; the OCaml float arrays passed as [inputs]
+    are not mutated. [cb] fires exactly once on completion or error. *)
+
+open Js_of_ocaml
+open Spoc_webgpu_runtime
+
+(* ── JS compatibility shims (jsoo 6.x: no Js.to_int / js_of_int) ─────────── *)
+
+let js_to_int x = int_of_float (Js.to_float x)
+
+let js_of_int n = Js.float (float_of_int n)
+
+let js_of_float v = Js.float v
+
+let js_array_length arr = js_to_int (Js.Unsafe.get arr (Js.string "length"))
+
+(* ── Conversion helpers ───────────────────────────────────────────────────── *)
+
+(** Extract a named float array from a JS object. Returns [[||]] if key absent.
+*)
+let js_get_float_array obj key =
+  let arr_js = Js.Unsafe.get obj (Js.string key) in
+  if Js.Unsafe.equals arr_js Js.undefined || Js.Unsafe.equals arr_js Js.null
+  then [||]
+  else
+    let len = js_array_length arr_js in
+    Array.init len (fun i -> Js.to_float (Js.Unsafe.get arr_js (js_of_int i)))
+
+(** Build a JS Array from an OCaml float array. *)
+let float_array_to_js arr = Js.array (Array.map js_of_float arr)
+
+(** Invoke [cb(result, null)] on success. *)
+let cb_ok cb result =
+  Js.Unsafe.fun_call
+    cb
+    [|Js.Unsafe.inject (float_array_to_js result); Js.Unsafe.inject Js.null|]
+  |> ignore
+
+(** Invoke [cb(null, errorString)] on error. *)
+let cb_err cb msg =
+  Js.Unsafe.fun_call
+    cb
+    [|Js.Unsafe.inject Js.null; Js.Unsafe.inject (Js.string msg)|]
+  |> ignore
+
+(* ── Transpile helper ─────────────────────────────────────────────────────── *)
+
+(** Transpile a kernel source string to [(wgsl, abi_json)] or call [cb_err]. *)
+let transpile_or_err cb label src =
+  match Sarek_transpile.of_source_with_abi Sarek_transpile.WGSL src with
+  | Error e ->
+      let msg =
+        label ^ " transpile error: " ^ Sarek_transpile.string_of_error e
+      in
+      cb_err cb msg ;
+      None
+  | Ok (wgsl, abi_json) -> Some (wgsl, abi_json)
+
+(* ── Kernel-B dispatch (step 2 of composition) ───────────────────────────── *)
+
+(** After kernel A delivers [tmp], transpile and run kernel B. *)
+let run_kernel_b wgsl_b abi_b n tmp b_arr cb =
+  let zeros = Array.make n 0.0 in
+  Webgpu_runtime.run
+    ~wgsl:wgsl_b
+    ~abi_json:abi_b
+    ~inputs:[("tmp", tmp); ("b", b_arr); ("out", zeros)]
+    ~scalars:[]
+    ~outputs_wanted:["out"]
+    ~on_done:(fun results ->
+      let out =
+        match List.assoc_opt "out" results with None -> [||] | Some a -> a
+      in
+      cb_ok cb out)
+    ~on_error:(fun msg -> cb_err cb ("kernel B GPU error: " ^ msg))
+    ()
+
+(* ── Kernel-A dispatch (step 1 of composition) ───────────────────────────── *)
+
+(** Run kernel A; on success chain into [run_kernel_b]. *)
+let run_kernel_a wgsl_a abi_a wgsl_b abi_b n a_arr b_arr cb =
+  let zeros = Array.make n 0.0 in
+  Webgpu_runtime.run
+    ~wgsl:wgsl_a
+    ~abi_json:abi_a
+    ~inputs:[("a", a_arr); ("tmp", zeros)]
+    ~scalars:[]
+    ~outputs_wanted:["tmp"]
+    ~on_done:(fun results ->
+      let tmp =
+        match List.assoc_opt "tmp" results with None -> [||] | Some a -> a
+      in
+      run_kernel_b wgsl_b abi_b n tmp b_arr cb)
+    ~on_error:(fun msg -> cb_err cb ("kernel A GPU error: " ^ msg))
+    ()
+
+(* ── Public entry point ───────────────────────────────────────────────────── *)
+
+(** [run_fn kA_src kB_src inputs_obj cb] -- the JS-callable composition driver.
+
+    [inputs_obj] must expose [.a] and [.b] (JS arrays of equal length). [cb] is
+    called as [cb(resultArray, null)] on success or [cb(null, errorString)] on
+    any failure. *)
+let run_fn kernel_a_src kernel_b_src inputs_obj cb =
+  let src_a = Js.to_string kernel_a_src in
+  let src_b = Js.to_string kernel_b_src in
+  let a_arr = js_get_float_array inputs_obj "a" in
+  let b_arr = js_get_float_array inputs_obj "b" in
+  let n = Array.length a_arr in
+  match transpile_or_err cb "kernel A" src_a with
+  | None -> ()
+  | Some (wgsl_a, abi_a) -> (
+      match transpile_or_err cb "kernel B" src_b with
+      | None -> ()
+      | Some (wgsl_b, abi_b) ->
+          run_kernel_a wgsl_a abi_a wgsl_b abi_b n a_arr b_arr cb)
+
+let () =
+  let module_obj = Js.Unsafe.obj [||] in
+  Js.Unsafe.set
+    module_obj
+    "run"
+    (Js.Unsafe.callback (fun kA kB inputs cb -> run_fn kA kB inputs cb)) ;
+  Js.Unsafe.set Js.Unsafe.global "SpocCompose" module_obj

--- a/sarek/core_js/webgpu/lessons/compose_driver.ml
+++ b/sarek/core_js/webgpu/lessons/compose_driver.ml
@@ -85,10 +85,9 @@ let run_kernel_b wgsl_b abi_b n tmp b_arr cb =
     ~scalars:[]
     ~outputs_wanted:["out"]
     ~on_done:(fun results ->
-      let out =
-        match List.assoc_opt "out" results with None -> [||] | Some a -> a
-      in
-      cb_ok cb out)
+      match List.assoc_opt "out" results with
+      | None -> cb_err cb "kernel B: output buffer 'out' missing from results"
+      | Some out -> cb_ok cb out)
     ~on_error:(fun msg -> cb_err cb ("kernel B GPU error: " ^ msg))
     ()
 
@@ -104,10 +103,9 @@ let run_kernel_a wgsl_a abi_a wgsl_b abi_b n a_arr b_arr cb =
     ~scalars:[]
     ~outputs_wanted:["tmp"]
     ~on_done:(fun results ->
-      let tmp =
-        match List.assoc_opt "tmp" results with None -> [||] | Some a -> a
-      in
-      run_kernel_b wgsl_b abi_b n tmp b_arr cb)
+      match List.assoc_opt "tmp" results with
+      | None -> cb_err cb "kernel A: output buffer 'tmp' missing from results"
+      | Some tmp -> run_kernel_b wgsl_b abi_b n tmp b_arr cb)
     ~on_error:(fun msg -> cb_err cb ("kernel A GPU error: " ^ msg))
     ()
 

--- a/sarek/core_js/webgpu/lessons/dune
+++ b/sarek/core_js/webgpu/lessons/dune
@@ -1,0 +1,13 @@
+; sarek/core_js/webgpu/lessons - jsoo composition driver for the "Composing
+; kernels" course lesson.
+;
+; Build explicitly (not included in @install or dune runtest):
+;   dune build sarek/core_js/webgpu/lessons/compose_driver.bc.js
+
+(executable
+ (name compose_driver)
+ (modules compose_driver)
+ (libraries spoc_webgpu_runtime sarek_transpile js_of_ocaml)
+ (preprocess
+  (pps js_of_ocaml-ppx))
+ (modes js))


### PR DESCRIPTION
## Course: "Composing kernels" lesson — powered by the OCaml WebGPU runtime

The first lesson that does what the canned JS runner can't: a **precompiled OCaml host program** (jsoo) runs **two kernels in sequence** on the learner's GPU — `out = a²+b` as a square kernel then an add kernel, with the host orchestrating the hand-off. The learner edits both kernels, runs on their GPU, and the result is auto-checked. **Additive** — existing lessons and `sarek_webgpu_runner.js`/`sarek_lesson.js` are untouched (per the chosen "new lessons first" approach).

- `sarek/core_js/webgpu/lessons/compose_driver.ml` — exports `SpocCompose.run(kA, kB, {a,b}, cb)`: transpiles both kernels eagerly (compile errors surfaced before any GPU work), runs A→`tmp` then B(`tmp`,`b`)→`out` via the merged `Webgpu_runtime`, `cb` fires exactly once on every path.
- `gh-pages/learn/07-compose.html` — two editors + host-orchestration explanation + Run + auto-check (`a²+b`), self-contained inline script (does not touch the shared `sarek_lesson.js`); nav/index entry.
- `docs.yml` — builds `compose_driver.bc.js` → `javascripts/spoc_compose.js` (mirrors the transpiler-bundle step).
- `gh-pages/learn/test/compose_gpu_test.mjs` + `make compose-gpu-test`.

### Verification
- **Playwright on the real RX 7900 XTX:** correct kernels → `out == a²+b`; wrong kernel A → fails. **ALL PASS.**
- **Fresh independent review: VERDICT GO** — additive (0 deletions; no existing-lesson/native changes), driver `cb`-once verified, page consistent, docs.yml correct, files <500 / functions ≤50 / nesting ≤4, FFI-free.
- Goldens byte-identical; `@fmt` clean.

Non-blocking follow-up: the lesson's "Show WGSL" panes are empty (driver doesn't yet surface WGSL) — tracked to populate them (an educational win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive "Composing kernels" lesson: live editors and controls to run two GPU kernels in sequence and view/validate outputs in-browser.

* **Documentation**
  * Learn index updated to include Lesson 7 and its description.

* **Tests**
  * Added an automated browser test that verifies compose scenarios (correct vs. incorrect kernel behavior).

* **Chores**
  * Build tooling extended to produce the lesson's runtime bundle for the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->