### PR TITLE
fix(runtime): DomainPool record-aliasing drops work items at high core count

### DIFF
--- a/sarek/interp/Sarek_ir_interp.ml
+++ b/sarek/interp/Sarek_ir_interp.ml
@@ -84,8 +84,19 @@ module DomainPool = struct
     mutex : Mutex.t;
     cond : Condition.t;
     mutable shutdown : bool;
-    domains : unit Domain.t array;
+    (* [domains] MUST be a mutable field mutated in place (never rebuilt via
+       [{pool with domains}]): worker domains close over the exact record
+       returned by [create]. A functional record update after [Domain.spawn]
+       allocates a *new* block, so [mutable active_tasks]/[mutable shutdown]
+       - stored inline in the record, not behind a shared box - would live at
+       two different addresses: the one workers mutate and the one
+       [submit]/[wait_all] read. [wait_all] then observes [active_tasks]
+       stuck at 0 and can return before the last popped task has finished
+       running, dropping that task's output. See the regression test in
+       sarek/tests/e2e/test_domain_pool_stress.ml. *)
+    mutable domains : unit Domain.t array;
     mutable active_tasks : int;
+    mutable first_error : exn option;
     done_cond : Condition.t;
   }
 
@@ -102,8 +113,20 @@ module DomainPool = struct
         let task = Queue.pop pool.task_queue in
         pool.active_tasks <- pool.active_tasks + 1 ;
         Mutex.unlock pool.mutex ;
-        (try task () with _ -> ()) ;
+        (* Never silently swallow a work-item exception: a raise here used to
+           be caught and dropped, leaving the block's output unwritten while
+           [wait_all] still reported success. Capture the first error and
+           re-raise it from [wait_all] instead. *)
+        let task_error =
+          try
+            task () ;
+            None
+          with exn -> Some exn
+        in
         Mutex.lock pool.mutex ;
+        (match (pool.first_error, task_error) with
+        | None, Some exn -> pool.first_error <- Some exn
+        | _ -> ()) ;
         pool.active_tasks <- pool.active_tasks - 1 ;
         if pool.active_tasks = 0 && Queue.is_empty pool.task_queue then
           Condition.broadcast pool.done_cond ;
@@ -123,13 +146,15 @@ module DomainPool = struct
         shutdown = false;
         domains = [||];
         active_tasks = 0;
+        first_error = None;
         done_cond = Condition.create ();
       }
     in
-    let domains =
-      Array.init num_domains (fun _ -> Domain.spawn (fun () -> worker pool))
-    in
-    {pool with domains}
+    (* Mutate [domains] in place on [pool] - see the field comment above for
+       why a functional record update here would be unsound. *)
+    pool.domains <-
+      Array.init num_domains (fun _ -> Domain.spawn (fun () -> worker pool)) ;
+    pool
 
   let submit pool task =
     Mutex.lock pool.mutex ;
@@ -142,19 +167,48 @@ module DomainPool = struct
     while pool.active_tasks > 0 || not (Queue.is_empty pool.task_queue) do
       Condition.wait pool.done_cond pool.mutex
     done ;
-    Mutex.unlock pool.mutex
+    let first_error = pool.first_error in
+    pool.first_error <- None ;
+    Mutex.unlock pool.mutex ;
+    match first_error with Some exn -> raise exn | None -> ()
 end
+
+(** Resolve how many domains the interpreter's [DomainPool] should use.
+
+    Reads [SAREK_DOMAIN_COUNT] first (any positive integer) so tests can force a
+    domain count higher than the host's physical core count - this is the only
+    reliable way to reproduce oversubscription races such as the [DomainPool]
+    record-aliasing bug on a small developer machine. Falls back to
+    [Domain.recommended_domain_count ()], and finally to a fixed default if that
+    raises. *)
+let resolve_domain_count ~default () =
+  match Sys.getenv_opt "SAREK_DOMAIN_COUNT" with
+  | Some s -> (
+      match int_of_string_opt s with
+      | Some n when n > 0 -> n
+      | _ -> ( try Domain.recommended_domain_count () with _ -> default))
+  | None -> ( try Domain.recommended_domain_count () with _ -> default)
 
 (** Global pool - lazily initialized *)
 let global_pool : DomainPool.t option ref = ref None
