### PR TITLE
feat(ptx): extended int32 atomics + native-op math intrinsics

### DIFF
--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -569,22 +569,37 @@ and emit_intrinsic buf alloc env path name args : string =
   in
   (* atom.{shared,global}.add.s32 on an int32 array denoted by a plain
      variable; returns the old value. *)
-  let atomic_add_s32 intr ~global_only =
+  (* Atomic read-modify-write on a 4-byte element of an int32/float32 array
+     denoted by a plain variable; returns the old value. [op]/[ty] form the
+     PTX suffix (e.g. add.s32, min.s32, and.b32, exch.b32, add.f32). PTX has
+     no atom.sub, so "sub" is lowered to an add of the negated operand.
+     [result] selects the old-value register class. *)
+  let atomic_rmw intr ~global_only ~op ~ty ~result =
     match args with
     | [EVar arr; idx_e; val_e] ->
         let r_base = env_lookup env arr.var_name in
         let r_idx = emit_expr buf alloc env idx_e in
-        let r_val = emit_expr buf alloc env val_e in
+        let r_val0 = emit_expr buf alloc env val_e in
+        let op, r_val =
+          if op = "sub" then begin
+            let r = new_u32 alloc in
+            emit buf "neg.s32 %s, %s;" r r_val0 ;
+            ("add", r)
+          end
+          else (op, r_val0)
+        in
         let is_shared =
           (not global_only) && Hashtbl.mem alloc.arr_memspaces arr.var_name
         in
-        let r_old = new_u32 alloc in
+        let r_old =
+          match result with `F32 -> new_f32 alloc | `U32 -> new_u32 alloc
+        in
         if is_shared then begin
           let r_off = new_u32 alloc in
           let r_addr = new_u32 alloc in
           emit buf "shl.b32 %s, %s, 2;" r_off r_idx ;
           emit buf "add.u32 %s, %s, %s;" r_addr r_base r_off ;
-          emit buf "atom.shared.add.s32 %s, [%s], %s;" r_old r_addr r_val
+          emit buf "atom.shared.%s%s %s, [%s], %s;" op ty r_old r_addr r_val
         end
         else begin
           let r_idx64 = new_u64 alloc in
@@ -593,10 +608,46 @@ and emit_intrinsic buf alloc env path name args : string =
           emit buf "cvt.u64.u32 %s, %s;" r_idx64 r_idx ;
           emit buf "shl.b64 %s, %s, 2;" r_off r_idx64 ;
           emit buf "add.u64 %s, %s, %s;" r_addr r_base r_off ;
-          emit buf "atom.global.add.s32 %s, [%s], %s;" r_old r_addr r_val
+          emit buf "atom.global.%s%s %s, [%s], %s;" op ty r_old r_addr r_val
         end ;
         r_old
     | _ -> unsupported (intr ^ ": expects (array-variable, index, value)")
