### PR TITLE
feat(ptx): depth-bounded recursive helper inlining via sarek.inline pragma

### DIFF
--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -244,12 +244,23 @@ let emit_match_arms buf alloc (env : env) (scrut : binding)
     truth for the "sarek.inline N" string format) — the PPX is a separate
     library not linkable from the codegen. *)
 let helper_inline_budget (hf : helper_func) : int option =
+  (* A negative depth would never reach the [Some 0] exhaustion arm of
+     [emit_app_recursive] (the budget decrements past zero), making the
+     expansion non-terminating — reject it loudly instead of parsing it. *)
+  let checked n_str =
+    match int_of_string_opt n_str with
+    | Some n when n < 0 ->
+        unsupported
+          ("pragma [\"sarek.inline " ^ n_str
+         ^ "\"]: the inline depth must be >= 0")
+    | v -> v
+  in
   let parse = function
     | [opt] -> (
         match String.split_on_char ' ' opt with
-        | ["sarek.inline"; n] -> int_of_string_opt n
+        | ["sarek.inline"; n] -> checked n
         | _ -> None)
-    | ["sarek.inline"; n] -> int_of_string_opt n
+    | ["sarek.inline"; n] -> checked n
     | _ -> None
   in
   let rec root = function SBlock s -> root s | s -> s in

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -233,6 +233,47 @@ let emit_match_arms buf alloc (env : env) (scrut : binding)
              only variant values dispatch on a tag (tuple/record destructuring \
              takes a single pattern)")
 
+(** {1 Recursive-inline budget helpers}
+
+    A recursive helper is inlinable only when its body root carries
+    [pragma ["sarek.inline N"]]: N bounds the recursive re-entry depth. *)
+
+(** Inline budget declared by [hf], parsed from an [SPragma] at its body root.
+    Minimal re-implementation of the option parsing in
+    sarek/ppx/Sarek_tailrec_pragma.parse_sarek_inline_pragma (the source of
+    truth for the "sarek.inline N" string format) — the PPX is a separate
+    library not linkable from the codegen. *)
+let helper_inline_budget (hf : helper_func) : int option =
+  let parse = function
+    | [opt] -> (
+        match String.split_on_char ' ' opt with
+        | ["sarek.inline"; n] -> int_of_string_opt n
+        | _ -> None)
+    | ["sarek.inline"; n] -> int_of_string_opt n
+    | _ -> None
+  in
+  let rec root = function SBlock s -> root s | s -> s in
+  match root hf.hf_body with SPragma (opts, _) -> parse opts | _ -> None
+
+(** Write a typed zero into every scalar leaf of [b] — the result of a recursive
+    call at inline-budget exhaustion (a dynamically-unreachable branch; see
+    [emit_app_recursive]). *)
+let rec zero_binding buf (b : binding) : unit =
+  match b with
+  | Scalar r ->
+      let zero =
+        match reg_class r with
+        | RU32 | RU64 -> "0"
+        | RF32 -> "0F00000000"
+        | RF64 -> "0D0000000000000000"
+      in
+      emit buf "%s %s, %s;" (mov_op_of_class (reg_class r)) r zero
+  | Agg (ARecord fields) ->
+      List.iter (fun (_, fb) -> zero_binding buf fb) fields
+  | Agg (AVariant {tag_reg; ctors; _}) ->
+      emit buf "mov.u32 %s, 0;" tag_reg ;
+      List.iter (fun (_, bs) -> List.iter (zero_binding buf) bs) ctors
+
 (** {1 Expression emitter}
 
     Returns the PTX register name holding the result. Emits instructions into
@@ -485,56 +526,100 @@ and restore_helper_array_meta alloc saved =
           else Hashtbl.remove alloc.arr_memspaces name)
     saved
 
-(** Inline a helper call and return the binding holding its result. Aggregate
-    returns are pre-allocated from [hf_ret_type] (FR-023); SReturn inside the
-    inlined body movs leaf-wise into that binding. *)
+(** Inline a helper call and return the binding holding its result. First entry
+    seeds the helper's recursive-inline budget (from a [sarek.inline N] pragma
+    at its body root, if any); recursive re-entry dispatches to
+    [emit_app_recursive]. *)
 and emit_app buf alloc (env : env) (f : var) (args : expr list) : binding =
   match Hashtbl.find_opt alloc.funcs f.var_name with
   | None -> unsupported ("EApp to unknown function '" ^ f.var_name ^ "'")
   | Some hf ->
