### PR TITLE
PTX emitter: shared arrays, conversions, int32 atomics, helper inlining

### DIFF
--- a/benchmarks/bench_mandelbrot.ml
+++ b/benchmarks/bench_mandelbrot.ml
@@ -176,15 +176,22 @@ let benchmark_device dev size config =
 
     (* Generate image if requested *)
     (if config.generate_images then
-       let safe_name =
-         String.map (fun c -> if c = ' ' then '_' else c) dev.Device.name
+       let sanitize s =
+         String.map (fun c -> if c = ' ' || c = '/' then '_' else c) s
+       in
+       (* Distinct devices can sanitize name+framework to the same string
+          (e.g. differing only in '/'); a hash of the raw identity keeps the
+          filenames unique. *)
+       let tag =
+         Hashtbl.hash (dev.Device.name, dev.Device.framework) land 0xffff
        in
        let img_filename =
          Printf.sprintf
-           "%s/mandelbrot_%s_%s_%dx%d.ppm"
+           "%s/mandelbrot_%s_%s_%04x_%dx%d.ppm"
            config.output_dir
-           safe_name
-           dev.Device.framework
+           (sanitize dev.Device.name)
+           (sanitize dev.Device.framework)
+           tag
            width
            height
        in

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -23,6 +23,42 @@ let is_f64_reg r = String.length r >= 3 && r.[1] = 'f' && r.[2] = 'd'
 
 let is_f32_reg r = String.length r >= 2 && r.[1] = 'f' && not (is_f64_reg r)
 
+(** Whether an expression must NOT be evaluated speculatively — i.e. an [EIf]
+    with such a branch must emit real control flow rather than the eager
+    evaluate-both-branches [selp] path. Two reasons a subexpression qualifies:
+    - it has an observable effect (a store/atomic, or a helper call whose body
+      may store/atomic/barrier); running the not-taken branch is wrong;
+    - it dereferences memory (an array read); the not-taken branch's index may
+      be out of bounds (the classic [if i < n then a.(i) else d] guard), and an
+      unconditional load can fault or read garbage. *)
+let rec expr_needs_branch_guard (e : expr) : bool =
+  let is_atomic name =
+    String.length name >= 7 && String.sub name 0 7 = "atomic_"
+  in
+  (* Barriers/fences emit side-effecting, convergence-sensitive instructions
+     (bar.sync, membar); they must never run on a not-taken branch. *)
+  let is_barrier = function
+    | "block_barrier" | "warp_barrier" | "memory_fence" -> true
+    | _ -> false
+  in
+  match e with
+  | EApp _ -> true
+  | EIntrinsic (_, name, args) ->
+      is_atomic name || is_barrier name
+      || List.exists expr_needs_branch_guard args
+  (* Array reads must not be evaluated speculatively (out-of-bounds guard). *)
+  | EArrayRead _ | EArrayReadExpr _ -> true
+  | EConst _ | EVar _ | EArrayLen _ -> false
+  | EUnop (_, a) | ECast (_, a) -> expr_needs_branch_guard a
+  | EBinop (_, a, b) -> expr_needs_branch_guard a || expr_needs_branch_guard b
+  | EIf (c, t, f) ->
+      expr_needs_branch_guard c || expr_needs_branch_guard t
+      || expr_needs_branch_guard f
+  | EArrayCreate (_, s, _) -> expr_needs_branch_guard s
+  | EMatch _ | ERecord _ | ERecordField _ | ETuple _ | EVariant _ ->
+      (* Rejected later by the emitter; conservative answer is irrelevant. *)
+      true
+
 (** {1 Expression emitter}
 
     Returns the PTX register name holding the result. Emits instructions into
@@ -126,6 +162,32 @@ let rec emit_expr buf alloc (env : env) (expr : expr) : string =
   | ECast (ty, e) ->
       let r_src = emit_expr buf alloc env e in
       emit_cast buf alloc r_src ty
+  | EIf (cond, then_e, else_e)
+    when expr_needs_branch_guard then_e || expr_needs_branch_guard else_e ->
+      (* A branch with an effect or a (possibly out-of-bounds) array read must
+         not be evaluated eagerly (the selp path below computes both); emit
+         real control flow instead. *)
+      let r_cond = emit_expr buf alloc env cond in
+      let p = new_pred alloc in
+      emit buf "setp.ne.u32 %s, %s, 0;" p r_cond ;
+      let l_else = new_label alloc in
+      let l_merge = new_label alloc in
+      emit buf "@!%s bra %s;" p l_else ;
+      let r_then = emit_expr buf alloc env then_e in
+      let r_res = copy_reg buf alloc r_then in
+      emit buf "bra %s;" l_merge ;
+      emit_label buf l_else ;
+      let r_else = emit_expr buf alloc env else_e in
+      let mov_op =
+        if is_f64_reg r_res then "mov.f64"
+        else if is_f32_reg r_res then "mov.f32"
+        else if String.length r_res >= 3 && r_res.[1] = 'r' && r_res.[2] = 'd'
+        then "mov.u64"
+        else "mov.u32"
+      in
+      emit buf "%s %s, %s;" mov_op r_res r_else ;
+      emit_label buf l_merge ;
+      r_res
   | EIf (cond, then_e, else_e) ->
       let r_cond = emit_expr buf alloc env cond in
       let r_then = emit_expr buf alloc env then_e in
@@ -168,8 +230,107 @@ let rec emit_expr buf alloc (env : env) (expr : expr) : string =
   | ERecord _ -> unsupported "ERecord (requires struct layout)"
   | ERecordField _ -> unsupported "ERecordField (requires struct layout)"
   | ETuple _ -> unsupported "ETuple (no PTX equivalent)"
-  | EApp _ ->
-      unsupported "EApp (device function calls via .func not yet implemented)"
+  | EApp (EVar f, args) -> (
+      (* Helper-function call: inline the body at the call site. PTX .func
+         would need a per-function register frame and .param ABI the
+         single-pass emitter does not model; helpers are small and NVCC
+         inlines them anyway. Recursive helpers are rejected (guard below)
+         and fall back to another backend, as before. *)
+      match Hashtbl.find_opt alloc.funcs f.var_name with
+      | None -> unsupported ("EApp to unknown function '" ^ f.var_name ^ "'")
+      | Some hf ->
+          if List.mem hf.hf_name alloc.inline_stack then
+            unsupported
+              ("EApp: recursive helper '" ^ hf.hf_name
+             ^ "' (inlining supports non-recursive helpers only)")
+          else if List.length args <> List.length hf.hf_params then
+            fail
+              (Printf.sprintf
+                 "PTX codegen: helper '%s' called with %d args, expects %d"
+                 hf.hf_name
+                 (List.length args)
+                 (List.length hf.hf_params))
+          else begin
+            (* Evaluate arguments in the caller's environment. *)
+            let arg_regs = List.map (emit_expr buf alloc env) args in
+            (* Fresh environment for the helper body: only its parameters
+               are in scope (helpers are module-level, no capture). *)
+            let callee_env = make_env () in
+            (* Array params: register element type (from the param's own
+               type) and propagate shared-ness / length binding from the
+               caller when the argument is a plain array variable. Entries
+               we overwrite are saved and restored after the inline. *)
+            let saved =
+              List.map2
+                (fun (p : var) (arg, r_arg) ->
+                  (* Scalars are copied so mutations inside the helper (via
+                     mutable lets rebinding the param) can never clobber the
+                     caller's register; array params are base pointers and
+                     are never written through LVar, bind directly. *)
+                  (match p.var_type with
+                  | TVec _ | TArray _ -> env_bind callee_env p.var_name r_arg
+                  | _ ->
+                      env_bind callee_env p.var_name (copy_reg buf alloc r_arg)) ;
+                  match p.var_type with
+                  | TVec elt | TArray (elt, _) ->
+                      let prev_elt =
+                        Hashtbl.find_opt alloc.arr_elt_types p.var_name
+                      in
+                      let prev_ms =
+                        Hashtbl.mem alloc.arr_memspaces p.var_name
+                      in
+                      Hashtbl.replace alloc.arr_elt_types p.var_name elt ;
+                      (match arg with
+                      | EVar a -> (
+                          if Hashtbl.mem alloc.arr_memspaces a.var_name then
+                            Hashtbl.replace alloc.arr_memspaces p.var_name ()
+                          else Hashtbl.remove alloc.arr_memspaces p.var_name ;
+                          match
+                            Hashtbl.find_opt env (length_param_name a.var_name)
+                          with
+                          | Some r_len ->
+                              env_bind
+                                callee_env
+                                (length_param_name p.var_name)
+                                r_len
+                          | None -> ())
+                      | _ -> Hashtbl.remove alloc.arr_memspaces p.var_name) ;
+                      Some (p.var_name, prev_elt, prev_ms)
+                  | _ -> None)
+                hf.hf_params
+                (List.combine args arg_regs)
+            in
+            let l_end = new_label alloc in
+            let r_ret =
+              match hf.hf_ret_type with
+              | TUnit -> None
+              | t -> Some (new_reg_for_type alloc t)
+            in
+            alloc.inline_stack <- hf.hf_name :: alloc.inline_stack ;
+            alloc.inline_ret <- (r_ret, l_end) :: alloc.inline_ret ;
+            !stmt_emitter buf alloc callee_env hf.hf_body ;
+            alloc.inline_ret <- List.tl alloc.inline_ret ;
+            alloc.inline_stack <- List.tl alloc.inline_stack ;
+            emit_label buf l_end ;
+            (* Restore array metadata shadowed by parameter names. *)
+            List.iter
+              (function
+                | None -> ()
+                | Some (name, prev_elt, prev_ms) ->
+                    (match prev_elt with
+                    | Some e -> Hashtbl.replace alloc.arr_elt_types name e
+                    | None -> Hashtbl.remove alloc.arr_elt_types name) ;
+                    if prev_ms then Hashtbl.replace alloc.arr_memspaces name ()
+                    else Hashtbl.remove alloc.arr_memspaces name)
+              saved ;
+            match r_ret with
+            | Some r -> r
+            | None ->
+                let r = new_u32 alloc in
+                emit buf "mov.u32 %s, 0;" r ;
+                r
+          end)
+  | EApp _ -> unsupported "EApp with non-variable callee"
   | EVariant _ -> unsupported "EVariant (requires tagged-union lowering)"
 
 and emit_binop buf alloc env op e1 e2 : string =
@@ -399,7 +560,44 @@ and emit_cast buf alloc r_src dst_ty : string =
         r
   | _ -> unsupported ("ECast to " ^ ptx_reg_type_of dst_ty)
 
-and emit_intrinsic buf alloc env _path name args : string =
+and emit_intrinsic buf alloc env path name args : string =
+  (* Type conversions delegate to emit_cast; a unary helper for them. *)
+  let unary_cast intr dst_ty =
+    match args with
+    | [a] -> emit_cast buf alloc (emit_expr buf alloc env a) dst_ty
+    | _ -> unsupported (intr ^ " arity != 1")
+  in
+  (* atom.{shared,global}.add.s32 on an int32 array denoted by a plain
+     variable; returns the old value. *)
+  let atomic_add_s32 intr ~global_only =
+    match args with
+    | [EVar arr; idx_e; val_e] ->
+        let r_base = env_lookup env arr.var_name in
+        let r_idx = emit_expr buf alloc env idx_e in
+        let r_val = emit_expr buf alloc env val_e in
+        let is_shared =
+          (not global_only) && Hashtbl.mem alloc.arr_memspaces arr.var_name
+        in
+        let r_old = new_u32 alloc in
+        if is_shared then begin
+          let r_off = new_u32 alloc in
+          let r_addr = new_u32 alloc in
+          emit buf "shl.b32 %s, %s, 2;" r_off r_idx ;
+          emit buf "add.u32 %s, %s, %s;" r_addr r_base r_off ;
+          emit buf "atom.shared.add.s32 %s, [%s], %s;" r_old r_addr r_val
+        end
+        else begin
+          let r_idx64 = new_u64 alloc in
+          let r_off = new_u64 alloc in
+          let r_addr = new_u64 alloc in
+          emit buf "cvt.u64.u32 %s, %s;" r_idx64 r_idx ;
+          emit buf "shl.b64 %s, %s, 2;" r_off r_idx64 ;
+          emit buf "add.u64 %s, %s, %s;" r_addr r_base r_off ;
+          emit buf "atom.global.add.s32 %s, [%s], %s;" r_old r_addr r_val
+        end ;
+        r_old
+    | _ -> unsupported (intr ^ ": expects (array-variable, index, value)")
+  in
   (* Emit the single argument of a unary f32 intrinsic, rejecting f64
      operands (the .approx PTX ops used below are f32-only; an f64 operand
      would emit invalid PTX that only fails at module-load time). *)
@@ -559,4 +757,17 @@ and emit_intrinsic buf alloc env _path name args : string =
           emit buf "fma.rn.f32 %s, %s, %s, %s;" r ra rb rc ;
           r
       | _ -> unsupported "fma arity != 3")
+  (* Type conversions (Gpu.float / Float32.of_int / …). "of_int"/"to_int"
+     are path-dependent: they exist in both the Float32 and Float64 stdlib
+     modules. *)
+  | "float" | "float_of_int" -> unary_cast name TFloat32
+  | "float64" | "float64_of_int" -> unary_cast name TFloat64
+  | "int_of_float" | "int_of_float64" -> unary_cast name TInt32
+  | "of_int" ->
+      if List.exists (fun p -> p = "Float64") path then unary_cast name TFloat64
+      else unary_cast name TFloat32
+  | "to_int" -> unary_cast name TInt32
+  (* Atomics (int32 add; old value returned). *)
+  | "atomic_add_int32" -> atomic_add_s32 name ~global_only:false
+  | "atomic_add_global_int32" -> atomic_add_s32 name ~global_only:true
   | n -> unsupported ("intrinsic: " ^ n)

--- a/sarek/codegen/Sarek_ir_ptx_expr.mli
+++ b/sarek/codegen/Sarek_ir_ptx_expr.mli
@@ -16,7 +16,8 @@ open Sarek_ir_ptx_types
     and returns the register name holding the result.
 
     Raises {!Ptx_codegen_error} for IR constructs not yet covered by the PTX
-    backend (variants, records, device function calls, etc.). *)
+    backend (variants, records, recursive device functions, etc.). Non-recursive
+    helper-function calls (EApp) are inlined at the call site. *)
 val emit_expr : Buffer.t -> reg_alloc -> env -> expr -> string
 
 (** [emit_binop buf alloc env op e1 e2] emits a binary operation. Type is
@@ -29,7 +30,8 @@ val emit_binop : Buffer.t -> reg_alloc -> env -> binop -> expr -> expr -> string
 val emit_cast : Buffer.t -> reg_alloc -> string -> elttype -> string
 
 (** [emit_intrinsic buf alloc env path name args] emits the PTX sequence for the
-    named Sarek intrinsic. [path] is ignored (reserved for future namespacing).
-    Raises {!Ptx_codegen_error} for unknown intrinsic names. *)
+    named Sarek intrinsic. [path] disambiguates module-qualified names ("of_int"
+    resolves to f32 or f64 by its Float32/Float64 path). Raises
+    {!Ptx_codegen_error} for unknown intrinsic names. *)
 val emit_intrinsic :
   Buffer.t -> reg_alloc -> env -> string list -> string -> expr list -> string

