### PR TITLE
feat(type-safety): T3-S2 — operator typing (EBinop/EUnop, 4 theorems, 0 admits)

### DIFF
--- a/formal/type-safety/PLAN.md
+++ b/formal/type-safety/PLAN.md
@@ -33,8 +33,8 @@ Coq has no mutable unification, so the spec models **post-unification** types
 | T2-VEC | TVec/TArr inference + vec/arr get/set typing | T2 | **done** (5 theorems, 10/10 smoke) | T1-CMBT |
 | T2-REGISTRY | TRecord/TVariant field access typing | T2 | **done** (5 theorems, 10/10 smoke) | T2-VEC |
 | T3-S1 | Control flow (CFIfThen/IfElse/For/While/Seq) — ControlFlowSpec.v | T3 | **done** (4 theorems, 10/10 smoke) | T2-REGISTRY |
-| T3-S2 | Operators (EBinop/EUnop) — OperatorSpec.v | T3 | **next** | T3-S1 |
-| T3-S3 | Function application (EApp, ELetRec) — FunSpec.v | T3 | TBD | T3-S2 |
+| T3-S2 | Operators (EBinop/EUnop) — OperatorSpec.v | T3 | **done** (4 theorems, 10/10 smoke) | T3-S1 |
+| T3-S3 | Function application (EApp, ELetRec) — FunSpec.v | T3 | **next** | T3-S2 |
 | T3-S4 | Mutable bindings (ELetMut, EAssign) — MutSpec.v | T3 | TBD | T3-S2 |
 | T3-S5 | Pattern matching (EMatch) — PatternSpec.v | T3 | TBD | T3-S2 |
 | T3-S6 | Algebraic construction (ERecord, EConstr) — ConstrSpec.v | T3 | TBD | T3-S5 |
@@ -71,24 +71,15 @@ T1-CMBT dune-driven OCaml extraction conformance harness (added in T1-CMBT).
 
 ---
 
-## Next autopilot tick (T3-S2 — operator typing)
+## Next autopilot tick (T3-S3 — function application)
 
-T3-S1 is closed: 4 theorems for CFIfThen/IfElse/For/While/Seq, 10/10 smoke tests,
-0 admits. Branch formal/type-safety-phase1e, PR #191.
+T3-S2 is closed: 4 theorems (sound/complete/det/preservation) for
+OPBinop/OPUnop, 10/10 smoke tests, 0 admits. Branch formal/type-safety-phase1e.
 
-T3-S2 adds `OperatorSpec.v` modelling `Sarek_typer.ml:infer_binop_unop` (lines 213-221).
-Key rules from `Sarek_types.ml:infer_binop` / `infer_unop`:
-- Arithmetic (Add/Sub/Mul/Div/Mod): operands and result must match numeric type
-- Comparison (Eq/Ne/Lt/Le/Gt/Ge): numeric operands, bool result
-- Logical (And/Or): bool operands, bool result
-- Bitwise (Land/Lor/Lxor/Lsl/Lsr/Asr): int32 operands, int32 result
-- Unary Neg: numeric operand, same type result
-- Unary Not: bool operand, bool result
-- Unary Lnot: int32 operand, int32 result
+T3-S3 adds `FunSpec.v` modelling `Sarek_typer.ml:infer` for function application
+(`EApp`) and recursive bindings (`ELetRec`). Key rules:
+- EApp: infer function type, infer argument type, unify argument with param type,
+  result is return type.
+- ELetRec: bind name with function type (allowing recursion), infer body.
 
-Architecture: `op_expr` wraps `cf_expr` with `OPCf : cf_expr -> op_expr`
-plus `OPBinop : binop -> op_expr -> op_expr -> op_expr`
-and `OPUnop : unop -> op_expr -> op_expr`.
-
-Divergence policy stays: any disagreement on a covered fragment is a model bug
-(the model is the spec) — record in FINDINGS.md, do not silently widen the model.
+Divergence policy stays: any disagreement on a covered fragment is a model bug.

--- a/formal/type-safety/STATUS.md
+++ b/formal/type-safety/STATUS.md
@@ -1,23 +1,24 @@
 # TypeSafety — Status
 
 **Branch**: formal/type-safety-phase1e
-**Phase**: T3-S1 (ControlFlowSpec, done 2026-06-14) -> T3-S2 (next)
+**Phase**: T3-S2 (OperatorSpec, done 2026-06-14) -> T3-S3 (next)
 **Toolchain**: Rocq 9.1.1 / OCaml 5.4.0
 
 ## Scoreboard
 
 | Metric | Value |
 |---|---|
-| Theorems proven | 50 |
+| Theorems proven | 54 |
 | Admits | 0 |
 | Axioms | 0 |
-| Definitions | infer_type, lookup_env, has_type, pre_type, follow, follow_pvar, occurs_in, unify_fun, apply_subst, infer_mem_type, sarek_type_eq_dec, has_mem_type, field_lookup, infer_rec_type, has_rec_type, infer_cf_type, has_cf_type, + more |
+| Definitions | infer_type, lookup_env, has_type, pre_type, follow, follow_pvar, occurs_in, unify_fun, apply_subst, infer_mem_type, sarek_type_eq_dec, has_mem_type, field_lookup, infer_rec_type, has_rec_type, infer_cf_type, has_cf_type, is_numeric, is_integer, infer_op_type, has_op_type |
 | Build | green (CoqMakefile, exit 0; dune build/test, exit 0) |
 | T1-CMBT harness | green -- differential QCheck 2000/2000 (0 errors, 0 fails) + 20/20 smoke |
 | T2-UNIFY harness | green -- differential QCheck 1000/1000 (0 errors, 0 fails) + 15/15 smoke |
 | T2-VEC harness | green -- 10/10 smoke (EVecGet/EVecSet/EArrGet/EArrSet + error cases) |
 | T2-REGISTRY harness | green -- 10/10 smoke (EFieldGet/EFieldSet + error cases + nested + vec delegation) |
 | T3-S1 harness | green -- 10/10 smoke (CFIfThen/IfElse/For/While/Seq + error cases + loop var scope) |
+| T3-S2 harness | green -- 10/10 smoke (Add/Mod/Eq/Lt/And/Neg/Not/Lnot + mismatch + NotBool) |
 | Findings | F-TS-01 (ELet scope leak) -- found by T1-CMBT, RESOLVED |
 
 ## Termination design (T2-UNIFY)
@@ -151,4 +152,36 @@ TRecord and TVariant are now full constructors in `sarek_type`:
    `infer_cf_type_complete H1/H2` gives two equations; rewriting one into the
    other and injecting gives the equality. No case analysis on `e` needed.
 
-## Next: T3-S2 (OperatorSpec)
+## Proven (tick 7, OperatorSpec.v -- T3-S2, all Qed, 0 admits)
+
+51. `infer_op_type_sound` -- OPBinop/OPUnop inference -> has_op_type
+52. `infer_op_type_complete` -- has_op_type -> inference
+53. `has_op_type_det` -- uniqueness of the declarative op_expr judgement
+54. `op_type_preservation` -- infer_op_type env e = inl t <-> has_op_type env e t
+
+## Proof technique notes (T3-S2)
+
+1. **19-goal OPBinop dispatch**: `destruct op; simpl in H` opens 19 subgoals (one per
+   binop constructor). The `all: try (...)` pattern is UNRELIABLE in Rocq 9 Ltac1 —
+   partial success leaves goals in an inconsistent state. Use explicit `N-M:` goal
+   selectors throughout: `1-4:` (Add/Sub/Mul/Div numeric), `1:` (Mod integer), `1-2:`
+   (And/Or bool), `1-2:` (Eq/Ne eq), `1-4:` (Lt/Le/Gt/Ge cmp), `1-6:` (Land...Asr integer).
+
+2. **Iota substitution eliminates rewrite**: `destruct (sarek_type_eq_dec t1 t2) as [Hb|Hne]`
+   automatically reduces `match sarek_type_eq_dec t1 t2 with Left _ => ... | Right _ => ...`
+   in the context via iota substitution. No `rewrite` or `simpl` needed after destruct.
+   Adding `eqn:Heqb` followed by `rewrite Heqb in H` FAILS with "term not found in H".
+
+3. **HOT_BoolBinop rewrite pattern**: For And/Or, the spec rewrites the bool constraint
+   into the IH hypotheses before applying the constructor. Specifically, `Hb : t1 = TPrim TBool`
+   is used as `rewrite Hb in Hl; rewrite Hb in Hr` (not `subst`) to avoid "variable used
+   in conclusion" errors when `t1` still appears in the goal.
+
+4. **Completeness hypothesis naming**: `induction H; simpl.` for constructor
+   `HOT_NumericBinop env op lhs rhs t (P1) (IH1) (IH2) (P2)` gives H=P1 (first
+   non-recursive premise), IHhas_op_type1=IH1, IHhas_op_type2=IH2, H0=P2 (second
+   non-recursive). Use `destruct (is_numeric t) eqn:Hnum; [reflexivity | congruence]`
+   to avoid relying on these names — `congruence` finds the contradiction between
+   `Hnum : is_numeric t = false` and the constructor's `is_numeric t = true` premise.
+
+## Next: T3-S3 (FunSpec)

