### PR TITLE
WGSL backend: prefix builtin params with sarek_ to prevent user name collisions

### DIFF
--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -149,29 +149,29 @@ let rec has_float64 = function
 (** {1 Thread Intrinsics}
 
     WGSL uses three distinct builtins:
-    - [local_invocation_id] (lid) — thread within workgroup
-    - [workgroup_id] (wid) — workgroup index in the dispatch grid
-    - [global_invocation_id] (gid) — globally unique thread index
+    - [local_invocation_id] (sarek_lid) — thread within workgroup
+    - [workgroup_id] (sarek_wid) — workgroup index in the dispatch grid
+    - [global_invocation_id] (sarek_gid) — globally unique thread index
 
     All are [vec3<u32>]; we cast to i32 to match the IR's i32 type for thread
     ids. The entry point declares all three builtins; unused ones are harmless
     (WGSL permits unused builtin params). *)
 let wgsl_thread_intrinsic = function
-  | "thread_id_x" | "thread_idx_x" -> "i32(lid.x)"
-  | "thread_id_y" | "thread_idx_y" -> "i32(lid.y)"
-  | "thread_id_z" | "thread_idx_z" -> "i32(lid.z)"
-  | "block_id_x" | "block_idx_x" -> "i32(wid.x)"
-  | "block_id_y" | "block_idx_y" -> "i32(wid.y)"
-  | "block_id_z" | "block_idx_z" -> "i32(wid.z)"
+  | "thread_id_x" | "thread_idx_x" -> "i32(sarek_lid.x)"
+  | "thread_id_y" | "thread_idx_y" -> "i32(sarek_lid.y)"
+  | "thread_id_z" | "thread_idx_z" -> "i32(sarek_lid.z)"
+  | "block_id_x" | "block_idx_x" -> "i32(sarek_wid.x)"
+  | "block_id_y" | "block_idx_y" -> "i32(sarek_wid.y)"
+  | "block_id_z" | "block_idx_z" -> "i32(sarek_wid.z)"
   | "block_dim_x" -> "256i"
   | "block_dim_y" -> "1i"
   | "block_dim_z" -> "1i"
-  | "grid_dim_x" -> "i32(nwg.x)"
-  | "grid_dim_y" -> "i32(nwg.y)"
-  | "grid_dim_z" -> "i32(nwg.z)"
-  | "global_thread_id" | "global_idx" | "global_idx_x" -> "i32(gid.x)"
-  | "global_idx_y" -> "i32(gid.y)"
-  | "global_idx_z" -> "i32(gid.z)"
+  | "grid_dim_x" -> "i32(sarek_nwg.x)"
+  | "grid_dim_y" -> "i32(sarek_nwg.y)"
+  | "grid_dim_z" -> "i32(sarek_nwg.z)"
+  | "global_thread_id" | "global_idx" | "global_idx_x" -> "i32(sarek_gid.x)"
+  | "global_idx_y" -> "i32(sarek_gid.y)"
+  | "global_idx_z" -> "i32(sarek_gid.z)"
   | "global_size" -> "0i"
   | name -> Codegen_error.raise_error (Codegen_error.unknown_intrinsic name)
 
@@ -972,10 +972,10 @@ let wgsl_header ~kernel_name ?(block = (256, 1, 1)) () =
   Printf.sprintf
     "@compute @workgroup_size(%d, %d, %d)\n\
      fn main(\n\
-    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
-    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
-    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
-    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+    \  @builtin(global_invocation_id) sarek_gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) sarek_lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) sarek_wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) sarek_nwg : vec3<u32>\n\
      ) {\n"
     bx
     by

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -108,6 +108,12 @@ let wgsl_reserved_keywords =
     (* Params struct name we emit *)
     "Params";
     "params";
+    (* Internal builtin parameter names emitted by wgsl_header; must not
+       be shadowed by user variable declarations in the kernel body. *)
+    "sarek_gid";
+    "sarek_lid";
+    "sarek_wid";
+    "sarek_nwg";
   ]
 
 (** Escape reserved WGSL keywords by adding 'v' suffix. *)

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -722,12 +722,12 @@ let () =
      // Sarek-generated compute shader: scalar_vec_add\n\
      @compute @workgroup_size(256, 1, 1)\n\
      fn main(\n\
-    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
-    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
-    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
-    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+    \  @builtin(global_invocation_id) sarek_gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) sarek_lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) sarek_wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) sarek_nwg : vec3<u32>\n\
      ) {\n\
-    \  let idx : i32 = i32(gid.x);\n\
+    \  let idx : i32 = i32(sarek_gid.x);\n\
     \  c[idx] = (a[idx] + b[idx]);\n\
      }\n" ;
 