+
+let global_pool_mutex = Mutex.create ()
 
 let get_pool () =
   match !global_pool with
   | Some pool -> pool
   | None ->
-      let num_cores = try Domain.recommended_domain_count () with _ -> 4 in
-      let pool = DomainPool.create num_cores in
-      global_pool := Some pool ;
+      Mutex.lock global_pool_mutex ;
+      let pool =
+        match !global_pool with
+        | Some pool -> pool
+        | None ->
+            let num_cores = resolve_domain_count ~default:4 () in
+            let pool = DomainPool.create num_cores in
+            global_pool := Some pool ;
+            pool
+      in
+      Mutex.unlock global_pool_mutex ;
       pool
 
 (** Run all blocks in a grid (parallel - distributes blocks across domain pool)

--- a/sarek/interp/Sarek_ir_interp.ml
+++ b/sarek/interp/Sarek_ir_interp.ml
@@ -96,7 +96,7 @@ module DomainPool = struct
        sarek/tests/e2e/test_domain_pool_stress.ml. *)
     mutable domains : unit Domain.t array;
     mutable active_tasks : int;
-    mutable first_error : exn option;
+    mutable first_error : (exn * Printexc.raw_backtrace) option;
     done_cond : Condition.t;
   }
 
@@ -121,11 +121,11 @@ module DomainPool = struct
           try
             task () ;
             None
-          with exn -> Some exn
+          with exn -> Some (exn, Printexc.get_raw_backtrace ())
         in
         Mutex.lock pool.mutex ;
         (match (pool.first_error, task_error) with
-        | None, Some exn -> pool.first_error <- Some exn
+        | None, Some err -> pool.first_error <- Some err
         | _ -> ()) ;
         pool.active_tasks <- pool.active_tasks - 1 ;
         if pool.active_tasks = 0 && Queue.is_empty pool.task_queue then
@@ -170,7 +170,9 @@ module DomainPool = struct
     let first_error = pool.first_error in
     pool.first_error <- None ;
     Mutex.unlock pool.mutex ;
-    match first_error with Some exn -> raise exn | None -> ()
+    match first_error with
+    | Some (exn, bt) -> Printexc.raise_with_backtrace exn bt
+    | None -> ()
 end
 
 (** Resolve how many domains the interpreter's [DomainPool] should use.
@@ -199,17 +201,19 @@ let get_pool () =
   | Some pool -> pool
   | None ->
       Mutex.lock global_pool_mutex ;
-      let pool =
-        match !global_pool with
-        | Some pool -> pool
-        | None ->
-            let num_cores = resolve_domain_count ~default:4 () in
-            let pool = DomainPool.create num_cores in
-            global_pool := Some pool ;
-            pool
-      in
-      Mutex.unlock global_pool_mutex ;
-      pool
+      (* [Fun.protect]: if [DomainPool.create] raises (e.g. [Domain.spawn]
+         failure), the mutex must still be released or every later
+         [get_pool] caller deadlocks. *)
+      Fun.protect
+        ~finally:(fun () -> Mutex.unlock global_pool_mutex)
+        (fun () ->
+          match !global_pool with
+          | Some pool -> pool
+          | None ->
+              let num_cores = resolve_domain_count ~default:4 () in
+              let pool = DomainPool.create num_cores in
+              global_pool := Some pool ;
+              pool)
 
 (** Run all blocks in a grid (parallel - distributes blocks across domain pool)
 *)

--- a/sarek/sarek/Sarek_cpu_runtime_pools.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_pools.ml
@@ -43,7 +43,7 @@ module DomainPool = struct
        sarek/interp/Sarek_ir_interp.ml's [DomainPool]. *)
     mutable domains : unit Domain.t array;
     mutable active_tasks : int;
-    mutable first_error : exn option;
+    mutable first_error : (exn * Printexc.raw_backtrace) option;
     done_cond : Condition.t;
   }
 