--- a/sarek/codegen/Sarek_ir_ptx_kernel.ml
+++ b/sarek/codegen/Sarek_ir_ptx_kernel.ml
@@ -98,18 +98,9 @@ let emit_params buf alloc (env : env) (params : decl list) : string =
     params ;
   Buffer.contents param_decls
 
-let ptx_align_of_elttype = function
-  | TFloat32 | TInt32 | TBool -> 4
-  | TFloat64 | TInt64 -> 8
-  | TUnit -> 4
-  | TVec _ | TArray _ -> 8
-  | TRecord _ | TVariant _ -> unsupported "align of custom type"
-
-let ptx_btype_of_elttype = function
-  | TFloat32 | TInt32 | TBool | TUnit -> "b32"
-  | TFloat64 | TInt64 -> "b64"
-  | TVec _ | TArray _ -> "b64"
-  | TRecord _ | TVariant _ -> unsupported "btype of custom type"
+(* ptx_align_of_elttype / ptx_btype_of_elttype now live in
+   Sarek_ir_ptx_types, shared with the SLet shared-array path in
+   Sarek_ir_ptx_stmt. *)
 
 let emit_locals buf shared_buf alloc (env : env) (locals : decl list) : unit =
   List.iter
@@ -201,6 +192,7 @@ let make_ptx_header ?(sm_target = "sm_86") ?(ptx_version = "8.0") () =
     @param sm_target Override the default [sm_86] target for older hardware. *)
 let generate ?(sm_target = "sm_86") (k : kernel) : string =
   let alloc = make_alloc () in