--- a/formal/type-safety/_CoqProject
+++ b/formal/type-safety/_CoqProject
@@ -4,3 +4,4 @@ theories/UnifySpec.v
 theories/VecSpec.v
 theories/RegistrySpec.v
 theories/ControlFlowSpec.v
+theories/OperatorSpec.v

--- a/formal/type-safety/extraction/OperatorExtraction.v
+++ b/formal/type-safety/extraction/OperatorExtraction.v
@@ -1,0 +1,25 @@
+(******************************************************************************)
+(* OperatorExtraction.v
+ *
+ * Rocq -> OCaml extraction for OperatorSpec.
+ * Extracts the operator type inference model to OperatorModel.ml;
+ * committed to repo so test/test_type_safety_conformance.ml can use it for
+ * T3-S2 smoke tests.
+ *
+ * Run to refresh after spec changes:
+ *   cd formal/type-safety
+ *   eval $(opam env --switch=~/dev/SPOC)
+ *   rocq compile -R theories TypeSafety \
+ *         -output-directory extraction \
+ *         extraction/OperatorExtraction.v
+ ******************************************************************************)
+
+From Stdlib Require Import Extraction ExtrOcamlBasic ExtrOcamlNatInt.
+From TypeSafety Require Import TypeSafetySpec.
+From TypeSafety Require Import VecSpec.
+From TypeSafety Require Import RegistrySpec.
+From TypeSafety Require Import ControlFlowSpec.
+From TypeSafety Require Import OperatorSpec.
+
+Extraction "OperatorModel.ml"
+  infer_op_type.

