### PR TITLE
refactor(framework): FFI-free spoc_framework via nativeint ptr boundary [HOLD: CUDA runtime pending]

### DIFF
--- a/sarek-cuda/Cuda_plugin_base.ml
+++ b/sarek-cuda/Cuda_plugin_base.ml
@@ -82,9 +82,17 @@ module Cuda : Framework_sig.PLUGIN_BASE = struct
 
     let device_to_host = Cuda_api.Memory.device_to_host
 
-    let host_ptr_to_device = Cuda_api.Memory.host_ptr_to_device
+    let host_ptr_to_device ~src_ptr ~byte_size ~dst =
+      Cuda_api.Memory.host_ptr_to_device
+        ~src_ptr:(Ctypes.ptr_of_raw_address src_ptr)
+        ~byte_size
+        ~dst
 
-    let device_to_host_ptr = Cuda_api.Memory.device_to_host_ptr
+    let device_to_host_ptr ~src ~dst_ptr ~byte_size =
+      Cuda_api.Memory.device_to_host_ptr
+        ~src
+        ~dst_ptr:(Ctypes.ptr_of_raw_address dst_ptr)
+        ~byte_size
 
     let device_to_device = Cuda_api.Memory.device_to_device
 

--- a/sarek-metal/Metal_plugin_base.ml
+++ b/sarek-metal/Metal_plugin_base.ml
@@ -142,10 +142,16 @@ module Metal : Framework_sig.PLUGIN_BASE = struct
         ~size:byte_size
 
     let host_ptr_to_device ~src_ptr ~byte_size ~dst =
-      Metal_api.memcpy ~dst:dst.buf.contents ~src:src_ptr ~size:byte_size
+      Metal_api.memcpy
+        ~dst:dst.buf.contents
+        ~src:(Ctypes.ptr_of_raw_address src_ptr)
+        ~size:byte_size
 
     let device_to_host_ptr ~src ~dst_ptr ~byte_size =
-      Metal_api.memcpy ~dst:dst_ptr ~src:src.buf.contents ~size:byte_size
+      Metal_api.memcpy
+        ~dst:(Ctypes.ptr_of_raw_address dst_ptr)
+        ~src:src.buf.contents
+        ~size:byte_size
 
     let device_to_device ~src ~dst =
       let byte_size =

--- a/sarek-opencl/Opencl_plugin_base.ml
+++ b/sarek-opencl/Opencl_plugin_base.ml
@@ -137,7 +137,7 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
       let state = get_state dst.device_id in
       Opencl_api.Memory.host_ptr_to_device
         state.queue
-        ~src_ptr
+        ~src_ptr:(Ctypes.ptr_of_raw_address src_ptr)
         ~byte_size
         ~dst:dst.buf
 
@@ -146,7 +146,7 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
       Opencl_api.Memory.device_to_host_ptr
         state.queue
         ~src:src.buf
-        ~dst_ptr
+        ~dst_ptr:(Ctypes.ptr_of_raw_address dst_ptr)
         ~byte_size
 
     let device_to_device ~src ~dst =

--- a/sarek-vulkan/Vulkan_plugin_base.ml
+++ b/sarek-vulkan/Vulkan_plugin_base.ml
@@ -99,9 +99,17 @@ module Vulkan = struct
 
     let device_to_host = Vulkan_api.Memory.device_to_host
 
-    let host_ptr_to_device = Vulkan_api.Memory.host_ptr_to_device
+    let host_ptr_to_device ~src_ptr ~byte_size ~dst =
+      Vulkan_api.Memory.host_ptr_to_device
+        ~src_ptr:(Ctypes.ptr_of_raw_address src_ptr)
+        ~byte_size
+        ~dst
 
-    let device_to_host_ptr = Vulkan_api.Memory.device_to_host_ptr
+    let device_to_host_ptr ~src ~dst_ptr ~byte_size =
+      Vulkan_api.Memory.device_to_host_ptr
+        ~src
+        ~dst_ptr:(Ctypes.ptr_of_raw_address dst_ptr)
+        ~byte_size
 
     let device_to_device = Vulkan_api.Memory.device_to_device
 

--- a/sarek/core/Memory.ml
+++ b/sarek/core/Memory.ml
@@ -94,10 +94,16 @@ let alloc (device : Device.t) (size : int) (kind : ('a, 'b) Bigarray.kind) :
           let device_ptr = B.Memory.device_ptr buf
 
           let host_ptr_to_device src_ptr ~byte_size =