+  List.iter (fun hf -> Hashtbl.replace alloc.funcs hf.hf_name hf) k.kern_funcs ;
   let env = make_env () in
   let body_buf = Buffer.create 2048 in
   let shared_buf = Buffer.create 256 in
@@ -216,6 +208,8 @@ let generate ?(sm_target = "sm_86") (k : kernel) : string =
   Buffer.add_string out "\n)\n{\n" ;
   emit_reg_decls out alloc ;
   Buffer.add_buffer out shared_buf ;
+  (* Shared arrays declared mid-body (SLet-bound let%shared). *)
+  Buffer.add_buffer out alloc.shared_decls ;
   Buffer.add_char out '\n' ;
   Buffer.add_buffer out body_buf ;
   Buffer.add_string out "}\n" ;

--- a/sarek/codegen/Sarek_ir_ptx_stmt.ml
+++ b/sarek/codegen/Sarek_ir_ptx_stmt.ml
@@ -19,12 +19,61 @@ let rec emit_stmt buf alloc (env : env) (stmt : stmt) : unit =
   match stmt with
   | SEmpty -> ()
   | SSeq stmts -> List.iter (emit_stmt buf alloc env) stmts
+  | SLet (v, EArrayCreate (elt, size_e, Shared), body) ->
+      (* let%shared lowers to this shape (the PPX never emits DShared decls).
+         Declare the array in .shared space and bind its base address. *)
+      let n =
+        match size_e with
+        | EConst (CInt32 n) when Int32.compare n 0l > 0 -> Int32.to_int n
+        | EConst (CInt32 _) ->
+            fail
+              (Printf.sprintf
+                 "PTX codegen: shared array '%s': size must be positive"
+                 v.var_name)
+        | _ ->
+            unsupported
+              (Printf.sprintf
+                 "shared array '%s' with non-literal size"
+                 v.var_name)
+      in
+      if Hashtbl.mem alloc.arr_memspaces v.var_name then
+        fail
+          (Printf.sprintf
+             "PTX codegen: duplicate shared array name '%s'"
+             v.var_name) ;
+      Buffer.add_string
+        alloc.shared_decls
+        (Printf.sprintf
+           "    .shared .align %d .%s %s[%d];\n"
+           (ptx_align_of_elttype elt)
+           (ptx_btype_of_elttype elt)
+           v.var_name
+           n) ;
+      let r = new_u32 alloc in
+      env_bind env v.var_name r ;
+      emit buf "mov.u32 %s, %s;" r v.var_name ;
+      Hashtbl.replace alloc.arr_memspaces v.var_name () ;
+      Hashtbl.replace alloc.arr_elt_types v.var_name elt ;
+      emit_stmt buf alloc env body
+  | SLet (v, EArrayCreate (_, _, ms), _) ->
+      unsupported
+        (Printf.sprintf
+           "%s array creation for '%s' (only Shared is supported)"
+           (match ms with
+           | Sarek_ir_types.Local -> "Local"
+           | Sarek_ir_types.Global -> "Global"
+           | Sarek_ir_types.Shared -> assert false)
+           v.var_name)
   | SLet (v, e, body) ->
       let r = emit_expr buf alloc env e in
       env_bind env v.var_name r ;
       emit_stmt buf alloc env body
   | SLetMut (v, e, body) ->
