### PR TITLE
fix(ppx): close file descriptor on malformed-file scan path

### DIFF
--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -256,11 +256,18 @@ let register_sarek_module_item ~loc:_ item =
 let scan_file_for_sarek_types path : string option =
   try
     let ic = open_in path in
-    let lexbuf = Lexing.from_channel ic in
-    lexbuf.lex_curr_p <-
-      {lexbuf.lex_curr_p with pos_fname = path; pos_bol = 0; pos_lnum = 1} ;
-    let st = Parse.implementation lexbuf in
-    close_in ic ;
+    (* close_in must run whether or not Parse.implementation raises: this
+       function's whole purpose is to handle malformed files gracefully, so the
+       parse-failure path is expected and must not leak the descriptor. *)
+    let st =
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () ->
+          let lexbuf = Lexing.from_channel ic in
+          lexbuf.lex_curr_p <-
+            {lexbuf.lex_curr_p with pos_fname = path; pos_bol = 0; pos_lnum = 1} ;
+          Parse.implementation lexbuf)
+    in
     List.iter
       (fun item ->
         match item.pstr_desc with


### PR DESCRIPTION
Restores a fix that was lost to a rebase/force-push during the audit PR merges (originally reviewed and CodeRabbit-approved on #211, then silently dropped when a stale local branch was rebased over the pushed fix).

`scan_file_for_sarek_types` opens the file but `close_in` ran only after a successful `Parse.implementation` — so the malformed-file path (the exact case this graceful handler exists to absorb) leaked the descriptor. In a long-lived PPX/dune driver scanning many files, these accumulate. Fixed by wrapping the parse in `Fun.protect ~finally:(fun () -> close_in_noerr ic)`.

Verified: `dune build` clean, `test_ppx_scan_diagnostics` passes (scan still returns the diagnostic and continues on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)