-            B.Memory.host_ptr_to_device ~src_ptr ~byte_size ~dst:buf
+            B.Memory.host_ptr_to_device
+              ~src_ptr:(Ctypes.raw_address_of_ptr src_ptr)
+              ~byte_size
+              ~dst:buf
 
           let device_to_host_ptr dst_ptr ~byte_size =
-            B.Memory.device_to_host_ptr ~src:buf ~dst_ptr ~byte_size
+            B.Memory.device_to_host_ptr
+              ~src:buf
+              ~dst_ptr:(Ctypes.raw_address_of_ptr dst_ptr)
+              ~byte_size
 
           let bind_to_kargs kargs idx =
             match B.unwrap_kargs kargs with
@@ -126,10 +132,16 @@ let alloc_custom (device : Device.t) ~(size : int) ~(elem_size : int) :
           let device_ptr = B.Memory.device_ptr buf
 
           let host_ptr_to_device src_ptr ~byte_size =
-            B.Memory.host_ptr_to_device ~src_ptr ~byte_size ~dst:buf
+            B.Memory.host_ptr_to_device
+              ~src_ptr:(Ctypes.raw_address_of_ptr src_ptr)
+              ~byte_size
+              ~dst:buf
 
           let device_to_host_ptr dst_ptr ~byte_size =
-            B.Memory.device_to_host_ptr ~src:buf ~dst_ptr ~byte_size
+            B.Memory.device_to_host_ptr
+              ~src:buf
+              ~dst_ptr:(Ctypes.raw_address_of_ptr dst_ptr)
+              ~byte_size
 
           let bind_to_kargs kargs idx =
             match B.unwrap_kargs kargs with

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -71,11 +71,19 @@ let alloc_scalar_buffer (type a b) (dev : Device.t) (length : int)
             (Int64.of_nativeint device_ptr)
             byte_size ;
           if B.Memory.is_zero_copy buf then () (* Skip for zero-copy *)
-          else B.Memory.host_ptr_to_device ~src_ptr ~byte_size ~dst:buf
+          else
+            B.Memory.host_ptr_to_device
+              ~src_ptr:(Ctypes.raw_address_of_ptr src_ptr)
+              ~byte_size
+              ~dst:buf
 
         let device_to_host_ptr dst_ptr ~byte_size =
           if B.Memory.is_zero_copy buf then () (* Skip for zero-copy *)
-          else B.Memory.device_to_host_ptr ~src:buf ~dst_ptr ~byte_size
+          else
+            B.Memory.device_to_host_ptr
+              ~src:buf
+              ~dst_ptr:(Ctypes.raw_address_of_ptr dst_ptr)
+              ~byte_size
 
         let free () = B.Memory.free buf
       end : Vector.DEVICE_BUFFER)
@@ -157,10 +165,16 @@ let alloc_custom_buffer (dev : Device.t) (length : int) (elem_sz : int) :
           | None -> failwith "bind_to_kargs: backend mismatch"
 
         let host_ptr_to_device src_ptr ~byte_size =
-          B.Memory.host_ptr_to_device ~src_ptr ~byte_size ~dst:buf
+          B.Memory.host_ptr_to_device
+            ~src_ptr:(Ctypes.raw_address_of_ptr src_ptr)
+            ~byte_size
+            ~dst:buf
 
         let device_to_host_ptr dst_ptr ~byte_size =
-          B.Memory.device_to_host_ptr ~src:buf ~dst_ptr ~byte_size
+          B.Memory.device_to_host_ptr
+            ~src:buf
+            ~dst_ptr:(Ctypes.raw_address_of_ptr dst_ptr)
+            ~byte_size
 
         let free () = B.Memory.free buf
       end : Vector.DEVICE_BUFFER)

--- a/sarek/core/test/dune
+++ b/sarek/core/test/dune
@@ -8,3 +8,7 @@
   test_kernel_arg
   test_gpu_memory)
  (libraries spoc_core ctypes))
+
+(test
+ (name test_nativeint_round_trip)
+ (libraries spoc_core ctypes sarek_native sarek_interpreter))