-      let r = emit_expr buf alloc env e in
+      (* Mutable binding: copy into a fresh register. Binding the initializer
+         register directly would alias it — `let mutable acc = y` followed by
+         `acc <- …` would silently clobber y. *)
+      let r_init = emit_expr buf alloc env e in
+      let r = copy_reg buf alloc r_init in
       env_bind env v.var_name r ;
       emit_stmt buf alloc env body
   | SAssign (lv, e) -> emit_assign buf alloc env lv e
@@ -83,9 +132,32 @@ let rec emit_stmt buf alloc (env : env) (stmt : stmt) : unit =
   | SBarrier -> emit buf "bar.sync 0;"
   | SWarpBarrier -> emit buf "bar.warp.sync 0xffffffff;"
   | SMemFence -> emit buf "membar.gl;"
-  | SReturn e ->
-      ignore (emit_expr buf alloc env e) ;
-      emit buf "ret;"
+  | SReturn e -> (
+      match alloc.inline_ret with
+      | (r_ret, l_end) :: _ ->
+          (* Inside an inlined helper body: write the result register (if the
+             helper returns a value) and branch to the inline end label
+             instead of returning from the kernel. *)
+          let r_val = emit_expr buf alloc env e in
+          (match r_ret with
+          | None -> ()
+          | Some r_dst ->
+              let mov_op =
+                if
+                  String.length r_dst >= 3 && r_dst.[1] = 'r' && r_dst.[2] = 'd'
+                then "mov.u64"
+                else if
+                  String.length r_dst >= 3 && r_dst.[1] = 'f' && r_dst.[2] = 'd'
+                then "mov.f64"
+                else if String.length r_dst >= 2 && r_dst.[1] = 'f' then
+                  "mov.f32"
+                else "mov.u32"
+              in
+              emit buf "%s %s, %s;" mov_op r_dst r_val) ;
+          emit buf "bra %s;" l_end
+      | [] ->
+          ignore (emit_expr buf alloc env e) ;
+          emit buf "ret;")
   | SExpr e -> ignore (emit_expr buf alloc env e)
   | SBlock inner -> emit_stmt buf alloc env inner
   | SPragma (_hints, body) ->