@@ -65,11 +65,11 @@ module DomainPool = struct
           try
             task () ;
             None
-          with exn -> Some exn
+          with exn -> Some (exn, Printexc.get_raw_backtrace ())
         in
         Mutex.lock pool.mutex ;
         (match (pool.first_error, task_error) with
-        | None, Some exn -> pool.first_error <- Some exn
+        | None, Some err -> pool.first_error <- Some err
         | _ -> ()) ;
         pool.active_tasks <- pool.active_tasks - 1 ;
         if pool.active_tasks = 0 && Queue.is_empty pool.task_queue then
@@ -114,7 +114,9 @@ module DomainPool = struct
     let first_error = pool.first_error in
     pool.first_error <- None ;
     Mutex.unlock pool.mutex ;
-    match first_error with Some exn -> raise exn | None -> ()
+    match first_error with
+    | Some (exn, bt) -> Printexc.raise_with_backtrace exn bt
+    | None -> ()
 
   let shutdown pool =
     Mutex.lock pool.mutex ;
@@ -136,17 +138,18 @@ let get_pool () =
   | Some pool -> pool
   | None ->
       Mutex.lock global_pool_mutex ;
-      let pool =
-        match !global_pool with
-        | Some p -> p
-        | None ->
-            let num_cores = resolve_domain_count ~default:4 () in
-            let p = DomainPool.create num_cores in
-            global_pool := Some p ;
-            p
-      in
-      Mutex.unlock global_pool_mutex ;
-      pool
+      (* [Fun.protect]: pool creation can raise (e.g. [Domain.spawn]); the
+         mutex must still be released or later callers deadlock. *)
+      Fun.protect
+        ~finally:(fun () -> Mutex.unlock global_pool_mutex)
+        (fun () ->
+          match !global_pool with
+          | Some p -> p
+          | None ->
+              let num_cores = resolve_domain_count ~default:4 () in
+              let p = DomainPool.create num_cores in
+              global_pool := Some p ;
+              p)
 
 (** {1 Persistent Thread Pool for Fission Mode}
 
@@ -200,7 +203,8 @@ module ThreadPool = struct
     mutable pending_workers : int;
     mutable shutdown : bool;
     mutable generation : int; (* Incremented each kernel launch *)
-    mutable first_error : exn option; (* First error across all workers *)
+    mutable first_error : (exn * Printexc.raw_backtrace) option;
+        (* First error across all workers *)
   }
 
   (** Run a single block with BSP barriers using Effect.Shallow fibers *)