--- a/sarek/core/test/test_nativeint_round_trip.ml
+++ b/sarek/core/test/test_nativeint_round_trip.ml
@@ -1,0 +1,95 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Round-trip test for the nativeint boundary change (PR 2a).
+ *
+ * Verifies that host_ptr_to_device / device_to_host_ptr correctly round-trip
+ * a known byte pattern through both the Native and Interpreter backends after
+ * Framework_sig changed from unit Ctypes.ptr to nativeint.
+ *
+ * Load-bearing: if raw_address_of_ptr / ptr_of_raw_address were swapped or
+ * dropped this test fails with mismatched bytes.
+ *
+ * Coverage: exercises the Custom_storage (alloc_custom) arm. The bigarray arm
+ * of the same methods uses the identical conversion and is covered transitively
+ * by the existing vector-transfer goldens (@sarek/tests/runtest).
+ ******************************************************************************)
+
+open Spoc_core
+
+(* Force registration of both CPU backends before Device.init *)
+let () =
+  ignore (Lazy.force Sarek_native.Native_plugin.registered_backend) ;
+  ignore (Lazy.force Sarek_interpreter.Interpreter_plugin.registered_backend)
+
+let all_devices = Device.init ~frameworks:["Native"; "Interpreter"] ()
+
+let elem_count = 16
+
+(** Fill a ctypes uint8_t array with pattern i mod 256 and return void ptr. *)
+let make_and_fill_buf n =
+  let buf = Ctypes.(allocate_n uint8_t ~count:n) in
+  for i = 0 to n - 1 do
+    let v = Unsigned.UInt8.of_int (i mod 256) in
+    Ctypes.(buf +@ i <-@ v)
+  done ;
+  (buf, Ctypes.to_voidp buf)
+
+(** Read n bytes from void* into an int array. *)
+let read_buf void_ptr n =
+  let p = Ctypes.(from_voidp uint8_t void_ptr) in
+  Array.init n (fun i -> Unsigned.UInt8.to_int Ctypes.(!@(p +@ i)))
+
+(** Zero n bytes at void*. *)
+let zero_buf void_ptr n =
+  let p = Ctypes.(from_voidp uint8_t void_ptr) in
+  for i = 0 to n - 1 do
+    Ctypes.(p +@ i <-@ Unsigned.UInt8.zero)
+  done
+
+let test_backend_round_trip framework_name =
+  let dev =
+    match
+      Array.to_list all_devices
+      |> List.filter (fun d -> d.Device.framework = framework_name)
+    with
+    | d :: _ -> d
+    | [] -> failwith (Printf.sprintf "No %s device found" framework_name)
+  in
+  let elem_size = 1 in
+  let byte_count = elem_count * elem_size in
+  let gpu_buf = Memory.alloc_custom dev ~size:elem_count ~elem_size in
+  let _ocaml_buf, void_ptr = make_and_fill_buf byte_count in
+  (* host -> device (exercises ptr -> nativeint -> ptr conversion) *)
+  Memory.host_ptr_to_device ~src_ptr:void_ptr ~dst:gpu_buf ;
+  (* Zero host buf to prove data lives in device buffer *)
+  zero_buf void_ptr byte_count ;
+  (* device -> host (exercises the reverse path) *)
+  Memory.device_to_host_ptr ~src:gpu_buf ~dst_ptr:void_ptr ;
+  let actual = read_buf void_ptr byte_count in
+  Array.iteri
+    (fun i v ->
+      let expected = i mod 256 in
+      if v <> expected then
+        failwith
+          (Printf.sprintf
+             "%s round-trip FAIL at byte %d: expected %d got %d"
+             framework_name
+             i
+             expected
+             v))
+    actual ;
+  Memory.free gpu_buf ;
+  Printf.printf
+    "PASS: %s nativeint round-trip (%d bytes)\n"
+    framework_name
+    byte_count
+
+let () =
+  Printf.printf "nativeint round-trip tests:\n" ;
+  test_backend_round_trip "Native" ;
+  test_backend_round_trip "Interpreter" ;
+  Printf.printf "All nativeint round-trip tests passed!\n"

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -78,10 +78,10 @@ module Interpreter : sig
       src:'a buffer -> dst:('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> unit
 
     val host_ptr_to_device :
-      src_ptr:unit Ctypes.ptr -> byte_size:int -> dst:'a buffer -> unit
+      src_ptr:nativeint -> byte_size:int -> dst:'a buffer -> unit
 
     val device_to_host_ptr :