@@ -148,3 +220,7 @@ and emit_assign buf alloc (env : env) (lv : lvalue) (e : expr) : unit =
       emit_array_write buf alloc r_base r_idx r_val elt_type ~is_shared
   | LRecordField _ ->
       unsupported "LRecordField assignment (requires struct layout)"
+
+(* Install the statement emitter for EApp inlining (see stmt_emitter in
+   Sarek_ir_ptx_types). *)
+let () = Sarek_ir_ptx_types.stmt_emitter := emit_stmt

--- a/sarek/codegen/Sarek_ir_ptx_types.ml
+++ b/sarek/codegen/Sarek_ir_ptx_types.ml
@@ -29,6 +29,17 @@ type reg_alloc = {
   mutable label : int;
   arr_elt_types : (string, elttype) Hashtbl.t;
   arr_memspaces : (string, unit) Hashtbl.t;
+  shared_decls : Buffer.t;
+      (** [.shared] declarations discovered while emitting the body (SLet-bound
+          shared arrays); spliced into the kernel prologue by [generate]. *)
+  funcs : (string, helper_func) Hashtbl.t;
+      (** Kernel helper functions ([kern_funcs]), inlined at EApp sites. *)
+  mutable inline_stack : string list;
+      (** Helper names currently being inlined — recursion guard. *)
+  mutable inline_ret : (string option * string) list;
+      (** Per-inline (result register, end label); SReturn inside an inlined
+          body writes the register (if any) and branches to the label instead of
+          emitting [ret]. *)
 }
 
 let make_alloc () =