@@ -269,7 +273,8 @@ module ThreadPool = struct
             end);
         exnc =
           (fun exn ->
-            if !first_error = None then first_error := Some exn ;
+            if !first_error = None then
+              first_error := Some (exn, Printexc.get_raw_backtrace ()) ;
             if status.(tid) <> 2 then begin
               status.(tid) <- 2 ;
               incr num_completed
@@ -310,7 +315,9 @@ module ThreadPool = struct
         end
       done
     done ;
-    match !first_error with Some exn -> raise exn | None -> ()
+    match !first_error with
+    | Some (exn, bt) -> Printexc.raise_with_backtrace exn bt
+    | None -> ()
 
   (** Run a range of global threads directly - for barrier-free kernels. More
       efficient than block distribution when no barriers are needed. *)
@@ -408,7 +415,7 @@ module ThreadPool = struct
                     (* Thread distribution - more granular, faster *)
                     run_threads w ;
                   None
-                with exn -> Some exn
+                with exn -> Some (exn, Printexc.get_raw_backtrace ())
               in
               Atomic.set pool.work.(worker_id) None ;
               (true, err)
@@ -417,7 +424,7 @@ module ThreadPool = struct
         if had_work then begin
           Mutex.lock pool.mutex ;
           (match (pool.first_error, work_error) with
-          | None, Some exn -> pool.first_error <- Some exn
+          | None, Some err -> pool.first_error <- Some err
           | _ -> ()) ;
           pool.pending_workers <- pool.pending_workers - 1 ;
           if pool.pending_workers = 0 then Condition.broadcast pool.work_done ;
@@ -542,7 +549,9 @@ module ThreadPool = struct
     let first_error = pool.first_error in
     pool.first_error <- None ;
     Mutex.unlock pool.mutex ;
-    match first_error with Some exn -> raise exn | None -> ()
+    match first_error with
+    | Some (exn, bt) -> Printexc.raise_with_backtrace exn bt
+    | None -> ()
 
   let shutdown pool =
     Mutex.lock pool.mutex ;
@@ -561,17 +570,16 @@ let fission_pool_mutex = Mutex.create ()
 
 let get_fission_pool () =
   Mutex.lock fission_pool_mutex ;
-  let pool =
-    match !fission_pool with
-    | Some p -> p
-    | None ->
-        let num_cores = resolve_domain_count ~default:4 () in
-        let p = ThreadPool.create num_cores in
-        fission_pool := Some p ;
-        p
-  in
-  Mutex.unlock fission_pool_mutex ;
-  pool
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock fission_pool_mutex)
+    (fun () ->
+      match !fission_pool with
+      | Some p -> p
+      | None ->
+          let num_cores = resolve_domain_count ~default:4 () in
+          let p = ThreadPool.create num_cores in
+          fission_pool := Some p ;
+          p)
 
 (** {1 Simple Parallel Pool for Simple Kernels}
 
@@ -604,7 +612,7 @@ module ParallelPool = struct
     mutable pending_workers : int;
     mutable shutdown : bool;
     mutable generation : int;
-    mutable first_error : exn option;
+    mutable first_error : (exn * Printexc.raw_backtrace) option;
   }
 
   (** Worker function - claims chunks via atomic counter *)
@@ -648,13 +656,13 @@ module ParallelPool = struct
           try
             process_chunks () ;
             None
-          with exn -> Some exn
+          with exn -> Some (exn, Printexc.get_raw_backtrace ())
         in
 
         (* Signal completion - always, even on error *)
         Mutex.lock pool.mutex ;
         (match (pool.first_error, work_error) with
-        | None, Some exn -> pool.first_error <- Some exn
+        | None, Some err -> pool.first_error <- Some err
         | _ -> ()) ;
         pool.pending_workers <- pool.pending_workers - 1 ;
         if pool.pending_workers = 0 then Condition.signal pool.work_done ;
@@ -716,7 +724,9 @@ module ParallelPool = struct
       let first_error = pool.first_error in
       pool.first_error <- None ;
       Mutex.unlock pool.mutex ;