-      src:'a buffer -> dst_ptr:unit Ctypes.ptr -> byte_size:int -> unit
+      src:'a buffer -> dst_ptr:nativeint -> byte_size:int -> unit
 
     val device_to_device : src:'a buffer -> dst:'a buffer -> unit
 
@@ -434,6 +434,7 @@ end = struct
           invalid_arg "device_to_host: source is ctypes buffer"
 
     let host_ptr_to_device ~src_ptr ~byte_size ~dst =
+      let src_ptr = Ctypes.ptr_of_raw_address src_ptr in
       let open Ctypes in
       let byte_size = min byte_size (buffer_byte_size dst) in
       match dst.storage with
@@ -447,6 +448,7 @@ end = struct
           invalid_arg "host_ptr_to_device: destination is bigarray"
 
     let device_to_host_ptr ~src ~dst_ptr ~byte_size =
+      let dst_ptr = Ctypes.ptr_of_raw_address dst_ptr in
       let open Ctypes in
       let byte_size = min byte_size (buffer_byte_size src) in
       match src.storage with

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -85,10 +85,10 @@ module Native : sig
       src:'a buffer -> dst:('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> unit
 
     val host_ptr_to_device :
-      src_ptr:unit Ctypes.ptr -> byte_size:int -> dst:'a buffer -> unit
+      src_ptr:nativeint -> byte_size:int -> dst:'a buffer -> unit
 
     val device_to_host_ptr :
-      src:'a buffer -> dst_ptr:unit Ctypes.ptr -> byte_size:int -> unit
+      src:'a buffer -> dst_ptr:nativeint -> byte_size:int -> unit
 
     val device_to_device : src:'a buffer -> dst:'a buffer -> unit
 
@@ -455,6 +455,7 @@ end = struct
     (** Transfer from raw pointer to native buffer (for custom types). For
         native, this is a memcpy using ctypes. *)
     let host_ptr_to_device ~src_ptr ~byte_size ~dst =
+      let src_ptr = Ctypes.ptr_of_raw_address src_ptr in
       let open Ctypes in
       let byte_size = min byte_size (buffer_byte_size dst) in
       match dst.storage with
@@ -474,6 +475,7 @@ end = struct
 
     (** Transfer from native buffer to raw pointer (for custom types). *)
     let device_to_host_ptr ~src ~dst_ptr ~byte_size =
+      let dst_ptr = Ctypes.ptr_of_raw_address dst_ptr in
       let open Ctypes in
       let byte_size = min byte_size (buffer_byte_size src) in
       match src.storage with

--- a/sarek/tests/dune
+++ b/sarek/tests/dune
@@ -8,4 +8,6 @@
   (:e2e
    (alias e2e/runtest))
   (:codegen_golden
-   (alias codegen_golden/runtest))))
+   (alias codegen_golden/runtest))
+  (:core
+   (alias ../core/test/runtest))))

--- a/spoc/README.md
+++ b/spoc/README.md
@@ -89,7 +89,6 @@ module type SCALAR_TYPE = sig
   val size : int
   val to_primitive : t -> primitive
   val of_primitive : primitive -> t
-  val ctype : t Ctypes.typ
 end
 
 (* Values are wrapped with their type module *)
@@ -229,6 +228,4 @@ Tests are located in each subpackage:
 
 ## Dependencies
 
-- `ctypes` - For FFI type descriptions (used in SCALAR_TYPE.ctype)
-
-No GPU runtime dependencies.
+No GPU runtime dependencies. No ctypes dependency.

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -205,14 +205,20 @@ module type BACKEND = sig
     val device_to_host :
       src:'a buffer -> dst:('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> unit
 
-    (** Transfer from raw pointer to device (for custom types). src_ptr should
-        be obtained via Ctypes from a customarray. *)
+    (** Transfer from raw pointer to device (for custom types). [src_ptr] is a
+        raw machine address (as produced by [raw_address_of_ptr]); a [nativeint]
+        is NOT a GC root, so the CALLER must keep the pointed-to allocation live
+        across this call. Transfers are synchronous today (a live source on the
+        caller's stack suffices); an async backend (e.g. the worker+SAB readback
+        planned for the jsoo path) must root the source explicitly. *)
     val host_ptr_to_device :
-      src_ptr:unit Ctypes.ptr -> byte_size:int -> dst:'a buffer -> unit
+      src_ptr:nativeint -> byte_size:int -> dst:'a buffer -> unit
 