@@ -41,6 +52,10 @@ let make_alloc () =
     label = 0;
     arr_elt_types = Hashtbl.create 8;
     arr_memspaces = Hashtbl.create 8;
+    shared_decls = Buffer.create 128;
+    funcs = Hashtbl.create 4;
+    inline_stack = [];
+    inline_ret = [];
   }
 
 let new_u32 a =
@@ -120,3 +135,53 @@ let length_param_name arr_name = Printf.sprintf "sarek_%s_length" arr_name
 let emit buf fmt = Printf.bprintf buf ("    " ^^ fmt ^^ "\n")
 
 let emit_label buf lbl = Printf.bprintf buf "%s:\n" lbl
+
+(** [copy_reg buf alloc r] allocates a fresh register of [r]'s class and emits a
+    mov from [r] into it. Used wherever a binding must not alias the source
+    register (mutable lets, inlined helper parameters). *)
+let copy_reg buf a r_src =
+  if String.length r_src >= 3 && r_src.[1] = 'f' && r_src.[2] = 'd' then begin
+    let r = new_f64 a in
+    emit buf "mov.f64 %s, %s;" r r_src ;
+    r
+  end
+  else if String.length r_src >= 2 && r_src.[1] = 'f' then begin
+    let r = new_f32 a in
+    emit buf "mov.f32 %s, %s;" r r_src ;
+    r
+  end
+  else if String.length r_src >= 3 && r_src.[1] = 'r' && r_src.[2] = 'd' then begin
+    let r = new_u64 a in
+    emit buf "mov.u64 %s, %s;" r r_src ;
+    r
+  end
+  else begin
+    let r = new_u32 a in
+    emit buf "mov.u32 %s, %s;" r r_src ;
+    r
+  end
+
+(** {1 Shared-memory declaration helpers} *)
+
+let ptx_align_of_elttype = function
+  | TFloat32 | TInt32 | TBool -> 4
+  | TFloat64 | TInt64 -> 8
+  | TUnit -> 4
+  | TVec _ | TArray _ -> 8
+  | TRecord _ | TVariant _ -> unsupported "align of custom type"
+
+let ptx_btype_of_elttype = function
+  | TFloat32 | TInt32 | TBool | TUnit -> "b32"
+  | TFloat64 | TInt64 -> "b64"
+  | TVec _ | TArray _ -> "b64"
+  | TRecord _ | TVariant _ -> unsupported "btype of custom type"
+
+(** {1 Statement-emitter hook}
+
+    EApp inlining in the expression emitter must emit the helper body, a
+    statement — but Sarek_ir_ptx_stmt depends on Sarek_ir_ptx_expr. This hook
+    breaks the cycle: Sarek_ir_ptx_stmt installs [emit_stmt] here at load time,
+    and the expression emitter calls through it. *)
+let stmt_emitter :
+    (Buffer.t -> reg_alloc -> env -> Sarek_ir_types.stmt -> unit) ref =
+  ref (fun _ _ _ _ -> fail "PTX codegen: stmt_emitter not initialized")

--- a/sarek/codegen/Sarek_ir_ptx_types.mli
+++ b/sarek/codegen/Sarek_ir_ptx_types.mli
@@ -34,6 +34,15 @@ type reg_alloc = {
   mutable label : int;
   arr_elt_types : (string, elttype) Hashtbl.t;
   arr_memspaces : (string, unit) Hashtbl.t;
+  shared_decls : Buffer.t;
+      (** [.shared] declarations discovered while emitting the body; spliced
+          into the kernel prologue by [generate]. *)
+  funcs : (string, helper_func) Hashtbl.t;
+      (** Kernel helper functions ([kern_funcs]), inlined at EApp sites. *)
+  mutable inline_stack : string list;
+      (** Helper names currently being inlined — recursion guard. *)
+  mutable inline_ret : (string option * string) list;
+      (** Per-inline (result register, end label) for SReturn lowering. *)
 }
 
 (** [make_alloc ()] returns a fresh zeroed allocator. *)