-      if List.mem hf.hf_name alloc.inline_stack then
-        unsupported
-          ("EApp: recursive helper '" ^ hf.hf_name
-         ^ "' (inlining supports non-recursive helpers only)")
-      else if List.length args <> List.length hf.hf_params then
+      if List.length args <> List.length hf.hf_params then
         fail
           (Printf.sprintf
              "PTX codegen: helper '%s' called with %d args, expects %d"
              hf.hf_name
              (List.length args)
              (List.length hf.hf_params))
+      else if List.mem hf.hf_name alloc.inline_stack then
+        emit_app_recursive buf alloc env hf args
       else begin
-        (* Evaluate arguments in the caller's environment. *)
-        let arg_vals = List.map (emit_value buf alloc env) args in
-        (* Fresh environment for the helper body: only its parameters are in
-           scope (helpers are module-level, no capture). *)
-        let callee_env = make_env () in
-        let saved =
-          List.map2
-            (bind_helper_param buf alloc env callee_env)
-            hf.hf_params
-            (List.combine args arg_vals)
-        in
-        let l_end = new_label alloc in
-        let ret =
-          match hf.hf_ret_type with
-          | TUnit -> None
-          | t -> Some (binding_of_elttype alloc t)
-        in
-        alloc.inline_stack <- hf.hf_name :: alloc.inline_stack ;
-        alloc.inline_ret <- (ret, l_end) :: alloc.inline_ret ;
-        !stmt_emitter buf alloc callee_env hf.hf_body ;
-        alloc.inline_ret <- List.tl alloc.inline_ret ;
-        alloc.inline_stack <- List.tl alloc.inline_stack ;
-        emit_label buf l_end ;
-        restore_helper_array_meta alloc saved ;
-        match ret with
-        | Some b -> b
-        | None ->
-            let r = new_u32 alloc in
-            emit buf "mov.u32 %s, 0;" r ;
-            Scalar r
+        (match helper_inline_budget hf with
+        | Some n -> Hashtbl.replace alloc.inline_budget hf.hf_name n
+        | None -> ()) ;
+        let res = emit_app_inline buf alloc env hf args in
+        Hashtbl.remove alloc.inline_budget hf.hf_name ;
+        res
       end
+
+(** Recursive re-entry into a helper already on the inline stack. Allowed only
+    for helpers carrying [pragma ["sarek.inline N"]]: each re-entry consumes one
+    unit of the remaining budget (restored on exit, so sibling calls — e.g.
+    fib's two — each see the same depth). At exhaustion the call's result is a
+    typed zero: the pragma is the author's contract that N levels cover all
+    runtime inputs, so the residual call site is dynamically unreachable and
+    only needs to be well-formed PTX, never correct. *)
+and emit_app_recursive buf alloc env hf args : binding =
+  match Hashtbl.find_opt alloc.inline_budget hf.hf_name with
+  | None ->
+      unsupported
+        ("EApp: recursive helper '" ^ hf.hf_name
+       ^ "' (inlining supports non-recursive helpers only; annotate the helper \
+          body with pragma [\"sarek.inline N\"] to enable depth-bounded \
+          inlining)")
+  | Some 0 -> (
+      (* Evaluate the arguments even though the residual call is elided —
+         keeps emitted PTX consistent with every budgeted level (argument
+         side effects are never silently dropped). *)
+      List.iter (fun a -> ignore (emit_value buf alloc env a)) args ;
+      match hf.hf_ret_type with
+      | TUnit ->
+          let r = new_u32 alloc in
+          emit buf "mov.u32 %s, 0;" r ;
+          Scalar r
+      | t ->
+          let b = binding_of_elttype alloc t in
+          zero_binding buf b ;
+          b)
+  | Some n ->
+      Hashtbl.replace alloc.inline_budget hf.hf_name (n - 1) ;
+      let res = emit_app_inline buf alloc env hf args in
+      Hashtbl.replace alloc.inline_budget hf.hf_name n ;
+      res
+
+(** Emit the inline expansion of a call to [hf] — shared by first entry and
+    budgeted recursive re-entry. *)
+and emit_app_inline buf alloc env hf args : binding =
+  (* Evaluate arguments in the caller's environment. *)
+  let arg_vals = List.map (emit_value buf alloc env) args in
+  (* Fresh environment for the helper body: only its parameters are in
+     scope (helpers are module-level, no capture). *)
+  let callee_env = make_env () in
+  let saved =
+    List.map2
+      (bind_helper_param buf alloc env callee_env)
+      hf.hf_params
+      (List.combine args arg_vals)
+  in
+  let l_end = new_label alloc in
+  let ret =
+    match hf.hf_ret_type with
+    | TUnit -> None
+    | t -> Some (binding_of_elttype alloc t)
+  in
+  alloc.inline_stack <- hf.hf_name :: alloc.inline_stack ;
+  alloc.inline_ret <- (ret, l_end) :: alloc.inline_ret ;
+  !stmt_emitter buf alloc callee_env hf.hf_body ;
+  alloc.inline_ret <- List.tl alloc.inline_ret ;
+  alloc.inline_stack <- List.tl alloc.inline_stack ;
+  emit_label buf l_end ;
+  restore_helper_array_meta alloc saved ;
+  match ret with
+  | Some b -> b
+  | None ->
+      let r = new_u32 alloc in
+      emit buf "mov.u32 %s, 0;" r ;
+      Scalar r
 
 (** {1 Value emitter (scalar or aggregate)}
 

--- a/sarek/codegen/Sarek_ir_ptx_types.ml
+++ b/sarek/codegen/Sarek_ir_ptx_types.ml
@@ -65,6 +65,11 @@ type reg_alloc = {
           payload slots and compute the tag index. *)
   mutable inline_stack : string list;
       (** Helper names currently being inlined — recursion guard. *)
+  inline_budget : (string, int) Hashtbl.t;
+      (** Remaining recursive-inline depth per helper, seeded from the helper's
+          [pragma ["sarek.inline N"]] at first entry; consulted (and
+          decremented) only on recursive re-entry. Helpers without the pragma
+          have no entry and recursive re-entry stays an error. *)
   mutable inline_ret : (binding option * string) list;
       (** Per-inline (result binding, end label); SReturn inside an inlined body
           writes the binding (if any) and branches to the label instead of
@@ -85,6 +90,7 @@ let make_alloc () =
     funcs = Hashtbl.create 4;
     variant_decls = Hashtbl.create 4;
     inline_stack = [];
+    inline_budget = Hashtbl.create 4;
     inline_ret = [];
   }
 

--- a/sarek/codegen/Sarek_ir_ptx_types.mli
+++ b/sarek/codegen/Sarek_ir_ptx_types.mli
@@ -67,6 +67,11 @@ type reg_alloc = {
           carries the type name). *)
   mutable inline_stack : string list;
       (** Helper names currently being inlined — recursion guard. *)
+  inline_budget : (string, int) Hashtbl.t;
+      (** Remaining recursive-inline depth per helper, seeded from the helper's
+          [pragma ["sarek.inline N"]] at first entry; consulted (and
+          decremented) only on recursive re-entry. Helpers without the pragma
+          have no entry and recursive re-entry stays an error. *)
   mutable inline_ret : (binding option * string) list;
       (** Per-inline (result binding, end label) for SReturn lowering. *)
 }

--- a/sarek/ppx/Sarek_tailrec.ml
+++ b/sarek/ppx/Sarek_tailrec.ml
@@ -129,7 +129,22 @@ let transform_kernel (kernel : tkernel) : tkernel =
                               "Sarek: successfully inlined '%s' (%d nodes)@."
                               name
                               (Sarek_tailrec_pragma.count_nodes new_body) ;
-                          TMFun (name, is_rec, params, new_body)
+                          (* Re-wrap the unrolled body with a zero-budget
+                             inline pragma: residual recursive calls left in
+                             dead branches (see inline_with_pragma) have no
+                             remaining inline depth. Backends that must fully
+                             resolve calls at codegen time (PTX) read this
+                             marker and lower such residual calls as
+                             dynamically-unreachable typed zeros; C-family
+                             backends emit "#pragma sarek.inline 0", which C99
+                             defines as an ignored unknown pragma. *)
+                          let final_body =
+                            {
+                              body with
+                              te = TEPragma (["sarek.inline 0"], new_body);
+                            }
+                          in
+                          TMFun (name, is_rec, params, final_body)
                       | Error msg ->
                           Format.eprintf "Sarek error in '%s': %s@." name msg ;
                           failwith msg)

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -232,6 +232,69 @@ let test_recursive_helper_rejected () =
   | _ -> Alcotest.fail "recursive helper should raise Ptx_codegen_error"
   | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
 
+(** Number of (possibly overlapping) occurrences of [sub] in [s]. *)
+let count_substr s sub =
+  let subl = String.length sub in
+  let c = ref 0 in
+  for i = 0 to String.length s - subl do
+    if String.sub s i subl = sub then incr c
+  done ;
+  !c
+
+(** Recursive int32 pow2-style helper whose body root carries
+    [pragma ["sarek.inline 3"]]. *)
+let make_pragma_pow2_helper n self =
+  {
+    hf_name = "pow2";
+    hf_params = [n];
+    hf_ret_type = TInt32;
+    hf_body =
+      SPragma
+        ( ["sarek.inline 3"],
+          SReturn
+            (EIf
+               ( EBinop (Le, EVar n, EConst (CInt32 0l)),
+                 EConst (CInt32 1l),
+                 EBinop
+                   ( Mul,
+                     EConst (CInt32 2l),
+                     EApp (EVar self, [EBinop (Sub, EVar n, EConst (CInt32 1l))])
+                   ) )) );
+  }
+
+(** Recursive helper WITH [pragma ["sarek.inline 3"]] is depth-unrolled inline:
+    the body multiply appears once per unrolled level (>= 3 times) and no .func
+    is emitted. *)
+let test_recursive_helper_pragma_unrolled () =
+  let out = make_var "out" (TVec TInt32) in
+  let n = make_var "n" TInt32 in
+  let self = make_var "pow2" TInt32 in
+  let helper = make_pragma_pow2_helper n self in
+  let body =
+    SAssign (LArrayElem ("out", EConst (CInt32 0l)), EApp (EVar self, [EVar n]))
+  in
+  let k =
+    base_kernel
+      "pow2_unrolled"
+      [
+        DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global});
+        DParam (n, None);
+      ]
+      body
+      [helper]
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  let muls = count_substr ptx "mul.lo.u32" in
+  if muls < 3 then
+    Alcotest.fail
+      (Printf.sprintf
+         "expected >=3 unrolled multiplies, found %d:\n%s"
+         muls
+         ptx) ;
+  if count_substr ptx ".func" > 0 then
+    Alcotest.fail
+      "pragma-unrolled helper must be inlined, found .func directive"
+
 (** A guarded array read in an if-EXPRESSION must compile to real control flow
     (a predicated branch), never the eager evaluate-both + selp path, so the
     not-taken (possibly out-of-bounds) load is never executed. *)
