### PR TITLE
Compose lesson: populate Show WGSL panes

### DIFF
--- a/gh-pages/learn/07-compose.html
+++ b/gh-pages/learn/07-compose.html
@@ -228,8 +228,9 @@ let run kA_src kB_src ~a ~b ~cb =
             return;
           }
 
-          // Populate WGSL panes if available via SpocCompose internals.
-          // (The driver does not expose WGSL; panes stay empty unless filled.)
+          // Populate the WGSL panes from the driver's stored WGSL strings.
+          if (wgslPaneA) wgslPaneA.textContent = SpocCompose.lastWgslA || '';
+          if (wgslPaneB) wgslPaneB.textContent = SpocCompose.lastWgslB || '';
 
           var bad = checkResult(Array.from(result), inputs);
           if (bad.length === 0) {

--- a/sarek/core_js/webgpu/lessons/compose_driver.ml
+++ b/sarek/core_js/webgpu/lessons/compose_driver.ml
@@ -128,10 +128,16 @@ let run_fn kernel_a_src kernel_b_src inputs_obj cb =
       match transpile_or_err cb "kernel B" src_b with
       | None -> ()
       | Some (wgsl_b, abi_b) ->
+          (* Expose generated WGSL so the lesson page can populate panes. *)
+          let m = Js.Unsafe.get Js.Unsafe.global (Js.string "SpocCompose") in
+          Js.Unsafe.set m "lastWgslA" (Js.string wgsl_a) ;
+          Js.Unsafe.set m "lastWgslB" (Js.string wgsl_b) ;
           run_kernel_a wgsl_a abi_a wgsl_b abi_b n a_arr b_arr cb)
 
 let () =
   let module_obj = Js.Unsafe.obj [||] in
+  Js.Unsafe.set module_obj "lastWgslA" (Js.string "") ;
+  Js.Unsafe.set module_obj "lastWgslB" (Js.string "") ;
   Js.Unsafe.set
     module_obj
     "run"

--- a/sarek/core_js/webgpu/lessons/compose_driver.ml
+++ b/sarek/core_js/webgpu/lessons/compose_driver.ml
@@ -117,6 +117,10 @@ let run_kernel_a wgsl_a abi_a wgsl_b abi_b n a_arr b_arr cb =
     called as [cb(resultArray, null)] on success or [cb(null, errorString)] on
     any failure. *)
 let run_fn kernel_a_src kernel_b_src inputs_obj cb =
+  (* Clear stale WGSL from any previous successful run. *)
+  let m = Js.Unsafe.get Js.Unsafe.global (Js.string "SpocCompose") in
+  Js.Unsafe.set m "lastWgslA" (Js.string "") ;
+  Js.Unsafe.set m "lastWgslB" (Js.string "") ;
   let src_a = Js.to_string kernel_a_src in
   let src_b = Js.to_string kernel_b_src in
   let a_arr = js_get_float_array inputs_obj "a" in
@@ -129,7 +133,6 @@ let run_fn kernel_a_src kernel_b_src inputs_obj cb =
       | None -> ()
       | Some (wgsl_b, abi_b) ->
           (* Expose generated WGSL so the lesson page can populate panes. *)
-          let m = Js.Unsafe.get Js.Unsafe.global (Js.string "SpocCompose") in
           Js.Unsafe.set m "lastWgslA" (Js.string wgsl_a) ;
           Js.Unsafe.set m "lastWgslB" (Js.string wgsl_b) ;
           run_kernel_a wgsl_a abi_a wgsl_b abi_b n a_arr b_arr cb)


### PR DESCRIPTION
Lesson 7's "Show WGSL" buttons toggled permanently-empty panes — the driver
did not expose the generated WGSL (flagged as a non-blocking follow-up in PR #171).

Additive fix:
- Driver stores `lastWgslA`/`lastWgslB` on the `SpocCompose` module object after successful transpilation.
- Page reads them in the run callback to populate both WGSL `<pre>` elements.
- No callback signature change; initial values are empty strings.

GPU test: COMPOSE-GPU: ALL PASS. `@fmt` clean. Goldens byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kernel composition lesson now displays the generated WGSL shader code after execution
  * Transpiled shader output is automatically shown in the "Show WGSL" panes, enabling users to inspect the composition results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->