### PR TITLE
fix(codegen/glsl,metal): correct GLSL/Metal math intrinsic names

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -351,183 +351,225 @@ and gen_binop = function
 
 and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
 
+(** GLSL has no [cbrt]/[hypot]/[expm1]/[log1p] builtins under any name (unlike
+    [fabs]/[rsqrt]/[atan2], which are simple renames — see
+    [Sarek_pure_registry.glsl_override_name]). These need a multi-token
+    expression instead of a function-name substitution, so they're special-cased
+    here ahead of both the unqualified match arms and the pure registry,
+    applying uniformly to qualified (Float32.cbrt) and unqualified calls alike.
+    [cbrt] uses [sign(x)*pow(abs(x),...)] rather than bare [pow] because GLSL's
+    [pow] is undefined for a negative base. *)
+and gen_glsl_polyfill buf name args =
+  match (name, args) with
+  | "cbrt", [x] ->
+      Buffer.add_string buf "(sign(" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") * pow(abs(" ;
+      gen_expr buf x ;
+      Buffer.add_string buf "), 1.0 / 3.0))"
+  | "hypot", [x; y] ->
+      Buffer.add_string buf "sqrt((" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") * (" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") + (" ;
+      gen_expr buf y ;
+      Buffer.add_string buf ") * (" ;
+      gen_expr buf y ;
+      Buffer.add_string buf "))"
+  | "expm1", [x] ->
+      Buffer.add_string buf "(exp(" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") - 1.0)"
+  | "log1p", [x] ->
+      Buffer.add_string buf "log(1.0 + (" ;
+      gen_expr buf x ;
+      Buffer.add_string buf "))"
+  | _ ->
+      Codegen_error.raise_error
+        (Codegen_error.unknown_intrinsic
+           (Printf.sprintf "%s (wrong arity for GLSL polyfill)" name))
+
 and gen_intrinsic buf path name args =
   let full_name =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