--- a/formal/type-safety/extraction/OperatorModel.ml
+++ b/formal/type-safety/extraction/OperatorModel.ml
@@ -1,0 +1,628 @@
+type ('a, 'b) sum = Inl of 'a | Inr of 'b
+
+(** val bool_dec : bool -> bool -> bool **)
+
+let bool_dec b1 b2 =
+  if b1 then if b2 then true else false else if b2 then false else true
+
+(** val eqb : bool -> bool -> bool **)
+
+let eqb b1 b2 = if b1 then b2 else if b2 then false else true
+
+type ascii = Ascii of bool * bool * bool * bool * bool * bool * bool * bool
+
+(** val ascii_dec : ascii -> ascii -> bool **)
+
+let ascii_dec a b =
+  let (Ascii (b0, b1, b2, b3, b4, b5, b6, b7)) = a in
+  let (Ascii (b8, b9, b10, b11, b12, b13, b14, b15)) = b in
+  if bool_dec b0 b8 then
+    if bool_dec b1 b9 then
+      if bool_dec b2 b10 then
+        if bool_dec b3 b11 then
+          if bool_dec b4 b12 then
+            if bool_dec b5 b13 then
+              if bool_dec b6 b14 then bool_dec b7 b15 else false
+            else false
+          else false
+        else false
+      else false
+    else false
+  else false
+
+(** val eqb0 : ascii -> ascii -> bool **)
+
+let eqb0 a b =
+  let (Ascii (a0, a1, a2, a3, a4, a5, a6, a7)) = a in
+  let (Ascii (b0, b1, b2, b3, b4, b5, b6, b7)) = b in
+  if
+    if
+      if
+        if
+          if if if eqb a0 b0 then eqb a1 b1 else false then eqb a2 b2 else false
+          then eqb a3 b3
+          else false
+        then eqb a4 b4
+        else false
+      then eqb a5 b5
+      else false
+    then eqb a6 b6
+    else false
+  then eqb a7 b7
+  else false
+
+type string = EmptyString | String of ascii * string
+
+(** val string_dec : string -> string -> bool **)
+
+let rec string_dec s x =
+  match s with
+  | EmptyString -> (
+      match x with EmptyString -> true | String (_, _) -> false)
+  | String (a, s0) -> (
+      match x with
+      | EmptyString -> false
+      | String (a0, s1) -> if ascii_dec a a0 then string_dec s0 s1 else false)
+
+(** val eqb1 : string -> string -> bool **)
+
+let rec eqb1 s1 s2 =
+  match s1 with
+  | EmptyString -> (
+      match s2 with EmptyString -> true | String (_, _) -> false)
+  | String (c1, s1') -> (
+      match s2 with
+      | EmptyString -> false
+      | String (c2, s2') -> if eqb0 c1 c2 then eqb1 s1' s2' else false)
+
+type prim_type = TUnit | TBool | TInt32
+
+type reg_type = RInt | RInt64 | RFloat32 | RFloat64 | RChar
+
+type mem_space = Local | Shared | Global
+
+type sarek_type =
+  | TPrim of prim_type
+  | TReg of reg_type
+  | TVec of sarek_type
+  | TArr of sarek_type * mem_space
+  | TFun of sarek_type list * sarek_type
+  | TTuple of sarek_type list
+  | TRecord of string * (string * sarek_type) list
+  | TVariant of string * (string * sarek_type option) list
+
+(** val prim_type_beq : prim_type -> prim_type -> bool **)
+
+let prim_type_beq x y =
+  match x with
+  | TUnit -> ( match y with TUnit -> true | _ -> false)
+  | TBool -> ( match y with TBool -> true | _ -> false)
+  | TInt32 -> ( match y with TInt32 -> true | _ -> false)
+
+(** val prim_type_eq_dec : prim_type -> prim_type -> bool **)
+
+let prim_type_eq_dec x y =
+  let b = prim_type_beq x y in
+  if b then true else false
+
+(** val reg_type_beq : reg_type -> reg_type -> bool **)
+
+let reg_type_beq x y =
+  match x with
+  | RInt -> ( match y with RInt -> true | _ -> false)
+  | RInt64 -> ( match y with RInt64 -> true | _ -> false)
+  | RFloat32 -> ( match y with RFloat32 -> true | _ -> false)
+  | RFloat64 -> ( match y with RFloat64 -> true | _ -> false)
+  | RChar -> ( match y with RChar -> true | _ -> false)
+
+(** val reg_type_eq_dec : reg_type -> reg_type -> bool **)
+
+let reg_type_eq_dec x y =
+  let b = reg_type_beq x y in
+  if b then true else false
+
+(** val mem_space_beq : mem_space -> mem_space -> bool **)
+
+let mem_space_beq x y =
+  match x with
+  | Local -> ( match y with Local -> true | _ -> false)
+  | Shared -> ( match y with Shared -> true | _ -> false)
+  | Global -> ( match y with Global -> true | _ -> false)
+
+(** val mem_space_eq_dec : mem_space -> mem_space -> bool **)
+
+let mem_space_eq_dec x y =
+  let b = mem_space_beq x y in
+  if b then true else false
+
+type lit = LInt of int | LFloat of int | LBool of bool | LUnit
+
+type expr =
+  | ELit of lit
+  | EVar of string
+  | ELet of string * expr * expr
+  | ETuple of expr list
+
+type type_env = (string * sarek_type) list
+
+(** val lookup_env : type_env -> string -> sarek_type option **)
+
+let rec lookup_env env x =
+  match env with
+  | [] -> None
+  | p :: rest ->
+      let y, t = p in
+      if eqb1 x y then Some t else lookup_env rest x
+
+type type_error =
+  | UnboundVar of string
+  | TypeMismatch of sarek_type * sarek_type
+
+type infer_result = (sarek_type, type_error) sum
+
+(** val infer_list_with : (type_env -> expr -> infer_result) -> type_env -> expr
+    list -> (sarek_type list, type_error) sum **)
+
+let rec infer_list_with infer_f env = function
+  | [] -> Inl []
+  | e :: rest -> (
+      match infer_f env e with
+      | Inl t -> (
+          match infer_list_with infer_f env rest with
+          | Inl ts -> Inl (t :: ts)
+          | Inr err -> Inr err)
+      | Inr err -> Inr err)
+
+(** val infer_type : type_env -> expr -> infer_result **)
+
+let rec infer_type env = function
+  | ELit l -> (
+      match l with
+      | LInt _ -> Inl (TPrim TInt32)
+      | LFloat _ -> Inl (TReg RFloat32)
+      | LBool _ -> Inl (TPrim TBool)
+      | LUnit -> Inl (TPrim TUnit))
+  | EVar x -> (
+      match lookup_env env x with Some t -> Inl t | None -> Inr (UnboundVar x))
+  | ELet (x, e1, e2) -> (
+      match infer_type env e1 with
+      | Inl t1 -> infer_type ((x, t1) :: env) e2
+      | Inr err -> Inr err)
+  | ETuple es -> (
+      match infer_list_with infer_type env es with
+      | Inl ts -> Inl (TTuple ts)
+      | Inr err -> Inr err)
+
+(** val sarek_type_eq_dec : sarek_type -> sarek_type -> bool **)
+
+let rec sarek_type_eq_dec t1 t2 =
+  match t1 with
+  | TPrim p -> ( match t2 with TPrim p0 -> prim_type_eq_dec p p0 | _ -> false)
+  | TReg r -> ( match t2 with TReg r0 -> reg_type_eq_dec r r0 | _ -> false)
+  | TVec s -> ( match t2 with TVec s0 -> sarek_type_eq_dec s s0 | _ -> false)
+  | TArr (s, m) -> (
+      match t2 with
+      | TArr (s0, m0) ->
+          let s1 = sarek_type_eq_dec s s0 in
+          if s1 then mem_space_eq_dec m m0 else false
+      | _ -> false)
+  | TFun (l, s) -> (
+      match t2 with
+      | TFun (l0, s0) ->
+          let iHL =
+            let rec iHL ts1 ts2 =
+              match ts1 with
+              | [] -> ( match ts2 with [] -> true | _ :: _ -> false)
+              | s1 :: l1 -> (
+                  match ts2 with
+                  | [] -> false
+                  | s2 :: l2 ->
+                      let s3 = sarek_type_eq_dec s1 s2 in
+                      if s3 then iHL l1 l2 else false)
+            in
+            iHL
+          in
+          let s1 = iHL l l0 in
+          if s1 then sarek_type_eq_dec s s0 else false
+      | _ -> false)
+  | TTuple l -> (
+      match t2 with
+      | TTuple l0 ->
+          let rec iHL ts1 ts2 =
+            match ts1 with
+            | [] -> ( match ts2 with [] -> true | _ :: _ -> false)
+            | s :: l1 -> (
+                match ts2 with
+                | [] -> false
+                | s0 :: l2 ->
+                    let s1 = sarek_type_eq_dec s s0 in
+                    if s1 then iHL l1 l2 else false)
+          in
+          iHL l l0
+      | _ -> false)
+  | TRecord (s, l) -> (
+      match t2 with
+      | TRecord (s0, l0) ->
+          let iHLR =
+            let rec iHLR fs1 fs2 =
+              match fs1 with
+              | [] -> ( match fs2 with [] -> true | _ :: _ -> false)
+              | p :: l1 -> (
+                  let s1, s2 = p in
+                  match fs2 with
+                  | [] -> false
+                  | p0 :: l2 ->
+                      let s3, s4 = p0 in
+                      let s5 = string_dec s1 s3 in
+                      if s5 then
+                        let s6 = sarek_type_eq_dec s2 s4 in
+                        if s6 then iHLR l1 l2 else false
+                      else false)
+            in
+            iHLR
+          in
+          let s1 = string_dec s s0 in
+          if s1 then iHLR l l0 else false
+      | _ -> false)
+  | TVariant (s, l) -> (
+      match t2 with
+      | TVariant (s0, l0) ->
+          let iHLV =
+            let rec iHLV cs1 cs2 =
+              match cs1 with
+              | [] -> ( match cs2 with [] -> true | _ :: _ -> false)
+              | p :: l1 -> (
+                  let s1, o = p in
+                  match cs2 with
+                  | [] -> false
+                  | p0 :: l2 ->
+                      let s2, o0 = p0 in
+                      let s3 = string_dec s1 s2 in
+                      if s3 then
+                        match o with
+                        | Some s4 -> (
+                            match o0 with
+                            | Some s5 ->
+                                let s6 = sarek_type_eq_dec s4 s5 in
+                                if s6 then iHLV l1 l2 else false
+                            | None -> false)
+                        | None -> (
+                            match o0 with Some _ -> false | None -> iHLV l1 l2)
+                      else false)
+            in
+            iHLV
+          in
+          let s1 = string_dec s s0 in
+          if s1 then iHLV l l0 else false
+      | _ -> false)
+
+type vec_error =
+  | VCoreError of type_error
+  | NotAVector of sarek_type
+  | NotAnArray of sarek_type
+  | IndexNotInt of sarek_type
+  | ElemMismatch of sarek_type * sarek_type
+
+type vec_result = (sarek_type, vec_error) sum
+
+type mem_expr =
+  | MCore of expr
+  | EVecGet of mem_expr * mem_expr
+  | EVecSet of mem_expr * mem_expr * mem_expr
+  | EArrGet of mem_expr * mem_expr
+  | EArrSet of mem_expr * mem_expr * mem_expr
+
+(** val infer_mem_type : type_env -> mem_expr -> vec_result **)
+
+let rec infer_mem_type env = function
+  | MCore ce -> (
+      match infer_type env ce with
+      | Inl t -> Inl t
+      | Inr err -> Inr (VCoreError err))
+  | EVecGet (vec, idx) -> (
+      match infer_mem_type env vec with
+      | Inl tv -> (
+          match tv with
+          | TVec elem_t -> (
+              match infer_mem_type env idx with
+              | Inl ti -> (
+                  match ti with
+                  | TPrim p -> (
+                      match p with
+                      | TInt32 -> Inl elem_t
+                      | _ -> Inr (IndexNotInt ti))
+                  | _ -> Inr (IndexNotInt ti))
+              | Inr err -> Inr err)
+          | _ -> Inr (NotAVector tv))
+      | Inr err -> Inr err)
+  | EVecSet (vec, idx, value) -> (
+      match infer_mem_type env vec with
+      | Inl tv -> (
+          match tv with
+          | TVec elem_t -> (
+              match infer_mem_type env idx with
+              | Inl ti -> (
+                  match ti with
+                  | TPrim p -> (
+                      match p with
+                      | TInt32 -> (
+                          match infer_mem_type env value with
+                          | Inl vt ->
+                              if sarek_type_eq_dec vt elem_t then
+                                Inl (TPrim TUnit)
+                              else Inr (ElemMismatch (vt, elem_t))
+                          | Inr err -> Inr err)
+                      | _ -> Inr (IndexNotInt ti))
+                  | _ -> Inr (IndexNotInt ti))
+              | Inr err -> Inr err)
+          | _ -> Inr (NotAVector tv))
+      | Inr err -> Inr err)
+  | EArrGet (arr, idx) -> (
+      match infer_mem_type env arr with
+      | Inl ta -> (
+          match ta with
+          | TArr (elem_t, _) -> (
+              match infer_mem_type env idx with
+              | Inl ti -> (
+                  match ti with
+                  | TPrim p -> (
+                      match p with
+                      | TInt32 -> Inl elem_t
+                      | _ -> Inr (IndexNotInt ti))
+                  | _ -> Inr (IndexNotInt ti))
+              | Inr err -> Inr err)
+          | _ -> Inr (NotAnArray ta))
+      | Inr err -> Inr err)
+  | EArrSet (arr, idx, value) -> (
+      match infer_mem_type env arr with
+      | Inl ta -> (
+          match ta with
+          | TArr (elem_t, _) -> (
+              match infer_mem_type env idx with
+              | Inl ti -> (
+                  match ti with
+                  | TPrim p -> (
+                      match p with
+                      | TInt32 -> (
+                          match infer_mem_type env value with
+                          | Inl vt ->
+                              if sarek_type_eq_dec vt elem_t then
+                                Inl (TPrim TUnit)
+                              else Inr (ElemMismatch (vt, elem_t))
+                          | Inr err -> Inr err)
+                      | _ -> Inr (IndexNotInt ti))
+                  | _ -> Inr (IndexNotInt ti))
+              | Inr err -> Inr err)
+          | _ -> Inr (NotAnArray ta))
+      | Inr err -> Inr err)
+
+(** val field_lookup : string -> (string * sarek_type) list -> sarek_type option
+    **)
+
+let rec field_lookup field = function
+  | [] -> None
+  | p :: rest ->
+      let f, t = p in
+      if eqb1 f field then Some t else field_lookup field rest
+
+type rec_error =
+  | RMemError of vec_error
+  | NotARecord of sarek_type
+  | FieldNotFound of string * sarek_type
+  | FieldMismatch of sarek_type * sarek_type
+
+type rec_result = (sarek_type, rec_error) sum
+
+type rec_expr =
+  | RMem of mem_expr
+  | EFieldGet of string * rec_expr
+  | EFieldSet of string * rec_expr * rec_expr
+
+(** val infer_rec_type : type_env -> rec_expr -> rec_result **)
+
+let rec infer_rec_type env = function
+  | RMem me -> (
+      match infer_mem_type env me with
+      | Inl t -> Inl t
+      | Inr err -> Inr (RMemError err))
+  | EFieldGet (field, rec0) -> (
+      match infer_rec_type env rec0 with
+      | Inl t -> (
+          match t with
+          | TRecord (name, fields) -> (
+              match field_lookup field fields with
+              | Some t0 -> Inl t0
+              | None -> Inr (FieldNotFound (field, TRecord (name, fields))))
+          | _ -> Inr (NotARecord t))
+      | Inr err -> Inr err)
+  | EFieldSet (field, rec0, value) -> (
+      match infer_rec_type env rec0 with
+      | Inl t -> (
+          match t with
+          | TRecord (name, fields) -> (
+              match field_lookup field fields with
+              | Some field_t -> (
+                  match infer_rec_type env value with
+                  | Inl vt ->
+                      if sarek_type_eq_dec vt field_t then Inl (TPrim TUnit)
+                      else Inr (FieldMismatch (vt, field_t))
+                  | Inr err -> Inr err)
+              | None -> Inr (FieldNotFound (field, TRecord (name, fields))))
+          | _ -> Inr (NotARecord t))
+      | Inr err -> Inr err)
+
+type cf_error =
+  | CRec of rec_error
+  | CondNotBool of sarek_type
+  | BranchMismatch of sarek_type * sarek_type
+  | BoundNotInt32 of sarek_type
+
+type cf_expr =
+  | CFRec of rec_expr
+  | CFIfThen of cf_expr * cf_expr
+  | CFIfElse of cf_expr * cf_expr * cf_expr
+  | CFFor of string * cf_expr * cf_expr * cf_expr
+  | CFWhile of cf_expr * cf_expr
+  | CFSeq of cf_expr * cf_expr
+
+(** val infer_cf_type : type_env -> cf_expr -> (sarek_type, cf_error) sum **)
+
+let rec infer_cf_type env = function
+  | CFRec re -> (
+      match infer_rec_type env re with
+      | Inl t -> Inl t
+      | Inr err -> Inr (CRec err))
+  | CFIfThen (cond, then_e) -> (
+      match infer_cf_type env cond with
+      | Inl cond_t ->
+          if sarek_type_eq_dec cond_t (TPrim TBool) then
+            match infer_cf_type env then_e with
+            | Inl then_t ->
+                if sarek_type_eq_dec then_t (TPrim TUnit) then Inl (TPrim TUnit)
+                else Inr (BranchMismatch (then_t, TPrim TUnit))
+            | Inr err -> Inr err
+          else Inr (CondNotBool cond_t)
+      | Inr err -> Inr err)
+  | CFIfElse (cond, then_e, else_e) -> (
+      match infer_cf_type env cond with
+      | Inl cond_t ->
+          if sarek_type_eq_dec cond_t (TPrim TBool) then
+            match infer_cf_type env then_e with
+            | Inl then_t -> (
+                match infer_cf_type env else_e with
+                | Inl else_t ->
+                    if sarek_type_eq_dec then_t else_t then Inl then_t
+                    else Inr (BranchMismatch (then_t, else_t))
+                | Inr err -> Inr err)
+            | Inr err -> Inr err
+          else Inr (CondNotBool cond_t)
+      | Inr err -> Inr err)
+  | CFFor (var, lo, hi, body) -> (
+      match infer_cf_type env lo with
+      | Inl lo_t ->
+          if sarek_type_eq_dec lo_t (TPrim TInt32) then
+            match infer_cf_type env hi with
+            | Inl hi_t ->
+                if sarek_type_eq_dec hi_t (TPrim TInt32) then
+                  match infer_cf_type ((var, TPrim TInt32) :: env) body with
+                  | Inl _ -> Inl (TPrim TUnit)
+                  | Inr err -> Inr err
+                else Inr (BoundNotInt32 hi_t)
+            | Inr err -> Inr err
+          else Inr (BoundNotInt32 lo_t)
+      | Inr err -> Inr err)
+  | CFWhile (cond, body) -> (
+      match infer_cf_type env cond with
+      | Inl cond_t ->
+          if sarek_type_eq_dec cond_t (TPrim TBool) then
+            match infer_cf_type env body with
+            | Inl _ -> Inl (TPrim TUnit)
+            | Inr err -> Inr err
+          else Inr (CondNotBool cond_t)
+      | Inr err -> Inr err)
+  | CFSeq (e1, e2) -> (
+      match infer_cf_type env e1 with
+      | Inl _ -> infer_cf_type env e2
+      | Inr err -> Inr err)
+
+type binop =
+  | Add
+  | Sub
+  | Mul
+  | Div
+  | Mod
+  | And
+  | Or
+  | Eq
+  | Ne
+  | Lt
+  | Le
+  | Gt
+  | Ge
+  | Land
+  | Lor
+  | Lxor
+  | Lsl
+  | Lsr
+  | Asr
+
+type unop = Neg | Not | Lnot
+
+(** val is_numeric : sarek_type -> bool **)
+
+let is_numeric = function
+  | TPrim p -> ( match p with TInt32 -> true | _ -> false)
+  | TReg r -> ( match r with RChar -> false | _ -> true)
+  | _ -> false
+
+(** val is_integer : sarek_type -> bool **)
+
+let is_integer = function
+  | TPrim p -> ( match p with TInt32 -> true | _ -> false)
+  | TReg r -> ( match r with RInt -> true | RInt64 -> true | _ -> false)
+  | _ -> false
+
+type op_error =
+  | OCF of cf_error
+  | NotNumeric of sarek_type
+  | NotInteger of sarek_type
+  | NotBool of sarek_type
+  | OperandMismatch of sarek_type * sarek_type
+
+type op_expr =
+  | OPCf of cf_expr
+  | OPBinop of binop * op_expr * op_expr
+  | OPUnop of unop * op_expr
+
+(** val infer_op_type : type_env -> op_expr -> (sarek_type, op_error) sum **)
+
+let rec infer_op_type env = function
+  | OPCf ce -> (
+      match infer_cf_type env ce with
+      | Inl t -> Inl t
+      | Inr err -> Inr (OCF err))
+  | OPBinop (op, lhs, rhs) -> (
+      match infer_op_type env lhs with
+      | Inl t1 -> (
+          match infer_op_type env rhs with
+          | Inl t2 ->
+              if sarek_type_eq_dec t1 t2 then
+                match op with
+                | Add -> if is_numeric t1 then Inl t1 else Inr (NotNumeric t1)
+                | Sub -> if is_numeric t1 then Inl t1 else Inr (NotNumeric t1)
+                | Mul -> if is_numeric t1 then Inl t1 else Inr (NotNumeric t1)
+                | Div -> if is_numeric t1 then Inl t1 else Inr (NotNumeric t1)
+                | And ->
+                    if sarek_type_eq_dec t1 (TPrim TBool) then Inl (TPrim TBool)
+                    else Inr (NotBool t1)
+                | Or ->
+                    if sarek_type_eq_dec t1 (TPrim TBool) then Inl (TPrim TBool)
+                    else Inr (NotBool t1)
+                | Eq -> Inl (TPrim TBool)
+                | Ne -> Inl (TPrim TBool)
+                | Lt ->
+                    if is_numeric t1 then Inl (TPrim TBool)
+                    else Inr (NotNumeric t1)
+                | Le ->
+                    if is_numeric t1 then Inl (TPrim TBool)
+                    else Inr (NotNumeric t1)
+                | Gt ->
+                    if is_numeric t1 then Inl (TPrim TBool)
+                    else Inr (NotNumeric t1)
+                | Ge ->
+                    if is_numeric t1 then Inl (TPrim TBool)
+                    else Inr (NotNumeric t1)
+                | _ -> if is_integer t1 then Inl t1 else Inr (NotInteger t1)
+              else Inr (OperandMismatch (t1, t2))
+          | Inr err -> Inr err)
+      | Inr err -> Inr err)
+  | OPUnop (op, operand) -> (
+      match infer_op_type env operand with
+      | Inl t -> (
+          match op with
+          | Neg -> if is_numeric t then Inl t else Inr (NotNumeric t)
+          | Not ->
+              if sarek_type_eq_dec t (TPrim TBool) then Inl (TPrim TBool)
+              else Inr (NotBool t)
+          | Lnot -> if is_integer t then Inl t else Inr (NotInteger t))
+      | Inr err -> Inr err)

--- a/formal/type-safety/extraction/OperatorModel.mli
+++ b/formal/type-safety/extraction/OperatorModel.mli
@@ -1,0 +1,165 @@
+type ('a, 'b) sum = Inl of 'a | Inr of 'b
+
+val bool_dec : bool -> bool -> bool
+
+val eqb : bool -> bool -> bool
+
+type ascii = Ascii of bool * bool * bool * bool * bool * bool * bool * bool
+
+val ascii_dec : ascii -> ascii -> bool
+
+val eqb0 : ascii -> ascii -> bool
+
+type string = EmptyString | String of ascii * string
+
+val string_dec : string -> string -> bool
+
+val eqb1 : string -> string -> bool
+
+type prim_type = TUnit | TBool | TInt32
+
+type reg_type = RInt | RInt64 | RFloat32 | RFloat64 | RChar
+
+type mem_space = Local | Shared | Global
+
+type sarek_type =
+  | TPrim of prim_type
+  | TReg of reg_type
+  | TVec of sarek_type
+  | TArr of sarek_type * mem_space
+  | TFun of sarek_type list * sarek_type
+  | TTuple of sarek_type list
+  | TRecord of string * (string * sarek_type) list
+  | TVariant of string * (string * sarek_type option) list
+
+val prim_type_beq : prim_type -> prim_type -> bool
+
+val prim_type_eq_dec : prim_type -> prim_type -> bool
+
+val reg_type_beq : reg_type -> reg_type -> bool
+
+val reg_type_eq_dec : reg_type -> reg_type -> bool
+
+val mem_space_beq : mem_space -> mem_space -> bool
+
+val mem_space_eq_dec : mem_space -> mem_space -> bool
+
+type lit = LInt of int | LFloat of int | LBool of bool | LUnit
+
+type expr =
+  | ELit of lit
+  | EVar of string
+  | ELet of string * expr * expr
+  | ETuple of expr list
+
+type type_env = (string * sarek_type) list
+
+val lookup_env : type_env -> string -> sarek_type option
+
+type type_error =
+  | UnboundVar of string
+  | TypeMismatch of sarek_type * sarek_type
+
+type infer_result = (sarek_type, type_error) sum
+
+val infer_list_with :
+  (type_env -> expr -> infer_result) ->
+  type_env ->
+  expr list ->
+  (sarek_type list, type_error) sum
+
+val infer_type : type_env -> expr -> infer_result
+
+val sarek_type_eq_dec : sarek_type -> sarek_type -> bool
+
+type vec_error =
+  | VCoreError of type_error
+  | NotAVector of sarek_type
+  | NotAnArray of sarek_type
+  | IndexNotInt of sarek_type
+  | ElemMismatch of sarek_type * sarek_type
+
+type vec_result = (sarek_type, vec_error) sum
+
+type mem_expr =
+  | MCore of expr
+  | EVecGet of mem_expr * mem_expr
+  | EVecSet of mem_expr * mem_expr * mem_expr
+  | EArrGet of mem_expr * mem_expr
+  | EArrSet of mem_expr * mem_expr * mem_expr
+
+val infer_mem_type : type_env -> mem_expr -> vec_result
+
+val field_lookup : string -> (string * sarek_type) list -> sarek_type option
+
+type rec_error =
+  | RMemError of vec_error
+  | NotARecord of sarek_type
+  | FieldNotFound of string * sarek_type
+  | FieldMismatch of sarek_type * sarek_type
+
+type rec_result = (sarek_type, rec_error) sum
+
+type rec_expr =
+  | RMem of mem_expr
+  | EFieldGet of string * rec_expr
+  | EFieldSet of string * rec_expr * rec_expr
+
+val infer_rec_type : type_env -> rec_expr -> rec_result
+
+type cf_error =
+  | CRec of rec_error
+  | CondNotBool of sarek_type
+  | BranchMismatch of sarek_type * sarek_type
+  | BoundNotInt32 of sarek_type
+
+type cf_expr =
+  | CFRec of rec_expr
+  | CFIfThen of cf_expr * cf_expr
+  | CFIfElse of cf_expr * cf_expr * cf_expr
+  | CFFor of string * cf_expr * cf_expr * cf_expr
+  | CFWhile of cf_expr * cf_expr
+  | CFSeq of cf_expr * cf_expr
+
+val infer_cf_type : type_env -> cf_expr -> (sarek_type, cf_error) sum
+
+type binop =
+  | Add
+  | Sub
+  | Mul
+  | Div
+  | Mod
+  | And
+  | Or
+  | Eq
+  | Ne
+  | Lt
+  | Le
+  | Gt
+  | Ge
+  | Land
+  | Lor
+  | Lxor
+  | Lsl
+  | Lsr
+  | Asr
+
+type unop = Neg | Not | Lnot
+
+val is_numeric : sarek_type -> bool
+
+val is_integer : sarek_type -> bool
+
+type op_error =
+  | OCF of cf_error
+  | NotNumeric of sarek_type
+  | NotInteger of sarek_type
+  | NotBool of sarek_type
+  | OperandMismatch of sarek_type * sarek_type
+
+type op_expr =
+  | OPCf of cf_expr
+  | OPBinop of binop * op_expr * op_expr
+  | OPUnop of unop * op_expr
+
+val infer_op_type : type_env -> op_expr -> (sarek_type, op_error) sum

--- a/formal/type-safety/extraction/dune
+++ b/formal/type-safety/extraction/dune
@@ -2,7 +2,13 @@
 
 (library
  (name type_safety_model)
- (modules TypeSafetyModel UnifyModel VecModel RegistryModel ControlFlowModel)
+ (modules
+  TypeSafetyModel
+  UnifyModel
+  VecModel
+  RegistryModel
+  ControlFlowModel
+  OperatorModel)
  ; Extracted OCaml from Rocq: relax warnings that fire on machine-generated
  ; code (unused rec flags, unused vars, redundant matches).
  (flags

--- a/formal/type-safety/proof-ledger/proof-ledger.json
+++ b/formal/type-safety/proof-ledger/proof-ledger.json
@@ -1,15 +1,15 @@
 {
   "project": "type-safety",
   "branch": "formal/type-safety-phase1e",
-  "phase": "T3-S1 (ControlFlowSpec)",
+  "phase": "T3-S2 (OperatorSpec)",
   "toolchain": {
     "rocq": "9.1.1",
     "ocaml": "5.4.0"
   },
   "summary": {
-    "proven": 50,
-    "definitions": 24,
-    "total": 50,
+    "proven": 54,
+    "definitions": 27,
+    "total": 54,
     "admits": 0
   },
   "cmbt": {

--- a/formal/type-safety/proof-ledger/proof-ledger.json
+++ b/formal/type-safety/proof-ledger/proof-ledger.json
@@ -473,6 +473,42 @@
       "proof": "split; apply infer_cf_type_sound / infer_cf_type_complete",
       "file": "theories/ControlFlowSpec.v",
       "tick": 6
+    },
+    {
+      "id": "infer_op_type_sound",
+      "kind": "theorem",
+      "statement": "infer_op_type env e = inl t -> has_op_type env e t",
+      "status": "proven",
+      "proof": "induction e as [ce | op lhs IHl rhs IHr | op' e' IHop]; OPCf: infer_cf_type_sound; OPBinop: destruct lhs/rhs results, sarek_type_eq_dec t1=t2, then 19-goal destruct op with explicit N-M: goal selectors for NumericBinop/IntegerBinop/BoolBinop/EqBinop/CmpBinop groups; OPUnop: destruct op, Neg: is_numeric check, Not: sarek_type_eq_dec bool check, Lnot: is_integer check",
+      "file": "theories/OperatorSpec.v",
+      "tick": 7
+    },
+    {
+      "id": "infer_op_type_complete",
+      "kind": "theorem",
+      "statement": "has_op_type env e t -> infer_op_type env e = inl t",
+      "status": "proven",
+      "proof": "induction H; HOT_CF: infer_cf_type_complete; HOT_NumericBinop/IntegerBinop: rewrite IH1/IH2, eq_dec self, destruct op (discriminate non-matching), destruct is_numeric/is_integer eqn (reflexivity or congruence); HOT_BoolBinop: rewrite IH1/IH2, eq_dec self, nested eq_dec TPrim TBool self; HOT_EqBinop: rewrite IH1/IH2, eq_dec self, destruct op (discriminate), reflexivity; HOT_CmpBinop: similar with is_numeric check; HOT_Neg/HOT_Lnot: rewrite IH, is_numeric/is_integer check; HOT_Not: rewrite IH, eq_dec TPrim TBool self",
+      "file": "theories/OperatorSpec.v",
+      "tick": 7
+    },
+    {
+      "id": "has_op_type_det",
+      "kind": "lemma",
+      "statement": "has_op_type env e t1 -> has_op_type env e t2 -> t1 = t2",
+      "status": "proven",
+      "proof": "pose proof infer_op_type_complete H1/H2; rewrite Ho1 in Ho2; injection Ho2 as <-; reflexivity",
+      "file": "theories/OperatorSpec.v",
+      "tick": 7
+    },
+    {
+      "id": "op_type_preservation",
+      "kind": "theorem",
+      "statement": "infer_op_type env e = inl t <-> has_op_type env e t",
+      "status": "proven",
+      "proof": "split; apply infer_op_type_sound / infer_op_type_complete",
+      "file": "theories/OperatorSpec.v",
+      "tick": 7
     }
   ],
   "cmbt_t2_unify": {
@@ -507,6 +543,15 @@
   },
   "cmbt_t3_s1": {
     "id": "T3-S1-CMBT",
+    "status": "done",
+    "harness": "formal/type-safety/test/test_type_safety_conformance.ml",
+    "smoke_cases": 10,
+    "smoke_pass": 10,
+    "errors": 0,
+    "fails": 0
+  },
+  "cmbt_t3_s2": {
+    "id": "T3-S2-CMBT",
     "status": "done",
     "harness": "formal/type-safety/test/test_type_safety_conformance.ml",
     "smoke_cases": 10,

--- a/formal/type-safety/test/test_type_safety_conformance.ml
+++ b/formal/type-safety/test/test_type_safety_conformance.ml
@@ -1201,7 +1201,8 @@ let test_op_add_int32 () =
 (* Test 2: Add int32 bool -> OperandMismatch (type mismatch) *)
 let test_op_add_mismatch () =
   let result = OP.infer_op_type [] (OP.OPBinop (OP.Add, opint32, opbool)) in
-  assert (result <> OP.Inl (OP.TPrim OP.TInt32)) ;
+  assert (
+    result = OP.Inr (OP.OperandMismatch (OP.TPrim OP.TInt32, OP.TPrim OP.TBool))) ;
   Printf.printf "  Add int32 bool -> error (mismatch) [ok]\n"
 
 (* Test 3: Mod int32 int32 -> int32 (integer binop) *)
@@ -1231,7 +1232,7 @@ let test_op_and_bool () =
 (* Test 7: And int32 int32 -> error (NotBool) *)
 let test_op_and_not_bool () =
   let result = OP.infer_op_type [] (OP.OPBinop (OP.And, opint32, opint32)) in
-  assert (result <> OP.Inl (OP.TPrim OP.TBool)) ;
+  assert (result = OP.Inr (OP.NotBool (OP.TPrim OP.TInt32))) ;
   Printf.printf "  And int32 int32 -> error (NotBool) [ok]\n"
 
 (* Test 8: Neg float32 -> float32 (numeric unop) *)

--- a/formal/type-safety/test/test_type_safety_conformance.ml
+++ b/formal/type-safety/test/test_type_safety_conformance.ml
@@ -1180,5 +1180,89 @@ let () =
   test_cf_while_ok () ;
   test_cf_seq_type () ;
   test_cf_for_var_in_scope () ;
-  Printf.printf "=== T3-S1 control flow smoke tests passed ===\n" ;
+  Printf.printf "=== T3-S1 control flow smoke tests passed ===\n"
+
+(* ===== T3-S2: OperatorSpec smoke tests ===== *)
+
+module OP = Type_safety_model.OperatorModel
+
+let opint32 = OP.OPCf (OP.CFRec (OP.RMem (OP.MCore (OP.ELit (OP.LInt 0)))))
+
+let opbool = OP.OPCf (OP.CFRec (OP.RMem (OP.MCore (OP.ELit (OP.LBool false)))))
+
+let opfloat = OP.OPCf (OP.CFRec (OP.RMem (OP.MCore (OP.ELit (OP.LFloat 0)))))
+
+(* Test 1: Add int32 int32 -> int32 (numeric binop) *)
+let test_op_add_int32 () =
+  let result = OP.infer_op_type [] (OP.OPBinop (OP.Add, opint32, opint32)) in
+  assert (result = OP.Inl (OP.TPrim OP.TInt32)) ;
+  Printf.printf "  Add int32 int32 -> TInt32 [ok]\n"
+
+(* Test 2: Add int32 bool -> OperandMismatch (type mismatch) *)
+let test_op_add_mismatch () =
+  let result = OP.infer_op_type [] (OP.OPBinop (OP.Add, opint32, opbool)) in
+  assert (result <> OP.Inl (OP.TPrim OP.TInt32)) ;
+  Printf.printf "  Add int32 bool -> error (mismatch) [ok]\n"
+
+(* Test 3: Mod int32 int32 -> int32 (integer binop) *)
+let test_op_mod_int32 () =
+  let result = OP.infer_op_type [] (OP.OPBinop (OP.Mod, opint32, opint32)) in
+  assert (result = OP.Inl (OP.TPrim OP.TInt32)) ;
+  Printf.printf "  Mod int32 int32 -> TInt32 [ok]\n"
+
+(* Test 4: Eq int32 int32 -> bool (eq binop) *)
+let test_op_eq_int32 () =
+  let result = OP.infer_op_type [] (OP.OPBinop (OP.Eq, opint32, opint32)) in
+  assert (result = OP.Inl (OP.TPrim OP.TBool)) ;
+  Printf.printf "  Eq int32 int32 -> TBool [ok]\n"
+
+(* Test 5: Lt int32 int32 -> bool (cmp binop, numeric type) *)
+let test_op_lt_int32 () =
+  let result = OP.infer_op_type [] (OP.OPBinop (OP.Lt, opint32, opint32)) in
+  assert (result = OP.Inl (OP.TPrim OP.TBool)) ;
+  Printf.printf "  Lt int32 int32 -> TBool [ok]\n"
+
+(* Test 6: And bool bool -> bool *)
+let test_op_and_bool () =
+  let result = OP.infer_op_type [] (OP.OPBinop (OP.And, opbool, opbool)) in
+  assert (result = OP.Inl (OP.TPrim OP.TBool)) ;
+  Printf.printf "  And bool bool -> TBool [ok]\n"
+
+(* Test 7: And int32 int32 -> error (NotBool) *)
+let test_op_and_not_bool () =
+  let result = OP.infer_op_type [] (OP.OPBinop (OP.And, opint32, opint32)) in
+  assert (result <> OP.Inl (OP.TPrim OP.TBool)) ;
+  Printf.printf "  And int32 int32 -> error (NotBool) [ok]\n"
+
+(* Test 8: Neg float32 -> float32 (numeric unop) *)
+let test_op_neg_float () =
+  let result = OP.infer_op_type [] (OP.OPUnop (OP.Neg, opfloat)) in
+  assert (result = OP.Inl (OP.TReg OP.RFloat32)) ;
+  Printf.printf "  Neg float32 -> TReg RFloat32 [ok]\n"
+
+(* Test 9: Not bool -> bool *)
+let test_op_not_bool () =
+  let result = OP.infer_op_type [] (OP.OPUnop (OP.Not, opbool)) in
+  assert (result = OP.Inl (OP.TPrim OP.TBool)) ;
+  Printf.printf "  Not bool -> TBool [ok]\n"
+
+(* Test 10: Lnot int32 -> int32 (integer unop) *)
+let test_op_lnot_int32 () =
+  let result = OP.infer_op_type [] (OP.OPUnop (OP.Lnot, opint32)) in
+  assert (result = OP.Inl (OP.TPrim OP.TInt32)) ;
+  Printf.printf "  Lnot int32 -> TInt32 [ok]\n"
+
+let () =
+  Printf.printf "\n=== T3-S2 operator smoke tests (OperatorModel oracle) ===\n" ;
+  test_op_add_int32 () ;
+  test_op_add_mismatch () ;
+  test_op_mod_int32 () ;
+  test_op_eq_int32 () ;
+  test_op_lt_int32 () ;
+  test_op_and_bool () ;
+  test_op_and_not_bool () ;
+  test_op_neg_float () ;
+  test_op_not_bool () ;
+  test_op_lnot_int32 () ;
+  Printf.printf "=== T3-S2 operator smoke tests passed ===\n" ;
   exit 0

--- a/formal/type-safety/theories/OperatorSpec.v
+++ b/formal/type-safety/theories/OperatorSpec.v
@@ -1,0 +1,330 @@
+(******************************************************************************)
+(* Rocq 9 spec for GPU operator typing -- T3-S2 (OperatorSpec).
+ *
+ * Extends ControlFlowSpec.v with an op_expr language that adds:
+ *
+ *   OPBinop op lhs rhs  -- binary operation (Add/Sub/Mul/Div/Mod/Eq/Ne/...)
+ *   OPUnop  op operand  -- unary operation (Neg/Not/Lnot)
+ *
+ * Rules mirror Sarek_typer.ml: infer_binop (lines 146-176), infer_unop
+ * (lines 179-189). Post-unification model: both operands must already be the
+ * same resolved type; TVar is not modelled.
+ *
+ * Type-class predicates (post-unification, no TVar):
+ *   is_numeric : TPrim TInt32, TReg RInt/RInt64/RFloat32/RFloat64
+ *   is_integer : TPrim TInt32, TReg RInt/RInt64
+ *
+ * Binop groups (mirroring the 5 match arms of infer_binop):
+ *   NumericBinop   (Add/Sub/Mul/Div) : t1=t2, numeric(t)  -> t
+ *   IntegerBinop   (Mod/Land/Lor/Lxor/Lsl/Lsr/Asr) : t1=t2, integer(t) -> t
+ *   EqBinop        (Eq/Ne)           : t1=t2              -> TPrim TBool
+ *   CmpBinop       (Lt/Le/Gt/Ge)     : t1=t2, numeric(t)  -> TPrim TBool
+ *   BoolBinop      (And/Or)          : t1=t2=TBool         -> TPrim TBool
+ *
+ * Proven (all Qed, 0 admits):
+ *   infer_op_type_sound    -- infer succeeds -> has_op_type
+ *   infer_op_type_complete -- has_op_type -> infer succeeds
+ *   has_op_type_det        -- uniqueness of the declarative judgement
+ *   op_type_preservation   -- bi-directional iff
+ ******************************************************************************)
+
+From Stdlib Require Import Bool List String Arith Nat.
+From TypeSafety Require Import TypeSafetySpec.
+From TypeSafety Require Import VecSpec.
+From TypeSafety Require Import RegistrySpec.
+From TypeSafety Require Import ControlFlowSpec.
+Import TypeSafetySpec VecSpec RegistrySpec ControlFlowSpec.
+Import ListNotations.
+
+Set Implicit Arguments.
+
+(* ===== 1. Operator AST (mirrors Sarek_ast.ml binop / unop) ===== *)
+
+Inductive binop : Type :=
+  | Add | Sub | Mul | Div | Mod
+  | And | Or
+  | Eq | Ne | Lt | Le | Gt | Ge
+  | Land | Lor | Lxor | Lsl | Lsr | Asr.
+
+Inductive unop : Type :=
+  | Neg | Not | Lnot.
+
+(* ===== 2. Type-class predicates ===== *)
+
+Definition is_numeric (t : sarek_type) : bool :=
+  match t with
+  | TPrim TInt32 => true
+  | TReg RInt | TReg RInt64 | TReg RFloat32 | TReg RFloat64 => true
+  | _ => false
+  end.
+
+Definition is_integer (t : sarek_type) : bool :=
+  match t with
+  | TPrim TInt32 => true
+  | TReg RInt | TReg RInt64 => true
+  | _ => false
+  end.
+
+(* ===== 3. Operator error kinds ===== *)
+
+Inductive op_error : Type :=
+  | OCF          : cf_error -> op_error
+  | NotNumeric   : sarek_type -> op_error
+  | NotInteger   : sarek_type -> op_error
+  | NotBool      : sarek_type -> op_error
+  | OperandMismatch : sarek_type -> sarek_type -> op_error.
+
+(* ===== 4. Operator expression language ===== *)
+
+Inductive op_expr : Type :=
+  | OPCf    : cf_expr -> op_expr
+  | OPBinop : binop -> op_expr -> op_expr -> op_expr
+  | OPUnop  : unop -> op_expr -> op_expr.
+
+(* ===== 5. Algorithmic type inference ===== *)
+
+Fixpoint infer_op_type (env : type_env) (e : op_expr)
+    : (sarek_type + op_error)%type :=
+  match e with
+  | OPCf ce =>
+      match infer_cf_type env ce with
+      | inl t   => inl t
+      | inr err => inr (OCF err)
+      end
+  | OPBinop op lhs rhs =>
+      match infer_op_type env lhs with
+      | inr err => inr err
+      | inl t1  =>
+          match infer_op_type env rhs with
+          | inr err => inr err
+          | inl t2  =>
+              match sarek_type_eq_dec t1 t2 with
+              | right _ => inr (OperandMismatch t1 t2)
+              | left  _ =>
+                  match op with
+                  | Add | Sub | Mul | Div =>
+                      if is_numeric t1 then inl t1 else inr (NotNumeric t1)
+                  | Mod | Land | Lor | Lxor | Lsl | Lsr | Asr =>
+                      if is_integer t1 then inl t1 else inr (NotInteger t1)
+                  | Eq | Ne => inl (TPrim TBool)
+                  | Lt | Le | Gt | Ge =>
+                      if is_numeric t1 then inl (TPrim TBool) else inr (NotNumeric t1)
+                  | And | Or =>
+                      match sarek_type_eq_dec t1 (TPrim TBool) with
+                      | right _ => inr (NotBool t1)
+                      | left  _ => inl (TPrim TBool)
+                      end
+                  end
+              end
+          end
+      end
+  | OPUnop op operand =>
+      match infer_op_type env operand with
+      | inr err => inr err
+      | inl t   =>
+          match op with
+          | Neg  => if is_numeric t then inl t else inr (NotNumeric t)
+          | Not  =>
+              match sarek_type_eq_dec t (TPrim TBool) with
+              | right _ => inr (NotBool t)
+              | left  _ => inl (TPrim TBool)
+              end
+          | Lnot => if is_integer t then inl t else inr (NotInteger t)
+          end
+      end
+  end.
+
+(* ===== 6. Declarative well-typedness judgement =====
+   Five grouped binop constructors mirror the five match arms of infer_binop.
+   This keeps the inductive concise and the soundness proof uniform. *)
+
+(* Shorthand predicates for op-group membership *)
+Definition is_numeric_binop (op : binop) : bool :=
+  match op with Add | Sub | Mul | Div => true | _ => false end.
+
+Definition is_integer_binop (op : binop) : bool :=
+  match op with Mod | Land | Lor | Lxor | Lsl | Lsr | Asr => true | _ => false end.
+
+Definition is_eq_binop (op : binop) : bool :=
+  match op with Eq | Ne => true | _ => false end.
+
+Definition is_cmp_binop (op : binop) : bool :=
+  match op with Lt | Le | Gt | Ge => true | _ => false end.
+
+Definition is_bool_binop (op : binop) : bool :=
+  match op with And | Or => true | _ => false end.
+
+Inductive has_op_type : type_env -> op_expr -> sarek_type -> Prop :=
+  | HOT_CF : forall env ce t,
+      has_cf_type env ce t ->
+      has_op_type env (OPCf ce) t
+  | HOT_NumericBinop : forall env op lhs rhs t,
+      is_numeric_binop op = true ->
+      has_op_type env lhs t ->
+      has_op_type env rhs t ->
+      is_numeric t = true ->
+      has_op_type env (OPBinop op lhs rhs) t
+  | HOT_IntegerBinop : forall env op lhs rhs t,
+      is_integer_binop op = true ->
+      has_op_type env lhs t ->
+      has_op_type env rhs t ->
+      is_integer t = true ->
+      has_op_type env (OPBinop op lhs rhs) t
+  | HOT_EqBinop : forall env op lhs rhs t,
+      is_eq_binop op = true ->
+      has_op_type env lhs t ->
+      has_op_type env rhs t ->
+      has_op_type env (OPBinop op lhs rhs) (TPrim TBool)
+  | HOT_CmpBinop : forall env op lhs rhs t,
+      is_cmp_binop op = true ->
+      has_op_type env lhs t ->
+      has_op_type env rhs t ->
+      is_numeric t = true ->
+      has_op_type env (OPBinop op lhs rhs) (TPrim TBool)
+  | HOT_BoolBinop : forall env op lhs rhs,
+      is_bool_binop op = true ->
+      has_op_type env lhs (TPrim TBool) ->
+      has_op_type env rhs (TPrim TBool) ->
+      has_op_type env (OPBinop op lhs rhs) (TPrim TBool)
+  | HOT_Neg : forall env operand t,
+      has_op_type env operand t ->
+      is_numeric t = true ->
+      has_op_type env (OPUnop Neg operand) t
+  | HOT_Not : forall env operand,
+      has_op_type env operand (TPrim TBool) ->
+      has_op_type env (OPUnop Not operand) (TPrim TBool)
+  | HOT_Lnot : forall env operand t,
+      has_op_type env operand t ->
+      is_integer t = true ->
+      has_op_type env (OPUnop Lnot operand) t.
+
+(* ===== 7. Soundness: infer succeeds -> has_op_type ===== *)
+
+Theorem infer_op_type_sound :
+  forall env e t,
+    infer_op_type env e = inl t ->
+    has_op_type env e t.
+Proof.
+  intros env e. revert env.
+  induction e as [ce | op lhs IHl rhs IHr | op operand IHop];
+  intros env t H; simpl in H.
+  - (* OPCf *)
+    destruct (infer_cf_type env ce) as [ct | err] eqn:Hce; [| discriminate].
+    injection H as <-. apply HOT_CF. apply infer_cf_type_sound. exact Hce.
+  - (* OPBinop *)
+    destruct (infer_op_type env lhs) as [t1 | err] eqn:Hl; [| discriminate].
+    destruct (infer_op_type env rhs) as [t2 | err] eqn:Hr; [| discriminate].
+    destruct (sarek_type_eq_dec t1 t2) as [Heq | _]; [| discriminate]. subst t2.
+    (* Goal order after destruct op:
+       1=Add 2=Sub 3=Mul 4=Div 5=Mod 6=And 7=Or 8=Eq 9=Ne
+       10=Lt 11=Le 12=Gt 13=Ge 14=Land 15=Lor 16=Lxor 17=Lsl 18=Lsr 19=Asr *)
+    destruct op; simpl in H.
+    (* 1-4: Add Sub Mul Div *)
+    1-4: (destruct (is_numeric t1) eqn:Hk; [| discriminate]; injection H as <-;
+          apply HOT_NumericBinop; [reflexivity | apply IHl; exact Hl |
+                                   apply IHr; exact Hr | exact Hk]).
+    (* 1=Mod (was 5) *)
+    1: (destruct (is_integer t1) eqn:Hk; [| discriminate]; injection H as <-;
+        apply HOT_IntegerBinop; [reflexivity | apply IHl; exact Hl |
+                                 apply IHr; exact Hr | exact Hk]).
+    (* 1-2=And Or (were 6-7) *)
+    1-2: (destruct (sarek_type_eq_dec t1 (TPrim TBool)) as [Hb | Hne];
+          [injection H as <-; rewrite Hb in Hl; rewrite Hb in Hr;
+           apply HOT_BoolBinop; [reflexivity | apply IHl; exact Hl | apply IHr; exact Hr]
+          | discriminate]).
+    (* 1-2=Eq Ne (were 8-9) *)
+    1-2: (injection H as <-;
+          apply HOT_EqBinop with (t := t1);
+          [reflexivity | apply IHl; exact Hl | apply IHr; exact Hr]).
+    (* 1-4=Lt Le Gt Ge (were 10-13) *)
+    1-4: (destruct (is_numeric t1) eqn:Hk; [| discriminate]; injection H as <-;
+          apply HOT_CmpBinop with (t := t1);
+          [reflexivity | apply IHl; exact Hl | apply IHr; exact Hr | exact Hk]).
+    (* 1-6=Land Lor Lxor Lsl Lsr Asr (were 14-19) *)
+    1-6: (destruct (is_integer t1) eqn:Hk; [| discriminate]; injection H as <-;
+          apply HOT_IntegerBinop; [reflexivity | apply IHl; exact Hl |
+                                   apply IHr; exact Hr | exact Hk]).
+  - (* OPUnop *)
+    destruct (infer_op_type env operand) as [t' | err] eqn:Hop; [| discriminate].
+    destruct op; simpl in H.
+    + destruct (is_numeric t') eqn:Hk; [| discriminate]. injection H as <-.
+      apply HOT_Neg. apply IHop. exact Hop. exact Hk.
+    + destruct (sarek_type_eq_dec t' (TPrim TBool)) as [Hb | Hne];
+      [injection H as <-; rewrite Hb in Hop; apply HOT_Not; apply IHop; exact Hop
+      | discriminate].
+    + destruct (is_integer t') eqn:Hk; [| discriminate]. injection H as <-.
+      apply HOT_Lnot. apply IHop. exact Hop. exact Hk.
+Qed.
+
+(* ===== 8. Completeness: has_op_type -> infer succeeds ===== *)
+
+Theorem infer_op_type_complete :
+  forall env e t,
+    has_op_type env e t ->
+    infer_op_type env e = inl t.
+Proof.
+  intros env e t H. induction H; simpl.
+  - (* HOT_CF *)
+    rewrite (infer_cf_type_complete H). reflexivity.
+  - (* HOT_NumericBinop *)
+    rewrite IHhas_op_type1. rewrite IHhas_op_type2.
+    destruct (sarek_type_eq_dec t t) as [_ | Hne]; [| exfalso; apply Hne; reflexivity].
+    destruct op; simpl in H; try discriminate.
+    all: (destruct (is_numeric t) eqn:Hnum; [reflexivity | congruence]).
+  - (* HOT_IntegerBinop *)
+    rewrite IHhas_op_type1. rewrite IHhas_op_type2.
+    destruct (sarek_type_eq_dec t t) as [_ | Hne]; [| exfalso; apply Hne; reflexivity].
+    destruct op; simpl in H; try discriminate.
+    all: (destruct (is_integer t) eqn:Hnum; [reflexivity | congruence]).
+  - (* HOT_EqBinop *)
+    rewrite IHhas_op_type1. rewrite IHhas_op_type2.
+    destruct (sarek_type_eq_dec t t) as [_ | Hne]; [| exfalso; apply Hne; reflexivity].
+    destruct op; simpl in H; try discriminate; reflexivity.
+  - (* HOT_CmpBinop *)
+    rewrite IHhas_op_type1. rewrite IHhas_op_type2.
+    destruct (sarek_type_eq_dec t t) as [_ | Hne]; [| exfalso; apply Hne; reflexivity].
+    destruct op; simpl in H; try discriminate.
+    all: (destruct (is_numeric t) eqn:Hnum; [reflexivity | congruence]).
+  - (* HOT_BoolBinop *)
+    rewrite IHhas_op_type1. rewrite IHhas_op_type2.
+    destruct (sarek_type_eq_dec (TPrim TBool) (TPrim TBool)) as [_ | Hne];
+      [| exfalso; apply Hne; reflexivity].
+    destruct op; simpl in H; try discriminate.
+    all: (destruct (sarek_type_eq_dec (TPrim TBool) (TPrim TBool)) as [_ | Hne2];
+          [reflexivity | exfalso; apply Hne2; reflexivity]).
+  - (* HOT_Neg *)
+    rewrite IHhas_op_type.
+    destruct (is_numeric t) eqn:Hnum; [reflexivity | congruence].
+  - (* HOT_Not *)
+    rewrite IHhas_op_type.
+    destruct (sarek_type_eq_dec (TPrim TBool) (TPrim TBool)) as [_ | Hne];
+      [reflexivity | exfalso; apply Hne; reflexivity].
+  - (* HOT_Lnot *)
+    rewrite IHhas_op_type.
+    destruct (is_integer t) eqn:Hnum; [reflexivity | congruence].
+Qed.
+
+(* ===== 9. Determinism: piggybacking on completeness ===== *)
+
+Lemma has_op_type_det :
+  forall env e t1 t2,
+    has_op_type env e t1 ->
+    has_op_type env e t2 ->
+    t1 = t2.
+Proof.
+  intros env e t1 t2 H1 H2.
+  pose proof (infer_op_type_complete H1) as Hc1.
+  pose proof (infer_op_type_complete H2) as Hc2.
+  rewrite Hc1 in Hc2. injection Hc2 as <-. reflexivity.
+Qed.
+
+(* ===== 10. Type preservation: algorithmic <-> declarative ===== *)
+
+Theorem op_type_preservation :
+  forall env e t,
+    infer_op_type env e = inl t <-> has_op_type env e t.
+Proof.
+  intros env e t. split.
+  - apply infer_op_type_sound.
+  - apply infer_op_type_complete.
+Qed.


### PR DESCRIPTION
## Summary

- **OperatorSpec.v** (321 lines): formalises `infer_op_type` for all 19 `binop` constructors (grouped as NumericBinop/IntegerBinop/BoolBinop/EqBinop/CmpBinop) and 3 `unop` constructors (Neg/Not/Lnot)
- **4 theorems proven** (all Qed, 0 admits): `infer_op_type_sound`, `infer_op_type_complete`, `has_op_type_det`, `op_type_preservation`
- **Extraction** to `OperatorModel.ml` via `OperatorExtraction.v`; `dune` library updated
- **10/10 smoke tests** green (Add/Mod/Eq/Lt/And/Neg/Not/Lnot + mismatch + NotBool cases)
- Running total: **54 theorems, 0 admits, 0 axioms**

## Key proof insight

`all: try (...)` is unreliable in Rocq 9 Ltac1 for the 19-subgoal OPBinop dispatch — partial tactic success leaves goals in inconsistent state. Replaced with explicit `N-M:` goal selectors per operator group. `destruct` on an opaque `sumbool` automatically reduces the match via iota substitution (no `rewrite`/`simpl` needed).

## Test plan

- [x] `make -f CoqMakefile` green (CoqMakefile exit 0)
- [x] `dune build` green
- [x] `dune test` green — all prior suites + 10 new T3-S2 smoke tests pass
- [x] 0 `admit`/`Admitted`/`sorry` in any `.v` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added formal GPU operator typing with algorithmic inference plus soundness/completeness verification.

* **Chores**
  * Advanced the type-safety phase planning and “next” pointers, updated phase/status reporting, and refreshed the proof ledger with new operator-theorem results.

* **Tests**
  * Added an operator conformance smoke suite and refreshed extracted operator model artifacts to match the new specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->