### PR TITLE
fix: semantic-correctness batch from the 2026-07-02 whole-tree audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_convention_kernel_fail.cma > "$$out" 2>&1; if grep -q "Unbound record field.*Geometry_lib\.z" "$$out"; then echo "  PASS: convention kernel field not found"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing warp collective in diverged control flow..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_warp_diverged.cma > "$$out" 2>&1; if grep -q "Warp collective 'warp_shuffle' called in diverged control flow" "$$out"; then echo "  PASS: warp diverged"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing tuple-typed kernel parameter rejection..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tuple_param.cma > "$$out" 2>&1; if grep -q "Tuple-typed kernel parameters are not supported" "$$out"; then echo "  PASS: tuple param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing function-typed kernel parameter rejection..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_param.cma > "$$out" 2>&1; if grep -q "Function-typed kernel parameters are not supported" "$$out"; then echo "  PASS: function param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "All negative tests checked (see KNOWN-ISSUE line above for the one non-blocking gap, if any)"
 
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ clean:
 opam:
 	dune build @install
 
+# Guard against a "make opam" regression (see scripts/check-opam-clean.sh)
+check-opam-clean:
+	./scripts/check-opam-clean.sh
+
 install: opam
 	dune install
 
@@ -149,7 +153,7 @@ test_sarek_core:
 	@echo "=== Sarek core tests passed ==="
 
 # Run all tests: unit tests, e2e tests, negative tests, and spoc tests
-test-all: test test_spoc test_sarek_core test_interpreter test_negative
+test-all: test test_spoc test_sarek_core test_interpreter test_negative check-opam-clean
 	@echo "=== All tests passed ==="
 
 # E2E tests - quick verification with small datasets comparing GPU vs native CPU

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,6 @@ clean:
 
 opam:
 	dune build @install
-	echo 'available: [ os = "linux" ]'  >> sarek.opam
-	echo 'available: [ os = "linux" ]'  >> sarek_ppx.opam
-
 
 install: opam
 	dune install