-  (* For path-qualified intrinsics, query the pure registry first.
+  if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"] then
+    gen_glsl_polyfill buf name args
+  else
+    (* For path-qualified intrinsics, query the pure registry first.
      Float32.sin -> sin on GLSL (GLSL uses un-suffixed names). *)
-  let pure_registry_hit =
-    match path with
-    | [] -> None
-    | _ -> (
-        match
-          Sarek_pure_registry.fun_device_template ~module_path:path name
-        with
-        | Some f -> Some (f ~framework:"GLSL")
-        | None -> None)
-  in
-  match pure_registry_hit with
-  | Some device_name ->
-      Buffer.add_string buf device_name ;
-      Buffer.add_char buf '(' ;
-      List.iteri
-        (fun i e ->
-          if i > 0 then Buffer.add_string buf ", " ;
-          gen_expr buf e)
-        args ;
-      Buffer.add_char buf ')'
-  | None -> (
-      if
-        (* Try thread intrinsics *)
-        List.mem
-          name
-          [
-            "thread_id_x";
-            "thread_idx_x";
-            "thread_id_y";
-            "thread_idx_y";
-            "thread_id_z";
-            "thread_idx_z";
-            "block_id_x";
-            "block_idx_x";
-            "block_id_y";
-            "block_idx_y";
-            "block_id_z";
-            "block_idx_z";
-            "block_dim_x";
-            "block_dim_y";
-            "block_dim_z";
-            "grid_dim_x";
-            "grid_dim_y";
-            "grid_dim_z";
-            "global_thread_id";
-            "global_idx";
-            "global_idx_x";
-            "global_idx_y";
-            "global_idx_z";
-            "global_size";
-          ]
-      then Buffer.add_string buf (glsl_thread_intrinsic name)
-      else
-        (* Standard math intrinsics - GLSL versions *)
-        match name with
-        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-        | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
-        | "round" | "trunc" | "abs" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "fabs" ->
-            Buffer.add_string buf "abs" ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "rsqrt" ->
-            Buffer.add_string buf "inversesqrt" ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "atan2" | "pow" | "min" | "max" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "fma" ->
-            Buffer.add_string buf "fma" ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        (* Barrier synchronization *)
-        | "block_barrier" -> Buffer.add_string buf "barrier()"
-        (* Atomic operations - GLSL uses atomicAdd etc. *)
-        | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-            Buffer.add_string buf "atomicAdd(" ;
-            (match args with
-            | [addr; value] ->
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | [arr; idx; value] ->
-                gen_expr buf arr ;
-                Buffer.add_char buf '[' ;
-                gen_expr buf idx ;
-                Buffer.add_string buf "], " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_add"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | "atomic_min" ->
-            Buffer.add_string buf "atomicMin(" ;
-            (match args with
-            | [addr; value] ->
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_min"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | "atomic_max" ->
-            Buffer.add_string buf "atomicMax(" ;
-            (match args with
-            | [addr; value] ->
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_max"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | "float" ->
-            Buffer.add_string buf "float(" ;
-            (match args with [e] -> gen_expr buf e | _ -> ()) ;
-            Buffer.add_char buf ')'
-        | "int_of_float" ->
-            Buffer.add_string buf "int(" ;
-            (match args with [e] -> gen_expr buf e | _ -> ()) ;
-            Buffer.add_char buf ')'
-        | _ ->
-            (* Unknown intrinsic - emit as function call *)
-            Buffer.add_string buf full_name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')')
+    let pure_registry_hit =
+      match path with
+      | [] -> None
+      | _ -> (
+          match
+            Sarek_pure_registry.fun_device_template ~module_path:path name
+          with
+          | Some f -> Some (f ~framework:"GLSL")
+          | None -> None)
+    in
+    match pure_registry_hit with
+    | Some device_name ->
+        Buffer.add_string buf device_name ;
+        Buffer.add_char buf '(' ;
+        List.iteri
+          (fun i e ->
+            if i > 0 then Buffer.add_string buf ", " ;
+            gen_expr buf e)
+          args ;
+        Buffer.add_char buf ')'
+    | None -> (
+        if
+          (* Try thread intrinsics *)
+          List.mem
+            name
+            [
+              "thread_id_x";
+              "thread_idx_x";
+              "thread_id_y";
+              "thread_idx_y";
+              "thread_id_z";
+              "thread_idx_z";
+              "block_id_x";
+              "block_idx_x";
+              "block_id_y";
+              "block_idx_y";
+              "block_id_z";
+              "block_idx_z";
+              "block_dim_x";
+              "block_dim_y";
+              "block_dim_z";
+              "grid_dim_x";
+              "grid_dim_y";
+              "grid_dim_z";
+              "global_thread_id";
+              "global_idx";
+              "global_idx_x";
+              "global_idx_y";
+              "global_idx_z";
+              "global_size";
+            ]
+        then Buffer.add_string buf (glsl_thread_intrinsic name)
+        else
+          (* Standard math intrinsics - GLSL versions *)
+          match name with
+          | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+          | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
+          | "round" | "trunc" | "abs" ->
+              Buffer.add_string buf name ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')'
+          | "fabs" ->
+              Buffer.add_string buf "abs" ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')'
+          | "rsqrt" ->
+              Buffer.add_string buf "inversesqrt" ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')'
+          | "atan2" | "pow" | "min" | "max" ->
+              Buffer.add_string buf name ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')'
+          | "fma" ->
+              Buffer.add_string buf "fma" ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')'
+          (* Barrier synchronization *)
+          | "block_barrier" -> Buffer.add_string buf "barrier()"
+          (* Atomic operations - GLSL uses atomicAdd etc. *)
+          | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
+              Buffer.add_string buf "atomicAdd(" ;
+              (match args with
+              | [addr; value] ->
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | [arr; idx; value] ->
+                  gen_expr buf arr ;
+                  Buffer.add_char buf '[' ;
+                  gen_expr buf idx ;
+                  Buffer.add_string buf "], " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_add"
+                       2
+                       (List.length args))) ;
+              Buffer.add_char buf ')'
+          | "atomic_min" ->
+              Buffer.add_string buf "atomicMin(" ;
+              (match args with
+              | [addr; value] ->
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_min"
+                       2
+                       (List.length args))) ;
+              Buffer.add_char buf ')'
+          | "atomic_max" ->
+              Buffer.add_string buf "atomicMax(" ;
+              (match args with
+              | [addr; value] ->
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_max"
+                       2
+                       (List.length args))) ;
+              Buffer.add_char buf ')'
+          | "float" ->
+              Buffer.add_string buf "float(" ;
+              (match args with [e] -> gen_expr buf e | _ -> ()) ;
+              Buffer.add_char buf ')'
+          | "int_of_float" ->
+              Buffer.add_string buf "int(" ;
+              (match args with [e] -> gen_expr buf e | _ -> ()) ;
+              Buffer.add_char buf ')'
+          | _ ->
+              (* Unknown intrinsic - emit as function call *)
+              Buffer.add_string buf full_name ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')')
 
 (** {1 L-value Generation} *)
 

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -252,245 +252,292 @@ and gen_binop = function
 
 and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
 
+(** MSL has no [cbrt]/[hypot]/[expm1]/[log1p] builtins under any name (unlike
+    [fabs]/[rsqrt]/[atan2], which MSL does define — see Table 6.4 of the Metal
+    Shading Language Specification). These need a multi-token expression instead
+    of a function-name substitution, so they're special-cased here ahead of both
+    the unqualified match arms and the pure registry, applying uniformly to
+    qualified (Float32.cbrt) and unqualified calls alike. [cbrt] uses
+    [sign(x)*pow(abs(x),...)] rather than bare [pow] because [pow] is undefined
+    for a negative base. *)
+and gen_metal_polyfill buf name args =
+  match (name, args) with
+  | "cbrt", [x] ->
+      Buffer.add_string buf "(sign(" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") * pow(abs(" ;
+      gen_expr buf x ;
+      Buffer.add_string buf "), 1.0 / 3.0))"
+  | "hypot", [x; y] ->
+      Buffer.add_string buf "sqrt((" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") * (" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") + (" ;
+      gen_expr buf y ;
+      Buffer.add_string buf ") * (" ;
+      gen_expr buf y ;
+      Buffer.add_string buf "))"
+  | "expm1", [x] ->
+      Buffer.add_string buf "(exp(" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") - 1.0)"
+  | "log1p", [x] ->
+      Buffer.add_string buf "log(1.0 + (" ;
+      gen_expr buf x ;
+      Buffer.add_string buf "))"
+  | _ ->
+      Codegen_error.raise_error
+        (Codegen_error.unknown_intrinsic
+           (Printf.sprintf "%s (wrong arity for Metal polyfill)" name))
+
 and gen_intrinsic buf path name args =
   let full_name =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
-  (* For path-qualified intrinsics, query the pure registry first.
+  if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"] then
+    gen_metal_polyfill buf name args
+  else
+    (* For path-qualified intrinsics, query the pure registry first.
      Float32.sin -> sin on Metal (Metal uses un-suffixed names). *)
-  let pure_registry_hit =
-    match path with
-    | [] -> None
-    | _ -> (
-        let framework = Option.value ~default:"Metal" !current_framework in
-        match
-          Sarek_pure_registry.fun_device_template ~module_path:path name
-        with
-        | Some f -> Some (f ~framework)
-        | None -> None)
-  in
-  match pure_registry_hit with
-  | Some device_name ->
-      Buffer.add_string buf device_name ;
-      Buffer.add_char buf '(' ;
-      List.iteri
-        (fun i e ->
-          if i > 0 then Buffer.add_string buf ", " ;
-          gen_expr buf e)
-        args ;
-      Buffer.add_char buf ')'
-  | None -> (
-      if
-        (* Try thread intrinsics - support both idx and id naming *)
-        List.mem
-          name
-          [
-            "thread_id_x";
-            "thread_idx_x";
-            "thread_id_y";
-            "thread_idx_y";
-            "thread_id_z";
-            "thread_idx_z";
-            "block_id_x";
-            "block_idx_x";
-            "block_id_y";
-            "block_idx_y";
-            "block_id_z";
-            "block_idx_z";
-            "block_dim_x";
-            "block_dim_y";
-            "block_dim_z";
-            "grid_dim_x";
-            "grid_dim_y";
-            "grid_dim_z";
-            "global_thread_id";
-            "global_idx";
-            "global_idx_x";
-            "global_idx_y";
-            "global_idx_z";
-            "global_size";
-          ]
-      then Buffer.add_string buf (metal_thread_intrinsic name)
-      else
-        (* Standard math intrinsics - Metal uses same names *)
-        match name with
-        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-        | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
-        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "atan2" | "pow" | "fma" | "min" | "max" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        (* Barrier synchronization *)
-        | "block_barrier" ->
-            Buffer.add_string
-              buf
-              "threadgroup_barrier(mem_flags::mem_threadgroup)"
-        | "atomic_add" | "atomic_add_int32" ->
-            Buffer.add_string buf "atomic_fetch_add_explicit(" ;
-            (match args with
-            | [addr; value] ->
-                (* Cast pointer to threadgroup atomic type *)
-                Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | [arr; idx; value] ->
-                (* Array element atomic with threadgroup cast *)
-                Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
-                gen_expr buf arr ;
-                Buffer.add_char buf '[' ;
-                gen_expr buf idx ;
-                Buffer.add_string buf "], " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_add"
-                     2
-                     (List.length args))) ;
-            Buffer.add_string buf ", memory_order_relaxed)"
-        | "atomic_add_global_int32" ->
-            Buffer.add_string buf "atomic_fetch_add_explicit(" ;
-            (match args with
-            | [addr; value] ->
-                (* Cast pointer to device atomic type *)
-                Buffer.add_string buf "(volatile device atomic_int*)&" ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | [arr; idx; value] ->
-                (* Array element atomic with device cast *)
-                Buffer.add_string buf "(volatile device atomic_int*)&" ;
-                gen_expr buf arr ;
-                Buffer.add_char buf '[' ;
-                gen_expr buf idx ;
-                Buffer.add_string buf "], " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_add_global"
-                     2
-                     (List.length args))) ;
-            (* Use relaxed memory order *)
-            Buffer.add_string buf ", memory_order_relaxed)"
-        | "atomic_sub" ->
-            Buffer.add_string buf "atomic_sub(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_sub"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | "atomic_min" ->
-            Buffer.add_string buf "atomic_min(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_min"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | "atomic_max" ->
-            Buffer.add_string buf "atomic_max(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_max"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | _ -> (
-            (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
-            match Sarek_registry.fun_device_template ~module_path:path name with
-            | Some template ->
-                (* Generate argument strings *)
-                let arg_strs =
-                  List.map
-                    (fun e ->
-                      let b = Buffer.create 64 in
-                      gen_expr b e ;
-                      Buffer.contents b)
-                    args
-                in
-                (* Count %s placeholders in template *)
-                let count_placeholders s =
-                  let rec count i acc =
-                    if i >= String.length s - 1 then acc
-                    else if s.[i] = '%' && s.[i + 1] = 's' then
-                      count (i + 2) (acc + 1)
-                    else count (i + 1) acc
+    let pure_registry_hit =
+      match path with
+      | [] -> None
+      | _ -> (
+          let framework = Option.value ~default:"Metal" !current_framework in
+          match
+            Sarek_pure_registry.fun_device_template ~module_path:path name
+          with
+          | Some f -> Some (f ~framework)
+          | None -> None)
+    in
+    match pure_registry_hit with
+    | Some device_name ->
+        Buffer.add_string buf device_name ;
+        Buffer.add_char buf '(' ;
+        List.iteri
+          (fun i e ->
+            if i > 0 then Buffer.add_string buf ", " ;
+            gen_expr buf e)
+          args ;
+        Buffer.add_char buf ')'
+    | None -> (
+        if
+          (* Try thread intrinsics - support both idx and id naming *)
+          List.mem
+            name
+            [
+              "thread_id_x";
+              "thread_idx_x";
+              "thread_id_y";
+              "thread_idx_y";
+              "thread_id_z";
+              "thread_idx_z";
+              "block_id_x";
+              "block_idx_x";
+              "block_id_y";
+              "block_idx_y";
+              "block_id_z";
+              "block_idx_z";
+              "block_dim_x";
+              "block_dim_y";
+              "block_dim_z";
+              "grid_dim_x";
+              "grid_dim_y";
+              "grid_dim_z";
+              "global_thread_id";
+              "global_idx";
+              "global_idx_x";
+              "global_idx_y";
+              "global_idx_z";
+              "global_size";
+            ]
+        then Buffer.add_string buf (metal_thread_intrinsic name)
+        else
+          (* Standard math intrinsics - Metal uses same names *)
+          match name with
+          | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+          | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt"
+          | "rsqrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
+              Buffer.add_string buf name ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')'
+          | "atan2" | "pow" | "fma" | "min" | "max" ->
+              Buffer.add_string buf name ;
+              Buffer.add_char buf '(' ;
+              List.iteri
+                (fun i e ->
+                  if i > 0 then Buffer.add_string buf ", " ;
+                  gen_expr buf e)
+                args ;
+              Buffer.add_char buf ')'
+          (* Barrier synchronization *)
+          | "block_barrier" ->
+              Buffer.add_string
+                buf
+                "threadgroup_barrier(mem_flags::mem_threadgroup)"
+          | "atomic_add" | "atomic_add_int32" ->
+              Buffer.add_string buf "atomic_fetch_add_explicit(" ;
+              (match args with
+              | [addr; value] ->
+                  (* Cast pointer to threadgroup atomic type *)
+                  Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | [arr; idx; value] ->
+                  (* Array element atomic with threadgroup cast *)
+                  Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
+                  gen_expr buf arr ;
+                  Buffer.add_char buf '[' ;
+                  gen_expr buf idx ;
+                  Buffer.add_string buf "], " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_add"
+                       2
+                       (List.length args))) ;
+              Buffer.add_string buf ", memory_order_relaxed)"
+          | "atomic_add_global_int32" ->
+              Buffer.add_string buf "atomic_fetch_add_explicit(" ;
+              (match args with
+              | [addr; value] ->
+                  (* Cast pointer to device atomic type *)
+                  Buffer.add_string buf "(volatile device atomic_int*)&" ;
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | [arr; idx; value] ->
+                  (* Array element atomic with device cast *)
+                  Buffer.add_string buf "(volatile device atomic_int*)&" ;
+                  gen_expr buf arr ;
+                  Buffer.add_char buf '[' ;
+                  gen_expr buf idx ;
+                  Buffer.add_string buf "], " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_add_global"
+                       2
+                       (List.length args))) ;
+              (* Use relaxed memory order *)
+              Buffer.add_string buf ", memory_order_relaxed)"
+          | "atomic_sub" ->
+              Buffer.add_string buf "atomic_sub(" ;
+              (match args with
+              | [addr; value] ->
+                  Buffer.add_char buf '&' ;
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_sub"
+                       2
+                       (List.length args))) ;
+              Buffer.add_char buf ')'
+          | "atomic_min" ->
+              Buffer.add_string buf "atomic_min(" ;
+              (match args with
+              | [addr; value] ->
+                  Buffer.add_char buf '&' ;
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_min"
+                       2
+                       (List.length args))) ;
+              Buffer.add_char buf ')'
+          | "atomic_max" ->
+              Buffer.add_string buf "atomic_max(" ;
+              (match args with
+              | [addr; value] ->
+                  Buffer.add_char buf '&' ;
+                  gen_expr buf addr ;
+                  Buffer.add_string buf ", " ;
+                  gen_expr buf value
+              | args ->
+                  Codegen_error.raise_error
+                    (Codegen_error.invalid_arg_count
+                       "atomic_max"
+                       2
+                       (List.length args))) ;
+              Buffer.add_char buf ')'
+          | _ -> (
+              (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
+              match
+                Sarek_registry.fun_device_template ~module_path:path name
+              with
+              | Some template ->
+                  (* Generate argument strings *)
+                  let arg_strs =
+                    List.map
+                      (fun e ->
+                        let b = Buffer.create 64 in
+                        gen_expr b e ;
+                        Buffer.contents b)
+                      args
                   in
-                  count 0 0
-                in
-                let num_placeholders = count_placeholders template in
-                let result =
-                  if num_placeholders = 0 then
-                    (* Plain function/cast like "(float)" -> call as function *)
-                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                  else if num_placeholders = 1 && List.length arg_strs = 1 then
-                    Printf.sprintf
-                      (Scanf.format_from_string template "%s")
-                      (List.hd arg_strs)
-                  else if num_placeholders = 2 && List.length arg_strs = 2 then
-                    Printf.sprintf
-                      (Scanf.format_from_string template "%s%s")
-                      (List.nth arg_strs 0)
-                      (List.nth arg_strs 1)
-                  else if num_placeholders = 3 && List.length arg_strs = 3 then
-                    Printf.sprintf
-                      (Scanf.format_from_string template "%s%s%s")
-                      (List.nth arg_strs 0)
-                      (List.nth arg_strs 1)
-                      (List.nth arg_strs 2)
-                  else
-                    (* Fallback: treat as function call *)
-                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                in
-                Buffer.add_string buf result
-            | None ->
-                (* Unknown intrinsic - emit as function call *)
-                Buffer.add_string buf full_name ;
-                Buffer.add_char buf '(' ;
-                List.iteri
-                  (fun i e ->
-                    if i > 0 then Buffer.add_string buf ", " ;
-                    gen_expr buf e)
-                  args ;
-                Buffer.add_char buf ')'))
+                  (* Count %s placeholders in template *)
+                  let count_placeholders s =
+                    let rec count i acc =
+                      if i >= String.length s - 1 then acc
+                      else if s.[i] = '%' && s.[i + 1] = 's' then
+                        count (i + 2) (acc + 1)
+                      else count (i + 1) acc
+                    in
+                    count 0 0
+                  in
+                  let num_placeholders = count_placeholders template in
+                  let result =
+                    if num_placeholders = 0 then
+                      (* Plain function/cast like "(float)" -> call as function *)
+                      template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                    else if num_placeholders = 1 && List.length arg_strs = 1
+                    then
+                      Printf.sprintf
+                        (Scanf.format_from_string template "%s")
+                        (List.hd arg_strs)
+                    else if num_placeholders = 2 && List.length arg_strs = 2
+                    then
+                      Printf.sprintf
+                        (Scanf.format_from_string template "%s%s")
+                        (List.nth arg_strs 0)
+                        (List.nth arg_strs 1)
+                    else if num_placeholders = 3 && List.length arg_strs = 3
+                    then
+                      Printf.sprintf
+                        (Scanf.format_from_string template "%s%s%s")
+                        (List.nth arg_strs 0)
+                        (List.nth arg_strs 1)
+                        (List.nth arg_strs 2)
+                    else
+                      (* Fallback: treat as function call *)
+                      template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+                  in
+                  Buffer.add_string buf result
+              | None ->
+                  (* Unknown intrinsic - emit as function call *)
+                  Buffer.add_string buf full_name ;
+                  Buffer.add_char buf '(' ;
+                  List.iteri
+                    (fun i e ->
+                      if i > 0 then Buffer.add_string buf ", " ;
+                      gen_expr buf e)
+                    args ;
+                  Buffer.add_char buf ')'))
 
 (** {1 L-value Generation} *)
 

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -185,6 +185,175 @@ let float32_sin_path_kernel () =
     []
     body
 