-    (** Transfer from device to raw pointer (for custom types) *)
+    (** Transfer from device to raw pointer (for custom types). Same keep-alive
+        contract as {!host_ptr_to_device}: the caller owns [dst_ptr]'s liveness.
+    *)
     val device_to_host_ptr :
-      src:'a buffer -> dst_ptr:unit Ctypes.ptr -> byte_size:int -> unit
+      src:'a buffer -> dst_ptr:nativeint -> byte_size:int -> unit
 
     val device_to_device : src:'a buffer -> dst:'a buffer -> unit
 
@@ -412,10 +418,10 @@ module type PLUGIN_BASE = sig
       src:'a buffer -> dst:('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> unit
 
     val host_ptr_to_device :
-      src_ptr:unit Ctypes.ptr -> byte_size:int -> dst:'a buffer -> unit
+      src_ptr:nativeint -> byte_size:int -> dst:'a buffer -> unit
 
     val device_to_host_ptr :
-      src:'a buffer -> dst_ptr:unit Ctypes.ptr -> byte_size:int -> unit
+      src:'a buffer -> dst_ptr:nativeint -> byte_size:int -> unit
 
     val device_to_device : src:'a buffer -> dst:'a buffer -> unit
 

--- a/spoc/framework/Typed_value.ml
+++ b/spoc/framework/Typed_value.ml
@@ -47,9 +47,6 @@ module type SCALAR_TYPE = sig
 
   (** Deserialize from primitive storage *)
   val of_primitive : primitive -> t
-
-  (** Ctypes representation for FFI *)
-  val ctype : t Ctypes.typ
 end
 
 (** {1 Composite Type Interface}
@@ -195,8 +192,6 @@ module Int32_type : SCALAR_TYPE with type t = int32 = struct
 
   let size = 4
 
-  let ctype = Ctypes.int32_t
-
   let to_primitive v = PInt32 v
 
   let of_primitive = function
@@ -210,8 +205,6 @@ module Int64_type : SCALAR_TYPE with type t = int64 = struct
   let name = "int64"
 
   let size = 8
-
-  let ctype = Ctypes.int64_t
 
   let to_primitive v = PInt64 v
 
@@ -227,8 +220,6 @@ module Float32_type : SCALAR_TYPE with type t = float = struct
 
   let size = 4
 
-  let ctype = Ctypes.float
-
   let to_primitive v = PFloat v
 
   let of_primitive = function
@@ -243,8 +234,6 @@ module Float64_type : SCALAR_TYPE with type t = float = struct
 
   let size = 8
 
-  let ctype = Ctypes.double
-
   let to_primitive v = PFloat v
 
   let of_primitive = function
@@ -258,8 +247,6 @@ module Bool_type : SCALAR_TYPE with type t = bool = struct
   let name = "bool"
 
   let size = 1
-
-  let ctype = Ctypes.bool
 
   let to_primitive v = PBool v
 

--- a/spoc/framework/dune
+++ b/spoc/framework/dune
@@ -2,7 +2,7 @@
  (name spoc_framework)
  (public_name spoc.framework)
  (modules Framework_sig Device_type Typed_value Backend_error)
- (libraries ctypes sarek_ir sarek_backend_error)
+ (libraries sarek_ir sarek_backend_error)
  (preprocess no_preprocessing)
  (instrumentation
   (backend bisect_ppx)))

--- a/spoc/framework/ffi_free_gate/dune
+++ b/spoc/framework/ffi_free_gate/dune
@@ -1,0 +1,12 @@
+; FFI-free gate — regression target ensuring spoc_framework builds without
+; ctypes or unix. If either re-enters spoc_framework, this target fails to
+; link as bytecode / js_of_ocaml.
+;
+; This stanza must NOT list ctypes or unix in (libraries ...).
+
+(executable
+ (name gate_framework)
+ (modes byte js)
+ (modules gate_framework)
+ (libraries spoc_framework)
+ (preprocess no_preprocessing))