--- a/benchmarks/descriptions/generated/radix_sort_histogram_generated.md
+++ b/benchmarks/descriptions/generated/radix_sort_histogram_generated.md
@@ -21,7 +21,7 @@ __global__ void sarek_kern(int* __restrict__ input, int sarek_input_length, int*
   {
     if ((gid < n)) {
       int value = input[gid];
-      int digit = ((value >> shift) & mask);
+      int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
       int _old = atomicAdd(&local_hist[digit], 1);
     }
   }
@@ -53,7 +53,7 @@ __kernel void sarek_kern(__global int* restrict input, int sarek_input_length, _
   {
     if ((gid < n)) {
       int value = input[gid];
-      int digit = ((value >> shift) & mask);
+      int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
       int _old = atomic_add(&local_hist[digit], 1);
     }
   }
@@ -111,7 +111,7 @@ void main() {
   {
     if ((gid < n)) {
       int value = inputv[gid];
-      int digit = ((value >> shift) & mask);
+      int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
       int _old = atomicAdd(local_hist[digit], 1);
     }
   }
@@ -150,7 +150,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   {
     if ((gid < n)) {
       int value = input[gid];
-      int digit = ((value >> shift) & mask);
+      int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
       int _old = atomic_fetch_add_explicit((volatile threadgroup atomic_int*)&local_hist[digit], 1, memory_order_relaxed);
     }
   }

--- a/benchmarks/descriptions/generated/radix_sort_scatter_generated.md
+++ b/benchmarks/descriptions/generated/radix_sort_scatter_generated.md
@@ -11,7 +11,7 @@ __global__ void sarek_kern(int* __restrict__ input, int sarek_input_length, int*
   int gid = (threadIdx.x + blockIdx.x * blockDim.x);
   if ((gid < n)) {
     int value = input[gid];
-    int digit = ((value >> shift) & mask);
+    int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
     int pos = atomicAdd(&counters[digit], 1);
     output[pos] = value;
   }
@@ -26,7 +26,7 @@ __kernel void sarek_kern(__global int* restrict input, int sarek_input_length, _
   int gid = get_global_id(0);
   if ((gid < n)) {
     int value = input[gid];
-    int digit = ((value >> shift) & mask);
+    int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
     int pos = atomic_add(&counters[digit], 1);
     output[pos] = value;
   }
@@ -70,7 +70,7 @@ void main() {
   int gid = int(gl_GlobalInvocationID.x);
   if ((gid < n)) {
     int value = inputv[gid];
-    int digit = ((value >> shift) & mask);
+    int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
     int pos = atomicAdd(counters[digit], 1);
     outputv[pos] = value;
   }
@@ -92,7 +92,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int gid = __metal_gid.x;
   if ((gid < n)) {
     int value = input[gid];
-    int digit = ((value >> shift) & mask);
+    int digit = (((shift == 0) ? value : ((value >> shift) ^ ((value >> 31) << ((32 - shift) & 31)))) & mask);
     int pos = atomic_fetch_add_explicit((volatile device atomic_int*)&counters[digit], 1, memory_order_relaxed);
     output[pos] = value;
   }

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -300,8 +300,19 @@ and emit_binop buf alloc env op e1 e2 : string =
       emit buf "shl.b32 %s, %s, %s;" r r1 r2 ;
       r
   | Shr ->
+      (* Arithmetic (sign-extending) shift: Ir.Shr is arithmetic on every
+         backend (CUDA/OpenCL/Metal/GLSL/WGSL emit plain [>>] on a signed
+         int type; the interpreter uses Int32.shift_right). [lsr] is lowered
+         to a separate expression tree in Sarek_lower_ir.ml precisely
+         because this node is arithmetic - see G phase 1 in
+         briefs/fix-critical-semantics-evidence.md. Formal spec note:
+         formal/codegen-ptx/theories/PtxTypes.v models Shr as a logical
+         Nat.shiftr on U32; that model was written against the old (wrong)
+         shr.u32 emission and is now out of sync with this fix. formal/ is
+         out of scope for this task - flagged for the formal-verification
+         owner. *)
       let r = new_u32 alloc in
-      emit buf "shr.u32 %s, %s, %s;" r r1 r2 ;
+      emit buf "shr.s32 %s, %s, %s;" r r1 r2 ;
       r
   | BitAnd ->
       let r = new_u32 alloc in

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -243,7 +243,14 @@ let eval_binop op v1 v2 =
   | And -> VBool (to_bool v1 && to_bool v2)
   | Or -> VBool (to_bool v1 || to_bool v2)
   | Shl -> VInt32 (Int32.shift_left (to_int32 v1) (to_int v2))
-  | Shr -> VInt32 (Int32.shift_right_logical (to_int32 v1) (to_int v2))
+  | Shr ->
+      (* Arithmetic (sign-extending) shift, matching every codegen backend:
+         CUDA/OpenCL/Metal/GLSL/WGSL emit plain [>>] on a signed int type,
+         and PTX emits shr.s32. [lsr] is lowered to a separate expression
+         tree in Sarek_lower_ir.ml precisely because this node is
+         arithmetic - see G phase 1 in
+         briefs/fix-critical-semantics-evidence.md. *)
+      VInt32 (Int32.shift_right (to_int32 v1) (to_int v2))
   | BitAnd -> VInt32 (Int32.logand (to_int32 v1) (to_int32 v2))
   | BitOr -> VInt32 (Int32.logor (to_int32 v1) (to_int32 v2))
   | BitXor -> VInt32 (Int32.logxor (to_int32 v1) (to_int32 v2))

--- a/sarek/ppx/Sarek_lower.ml
+++ b/sarek/ppx/Sarek_lower.ml
@@ -378,15 +378,19 @@ let rec lower_expr (state : state) (te : texpr) : Kirc_Ast.k_ext =
           let else_ir = lower_expr state else_e in
           Kirc_Ast.Ife (cond_ir, then_ir, else_ir))
   (* For loop *)
-  | TEFor (var, id, lo, hi, dir, body) ->
-      let lo_ir = lower_expr state lo in
-      let hi_ir = lower_expr state hi in
-      let var_ir = lower_ref id var te.ty in
-      let body_ir = lower_expr state body in
-      (* DoLoop takes: var, start, end, body *)
-      (* For downto, we need to handle differently - for now assume upto *)
-      let _ = dir in
-      Kirc_Ast.DoLoop (var_ir, lo_ir, hi_ir, body_ir)
+  | TEFor (var, id, lo, hi, dir, body) -> (
+      match dir with
+      | Sarek_ast.Downto ->
+          Location.raise_errorf
+            ~loc:(Sarek_ast.loc_to_ppxlib te.te_loc)
+            "downto is not supported by the legacy lowering path"
+      | Sarek_ast.Upto ->
+          let lo_ir = lower_expr state lo in
+          let hi_ir = lower_expr state hi in
+          let var_ir = lower_ref id var te.ty in
+          let body_ir = lower_expr state body in
+          (* DoLoop takes: var, start, end, body *)
+          Kirc_Ast.DoLoop (var_ir, lo_ir, hi_ir, body_ir))
   (* While loop *)
   | TEWhile (cond, body) ->
       let cond_ir = lower_expr state cond in

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -49,6 +49,16 @@ let rec elttype_of_typ (ty : typ) : Ir.elttype =
               ( n,
                 match ty_opt with None -> [] | Some ty -> [elttype_of_typ ty] ))
             constrs )
+  (* NOTE: TTuple/TFun are NOT rejected here even though this is where the
+     original bug report pointed. This function converts the type of *any*
+     typed value reachable during lowering, including local/helper function
+     bindings inside a kernel body (e.g. `let make_p x y z = ... in ...`,
+     see test_visibility_private.ml, test_transpose.ml, bench_nbody.ml) -
+     those legitimately have TFun type and must keep lowering (their
+     "elttype" is a don't-care placeholder, never actually used as data).
+     The real defect is kernel *parameters* of tuple/function type, which
+     are rejected explicitly in lower_param below, at the point where a
+     type is about to become a formal parameter. *)
   | TTuple _ -> Ir.TInt32
   | TFun _ -> Ir.TInt32
   | TVar _ ->
@@ -580,6 +590,17 @@ and extract_pattern_vars (pat : tpattern) : string list =
 
 (** Convert a kernel parameter to IR declaration *)
 let lower_param (p : tparam) : Ir.decl =
+  (match repr p.tparam_type with
+  | TTuple _ ->
+      Ppxlib.Location.raise_errorf
+        ~loc:Ppxlib.Location.none
+        "Tuple-typed kernel parameters are not supported; pass components as \
+         separate parameters."
+  | TFun _ ->
+      Ppxlib.Location.raise_errorf
+        ~loc:Ppxlib.Location.none
+        "Function-typed kernel parameters are not supported."
+  | _ -> ()) ;
   let elt = elttype_of_typ p.tparam_type in
   let v =
     {

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -230,8 +230,15 @@ let ir_binop (op : binop) (_ty : typ) : Ir.binop =
   | And -> Ir.And
   | Or -> Ir.Or
   | Lsl -> Ir.Shl
-  | Lsr -> Ir.Shr
-  | Asr -> Ir.Shr
+  | Lsr ->
+      (* Never reached: TEBinop (Lsr, _, _) is intercepted in lower_expr
+         and rewritten via lower_lsr into a logical-shift expression tree,
+         because Ir.Shr is arithmetic on every backend (see
+         briefs/fix-critical-semantics-evidence.md, G phase 1). Kept here
+         so this match stays a total, honest structural map of
+         Sarek_ast.binop. *)
+      Ir.Shr
+  | Asr -> Ir.Shr (* arithmetic shift; Ir.Shr is arithmetic on every backend *)
   | Land -> Ir.BitAnd
   | Lor -> Ir.BitOr
   | Lxor -> Ir.BitXor
@@ -285,6 +292,45 @@ let rec make_returning stmt =
       Ir.SSeq [stmt; Ir.SReturn (Ir.EConst Ir.CUnit)]
   | Ir.SBlock body -> Ir.SBlock (make_returning body)
 
+(** Lower [a lsr b] (logical/unsigned right shift) to an IR expression tree
+    built only from existing IR nodes.
+
+    Ir.Shr is emitted as an *arithmetic* (sign-extending) shift by every
+    consumer (CUDA/OpenCL/Metal/GLSL/WGSL emit plain [>>] on a signed C/GLSL int
+    type; PTX and the interpreter use [shr.s32]/[Int32.shift_right] - see G
+    phase 1 in briefs/fix-critical-semantics-evidence.md). There is no IR node
+    for a logical shift and none may be added (formal/codegen-ptx models [Shr]
+    itself), so [lsr] is expressed via the classic arithmetic-shift identity,
+    width-aware via [width_bits]:
+
+    {[
+      lshr (a, n)
+      =
+      if n = 0 then a else ashr (a, n) lxor (ashr (a, width - 1) lsl (width - n))
+    ]}
+
+    [ashr(a, width-1)] is all-1s when [a] is negative and all-0s otherwise;
+    shifted left by [width - n] it isolates exactly the [n] sign-extended bits
+    that [ashr(a, n)] filled in, and XOR-ing them off recovers the zero-filled
+    logical shift. The [n = 0] guard avoids shifting by [width] (undefined
+    behaviour on the C-family backends). Shift amounts with [n < 0] or
+    [n >= width] are unspecified, matching the pre-existing behaviour of
+    [Shl]/[Shr] on out-of-range counts. *)
+let lower_lsr (a_ir : Ir.expr) (b_ir : Ir.expr) (ty : Ir.elttype) : Ir.expr =
+  let width_bits = match ty with Ir.TInt64 -> 64 | _ -> 32 in
+  let const n =
+    match ty with
+    | Ir.TInt64 -> Ir.EConst (Ir.CInt64 (Int64.of_int n))
+    | _ -> Ir.EConst (Ir.CInt32 (Int32.of_int n))
+  in
+  let sign_fill = Ir.EBinop (Ir.Shr, a_ir, const (width_bits - 1)) in
+  let top_bits =
+    Ir.EBinop (Ir.Shl, sign_fill, Ir.EBinop (Ir.Sub, const width_bits, b_ir))
+  in
+  let arith_shift = Ir.EBinop (Ir.Shr, a_ir, b_ir) in
+  let logical_shift = Ir.EBinop (Ir.BitXor, arith_shift, top_bits) in
+  Ir.EIf (Ir.EBinop (Ir.Eq, b_ir, const 0), a_ir, logical_shift)
+
 (** Convert a typed expression to IR expression *)
 let rec lower_expr (state : state) (te : texpr) : Ir.expr =
   incr ir_lower_expr_count ;
@@ -318,6 +364,8 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
       | TEVar (name, _) -> Ir.EArrayRead (name, lower_expr state idx)
       | _ -> Ir.EArrayReadExpr (lower_expr state arr, lower_expr state idx))
   | TEFieldGet (r, field, _) -> Ir.ERecordField (lower_expr state r, field)
+  | TEBinop (Lsr, a, b) ->
+      lower_lsr (lower_expr state a) (lower_expr state b) (elttype_of_typ te.ty)
   | TEBinop (op, a, b) ->
       Ir.EBinop (ir_binop op te.ty, lower_expr state a, lower_expr state b)
   | TEUnop (op, a) -> Ir.EUnop (ir_unop op, lower_expr state a)

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -292,6 +292,12 @@ let rec make_returning stmt =
       Ir.SSeq [stmt; Ir.SReturn (Ir.EConst Ir.CUnit)]
   | Ir.SBlock body -> Ir.SBlock (make_returning body)
 
+(** [true] iff [e] is a syntactically trivial IR expression ([EVar] or
+    [EConst]). Trivial expressions have no side effects, so duplicating them in
+    the tree built by {!lower_lsr} is semantically inert. *)
+let is_trivial_ir_expr (e : Ir.expr) : bool =
+  match e with Ir.EVar _ | Ir.EConst _ -> true | _ -> false
+
 (** Lower [a lsr b] (logical/unsigned right shift) to an IR expression tree
     built only from existing IR nodes.
 
@@ -306,17 +312,60 @@ let rec make_returning stmt =
     {[
       lshr (a, n)
       =
-      if n = 0 then a else ashr (a, n) lxor (ashr (a, width - 1) lsl (width - n))
+      if n = 0 then a
+      else
+        ashr (a, n) lxor (ashr (a, width - 1) lsl ((width - n) land (width - 1)))
     ]}
 
     [ashr(a, width-1)] is all-1s when [a] is negative and all-0s otherwise;
-    shifted left by [width - n] it isolates exactly the [n] sign-extended bits
+    shifted left by [(width - n) land (width - 1)] (equal to [width - n] for
+    every [n] in [1..width-1]) it isolates exactly the [n] sign-extended bits
     that [ashr(a, n)] filled in, and XOR-ing them off recovers the zero-filled
-    logical shift. The [n = 0] guard avoids shifting by [width] (undefined
-    behaviour on the C-family backends). Shift amounts with [n < 0] or
+    logical shift.
+
+    {b Why the [land (width - 1)] mask, not just an [n = 0] guard.} PTX's [selp]
+    and WGSL's [select()] (see [Sarek_ir_ptx_expr.ml] and [Sarek_ir_wgsl.ml])
+    evaluate BOTH branches of the resulting [EIf] before selecting one - the
+    [EIf] only picks which *value* is used, it does not skip *computing* the
+    other branch's subexpressions on those backends. So even though the
+    then-branch ([a_ir]) is selected when [n = 0], the else-branch's internal
+    [Sub(width_bits, b_ir)] is still evaluated, and without masking it would be
+    exactly [width_bits] (shift-by-32/64), which is undefined/rejected on some
+    backends. Masking with [width_bits - 1] keeps that shift count in
+    [0..width_bits-1] for every [n], including [n = 0] (where it reduces to a
+    well-defined shift-by-0, unused anyway since the [EIf] selects [a_ir]),
+    while leaving the result unchanged for [n] in [1..width_bits-1] (masking a
+    value already in range is a no-op). Shift amounts with [n < 0] or
     [n >= width] are unspecified, matching the pre-existing behaviour of
-    [Shl]/[Shr] on out-of-range counts. *)
-let lower_lsr (a_ir : Ir.expr) (b_ir : Ir.expr) (ty : Ir.elttype) : Ir.expr =
+    [Shl]/[Shr] on out-of-range counts.
+
+    {b Duplication / side-effect safety.} [a_ir] and [b_ir] each appear three
+    times in the tree above (in [sign_fill], in [arith_shift]/[top_bits], and in
+    the final [EIf]'s branches/condition). [Sarek_ir_ppx.expr] is documented as
+    "pure, no side effects" and has no let-binding form (only [Ir.stmt]'s
+    [SLet]/[SLetMut] bind values, and those wrap a *statement* continuation, not
+    an expression one) - so there is no way to evaluate a subexpression once and
+    reuse the result across multiple expression positions. Hoisting via a
+    synthetic [EApp] call (which would single-evaluate its arguments) is not
+    viable either: PTX - the backend this rewrite specifically targets - does
+    not implement device function calls ([Sarek_ir_ptx_expr.ml] rejects [EApp]
+    outright). Consequently, if [a_ir] or [b_ir] is *not* trivial (e.g. it
+    embeds an [EIntrinsic] atomic call), this tree would silently evaluate that
+    operand's side effect multiple times. Rather than accept that, this function
+    restricts the rewrite to trivial operands ([EVar]/[EConst], see
+    {!is_trivial_ir_expr}) and raises a located PPX error for every other case,
+    directing the user to hoist the operand into a `let` before the shift. This
+    tree is NOT safe for arbitrary operands - only for trivial ones. *)
+let lower_lsr ~(loc : Ppxlib.Location.t) (a_ir : Ir.expr) (b_ir : Ir.expr)
+    (ty : Ir.elttype) : Ir.expr =
+  if not (is_trivial_ir_expr a_ir && is_trivial_ir_expr b_ir) then
+    Ppxlib.Location.raise_errorf
+      ~loc
+      "lsr: this logical-shift operand is not a plain variable or constant. \
+       Sarek_ir_ppx.expr has no let-binding form, so the lsr expansion would \
+       evaluate this operand multiple times, silently duplicating any side \
+       effect it contains (e.g. an atomic intrinsic call). Bind it to a local \
+       variable first and retry, e.g. `let x = <expr> in x lsr n`." ;
   let width_bits = match ty with Ir.TInt64 -> 64 | _ -> 32 in
   let const n =
     match ty with
@@ -324,9 +373,13 @@ let lower_lsr (a_ir : Ir.expr) (b_ir : Ir.expr) (ty : Ir.elttype) : Ir.expr =
     | _ -> Ir.EConst (Ir.CInt32 (Int32.of_int n))
   in
   let sign_fill = Ir.EBinop (Ir.Shr, a_ir, const (width_bits - 1)) in
-  let top_bits =
-    Ir.EBinop (Ir.Shl, sign_fill, Ir.EBinop (Ir.Sub, const width_bits, b_ir))
+  let shift_count =
+    Ir.EBinop
+      ( Ir.BitAnd,
+        Ir.EBinop (Ir.Sub, const width_bits, b_ir),
+        const (width_bits - 1) )
   in
+  let top_bits = Ir.EBinop (Ir.Shl, sign_fill, shift_count) in
   let arith_shift = Ir.EBinop (Ir.Shr, a_ir, b_ir) in
   let logical_shift = Ir.EBinop (Ir.BitXor, arith_shift, top_bits) in
   Ir.EIf (Ir.EBinop (Ir.Eq, b_ir, const 0), a_ir, logical_shift)
@@ -365,7 +418,11 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
       | _ -> Ir.EArrayReadExpr (lower_expr state arr, lower_expr state idx))
   | TEFieldGet (r, field, _) -> Ir.ERecordField (lower_expr state r, field)
   | TEBinop (Lsr, a, b) ->
-      lower_lsr (lower_expr state a) (lower_expr state b) (elttype_of_typ te.ty)
+      lower_lsr
+        ~loc:(Sarek_ast.loc_to_ppxlib te.te_loc)
+        (lower_expr state a)
+        (lower_expr state b)
+        (elttype_of_typ te.ty)
   | TEBinop (op, a, b) ->
       Ir.EBinop (ir_binop op te.ty, lower_expr state a, lower_expr state b)
   | TEUnop (op, a) -> Ir.EUnop (ir_unop op, lower_expr state a)

--- a/sarek/ppx/Sarek_native_gen_expr.ml
+++ b/sarek/ppx/Sarek_native_gen_expr.ml
@@ -199,10 +199,13 @@ let gen_control_flow ~loc ~gen_expr (te : texpr) : expression =
               [%e wrapped_body]
             done]
       | Sarek_ast.Downto ->
+          (* The parser stores `for i = start downto stop` positionally as
+             (lo, hi) = (start, stop) (see Sarek_parse.ml, Pexp_for handling),
+             so the OCaml `downto` loop must run from lo to hi, not hi to lo. *)
           [%expr
             for
-              [%p int_var_pat] = Int32.to_int [%e hi_e]
-              downto Int32.to_int [%e lo_e]
+              [%p int_var_pat] = Int32.to_int [%e lo_e]
+              downto Int32.to_int [%e hi_e]
             do
               [%e wrapped_body]
             done])
@@ -329,9 +332,11 @@ let gen_data_structure ~loc ~ctx ~gen_expr (te : texpr) : expression =
       Ast_builder.Default.pexp_tuple ~loc exprs_e
   (* Create local array - use regular OCaml arrays for native mode *)
   | TECreateArray (size, elem_ty, _memspace) ->
+      (* [size] is a Sarek int32-typed expression; Array.make expects an
+         OCaml int, so convert like the for-loop bounds do (see :196-208). *)
       let size_e = gen_expr ~loc size in
       let default_e = default_value_for_type ~loc elem_ty in
-      [%expr Array.make [%e size_e] [%e default_e]]
+      [%expr Array.make (Int32.to_int [%e size_e]) [%e default_e]]
   | _ -> failwith "gen_data_structure: not a data structure expression"
 
 (** Generate special expressions (return, global ref, native, pragma, open) *)

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -219,8 +219,41 @@ let register_sarek_module_item ~loc:_ item =
   registered_mods := item :: !registered_mods
 
 (** Scan a single .ml file for [@@sarek.type] and [@sarek.module] declarations
-*)
-let scan_file_for_sarek_types path =
+    and register them as a side effect (see [register_sarek_type_decl],
+    [register_sarek_module_item]).
+
+    This is a best-effort scan of a file that may be *different* from the one
+    currently being compiled (e.g. a co-located file scanned implicitly by
+    [expand_kernel], or an explicit [%sarek_include] target) - a failure here
+    (unreadable file, parse error, or a downstream registration error triggered
+    by malformed [@sarek.*] content in the scanned file) must not silently
+    vanish, but it also must not abort compilation of the file that triggered
+    the scan. The whole scan (read + parse + per-declaration registration) is
+    wrapped in one handler on purpose: every exception it can raise originates
+    from processing the *scanned* file's content, so a malformed registration
+    deep inside a well-parsed file is exactly as much "this file's problem" as a
+    read or parse failure - narrowing the try to only the read/parse steps would
+    just move the same silent swallow one level down instead of fixing it.
+
+    On failure, prints a diagnostic naming the scanned file and the exception to
+    stderr via [Printf.eprintf] and returns [Some diagnostic] (the returned
+    value lets callers/tests inspect the exact message; the printed side effect
+    is what makes the failure visible during a real build). Returns [None] on
+    success.
+
+    Mechanism choice: an [@ocaml.ppwarning] attribute (surfaced as OCaml warning
+    22) was tried first and rejected - this project's dune default ("dev")
+    profile promotes warning 22 to a hard error (dune's default warning flags
+    treat warnings 5 through 28 as fatal), so attaching it here would turn "a
+    sibling file failed to scan" into a build failure for the *current* file,
+    which is exactly the "compilation must still succeed" property this fix is
+    required to preserve. A ppxlib driver-level diagnostic reduces to the same
+    ppwarning-attribute mechanism under the hood (see [Ppxlib.Driver]'s own
+    lint-error-to-attribute conversion) and has the same fatality problem. Plain
+    stderr output has no interaction with the warning/error machinery, so it is
+    the only one of the three ranked options that is testable while satisfying
+    "the build succeeds". *)
+let scan_file_for_sarek_types path : string option =
   try
     let ic = open_in path in
     let lexbuf = Lexing.from_channel ic in