+(** Kernel 5b/5c/5d: path-qualified Float32 intrinsics whose GLSL builtin name
+    differs from the OpenCL/Metal/CUDA generic name. GLSL has no [fabs] or
+    [rsqrt] builtin (only [abs] and [inversesqrt]), and no [atan2] (the
+    two-argument arctangent is the [atan] overload). These exist to prove the
+    pure-registry framework dispatch renames correctly per backend, not just for
+    [sin] (which happens to be spelled the same everywhere). *)
+let float32_rsqrt_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float32"], "rsqrt", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float32_rsqrt_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+let float32_abs_float_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float32"], "abs_float", [EArrayRead ("a", EVar idx)])
+          ) )
+  in
+  empty_kernel
+    "float32_abs_float_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+let float32_atan2_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("c", EVar idx),
+            EIntrinsic
+              ( ["Float32"],
+                "atan2",
+                [EArrayRead ("a", EVar idx); EArrayRead ("b", EVar idx)] ) ) )
+  in
+  empty_kernel
+    "float32_atan2_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+(** Kernel 5e/5f/5g/5h: path-qualified Float32 intrinsics with NO GLSL/Metal
+    builtin under any name (cbrt, hypot, expm1, log1p) — unlike
+    fabs/rsqrt/atan2, these require a multi-token expression polyfill, not a
+    rename. CUDA/OpenCL do have direct builtins for these, so only
+    glsl_only/metal_only goldens are needed. *)
+let float32_cbrt_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float32"], "cbrt", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float32_cbrt_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+let float32_hypot_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("c", EVar idx),
+            EIntrinsic
+              ( ["Float32"],
+                "hypot",
+                [EArrayRead ("a", EVar idx); EArrayRead ("b", EVar idx)] ) ) )
+  in
+  empty_kernel
+    "float32_hypot_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+let float32_expm1_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float32"], "expm1", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float32_expm1_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+let float32_log1p_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float32"], "log1p", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float32_log1p_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
 (** Kernel 6: bounds-check with if-expression. WGSL-specific: exercises EIf
     which must emit [select(else, then, cond)] (no ternary in WGSL). fun (a :
     float32 vec) (b : float32 vec) (n : int32) -> let i = global_thread_id in
@@ -963,8 +1132,313 @@ let wgsl_only_tests () =
           check_golden "wgsl" kernel_name actual))
     (wgsl_only_kernels ())
 