--- a/spoc/framework/ffi_free_gate/gate_framework.ml
+++ b/spoc/framework/ffi_free_gate/gate_framework.ml
@@ -1,0 +1,51 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * ffi_free_gate — regression gate for the FFI-free spoc_framework library.
+ *
+ * This executable must build as .bc and .bc.js (js_of_ocaml). It depends
+ * ONLY on spoc_framework. If ctypes or unix re-enter spoc_framework,
+ * this target fails to build.
+ *
+ * Exercises: dims helpers, typed_value primitives, typed_value registry.
+ ******************************************************************************)
+
+open Spoc_framework
+
+(* Compile-time pin: the FFI-free boundary methods must stay [nativeint]. If
+   they revert to [Ctypes.ptr] this fails to type-check (and would require
+   ctypes, which this gate does not link) — so the gate catches both a ctypes
+   re-entry AND a silent signature regression. Never called; only type-checked. *)
+let _pin_boundary (module B : Framework_sig.BACKEND) =
+  let _h2d : src_ptr:nativeint -> byte_size:int -> dst:_ B.Memory.buffer -> unit
+      =
+    B.Memory.host_ptr_to_device
+  in
+  let _d2h : src:_ B.Memory.buffer -> dst_ptr:nativeint -> byte_size:int -> unit
+      =
+    B.Memory.device_to_host_ptr
+  in
+  ignore _h2d ;
+  ignore _d2h
+
+let () =
+  (* dims constructors — pure functions, no FFI *)
+  let d1 = Framework_sig.dims_1d 32 in
+  assert (d1.Framework_sig.x = 32) ;
+  assert (d1.Framework_sig.y = 1) ;
+  assert (d1.Framework_sig.z = 1) ;
+  let d2 = Framework_sig.dims_2d 8 16 in
+  assert (d2.Framework_sig.x = 8) ;
+  assert (d2.Framework_sig.y = 16) ;
+  assert (d2.Framework_sig.z = 1) ;
+  (* Typed_value: primitive storage and registry, no ctypes *)
+  let open Typed_value in
+  let p = PInt32 42l in
+  assert (primitive_type_name p = "int32") ;
+  let scalars = Registry.list_scalars () in
+  assert (List.mem "float32" scalars) ;
+  assert (List.mem "float64" scalars) ;
+  Printf.printf "spoc_framework ffi_free_gate: all assertions passed\n%!"

--- a/spoc/framework/test/test_typed_value.ml
+++ b/spoc/framework/test/test_typed_value.ml
@@ -130,8 +130,6 @@ let test_registry_custom_scalar () =
 
     let size = 4
 
-    let ctype = Ctypes.int
-
     let to_primitive v = PInt32 (Int32.of_int v)
 
     let of_primitive = function


### PR DESCRIPTION
**⛔ DO NOT MERGE until CUDA runtime is verified on a CUDA machine** (per maintainer directive). The branch is pushed so the CUDA box can fetch it.

**PR 2a of the in-browser Execute-parity arc** (refs #26). Makes `spoc_framework` FFI-free at the signature level so a later PR can build a single `Execute.ml` under js_of_ocaml.

## What
- `Framework_sig` BACKEND/PLUGIN_BASE `host_ptr_to_device`/`device_to_host_ptr`: `unit Ctypes.ptr → nativeint` (precedent: `device_ptr` already returns `nativeint`; `raw_address_of_ptr`/`ptr_of_raw_address` round-trip losslessly).
- Removed the unconsumed `Typed_value.ctype`; dropped `ctypes` from `spoc/framework/dune`.
- Conversion confined to the **6 backend `plugin_base` adapters** (native, interpreter, cuda, opencl, metal, vulkan) + 4 `Memory.ml`/`Transfer.ml` boundary call sites. Low-level `*_api` FFI and `Memory.BUFFER` stay on ctypes (deferred to PR 2b).
- New host→device→host **round-trip test** (the load-bearing proof; goldens don't touch this boundary) + `ffi_free_gate` (`.bc.js` build + a `nativeint` type-witness).

## Verification
- `@sarek/tests/runtest` green, **goldens byte-identical**; round-trip test PASS on native + interpreter; `@fmt` clean; no `Ctypes` in `spoc/framework/*.ml`.
- All 6 backends compile locally; **Metal compiled clean on real macOS (Apple Silicon)**.
- 2 fresh-agent reviews: **GO** (correctness + architecture).
- **Pending: CUDA runtime verification = the only merge blocker.**

(Whole-tree `dune build` also needs the unrelated nvrtc fix in #178.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a nativeint round-trip test validating memory transfers across backends.

* **Refactor**
  * Memory transfer APIs now use raw pointer addresses, with backend implementations adapted for consistent pointer handling.

* **Documentation**
  * Updated docs to reflect removal of ctypes usage and clarify dependency expectations.

* **Chores**
  * Added an FFI-free gate target and adjusted build stanzas for portability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->