@@ -315,20 +348,32 @@ let scan_file_for_sarek_types path =
                        ~item)))
               vbs
         | _ -> ())
-      st
-  with _ -> ()
+      st ;
+    None
+  with e ->
+    let msg =
+      Printf.sprintf
+        "Sarek PPX: scanning %s for [@sarek.*] declarations failed (%s); \
+         skipping this file's Sarek registrations."
+        path
+        (Printexc.to_string e)
+    in
+    Printf.eprintf "%s\n%!" msg ;
+    Some msg
 
 (** Scan a directory for .ml files with Sarek declarations, or scan a single
-    file *)
+    file. Not currently invoked (dead code, pre-existing - flagged, not removed:
+    out of scope for this change); return values are discarded here since there
+    is no caller to surface a diagnostic to. *)
 let scan_dir_for_sarek_types ?single_file directory =
   match single_file with
-  | Some path -> scan_file_for_sarek_types path
+  | Some path -> ignore (scan_file_for_sarek_types path : string option)
   | None ->
       Array.iter
         (fun fname ->
           if Filename.check_suffix fname ".ml" then
             let path = Filename.concat directory fname in
-            scan_file_for_sarek_types path)
+            ignore (scan_file_for_sarek_types path : string option))
         (try Sys.readdir directory with Sys_error _ -> [||])
 
 (* Attribute used to mark Sarek-visible type declarations *)
@@ -1424,7 +1469,11 @@ let expand_kernel ~ctxt payload : expression =
        This is needed because the impl pass (process_structure_for_module_items)
        runs AFTER extensions are expanded, so we need to scan now. *)
     let current_file = loc.loc_start.pos_fname in
-    if Sys.file_exists current_file then scan_file_for_sarek_types current_file ;
+    (* scan_file_for_sarek_types never raises (see its doc comment); a scan
+       failure is reported via eprintf as a side effect, so its return value
+       is not needed here. *)
+    if Sys.file_exists current_file then
+      ignore (scan_file_for_sarek_types current_file : string option) ;
     (* Types and module items registered in the current compilation unit. *)
     let pre_types = dedup_tdecls !registered_types in
     let local_mods = dedup_mods !registered_mods in
@@ -1823,14 +1872,12 @@ let expand_sarek_include ~ctxt payload =
           "sarek_include: scanning %s (exists=%b)"
           full_path
           (Sys.file_exists full_path) ;
-      (* Scan the file for types and module items *)
-      (try scan_file_for_sarek_types full_path
-       with e ->
-         Location.raise_errorf
-           ~loc
-           "%%sarek_include: failed to scan %s: %s"
-           full_path
-           (Printexc.to_string e)) ;
+      (* Scan the file for types and module items. scan_file_for_sarek_types
+         never raises (see its doc comment) - it reports failures via
+         eprintf as a side effect instead, so this file's compilation
+         succeeds even if the included file was
+         unreadable/unparseable/mis-annotated. *)
+      ignore (scan_file_for_sarek_types full_path : string option) ;
       (* Return empty structure item - the side effect is registration *)
       [%stri let () = ()]
   | None ->

--- a/sarek/ppx/Sarek_types.ml
+++ b/sarek/ppx/Sarek_types.ml
@@ -319,7 +319,12 @@ let rec type_of_type_expr (te : Sarek_ast.type_expr) : typ =
   | Sarek_ast.TEConstr ("int64", []) -> t_int64
   | Sarek_ast.TEConstr ("float32", []) -> t_float32
   | Sarek_ast.TEConstr ("float64", []) -> t_float64
-  | Sarek_ast.TEConstr ("float", []) -> t_float64 (* OCaml float = float64 *)
+  | Sarek_ast.TEConstr ("float", []) ->
+      t_float32
+      (* Bare `float` defaults to float32 in GPGPU kernels (human decision
+         2026-07-02): most GPU hardware executes float32 natively while
+         float64 is slow or unsupported, so the DSL's default should match
+         the common case. Use `float64` explicitly for double precision. *)
   | Sarek_ast.TEConstr ("char", []) -> t_char
   | Sarek_ast.TEConstr ("vector", [elem]) -> TVec (type_of_type_expr elem)
   | Sarek_ast.TEConstr (name, [elem])

--- a/sarek/sarek/Sarek_fusion.ml
+++ b/sarek/sarek/Sarek_fusion.ml
@@ -327,7 +327,7 @@ let analyze_pattern reads arr =
     - Which arrays are read and with what access patterns
     - Which arrays are written and with what access patterns
     - Whether barriers are present (prevents fusion)
-    - Whether atomic operations are present (TODO: not yet detected)
+    - Whether atomic operations are present (prevents fusion)
 
     Access patterns determine fusability:
     - OneToOne: Element-wise access (arr[tid]) - always fusable
@@ -349,8 +349,7 @@ let analyze (k : kernel) : fusion_info =
     reads = List.map (fun arr -> (arr, analyze_pattern reads arr)) read_arrs;
     writes = List.map (fun arr -> (arr, analyze_pattern writes arr)) write_arrs;
     has_barriers = has_barrier k.kern_body;
-    has_atomics = false;
-    (* TODO: detect atomics *)
+    has_atomics = Sarek_ir_analysis.kernel_uses_atomics k;
   }
 
 (** {1 Fusion} *)
@@ -429,7 +428,13 @@ let can_fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
     (not prod_info.has_barriers) && not cons_info.has_barriers
   in
 
+  (* No atomics in either: an atomic's ordering/visibility guarantees depend
+     on the kernel boundary being preserved, so fusing it into another
+     kernel would silently change its semantics. *)
+  let no_atomics = (not prod_info.has_atomics) && not cons_info.has_atomics in
+
   prod_writes_inter && cons_reads_inter && patterns_ok && no_barriers