+(** {1 GLSL-only golden tests}
+
+    GLSL's math builtin names diverge from the CUDA/OpenCL/Metal generic names
+    for a few functions: [fabs] -> [abs], [rsqrt] -> [inversesqrt], [atan2] ->
+    the two-arg [atan] overload. These are path-qualified Float32 intrinsics, so
+    they resolve through [Sarek_pure_registry], not through the per-backend
+    unqualified-name match arms. Only GLSL needs its own goldens here because
+    CUDA/OpenCL/Metal/WGSL all keep the generic spelling. *)
+
+let () =
+  register_golden
+    "glsl"
+    "float32_rsqrt_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_rsqrt_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = inversesqrt(a[idx]);\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_abs_float_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_abs_float_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = abs(a[idx]);\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_atan2_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_atan2_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(std430, set=0, binding = 2) buffer Buffer_c {\n\
+    \  float c[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+    \  int c_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\
+     #define c_len pc.c_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  c[idx] = atan(a[idx], b[idx]);\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_cbrt_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_cbrt_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = (sign(a[idx]) * pow(abs(a[idx]), 1.0 / 3.0));\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_hypot_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_hypot_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(std430, set=0, binding = 2) buffer Buffer_c {\n\
+    \  float c[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+    \  int c_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\
+     #define c_len pc.c_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  c[idx] = sqrt((a[idx]) * (a[idx]) + (b[idx]) * (b[idx]));\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_expm1_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_expm1_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = (exp(a[idx]) - 1.0);\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_log1p_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_log1p_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = log(1.0 + (a[idx]));\n\
+     }\n"
+
+let glsl_only_kernels () =
+  [
+    ("float32_rsqrt_path", float32_rsqrt_path_kernel ());
+    ("float32_abs_float_path", float32_abs_float_path_kernel ());
+    ("float32_atan2_path", float32_atan2_path_kernel ());
+    ("float32_cbrt_path", float32_cbrt_path_kernel ());
+    ("float32_hypot_path", float32_hypot_path_kernel ());
+    ("float32_expm1_path", float32_expm1_path_kernel ());
+    ("float32_log1p_path", float32_log1p_path_kernel ());
+  ]
+
+let glsl_only_tests () =
+  List.map
+    (fun (kernel_name, k) ->
+      Alcotest.test_case
+        (Printf.sprintf "glsl/%s" kernel_name)
+        `Quick
+        (fun () ->
+          Gen_glsl.reset_state () ;
+          let actual = Gen_glsl.generate_with_types ~types:k.kern_types k in
+          check_golden "glsl" kernel_name actual))
+    (glsl_only_kernels ())
+
+(** {1 Metal-only golden tests}
+
+    Same rationale as the GLSL-only block above: cbrt/hypot/expm1/log1p have no
+    MSL builtin under any name, so they resolve to a multi-token expression
+    polyfill in [Sarek_ir_metal.gen_metal_polyfill] rather than a renamed
+    function call. *)
+
+let () =
+  register_golden
+    "metal"
+    "float32_cbrt_path"
+    "#include <metal_stdlib>\n\
+     using namespace metal;\n\n\
+     kernel void float32_cbrt_path(device float* a [[buffer(0)]], constant int \
+     &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant \
+     int &sarek_b_length [[buffer(3)]],\n\
+     uint3 __metal_gid [[thread_position_in_grid]],\n\
+     uint3 __metal_tid [[thread_position_in_threadgroup]],\n\
+     uint3 __metal_bid [[threadgroup_position_in_grid]],\n\
+     uint3 __metal_tpg [[threads_per_threadgroup]],\n\
+     uint3 __metal_num_groups [[threadgroups_per_grid]]) {\n\
+    \  int idx = __metal_gid.x;\n\
+    \  b[idx] = (sign(a[idx]) * pow(abs(a[idx]), 1.0 / 3.0));\n\
+     }\n\n" ;
+
+  register_golden
+    "metal"
+    "float32_hypot_path"
+    "#include <metal_stdlib>\n\
+     using namespace metal;\n\n\
+     kernel void float32_hypot_path(device float* a [[buffer(0)]], constant \
+     int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], \
+     constant int &sarek_b_length [[buffer(3)]], device float* c \
+     [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]],\n\
+     uint3 __metal_gid [[thread_position_in_grid]],\n\
+     uint3 __metal_tid [[thread_position_in_threadgroup]],\n\
+     uint3 __metal_bid [[threadgroup_position_in_grid]],\n\
+     uint3 __metal_tpg [[threads_per_threadgroup]],\n\
+     uint3 __metal_num_groups [[threadgroups_per_grid]]) {\n\
+    \  int idx = __metal_gid.x;\n\
+    \  c[idx] = sqrt((a[idx]) * (a[idx]) + (b[idx]) * (b[idx]));\n\
+     }\n\n" ;
+
+  register_golden
+    "metal"
+    "float32_expm1_path"
+    "#include <metal_stdlib>\n\
+     using namespace metal;\n\n\
+     kernel void float32_expm1_path(device float* a [[buffer(0)]], constant \
+     int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], \
+     constant int &sarek_b_length [[buffer(3)]],\n\
+     uint3 __metal_gid [[thread_position_in_grid]],\n\
+     uint3 __metal_tid [[thread_position_in_threadgroup]],\n\
+     uint3 __metal_bid [[threadgroup_position_in_grid]],\n\
+     uint3 __metal_tpg [[threads_per_threadgroup]],\n\
+     uint3 __metal_num_groups [[threadgroups_per_grid]]) {\n\
+    \  int idx = __metal_gid.x;\n\
+    \  b[idx] = (exp(a[idx]) - 1.0);\n\
+     }\n\n" ;
+
+  register_golden
+    "metal"
+    "float32_log1p_path"
+    "#include <metal_stdlib>\n\
+     using namespace metal;\n\n\
+     kernel void float32_log1p_path(device float* a [[buffer(0)]], constant \
+     int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], \
+     constant int &sarek_b_length [[buffer(3)]],\n\
+     uint3 __metal_gid [[thread_position_in_grid]],\n\
+     uint3 __metal_tid [[thread_position_in_threadgroup]],\n\
+     uint3 __metal_bid [[threadgroup_position_in_grid]],\n\
+     uint3 __metal_tpg [[threads_per_threadgroup]],\n\
+     uint3 __metal_num_groups [[threadgroups_per_grid]]) {\n\
+    \  int idx = __metal_gid.x;\n\
+    \  b[idx] = log(1.0 + (a[idx]));\n\
+     }\n\n"
+
+let metal_only_kernels () =
+  [
+    ("float32_cbrt_path", float32_cbrt_path_kernel ());
+    ("float32_hypot_path", float32_hypot_path_kernel ());
+    ("float32_expm1_path", float32_expm1_path_kernel ());
+    ("float32_log1p_path", float32_log1p_path_kernel ());
+  ]
+
+let metal_only_tests () =
+  List.map
+    (fun (kernel_name, k) ->
+      Alcotest.test_case
+        (Printf.sprintf "metal/%s" kernel_name)
+        `Quick
+        (fun () ->
+          Gen_metal.reset_state () ;
+          let actual = Gen_metal.generate_with_types ~types:k.kern_types k in
+          check_golden "metal" kernel_name actual))
+    (metal_only_kernels ())
+
 let () =
   Alcotest.run
     "codegen_golden"
     (List.map make_backend_tests all_backends
-    @ [("wgsl_only", wgsl_only_tests ())])
+    @ [
+        ("wgsl_only", wgsl_only_tests ());
+        ("glsl_only", glsl_only_tests ());
+        ("metal_only", metal_only_tests ());
+      ])

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -196,6 +196,17 @@
  (libraries sarek sarek_ir spoc_core test_helpers unix)
  (preprocess no_preprocessing))
 
