### PR TITLE
ci: fail PRs that target the stale master branch

### DIFF
--- a/.github/workflows/block-master-prs.yml
+++ b/.github/workflows/block-master-prs.yml
@@ -1,0 +1,16 @@
+# Guard: 'master' is a stale legacy branch (diverged from 'main' in 2019).
+# Several PRs silently targeted it via stale local origin/HEAD symrefs
+# (see PRs #201/#202/#205/#206, reconciled onto main via #199/#208/#209).
+# This check makes that failure mode loud instead of silent.
+name: Block PRs targeting master
+on:
+  pull_request:
+    branches: [master]
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::This PR targets 'master', a stale legacy branch. The default branch is 'main'."
+          echo "::error::Retarget with: gh pr edit ${{ github.event.pull_request.number }} --base main (or the 'Edit' button next to the base branch)."
+          exit 1


### PR DESCRIPTION
## Summary

Adds a guard workflow that fails any PR whose base is `master`, with a clear error message and retargeting instructions.

**Why:** `master` diverged from `main` in 2019 and silently became the target of several recent PRs (#201/#202/#205/#206) via stale local `origin/HEAD` symrefs. Their content has now been reconciled onto `main` (#199 merged, #208/#209 open). This makes any recurrence loud instead of silent.

- Triggers **only** on `pull_request` with base `master` — PRs targeting `main` (including the in-flight reconciliation PRs #208/#209) never run it.
- Explicitly human-approved per the repo's escalation rules on CI modifications (spec `specs/main-master-reconcile.md`, AC-10/AC-11).

## Test plan

- [x] Workflow YAML lints (actionlint-clean structure, no external deps)
- [ ] After merge: a test PR with base `master` shows the failing check; a PR with base `main` shows no such check

🤖 Generated with [Claude Code](https://claude.com/claude-code)