+  && no_atomics
 
 (** Fuse producer into consumer, eliminating intermediate array.
 
@@ -692,7 +697,12 @@ let can_fuse_reduction (map_kernel : kernel) (reduce_kernel : kernel)
     (not map_info.has_barriers) && not reduce_info.has_barriers
   in
 
-  map_writes_inter && Option.is_some reduce_reads_inter && no_barriers
+  (* No atomics: see can_fuse for rationale *)
+  let no_atomics = (not map_info.has_atomics) && not reduce_info.has_atomics in
+
+  map_writes_inter
+  && Option.is_some reduce_reads_inter
+  && no_barriers && no_atomics
 
 (** Fuse a map kernel into a reduction kernel, eliminating intermediate array.
 
@@ -849,7 +859,10 @@ let can_fuse_stencil (producer : kernel) (consumer : kernel)
     (not prod_info.has_barriers) && not cons_info.has_barriers
   in
 
-  prod_writes_inter && cons_stencil && no_barriers
+  (* No atomics: see can_fuse for rationale *)
+  let no_atomics = (not prod_info.has_atomics) && not cons_info.has_atomics in
+
+  prod_writes_inter && cons_stencil && no_barriers && no_atomics
 
 (** Information about fused stencil *)
 type stencil_fusion_info = {
@@ -1104,8 +1117,15 @@ let should_fuse (producer : kernel) (consumer : kernel) (intermediate : string)
   let prod_info = analyze producer in
   let cons_info = analyze consumer in
 
-  (* Rule 1: Can't fuse if barriers present *)
-  if prod_info.has_barriers || cons_info.has_barriers then
+  (* Rule 0: Can't fuse if atomics present in either kernel — see can_fuse
+     for rationale. Checked before Rule 1 so auto_fuse_pipeline_list reports
+     an accurate skip reason instead of falling through to try_fuse's None
+     (which can_fuse/can_fuse_reduction already reject, but with a generic
+     reason). *)
+  if prod_info.has_atomics || cons_info.has_atomics then
+    {decision = DontFuse; reason = "Atomic operation prevents fusion"}
+    (* Rule 1: Can't fuse if barriers present *)
+  else if prod_info.has_barriers || cons_info.has_barriers then
     {decision = DontFuse; reason = "Barrier prevents fusion"}
   else
     (* Rule 2: Always fuse simple element-wise (OneToOne -> OneToOne) *)

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -383,6 +383,30 @@
  (preprocess
   (pps sarek_ppx)))
 
+; Regression test: TECreateArray native codegen (Sarek_native_gen_expr.ml).
+; Fails to compile pre-fix (int32/int mismatch on Array.make); runs and
+; asserts correctness post-fix. Run with:
+;   dune exec sarek/tests/e2e/test_native_create_array.exe
+
+(executable
+ (name test_native_create_array)
+ (modules test_native_create_array)
+ (libraries sarek sarek_native sarek_stdlib spoc_core unix)
+ (preprocess
+  (pps sarek_ppx)))
+
+; Regression test: `downto` loop native codegen (Sarek_native_gen_expr.ml).
+; Pre-fix, the loop bounds are swapped and the loop body never executes.
+; Run with:
+;   dune exec sarek/tests/e2e/test_native_downto.exe
+
+(executable
+ (name test_native_downto)
+ (modules test_native_downto)
+ (libraries sarek sarek_native sarek_stdlib spoc_core unix)
+ (preprocess
+  (pps sarek_ppx)))
+
 ; PR-2 Float32.sin pure-registry GPU e2e test
 ; Run with: dune exec sarek/tests/e2e/test_float32_sin_pure.exe -- --vulkan
 

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -407,6 +407,17 @@
  (preprocess
   (pps sarek_ppx)))
 
+; Regression test: bare `float` in kernel type annotations types as float32,
+; not float64 (Sarek_types.ml:322). Run with:
+;   dune exec sarek/tests/e2e/test_bare_float_is_float32.exe
+
+(executable
+ (name test_bare_float_is_float32)
+ (modules test_bare_float_is_float32)
+ (libraries sarek sarek_native sarek_stdlib sarek_ir spoc_core unix)
+ (preprocess
+  (pps sarek_ppx)))
+
 ; Regression test: Sarek_ppx.scan_file_for_sarek_types's `with _ -> ()`
 ; catch-all. %sarek_includes a deliberately unparseable sibling fixture; this
 ; file must still compile (see fixture_scan_failure_include.ml.fixture and

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -407,6 +407,21 @@
  (preprocess
   (pps sarek_ppx)))
 
+; Regression test: Sarek_ppx.scan_file_for_sarek_types's `with _ -> ()`
+; catch-all. %sarek_includes a deliberately unparseable sibling fixture; this
+; file must still compile (see fixture_scan_failure_include.ml.fixture and
+; sarek/tests/unit/test_ppx_scan_diagnostics.ml for the diagnostic-content
+; half of the contract). Run with:
+;   dune build sarek/tests/e2e/test_ppx_scan_failure_warning.exe
+
+(executable
+ (name test_ppx_scan_failure_warning)
+ (modules test_ppx_scan_failure_warning)
+ (libraries sarek_stdlib)
+ (preprocessor_deps fixture_scan_failure_include.ml.fixture)
+ (preprocess
+  (pps sarek_ppx)))
+
 ; PR-2 Float32.sin pure-registry GPU e2e test
 ; Run with: dune exec sarek/tests/e2e/test_float32_sin_pure.exe -- --vulkan
 

--- a/sarek/tests/e2e/fixture_scan_failure_include.ml.fixture
+++ b/sarek/tests/e2e/fixture_scan_failure_include.ml.fixture
@@ -1,0 +1,10 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Fixture for test_ppx_scan_failure_warning.ml - deliberately unparseable
+   OCaml. Named with a .ml.fixture suffix (not .ml) so dune never tries to
+   compile it as a module in this directory; it is only read as raw text by
+   Sarek_ppx.scan_file_for_sarek_types via `let%sarek_include`. *)
+let broken = fun x -> x +

--- a/sarek/tests/e2e/test_bare_float_is_float32.ml
+++ b/sarek/tests/e2e/test_bare_float_is_float32.ml
@@ -1,0 +1,116 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Regression test: bare `float` in Sarek kernel type annotations now types as
+   float32, not float64 (Sarek_types.ml:322 - human decision 2026-07-02: "keep
+   float the default for GPGPU kernels and not float64"). Pre-fix, a kernel
+   using bare `float` for a parameter or local silently got the float64
+   representation internally (`Sarek_ir_types.TFloat64`), which
+   `Sarek_ir_analysis.kernel_uses_float64` would report as `true`; post-fix
+   it reports `false`, matching the actual float32 GPU representation.
+
+   Two halves, both load-bearing:
+   (i)  kernel_uses_float64 on the lowered IR of a bare-float kernel is
+        false (fails pre-fix: was true).
+   (ii) the kernel actually executes on the float32 path and produces correct
+        results (proves the IR-level classification matches runtime
+        behavior, not just a label). *)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Sarek_native.Native_plugin.init ()
+
+(* `a`, `b`, `out` are all bare `float` - no `float32`/`float64` anywhere in
+   this kernel's source. `sum` is a bare-`float` local. Deliberately no float
+   *literal* anywhere in the body: float literals (`2.0`) always type as
+   float32 regardless of this fix (Sarek_typer.ml's `EFloat` arm - unrelated,
+   unaffected code), so mixing one in here would conflate two different
+   pre-fix failure modes. Confirmed empirically: temporarily reverting the
+   Sarek_types.ml fix and adding a `let local : float = 2.0` local to this
+   kernel does not merely misclassify - it fails to *compile* at all
+   ("Cannot unify types: float64 and float32"), because pre-fix bare
+   `float`-annotated locals wanted float64 while float literals are always
+   float32. That is a real, separate, pre-existing inconsistency this fix
+   incidentally also resolves (post-fix both sides agree on float32) - see
+   the evidence file for the exact repro. This test isolates the
+   classification-only claim: no literals, so it compiles both before and
+   after, and only `kernel_uses_float64`'s answer differs. *)
+let bare_float_kernel =
+  [%kernel
+    fun (a : float vector) (b : float vector) (out : float vector) ->
+      let open Std in
+      let tid = global_thread_id in
+      let sum : float = a.(tid) +. b.(tid) in
+      out.(tid) <- sum +. sum]
+
+let () =
+  let _, kirc = bare_float_kernel in
+  let ir =
+    match kirc.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "no ir"
+  in
+
+  (* (i) IR-level classification *)
+  let uses_f64 = Sarek_ir_analysis.kernel_uses_float64 ir in
+  if uses_f64 then begin
+    print_endline
+      "test_bare_float_is_float32: FAILED (kernel_uses_float64 = true; bare \
+       `float` is still resolving to float64)" ;
+    exit 1
+  end ;
+
+  (* (ii) Execution on the float32 path. The host vectors are created with
+     Vector.float32 - the same representation bare `float` now resolves to
+     internally, so this is the representation-matching choice, not an
+     arbitrary one. *)
+  let devs = Device.init ~frameworks:["Native"] () in
+  let native_dev = devs.(0) in
+  let n = 8 in
+  let a = Vector.create Vector.float32 n in
+  let b = Vector.create Vector.float32 n in
+  let out = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set a i (float_of_int i) ;
+    Vector.set b i (float_of_int (i * 2)) ;
+    Vector.set out i (-1.0)
+  done ;
+
+  Execute.run_vectors
+    ~device:native_dev
+    ~ir
+    ~args:[Execute.Vec a; Execute.Vec b; Execute.Vec out]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush native_dev ;
+
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    let expected = float_of_int (i + (i * 2)) *. 2.0 in
+    let got = Vector.get out i in
+    (* float32 tolerance: values here are small integers scaled by 2, exactly
+       representable in float32, so an exact comparison is legitimate and
+       also lets an accidental float64 execution path (different rounding
+       for the same inputs would not actually differ here, since all values
+       are exactly representable in both widths - this assertion is a
+       sanity check on the arithmetic, not a width-detection probe; (i)
+       above is the width-detection assertion). *)
+    if Stdlib.abs_float (got -. expected) > 0.001 then begin
+      Printf.printf "MISMATCH at %d: expected %f, got %f\n%!" i expected got ;
+      ok := false
+    end
+  done ;
+  if !ok then print_endline "test_bare_float_is_float32: PASSED"
+  else begin
+    print_endline "test_bare_float_is_float32: FAILED" ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_native_create_array.ml
+++ b/sarek/tests/e2e/test_native_create_array.ml
@@ -1,0 +1,81 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Regression test for TECreateArray native codegen (Sarek_native_gen_expr.ml).
+   Pre-fix, `create_array` in a kernel body was lowered to
+   [Array.make size_e default_e] where [size_e] evaluates at type [int32]
+   while [Array.make] expects [int]. This is a native-mode compile-time type
+   error ("This expression has type int32 but an expression was expected of
+   type int"), i.e. this file fails to build at all pre-fix. Post-fix, the
+   size expression is converted with [Int32.to_int] and the kernel compiles
+   and runs correctly. *)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Sarek_native.Native_plugin.init ()
+
+(* Kernel that creates a local array, fills it, and writes back a computed
+   value that depends on the array contents so the test genuinely exercises
+   both allocation and use of the created array. *)
+let create_array_kernel =
+  [%kernel
+    fun (output : int32 vector) (n : int32) ->
+      let open Std in
+      let tid = global_thread_id in
+      if tid < n then begin
+        let arr = create_array n Local in
+        arr.(tid) <- (tid * 2l) + 1l ;
+        output.(tid) <- arr.(tid)
+      end]
+
+let () =
+  let devs = Device.init ~frameworks:["Native"] () in
+  let native_dev = devs.(0) in
+  let n = 16 in
+  let output = Vector.create Vector.int32 n in
+  for i = 0 to n - 1 do
+    Vector.set output i 0l
+  done ;
+
+  let _, kirc = create_array_kernel in
+  let ir =
+    match kirc.Sarek.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "no ir"
+  in
+
+  Execute.run_vectors
+    ~device:native_dev
+    ~ir
+    ~args:[Execute.Vec output; Execute.Int32 (Int32.of_int n)]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush native_dev ;
+
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    let expected = Int32.add (Int32.mul (Int32.of_int i) 2l) 1l in
+    let got = Vector.get output i in
+    if got <> expected then begin
+      Printf.printf
+        "MISMATCH at %d: expected %ld, got %ld\n%!"
+        i
+        expected
+        got ;
+      ok := false
+    end
+  done ;
+  if !ok then print_endline "test_native_create_array: PASSED"
+  else begin
+    print_endline "test_native_create_array: FAILED" ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_native_create_array.ml
+++ b/sarek/tests/e2e/test_native_create_array.ml
@@ -66,11 +66,7 @@ let () =
     let expected = Int32.add (Int32.mul (Int32.of_int i) 2l) 1l in
     let got = Vector.get output i in
     if got <> expected then begin
-      Printf.printf
-        "MISMATCH at %d: expected %ld, got %ld\n%!"
-        i
-        expected
-        got ;
+      Printf.printf "MISMATCH at %d: expected %ld, got %ld\n%!" i expected got ;
       ok := false
     end
   done ;

--- a/sarek/tests/e2e/test_native_downto.ml
+++ b/sarek/tests/e2e/test_native_downto.ml
@@ -1,0 +1,91 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Regression test for `downto` loop native codegen (Sarek_native_gen_expr.ml).
+   The parser (Sarek_parse.ml) stores `for i = start downto stop` positionally
+   as (lo, hi) = (start, stop), regardless of direction. Pre-fix, the Downto
+   codegen arm emitted `for i = hi downto lo`, i.e. for `for i = 9 downto 0`
+   it emitted the OCaml loop `for i = 0 downto 9`, which never executes any
+   iteration (0 is not >= 9). Post-fix it emits `for i = lo downto hi`
+   ( = `for i = 9 downto 0`), running the expected 10 descending
+   iterations. *)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Sarek_native.Native_plugin.init ()
+
+(* Writes the loop counter of `for i = 9 downto 0` into successive output
+   slots, so the recorded sequence exposes both iteration count and order. *)
+let downto_kernel =
+  [%kernel
+    fun (output : int32 vector) (count : int32 vector) ->
+      let open Std in
+      let tid = global_thread_id in
+      if tid = 0l then begin
+        let idx = mut 0l in
+        for i = 9 downto 0 do
+          output.(idx) <- i ;
+          idx := idx + 1l
+        done ;
+        count.(0) <- idx
+      end]
+
+let () =
+  let devs = Device.init ~frameworks:["Native"] () in
+  let native_dev = devs.(0) in
+  let n = 10 in
+  let output = Vector.create Vector.int32 n in
+  let count = Vector.create Vector.int32 1 in
+  for i = 0 to n - 1 do
+    Vector.set output i (-1l)
+  done ;
+  Vector.set count 0 (-1l) ;
+
+  let _, kirc = downto_kernel in
+  let ir =
+    match kirc.Sarek.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "no ir"
+  in
+
+  Execute.run_vectors
+    ~device:native_dev
+    ~ir
+    ~args:[Execute.Vec output; Execute.Vec count]
+    ~block:(Execute.dims1d 1)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush native_dev ;
+
+  let got_count = Vector.get count 0 in
+  let ok = ref (got_count = Int32.of_int n) in
+  if not !ok then
+    Printf.printf
+      "MISMATCH: expected %d iterations, got %ld\n%!"
+      n
+      got_count ;
+  for i = 0 to n - 1 do
+    let expected = Int32.of_int (9 - i) in
+    let got = Vector.get output i in
+    if got <> expected then begin
+      Printf.printf
+        "MISMATCH at slot %d: expected %ld, got %ld\n%!"
+        i
+        expected
+        got ;
+      ok := false
+    end
+  done ;
+  if !ok then print_endline "test_native_downto: PASSED"
+  else begin
+    print_endline "test_native_downto: FAILED" ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_native_downto.ml
+++ b/sarek/tests/e2e/test_native_downto.ml
@@ -68,10 +68,7 @@ let () =
   let got_count = Vector.get count 0 in
   let ok = ref (got_count = Int32.of_int n) in
   if not !ok then
-    Printf.printf
-      "MISMATCH: expected %d iterations, got %ld\n%!"
-      n
-      got_count ;
+    Printf.printf "MISMATCH: expected %d iterations, got %ld\n%!" n got_count ;
   for i = 0 to n - 1 do
     let expected = Int32.of_int (9 - i) in
     let got = Vector.get output i in

--- a/sarek/tests/e2e/test_ppx_scan_failure_warning.ml
+++ b/sarek/tests/e2e/test_ppx_scan_failure_warning.ml
@@ -1,0 +1,23 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression test: Sarek_ppx.scan_file_for_sarek_types's error handling
+ * (Sarek_ppx.ml, formerly `with _ -> ()` at the end of the function).
+ *
+ * %sarek_include's scan target (fixture_scan_failure_include.ml.fixture) is
+ * deliberately unparseable OCaml. Pre-fix, scan_file_for_sarek_types would
+ * silently swallow the parse failure and this file would compile with no
+ * trace that anything went wrong. Post-fix, the same parse failure is
+ * printed to stderr (naming the file and the exception) during this file's
+ * compilation - but compilation still succeeds, which this executable
+ * existing and running proves. Run `dune build
+ * sarek/tests/e2e/test_ppx_scan_failure_warning.exe --force` to see the
+ * diagnostic on stderr.
+ ******************************************************************************)
+
+let%sarek_include _ = "fixture_scan_failure_include.ml.fixture"
+
+let () = print_endline "test_ppx_scan_failure_warning: PASSED (build succeeded)"

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -14,6 +14,8 @@
 ; - test_convention_kernel_fail: "Field z not found"
 ; - test_convention_kernel_fail2: "Cannot unify types"
 ; - test_inline_node_exhaustion: "Inlining produced N nodes (limit: 10000)"
+; - test_tuple_param: "Tuple-typed kernel parameters are not supported"
+; - test_fun_param: "Function-typed kernel parameters are not supported"
 
 (library
  (name neg_test_convention_kernel_fail)
@@ -95,6 +97,28 @@
 (library
  (name neg_test_inline_node_exhaustion)
  (modules test_inline_node_exhaustion)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+(library
+ (name neg_test_tuple_param)
+ (modules test_tuple_param)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+(library
+ (name neg_test_fun_param)
+ (modules test_fun_param)
  (libraries sarek sarek.stdlib sarek.ppx.lib)
  (preprocess
   (pps sarek_ppx))

--- a/sarek/tests/negative/test_fun_param.ml
+++ b/sarek/tests/negative/test_fun_param.ml
@@ -1,0 +1,18 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile:
+   - Uses a function-typed kernel parameter, which the V2 lowering path
+     (Sarek_lower_ir.ml, elttype_of_typ) cannot represent. *)
+
+let () =
+  let bad_kernel =
+    [%kernel
+      fun (v : float32 vector) (f : int32 -> int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        v.(tid) <- Float32.of_int (Int32.to_int tid)]
+  in
+  ignore bad_kernel ;
+  print_endline "This should not print - test should have failed to compile"

--- a/sarek/tests/negative/test_tuple_param.ml
+++ b/sarek/tests/negative/test_tuple_param.ml
@@ -1,0 +1,18 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile:
+   - Uses a tuple-typed kernel parameter, which the V2 lowering path
+     (Sarek_lower_ir.ml, elttype_of_typ) cannot represent. *)
+
+let () =
+  let bad_kernel =
+    [%kernel
+      fun (v : float32 vector) (pair : int32 * int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        v.(tid) <- Float32.of_int (Int32.to_int tid)]
+  in
+  ignore bad_kernel ;
+  print_endline "This should not print - test should have failed to compile"

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -59,3 +59,13 @@
 (test
  (name test_ptx_snapshot)
  (libraries sarek.codegen alcotest))
+
+; Regression test: Sarek_ppx.scan_file_for_sarek_types's `with _ -> ()`
+; catch-all (pre-fix: silently swallowed the scanned file's name and the
+; exception, on ANY failure). Post-fix it returns a diagnostic instead of
+; unit. See sarek/tests/e2e/test_ppx_scan_failure_warning.ml for the
+; complementary "compilation still succeeds" half of the contract.
+
+(test
+ (name test_ppx_scan_diagnostics)
+ (libraries sarek_ppx alcotest))

--- a/sarek/tests/unit/test_fusion.ml
+++ b/sarek/tests/unit/test_fusion.ml
@@ -170,6 +170,140 @@ let test_can_fuse_with_barrier () =
   assert (not result) ;
   Printf.printf "test_can_fuse_with_barrier: PASSED\n"
 
+(** Test: can_fuse returns false when the producer contains a direct atomic
+    operation. Pre-fix (Sarek_fusion.ml hardcoded [has_atomics = false]), this
+    incorrectly returned [true]. *)
+let test_can_fuse_with_direct_atomic () =
+  let producer =
+    {
+      kern_name = "producer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SSeq
+          [
+            SExpr
+              (EIntrinsic
+                 ([], "atomic_add_int32", [thread_idx_x; EConst (CInt32 1l)]));
+            SAssign
+              ( LArrayElem ("temp", thread_idx_x),
+                EArrayRead ("input", thread_idx_x) );
+          ];
+      kern_types = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let consumer =
+    {
+      kern_name = "consumer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LArrayElem ("output", thread_idx_x),
+            EArrayRead ("temp", thread_idx_x) );
+      kern_types = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let result = can_fuse producer consumer "temp" in
+  assert (not result) ;
+  Printf.printf "test_can_fuse_with_direct_atomic: PASSED\n"
+
+(** Test: can_fuse returns false when an atomic is only reachable through a
+    helper function called from the kernel, not from kern_body directly. This is
+    the load-bearing case: a walk that only inspects kern_body (rather than also
+    walking kern_funcs) misses it and would wrongly permit fusion. *)
+let test_can_fuse_with_atomic_in_helper () =
+  let bump_param =
+    {var_name = "x"; var_id = 0; var_type = TInt32; var_mutable = false}
+  in
+  let atomic_helper =
+    {
+      hf_name = "bump";
+      hf_params = [bump_param];
+      hf_ret_type = TInt32;
+      hf_body =
+        SReturn
+          (EIntrinsic
+             ([], "atomic_add_int32", [EVar bump_param; EConst (CInt32 1l)]));
+    }
+  in
+  let producer =
+    {
+      kern_name = "producer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          (LArrayElem ("temp", thread_idx_x), EArrayRead ("input", thread_idx_x));
+      kern_types = [];
+      kern_funcs = [atomic_helper];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let consumer =
+    {
+      kern_name = "consumer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LArrayElem ("output", thread_idx_x),
+            EArrayRead ("temp", thread_idx_x) );
+      kern_types = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let result = can_fuse producer consumer "temp" in
+  assert (not result) ;
+  Printf.printf "test_can_fuse_with_atomic_in_helper: PASSED\n"
+
+(** Test: atomic-free kernels still fuse (no regression) *)
+let test_can_fuse_no_atomics_regression () =
+  let producer =
+    {
+      kern_name = "producer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LArrayElem ("temp", thread_idx_x),
+            EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
+          );
+      kern_types = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let consumer =
+    {
+      kern_name = "consumer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LArrayElem ("output", thread_idx_x),
+            EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
+          );
+      kern_types = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let result = can_fuse producer consumer "temp" in
+  assert result ;
+  Printf.printf "test_can_fuse_no_atomics_regression: PASSED\n"
+
 (** Test: fuse inlines producer into consumer *)
 let test_fuse_simple () =
   (* Producer: temp[i] = input[i] * 2 *)
@@ -1159,6 +1293,9 @@ let () =
   test_analyze_with_barrier () ;
   test_can_fuse_compatible () ;
   test_can_fuse_with_barrier () ;
+  test_can_fuse_with_direct_atomic () ;
+  test_can_fuse_with_atomic_in_helper () ;
+  test_can_fuse_no_atomics_regression () ;
   test_fuse_simple () ;
   test_fuse_pipeline () ;
   test_fuse_pipeline_list_preserves_unfused () ;

--- a/sarek/tests/unit/test_fusion.ml
+++ b/sarek/tests/unit/test_fusion.ml
@@ -266,6 +266,53 @@ let test_can_fuse_with_atomic_in_helper () =
   assert (not result) ;
   Printf.printf "test_can_fuse_with_atomic_in_helper: PASSED\n"
 
+(** Test: can_fuse returns false when the only atomic in the producer is inside
+    an SAssign's lvalue index expression (e.g.
+    [arr.(atomic_add arr2 0 1) <- 5]), not in the RHS. This is the finding-3
+    case: a walk that ignores the lvalue and only inspects the RHS expression
+    would miss it and would wrongly permit fusion. *)
+let test_can_fuse_with_atomic_in_assign_lvalue () =
+  let atomic_idx =
+    EIntrinsic ([], "atomic_add_int32", [EConst (CInt32 0l); EConst (CInt32 1l)])
+  in
+  let producer =
+    {
+      kern_name = "producer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SSeq
+          [
+            SAssign (LArrayElem ("temp", atomic_idx), EConst (CInt32 5l));
+            SAssign
+              ( LArrayElem ("temp", thread_idx_x),
+                EArrayRead ("input", thread_idx_x) );
+          ];
+      kern_types = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let consumer =
+    {
+      kern_name = "consumer";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LArrayElem ("output", thread_idx_x),
+            EArrayRead ("temp", thread_idx_x) );
+      kern_types = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+      kern_variants = [];
+    }
+  in
+  let result = can_fuse producer consumer "temp" in
+  assert (not result) ;
+  Printf.printf "test_can_fuse_with_atomic_in_assign_lvalue: PASSED\n"
+
 (** Test: atomic-free kernels still fuse (no regression) *)
 let test_can_fuse_no_atomics_regression () =
   let producer =
@@ -1295,6 +1342,7 @@ let () =
   test_can_fuse_with_barrier () ;
   test_can_fuse_with_direct_atomic () ;
   test_can_fuse_with_atomic_in_helper () ;
+  test_can_fuse_with_atomic_in_assign_lvalue () ;
   test_can_fuse_no_atomics_regression () ;
   test_fuse_simple () ;
   test_fuse_pipeline () ;

--- a/sarek/tests/unit/test_ir_interp.ml
+++ b/sarek/tests/unit/test_ir_interp.ml
@@ -223,6 +223,17 @@ let test_binop_lt () =
   | VBool b -> check bool "less than true" true b
   | _ -> fail "expected VBool"
 
+let test_binop_shr_negative_is_arithmetic () =
+  (* Ir.Shr is arithmetic (sign-extending) on every consumer - see G phase 1
+     in briefs/fix-critical-semantics-evidence.md. (-16) >> 2 must be -4,
+     not the logical-shift result 1073741820. *)
+  let env = make_env () in
+  let state = make_state () in
+  let expr = EBinop (Shr, EConst (CInt32 (-16l)), EConst (CInt32 2l)) in
+  match eval_expr state env expr with
+  | VInt32 n -> check int32 "(-16) shr 2 is arithmetic" (-4l) n
+  | _ -> fail "expected VInt32"
+
 let test_binop_eq () =
   let env = make_env () in
   let state = make_state () in
@@ -376,6 +387,10 @@ let () =
           test_case "multiply" `Quick test_binop_mul;
           test_case "less_than" `Quick test_binop_lt;
           test_case "equals" `Quick test_binop_eq;
+          test_case
+            "shr_negative_is_arithmetic"
+            `Quick
+            test_binop_shr_negative_is_arithmetic;
         ] );
       ( "unary_operations",
         [

--- a/sarek/tests/unit/test_lower.ml
+++ b/sarek/tests/unit/test_lower.ml
@@ -255,6 +255,32 @@ let test_lower_for () =
     | DoLoop (IntId ("i", 0), Int 0, Int 10, Unit) -> true
     | _ -> false)
 
+(* The legacy (Kirc_Ast) lowering path has no production callers for
+   `downto` loops: the V2 path (Sarek_lower_ir.ml) and the native backend
+   (Sarek_native_gen_expr.ml) both handle downto themselves, and nothing
+   routes a Sarek-level downto loop through Sarek_lower.lower_expr in
+   normal use. This test therefore calls lower_expr directly on a
+   hand-built Downto AST fragment - there is no kernel source that would
+   exercise this path today - to pin down that the legacy path fails
+   loudly (a located PPX error) instead of silently mis-lowering the loop
+   as if it were Upto (which is what happened before this fix: the `dir`
+   value was discarded with `let _ = dir in`). *)
+let test_lower_for_downto_raises () =
+  let te =
+    mk_texpr
+      (TEFor
+         ("i", 0, int_texpr 10, int_texpr 0, Downto, mk_texpr TEUnit t_unit))
+      t_unit
+  in
+  let state = create_state (empty_fun_map ()) in
+  let raised =
+    try
+      let _ = lower_expr state te in
+      false
+    with Ppxlib.Location.Error _ -> true
+  in
+  Alcotest.(check bool) "downto raises a located error" true raised
+
 (* Test lowering sequence *)
 let test_lower_seq () =
   let te = mk_texpr (TESeq [int_texpr 1; int_texpr 2; int_texpr 3]) t_int32 in
@@ -422,6 +448,10 @@ let () =
           Alcotest.test_case "if no else" `Quick test_lower_if_no_else;
           Alcotest.test_case "while" `Quick test_lower_while;
           Alcotest.test_case "for" `Quick test_lower_for;
+          Alcotest.test_case
+            "for downto raises"
+            `Quick
+            test_lower_for_downto_raises;
         ] );
       ( "other",
         [

--- a/sarek/tests/unit/test_lower.ml
+++ b/sarek/tests/unit/test_lower.ml
@@ -268,8 +268,7 @@ let test_lower_for () =
 let test_lower_for_downto_raises () =
   let te =
     mk_texpr
-      (TEFor
-         ("i", 0, int_texpr 10, int_texpr 0, Downto, mk_texpr TEUnit t_unit))
+      (TEFor ("i", 0, int_texpr 10, int_texpr 0, Downto, mk_texpr TEUnit t_unit))
       t_unit
   in
   let state = create_state (empty_fun_map ()) in

--- a/sarek/tests/unit/test_lower_ir.ml
+++ b/sarek/tests/unit/test_lower_ir.ml
@@ -314,10 +314,14 @@ let test_lower_param () =
 
 (* Minimal, self-contained evaluator for the fragment of Sarek_ir_ppx.expr
    that lower_lsr/ir_binop can produce for an int32 Lsr/Asr binop (EConst
-   CInt32/CBool, EBinop over Add/Sub/Shl/Shr/BitXor/Eq, EIf). This exercises
-   the REAL production lowering (Sarek_lower_ir.lower_expr / lower_lsr)
-   without reaching into sarek_transpile's private Sarek_ir_conv (not part
-   of that library's public .mli). *)
+   CInt32/CBool, EBinop over Add/Sub/Shl/Shr/BitAnd/BitXor/Eq, EIf). This
+   exercises the REAL production lowering (Sarek_lower_ir.lower_expr /
+   lower_lsr) without reaching into sarek_transpile's private Sarek_ir_conv
+   (not part of that library's public .mli).
+   [BitAnd] was added to the fragment when [lower_lsr] started masking its
+   internal shift-count with [width - 1] (finding 2: PTX/WGSL evaluate both
+   [EIf] branches, so the else-branch's shift-by-[width-n] must itself be
+   well-defined for every [n], including [n = 0]). *)
 let rec eval_ir_int32 (e : Ir.expr) : int32 =
   match e with
   | Ir.EConst (Ir.CInt32 n) -> n
@@ -328,6 +332,8 @@ let rec eval_ir_int32 (e : Ir.expr) : int32 =
   | Ir.EBinop (Ir.Shr, a, b) ->
       (* Ir.Shr is arithmetic on every backend post-fix (G phase 1) *)
       Int32.shift_right (eval_ir_int32 a) (Int32.to_int (eval_ir_int32 b))
+  | Ir.EBinop (Ir.BitAnd, a, b) ->
+      Int32.logand (eval_ir_int32 a) (eval_ir_int32 b)
   | Ir.EBinop (Ir.BitXor, a, b) ->
       Int32.logxor (eval_ir_int32 a) (eval_ir_int32 b)
   | Ir.EIf (cond, then_, else_) ->
@@ -374,6 +380,106 @@ let test_lsr_positive_matches_asr () =
   let asr_result = eval_int32_binop Sarek_ast.Asr 16l 2l in
   Alcotest.(check int32) "16 lsr 2" 4l lsr_result ;
   Alcotest.(check int32) "16 asr 2 matches lsr" lsr_result asr_result
+
+(* Finding 1 (review pass): lower_lsr used to build a tree that references
+   its [a]/[b] IR operands three times each (sign_fill, top_bits, and the
+   final EIf's branches/condition) with no way to evaluate a non-trivial
+   operand once and reuse the result (Sarek_ir_ppx.expr has no let-binding
+   form - see the doc comment on lower_lsr). If the operand carried a side
+   effect (e.g. an EIntrinsic atomic call), it would be silently evaluated
+   multiple times. lower_lsr now raises a located Ppxlib PPX error instead of
+   building the unsafe tree whenever an operand is not a plain EVar/EConst.
+   This test lowers [(1 + 2) lsr n] - the left operand becomes
+   Ir.EBinop(Add, EConst, EConst) after lowering, which is not EVar/EConst,
+   so it is non-trivial - and asserts lower_expr raises. Fails pre-fix
+   (no check existed, so the duplicating tree was built silently) and
+   passes post-fix. *)
+let test_lsr_raises_on_nontrivial_operand () =
+  let ty = Sarek_types.(TReg Int) in
+  let mk te = Sarek_typed_ast.{te; ty; te_loc = Sarek_ast.dummy_loc} in
+  let non_trivial =
+    mk
+      (Sarek_typed_ast.TEBinop (Sarek_ast.Add, mk (TEInt32 1l), mk (TEInt32 2l)))
+  in
+  let texpr =
+    mk (Sarek_typed_ast.TEBinop (Sarek_ast.Lsr, non_trivial, mk (TEInt32 2l)))
+  in
+  let state = Sarek_lower_ir.create_state (Hashtbl.create 1) in
+  let raised =
+    try
+      let (_ : Ir.expr) = Sarek_lower_ir.lower_expr state texpr in
+      false
+    with Ppxlib.Location.Error _ -> true
+  in
+  Alcotest.(check bool) "lsr with non-trivial operand raises" true raised
+
+(* Companion case: a non-trivial *right* operand (the shift count) must also
+   be rejected, not just a non-trivial left operand. *)
+let test_lsr_raises_on_nontrivial_shift_count () =
+  let ty = Sarek_types.(TReg Int) in
+  let mk te = Sarek_typed_ast.{te; ty; te_loc = Sarek_ast.dummy_loc} in
+  let non_trivial_count =
+    mk
+      (Sarek_typed_ast.TEBinop (Sarek_ast.Add, mk (TEInt32 1l), mk (TEInt32 1l)))
+  in
+  let texpr =
+    mk
+      (Sarek_typed_ast.TEBinop
+         (Sarek_ast.Lsr, mk (TEInt32 16l), non_trivial_count))
+  in
+  let state = Sarek_lower_ir.create_state (Hashtbl.create 1) in
+  let raised =
+    try
+      let (_ : Ir.expr) = Sarek_lower_ir.lower_expr state texpr in
+      false
+    with Ppxlib.Location.Error _ -> true
+  in
+  Alcotest.(check bool) "lsr with non-trivial shift count raises" true raised
+
+(* Finding 1, negative check: trivial operands (plain int literals, which
+   lower to Ir.EConst) must NOT raise - this must not regress. *)
+let test_lsr_trivial_operands_do_not_raise () =
+  let result = eval_int32_binop Sarek_ast.Lsr (-16l) 2l in
+  Alcotest.(check int32) "(-16) lsr 2 (trivial operands)" 1073741820l result
+
+(* Finding 2 (review pass): PTX's selp / WGSL's select() evaluate BOTH
+   branches of the EIf lower_lsr builds, so the else-branch's internal
+   [width_bits - n] shift-count must itself be well-defined (in
+   [0..width_bits-1]) for every n, including n = 0 (where the unmasked
+   value would be exactly width_bits - a shift-by-32, undefined/rejected on
+   some backends - even though the EIf "selects" the then-branch for n = 0).
+   lower_lsr now wraps that shift-count in [BitAnd (_, width_bits - 1)].
+   This test lowers a real [x lsr n] end-to-end and inspects the resulting
+   Ir.expr tree structure directly (not just its evaluated value) for a
+   BitAnd node whose mask constant is 31 (= 32 - 1 for TInt32). Fails
+   pre-fix (no BitAnd node exists in the pre-fix tree) and passes
+   post-fix. *)
+let rec contains_bitand_mask (mask : int32) (e : Ir.expr) : bool =
+  match e with
+  | Ir.EBinop (Ir.BitAnd, _, Ir.EConst (Ir.CInt32 m)) when m = mask -> true
+  | Ir.EBinop (_, a, b) ->
+      contains_bitand_mask mask a || contains_bitand_mask mask b
+  | Ir.EIf (c, t, e2) ->
+      contains_bitand_mask mask c
+      || contains_bitand_mask mask t
+      || contains_bitand_mask mask e2
+  | Ir.EUnop (_, a) -> contains_bitand_mask mask a
+  | _ -> false
+
+let test_lsr_shift_count_is_masked () =
+  let ty = Sarek_types.(TReg Int) in
+  let mk te = Sarek_typed_ast.{te; ty; te_loc = Sarek_ast.dummy_loc} in
+  let texpr =
+    mk
+      (Sarek_typed_ast.TEBinop
+         (Sarek_ast.Lsr, mk (TEVar ("x", 0)), mk (TEInt32 0l)))
+  in
+  let state = Sarek_lower_ir.create_state (Hashtbl.create 1) in
+  let ir_expr = Sarek_lower_ir.lower_expr state texpr in
+  Alcotest.(check bool)
+    "lsr lowering masks the shift-count with (width - 1)"
+    true
+    (contains_bitand_mask 31l ir_expr)
 
 (* Test suite *)
 let () =
@@ -509,5 +615,21 @@ let () =
             "lsr positive matches asr"
             `Quick
             test_lsr_positive_matches_asr;
+          Alcotest.test_case
+            "lsr raises on non-trivial operand"
+            `Quick
+            test_lsr_raises_on_nontrivial_operand;
+          Alcotest.test_case
+            "lsr raises on non-trivial shift count"
+            `Quick
+            test_lsr_raises_on_nontrivial_shift_count;
+          Alcotest.test_case
+            "lsr trivial operands do not raise"
+            `Quick
+            test_lsr_trivial_operands_do_not_raise;
+          Alcotest.test_case
+            "lsr shift count is masked"
+            `Quick
+            test_lsr_shift_count_is_masked;
         ] );
     ]

--- a/sarek/tests/unit/test_lower_ir.ml
+++ b/sarek/tests/unit/test_lower_ir.ml
@@ -299,6 +299,82 @@ let test_lower_param () =
       Alcotest.(check int) "id" 0 var.Ir.var_id
   | _ -> Alcotest.fail "expected DParam"
 
+(* Test: TEBinop (Lsr, _, _) / (Asr, _, _) with a NEGATIVE left operand.
+   Group G (shift semantics): Sarek_ast.Lsr and Asr both used to map to the
+   same Ir.Shr constructor, which every consumer emits as an *arithmetic*
+   shift ([>>] on signed CUDA/OpenCL/Metal/GLSL/WGSL int types, shr.s32 on
+   PTX, Int32.shift_right in the interpreter - see
+   briefs/fix-critical-semantics-evidence.md, G phase 1). [asr] is correct;
+   [lsr] on a negative operand silently returned the wrong (sign-extended)
+   value. These tests lower a real Sarek_ast.Lsr/Asr binop end-to-end
+   (lower_expr -> Sarek_ir_conv.conv_expr -> the runtime interpreter) and
+   check the executed result against the true logical/arithmetic shift, so
+   they fail pre-fix and pass post-fix - see the evidence file for the
+   captured pre-fix failure. *)
+
+(* Minimal, self-contained evaluator for the fragment of Sarek_ir_ppx.expr
+   that lower_lsr/ir_binop can produce for an int32 Lsr/Asr binop (EConst
+   CInt32/CBool, EBinop over Add/Sub/Shl/Shr/BitXor/Eq, EIf). This exercises
+   the REAL production lowering (Sarek_lower_ir.lower_expr / lower_lsr)
+   without reaching into sarek_transpile's private Sarek_ir_conv (not part
+   of that library's public .mli). *)
+let rec eval_ir_int32 (e : Ir.expr) : int32 =
+  match e with
+  | Ir.EConst (Ir.CInt32 n) -> n
+  | Ir.EBinop (Ir.Add, a, b) -> Int32.add (eval_ir_int32 a) (eval_ir_int32 b)
+  | Ir.EBinop (Ir.Sub, a, b) -> Int32.sub (eval_ir_int32 a) (eval_ir_int32 b)
+  | Ir.EBinop (Ir.Shl, a, b) ->
+      Int32.shift_left (eval_ir_int32 a) (Int32.to_int (eval_ir_int32 b))
+  | Ir.EBinop (Ir.Shr, a, b) ->
+      (* Ir.Shr is arithmetic on every backend post-fix (G phase 1) *)
+      Int32.shift_right (eval_ir_int32 a) (Int32.to_int (eval_ir_int32 b))
+  | Ir.EBinop (Ir.BitXor, a, b) ->
+      Int32.logxor (eval_ir_int32 a) (eval_ir_int32 b)
+  | Ir.EIf (cond, then_, else_) ->
+      if eval_ir_bool cond then eval_ir_int32 then_ else eval_ir_int32 else_
+  | _ -> Alcotest.fail "eval_ir_int32: unsupported node"
+
+and eval_ir_bool (e : Ir.expr) : bool =
+  match e with
+  | Ir.EBinop (Ir.Eq, a, b) -> eval_ir_int32 a = eval_ir_int32 b
+  | _ -> Alcotest.fail "eval_ir_bool: unsupported node"
+
+let eval_int32_binop op a b =
+  let ty = Sarek_types.(TReg Int) in
+  let mk te = Sarek_typed_ast.{te; ty; te_loc = Sarek_ast.dummy_loc} in
+  let texpr =
+    mk (Sarek_typed_ast.TEBinop (op, mk (TEInt32 a), mk (TEInt32 b)))
+  in
+  let state = Sarek_lower_ir.create_state (Hashtbl.create 1) in
+  let ir_expr = Sarek_lower_ir.lower_expr state texpr in
+  eval_ir_int32 ir_expr
+
+let test_lsr_negative_is_logical () =
+  (* (-16) lsr 2 = 1073741820, NOT (-16) asr 2 = -4 *)
+  let result = eval_int32_binop Sarek_ast.Lsr (-16l) 2l in
+  Alcotest.(check int32) "(-16) lsr 2" 1073741820l result
+
+let test_asr_negative_is_arithmetic () =
+  let result = eval_int32_binop Sarek_ast.Asr (-16l) 2l in
+  Alcotest.(check int32) "(-16) asr 2" (-4l) result
+
+let test_lsr_negative_shift_by_zero () =
+  (* n = 0 must not hit the (width - n) = width shift-by-32 UB guard *)
+  let result = eval_int32_binop Sarek_ast.Lsr (-16l) 0l in
+  Alcotest.(check int32) "(-16) lsr 0" (-16l) result
+
+let test_lsr_negative_shift_by_31 () =
+  (* Top bit shifted all the way down to bit 0 *)
+  let result = eval_int32_binop Sarek_ast.Lsr (-16l) 31l in
+  Alcotest.(check int32) "(-16) lsr 31" 1l result
+
+let test_lsr_positive_matches_asr () =
+  (* For a non-negative operand, lsr and asr must agree *)
+  let lsr_result = eval_int32_binop Sarek_ast.Lsr 16l 2l in
+  let asr_result = eval_int32_binop Sarek_ast.Asr 16l 2l in
+  Alcotest.(check int32) "16 lsr 2" 4l lsr_result ;
+  Alcotest.(check int32) "16 asr 2 matches lsr" lsr_result asr_result
+
 (* Test suite *)
 let () =
   Alcotest.run
@@ -410,5 +486,28 @@ let () =
             test_lower_decl_immutable;
           Alcotest.test_case "lower decl mutable" `Quick test_lower_decl_mutable;
           Alcotest.test_case "lower param" `Quick test_lower_param;
+        ] );
+      ( "shift_semantics",
+        [
+          Alcotest.test_case
+            "lsr negative is logical"
+            `Quick
+            test_lsr_negative_is_logical;
+          Alcotest.test_case
+            "asr negative is arithmetic"
+            `Quick
+            test_asr_negative_is_arithmetic;
+          Alcotest.test_case
+            "lsr negative shift by zero"
+            `Quick
+            test_lsr_negative_shift_by_zero;
+          Alcotest.test_case
+            "lsr negative shift by 31"
+            `Quick
+            test_lsr_negative_shift_by_31;
+          Alcotest.test_case
+            "lsr positive matches asr"
+            `Quick
+            test_lsr_positive_matches_asr;
         ] );
     ]

--- a/sarek/tests/unit/test_ppx_scan_diagnostics.ml
+++ b/sarek/tests/unit/test_ppx_scan_diagnostics.ml
@@ -1,0 +1,103 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Unit tests for Sarek_ppx.scan_file_for_sarek_types's error handling.
+ *
+ * Pre-fix, this function wrapped its whole body in `with _ -> ()`, silently
+ * discarding the scanned file's name and the exception on ANY failure
+ * (unreadable file, parse error, or a registration error triggered by
+ * malformed [@sarek.*] content) while still letting compilation of the
+ * *caller* succeed. Post-fix it prints a diagnostic naming the file and the
+ * exception to stderr (via Printf.eprintf) and also returns
+ * `string option`: `None` on success, `Some diagnostic` on failure - so the
+ * failure is visible (in the build log) without breaking the "compilation
+ * still succeeds" property (an `[@ocaml.ppwarning ...]` attribute was
+ * considered and rejected: this project's dune "dev" profile promotes
+ * warning 22 to a hard error, which would defeat that same property - see
+ * Sarek_ppx.ml's scan_file_for_sarek_types doc comment for the full
+ * rationale).
+ *
+ * This test exercises the return-value contract directly (the mechanism
+ * that is actually assertable): a malformed fixture must yield
+ * `Some diagnostic` naming the file and mentioning a parse failure; a
+ * well-formed fixture must yield `None`. The "compilation still succeeds"
+ * half of the contract is proven separately by
+ * sarek/tests/e2e/test_ppx_scan_failure_warning.ml, which %sarek_includes
+ * a malformed sibling file and must still build.
+ *
+ * Fixture content is written to real temp files at runtime (rather than
+ * checked-in fixture files copied in by dune `(deps ...)`) so the test does
+ * not depend on dune's deps-vs-runtest-action copying semantics working the
+ * same way under both `dune build`/`dune runtest` and `dune exec`.
+ ******************************************************************************)
+
+(* Small substring check (avoids pulling in an extra string-utility library
+   just for this one test). *)
+let contains ~needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  let rec go i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else go (i + 1)
+  in
+  nlen = 0 || go 0
+
+let with_temp_file ~suffix contents f =
+  let path = Filename.temp_file "sarek_scan_test" suffix in
+  let oc = open_out path in
+  output_string oc contents ;
+  close_out oc ;
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () -> f path)
+
+let unparseable_contents = "let broken = fun x -> x +\n"
+
+let wellformed_contents = "let ok = 1 + 1\n"
+
+let test_scan_reports_unparseable_file () =
+  with_temp_file ~suffix:".ml" unparseable_contents (fun path ->
+      (* Pre-fix this call returned unit unconditionally and there was
+         nothing to assert; the function's whole point pre-fix was to be
+         silent. Post-fix, scanning a file that fails to parse must surface
+         a diagnostic naming both the file and the failure - not swallow
+         it. *)
+      match Sarek_ppx.scan_file_for_sarek_types path with
+      | None ->
+          Alcotest.fail
+            "expected Some diagnostic for an unparseable file, got None \
+             (pre-fix behavior: failure silently swallowed)"
+      | Some msg ->
+          Alcotest.(check bool)
+            "diagnostic names the scanned file"
+            true
+            (contains ~needle:path msg))
+
+let test_scan_ok_on_wellformed_file () =
+  with_temp_file ~suffix:".ml" wellformed_contents (fun path ->
+      match Sarek_ppx.scan_file_for_sarek_types path with
+      | None -> ()
+      | Some msg ->
+          Alcotest.failf
+            "expected None for a well-formed file with no [@sarek.*] \
+             declarations, got Some %S"
+            msg)
+
+let () =
+  Alcotest.run
+    "ppx_scan_diagnostics"
+    [
+      ( "scan_file_for_sarek_types",
+        [
+          ( "unparseable file yields Some diagnostic naming the file",
+            `Quick,
+            test_scan_reports_unparseable_file );
+          ( "well-formed file yields None",
+            `Quick,
+            test_scan_ok_on_wellformed_file );
+        ] );
+    ]