+; Float64 math intrinsics report across every fp64-capable device.
+; Report-only: a mismatch on one (device, function) pair does not fail the
+; test or block CI - see the module doc comment for why.
+; Run with: dune exec sarek/tests/e2e/test_float64_math_intrinsics.exe
+
+(executable
+ (name test_float64_math_intrinsics)
+ (modules test_float64_math_intrinsics)
+ (libraries sarek sarek_ir spoc_core test_helpers unix)
+ (preprocess no_preprocessing))
+
 ; External kernel test - works with any available backend
 
 (executable

--- a/sarek/tests/e2e/test_float64_math_intrinsics.ml
+++ b/sarek/tests/e2e/test_float64_math_intrinsics.ml
@@ -1,0 +1,406 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for Sarek Float64 math intrinsics, on every device that supports
+ * fp64.
+ *
+ * Builds Sarek IR kernels directly (no PPX) using
+ * EIntrinsic (["Float64"], name, ...) for every unary/binary function exposed
+ * by Sarek_float64.Float64, and runs each one on every device that reports
+ * fp64 support (Device.allows_fp64). This is the regression coverage for the
+ * pure-registry GLSL/Metal renaming fix: rsqrt, abs_float, atan2, hypot,
+ * expm1, and log1p previously reached codegen with names those backends
+ * don't define (see spoc/ir/Sarek_pure_registry.ml).
+ *
+ * Per the request that drove this test: a single (device, function) mismatch
+ * must NOT fail the whole suite or block CI. Every combination is run in
+ * isolation, failures and errors are collected into a report, and the
+ * process always exits 0. The report is the deliverable, not a pass/fail
+ * gate — read it to see which backend/function pairs are broken.
+ *
+ * Run with: dune exec sarek/tests/e2e/test_float64_math_intrinsics.exe
+ ******************************************************************************)
+
+open Sarek_ir_types
+open Sarek
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+(* Force backend registration *)
+let () = Test_helpers.Benchmarks.init_backends ()
+
+let n = 256
+
+(** {1 IR builders}
+
+    Path-qualified Float64 intrinsics resolve through [Sarek_pure_registry],
+    bypassing PPX entirely — the same shape as [test_float32_sin_pure.ml]'s
+    Float32.sin kernel, generalized to arity 1 and 2. *)
+
+let make_unary_ir name : kernel =
+  let a =
+    {var_name = "a"; var_id = 0; var_type = TVec TFloat64; var_mutable = false}
+  in
+  let b =
+    {var_name = "b"; var_id = 1; var_type = TVec TFloat64; var_mutable = false}
+  in
+  let idx =
+    {var_name = "idx"; var_id = 2; var_type = TInt32; var_mutable = false}
+  in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float64"], name, [EArrayRead ("a", EVar idx)]) ) )
+  in
+  {
+    kern_name = "float64_" ^ name ^ "_unary";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat64; arr_memspace = Global});
+        DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let make_binary_ir name : kernel =
+  let a =
+    {var_name = "a"; var_id = 0; var_type = TVec TFloat64; var_mutable = false}
+  in
+  let b =
+    {var_name = "b"; var_id = 1; var_type = TVec TFloat64; var_mutable = false}
+  in
+  let c =
+    {var_name = "c"; var_id = 2; var_type = TVec TFloat64; var_mutable = false}
+  in
+  let idx =
+    {var_name = "idx"; var_id = 3; var_type = TInt32; var_mutable = false}
+  in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("c", EVar idx),
+            EIntrinsic
+              ( ["Float64"],
+                name,
+                [EArrayRead ("a", EVar idx); EArrayRead ("b", EVar idx)] ) ) )
+  in
+  {
+    kern_name = "float64_" ^ name ^ "_binary";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat64; arr_memspace = Global});
+        DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(** {1 Function specs}
+
+    [gen] produces domain-safe inputs (e.g. positive for [log], bounded for
+    [asin]/[acos]) so a mismatch reflects a codegen bug, not a math-domain error
+    shared with the OCaml reference. *)
+
+type unary_spec = {
+  u_name : string;
+  u_ocaml : float -> float;
+  u_gen : int -> float;
+  u_tol : float;
+}
+
+type binary_spec = {
+  b_name : string;
+  b_ocaml : float -> float -> float;
+  b_gen : int -> float * float;
+  b_tol : float;
+}
+
+let bounded lo hi i = lo +. ((hi -. lo) *. (float_of_int (i mod 100) /. 100.0))
+
+let unary_specs =
+  [
+    {
+      u_name = "sin";
+      u_ocaml = Stdlib.sin;
+      u_gen = bounded (-3.0) 3.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "cos";
+      u_ocaml = Stdlib.cos;
+      u_gen = bounded (-3.0) 3.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "tan";
+      u_ocaml = Stdlib.tan;
+      u_gen = bounded (-1.0) 1.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "asin";
+      u_ocaml = Stdlib.asin;
+      u_gen = bounded (-0.95) 0.95;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "acos";
+      u_ocaml = Stdlib.acos;
+      u_gen = bounded (-0.95) 0.95;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "atan";
+      u_ocaml = Stdlib.atan;
+      u_gen = bounded (-3.0) 3.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "sinh";
+      u_ocaml = Stdlib.sinh;
+      u_gen = bounded (-2.0) 2.0;
+      u_tol = 1e-8;
+    };
+    {
+      u_name = "cosh";
+      u_ocaml = Stdlib.cosh;
+      u_gen = bounded (-2.0) 2.0;
+      u_tol = 1e-8;
+    };
+    {
+      u_name = "tanh";
+      u_ocaml = Stdlib.tanh;
+      u_gen = bounded (-2.0) 2.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "exp";
+      u_ocaml = Stdlib.exp;
+      u_gen = bounded (-2.0) 2.0;
+      u_tol = 1e-8;
+    };
+    {
+      u_name = "expm1";
+      u_ocaml = Stdlib.expm1;
+      u_gen = bounded (-2.0) 2.0;
+      u_tol = 1e-8;
+    };
+    {
+      u_name = "log";
+      u_ocaml = Stdlib.log;
+      u_gen = bounded 0.01 5.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "log10";
+      u_ocaml = Stdlib.log10;
+      u_gen = bounded 0.01 5.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "log1p";
+      u_ocaml = Stdlib.log1p;
+      u_gen = bounded (-0.9) 5.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "sqrt";
+      u_ocaml = Stdlib.sqrt;
+      u_gen = bounded 0.01 10.0;
+      u_tol = 1e-9;
+    };
+    {
+      u_name = "rsqrt";
+      u_ocaml = (fun x -> 1.0 /. Stdlib.sqrt x);
+      u_gen = bounded 0.1 10.0;
+      u_tol = 1e-6;
+    };
+    {
+      u_name = "ceil";
+      u_ocaml = Stdlib.ceil;
+      u_gen = bounded (-5.0) 5.0;
+      u_tol = 0.0;
+    };
+    {
+      u_name = "floor";
+      u_ocaml = Stdlib.floor;
+      u_gen = bounded (-5.0) 5.0;
+      u_tol = 0.0;
+    };
+    {
+      u_name = "abs_float";
+      u_ocaml = Stdlib.abs_float;
+      u_gen = bounded (-5.0) 5.0;
+      u_tol = 0.0;
+    };
+  ]
+
+let binary_specs =
+  [
+    {
+      b_name = "pow";
+      b_ocaml = Float.pow;
+      b_gen = (fun i -> (bounded 0.1 3.0 i, bounded (-2.0) 2.0 (i + 7)));
+      b_tol = 1e-6;
+    };
+    {
+      b_name = "atan2";
+      b_ocaml = Stdlib.atan2;
+      b_gen = (fun i -> (bounded (-3.0) 3.0 i, bounded (-3.0) 3.0 (i + 13)));
+      b_tol = 1e-9;
+    };
+    {
+      b_name = "hypot";
+      b_ocaml = Stdlib.hypot;
+      b_gen = (fun i -> (bounded (-3.0) 3.0 i, bounded (-3.0) 3.0 (i + 5)));
+      b_tol = 1e-8;
+    };
+    {
+      b_name = "copysign";
+      b_ocaml = Stdlib.copysign;
+      b_gen = (fun i -> (bounded (-3.0) 3.0 i, bounded (-3.0) 3.0 (i + 11)));
+      b_tol = 0.0;
+    };
+  ]
+
+(** {1 Runner} *)
+
+type outcome = Pass | Mismatch of int | Skipped of string | Errored of string
+
+let run_unary (dev : Device.t) spec =
+  let ir = make_unary_ir spec.u_name in
+  let a_vec = Vector.create Vector.float64 n in
+  let b_vec = Vector.create Vector.float64 n in
+  for i = 0 to n - 1 do
+    Vector.set a_vec i (spec.u_gen i) ;
+    Vector.set b_vec i 0.0
+  done ;
+  let block = Execute.dims1d 256 in
+  let grid = Execute.dims1d 1 in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Execute.Vec a_vec; Execute.Vec b_vec]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let result = Vector.to_array b_vec in
+  let errors = ref 0 in
+  for i = 0 to n - 1 do
+    let expected = spec.u_ocaml (spec.u_gen i) in
+    if abs_float (result.(i) -. expected) > spec.u_tol then incr errors
+  done ;
+  if !errors = 0 then Pass else Mismatch !errors
+
+let run_binary (dev : Device.t) spec =
+  let ir = make_binary_ir spec.b_name in
+  let a_vec = Vector.create Vector.float64 n in
+  let b_vec = Vector.create Vector.float64 n in
+  let c_vec = Vector.create Vector.float64 n in
+  for i = 0 to n - 1 do
+    let x, y = spec.b_gen i in
+    Vector.set a_vec i x ;
+    Vector.set b_vec i y ;
+    Vector.set c_vec i 0.0
+  done ;
+  let block = Execute.dims1d 256 in
+  let grid = Execute.dims1d 1 in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Execute.Vec a_vec; Execute.Vec b_vec; Execute.Vec c_vec]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let result = Vector.to_array c_vec in
+  let errors = ref 0 in
+  for i = 0 to n - 1 do
+    let x, y = spec.b_gen i in
+    let expected = spec.b_ocaml x y in
+    if abs_float (result.(i) -. expected) > spec.b_tol then incr errors
+  done ;
+  if !errors = 0 then Pass else Mismatch !errors
+
+let outcome_of_exn f =
+  try f () with
+  | Spoc_framework.Backend_error.Backend_error err ->
+      Skipped (Spoc_framework.Backend_error.to_string err)
+  | e -> Errored (Printexc.to_string e)
+
+let string_of_outcome = function
+  | Pass -> "PASS"
+  | Mismatch n -> Printf.sprintf "FAIL (%d/%d mismatched)" n n
+  | Skipped reason -> Printf.sprintf "SKIP (%s)" reason
+  | Errored reason -> Printf.sprintf "ERROR (%s)" reason
+
+let () =
+  let cfg = Test_helpers.parse_args "test_float64_math_intrinsics" in
+  let devs = Test_helpers.init_devices cfg in
+  let fp64_devs = Array.to_list devs |> List.filter Device.allows_fp64 in
+  print_endline
+    "=== Float64 Math Intrinsics Report (all fp64-capable devices) ===" ;
+  Printf.printf
+    "fp64-capable devices: %d / %d total\n\n"
+    (List.length fp64_devs)
+    (Array.length devs) ;
+  if fp64_devs = [] then
+    print_endline
+      "No fp64-capable device found - nothing to report (not a failure)."
+  else begin
+    let results = ref [] in
+    List.iter
+      (fun (dev : Device.t) ->
+        Printf.printf "-- %s (%s) --\n" dev.Device.name dev.Device.framework ;
+        List.iter
+          (fun spec ->
+            let outcome = outcome_of_exn (fun () -> run_unary dev spec) in
+            Printf.printf
+              "  %-12s %s\n%!"
+              spec.u_name
+              (string_of_outcome outcome) ;
+            results := (dev, spec.u_name, outcome) :: !results)
+          unary_specs ;
+        List.iter
+          (fun spec ->
+            let outcome = outcome_of_exn (fun () -> run_binary dev spec) in
+            Printf.printf
+              "  %-12s %s\n%!"
+              spec.b_name
+              (string_of_outcome outcome) ;
+            results := (dev, spec.b_name, outcome) :: !results)
+          binary_specs)
+      fp64_devs ;
+    let total = List.length !results in
+    let passed =
+      List.length (List.filter (fun (_, _, o) -> o = Pass) !results)
+    in
+    Printf.printf
+      "\n=== Summary: %d/%d (device, function) combinations passed ===\n"
+      passed
+      total ;
+    Printf.printf
+      "This is a report, not a gate: individual failures above do not fail \
+       this test or block CI.\n"
+  end ;
+  exit 0