@@ -98,3 +107,24 @@ val emit : Buffer.t -> ('a, Buffer.t, unit) format -> 'a
 
 (** [emit_label buf lbl] appends [lbl:] followed by a newline to [buf]. *)
 val emit_label : Buffer.t -> string -> unit
+
+(** [copy_reg buf alloc r] allocates a fresh register of [r]'s class and emits a
+    mov from [r] into it — for bindings that must not alias the source register
+    (mutable lets, inlined helper parameters). *)
+val copy_reg : Buffer.t -> reg_alloc -> string -> string
+
+(** {1 Shared-memory declaration helpers} *)
+
+(** Byte alignment of a [.shared] array of the given element type. *)
+val ptx_align_of_elttype : elttype -> int
+
+(** PTX untyped-bits type ([b32]/[b64]) for a [.shared] array declaration. *)
+val ptx_btype_of_elttype : elttype -> string
+
+(** {1 Statement-emitter hook}
+
+    Installed by Sarek_ir_ptx_stmt at load time so the expression emitter can
+    emit helper-function bodies (statements) when inlining EApp without a
+    circular module dependency. *)
+val stmt_emitter :
+  (Buffer.t -> reg_alloc -> env -> Sarek_ir_types.stmt -> unit) ref

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -81,6 +81,208 @@ let test_vector_add_markers () =
   assert_contains ptx "st.global" ;
   assert_contains ptx "ret"
 
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let base_kernel name params body funcs =
+  {
+    kern_name = name;
+    kern_params = params;
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = funcs;
+    kern_native_fn = None;
+  }
+
+(** Shared-array reduction shape: let%shared sdata = 256 lowers to SLet (sdata,
+    EArrayCreate (f32, 256, Shared), ...). *)
+let test_shared_array_markers () =
+  let inp = make_var "inp" (TVec TFloat32) in
+  let sdata = make_var "sdata" (TArray (TFloat32, Shared)) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "thread_idx_x", []),
+        SLet
+          ( sdata,
+            EArrayCreate (TFloat32, EConst (CInt32 256l), Shared),
+            SSeq
+              [
+                SAssign
+                  (LArrayElem ("sdata", EVar tid), EArrayRead ("inp", EVar tid));
+                SBarrier;
+                SAssign
+                  (LArrayElem ("inp", EVar tid), EArrayRead ("sdata", EVar tid));
+              ] ) )
+  in
+  let k =
+    base_kernel
+      "shared_red"
+      [DParam (inp, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx ".shared .align 4 .b32 sdata[256];" ;
+  assert_contains ptx "mov.u32" ;
+  assert_contains ptx "st.shared.f32" ;
+  assert_contains ptx "bar.sync 0;" ;
+  assert_contains ptx "ld.shared.f32"
+
+(** Helper-function call is inlined: no .func, body appears in the entry. *)
+let test_helper_inlining_markers () =
+  let out = make_var "out" (TVec TFloat32) in
+  let x = make_var "x" TFloat32 in
+  let helper =
+    {
+      hf_name = "twice";
+      hf_params = [x];
+      hf_ret_type = TFloat32;
+      hf_body = SReturn (EBinop (Add, EVar x, EVar x));
+    }
+  in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar tid),
+            EApp
+              (EVar (make_var "twice" TFloat32), [EArrayRead ("out", EVar tid)])
+          ) )
+  in
+  let k =
+    base_kernel
+      "use_helper"
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+      body
+      [helper]
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "add.f32" ;
+  (* inlined, not a PTX function call *)
+  if
+    String.length ptx >= 5
+    &&
+    let found = ref false in
+    for i = 0 to String.length ptx - 5 do
+      if String.sub ptx i 5 = ".func" then found := true
+    done ;
+    !found
+  then Alcotest.fail "helper should be inlined, found .func directive"
+
+(** Conversion intrinsic float (int -> f32) emits cvt. *)
+let test_float_conversion_markers () =
+  let out = make_var "out" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar tid),
+            EIntrinsic (["Sarek_stdlib"; "Gpu"], "float", [EVar tid]) ) )
+  in
+  let k =
+    base_kernel
+      "conv"
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "cvt.rn.f32.s32"
+
+(** Recursive helper is rejected (falls back), not emitted as garbage. *)
+let test_recursive_helper_rejected () =
+  let out = make_var "out" (TVec TFloat32) in
+  let x = make_var "x" TFloat32 in
+  let helper =
+    {
+      hf_name = "loop_forever";
+      hf_params = [x];
+      hf_ret_type = TFloat32;
+      hf_body =
+        SReturn (EApp (EVar (make_var "loop_forever" TFloat32), [EVar x]));
+    }
+  in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar tid),
+            EApp
+              ( EVar (make_var "loop_forever" TFloat32),
+                [EArrayRead ("out", EVar tid)] ) ) )
+  in
+  let k =
+    base_kernel
+      "recursive"
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+      body
+      [helper]
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ -> Alcotest.fail "recursive helper should raise Ptx_codegen_error"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
+(** A guarded array read in an if-EXPRESSION must compile to real control flow
+    (a predicated branch), never the eager evaluate-both + selp path, so the
+    not-taken (possibly out-of-bounds) load is never executed. *)
+let test_guarded_array_read_branches () =
+  let out = make_var "out" (TVec TFloat32) in
+  let a = make_var "a" (TVec TFloat32) in
+  let n = make_var "n" TInt32 in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        (* out[tid] = if tid < n then a[tid] else 0.0 *)
+        SAssign
+          ( LArrayElem ("out", EVar tid),
+            EIf
+              ( EBinop (Lt, EVar tid, EVar n),
+                EArrayRead ("a", EVar tid),
+                EConst (CFloat32 0.0) ) ) )
+  in
+  let k =
+    base_kernel
+      "guarded_read"
+      [
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (n, None);
+      ]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  (* Branch-based lowering: the predicated bra guards the load, and the f32
+     result is merged with mov.f32 — the eager path would instead select the
+     result with selp.f32 (having already done the speculative load). Note a
+     selp.u32 still appears for the comparison's 0/1 value; only the result
+     selp.f32 signals the eager path. *)
+  assert_contains ptx "@!" ;
+  assert_contains ptx "bra " ;
+  if
+    let found = ref false in
+    let m = "selp.f32" in
+    for i = 0 to String.length ptx - String.length m do
+      if String.sub ptx i (String.length m) = m then found := true
+    done ;
+    !found
+  then
+    Alcotest.fail
+      "guarded array read must branch, not selp.f32 (speculative load risks \
+       OOB)"
+
 let () =
   Alcotest.run
     "ptx_snapshot"