-      match first_error with Some exn -> raise exn | None -> ()
+      match first_error with
+      | Some (exn, bt) -> Printexc.raise_with_backtrace exn bt
+      | None -> ()
     end
 
   (** Run a parallel_for over the range 0 to total (exclusive) with default
@@ -744,24 +754,28 @@ let get_parallel_pool () =
   | Some p -> p
   | None ->
       Mutex.lock parallel_pool_mutex ;
-      let p =
-        match !parallel_pool with
-        | Some p -> p
-        | None ->
-            let num_workers =
-              match Sys.getenv_opt "SAREK_DOMAIN_COUNT" with
-              | Some s -> (
-                  match int_of_string_opt s with
-                  | Some n when n > 0 -> n
-                  | _ -> max 1 (Domain.recommended_domain_count () - 1))
-              | None -> max 1 (Domain.recommended_domain_count () - 1)
-            in
-            let p = ParallelPool.create num_workers in
-            parallel_pool := Some p ;
-            p
-      in
-      Mutex.unlock parallel_pool_mutex ;
-      p
+      Fun.protect
+        ~finally:(fun () -> Mutex.unlock parallel_pool_mutex)
+        (fun () ->
+          match !parallel_pool with
+          | Some p -> p
+          | None ->
+              (* Workers = cores - 1 (min 1); an explicit SAREK_DOMAIN_COUNT
+                 is taken as-is. [resolve_domain_count] already guards
+                 [Domain.recommended_domain_count] with a fallback so this
+                 cannot raise while the mutex is held. *)
+              let num_workers =
+                match Sys.getenv_opt "SAREK_DOMAIN_COUNT" with
+                | Some s
+                  when match int_of_string_opt s with
+                       | Some n -> n > 0
+                       | None -> false ->
+                    int_of_string s
+                | _ -> max 1 (resolve_domain_count ~default:4 () - 1)
+              in
+              let p = ParallelPool.create num_workers in
+              parallel_pool := Some p ;
+              p)
 
 (** {1 Fission Queue with Thread Pool Execution}
 

--- a/sarek/sarek/Sarek_cpu_runtime_pools.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_pools.ml
@@ -5,6 +5,22 @@
 
 open Sarek_cpu_runtime_types
 
+(** Resolve how many domains a CPU worker pool should use.
+
+    Reads [SAREK_DOMAIN_COUNT] first (any positive integer) so tests can force a
+    domain count higher than the host's physical core count - this is the only
+    reliable way to reproduce oversubscription races on a small developer
+    machine that only show up at CI's higher core counts. Falls back to
+    [Domain.recommended_domain_count ()], and finally to [default] if that
+    raises. *)
+let resolve_domain_count ~default () =
+  match Sys.getenv_opt "SAREK_DOMAIN_COUNT" with
+  | Some s -> (
+      match int_of_string_opt s with
+      | Some n when n > 0 -> n
+      | _ -> ( try Domain.recommended_domain_count () with _ -> default))
+  | None -> ( try Domain.recommended_domain_count () with _ -> default)
+
 (** Global domain pool for parallel execution *)
 module DomainPool = struct
   type task = unit -> unit
@@ -15,7 +31,17 @@ module DomainPool = struct
     mutex : Mutex.t;
     cond : Condition.t;
     mutable shutdown : bool;
-    domains : unit Domain.t array;
+    (* [domains] MUST be mutated in place (never rebuilt via
+       [{pool with domains}]): worker domains close over the exact record
+       returned by [create]. A functional record update after [Domain.spawn]
+       allocates a *new* block, so the [mutable] fields above - stored inline,
+       not behind a shared box - would live at two different addresses: the
+       one workers mutate and the one [submit]/[wait_all] read. [wait_all]
+       would then observe [active_tasks] stuck at 0 and could return before
+       the last popped task finished running, silently dropping its output.
+       See the interpreter-side twin of this bug in
+       sarek/interp/Sarek_ir_interp.ml's [DomainPool]. *)
+    mutable domains : unit Domain.t array;
     mutable active_tasks : int;
     mutable first_error : exn option;
     done_cond : Condition.t;
@@ -68,10 +94,11 @@ module DomainPool = struct
         done_cond = Condition.create ();
       }
     in
-    let domains =
-      Array.init num_domains (fun _ -> Domain.spawn (fun () -> worker pool))
-    in
-    {pool with domains}
+    (* Mutate [domains] in place on [pool] - see the field comment above for
+       why a functional record update here would be unsound. *)
+    pool.domains <-
+      Array.init num_domains (fun _ -> Domain.spawn (fun () -> worker pool)) ;
+    pool
 
   let submit pool task =
     Mutex.lock pool.mutex ;
@@ -113,9 +140,7 @@ let get_pool () =
         match !global_pool with
         | Some p -> p
         | None ->
-            let num_cores =
-              try Domain.recommended_domain_count () with _ -> 4
-            in
+            let num_cores = resolve_domain_count ~default:4 () in
             let p = DomainPool.create num_cores in
             global_pool := Some p ;
             p
@@ -540,7 +565,7 @@ let get_fission_pool () =
     match !fission_pool with
     | Some p -> p
     | None ->
-        let num_cores = try Domain.recommended_domain_count () with _ -> 4 in
+        let num_cores = resolve_domain_count ~default:4 () in
         let p = ThreadPool.create num_cores in
         fission_pool := Some p ;
         p
@@ -579,6 +604,7 @@ module ParallelPool = struct
     mutable pending_workers : int;
     mutable shutdown : bool;
     mutable generation : int;
+    mutable first_error : exn option;
   }
 
   (** Worker function - claims chunks via atomic counter *)
@@ -604,19 +630,32 @@ module ParallelPool = struct
         let total = Atomic.get pool.total_work in
         let chunk_size = Atomic.get pool.current_chunk_size in
 
-        (* Claim and process chunks until done *)
-        let rec process_chunks () =
-          let start = Atomic.fetch_and_add pool.next_chunk chunk_size in
-          if start < total then begin
-            let end_ = min (start + chunk_size) total in
-            work_fn start end_ ;
-            process_chunks ()
-          end
+        (* Claim and process chunks until done. This MUST run under a
+           try/with: if [work_fn] raises, [process_chunks] used to propagate
+           the exception straight out of [worker_fn], skipping the
+           "signal completion" block below entirely. [pending_workers] would
+           then never reach 0 and [parallel_for_chunk]'s wait loop would hang
+           forever instead of surfacing the error. *)
+        let work_error =
+          let rec process_chunks () =
+            let start = Atomic.fetch_and_add pool.next_chunk chunk_size in
+            if start < total then begin
+              let end_ = min (start + chunk_size) total in
+              work_fn start end_ ;
+              process_chunks ()
+            end
+          in
+          try
+            process_chunks () ;
+            None
+          with exn -> Some exn
         in
-        process_chunks () ;
 
-        (* Signal completion *)
+        (* Signal completion - always, even on error *)
         Mutex.lock pool.mutex ;
+        (match (pool.first_error, work_error) with
+        | None, Some exn -> pool.first_error <- Some exn
+        | _ -> ()) ;
         pool.pending_workers <- pool.pending_workers - 1 ;
         if pool.pending_workers = 0 then Condition.signal pool.work_done ;
         Mutex.unlock pool.mutex ;
@@ -643,6 +682,7 @@ module ParallelPool = struct
         pending_workers = 0;
         shutdown = false;
         generation = 0;
+        first_error = None;
       }
     in
     (* Spawn worker domains - they reference the same pool record *)