--- a/scripts/check-opam-clean.sh
+++ b/scripts/check-opam-clean.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+#
+# Guard against a regression of the `make opam` target mutating sarek.opam
+# (it used to append a bogus `available: [ os = "linux" ]` line on every
+# run, and also tried to append to a non-existent sarek_ppx.opam). This
+# script asserts:
+#   - `make opam` can be run twice in a row without error
+#   - sarek.opam gains no `available:` line
+#   - sarek.opam gains no duplicated trailing line
+#   - sarek.opam is left byte-identical to the tracked version (git diff clean)
+#   - the Makefile no longer references sarek_ppx.opam (that package does
+#     not exist in this repo)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+fail() {
+    echo -e "${RED}FAIL: $1${NC}"
+    exit 1
+}
+
+echo "Running 'make opam' twice to check for corruption/non-idempotence..."
+make opam
+make opam
+
+if grep -q 'available:' sarek.opam; then
+    fail "sarek.opam contains an 'available:' line after 'make opam'"
+fi
+
+# Duplicate trailing line check: last line must not equal the second-to-last
+# non-empty line (guards against the old double-append corruption).
+last_line="$(tail -n 1 sarek.opam)"
+second_last_line="$(tail -n 2 sarek.opam | head -n 1)"
+if [ -n "$last_line" ] && [ "$last_line" = "$second_last_line" ]; then
+    fail "sarek.opam has a duplicated trailing line"
+fi
+
+if ! git diff --exit-code sarek.opam > /dev/null; then
+    fail "sarek.opam differs from the tracked version after 'make opam'"
+fi
+
+if grep -q 'sarek_ppx.opam' Makefile; then
+    fail "Makefile still references the non-existent sarek_ppx.opam"
+fi
+
+if [ -f sarek_ppx.opam ]; then
+    fail "sarek_ppx.opam was created by 'make opam' but should not exist"
+fi
+
+echo -e "${GREEN}PASS: 'make opam' is clean and idempotent${NC}"