@@ -91,5 +293,25 @@ let () =
             "vector_add PTX contains canonical markers"
             `Quick
             test_vector_add_markers;
+          Alcotest.test_case
+            "shared array SLet emits .shared decl + ld/st.shared"
+            `Quick
+            test_shared_array_markers;
+          Alcotest.test_case
+            "helper call is inlined without .func"
+            `Quick
+            test_helper_inlining_markers;
+          Alcotest.test_case
+            "float conversion emits cvt.rn.f32.s32"
+            `Quick
+            test_float_conversion_markers;
+          Alcotest.test_case
+            "recursive helper is rejected"
+            `Quick
+            test_recursive_helper_rejected;
+          Alcotest.test_case
+            "guarded array read in if-expr branches (no speculative load)"
+            `Quick
+            test_guarded_array_read_branches;
         ] );
     ]


### PR DESCRIPTION
## Overview

Closes the three PTX-emitter coverage gaps identified by ZLUDA benchmarking (follow-up to #219), plus two soundness fixes they made observable. The CUDA/PTX backend now runs the reduction/sort/fractal/transpose benchmark families.

## What's new

1. **Shared arrays** — `let%shared` lowers to `SLet (v, EArrayCreate (elt, N, Shared), _)` (the PPX never emits `DShared`); the emitter now declares these in `.shared` space and reuses the existing 32-bit shared addressing.
2. **Conversion intrinsics** — `float`, `of_int`, `int_of_float`, `float64_of_int`, … delegate to `emit_cast`; `of_int` picks f32/f64 from the module path.
3. **int32 atomics** — `atom.{shared,global}.add.s32` for `atomic_add_int32` / `atomic_add_global_int32`.
4. **Helper functions (`EApp`)** — inlined at the call site with a recursion guard (recursive helpers keep the old typed-error fallback). PTX `.func` would need a per-function register frame the single-pass emitter doesn't model, and NVCC inlines these anyway.

## Soundness fixes

- **Register aliasing**: `let mutable acc = y` (and inlined scalar params) bound the initializer register directly, so `acc <- …` clobbered `y`. Now copied via `copy_reg`.
- **Effectful `if` expressions**: the eager evaluate-both-branches + `selp` strategy was sound only while PTX expressions were pure; branches containing atomics or helper calls now emit real control flow (pure branches keep `selp` — golden output unchanged).

## Validation (RX 7900 XTX via ZLUDA v7-preview.3)

| Benchmark | CUDA/PTX before | after |
|---|---|---|
| dot_product, reduction, reduction_max | rejected (EArrayCreate) | **verified ✓** |
| histogram | rejected (EArrayCreate + atomics) | **verified ✓** |
| scan, radix_sort | rejected | **verified ✓** (bonus) |
| mandelbrot | rejected (`float` intrinsic) | **verified ✓**, fastest backend (0.41 ms vs 0.43 Vulkan) |
| transpose, transpose_tiled | rejected (EApp) | **verified ✓** |

- ZLUDA e2e unsupported-kernel errors: **29 → 10** (all remaining are the documented records/variants gap).
- Full suite green without ZLUDA; byte-exact PTX golden unchanged; 4 new snapshot tests (shared decl, inlining without `.func`, `cvt` emission, recursive-helper rejection).
- Residual (out of scope): `bitonic_sort` still hits a ZLUDA runtime memory fault (host address in the fault message — same class as the stream_triad@50M fault; ZLUDA bug, not codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared-memory array support in PTX generation, including declarations, accesses, and synchronization.
  * Inlined non-recursive helper calls into generated kernels.
  * Improved conditional codegen to use real branching when needed for guarded evaluation.
  * Extended PTX intrinsics with float conversions and int32 atomic add.
* **Bug Fixes**
  * Prevented register aliasing in mutable bindings.
  * Improved benchmark output filenames by sanitizing device identifiers and avoiding collisions.
* **Tests**
  * Expanded PTX snapshot coverage for shared memory, helper inlining, float conversion, conditional branching/guarding, and rejection of recursive helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->