--- a/spoc/ir/Sarek_pure_registry.ml
+++ b/spoc/ir/Sarek_pure_registry.ml
@@ -41,12 +41,38 @@ let fun_device_template ?(module_path = []) name =
  * Helpers
  ******************************************************************************)
 
+(** GLSL has no [fabs]/[rsqrt]/[atan2] builtins: it spells them [abs],
+    [inversesqrt], and the two-argument [atan] overload respectively. Every
+    other backend (CUDA, OpenCL, Metal, WGSL) uses the OpenCL-style generic name
+    directly, so this override only applies when [framework = "GLSL"]. *)
+let glsl_override_name = function
+  | "fabs" | "abs_float" -> Some "abs"
+  | "rsqrt" -> Some "inversesqrt"
+  | "atan2" -> Some "atan"
+  | _ -> None
+
+let glsl_name ~name ~generic_name =
+  match glsl_override_name name with Some g -> g | None -> generic_name
+
 (** Build a framework-dispatching closure for float32 math functions. CUDA uses
-    the [f]-suffixed form (sinf, cosf, …); OpenCL, Metal, and GLSL use the
-    un-suffixed form. *)
-let float32_math_template ~cuda_name ~generic_name =
+    the [f]-suffixed form (sinf, cosf, …); OpenCL and Metal use the un-suffixed
+    form; GLSL uses the un-suffixed form except where its builtin is spelled
+    differently (see [glsl_override_name]). *)
+let float32_math_template ~name ~cuda_name ~generic_name =
  fun ~framework ->