--- a/spoc/ir/Sarek_ir_analysis.ml
+++ b/spoc/ir/Sarek_ir_analysis.ml
@@ -70,6 +70,7 @@ let rec stmt_uses_float64 = function
       elttype_uses_float64 v.var_type
       || expr_uses_float64 e || stmt_uses_float64 body
   | SPragma (_, body) | SBlock body -> stmt_uses_float64 body
+  (* Deliberately asymmetric vs. stmt_uses_atomics's SNative arm: native-block float64 usage is a separate, not-yet-decided question - see KB / review notes; do not change this arm as part of the atomics fix. *)
   | SNative _ -> false
 
 (** Check if a declaration uses float64 *)
@@ -158,9 +159,19 @@ let rec expr_uses_atomics = function
       expr_uses_atomics scrutinee
       || List.exists (fun (_, e) -> expr_uses_atomics e) cases
 
+(** Check if an lvalue contains an atomic intrinsic call (in its index/base
+    expression). LVar has no sub-expression; LRecordField recurses into the
+    inner lvalue. *)
+let rec lvalue_uses_atomics = function
+  | LVar _ -> false
+  | LArrayElem (_, idx) -> expr_uses_atomics idx
+  | LArrayElemExpr (base, idx) ->
+      expr_uses_atomics base || expr_uses_atomics idx
+  | LRecordField (lv, _) -> lvalue_uses_atomics lv
+
 (** Check if a statement contains an atomic intrinsic call *)
 let rec stmt_uses_atomics = function
-  | SAssign (_, e) -> expr_uses_atomics e
+  | SAssign (lv, e) -> lvalue_uses_atomics lv || expr_uses_atomics e
   | SSeq stmts -> List.exists stmt_uses_atomics stmts
   | SIf (cond, then_, else_) ->
       expr_uses_atomics cond || stmt_uses_atomics then_
@@ -176,7 +187,10 @@ let rec stmt_uses_atomics = function
   | SLet (_, e, body) | SLetMut (_, e, body) ->
       expr_uses_atomics e || stmt_uses_atomics body
   | SPragma (_, body) | SBlock body -> stmt_uses_atomics body
-  | SNative _ -> false
+  | SNative _ ->
+      (* Conservative: inline native GPU code is opaque; fusion must not
+         assume it is atomic-free. *)
+      true
 
 (** Check if a declaration contains an atomic intrinsic call (in its
     initializer/size expression, if any) *)

--- a/spoc/ir/Sarek_ir_analysis.ml
+++ b/spoc/ir/Sarek_ir_analysis.ml
@@ -109,3 +109,91 @@ let kernel_uses_float64 k =
            (fun (_, args) -> List.exists elttype_uses_float64 args)
            constrs)
        k.kern_variants