@@ -746,12 +746,12 @@ let () =
      // Sarek-generated compute shader: record_kernel\n\
      @compute @workgroup_size(256, 1, 1)\n\
      fn main(\n\
-    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
-    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
-    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
-    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+    \  @builtin(global_invocation_id) sarek_gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) sarek_lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) sarek_wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) sarek_nwg : vec3<u32>\n\
      ) {\n\
-    \  let idx : i32 = i32(gid.x);\n\
+    \  let idx : i32 = i32(sarek_gid.x);\n\
     \  let p : Point2 = pts[idx];\n\
     \  pts[idx] = Point2((p.x * 2.0f), (p.y * 2.0f));\n\
      }\n" ;
@@ -786,12 +786,12 @@ let () =
      // Sarek-generated compute shader: variant_kernel\n\
      @compute @workgroup_size(256, 1, 1)\n\
      fn main(\n\
-    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
-    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
-    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
-    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+    \  @builtin(global_invocation_id) sarek_gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) sarek_lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) sarek_wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) sarek_nwg : vec3<u32>\n\
      ) {\n\
-    \  let idx : i32 = i32(gid.x);\n\
+    \  let idx : i32 = i32(sarek_gid.x);\n\
     \  let flag : i32 = flags[idx];\n\
     \  if ((flag != 0i)) {\n\
     \    out[idx] = make_Opt_OptSome(1.0f);\n\
@@ -813,12 +813,12 @@ let () =
      // Sarek-generated compute shader: sin_kernel\n\
      @compute @workgroup_size(256, 1, 1)\n\
      fn main(\n\
-    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
-    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
-    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
-    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+    \  @builtin(global_invocation_id) sarek_gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) sarek_lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) sarek_wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) sarek_nwg : vec3<u32>\n\
      ) {\n\
-    \  let idx : i32 = i32(gid.x);\n\
+    \  let idx : i32 = i32(sarek_gid.x);\n\
     \  b[idx] = sin(a[idx]);\n\
      }\n" ;
 
@@ -836,12 +836,12 @@ let () =
      // Sarek-generated compute shader: float32_sin_path\n\
      @compute @workgroup_size(256, 1, 1)\n\
      fn main(\n\
-    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
-    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
-    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
-    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+    \  @builtin(global_invocation_id) sarek_gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) sarek_lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) sarek_wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) sarek_nwg : vec3<u32>\n\
      ) {\n\
-    \  let idx : i32 = i32(gid.x);\n\
+    \  let idx : i32 = i32(sarek_gid.x);\n\
     \  b[idx] = sin(a[idx]);\n\
      }\n"
 
@@ -940,12 +940,12 @@ let () =
      // Sarek-generated compute shader: bounds_check\n\
      @compute @workgroup_size(256, 1, 1)\n\
      fn main(\n\
-    \  @builtin(global_invocation_id) gid : vec3<u32>,\n\
-    \  @builtin(local_invocation_id) lid : vec3<u32>,\n\
-    \  @builtin(workgroup_id) wid : vec3<u32>,\n\
-    \  @builtin(num_workgroups) nwg : vec3<u32>\n\
+    \  @builtin(global_invocation_id) sarek_gid : vec3<u32>,\n\
+    \  @builtin(local_invocation_id) sarek_lid : vec3<u32>,\n\
+    \  @builtin(workgroup_id) sarek_wid : vec3<u32>,\n\
+    \  @builtin(num_workgroups) sarek_nwg : vec3<u32>\n\
      ) {\n\
-    \  let idx : i32 = i32(gid.x);\n\
+    \  let idx : i32 = i32(sarek_gid.x);\n\
     \  b[idx] = select(0.0f, a[idx], (idx < params.n));\n\
      }\n"
 


### PR DESCRIPTION
## WGSL backend: prefix builtin params with `sarek_` to prevent user name collisions

The WGSL entry-point built-in parameters were named `gid`/`lid`/`wid`/`nwg`. These are completely natural kernel variable names, so writing `let gid = global_thread_id` produced an opaque WGSL compile error ("redeclaration of 'gid'") that was invisible at the OCaml/transpiler level — the kernel compiled cleanly in OCaml but failed silently in the browser.

**Fix:** rename to `sarek_gid`/`sarek_lid`/`sarek_wid`/`sarek_nwg` in the entry-point signature (`Sarek_ir_wgsl.ml:wgsl_header`) and all thread-intrinsic references (`wgsl_thread_intrinsic`). User code can now freely use `gid`, `lid`, `wid`, `nwg` as variable names — confirmed working.

**Goldens:** the 6 WGSL golden strings in `test_codegen_golden.ml` updated to the new names (the only diff is the builtin parameter names and their body references like `i32(sarek_gid.x)`). All **26 golden tests pass**.

**GPU:** all existing GPU tests still pass after the rename — WGSL-GPU (vector_add, sin, bounds_check), lessons (6/6), compose, bench **80/80 verified** at size 256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized WGSL builtin variable naming in generated code for improved consistency and readability across kernel outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->