### PR TITLE
fix(cuda): drop spurious static -lnvrtc link from runtime-comparison test

### DIFF
--- a/sarek/tests/new_runtime/dune
+++ b/sarek/tests/new_runtime/dune
@@ -16,5 +16,9 @@
   (pps sarek_ppx))
  (enabled_if
   (<> %{env:CUDA_PATH=} ""))
+ ; NVRTC + the CUDA driver are loaded lazily via Dl.dlopen at runtime
+ ; (see Cuda_nvrtc.ml / Cuda_bindings.ml), so no static -lnvrtc link is
+ ; needed. Linking it forced an unnecessary build-time dependency that
+ ; broke `dune build` on machines with CUDA_PATH set but libnvrtc absent.
  (flags
-  (:standard -w -33 -ccopt -L/opt/cuda/lib64 -cclib -lnvrtc)))
+  (:standard -w -33)))


### PR DESCRIPTION
NVRTC and the CUDA driver are loaded lazily via `Dl.dlopen` at runtime (`sarek-cuda/Cuda_nvrtc.ml:97-137`, `Cuda_bindings.ml`), so `sarek/tests/new_runtime/test_runtime_comparison` never needs a static `-lnvrtc` at link time.

The `-ccopt -L/opt/cuda/lib64 -cclib -lnvrtc` flag forced an unnecessary build-time dependency that broke `dune build` on any machine with `CUDA_PATH` set (which enables the target via `enabled_if`) but `libnvrtc` absent — e.g. a non-NVIDIA dev box with CUDA headers but no runtime libs.

Removing it lets the whole tree build everywhere; on a real CUDA machine NVRTC is still found via `dlopen` at runtime. **No behaviour change.** Verified: `dune build` (whole tree) green after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified test build configuration by removing static compilation flags for CUDA runtime libraries.
  * Enhanced build documentation with clarification on how CUDA components are dynamically loaded at runtime.
  * Streamlined compiler flags for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->