### PR TITLE
feat(interp): Addition of math intrinsic functions

### DIFF
--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -133,6 +133,55 @@ let eval_float32_math_intrinsic name args =
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "tan"; reason = "requires 1 argument"}))
+  | "asin" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.asin (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "asin"; reason = "requires 1 argument"}))
+  | "acos" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.acos (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "acos"; reason = "requires 1 argument"}))
+  | "atan" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.atan (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan"; reason = "requires 1 argument"}))
+  | "atan2" -> (
+      match args with
+      | arg1 :: arg2 :: _ -> Some (VFloat32 (F32.atan2 (to_float32 arg1) (to_float32 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan2"; reason = "requires 2 arguments"}))
+  | "sinh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.sinh (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "sinh"; reason = "requires 1 argument"}))
+  | "cosh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.cosh (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "cosh"; reason = "requires 1 argument"}))
+  | "tanh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.tanh (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "tanh"; reason = "requires 1 argument"}))
   | "sqrt" -> (
       match args with
       | arg :: _ -> Some (VFloat32 (F32.sqrt (to_float32 arg)))

--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -358,6 +358,44 @@ let eval_float64_math_intrinsic name args =
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "abs (float64)"; reason = "requires 1 argument"}))
+  | "floor" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (floor (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "floor (float64)"; reason = "requires 1 argument"}))
+  | "ceil" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (ceil (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "ceil (float64)"; reason = "requires 1 argument"}))
+  | "pow" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (Float.pow (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "pow (float64)"; reason = "requires 2 arguments"}))
+  | "min" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (min (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "min (float64)"; reason = "requires 2 arguments"}))
+  | "max" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (max (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "max (float64)"; reason = "requires 2 arguments"}))
   | "of_int" -> (
       match args with
       | arg :: _ -> Some (VFloat64 (Float.of_int (to_int arg)))

--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -274,6 +274,62 @@ let eval_float64_math_intrinsic name args =
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "cos (float64)"; reason = "requires 1 argument"}))
+  | "tan" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (tan (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "tan (float64)"; reason = "requires 1 argument"}))
+  | "asin" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (asin (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "asin (float64)"; reason = "requires 1 argument"}))
+  | "acos" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (acos (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "acos (float64)"; reason = "requires 1 argument"}))
+  | "atan" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (atan (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan (float64)"; reason = "requires 1 argument"}))
+  | "atan2" -> (
+      match args with
+      | arg1 :: arg2 :: _ -> Some (VFloat64 (atan2 (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan2 (float64)"; reason = "requires 2 arguments"}))
+  | "sinh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (sinh (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "sinh (float64)"; reason = "requires 1 argument"}))
+  | "cosh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (cosh (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "cosh (float64)"; reason = "requires 1 argument"}))
+  | "tanh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (tanh (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "tanh (float64)"; reason = "requires 1 argument"}))
   | "sqrt" -> (
       match args with
       | arg :: _ -> Some (VFloat64 (sqrt (to_float64 arg)))


### PR DESCRIPTION
# Overview

This PR introduces support for mathematical intrinsic operations within the interpreter. It adds mappings for mathematical trigonometric primitives (such as `atan`, `cosh`, `sinh`, `atan2`...) as well as additional mathematical primitives in `float64` (`min`, `max`, `floor`, `ceil`, `pow`).

Such primitives can be used in signal processing or spatial simulations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded math support for floating-point values, including inverse trig, hyperbolic, and additional common math operations.
  * Added more built-in handling for `Float32` and `Float64` calculations, with support for both single- and two-argument forms where applicable.
* **Bug Fixes**
  * Improved error reporting when math functions are called with the wrong number of arguments, making unsupported cases clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->