+  in
+  (* Binary min/max: native PTX op, typed by the first operand's register. *)
+  let binary_minmax intr op =
+    match args with
+    | [a; b] ->
+        let ra = emit_expr buf alloc env a in
+        let rb = emit_expr buf alloc env b in
+        if is_f64_reg ra then (
+          let r = new_f64 alloc in
+          emit buf "%s.f64 %s, %s, %s;" op r ra rb ;
+          r)
+        else if is_f32_reg ra then (
+          let r = new_f32 alloc in
+          emit buf "%s.f32 %s, %s, %s;" op r ra rb ;
+          r)
+        else
+          let r = new_u32 alloc in
+          emit buf "%s.s32 %s, %s, %s;" op r ra rb ;
+          r
+    | _ -> unsupported (intr ^ " arity != 2")
+  in
+  (* Unary same-type float rounding via cvt (rmi = floor, rpi = ceil). *)
+  let unary_round intr cvt =
+    match args with
+    | [a] ->
+        let r = emit_expr buf alloc env a in
+        if is_f64_reg r then (
+          let d = new_f64 alloc in
+          emit buf "%s.f64.f64 %s, %s;" cvt d r ;
+          d)
+        else if is_f32_reg r then (
+          let d = new_f32 alloc in
+          emit buf "%s.f32.f32 %s, %s;" cvt d r ;
+          d)
+        else unsupported (intr ^ ": float operand required")
+    | _ -> unsupported (intr ^ " arity != 1")
   in
   (* Emit the single argument of a unary f32 intrinsic, rejecting f64
      operands (the .approx PTX ops used below are f32-only; an f64 operand
@@ -768,6 +819,45 @@ and emit_intrinsic buf alloc env path name args : string =
       else unary_cast name TFloat32
   | "to_int" -> unary_cast name TInt32
   (* Atomics (int32 add; old value returned). *)
-  | "atomic_add_int32" -> atomic_add_s32 name ~global_only:false
-  | "atomic_add_global_int32" -> atomic_add_s32 name ~global_only:true
+  (* Native math with a direct PTX op. *)
+  | "min" -> binary_minmax name "min"
+  | "max" -> binary_minmax name "max"
+  | "floor" -> unary_round name "cvt.rmi"
+  | "ceil" -> unary_round name "cvt.rpi"
+  | "rsqrt" -> (
+      match args with
+      | [a] ->
+          let r = emit_expr buf alloc env a in
+          if is_f64_reg r then (
+            let d = new_f64 alloc in
+            emit buf "rsqrt.approx.f64 %s, %s;" d r ;
+            d)
+          else if is_f32_reg r then (
+            let d = new_f32 alloc in
+            emit buf "rsqrt.approx.f32 %s, %s;" d r ;
+            d)
+          else unsupported "rsqrt: float operand required"
+      | _ -> unsupported "rsqrt arity != 1")
+  (* Atomics (old value returned). Shared vs global is auto-detected from the
+     array's memory space; the *_global_* names force the global path. *)
+  | "atomic_add_int32" ->
+      atomic_rmw name ~global_only:false ~op:"add" ~ty:".s32" ~result:`U32
+  | "atomic_add_global_int32" ->
+      atomic_rmw name ~global_only:true ~op:"add" ~ty:".s32" ~result:`U32
+  | "atomic_sub_int32" ->
+      atomic_rmw name ~global_only:false ~op:"sub" ~ty:".s32" ~result:`U32
+  | "atomic_min_int32" ->
+      atomic_rmw name ~global_only:false ~op:"min" ~ty:".s32" ~result:`U32
+  | "atomic_max_int32" ->
+      atomic_rmw name ~global_only:false ~op:"max" ~ty:".s32" ~result:`U32
+  | "atomic_and_int32" ->
+      atomic_rmw name ~global_only:false ~op:"and" ~ty:".b32" ~result:`U32
+  | "atomic_or_int32" ->
+      atomic_rmw name ~global_only:false ~op:"or" ~ty:".b32" ~result:`U32
+  | "atomic_xor_int32" ->
+      atomic_rmw name ~global_only:false ~op:"xor" ~ty:".b32" ~result:`U32
+  | "atomic_exch_int32" ->
+      atomic_rmw name ~global_only:false ~op:"exch" ~ty:".b32" ~result:`U32
+  | "atomic_add_float32" ->
+      atomic_rmw name ~global_only:false ~op:"add" ~ty:".f32" ~result:`F32
   | n -> unsupported ("intrinsic: " ^ n)

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -283,6 +283,82 @@ let test_guarded_array_read_branches () =
       "guarded array read must branch, not selp.f32 (speculative load risks \
        OOB)"
 
+(** Native math: min/max/floor/ceil/rsqrt emit direct PTX ops. *)
+let test_native_math_markers () =
+  let out = make_var "out" (TVec TFloat32) in
+  let a = make_var "a" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let f name args = EIntrinsic (["Sarek_stdlib"; "Gpu"], name, args) in
+  let av = EArrayRead ("a", EVar tid) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SSeq
+          [
+            SAssign (LArrayElem ("out", EVar tid), f "min" [av; av]);
+            SAssign (LArrayElem ("out", EVar tid), f "max" [av; av]);
+            SAssign (LArrayElem ("out", EVar tid), f "floor" [av]);
+            SAssign (LArrayElem ("out", EVar tid), f "ceil" [av]);
+            SAssign (LArrayElem ("out", EVar tid), f "rsqrt" [av]);
+          ] )
+  in
+  let mk v = DParam (v, Some {arr_elttype = TFloat32; arr_memspace = Global}) in
+  let k = base_kernel "native_math" [mk out; mk a] body [] in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "min.f32" ;
+  assert_contains ptx "max.f32" ;
+  assert_contains ptx "cvt.rmi.f32.f32" ;
+  assert_contains ptx "cvt.rpi.f32.f32" ;
+  assert_contains ptx "rsqrt.approx.f32"
+
+(** Extended atomics emit atom.{shared,global}.<op>.<ty>; sub lowers to
+    neg + add. *)
+let test_atomic_family_markers () =
+  let hist = make_var "hist" (TVec TInt32) in
+  let facc = make_var "facc" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let a name args = EIntrinsic (["Sarek_stdlib"; "Gpu"], name, args) in
+  let one = EConst (CInt32 1l) in
+  let fone = EConst (CFloat32 1.0) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SSeq
+          [
+            SExpr (a "atomic_min_int32" [EVar hist; EVar tid; one]);
+            SExpr (a "atomic_max_int32" [EVar hist; EVar tid; one]);
+            SExpr (a "atomic_and_int32" [EVar hist; EVar tid; one]);
+            SExpr (a "atomic_or_int32" [EVar hist; EVar tid; one]);
+            SExpr (a "atomic_xor_int32" [EVar hist; EVar tid; one]);
+            SExpr (a "atomic_exch_int32" [EVar hist; EVar tid; one]);
+            SExpr (a "atomic_sub_int32" [EVar hist; EVar tid; one]);
+            SExpr (a "atomic_add_float32" [EVar facc; EVar tid; fone]);
+          ] )
+  in
+  let k =
+    base_kernel
+      "atomics"
+      [
+        DParam (hist, Some {arr_elttype = TInt32; arr_memspace = Global});
+        DParam (facc, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "atom.global.min.s32" ;
+  assert_contains ptx "atom.global.max.s32" ;
+  assert_contains ptx "atom.global.and.b32" ;
+  assert_contains ptx "atom.global.or.b32" ;
+  assert_contains ptx "atom.global.xor.b32" ;
+  assert_contains ptx "atom.global.exch.b32" ;
+  assert_contains ptx "atom.global.add.f32" ;
+  (* sub has no PTX atom op → negate then atom.add *)
+  assert_contains ptx "neg.s32" ;
+  assert_contains ptx "atom.global.add.s32"
+
 let () =
   Alcotest.run
     "ptx_snapshot"
@@ -293,6 +369,14 @@ let () =
             "vector_add PTX contains canonical markers"
             `Quick
             test_vector_add_markers;
+          Alcotest.test_case
+            "native math emits min/max/cvt.rmi/cvt.rpi/rsqrt"
+            `Quick
+            test_native_math_markers;
+          Alcotest.test_case
+            "extended atomics emit atom.*.<op> (+ neg for sub)"
+            `Quick
+            test_atomic_family_markers;
           Alcotest.test_case
             "shared array SLet emits .shared decl + ld/st.shared"
             `Quick


### PR DESCRIPTION
(Supersedes #222, which auto-closed when its base branch `feat/ptx-emitter-coverage` was deleted on merge of #220. Same single, reviewed commit, now rebased on `main`.)

## Summary

The PTX-emitter intrinsic lowerings that need only a **direct hardware op**:

- **Atomics** (generalized `atomic_rmw`): `atomic_sub / min / max / and / or / xor / exch_int32` and `atomic_add_float32`, shared + global. PTX has no `atom.sub`, so sub lowers to `neg` + `atom.add`.
- **Native math**: `min`/`max`, `floor`/`ceil` (`cvt.rmi`/`cvt.rpi`), `rsqrt` (`rsqrt.approx`, f32 and f64).

## Validation (RX 7900 XTX / ZLUDA v7-preview.3)

`floor`/`ceil`/`rsqrt` (incl. float64) pass on the CUDA/PTX device in the math e2e tests; float32 math suite passes; snapshot tests assert the emitted ops for all of the above (incl. `neg`+`add` for sub). Full suite green with and without ZLUDA.

Deferred to a later lot: transcendentals (`tan/asin/acos/atan/atan2/sinh/cosh/tanh/pow/log10`), atomic `cas`/`inc`/`dec`, int64/float64 atomic add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)