@@ -673,7 +713,10 @@ module ParallelPool = struct
       while pool.pending_workers > 0 do
         Condition.wait pool.work_done pool.mutex
       done ;
-      Mutex.unlock pool.mutex
+      let first_error = pool.first_error in
+      pool.first_error <- None ;
+      Mutex.unlock pool.mutex ;
+      match first_error with Some exn -> raise exn | None -> ()
     end
 
   (** Run a parallel_for over the range 0 to total (exclusive) with default
@@ -705,7 +748,14 @@ let get_parallel_pool () =
         match !parallel_pool with
         | Some p -> p
         | None ->
-            let num_workers = max 1 (Domain.recommended_domain_count () - 1) in
+            let num_workers =
+              match Sys.getenv_opt "SAREK_DOMAIN_COUNT" with
+              | Some s -> (
+                  match int_of_string_opt s with
+                  | Some n when n > 0 -> n
+                  | _ -> max 1 (Domain.recommended_domain_count () - 1))
+              | None -> max 1 (Domain.recommended_domain_count () - 1)
+            in
             let p = ParallelPool.create num_workers in
             parallel_pool := Some p ;
             p

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -330,6 +330,11 @@
  (action
   (run %{dep:test_float32_sin_pure.exe})))
 
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_domain_pool_stress.exe})))
+
 ; compile-only alias: the assertion IS successful compilation (PPX
 ; convergence-analysis positive cases, or a smoke test with no runtime
 ; check). Build-only - not executed - since there is nothing to run that
@@ -440,6 +445,18 @@
  (name test_float32_sin_pure)
  (modules test_float32_sin_pure)
  (libraries sarek sarek_ir spoc_core test_helpers unix)
+ (preprocess no_preprocessing))
+
+; Regression test for the DomainPool oversubscription race (dropped block
+; output under many concurrent domains) - see the module doc comment for the
+; full history. No PPX, no device abstraction: exercises
+; Sarek_ir_interp.run_kernel directly against a hand-built IR.
+; Run with: SAREK_DOMAIN_COUNT=128 dune exec sarek/tests/e2e/test_domain_pool_stress.exe
+
+(executable
+ (name test_domain_pool_stress)
+ (modules test_domain_pool_stress)
+ (libraries sarek sarek_ir spoc_core unix)
  (preprocess no_preprocessing))
 
 ; Float64 math intrinsics report across every fp64-capable device.