@@ -1392,6 +1455,10 @@ let () =
             "recursive helper is rejected"
             `Quick
             test_recursive_helper_rejected;
+          Alcotest.test_case
+            "recursive helper with sarek.inline pragma is depth-unrolled"
+            `Quick
+            test_recursive_helper_pragma_unrolled;
           Alcotest.test_case
             "guarded array read in if-expr branches (no speculative load)"
             `Quick


### PR DESCRIPTION
Follow-up 2 of the aggregate work: closes the last remaining ZLUDA e2e gap (`test_inline_pragma`).

- **PTX inliner:** recursive helpers carrying `pragma ["sarek.inline N"]` are depth-unrolled — each re-entry consumes one unit of a per-helper budget (restored on exit, so sibling calls like fib's two see the same depth). At exhaustion the residual call's arguments are still evaluated and its result is a typed zero: the pragma is the author's contract that N levels cover all runtime inputs, so the residual site is dynamically unreachable and only needs to be well-formed PTX. Recursion without the pragma stays rejected, with the pragma suggested as the workaround.
- **PPX fix:** `Sarek_tailrec.transform_kernel` already pre-unrolls N times but stripped the pragma, leaving residual recursive calls indistinguishable from unbounded recursion. It now re-wraps the unrolled body in `pragma ["sarek.inline 0"]` — semantically exact (zero remaining budget → residual calls lower as unreachable typed zeros). C-family backends emit `#pragma sarek.inline 0`, ignored per C99; all other consumers pass pragmas through.

e2e under ZLUDA (RX 7900 XTX, CUDA/PTX): pow2(5)=32 and fib(0/1/5/7)=0/1/5/13 all PASS; inliner regression checks (ktype_helper, nbody_ppx) stay green. fib at depth 6 lands at ~3.8k virtual registers — well within ptxas/ZLUDA territory. Snapshot suite extended (depth-3 unroll markers; no-pragma rejection unchanged).

With this, the full ZLUDA e2e sweep has **zero** `generate_source returned None` failures left — every construct either lowers or reports a precise unsupported message (the f64 transcendentals report, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added depth-limited inlining for recursive helpers using the `sarek.inline N` annotation.
  * Recursive helper expansion now respects the requested depth limit and ensures well-formed, zero-valued results when the limit is reached.
  * Enhanced PTX generation for recursive helpers to better support inlined/unrolled execution.

* **Tests**
  * Added a new PTX snapshot test covering a recursive helper annotated with `sarek.inline 3`, verifying unrolling to depth and absence of standalone function emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->