-  match framework with "CUDA" -> cuda_name | _ -> generic_name
+  match framework with
+  | "CUDA" -> cuda_name
+  | "GLSL" -> glsl_name ~name ~generic_name
+  | _ -> generic_name
+
+(** Same as [float32_math_template] but for functions spelled identically on
+    every backend except GLSL (e.g. Float64 math, which has no CUDA [f]-suffix).
+*)
+let generic_math_template name =
+ fun ~framework ->
+  match framework with
+  | "GLSL" -> glsl_name ~name ~generic_name:name
+  | _ -> name
 
 (******************************************************************************
  * Standard stdlib registrations (static table — PR-2 design)
@@ -71,7 +97,7 @@ let () =
     register_fun
       ~module_path:["Float32"]
       name
-      ~device:(float32_math_template ~cuda_name ~generic_name)
+      ~device:(float32_math_template ~name ~cuda_name ~generic_name)
   in
   reg32 "sin" "sinf" "sin" ;
   reg32 "cos" "cosf" "cos" ;
@@ -142,7 +168,7 @@ let () =
     register_fun
       ~module_path:["Math"; "Float32"]
       name
-      ~device:(float32_math_template ~cuda_name ~generic_name)
+      ~device:(float32_math_template ~name ~cuda_name ~generic_name)
   in
   reg_math32 "sin" "sinf" "sin" ;
   reg_math32 "cos" "cosf" "cos" ;
@@ -181,7 +207,7 @@ let () =
     register_fun
       ~module_path:["Math"; "Float64"]
       name
-      ~device:(fun ~framework:_ -> name)
+      ~device:(generic_math_template name)
   in
   reg_math64 "sin" ;
   reg_math64 "cos" ;
@@ -217,7 +243,7 @@ let () =
     register_fun
       ~module_path:["Sarek_stdlib_meta"; "Float32"]
       name
-      ~device:(float32_math_template ~cuda_name ~generic_name)
+      ~device:(float32_math_template ~name ~cuda_name ~generic_name)
   in
   reg32m "sin" "sinf" "sin" ;
   reg32m "cos" "cosf" "cos" ;
@@ -256,7 +282,7 @@ let () =
     register_fun
       ~module_path:["Sarek_stdlib_meta"; "Float64"]
       name
-      ~device:(fun ~framework:_ -> name)
+      ~device:(generic_math_template name)
   in
   reg64m "sin" ;
   reg64m "cos" ;
@@ -292,7 +318,7 @@ let () =
     register_fun
       ~module_path:["Sarek_stdlib_meta"; "Math"; "Float32"]
       name
-      ~device:(float32_math_template ~cuda_name ~generic_name)
+      ~device:(float32_math_template ~name ~cuda_name ~generic_name)
   in
   reg_meta_math32 "sin" "sinf" "sin" ;
   reg_meta_math32 "cos" "cosf" "cos" ;
@@ -331,7 +357,7 @@ let () =
     register_fun
       ~module_path:["Sarek_stdlib_meta"; "Math"; "Float64"]
       name
-      ~device:(fun ~framework:_ -> name)
+      ~device:(generic_math_template name)
   in
   reg_meta_math64 "sin" ;
   reg_meta_math64 "cos" ;


### PR DESCRIPTION
## Summary

- `Sarek_pure_registry` was using OpenCL-style generic names for path-qualified `Float32`/`Float64` math intrinsics regardless of target framework. GLSL has no `fabs`/`rsqrt`/`atan2` builtins (it uses `abs`/`inversesqrt`/`atan`), so kernels calling `Float32.rsqrt` etc. failed to compile as Vulkan shaders. Fixed by making the registry's GLSL branch rename these.
- `cbrt`/`hypot`/`expm1`/`log1p` have no builtin under any name in GLSL or MSL (verified directly against both specs). These need multi-token expression polyfills, not a rename. `gen_intrinsic` in `Sarek_ir_glsl.ml` and `Sarek_ir_metal.ml` now special-cases these four ahead of the pure-registry lookup, so the fix applies to both path-qualified and unqualified calls. Also removes a latent bug where Metal's codegen assumed `cbrt` was a native MSL builtin (it isn't).
- Adds `sarek/tests/e2e/test_float64_math_intrinsics.ml`: runs every Float64 math intrinsic across every fp64-capable device found and reports pass/fail per (device, function) combination without failing the whole suite or blocking CI — a report, not a gate.

## Test plan

- [x] `dune build` passes
- [x] `dune exec sarek/tests/codegen_golden/test_codegen_golden.exe` — 37/37 tests pass (added regression coverage for `rsqrt`/`abs_float`/`atan2`/`cbrt`/`hypot`/`expm1`/`log1p` on GLSL and Metal; confirmed each new test failed against pre-fix code, then passed post-fix)
- [x] `dune exec sarek/tests/e2e/test_float32_sin_pure.exe -- --vulkan` — passes on real AMD RX 7900 XTX hardware over Vulkan
- [x] `dune exec sarek/tests/e2e/test_float64_math_intrinsics.exe` — runs on real hardware, report-only, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)