--- a/sarek/tests/e2e/test_domain_pool_stress.ml
+++ b/sarek/tests/e2e/test_domain_pool_stress.ml
@@ -1,0 +1,129 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression test - DomainPool oversubscription race
+ *
+ * Historical bug: [Sarek_ir_interp.DomainPool.create] (and its twin in
+ * Sarek_cpu_runtime_pools.ml) built the pool record, spawned worker domains
+ * closing over it, then rebuilt the record via [{pool with domains}] to fill
+ * in the [domains] field. Because [active_tasks]/[shutdown] were plain
+ * (unboxed) [mutable] fields rather than refs, that second record allocation
+ * gave workers and [wait_all]/[submit] two different memory cells for the
+ * same logical counter. [wait_all] then always observed [active_tasks = 0]
+ * and could return as soon as the task queue drained - even if the last
+ * popped block was still executing - dropping that block's writes.
+ *
+ * This surfaced on CI's 96-core runner (many domains -> many blocks in
+ * flight -> wider race window) but was independent of core count: it
+ * reproduced locally on a 32-core box too, just less often. [SAREK_DOMAIN_COUNT]
+ * lets us force a high domain count to make the race close to certain within
+ * a bounded number of trials, on any machine.
+ *
+ * This test runs a kernel over a grid with many blocks, forces a high domain
+ * count, repeats many trials, and asserts EVERY output element was written -
+ * i.e. no block was silently dropped.
+ ******************************************************************************)
+
+open Sarek_ir_types
+open Sarek
+
+(* Force a domain count well above typical local core counts *before* the
+   interpreter's global pool is lazily created (first [run_kernel] call).
+   Do not override an operator-supplied value. *)
+let () =
+  if Sys.getenv_opt "SAREK_DOMAIN_COUNT" = None then
+    Unix.putenv "SAREK_DOMAIN_COUNT" "96"
+
+(** Kernel IR: dst.(idx) <- idx + 1, built directly (no PPX) so this test has no
+    dependency on kernel compilation - it only exercises
+    [Sarek_ir_interp.run_kernel]'s block scheduling. *)
+let make_ir () : kernel =
+  let make_var id name ty =
+    {var_name = name; var_id = id; var_type = ty; var_mutable = false}
+  in
+  let dst = make_var 0 "dst" (TVec TInt32) in
+  let idx = make_var 1 "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("dst", EVar idx),
+            EBinop (Add, EVar idx, EConst (CInt32 1l)) ) )
+  in
+  {
+    kern_name = "domain_pool_stress";
+    kern_params =
+      [DParam (dst, Some {arr_elttype = TInt32; arr_memspace = Global})];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let block_size = 64
+
+let num_blocks = 64
+
+let n = block_size * num_blocks
+
+let trials = 50
+
+let run_one_trial ir =
+  let dst = Array.make n (Sarek_ir_interp.VInt32 0l) in
+  Sarek_ir_interp.run_kernel
+    ir
+    ~block:(block_size, 1, 1)
+    ~grid:(num_blocks, 1, 1)
+    [("dst", Sarek_ir_interp.ArgArray dst)] ;
+  let dropped = ref [] in
+  for i = 0 to n - 1 do
+    let got = match dst.(i) with Sarek_ir_interp.VInt32 v -> v | _ -> -1l in
+    if got <> Int32.of_int (i + 1) then dropped := i :: !dropped
+  done ;
+  !dropped
+
+let () =
+  let ir = make_ir () in
+  Printf.printf
+    "Stressing DomainPool: %d trials, %d blocks x %d threads, \
+     SAREK_DOMAIN_COUNT=%s\n\
+     %!"
+    trials
+    num_blocks
+    block_size
+    (Option.value ~default:"(unset)" (Sys.getenv_opt "SAREK_DOMAIN_COUNT")) ;
+  let any_dropped = ref false in
+  for trial = 1 to trials do
+    match run_one_trial ir with
+    | [] -> ()
+    | dropped ->
+        any_dropped := true ;
+        Printf.printf
+          "FAIL: trial %d dropped %d/%d output elements (first few indices: %s)\n\
+           %!"
+          trial
+          (List.length dropped)
+          n
+          (String.concat
+             ", "
+             (List.filteri
+                (fun i _ -> i < 5)
+                (List.rev_map string_of_int dropped)))
+  done ;
+  if !any_dropped then begin
+    print_endline "Some tests failed!" ;
+    exit 1
+  end
+  else begin
+    Printf.printf
+      "PASS: all %d trials wrote every output element (no dropped blocks)\n"
+      trials ;
+    print_endline "All tests passed!" ;
+    exit 0
+  end


### PR DESCRIPTION
## Summary

Fixes a real concurrency bug (surfaced by CI's 96-core runner intermittently failing e2e tests — `test_polymorphism` on the interpreter with `dst[768]=0`, and `test_math_intrinsics`/`test_float32_sin_pure` "numerical mismatch"; they pass at 32 cores and passed on main only by luck).

### Root cause
`DomainPool.create` (in **both** `sarek/interp/Sarek_ir_interp.ml` and `sarek/sarek/Sarek_cpu_runtime_pools.ml`) spawned worker domains closing over the initial `pool` record, then returned `{pool with domains}`. Because `active_tasks`/`shutdown` are unboxed `mutable` record fields (not refs), that second record allocation created **two distinct cells** for each logical counter: workers mutate one, `submit`/`wait_all` read the other. `wait_all` therefore always saw `active_tasks = 0` and could return as soon as the queue drained — while the last popped block was still executing — silently dropping that block's writes.

### Reproduction (deterministic under load)
- Standalone 96-domain microbench: 107–158 dropped tasks / 300 iterations; 0 with the fix.
- `test_polymorphism`: 3/40 failures at default 32 domains pre-fix; 0/100 at `SAREK_DOMAIN_COUNT=96` post-fix.
- New `test_domain_pool_stress.ml` (64 blocks × 64 threads): 17/50 trials dropped 31–212 elements pre-fix; 0/250 post-fix.

### Fixes
- `DomainPool.domains` is now filled by in-place mutation (no `{pool with domains}`), so all fields share one record identity.
- Worker exceptions are captured as `first_error` and **re-raised from `wait_all`** instead of being swallowed by `(try task () with _ -> ())` — a dropped/failed block now surfaces loudly.
- `Sarek_cpu_runtime_pools.ParallelPool.worker_fn`: an exception in `work_fn` used to skip the completion-signal block entirely and permanently hang `parallel_for`'s wait — now captured/re-raised (audit-flagged hang, closed).
- Added a `SAREK_DOMAIN_COUNT` env override (both pools) for stress-testing oversubscription on any core count — also a lasting testability feature.
- New regression test asserts every grid output element is written at forced-high domain count.

### Triage of the "numerical mismatch" tests
`test_math_intrinsics` was confirmed to be this CPU race (4/60 pre-fix on the parallel Interpreter device; 0/100 post-fix), **not** fp precision — it already passes on real GPU hardware. `test_float32_sin_pure` shares the identical `DomainPool`/`run_grid_parallel` path (fixed) but is single-block, so it was verified by code-path rather than a forced live repro.

### Verification
`dune build`, `dune runtest` (0 failures), `dune fmt` clean; stress green 100/100 at `SAREK_DOMAIN_COUNT=96`. Per-block interpreter state was audited and is correctly isolated (`copy_env`); the bug was purely the record-identity split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worker-pool error handling so exceptions are surfaced instead of being silently lost.
  * Improved pool startup and synchronization to reduce race conditions and avoid missed work or hangs.
  * Added support for configuring worker count via an environment setting, with safe fallbacks.

* **Tests**
  * Added a new end-to-end stress test that verifies all work items complete correctly under heavy parallel load.
  * Wired the stress test into the default test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->