+
+(** {1 Atomic-operation detection}
+
+    Atomic intrinsics have no dedicated IR constructor: the PPX lowers every
+    atomic primitive (see the [category = "atomic"] entries registered in
+    [sarek/ppx/Sarek_core_primitives.ml], and the [%sarek_intrinsic] atomics in
+    [sarek/Sarek_stdlib/Gpu.ml]) to a plain [EIntrinsic (path, name, args)]
+    node, e.g. ["atomic_add_int32"], ["atomic_cas_int32"],
+    ["atomic_add_global_int32"], ... All such names share the ["atomic_"] prefix
+    by registration convention.
+
+    REGISTRATION POINT: this is the single source of truth for recognizing an
+    atomic intrinsic from IR. If a future atomic primitive is registered under a
+    name that does not start with ["atomic_"], update [is_atomic_intrinsic_name]
+    below (and consider exporting the name list from Sarek_core_primitives.ml
+    instead of relying on the prefix convention). Do not duplicate this check
+    elsewhere. *)
+let is_atomic_intrinsic_name name =
+  let prefix = "atomic_" in
+  String.length name >= String.length prefix
+  && String.sub name 0 (String.length prefix) = prefix
+
+(** Check if an expression contains an atomic intrinsic call *)
+let rec expr_uses_atomics = function
+  | EIntrinsic (_, name, args) ->
+      is_atomic_intrinsic_name name || List.exists expr_uses_atomics args
+  | EConst _ | EVar _ -> false
+  | EBinop (_, e1, e2) -> expr_uses_atomics e1 || expr_uses_atomics e2
+  | EUnop (_, e) -> expr_uses_atomics e
+  | EArrayRead (_, idx) -> expr_uses_atomics idx
+  | EArrayReadExpr (base, idx) ->
+      expr_uses_atomics base || expr_uses_atomics idx
+  | ERecordField (e, _) -> expr_uses_atomics e
+  | ECast (_, e) -> expr_uses_atomics e
+  | ETuple exprs -> List.exists expr_uses_atomics exprs
+  | EApp (fn, args) ->
+      expr_uses_atomics fn || List.exists expr_uses_atomics args
+  | ERecord (_, fields) ->
+      List.exists (fun (_, e) -> expr_uses_atomics e) fields
+  | EVariant (_, _, args) -> List.exists expr_uses_atomics args
+  | EArrayLen _ -> false
+  | EArrayCreate (_, size, _) -> expr_uses_atomics size
+  | EIf (cond, then_, else_) ->
+      expr_uses_atomics cond || expr_uses_atomics then_
+      || expr_uses_atomics else_
+  | EMatch (scrutinee, cases) ->
+      expr_uses_atomics scrutinee
+      || List.exists (fun (_, e) -> expr_uses_atomics e) cases
+
+(** Check if a statement contains an atomic intrinsic call *)
+let rec stmt_uses_atomics = function
+  | SAssign (_, e) -> expr_uses_atomics e
+  | SSeq stmts -> List.exists stmt_uses_atomics stmts
+  | SIf (cond, then_, else_) ->
+      expr_uses_atomics cond || stmt_uses_atomics then_
+      || Option.fold ~none:false ~some:stmt_uses_atomics else_
+  | SWhile (cond, body) -> expr_uses_atomics cond || stmt_uses_atomics body
+  | SFor (_, lo, hi, _, body) ->
+      expr_uses_atomics lo || expr_uses_atomics hi || stmt_uses_atomics body
+  | SMatch (scrutinee, cases) ->
+      expr_uses_atomics scrutinee
+      || List.exists (fun (_, s) -> stmt_uses_atomics s) cases
+  | SReturn e | SExpr e -> expr_uses_atomics e
+  | SBarrier | SWarpBarrier | SEmpty | SMemFence -> false
+  | SLet (_, e, body) | SLetMut (_, e, body) ->
+      expr_uses_atomics e || stmt_uses_atomics body
+  | SPragma (_, body) | SBlock body -> stmt_uses_atomics body
+  | SNative _ -> false
+
+(** Check if a declaration contains an atomic intrinsic call (in its
+    initializer/size expression, if any) *)
+let decl_uses_atomics = function
+  | DParam _ -> false
+  | DLocal (_, init) -> Option.fold ~none:false ~some:expr_uses_atomics init
+  | DShared (_, _, size) -> Option.fold ~none:false ~some:expr_uses_atomics size
+
+(** Check if a helper function contains an atomic intrinsic call *)
+let helper_uses_atomics hf = stmt_uses_atomics hf.hf_body
+
+(** Check if a kernel uses atomic operations anywhere: params/locals
+    initializers, body, and helper functions called from the kernel. Helper
+    bodies must be walked explicitly — a body-only check would miss atomics
+    hidden inside a called helper function. *)
+let kernel_uses_atomics k =
+  List.exists decl_uses_atomics k.kern_params
+  || List.exists decl_uses_atomics k.kern_locals
+  || stmt_uses_atomics k.kern_body
+  || List.exists helper_uses_atomics k.kern_funcs

