### PR TITLE
feat(ptx): extended atomics, float fmod, complete cast matrix

### DIFF
--- a/sarek-cuda/test/dune
+++ b/sarek-cuda/test/dune
@@ -34,3 +34,10 @@
  (libraries spoc_framework alcotest)
  (instrumentation
   (backend bisect_ppx)))
+
+(test
+ (name test_ptx_atomics_probe)
+ (modules test_ptx_atomics_probe)
+ (libraries sarek_cuda alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek-cuda/test/test_ptx_atomics_probe.ml
+++ b/sarek-cuda/test/test_ptx_atomics_probe.ml
@@ -1,0 +1,121 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Hardware probe for the wide/exotic atomic forms.
+
+    The emitter now produces [atom.global.add.f64], [atom.global.add.u64],
+    [atom.global.inc.u32]/[dec.u32] and [atom.global.cas.b32] — forms that
+    NVCC-generated PTX emits rarely, so PTX translators (ZLUDA) may under-test
+    them. This pins their runtime behavior on whatever driver is present, in the
+    style of test_ptx_stride_spike. Skips cleanly without a CUDA driver.
+
+    Kernel: every thread atomically adds 1.0 to acc_f64[0], adds 1 to acc_u64
+    (viewed as u64), increments acc_inc (wrap limit 0xffffffff) and performs one
+    CAS attempt on acc_cas (expected 0 -> 42; exactly one thread wins). *)
+
+open Sarek_cuda
+
+let atomics_ptx =
+  {|.version 8.0
+.target sm_86
+.address_size 64
+
+.entry atomics_probe(
+    .param .u64 param_acc,
+    .param .u32 param_sarek_acc_length,
+    .param .u32 param_n
+)
+{
+    .reg .u32 %r<8>;
+    .reg .u64 %rd<6>;
+    .reg .f64 %fd<3>;
+    .reg .pred %p<2>;
+
+    ld.param.u64 %rd0, [param_acc];
+    ld.param.u32 %r0, [param_sarek_acc_length];
+    ld.param.u32 %r1, [param_n];
+    mov.u32 %r2, %tid.x;
+    mov.u32 %r3, %ctaid.x;
+    mov.u32 %r4, %ntid.x;
+    mul.lo.u32 %r5, %r3, %r4;
+    add.u32 %r6, %r2, %r5;
+    setp.ge.s32 %p0, %r6, %r1;
+    @%p0 bra L0;
+    mov.f64 %fd0, 0D3FF0000000000000;
+    atom.global.add.f64 %fd1, [%rd0], %fd0;
+    add.u64 %rd1, %rd0, 8;
+    mov.u64 %rd2, 1;
+    atom.global.add.u64 %rd3, [%rd1], %rd2;
+    add.u64 %rd4, %rd0, 16;
+    mov.u32 %r7, 4294967295;
+    atom.global.inc.u32 %r7, [%rd4], %r7;
+    add.u64 %rd5, %rd0, 24;
+    atom.global.cas.b32 %r7, [%rd5], 0, 42;
+L0:
+    ret;
+}
+|}
+
+let n = 4096
+
+let block_size = 256
+
+(* The accumulator buffer is 4 x 8 bytes viewed as f64 lanes:
+   [0] f64 sum; [1] u64 count (bit pattern); [2] u32 inc count (low word);
+   [3] u32 cas cell (low word). *)
+let test_atomics () =
+  if not (Cuda_api.is_driver_available ()) then (
+    Printf.printf "  [SKIP] no CUDA device\n%!" ;
+    ())
+  else begin
+    Cuda_api.Device.init () ;
+    let dev = Cuda_api.Device.get 0 in
+    let h_acc = Bigarray.Array1.create Bigarray.float64 Bigarray.c_layout 4 in
+    Bigarray.Array1.fill h_acc 0.0 ;
+    let d_acc = Cuda_api.Memory.alloc dev 4 Bigarray.float64 in
+    Cuda_api.Memory.host_to_device ~src:h_acc ~dst:d_acc ;
+    let kernel =
+      Cuda_api.Kernel.load_from_ptx dev ~name:"atomics_probe" ~ptx:atomics_ptx
+    in
+    let grid = ((n + block_size - 1) / block_size, 1, 1) in
+    Cuda_api.Kernel.launch
+      kernel
+      ~args:
+        (let len = Cuda_api.Kernel.ArgInt32 (Int32.of_int n) in
+         [Cuda_api.Kernel.ArgBuffer d_acc; len; len (* param_n *)])
+      ~grid
+      ~block:(block_size, 1, 1)
+      ~shared_mem:0
+      ~stream:None ;
+    Cuda_api.Device.synchronize dev ;
+    Cuda_api.Memory.device_to_host ~src:d_acc ~dst:h_acc ;
+    let f64_sum = h_acc.{0} in
+    let u64_count = Int64.bits_of_float h_acc.{1} in
+    let low_word x =
+      Int64.to_int (Int64.logand (Int64.bits_of_float x) 0xffffffffL)
+    in
+    let inc_count = low_word h_acc.{2} in
+    let cas_cell = low_word h_acc.{3} in
+    Alcotest.(check (float 0.5))
+      "atom.add.f64 accumulates n"
+      (float_of_int n)
+      f64_sum ;
+    Alcotest.(check int64) "atom.add.u64 counts n" (Int64.of_int n) u64_count ;
+    Alcotest.(check int) "atom.inc.u32 counts n" n inc_count ;
+    Alcotest.(check int) "atom.cas.b32 exactly-one winner" 42 cas_cell
+  end
+
+let () =
+  Alcotest.run
+    "ptx_atomics_probe"
+    [
+      ( "atomics",
+        [
+          Alcotest.test_case
+            "wide/exotic atom forms execute correctly"
+            `Quick
+            test_atomics;
+        ] );
+    ]

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1111,35 +1111,70 @@ and emit_intrinsic_native buf alloc env path name args : string =
     | [a] -> emit_cast buf alloc (emit_expr buf alloc env a) dst_ty
     | _ -> unsupported (intr ^ " arity != 1")
   in
-  (* atom.{shared,global}.add.s32 on an int32 array denoted by a plain
-     variable; returns the old value. *)
-  (* Atomic read-modify-write on a 4-byte element of an int32/float32 array
-     denoted by a plain variable; returns the old value. [op]/[ty] form the
-     PTX suffix (e.g. add.s32, min.s32, and.b32, exch.b32, add.f32). PTX has
-     no atom.sub, so "sub" is lowered to an add of the negated operand.
-     [result] selects the old-value register class. *)
-  let atomic_rmw intr ~global_only ~op ~ty ~result =
+  (* An i64 register is "%rd<n>" (u64 class; distinct from f64 "%fd<n>"). *)
+  let is_u64_reg r = String.length r >= 3 && r.[1] = 'r' && r.[2] = 'd' in
+  (* The operand register class must agree with the atom.<op><ty> suffix; a
+     mismatched register would be invalid PTX (module-load failure). *)
+  let check_atom_operand intr result r =
+    let ok, want =
+      match result with
+      | `F32 -> (is_f32_reg r, "f32")
+      | `F64 -> (is_f64_reg r, "f64")
+      | `U64 -> (is_u64_reg r, "int64")
+      | `U32 ->
+          ( (not (is_f32_reg r)) && (not (is_f64_reg r)) && not (is_u64_reg r),
+            "int32" )
+    in
+    if not ok then
+      unsupported
+        (intr ^ ": operand " ^ r ^ " is not " ^ want ^ "; cast the value first")
+  in
+  let new_atom_result = function
+    | `F32 -> new_f32 alloc
+    | `F64 -> new_f64 alloc
+    | `U64 -> new_u64 alloc
+    | `U32 -> new_u32 alloc
+  in
+  (* Byte address of element [r_idx] of array [arr]: shared arrays use
+     32-bit byte addressing, global arrays 64-bit. [elt_shift] is log2 of
+     the element size (2 for 32-bit, 3 for 64-bit elements) — the stride
+     must match the atom width or neighbouring elements alias. Returns the
+     PTX space name and the address register. *)
+  let atomic_addr ~global_only ~elt_shift arr r_idx =
+    let r_base = env_lookup env arr.var_name in
+    let is_shared =
+      (not global_only) && Hashtbl.mem alloc.arr_memspaces arr.var_name
+    in
+    if is_shared then begin
+      let r_off = new_u32 alloc in
+      let r_addr = new_u32 alloc in
+      emit buf "shl.b32 %s, %s, %d;" r_off r_idx elt_shift ;
+      emit buf "add.u32 %s, %s, %s;" r_addr r_base r_off ;
+      ("shared", r_addr)
+    end
+    else begin
+      let r_idx64 = new_u64 alloc in
+      let r_off = new_u64 alloc in
+      let r_addr = new_u64 alloc in
+      emit buf "cvt.u64.u32 %s, %s;" r_idx64 r_idx ;
+      emit buf "shl.b64 %s, %s, %d;" r_off r_idx64 elt_shift ;
+      emit buf "add.u64 %s, %s, %s;" r_addr r_base r_off ;
+      ("global", r_addr)
+    end
+  in
+  (* Atomic read-modify-write on one element of an array denoted by a plain
+     variable; returns the old value. [op]/[ty] form the PTX suffix (e.g.
+     add.s32, min.s32, and.b32, exch.b32, add.f32, add.u64, add.f64 — u64
+     add is two's-complement, so it is also the int64 add). PTX has no
+     atom.sub, so int32 "sub" is lowered to an add of the negated operand.
+     [result] selects the old-value register class and the operand width
+     check; [elt_shift] the addressing stride. *)
+  let atomic_rmw intr ~global_only ~elt_shift ~op ~ty ~result =
     match args with
     | [EVar arr; idx_e; val_e] ->
-        let r_base = env_lookup env arr.var_name in
         let r_idx = emit_expr buf alloc env idx_e in
         let r_val0 = emit_expr buf alloc env val_e in
-        (* The value register class must agree with the atom.<op><ty> suffix;
-           a mismatched register would be invalid PTX (module-load failure). *)
-        (match result with
-        | `F32 when not (is_f32_reg r_val0) ->
-            unsupported
-              (intr ^ ": value operand " ^ r_val0
-             ^ " is not f32; cast the value first")
-        | `U32
-          when is_f32_reg r_val0 || is_f64_reg r_val0
-               || String.length r_val0 >= 3
-                  && r_val0.[1] = 'r'
-                  && r_val0.[2] = 'd' ->
-            unsupported
-              (intr ^ ": value operand " ^ r_val0
-             ^ " is not int32; cast the value first")
-        | _ -> ()) ;
+        check_atom_operand intr result r_val0 ;
         let op, r_val =
           if op = "sub" then begin
             let r = new_u32 alloc in
@@ -1148,30 +1183,59 @@ and emit_intrinsic_native buf alloc env path name args : string =
           end
           else (op, r_val0)
         in
-        let is_shared =
-          (not global_only) && Hashtbl.mem alloc.arr_memspaces arr.var_name
-        in
-        let r_old =
-          match result with `F32 -> new_f32 alloc | `U32 -> new_u32 alloc
-        in
-        if is_shared then begin
-          let r_off = new_u32 alloc in
-          let r_addr = new_u32 alloc in
-          emit buf "shl.b32 %s, %s, 2;" r_off r_idx ;
-          emit buf "add.u32 %s, %s, %s;" r_addr r_base r_off ;
-          emit buf "atom.shared.%s%s %s, [%s], %s;" op ty r_old r_addr r_val
-        end
-        else begin
-          let r_idx64 = new_u64 alloc in
-          let r_off = new_u64 alloc in
-          let r_addr = new_u64 alloc in
-          emit buf "cvt.u64.u32 %s, %s;" r_idx64 r_idx ;
-          emit buf "shl.b64 %s, %s, 2;" r_off r_idx64 ;
-          emit buf "add.u64 %s, %s, %s;" r_addr r_base r_off ;
-          emit buf "atom.global.%s%s %s, [%s], %s;" op ty r_old r_addr r_val
-        end ;
+        let space, r_addr = atomic_addr ~global_only ~elt_shift arr r_idx in
+        let r_old = new_atom_result result in
+        emit buf "atom.%s.%s%s %s, [%s], %s;" space op ty r_old r_addr r_val ;
         r_old
     | _ -> unsupported (intr ^ ": expects (array-variable, index, value)")
+  in
+  (* Atomic compare-and-swap: atom.{shared,global}.cas.b{32,64}
+     d, [addr], compare, value — stores value iff *addr == compare; returns
+     the old value either way. *)
+  let atomic_cas intr ~elt_shift ~ty ~result =
+    match args with
+    | [EVar arr; idx_e; cmp_e; val_e] ->
+        let r_idx = emit_expr buf alloc env idx_e in
+        let r_cmp = emit_expr buf alloc env cmp_e in
+        let r_val = emit_expr buf alloc env val_e in
+        check_atom_operand intr result r_cmp ;
+        check_atom_operand intr result r_val ;
+        let space, r_addr =
+          atomic_addr ~global_only:false ~elt_shift arr r_idx
+        in
+        let r_old = new_atom_result result in
+        emit
+          buf
+          "atom.%s.cas%s %s, [%s], %s, %s;"
+          space
+          ty
+          r_old
+          r_addr
+          r_cmp
+          r_val ;
+        r_old
+    | _ ->
+        unsupported (intr ^ ": expects (array-variable, index, compare, value)")
+  in
+  (* atom.{shared,global}.{inc,dec}.u32 with limit 0xffffffff. Semantics
+     note: PTX inc/dec WRAP at the limit operand —
+       inc: d = (old >= limit) ? 0 : old + 1
+       dec: d = (old == 0 || old > limit) ? limit : old - 1
+     With limit = 0xffffffff both coincide exactly with add/sub of 1 modulo
+     2^32, i.e. the interpreter's plain ±1 semantics; a smaller limit would
+     turn them into wrapping ring-buffer counters, which no Sarek intrinsic
+     exposes yet. *)
+  let atomic_incdec intr ~global_only ~op =
+    match args with
+    | [EVar arr; idx_e] ->
+        let r_idx = emit_expr buf alloc env idx_e in
+        let space, r_addr = atomic_addr ~global_only ~elt_shift:2 arr r_idx in
+        let r_lim = new_u32 alloc in
+        emit buf "mov.u32 %s, 0xffffffff;" r_lim ;
+        let r_old = new_u32 alloc in
+        emit buf "atom.%s.%s.u32 %s, [%s], %s;" space op r_old r_addr r_lim ;
+        r_old
+    | _ -> unsupported (intr ^ ": expects (array-variable, index)")
   in
   (* Binary min/max: native PTX op. Both operands must share a register
      class — a mixed-width op would be invalid PTX. *)
@@ -1579,23 +1643,121 @@ and emit_intrinsic_native buf alloc env path name args : string =
   (* Atomics (old value returned). Shared vs global is auto-detected from the
      array's memory space; the *_global_* names force the global path. *)
   | "atomic_add_int32" ->
-      atomic_rmw name ~global_only:false ~op:"add" ~ty:".s32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"add"
+        ~ty:".s32"
+        ~result:`U32
   | "atomic_add_global_int32" ->
-      atomic_rmw name ~global_only:true ~op:"add" ~ty:".s32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:true
+        ~elt_shift:2
+        ~op:"add"
+        ~ty:".s32"
+        ~result:`U32
   | "atomic_sub_int32" ->
-      atomic_rmw name ~global_only:false ~op:"sub" ~ty:".s32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"sub"
+        ~ty:".s32"
+        ~result:`U32
   | "atomic_min_int32" ->
-      atomic_rmw name ~global_only:false ~op:"min" ~ty:".s32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"min"
+        ~ty:".s32"
+        ~result:`U32
   | "atomic_max_int32" ->
-      atomic_rmw name ~global_only:false ~op:"max" ~ty:".s32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"max"
+        ~ty:".s32"
+        ~result:`U32
   | "atomic_and_int32" ->
-      atomic_rmw name ~global_only:false ~op:"and" ~ty:".b32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"and"
+        ~ty:".b32"
+        ~result:`U32
   | "atomic_or_int32" ->
-      atomic_rmw name ~global_only:false ~op:"or" ~ty:".b32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"or"
+        ~ty:".b32"
+        ~result:`U32
   | "atomic_xor_int32" ->
-      atomic_rmw name ~global_only:false ~op:"xor" ~ty:".b32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"xor"
+        ~ty:".b32"
+        ~result:`U32
   | "atomic_exch_int32" ->
-      atomic_rmw name ~global_only:false ~op:"exch" ~ty:".b32" ~result:`U32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"exch"
+        ~ty:".b32"
+        ~result:`U32
+  (* exch generalized to 64-bit elements. No stdlib/ppx int64-exch name
+     exists yet; the emitter accepts the conventional name ahead of it
+     (snapshot-only coverage). *)
+  | "atomic_exch_int64" ->
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:3
+        ~op:"exch"
+        ~ty:".b64"
+        ~result:`U64
+  (* atom.add.u64: PTX add has no .s64 form; u64 add is two's-complement,
+     identical to signed int64 add. *)
+  | "atomic_add_int64" ->
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:3
+        ~op:"add"
+        ~ty:".u64"
+        ~result:`U64
   | "atomic_add_float32" ->
-      atomic_rmw name ~global_only:false ~op:"add" ~ty:".f32" ~result:`F32
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:2
+        ~op:"add"
+        ~ty:".f32"
+        ~result:`F32
+  (* atom.add.f64 requires sm_60+; the default target is sm_86. ZLUDA
+     support for f64 atomics is unverified — snapshot coverage only. *)
+  | "atomic_add_float64" ->
+      atomic_rmw
+        name
+        ~global_only:false
+        ~elt_shift:3
+        ~op:"add"
+        ~ty:".f64"
+        ~result:`F64
+  | "atomic_cas_int32" -> atomic_cas name ~elt_shift:2 ~ty:".b32" ~result:`U32
+  (* No stdlib/ppx int64-CAS name exists yet; the emitter accepts the
+     conventional name ahead of it (snapshot-only coverage). *)
+  | "atomic_cas_int64" -> atomic_cas name ~elt_shift:3 ~ty:".b64" ~result:`U64
+  | "atomic_inc_int32" -> atomic_incdec name ~global_only:false ~op:"inc"
+  | "atomic_inc_global_int32" -> atomic_incdec name ~global_only:true ~op:"inc"
+  | "atomic_dec_int32" -> atomic_incdec name ~global_only:false ~op:"dec"
   | n -> unsupported ("intrinsic: " ^ n)

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -911,7 +911,32 @@ and emit_binop buf alloc env op e1 e2 : string =
         emit buf "div.u32 %s, %s, %s;" r r1 r2 ;
         r
   | Mod ->
-      if is_f32 r1 || is_f64 r1 then unsupported "Mod on float"
+      (* Float Mod is C fmod: x - trunc(x/y)*y, result sign follows the
+         dividend x. OCaml's Float.rem has the same contract (it is C fmod),
+         so this matches mod_float on the host. rn-rounded div (not the fast
+         .approx form): the trunc snaps the quotient to an integer, so the
+         quotient's rounding error only shows within 1 ulp of an integer
+         boundary; the final fma is a single rounding. *)
+      if is_f64 r1 then (
+        let q = new_f64 alloc in
+        emit buf "div.rn.f64 %s, %s, %s;" q r1 r2 ;
+        let t = new_f64 alloc in
+        emit buf "cvt.rzi.f64.f64 %s, %s;" t q ;
+        let nt = new_f64 alloc in
+        emit buf "neg.f64 %s, %s;" nt t ;
+        let r = new_f64 alloc in
+        emit buf "fma.rn.f64 %s, %s, %s, %s;" r nt r2 r1 ;
+        r)
+      else if is_f32 r1 then (
+        let q = new_f32 alloc in
+        emit buf "div.rn.f32 %s, %s, %s;" q r1 r2 ;
+        let t = new_f32 alloc in
+        emit buf "cvt.rzi.f32.f32 %s, %s;" t q ;
+        let nt = new_f32 alloc in
+        emit buf "neg.f32 %s, %s;" nt t ;
+        let r = new_f32 alloc in
+        emit buf "fma.rn.f32 %s, %s, %s, %s;" r nt r2 r1 ;
+        r)
       else if is_u64 r1 then (
         let r = new_u64 alloc in
         emit buf "rem.u64 %s, %s, %s;" r r1 r2 ;

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1093,6 +1093,9 @@ and emit_cast buf alloc r_src dst_ty : string =
         emit buf "%s %s, %s;" cvt r r_src ;
         r
   | TInt64 ->
+      (* i32 -> i64 widens with sign extension (cvt.s64.s32); the reverse
+         narrowing in the TInt32 arm (cvt.u32.u64) TRUNCATES to the low 32
+         bits — values outside int32 range wrap, matching Int64.to_int32. *)
       if is_u64 r_src then r_src
       else
         let r = new_u64 alloc in
@@ -1103,7 +1106,29 @@ and emit_cast buf alloc r_src dst_ty : string =
         in
         emit buf "%s %s, %s;" cvt r r_src ;
         r
-  | _ -> unsupported ("ECast to " ^ ptx_reg_type_of dst_ty)
+  | TBool ->
+      (* Bool lives in a u32 register as 0/1 (the setp/selp discipline). A
+         cast to bool is C truth-testing: nonzero -> 1, zero -> 0. Sources
+         that are already 0/1 pay one setp+selp normalization — the register
+         class alone cannot prove a u32 holds only 0/1. Float sources use
+         UNordered ne (setp.neu): NaN != 0.0 is true in C, so
+         (bool)NaN = 1. *)
+      let p = new_pred alloc in
+      if is_f64 r_src then
+        emit buf "setp.neu.f64 %s, %s, 0D0000000000000000;" p r_src
+      else if is_f32 r_src then
+        emit buf "setp.neu.f32 %s, %s, 0F00000000;" p r_src
+      else if is_u64 r_src then emit buf "setp.ne.s64 %s, %s, 0;" p r_src
+      else emit buf "setp.ne.u32 %s, %s, 0;" p r_src ;
+      let r = new_u32 alloc in
+      emit buf "selp.u32 %s, 1, 0, %s;" r p ;
+      r
+  | TUnit ->
+      (* No meaningful value to produce; a cast to unit is a lowering bug —
+         drop the expression (SExpr) instead of casting it. *)
+      unsupported "ECast to unit: drop the expression instead of casting it"
+  | TRecord _ | TVariant _ | TArray _ | TVec _ ->
+      unsupported "ECast to an aggregate type: casts are scalar-only"
 
 and emit_intrinsic buf alloc env path name args : string =
   match Sarek_ir_ptx_softmath.helper_name name with

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -491,6 +491,91 @@ let test_atomic_family_markers () =
   assert_contains ptx "neg.s32" ;
   assert_contains ptx "atom.global.add.s32"
 
+(** Extended atomics round 2: cas.b32/b64, wrapping inc/dec.u32 (limit
+    0xffffffff = plain ±1 mod 2^32), add.u64/f64, exch.b64; 64-bit elements use
+    an 8-byte stride (shl …, 3), and a shared cas addresses in 32-bit. *)
+let test_atomic_cas_incdec_wide_markers () =
+  let hist = make_var "hist" (TVec TInt32) in
+  let lacc = make_var "lacc" (TVec TInt64) in
+  let dacc = make_var "dacc" (TVec TFloat64) in
+  let slock = make_var "slock" (TArray (TInt32, Shared)) in
+  let tid = make_var "tid" TInt32 in
+  let a name args = EIntrinsic (["Sarek_stdlib"; "Gpu"], name, args) in
+  let one = EConst (CInt32 1l) in
+  let zero = EConst (CInt32 0l) in
+  let lone = EConst (CInt64 1L) in
+  let lzero = EConst (CInt64 0L) in
+  let done_ = EConst (CFloat64 1.0) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( slock,
+            EArrayCreate (TInt32, EConst (CInt32 32l), Shared),
+            SSeq
+              [
+                SExpr (a "atomic_cas_int32" [EVar hist; EVar tid; zero; one]);
+                SExpr (a "atomic_cas_int64" [EVar lacc; EVar tid; lzero; lone]);
+                SExpr (a "atomic_cas_int32" [EVar slock; EVar tid; zero; one]);
+                SExpr (a "atomic_inc_int32" [EVar hist; EVar tid]);
+                SExpr (a "atomic_dec_int32" [EVar hist; EVar tid]);
+                SExpr (a "atomic_add_int64" [EVar lacc; EVar tid; lone]);
+                SExpr (a "atomic_add_float64" [EVar dacc; EVar tid; done_]);
+                SExpr (a "atomic_exch_int64" [EVar lacc; EVar tid; lone]);
+              ] ) )
+  in
+  let k =
+    base_kernel
+      "atomics_ext"
+      [
+        DParam (hist, Some {arr_elttype = TInt32; arr_memspace = Global});
+        DParam (lacc, Some {arr_elttype = TInt64; arr_memspace = Global});
+        DParam (dacc, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      ]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "atom.global.cas.b32" ;
+  assert_contains ptx "atom.global.cas.b64" ;
+  assert_contains ptx "atom.shared.cas.b32" ;
+  assert_contains ptx "atom.global.inc.u32" ;
+  assert_contains ptx "atom.global.dec.u32" ;
+  (* inc/dec wrap at the limit operand; 0xffffffff makes them plain ±1 *)
+  assert_contains ptx "0xffffffff" ;
+  assert_contains ptx "atom.global.add.u64" ;
+  assert_contains ptx "atom.global.add.f64" ;
+  assert_contains ptx "atom.global.exch.b64" ;
+  (* 8-byte addressing stride for the 64-bit forms *)
+  assert_contains ptx ", 3;"
+
+(** A 32-bit value into a 64-bit atom form is invalid PTX; the emitter must
+    reject it (width discipline), never emit the mismatched suffix. *)
+let test_atomic_width_mismatch_rejected () =
+  let lacc = make_var "lacc" (TVec TInt64) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SExpr
+          (EIntrinsic
+             ( ["Sarek_stdlib"; "Gpu"],
+               "atomic_add_int64",
+               [EVar lacc; EVar tid; EConst (CInt32 1l)] )) )
+  in
+  let k =
+    base_kernel
+      "atomic_mismatch"
+      [DParam (lacc, Some {arr_elttype = TInt64; arr_memspace = Global})]
+      body
+      []
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ -> Alcotest.fail "int32 value into atom.add.u64 should be rejected"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
 (** Check that [ptx] does NOT contain [marker]. *)
 let assert_absent ptx marker ~why =
   let mlen = String.length marker in
@@ -1466,6 +1551,14 @@ let () =
             "extended atomics emit atom.*.<op> (+ neg for sub)"
             `Quick
             test_atomic_family_markers;
+          Alcotest.test_case
+            "cas/inc/dec/64-bit atomics emit atom forms + stride 3"
+            `Quick
+            test_atomic_cas_incdec_wide_markers;
+          Alcotest.test_case
+            "width-mismatched atomic value is rejected"
+            `Quick
+            test_atomic_width_mismatch_rejected;
           Alcotest.test_case
             "shared array SLet emits .shared decl + ld/st.shared"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -550,6 +550,48 @@ let test_atomic_cas_incdec_wide_markers () =
   (* 8-byte addressing stride for the 64-bit forms *)
   assert_contains ptx ", 3;"
 
+(** Float Mod lowers to C fmod: x − trunc(x/y)·y via rn-rounded div, cvt.rzi
+    trunc, neg and a single fma — for both f32 and f64. *)
+let test_float_mod_fmod_markers () =
+  let fa = make_var "fa" (TVec TFloat32) in
+  let da = make_var "da" (TVec TFloat64) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SSeq
+          [
+            SAssign
+              ( LArrayElem ("fa", EVar tid),
+                EBinop (Mod, EArrayRead ("fa", EVar tid), EConst (CFloat32 3.0))
+              );
+            SAssign
+              ( LArrayElem ("da", EVar tid),
+                EBinop (Mod, EArrayRead ("da", EVar tid), EConst (CFloat64 3.0))
+              );
+          ] )
+  in
+  let k =
+    base_kernel
+      "float_fmod"
+      [
+        DParam (fa, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (da, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      ]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "div.rn.f32" ;
+  assert_contains ptx "cvt.rzi.f32.f32" ;
+  assert_contains ptx "neg.f32" ;
+  assert_contains ptx "fma.rn.f32" ;
+  assert_contains ptx "div.rn.f64" ;
+  assert_contains ptx "cvt.rzi.f64.f64" ;
+  assert_contains ptx "neg.f64" ;
+  assert_contains ptx "fma.rn.f64"
+
 (** A 32-bit value into a 64-bit atom form is invalid PTX; the emitter must
     reject it (width discipline), never emit the mismatched suffix. *)
 let test_atomic_width_mismatch_rejected () =
@@ -1559,6 +1601,10 @@ let () =
             "width-mismatched atomic value is rejected"
             `Quick
             test_atomic_width_mismatch_rejected;
+          Alcotest.test_case
+            "float Mod lowers to fmod (div.rn + cvt.rzi + fma)"
+            `Quick
+            test_float_mod_fmod_markers;
           Alcotest.test_case
             "shared array SLet emits .shared decl + ld/st.shared"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -592,6 +592,64 @@ let test_float_mod_fmod_markers () =
   assert_contains ptx "neg.f64" ;
   assert_contains ptx "fma.rn.f64"
 
+(** ECast scalar-matrix coverage: bool casts normalize to a u32 0/1 via
+    setp+selp (float sources use unordered neu so NaN -> 1, matching C); i32 ->
+    i64 sign-extends (cvt.s64.s32); i64 -> i32 truncates (cvt.u32.u64). *)
+let test_cast_matrix_markers () =
+  let out = make_var "out" (TVec TInt32) in
+  let tid = make_var "tid" TInt32 in
+  let store i e = SAssign (LArrayElem ("out", i), e) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SSeq
+          [
+            store (EVar tid) (ECast (TBool, EVar tid));
+            store (EVar tid) (ECast (TBool, EConst (CFloat32 1.0)));
+            store (EVar tid) (ECast (TBool, EConst (CFloat64 1.0)));
+            store (EVar tid) (ECast (TBool, EConst (CInt64 1L)));
+            store (EVar tid) (ECast (TInt32, ECast (TInt64, EVar tid)));
+          ] )
+  in
+  let k =
+    base_kernel
+      "cast_matrix"
+      [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "setp.ne.u32" ;
+  assert_contains ptx "setp.neu.f32" ;
+  assert_contains ptx "setp.neu.f64" ;
+  assert_contains ptx "setp.ne.s64" ;
+  assert_contains ptx "selp.u32" ;
+  (* widen sign-extends, narrow truncates to the low 32 bits *)
+  assert_contains ptx "cvt.s64.s32" ;
+  assert_contains ptx "cvt.u32.u64"
+
+(** ECast to unit is semantically meaningless and must be rejected. *)
+let test_cast_to_unit_rejected () =
+  let out = make_var "out" (TVec TInt32) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign (LArrayElem ("out", EVar tid), ECast (TUnit, EVar tid)) )
+  in
+  let k =
+    base_kernel
+      "cast_unit"
+      [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+      body
+      []
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ -> Alcotest.fail "ECast to unit should be rejected"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
 (** A 32-bit value into a 64-bit atom form is invalid PTX; the emitter must
     reject it (width discipline), never emit the mismatched suffix. *)
 let test_atomic_width_mismatch_rejected () =
@@ -1605,6 +1663,14 @@ let () =
             "float Mod lowers to fmod (div.rn + cvt.rzi + fma)"
             `Quick
             test_float_mod_fmod_markers;
+          Alcotest.test_case
+            "ECast matrix: bool setp/selp + i32<->i64 cvt pairs"
+            `Quick
+            test_cast_matrix_markers;
+          Alcotest.test_case
+            "ECast to unit is rejected"
+            `Quick
+            test_cast_to_unit_rejected;
           Alcotest.test_case
             "shared array SLet emits .shared decl + ld/st.shared"
             `Quick


### PR DESCRIPTION
Campaign items L3+L4+L5, stacked on #229. Three orthogonal emitter extensions, one commit each + a hardware probe:

- **Atomics (L3):** `atom.{global,shared}.cas.b32`, `cas.b64`, wrapping `inc.u32`/`dec.u32` (limit 0xffffffff → exact ±1 mod 2^32, wrap semantics documented), `add.u64` (two's-complement ≡ s64), `add.f64` (sm_60+), `exch.b64`. `atomic_rmw` refactored into shared width-checked machinery (one operand check for all four register classes, parameterized addressing stride). `atomic_cas_int64`/`atomic_exch_int64` are emitter-level only (no PPX surface yet — flagged as follow-up).
- **Float `mod` (L4):** the "Mod on float" rejection becomes C-semantics fmod (`div.rn` + `cvt.rzi` + `fma.rn`; sign follows dividend; OCaml `Float.rem` has identical semantics so host/device agree).
- **Cast matrix (L5):** audit found the numeric 4×4 block complete; added bool casts (C truth-test via `setp` — unordered on floats so `(bool)NaN = true` — + `selp`), explicit unit/aggregate rejections; the cast match is now exhaustive.
- **Hardware probe:** hand-written PTX exercising `add.f64`/`add.u64`/`inc.u32`/`cas.b32` — all four verified correct under ZLUDA on the RX 7900 XTX (these shapes are rare in NVCC output, hence translator-risk).

Snapshot suite extended (width-mismatch rejection included); full `dune runtest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)