--- a/spoc/ir/test/test_sarek_ir_analysis.ml
+++ b/spoc/ir/test/test_sarek_ir_analysis.ml
@@ -377,6 +377,135 @@ let test_kernel_uses_float64_variants () =
 
   print_endline "  kernel_uses_float64 variants: OK"
 
+(** {1 is_atomic_intrinsic_name / expr_uses_atomics Tests} *)
+
+let test_is_atomic_intrinsic_name () =
+  assert (is_atomic_intrinsic_name "atomic_add_int32" = true) ;
+  assert (is_atomic_intrinsic_name "atomic_cas_int32" = true) ;
+  assert (is_atomic_intrinsic_name "atomic_add_global_int32" = true) ;
+  assert (is_atomic_intrinsic_name "thread_idx_x" = false) ;
+  assert (is_atomic_intrinsic_name "block_barrier" = false) ;
+  assert (is_atomic_intrinsic_name "" = false) ;
+  print_endline "  is_atomic_intrinsic_name: OK"
+
+let test_expr_uses_atomics () =
+  let non_atomic = EIntrinsic (["Gpu"], "thread_idx_x", []) in
+  assert (expr_uses_atomics non_atomic = false) ;
+  let direct_atomic =
+    EIntrinsic
+      ( [],
+        "atomic_add_int32",
+        [
+          EVar
+            {
+              var_name = "arr";
+              var_id = 0;
+              var_type = TInt32;
+              var_mutable = true;
+            };
+          EConst (CInt32 0l);
+          EConst (CInt32 1l);
+        ] )
+  in
+  assert (expr_uses_atomics direct_atomic = true) ;
+  (* Nested: atomic call buried inside an otherwise ordinary expression *)
+  let nested_atomic = EBinop (Add, EConst (CInt32 1l), direct_atomic) in
+  assert (expr_uses_atomics nested_atomic = true) ;
+  print_endline "  expr_uses_atomics: OK"
+
+(** {1 helper_uses_atomics / kernel_uses_atomics Tests} *)
+
+let test_helper_uses_atomics () =
+  let param : var =
+    {var_name = "x"; var_id = 0; var_type = TInt32; var_mutable = false}
+  in
+  let hf_atomic : helper_func =
+    {
+      hf_name = "bump";
+      hf_params = [param];
+      hf_ret_type = TInt32;
+      hf_body =
+        SReturn
+          (EIntrinsic ([], "atomic_add_int32", [EVar param; EConst (CInt32 1l)]));
+    }
+  in
+  assert (helper_uses_atomics hf_atomic = true) ;
+
+  let hf_no_atomic : helper_func =
+    {
+      hf_name = "identity";
+      hf_params = [param];
+      hf_ret_type = TInt32;
+      hf_body = SReturn (EVar param);
+    }
+  in
+  assert (helper_uses_atomics hf_no_atomic = false) ;
+  print_endline "  helper_uses_atomics: OK"
+
+let test_kernel_uses_atomics_direct () =
+  let k_direct : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SExpr
+          (EIntrinsic
+             ([], "atomic_add_int32", [EConst (CInt32 0l); EConst (CInt32 1l)]));
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_atomics k_direct = true) ;
+
+  let k_none : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body = SEmpty;
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_atomics k_none = false) ;
+  print_endline "  kernel_uses_atomics direct: OK"
+
+let test_kernel_uses_atomics_in_helper () =
+  (* Load-bearing case: the atomic is only reachable through kern_funcs, not
+     kern_body. A body-only walk would wrongly report false. *)
+  let param : var =
+    {var_name = "x"; var_id = 0; var_type = TInt32; var_mutable = false}
+  in
+  let hf_atomic : helper_func =
+    {
+      hf_name = "bump";
+      hf_params = [param];
+      hf_ret_type = TInt32;
+      hf_body =
+        SReturn
+          (EIntrinsic ([], "atomic_add_int32", [EVar param; EConst (CInt32 1l)]));
+    }
+  in
+  let k_helper_atomic : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body = SEmpty;
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [hf_atomic];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_atomics k_helper_atomic = true) ;
+  print_endline "  kernel_uses_atomics via helper: OK"
+
 (** {1 Main} *)
 
 let () =
@@ -406,4 +535,9 @@ let () =
   test_kernel_uses_float64_params () ;
   test_kernel_uses_float64_types () ;
   test_kernel_uses_float64_variants () ;
+  test_is_atomic_intrinsic_name () ;
+  test_expr_uses_atomics () ;
+  test_helper_uses_atomics () ;
+  test_kernel_uses_atomics_direct () ;
+  test_kernel_uses_atomics_in_helper () ;
   print_endline "All Sarek_ir_analysis tests passed!"

--- a/spoc/ir/test/test_sarek_ir_analysis.ml
+++ b/spoc/ir/test/test_sarek_ir_analysis.ml
@@ -506,6 +506,76 @@ let test_kernel_uses_atomics_in_helper () =
   assert (kernel_uses_atomics k_helper_atomic = true) ;
   print_endline "  kernel_uses_atomics via helper: OK"
 
+(** {1 lvalue_uses_atomics / SAssign lvalue Tests (finding 3)} *)
+
+let test_lvalue_uses_atomics () =
+  let atomic_idx =
+    EIntrinsic ([], "atomic_add_int32", [EConst (CInt32 0l); EConst (CInt32 1l)])
+  in
+  assert (
+    lvalue_uses_atomics
+      (LVar {var_name = "x"; var_id = 0; var_type = TInt32; var_mutable = true})
+    = false) ;
+  assert (lvalue_uses_atomics (LArrayElem ("arr", EConst (CInt32 0l))) = false) ;
+  assert (lvalue_uses_atomics (LArrayElem ("arr", atomic_idx)) = true) ;
+  assert (
+    lvalue_uses_atomics (LArrayElemExpr (EConst (CInt32 0l), atomic_idx)) = true) ;
+  assert (
+    lvalue_uses_atomics (LArrayElemExpr (atomic_idx, EConst (CInt32 0l))) = true) ;
+  assert (
+    lvalue_uses_atomics (LRecordField (LArrayElem ("arr", atomic_idx), "field"))
+    = true) ;
+  print_endline "  lvalue_uses_atomics: OK"
+
+(** Load-bearing case for finding 3: the only atomic in the kernel is inside an
+    [SAssign]'s lvalue index expression (e.g. [arr.(atomic_add ...) <- 5]), not
+    in the RHS. Pre-fix, [stmt_uses_atomics]'s [SAssign] case ignored the lvalue
+    entirely and only walked the RHS, so this wrongly returned false. *)
+let test_kernel_uses_atomics_in_assign_lvalue () =
+  let atomic_idx =
+    EIntrinsic ([], "atomic_add_int32", [EConst (CInt32 0l); EConst (CInt32 1l)])
+  in
+  let k_lvalue_atomic : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body = SAssign (LArrayElem ("arr", atomic_idx), EConst (CInt32 5l));
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_atomics k_lvalue_atomic = true) ;
+  print_endline "  kernel_uses_atomics via assign lvalue: OK"
+
+(** {1 SNative conservative-atomics Tests (finding 4)} *)
+
+let dummy_native_gpu ~framework:_ = ""
+
+let dummy_native_ocaml : ocaml_closure =
+  {run = (fun ~block:_ ~grid:_ _args -> ())}
+
+let test_kernel_uses_atomics_snative () =
+  (* SNative is opaque inline GPU code; stmt_uses_atomics must treat it
+     conservatively as atomic-bearing rather than hard-coding "no atomics
+     here". Pre-fix this returned false unconditionally. *)
+  let k_native : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body = SNative {gpu = dummy_native_gpu; ocaml = dummy_native_ocaml};
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_atomics k_native = true) ;
+  print_endline "  kernel_uses_atomics via SNative (conservative): OK"
+
 (** {1 Main} *)
 
 let () =
@@ -540,4 +610,7 @@ let () =
   test_helper_uses_atomics () ;
   test_kernel_uses_atomics_direct () ;
   test_kernel_uses_atomics_in_helper () ;
+  test_lvalue_uses_atomics () ;
+  test_kernel_uses_atomics_in_assign_lvalue () ;
+  test_kernel_uses_atomics_snative () ;
   print_endline "All Sarek_ir_analysis tests passed!"


### PR DESCRIPTION
## Summary

Fixes the CRITICAL + related HIGH semantic-correctness findings from the 2026-07-02 whole-tree audit (`briefs/audit-2026-07-02.md`, local): 10 fixes, each with a test verified to fail on the pre-fix code.

- **Makefile `opam` target** no longer corrupts dune-generated opam files (appended `available:` lines, phantom `sarek_ppx.opam`); new `check-opam-clean` guard wired into `test-all`.
- **Native `downto` loops** iterated zero times (bounds emitted reversed); fixed + execution test.
- **`TECreateArray`** passed an int32 size to `Array.make` (compile error on native path); fixed.
- **Legacy Kirc lowering** silently dropped `downto` direction; now a located error (path has no production callers).
- **Tuple/function-typed kernel parameters** silently lowered to `TInt32`; now rejected with actionable errors + negative-suite cases.
- **Include-scan** (`scan_file_for_sarek_types`) swallowed every exception; failures now reported to stderr with file + exception, scan continues (ppwarning rejected empirically: dev profile promotes warning 22 to error).
- **Bare `float` = float32** in GPGPU kernel contexts (explicit maintainer decision 2026-07-02) — typer aligned down from float64; bare-float kernels no longer require fp64 devices (`kernel_uses_float64 = false` test).
- **Shift semantics**: `Lsr` and `Asr` both lowered to `Ir.Shr`, whose polarity was *mixed* across backends (5 arithmetic, PTX + interpreter logical). Canonicalized `Shr` = arithmetic; `lsr` lowered via width-aware two's-complement tree (no new IR constructor); non-trivial `lsr` operands are rejected with a located error rather than multi-evaluated (no backend CSE); shift count masked for both-branch backends (PTX `selp`, WGSL `select`).
- **Fusion atomics**: `has_atomics` was hardcoded `false`; new `kernel_uses_atomics` predicate (single source of truth in `Sarek_ir_analysis`, covers helpers, assignment lvalues, and treats opaque `SNative` blocks conservatively) now blocks all fusion paths (`can_fuse`, reduction, stencil, `should_fuse`).

One audit finding was **downgraded during implementation**: the `global_size_*` convergence misclassification is unreachable — the intrinsic is not registered, so kernels using it already fail at typing. Registering it is a follow-up capability.

## Review & QA

Adversarial review (2 specialists + codex cross-runtime pass) found 3 HIGH issues in the first iteration (lsr operand multi-evaluation; atomics walk missing assignment lvalues and `SNative`) — all fixed and delta-verified. QA gates green on two runtimes incl. `make e2e-fast` on real GPU. The pre-existing `make test_negative` failure (`sarek_ppx.lib` dune typo) reproduces identically on `main` and is tracked separately.

## Tracked follow-ups (deliberate debt, not silent)

1. Rocq PTX spec re-sync: `formal/codegen-ptx/theories/PtxTypes.v:228-229` models `Shr` as logical; the emitter now (correctly) emits `shr.s32`. `formal/` deliberately untouched here.
2. IR let-expression form → single-eval lowering for non-trivial `lsr` operands.
3. Decide `%sarek_include` failure fatality (explicit include currently non-fatal to stderr).
4. Thread source locations into `lower_param` rejections.
5. Interpreter int64 shift/bitwise branches (pre-existing 32-bit truncation).
6. `global_size_*` intrinsic registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `downto` loop handling in native code generation and lowering, with clearer behavior when unsupported forms are used.
  * Updated shift behavior so right shifts match arithmetic semantics for negative values across execution paths.
  * `float` now defaults to 32-bit precision in kernels unless `float64` is explicitly requested.

* **Bug Fixes**
  * Fixed array creation sizing in native execution.
  * Prevented fusion when kernels use atomic operations.
  * Improved handling of file scan failures so builds can continue with a warning.

* **Tests**
  * Added new regression tests for loops, shifts, arrays, atomics, float precision, and scan diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->