### PR TITLE
feat(ptx): dynamic shared memory and per-thread local arrays

### DIFF
--- a/formal/codegen-ptx/test/test_codegen_ptx_conformance.ml
+++ b/formal/codegen-ptx/test/test_codegen_ptx_conformance.ml
@@ -844,14 +844,34 @@ let test_dshared_int32_write () =
   if contains_sub ptx "st.global" then
     Alcotest.failf "unexpected 'st.global' for shared array in:\n%s" ptx
 
-(* AC-3: dynamic DShared (None) → Ptx_codegen_error "dynamic shared memory" *)
-let test_dshared_dynamic_raises () =
+(* AC-3 (updated): dynamic DShared (None) is now SUPPORTED — it emits a
+   module-scope extern .shared incomplete-array declaration whose byte size
+   is supplied at launch (~shared_mem), like extern __shared__ in raw CUDA.
+   The Rocq spec (PtxKernelSpec.v) models only static DShared declarations;
+   the original AC-3 pinned the pre-support rejection, not a theorem. The
+   guarded invariant is now: exactly one extern region per kernel. *)
+let test_dshared_dynamic_extern () =
   let k = make_kernel "test_dyn" ~locals:[DShared ("x", TFloat32, None)] in
-  match Sarek_codegen.Sarek_ir_ptx_kernel.generate k with
+  let ptx = Sarek_codegen.Sarek_ir_ptx_kernel.generate k in
+  if not (contains_sub ptx ".extern .shared .align 4 .b32 x[];") then
+    Alcotest.failf "expected extern .shared declaration in:\n%s" ptx ;
+  (* The extern declaration must be module scope: before the .entry. *)
+  let ep = find_sub ptx ".extern .shared" in
+  let np = find_sub ptx ".entry" in
+  if ep < 0 || np < 0 || ep >= np then
+    Alcotest.failf ".extern .shared must precede .entry in:\n%s" ptx ;
+  (* A second dynamic region is rejected: single extern region per kernel. *)
+  let k2 =
+    make_kernel
+      "test_dyn2"
+      ~locals:[DShared ("x", TFloat32, None); DShared ("y", TInt32, None)]
+  in
+  match Sarek_codegen.Sarek_ir_ptx_kernel.generate k2 with
   | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error msg ->
-      if not (contains_sub msg "dynamic shared memory") then
-        Alcotest.failf "expected 'dynamic shared memory' in error, got: %s" msg
-  | _ -> Alcotest.fail "expected Ptx_codegen_error for dynamic DShared"
+      if not (contains_sub msg "single extern") then
+        Alcotest.failf "expected 'single extern' in error, got: %s" msg
+  | _ ->
+      Alcotest.fail "expected Ptx_codegen_error for two dynamic DShared decls"
 
 (* AC-4: zero size → Ptx_codegen_error "size must be positive" *)
 let test_dshared_zero_size_raises () =
@@ -1010,7 +1030,10 @@ let () =
             "mixed-global-shared"
             `Quick
             test_dshared_mixed_global_shared;
-          Alcotest.test_case "dynamic-raises" `Quick test_dshared_dynamic_raises;
+          Alcotest.test_case
+            "dynamic-extern-region"
+            `Quick
+            test_dshared_dynamic_extern;
           Alcotest.test_case
             "zero-size-raises"
             `Quick

--- a/sarek-cuda/test/dune
+++ b/sarek-cuda/test/dune
@@ -41,3 +41,10 @@
  (libraries sarek_cuda alcotest)
  (instrumentation
   (backend bisect_ppx)))
+
+(test
+ (name test_ptx_dynshared_probe)
+ (modules test_ptx_dynshared_probe)
+ (libraries sarek_cuda sarek.codegen spoc.ir alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek-cuda/test/dune
+++ b/sarek-cuda/test/dune
@@ -48,3 +48,10 @@
  (libraries sarek_cuda sarek.codegen spoc.ir alcotest)
  (instrumentation
   (backend bisect_ppx)))
+
+(test
+ (name test_ptx_localarr_probe)
+ (modules test_ptx_localarr_probe)
+ (libraries sarek_cuda sarek.codegen spoc.ir alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek-cuda/test/test_ptx_dynshared_probe.ml
+++ b/sarek-cuda/test/test_ptx_dynshared_probe.ml
@@ -1,0 +1,142 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Runtime probe for dynamic shared memory (extern .shared).
+
+    Generates PTX from hand-written IR with
+    [DShared ("dynbuf", TFloat32, None)], loads it, and launches with an
+    explicit [~shared_mem] byte size — proving both the emitter's
+    [.extern .shared] declaration and the host plumbing that delivers the
+    launch-time byte size (the same [Kernel.launch ~shared_mem] the
+    Execute.run_source path uses).
+
+    Kernel: one block; each thread stages out[tid] into the dynamic shared
+    buffer, barriers, and reads back the block-reversed element: out[tid] <-
+    dynbuf[ntid - 1 - tid]. A wrong or zero dynamic region size would trap or
+    produce non-reversed output.
+
+    Skips cleanly when no CUDA device is present. *)
+
+open Sarek_cuda
+open Sarek_ir_types
+
+let block_size = 64
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(** out[tid] <- dynbuf[ntid-1-tid] after staging out into dynbuf. *)
+let make_dynshared_kernel () : kernel =
+  let out = make_var "out" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let rev = make_var "rev" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "thread_idx_x", []),
+        SSeq
+          [
+            SAssign
+              (LArrayElem ("dynbuf", EVar tid), EArrayRead ("out", EVar tid));
+            SBarrier;
+            SLet
+              ( rev,
+                EBinop
+                  ( Sub,
+                    EBinop
+                      ( Sub,
+                        EIntrinsic ([], "block_dim_x", []),
+                        EConst (CInt32 1l) ),
+                    EVar tid ),
+                SAssign
+                  (LArrayElem ("out", EVar tid), EArrayRead ("dynbuf", EVar rev))
+              );
+          ] )
+  in
+  {
+    kern_name = "dynshared_probe";
+    kern_params =
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})];
+    kern_locals = [DShared ("dynbuf", TFloat32, None)];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let test_dynshared () =
+  let ptx = Sarek_codegen.Sarek_ir_ptx.generate (make_dynshared_kernel ()) in
+  (* The declaration must be the extern (launch-sized) form. *)
+  Alcotest.(check bool)
+    "PTX declares extern .shared dynbuf"
+    true
+    (let marker = ".extern .shared .align 4 .b32 dynbuf[];" in
+     let mlen = String.length marker in
+     let found = ref false in
+     for i = 0 to String.length ptx - mlen do
+       if String.sub ptx i mlen = marker then found := true
+     done ;
+     !found) ;
+  if not (Cuda_api.is_driver_available ()) then
+    Printf.printf "  [SKIP] no CUDA device (PTX emission checked)\n%!"
+  else begin
+    Cuda_api.Device.init () ;
+    let dev = Cuda_api.Device.get 0 in
+    let h_out =
+      Bigarray.Array1.create Bigarray.float32 Bigarray.c_layout block_size
+    in
+    for i = 0 to block_size - 1 do
+      h_out.{i} <- float_of_int i
+    done ;
+    let d_out = Cuda_api.Memory.alloc dev block_size Bigarray.float32 in
+    Cuda_api.Memory.host_to_device ~src:h_out ~dst:d_out ;
+    let kernel =
+      try Cuda_api.Kernel.load_from_ptx dev ~name:"dynshared_probe" ~ptx
+      with e ->
+        Printf.printf "LOAD ERROR: %s\nPTX:\n%s\n%!" (Printexc.to_string e) ptx ;
+        raise e
+    in
+    Cuda_api.Kernel.launch
+      kernel
+      ~args:
+        [
+          Cuda_api.Kernel.ArgBuffer d_out;
+          Cuda_api.Kernel.ArgInt32 (Int32.of_int block_size);
+        ]
+      ~grid:(1, 1, 1)
+      ~block:(block_size, 1, 1)
+      ~shared_mem:(block_size * 4) (* the dynamic region: ntid f32 lanes *)
+      ~stream:None ;
+    Cuda_api.Device.synchronize dev ;
+    Cuda_api.Memory.device_to_host ~src:d_out ~dst:h_out ;
+    let ok = ref true in
+    for i = 0 to block_size - 1 do
+      let expected = float_of_int (block_size - 1 - i) in
+      if abs_float (h_out.{i} -. expected) > 1e-6 then begin
+        Printf.printf
+          "  FAIL at i=%d: expected %f got %f\n%!"
+          i
+          expected
+          h_out.{i} ;
+        ok := false
+      end
+    done ;
+    Alcotest.(check bool) "block reversal through dynamic shared" true !ok ;
+    Cuda_api.Memory.free d_out
+  end
+
+let () =
+  Alcotest.run
+    "ptx_dynshared_probe"
+    [
+      ( "dynshared",
+        [
+          Alcotest.test_case
+            "extern .shared region sized at launch works"
+            `Quick
+            test_dynshared;
+        ] );
+    ]

--- a/sarek-cuda/test/test_ptx_localarr_probe.ml
+++ b/sarek-cuda/test/test_ptx_localarr_probe.ml
@@ -1,0 +1,176 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Runtime probe for per-thread local arrays (.local state space).
+
+    Generates PTX from hand-written IR with
+    [SLet (tmp, EArrayCreate (TFloat32, 8, Local), ...)], loads it and runs it.
+    Pins that the function-scope [.local .align A .bXX name[n]] declaration form
+    plus [mov.u64] symbol addressing and typed [ld.local]/[st.local] are
+    accepted and behave per-thread on whatever driver is present (ZLUDA
+    under-tests rare forms — the extern .shared probe caught exactly such a
+    load-time rejection).
+
+    Kernel: each thread fills its own 8-slot local array with tid*8+j, then sums
+    it back into out[tid]. Expected out[tid] = 8*(tid*8) + 28. Any cross-thread
+    interference (i.e. the array not being thread-private) or mis-addressing
+    breaks the sum.
+
+    Skips cleanly when no CUDA device is present. *)
+
+open Sarek_cuda
+open Sarek_ir_types
+
+let block_size = 64
+
+let slots = 8
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let make_localarr_kernel () : kernel =
+  let out = make_var "out" (TVec TFloat32) in
+  let tmp = make_var "tmp" (TArray (TFloat32, Local)) in
+  let tid = make_var "tid" TInt32 in
+  let acc = make_var "acc" TFloat32 in
+  let j = make_var "j" TInt32 in
+  let j2 = make_var "j2" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "thread_idx_x", []),
+        SLet
+          ( tmp,
+            EArrayCreate (TFloat32, EConst (CInt32 (Int32.of_int slots)), Local),
+            SSeq
+              [
+                SFor
+                  ( j,
+                    EConst (CInt32 0l),
+                    EConst (CInt32 (Int32.of_int (slots - 1))),
+                    Upto,
+                    SAssign
+                      ( LArrayElem ("tmp", EVar j),
+                        ECast
+                          ( TFloat32,
+                            EBinop
+                              ( Add,
+                                EBinop
+                                  ( Mul,
+                                    EVar tid,
+                                    EConst (CInt32 (Int32.of_int slots)) ),
+                                EVar j ) ) ) );
+                SLetMut
+                  ( acc,
+                    EConst (CFloat32 0.0),
+                    SSeq
+                      [
+                        SFor
+                          ( j2,
+                            EConst (CInt32 0l),
+                            EConst (CInt32 (Int32.of_int (slots - 1))),
+                            Upto,
+                            SAssign
+                              ( LVar acc,
+                                EBinop
+                                  (Add, EVar acc, EArrayRead ("tmp", EVar j2))
+                              ) );
+                        SAssign (LArrayElem ("out", EVar tid), EVar acc);
+                      ] );
+              ] ) )
+  in
+  {
+    kern_name = "localarr_probe";
+    kern_params =
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let test_localarr () =
+  let ptx = Sarek_codegen.Sarek_ir_ptx.generate (make_localarr_kernel ()) in
+  let contains_sub s sub =
+    let n = String.length sub in
+    let found = ref false in
+    for i = 0 to String.length s - n do
+      if String.sub s i n = sub then found := true
+    done ;
+    !found
+  in
+  Alcotest.(check bool)
+    "PTX declares .local tmp"
+    true
+    (contains_sub ptx ".local .align 4 .b32 tmp[8];") ;
+  Alcotest.(check bool)
+    "PTX stores via st.local"
+    true
+    (contains_sub ptx "st.local.f32") ;
+  Alcotest.(check bool)
+    "PTX loads via ld.local"
+    true
+    (contains_sub ptx "ld.local.f32") ;
+  if not (Cuda_api.is_driver_available ()) then
+    Printf.printf "  [SKIP] no CUDA device (PTX emission checked)\n%!"
+  else begin
+    Cuda_api.Device.init () ;
+    let dev = Cuda_api.Device.get 0 in
+    let h_out =
+      Bigarray.Array1.create Bigarray.float32 Bigarray.c_layout block_size
+    in
+    Bigarray.Array1.fill h_out 0.0 ;
+    let d_out = Cuda_api.Memory.alloc dev block_size Bigarray.float32 in
+    Cuda_api.Memory.host_to_device ~src:h_out ~dst:d_out ;
+    let kernel =
+      try Cuda_api.Kernel.load_from_ptx dev ~name:"localarr_probe" ~ptx
+      with e ->
+        Printf.printf "LOAD ERROR: %s\nPTX:\n%s\n%!" (Printexc.to_string e) ptx ;
+        raise e
+    in
+    Cuda_api.Kernel.launch
+      kernel
+      ~args:
+        [
+          Cuda_api.Kernel.ArgBuffer d_out;
+          Cuda_api.Kernel.ArgInt32 (Int32.of_int block_size);
+        ]
+      ~grid:(1, 1, 1)
+      ~block:(block_size, 1, 1)
+      ~shared_mem:0
+      ~stream:None ;
+    Cuda_api.Device.synchronize dev ;
+    Cuda_api.Memory.device_to_host ~src:d_out ~dst:h_out ;
+    let ok = ref true in
+    for i = 0 to block_size - 1 do
+      (* sum_{j<8} (i*8 + j) = 8*(i*8) + 28 *)
+      let expected = float_of_int ((8 * (i * slots)) + 28) in
+      if abs_float (h_out.{i} -. expected) > 1e-3 then begin
+        Printf.printf
+          "  FAIL at i=%d: expected %f got %f\n%!"
+          i
+          expected
+          h_out.{i} ;
+        ok := false
+      end
+    done ;
+    Alcotest.(check bool) "per-thread local array sums correct" true !ok ;
+    Cuda_api.Memory.free d_out
+  end
+
+let () =
+  Alcotest.run
+    "ptx_localarr_probe"
+    [
+      ( "localarr",
+        [
+          Alcotest.test_case
+            ".local array declare/fill/sum executes correctly"
+            `Quick
+            test_localarr;
+        ] );
+    ]

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -363,7 +363,7 @@ let rec emit_expr buf alloc (env : env) (expr : expr) : string =
         r_base
         r_idx
         (infer_elt_type alloc arr_name)
-        ~is_shared:(Hashtbl.mem alloc.arr_memspaces arr_name)
+        ~space:(arr_space_of alloc arr_name)
   | EArrayReadExpr (base_expr, idx_expr) ->
       let r_base = emit_expr buf alloc env base_expr in
       let r_idx = emit_expr buf alloc env idx_expr in
@@ -378,12 +378,10 @@ let rec emit_expr buf alloc (env : env) (expr : expr) : string =
               "EArrayReadExpr: cannot infer element type from non-variable \
                base expression"
       in
-      let is_shared =
-        match arr_name_opt with
-        | Some n -> Hashtbl.mem alloc.arr_memspaces n
-        | None -> false
+      let space =
+        match arr_name_opt with Some n -> arr_space_of alloc n | None -> None
       in
-      emit_array_read buf alloc r_base r_idx elt_type ~is_shared
+      emit_array_read buf alloc r_base r_idx elt_type ~space
   | EIntrinsic (path, name, args) -> emit_intrinsic buf alloc env path name args
   | ECast (ty, e) ->
       let r_src = emit_expr buf alloc env e in
@@ -506,13 +504,13 @@ and bind_helper_param buf alloc env callee_env (p : var) (arg, arg_val) =
   match p.var_type with
   | TVec elt | TArray (elt, _) ->
       let prev_elt = Hashtbl.find_opt alloc.arr_elt_types p.var_name in
-      let prev_ms = Hashtbl.mem alloc.arr_memspaces p.var_name in
+      let prev_ms = arr_space_of alloc p.var_name in
       Hashtbl.replace alloc.arr_elt_types p.var_name elt ;
       (match arg with
       | EVar a -> (
-          if Hashtbl.mem alloc.arr_memspaces a.var_name then
-            Hashtbl.replace alloc.arr_memspaces p.var_name ()
-          else Hashtbl.remove alloc.arr_memspaces p.var_name ;
+          (match arr_space_of alloc a.var_name with
+          | Some space -> Hashtbl.replace alloc.arr_memspaces p.var_name space
+          | None -> Hashtbl.remove alloc.arr_memspaces p.var_name) ;
           match Hashtbl.find_opt env (length_param_name a.var_name) with
           | Some len_binding ->
               env_bind_binding
@@ -529,12 +527,13 @@ and restore_helper_array_meta alloc saved =
   List.iter
     (function
       | None -> ()
-      | Some (name, prev_elt, prev_ms) ->
+      | Some (name, prev_elt, prev_ms) -> (
           (match prev_elt with
           | Some e -> Hashtbl.replace alloc.arr_elt_types name e
           | None -> Hashtbl.remove alloc.arr_elt_types name) ;
-          if prev_ms then Hashtbl.replace alloc.arr_memspaces name ()
-          else Hashtbl.remove alloc.arr_memspaces name)
+          match prev_ms with
+          | Some space -> Hashtbl.replace alloc.arr_memspaces name space
+          | None -> Hashtbl.remove alloc.arr_memspaces name))
     saved
 
 (** Inline a helper call and return the binding holding its result. First entry
@@ -714,7 +713,7 @@ and emit_agg_array_read buf alloc env arr_name idx_expr : binding =
       r_base
       r_idx
       ~stride:(elt_stride elt)
-      ~is_shared:(Hashtbl.mem alloc.arr_memspaces arr_name)
+      ~space:(arr_space_of alloc arr_name)
       ~arr_name
   in
   emit_agg_elem_load buf alloc r_addr ~offset:0 elt
@@ -754,7 +753,7 @@ and emit_record_field buf alloc env base field : binding =
           r_base
           r_idx
           ~stride:(elt_stride elt)
-          ~is_shared:(Hashtbl.mem alloc.arr_memspaces arr_name)
+          ~space:(arr_space_of alloc arr_name)
           ~arr_name
       in
       emit_agg_elem_load buf alloc r_addr ~offset fty
@@ -1192,8 +1191,15 @@ and emit_intrinsic_native buf alloc env path name args : string =
      PTX space name and the address register. *)
   let atomic_addr ~global_only ~elt_shift arr r_idx =
     let r_base = env_lookup env arr.var_name in
+    (* PTX has no atom.local — and per-thread memory needs no atomics. *)
+    (match arr_space_of alloc arr.var_name with
+    | Some SpaceLocal ->
+        unsupported
+          ("atomic operation on per-thread local array '" ^ arr.var_name
+         ^ "' (atomics require shared or global memory)")
+    | Some SpaceShared | None -> ()) ;
     let is_shared =
-      (not global_only) && Hashtbl.mem alloc.arr_memspaces arr.var_name
+      (not global_only) && arr_space_of alloc arr.var_name = Some SpaceShared
     in
     if is_shared then begin
       let r_off = new_u32 alloc in

--- a/sarek/codegen/Sarek_ir_ptx_kernel.ml
+++ b/sarek/codegen/Sarek_ir_ptx_kernel.ml
@@ -132,6 +132,20 @@ let emit_locals buf shared_buf alloc (env : env) (locals : decl list) : unit =
     (fun decl ->
       match decl with
       | DLocal (v, init_opt) -> (
+          (* Fail-closed: a DLocal of array type would silently fall through
+             new_reg_for_type to a bare, never-initialized u64 register with
+             no .local declaration behind it — dangling-pointer PTX. A DLocal
+             carries no size, so it can never become a real allocation. *)
+          (match v.var_type with
+          | TArray _ | TVec _ ->
+              fail
+                (Printf.sprintf
+                   "PTX codegen: local declaration '%s' has array type: a \
+                    DLocal carries no size and cannot allocate storage; create \
+                    the array in the kernel body instead (create_array n \
+                    Local, or let%%shared for shared memory)"
+                   v.var_name)
+          | _ -> ()) ;
           let r = new_reg_for_type alloc v.var_type in
           env_bind env v.var_name r ;
           match init_opt with
@@ -181,7 +195,7 @@ let emit_locals buf shared_buf alloc (env : env) (locals : decl list) : unit =
           let r = new_u32 alloc in
           env_bind env name r ;
           emit buf "mov.u32 %s, %s;" r name ;
-          Hashtbl.replace alloc.arr_memspaces name () ;
+          Hashtbl.replace alloc.arr_memspaces name SpaceShared ;
           Hashtbl.replace alloc.arr_elt_types name elt
       | DParam _ -> ())
     locals
@@ -250,6 +264,9 @@ let generate ?(sm_target = "sm_86") (k : kernel) : string =
   Buffer.add_buffer out shared_buf ;
   (* Shared arrays declared mid-body (SLet-bound let%shared). *)
   Buffer.add_buffer out alloc.shared_decls ;
+  (* Per-thread local arrays declared mid-body (SLet-bound create_array
+     Local). *)
+  Buffer.add_buffer out alloc.local_decls ;
   Buffer.add_char out '\n' ;
   Buffer.add_buffer out body_buf ;
   Buffer.add_string out "}\n" ;

--- a/sarek/codegen/Sarek_ir_ptx_kernel.ml
+++ b/sarek/codegen/Sarek_ir_ptx_kernel.ml
@@ -127,7 +127,11 @@ let emit_params buf alloc (env : env) (params : decl list) : string =
    Sarek_ir_ptx_types, shared with the SLet shared-array path in
    Sarek_ir_ptx_stmt. *)
 
-let emit_locals buf shared_buf alloc (env : env) (locals : decl list) : unit =
+let emit_locals buf shared_buf module_buf alloc (env : env) (locals : decl list)
+    : unit =
+  (* PTX allows at most one incomplete (extern) .shared array per kernel: all
+     dynamic shared memory is one region sized at launch, as in raw CUDA. *)
+  let dyn_shared : string option ref = ref None in
   List.iter
     (fun decl ->
       match decl with
@@ -161,37 +165,54 @@ let emit_locals buf shared_buf alloc (env : env) (locals : decl list) : unit =
               in
               emit buf "%s %s, %s;" mov_op r r_init)
       | DShared (name, elt, size_opt) ->
-          let n =
-            match size_opt with
-            | None ->
-                unsupported
-                  (Printf.sprintf
-                     "DShared '%s': dynamic shared memory (size=None) not yet \
-                      supported"
-                     name)
-            | Some (EConst (CInt32 n)) when Int32.compare n 0l > 0 ->
-                Int32.to_int n
-            | Some (EConst (CInt32 _)) ->
-                fail
-                  (Printf.sprintf
-                     "PTX codegen: DShared '%s': size must be positive"
-                     name)
-            | Some _ ->
-                unsupported
-                  (Printf.sprintf
-                     "DShared '%s': non-literal size not supported"
-                     name)
-          in
           let align = ptx_align_of_elttype elt in
           let btype = ptx_btype_of_elttype elt in
-          Buffer.add_string
-            shared_buf
-            (Printf.sprintf
-               "    .shared .align %d .%s %s[%d];\n"
-               align
-               btype
-               name
-               n) ;
+          (match size_opt with
+          | None ->
+              (* Dynamic shared memory: one extern region whose byte size is
+                 supplied at launch (Execute.run_vectors ~shared_mem →
+                 run_source ~shared_mem → cuLaunchKernel), exactly like
+                 extern __shared__ in raw CUDA. The incomplete-array
+                 declaration must be MODULE scope (before .entry) — NVCC
+                 emits it there, and ZLUDA rejects the function-scope form
+                 at cuModuleLoadData time. *)
+              (match !dyn_shared with
+              | Some first ->
+                  fail
+                    (Printf.sprintf
+                       "PTX codegen: kernel declares two dynamic shared arrays \
+                        ('%s' and '%s'); PTX allows a single extern .shared \
+                        region per kernel — merge them into one array with \
+                        manual offsets, or give all but one a static size"
+                       first
+                       name)
+              | None -> dyn_shared := Some name) ;
+              Buffer.add_string
+                module_buf
+                (Printf.sprintf
+                   ".extern .shared .align %d .%s %s[];\n"
+                   align
+                   btype
+                   name)
+          | Some (EConst (CInt32 n)) when Int32.compare n 0l > 0 ->
+              Buffer.add_string
+                shared_buf
+                (Printf.sprintf
+                   "    .shared .align %d .%s %s[%d];\n"
+                   align
+                   btype
+                   name
+                   (Int32.to_int n))
+          | Some (EConst (CInt32 _)) ->
+              fail
+                (Printf.sprintf
+                   "PTX codegen: DShared '%s': size must be positive"
+                   name)
+          | Some _ ->
+              unsupported
+                (Printf.sprintf
+                   "DShared '%s': non-literal size not supported"
+                   name)) ;
           let r = new_u32 alloc in
           env_bind env name r ;
           emit buf "mov.u32 %s, %s;" r name ;
@@ -250,13 +271,19 @@ let generate ?(sm_target = "sm_86") (k : kernel) : string =
   let env = make_env () in
   let body_buf = Buffer.create 2048 in
   let shared_buf = Buffer.create 256 in
+  let module_buf = Buffer.create 128 in
   let param_str = emit_params body_buf alloc env k.kern_params in
-  emit_locals body_buf shared_buf alloc env k.kern_locals ;
+  emit_locals body_buf shared_buf module_buf alloc env k.kern_locals ;
   emit_stmt body_buf alloc env k.kern_body ;
   Buffer.add_string body_buf "    ret;\n" ;
   let out = Buffer.create 4096 in
   Buffer.add_string out (make_ptx_header ~sm_target ()) ;
   Buffer.add_char out '\n' ;
+  (* Module-scope declarations (extern .shared dynamic region). *)
+  if Buffer.length module_buf > 0 then begin
+    Buffer.add_buffer out module_buf ;
+    Buffer.add_char out '\n'
+  end ;
   Printf.bprintf out ".entry %s(\n" k.kern_name ;
   Buffer.add_string out param_str ;
   Buffer.add_string out "\n)\n{\n" ;

--- a/sarek/codegen/Sarek_ir_ptx_kernel.mli
+++ b/sarek/codegen/Sarek_ir_ptx_kernel.mli
@@ -15,11 +15,17 @@ open Sarek_ir_ptx_types
     [.param] declaration block string for embedding in the [.entry] header. *)
 val emit_params : Buffer.t -> reg_alloc -> env -> decl list -> string
 
-(** [emit_locals buf shared_buf alloc env locals] emits register allocations and
-    optional initialisation moves for each [DLocal] declaration. [DShared]
-    declarations emit a [.shared] directive to [shared_buf] and a [mov.u32]
-    base-address load to [buf]. [DParam] entries are skipped. *)
-val emit_locals : Buffer.t -> Buffer.t -> reg_alloc -> env -> decl list -> unit
+(** [emit_locals buf shared_buf module_buf alloc env locals] emits register
+    allocations and optional initialisation moves for each [DLocal] declaration
+    ([DLocal] of array type is rejected fail-closed: it carries no size and
+    cannot allocate storage). Statically-sized [DShared] declarations emit a
+    [.shared] directive to [shared_buf]; a dynamic [DShared] (size [None]) emits
+    a module-scope [.extern .shared] incomplete-array directive to [module_buf]
+    (one per kernel; the region's byte size is supplied at launch via
+    [~shared_mem]). Both bind the base address with a [mov.u32] in [buf].
+    [DParam] entries are skipped. *)
+val emit_locals :
+  Buffer.t -> Buffer.t -> Buffer.t -> reg_alloc -> env -> decl list -> unit
 
 (** [emit_reg_decls buf alloc] emits [.reg] declarations based on the allocator
     high-water marks. Must be called {e after} all [emit_*] calls. *)

--- a/sarek/codegen/Sarek_ir_ptx_mem.ml
+++ b/sarek/codegen/Sarek_ir_ptx_mem.ml
@@ -3,9 +3,9 @@
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 
-(** PTX array load/store helpers: element stride, typed ld.global/st.global and
-    ld.shared/st.shared instruction emission, and element-type inference from
-    the allocator table. *)
+(** PTX array load/store helpers: element stride, typed ld.global/st.global,
+    ld.shared/st.shared and ld.local/st.local instruction emission, and
+    element-type inference from the allocator table. *)
 
 open Sarek_ir_types
 open Sarek_ir_ptx_types
@@ -14,9 +14,11 @@ open Sarek_ir_ptx_types
 
     Emit a typed array read or write into [buf]. The element type determines the
     stride (shift 2 = 4 bytes, shift 3 = 8 bytes) and the PTX load/store
-    qualifier. When [~is_shared:true], uses 32-bit pointer arithmetic and
-    [ld/st.shared.*]; otherwise uses 64-bit and [ld/st.global.*]. All other
-    element types raise [unsupported]. *)
+    qualifier. [~space] selects the state space: [Some SpaceShared] uses 32-bit
+    pointer arithmetic and [ld/st.shared.*]; [Some SpaceLocal] uses 64-bit
+    arithmetic and [ld/st.local.*] (per-thread stack memory); [None] (global)
+    uses 64-bit and [ld/st.global.*]. All other element types raise
+    [unsupported]. *)
 
 let elt_shift = function
   | TFloat32 | TInt32 -> 2
@@ -27,86 +29,62 @@ let elt_shift = function
        ^ "' reached the scalar array path (use the aggregate element helpers)")
   | t -> unsupported ("array element type " ^ ptx_reg_type_of t)
 
-let emit_array_read buf alloc r_base r_idx elt_type ~is_shared =
-  if is_shared then begin
-    let r_off = new_u32 alloc in
-    emit buf "shl.b32 %s, %s, %d;" r_off r_idx (elt_shift elt_type) ;
-    let r_addr = new_u32 alloc in
-    emit buf "add.u32 %s, %s, %s;" r_addr r_base r_off ;
-    match elt_type with
-    | TFloat32 ->
-        let r = new_f32 alloc in
-        emit buf "ld.shared.f32 %s, [%s];" r r_addr ;
-        r
-    | TInt32 ->
-        let r = new_u32 alloc in
-        emit buf "ld.shared.s32 %s, [%s];" r r_addr ;
-        r
-    | TFloat64 ->
-        let r = new_f64 alloc in
-        emit buf "ld.shared.f64 %s, [%s];" r r_addr ;
-        r
-    | TInt64 ->
-        let r = new_u64 alloc in
-        emit buf "ld.shared.s64 %s, [%s];" r r_addr ;
-        r
-    | t -> unsupported ("shared array read of element type " ^ ptx_reg_type_of t)
-  end
-  else begin
-    let r_idx64 = new_u64 alloc in
-    emit buf "cvt.u64.u32 %s, %s;" r_idx64 r_idx ;
-    let r_off = new_u64 alloc in
-    emit buf "shl.b64 %s, %s, %d;" r_off r_idx64 (elt_shift elt_type) ;
-    let r_addr = new_u64 alloc in
-    emit buf "add.u64 %s, %s, %s;" r_addr r_base r_off ;
-    match elt_type with
-    | TFloat32 ->
-        let r = new_f32 alloc in
-        emit buf "ld.global.f32 %s, [%s];" r r_addr ;
-        r
-    | TInt32 ->
-        let r = new_u32 alloc in
-        emit buf "ld.global.s32 %s, [%s];" r r_addr ;
-        r
-    | TFloat64 ->
-        let r = new_f64 alloc in
-        emit buf "ld.global.f64 %s, [%s];" r r_addr ;
-        r
-    | TInt64 ->
-        let r = new_u64 alloc in
-        emit buf "ld.global.s64 %s, [%s];" r r_addr ;
-        r
-    | t -> unsupported ("array read of element type " ^ ptx_reg_type_of t)
-  end
+(** PTX space qualifier of an array's loads/stores. *)
+let space_qualifier = function
+  | Some SpaceShared -> "shared"
+  | Some SpaceLocal -> "local"
+  | None -> "global"
 
-let emit_array_write buf alloc r_base r_idx r_val elt_type ~is_shared =
-  if is_shared then begin
-    let r_off = new_u32 alloc in
-    emit buf "shl.b32 %s, %s, %d;" r_off r_idx (elt_shift elt_type) ;
-    let r_addr = new_u32 alloc in
-    emit buf "add.u32 %s, %s, %s;" r_addr r_base r_off ;
-    match elt_type with
-    | TFloat32 -> emit buf "st.shared.f32 [%s], %s;" r_addr r_val
-    | TInt32 -> emit buf "st.shared.s32 [%s], %s;" r_addr r_val
-    | TFloat64 -> emit buf "st.shared.f64 [%s], %s;" r_addr r_val
-    | TInt64 -> emit buf "st.shared.s64 [%s], %s;" r_addr r_val
-    | t ->
-        unsupported ("shared array write of element type " ^ ptx_reg_type_of t)
-  end
-  else begin
-    let r_idx64 = new_u64 alloc in
-    emit buf "cvt.u64.u32 %s, %s;" r_idx64 r_idx ;
-    let r_off = new_u64 alloc in
-    emit buf "shl.b64 %s, %s, %d;" r_off r_idx64 (elt_shift elt_type) ;
-    let r_addr = new_u64 alloc in
-    emit buf "add.u64 %s, %s, %s;" r_addr r_base r_off ;
-    match elt_type with
-    | TFloat32 -> emit buf "st.global.f32 [%s], %s;" r_addr r_val
-    | TInt32 -> emit buf "st.global.s32 [%s], %s;" r_addr r_val
-    | TFloat64 -> emit buf "st.global.f64 [%s], %s;" r_addr r_val
-    | TInt64 -> emit buf "st.global.s64 [%s], %s;" r_addr r_val
-    | t -> unsupported ("array write of element type " ^ ptx_reg_type_of t)
-  end
+(** Element byte address: shared arrays use 32-bit pointer arithmetic (their
+    base is a 32-bit window offset); local and global arrays use 64-bit. *)
+let emit_elt_addr buf alloc r_base r_idx elt_type ~space =
+  match space with
+  | Some SpaceShared ->
+      let r_off = new_u32 alloc in
+      emit buf "shl.b32 %s, %s, %d;" r_off r_idx (elt_shift elt_type) ;
+      let r_addr = new_u32 alloc in
+      emit buf "add.u32 %s, %s, %s;" r_addr r_base r_off ;
+      r_addr
+  | Some SpaceLocal | None ->
+      let r_idx64 = new_u64 alloc in
+      emit buf "cvt.u64.u32 %s, %s;" r_idx64 r_idx ;
+      let r_off = new_u64 alloc in
+      emit buf "shl.b64 %s, %s, %d;" r_off r_idx64 (elt_shift elt_type) ;
+      let r_addr = new_u64 alloc in
+      emit buf "add.u64 %s, %s, %s;" r_addr r_base r_off ;
+      r_addr
+
+let emit_array_read buf alloc r_base r_idx elt_type ~space =
+  let sp = space_qualifier space in
+  let r_addr = emit_elt_addr buf alloc r_base r_idx elt_type ~space in
+  match elt_type with
+  | TFloat32 ->
+      let r = new_f32 alloc in
+      emit buf "ld.%s.f32 %s, [%s];" sp r r_addr ;
+      r
+  | TInt32 ->
+      let r = new_u32 alloc in
+      emit buf "ld.%s.s32 %s, [%s];" sp r r_addr ;
+      r
+  | TFloat64 ->
+      let r = new_f64 alloc in
+      emit buf "ld.%s.f64 %s, [%s];" sp r r_addr ;
+      r
+  | TInt64 ->
+      let r = new_u64 alloc in
+      emit buf "ld.%s.s64 %s, [%s];" sp r r_addr ;
+      r
+  | t -> unsupported (sp ^ " array read of element type " ^ ptx_reg_type_of t)
+
+let emit_array_write buf alloc r_base r_idx r_val elt_type ~space =
+  let sp = space_qualifier space in
+  let r_addr = emit_elt_addr buf alloc r_base r_idx elt_type ~space in
+  match elt_type with
+  | TFloat32 -> emit buf "st.%s.f32 [%s], %s;" sp r_addr r_val
+  | TInt32 -> emit buf "st.%s.s32 [%s], %s;" sp r_addr r_val
+  | TFloat64 -> emit buf "st.%s.f64 [%s], %s;" sp r_addr r_val
+  | TInt64 -> emit buf "st.%s.s64 [%s], %s;" sp r_addr r_val
+  | t -> unsupported (sp ^ " array write of element type " ^ ptx_reg_type_of t)
 
 let infer_elt_type alloc arr_name =
   match Hashtbl.find_opt alloc.arr_elt_types arr_name with
@@ -184,18 +162,20 @@ let agg_field_path (t : elttype) (path : string list) : int * elttype =
   in
   go 0 t path
 
-(** [emit_agg_elem_addr buf alloc r_base r_idx ~stride ~is_shared ~arr_name]
-    emits the element base address of an aggregate vector element:
-    [mul.wide.u32] of the u32 index by the byte stride, then [add.u64] with the
-    base pointer. Shared-memory aggregate arrays are not supported. *)
-let emit_agg_elem_addr buf alloc r_base r_idx ~stride ~is_shared ~arr_name =
-  if is_shared then
+(** [emit_agg_elem_addr buf alloc r_base r_idx ~stride ~space ~arr_name] emits
+    the element base address of an aggregate vector element: [mul.wide.u32] of
+    the u32 index by the byte stride, then [add.u64] with the base pointer.
+    Shared- and local-memory aggregate arrays are not supported. *)
+let emit_agg_elem_addr buf alloc r_base r_idx ~stride ~space ~arr_name =
+  if space <> None then
     unsupported
       (Printf.sprintf
-         "shared-memory array '%s' with record/variant elements (aggregate \
+         "%s-memory array '%s' with record/variant elements (aggregate \
           elements are supported in global vectors only; use a vector \
-          parameter or scalar shared arrays)"
-         arr_name)
+          parameter or scalar %s arrays)"
+         (space_qualifier space)
+         arr_name
+         (space_qualifier space))
   else begin
     let r_off = new_u64 alloc in
     emit buf "mul.wide.u32 %s, %s, %d;" r_off r_idx stride ;

--- a/sarek/codegen/Sarek_ir_ptx_mem.mli
+++ b/sarek/codegen/Sarek_ir_ptx_mem.mli
@@ -5,10 +5,11 @@
 
 (** PTX array load/store helpers.
 
-    Emits typed [ld.global]/[st.global] or [ld.shared]/[st.shared] instruction
-    sequences into a {!Buffer.t}. Global paths use 64-bit pointer arithmetic;
-    shared paths use 32-bit. The element type is either supplied explicitly or
-    inferred from the allocator's element-type table. *)
+    Emits typed [ld.global]/[st.global], [ld.shared]/[st.shared] or
+    [ld.local]/[st.local] instruction sequences into a {!Buffer.t}. Global and
+    local paths use 64-bit pointer arithmetic; shared paths use 32-bit. The
+    element type is either supplied explicitly or inferred from the allocator's
+    element-type table. *)
 
 open Sarek_ir_types
 open Sarek_ir_ptx_types
@@ -18,10 +19,11 @@ open Sarek_ir_ptx_types
     unsupported element types. *)
 val elt_shift : elttype -> int
 
-(** [emit_array_read buf alloc r_base r_idx elt_type ~is_shared] emits a
+(** [emit_array_read buf alloc r_base r_idx elt_type ~space] emits a
     pointer-arithmetic sequence followed by a typed load and returns the
-    destination register name. When [~is_shared:true], uses 32-bit pointer
-    arithmetic and [ld.shared.*]; otherwise uses 64-bit and [ld.global.*].
+    destination register name. [Some SpaceShared] uses 32-bit pointer arithmetic
+    and [ld.shared.*]; [Some SpaceLocal] uses 64-bit and [ld.local.*]; [None]
+    (global) uses 64-bit and [ld.global.*].
 
     Ownership: [buf] is mutated; [alloc] counters are incremented. *)
 val emit_array_read :
@@ -30,13 +32,13 @@ val emit_array_read :
   string ->
   string ->
   elttype ->
-  is_shared:bool ->
+  space:arr_space option ->
   string
 
-(** [emit_array_write buf alloc r_base r_idx r_val elt_type ~is_shared] emits a
-    pointer-arithmetic sequence followed by a typed store. When
-    [~is_shared:true], uses 32-bit pointer arithmetic and [st.shared.*];
-    otherwise uses 64-bit and [st.global.*].
+(** [emit_array_write buf alloc r_base r_idx r_val elt_type ~space] emits a
+    pointer-arithmetic sequence followed by a typed store. [Some SpaceShared]
+    uses 32-bit pointer arithmetic and [st.shared.*]; [Some SpaceLocal] uses
+    64-bit and [st.local.*]; [None] (global) uses 64-bit and [st.global.*].
 
     Ownership: [buf] is mutated; [alloc] counters are incremented. *)
 val emit_array_write :
@@ -46,7 +48,7 @@ val emit_array_write :
   string ->
   string ->
   elttype ->
-  is_shared:bool ->
+  space:arr_space option ->
   unit
 
 (** [infer_elt_type alloc arr_name] returns the element type registered for
@@ -76,17 +78,17 @@ val elt_stride : elttype -> int
     fields, variant projection, or layout rejection. *)
 val agg_field_path : elttype -> string list -> int * elttype
 
-(** [emit_agg_elem_addr buf alloc r_base r_idx ~stride ~is_shared ~arr_name]
-    emits [mul.wide.u32 r_idx, stride] + [add.u64 r_base] and returns the u64
-    element base address register. Raises {!Ptx_codegen_error} for shared-memory
-    aggregate arrays (unsupported). *)
+(** [emit_agg_elem_addr buf alloc r_base r_idx ~stride ~space ~arr_name] emits
+    [mul.wide.u32 r_idx, stride] + [add.u64 r_base] and returns the u64 element
+    base address register. Raises {!Ptx_codegen_error} for shared- or
+    local-memory aggregate arrays (unsupported). *)
 val emit_agg_elem_addr :
   Buffer.t ->
   reg_alloc ->
   string ->
   string ->
   stride:int ->
-  is_shared:bool ->
+  space:arr_space option ->
   arr_name:string ->
   string
 

--- a/sarek/codegen/Sarek_ir_ptx_stmt.ml
+++ b/sarek/codegen/Sarek_ir_ptx_stmt.ml
@@ -52,17 +52,54 @@ let rec emit_stmt buf alloc (env : env) (stmt : stmt) : unit =
       let r = new_u32 alloc in
       env_bind env v.var_name r ;
       emit buf "mov.u32 %s, %s;" r v.var_name ;
-      Hashtbl.replace alloc.arr_memspaces v.var_name () ;
+      Hashtbl.replace alloc.arr_memspaces v.var_name SpaceShared ;
       Hashtbl.replace alloc.arr_elt_types v.var_name elt ;
       emit_stmt buf alloc env body
-  | SLet (v, EArrayCreate (_, _, ms), _) ->
+  | SLet (v, EArrayCreate (elt, size_e, Local), body) ->
+      (* create_array n Local: per-thread array in the .local state space
+         (stack memory, backed by device memory with caching). Declared like a
+         shared array but addressed with 64-bit pointers and ld/st.local.
+         Small constant-indexed arrays would be faster fully promoted to
+         registers; that optimization pass is future work — this is the
+         baseline. *)
+      let n =
+        match size_e with
+        | EConst (CInt32 n) when Int32.compare n 0l > 0 -> Int32.to_int n
+        | EConst (CInt32 _) ->
+            fail
+              (Printf.sprintf
+                 "PTX codegen: local array '%s': size must be positive"
+                 v.var_name)
+        | _ ->
+            unsupported
+              (Printf.sprintf
+                 "local array '%s' with non-literal size"
+                 v.var_name)
+      in
+      if Hashtbl.mem alloc.arr_memspaces v.var_name then
+        fail
+          (Printf.sprintf
+             "PTX codegen: duplicate local array name '%s'"
+             v.var_name) ;
+      Buffer.add_string
+        alloc.local_decls
+        (Printf.sprintf
+           "    .local .align %d .%s %s[%d];\n"
+           (ptx_align_of_elttype elt)
+           (ptx_btype_of_elttype elt)
+           v.var_name
+           n) ;
+      let r = new_u64 alloc in
+      env_bind env v.var_name r ;
+      emit buf "mov.u64 %s, %s;" r v.var_name ;
+      Hashtbl.replace alloc.arr_memspaces v.var_name SpaceLocal ;
+      Hashtbl.replace alloc.arr_elt_types v.var_name elt ;
+      emit_stmt buf alloc env body
+  | SLet (v, EArrayCreate (_, _, Global), _) ->
       unsupported
         (Printf.sprintf
-           "%s array creation for '%s' (only Shared is supported)"
-           (match ms with
-           | Sarek_ir_types.Local -> "Local"
-           | Sarek_ir_types.Global -> "Global"
-           | Sarek_ir_types.Shared -> assert false)
+           "Global array creation for '%s' (only Shared and Local are \
+            supported; global arrays must be vector parameters)"
            v.var_name)
   | SLet (v, e, body) ->
       (* emit_value: scalar initializers behave exactly as before (Scalar of
@@ -199,7 +236,7 @@ and emit_assign buf alloc (env : env) (lv : lvalue) (e : expr) : unit =
         r_idx
         r_val
         (infer_elt_type alloc arr_name)
-        ~is_shared:(Hashtbl.mem alloc.arr_memspaces arr_name)
+        ~space:(arr_space_of alloc arr_name)
   | LArrayElemExpr (base_expr, idx_expr) ->
       let r_base = emit_expr buf alloc env base_expr in
       let r_val = emit_expr buf alloc env e in
@@ -215,12 +252,10 @@ and emit_assign buf alloc (env : env) (lv : lvalue) (e : expr) : unit =
               "LArrayElemExpr: cannot infer element type from non-variable \
                base expression"
       in
-      let is_shared =
-        match arr_name_opt with
-        | Some n -> Hashtbl.mem alloc.arr_memspaces n
-        | None -> false
+      let space =
+        match arr_name_opt with Some n -> arr_space_of alloc n | None -> None
       in
-      emit_array_write buf alloc r_base r_idx r_val elt_type ~is_shared
+      emit_array_write buf alloc r_base r_idx r_val elt_type ~space
   | LRecordField (root, field) -> (
       match split_elem_field_lvalue alloc (LRecordField (root, field)) with
       | Some (arr_name, idx_expr, path) ->
@@ -251,7 +286,7 @@ and emit_agg_elem_assign buf alloc env arr_name idx_expr e : unit =
       r_base
       r_idx
       ~stride:(elt_stride elt)
-      ~is_shared:(Hashtbl.mem alloc.arr_memspaces arr_name)
+      ~space:(arr_space_of alloc arr_name)
       ~arr_name
   in
   emit_agg_elem_store buf alloc r_addr ~offset:0 elt b_val
@@ -287,7 +322,7 @@ and emit_elem_field_assign buf alloc env arr_name idx_expr path e : unit =
       r_base
       r_idx
       ~stride:(elt_stride elt)
-      ~is_shared:(Hashtbl.mem alloc.arr_memspaces arr_name)
+      ~space:(arr_space_of alloc arr_name)
       ~arr_name
   in
   emit_agg_elem_store buf alloc r_addr ~offset fty b_val

--- a/sarek/codegen/Sarek_ir_ptx_types.ml
+++ b/sarek/codegen/Sarek_ir_ptx_types.ml
@@ -42,6 +42,10 @@ and binding = Scalar of string | Agg of agg_value
 
 (** {1 Register allocator} *)
 
+(** Non-global state space of an array known to the emitter. Arrays absent from
+    [arr_memspaces] are global (vector parameters). *)
+type arr_space = SpaceShared | SpaceLocal
+
 (** Counter-based register allocator. Each PTX type has an independent counter
     so that register names stay readable (e.g. %r0, %f0, %rd0). *)
 type reg_alloc = {
@@ -52,10 +56,14 @@ type reg_alloc = {
   mutable pred : int;
   mutable label : int;
   arr_elt_types : (string, elttype) Hashtbl.t;
-  arr_memspaces : (string, unit) Hashtbl.t;
+  arr_memspaces : (string, arr_space) Hashtbl.t;
   shared_decls : Buffer.t;
       (** [.shared] declarations discovered while emitting the body (SLet-bound
           shared arrays); spliced into the kernel prologue by [generate]. *)
+  local_decls : Buffer.t;
+      (** [.local] declarations discovered while emitting the body (SLet-bound
+          per-thread local arrays); spliced into the kernel prologue by
+          [generate]. *)
   funcs : (string, helper_func) Hashtbl.t;
       (** Kernel helper functions ([kern_funcs]), inlined at EApp sites. *)
   variant_decls : (string, (string * elttype list) list) Hashtbl.t;
@@ -87,12 +95,17 @@ let make_alloc () =
     arr_elt_types = Hashtbl.create 8;
     arr_memspaces = Hashtbl.create 8;
     shared_decls = Buffer.create 128;
+    local_decls = Buffer.create 128;
     funcs = Hashtbl.create 4;
     variant_decls = Hashtbl.create 4;
     inline_stack = [];
     inline_budget = Hashtbl.create 4;
     inline_ret = [];
   }
+
+(** [arr_space_of alloc name] is the registered non-global state space of array
+    [name], or [None] for global arrays (vector parameters). *)
+let arr_space_of a name = Hashtbl.find_opt a.arr_memspaces name
 
 let new_u32 a =
   let n = a.u32 in

--- a/sarek/codegen/Sarek_ir_ptx_types.mli
+++ b/sarek/codegen/Sarek_ir_ptx_types.mli
@@ -45,6 +45,10 @@ and binding = Scalar of string | Agg of agg_value
 
 (** {1 Register allocator} *)
 
+(** Non-global state space of an array known to the emitter. Arrays absent from
+    [arr_memspaces] are global (vector parameters). *)
+type arr_space = SpaceShared | SpaceLocal
+
 (** Counter-based register allocator. Each PTX type has an independent counter
     so that register names stay readable (e.g. [%r0], [%f0], [%rd0]). *)
 type reg_alloc = {
@@ -55,10 +59,14 @@ type reg_alloc = {
   mutable pred : int;
   mutable label : int;
   arr_elt_types : (string, elttype) Hashtbl.t;
-  arr_memspaces : (string, unit) Hashtbl.t;
+  arr_memspaces : (string, arr_space) Hashtbl.t;
   shared_decls : Buffer.t;
       (** [.shared] declarations discovered while emitting the body; spliced
           into the kernel prologue by [generate]. *)
+  local_decls : Buffer.t;
+      (** [.local] declarations discovered while emitting the body (SLet-bound
+          per-thread local arrays); spliced into the kernel prologue by
+          [generate]. *)
   funcs : (string, helper_func) Hashtbl.t;
       (** Kernel helper functions ([kern_funcs]), inlined at EApp sites. *)
   variant_decls : (string, (string * elttype list) list) Hashtbl.t;
@@ -78,6 +86,10 @@ type reg_alloc = {
 
 (** [make_alloc ()] returns a fresh zeroed allocator. *)
 val make_alloc : unit -> reg_alloc
+
+(** [arr_space_of alloc name] is the registered non-global state space of array
+    [name], or [None] for global arrays (vector parameters). *)
+val arr_space_of : reg_alloc -> string -> arr_space option
 
 (** Allocate a fresh [.u32] register and return its PTX name ([%rN]). *)
 val new_u32 : reg_alloc -> string

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -1763,6 +1763,96 @@ let test_atomic_on_local_array_rejected () =
   | _ -> Alcotest.fail "atomic on local array should be rejected"
   | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
 
+(** Dynamic shared memory: DShared (name, elt, None) declares one extern .shared
+    region whose byte size is supplied at kernel launch (run_vectors
+    ~shared_mem), like extern __shared__ in raw CUDA. Accesses go through the
+    normal 32-bit shared path. *)
+let test_dynamic_shared_markers () =
+  let out = make_var "out" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "thread_idx_x", []),
+        SSeq
+          [
+            SAssign
+              (LArrayElem ("dynbuf", EVar tid), EArrayRead ("out", EVar tid));
+            SBarrier;
+            SAssign
+              (LArrayElem ("out", EVar tid), EArrayRead ("dynbuf", EVar tid));
+          ] )
+  in
+  let k =
+    {
+      (base_kernel
+         "dyn_shared"
+         [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+         body
+         [])
+      with
+      kern_locals = [DShared ("dynbuf", TFloat32, None)];
+    }
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx ".extern .shared .align 4 .b32 dynbuf[];" ;
+  assert_contains ptx "st.shared.f32" ;
+  assert_contains ptx "ld.shared.f32"
+
+(** PTX allows one extern .shared region per kernel: a second dynamic shared
+    array must be rejected with an error naming both arrays. *)
+let test_two_dynamic_shared_rejected () =
+  let out = make_var "out" (TVec TFloat32) in
+  let k =
+    {
+      (base_kernel
+         "dyn_shared2"
+         [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+         (SAssign (LArrayElem ("out", EConst (CInt32 0l)), EConst (CFloat32 1.0)))
+         [])
+      with
+      kern_locals =
+        [DShared ("dyn_a", TFloat32, None); DShared ("dyn_b", TInt32, None)];
+    }
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ -> Alcotest.fail "two dynamic shared arrays should be rejected"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error msg ->
+      if not (contains msg "dyn_a" && contains msg "dyn_b") then
+        Alcotest.fail
+          (Printf.sprintf
+             "two-dynamic-shared rejection must name both arrays; got: %s"
+             msg)
+
+(** Statically-sized DShared decls keep the non-extern declaration shape. *)
+let test_static_dshared_markers () =
+  let out = make_var "out" (TVec TInt32) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "thread_idx_x", []),
+        SAssign (LArrayElem ("sbuf", EVar tid), EVar tid) )
+  in
+  let k =
+    {
+      (base_kernel
+         "static_dshared"
+         [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+         body
+         [])
+      with
+      kern_locals = [DShared ("sbuf", TInt32, Some (EConst (CInt32 128l)))];
+    }
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx ".shared .align 4 .b32 sbuf[128];" ;
+  assert_absent
+    ptx
+    ".extern"
+    ~why:"statically-sized shared array must not be extern" ;
+  assert_contains ptx "st.shared.s32"
+
 let () =
   Alcotest.run
     "ptx_snapshot"
@@ -1945,5 +2035,17 @@ let () =
             "atomic on per-thread local array rejected"
             `Quick
             test_atomic_on_local_array_rejected;
+          Alcotest.test_case
+            "dynamic shared emits .extern .shared decl"
+            `Quick
+            test_dynamic_shared_markers;
+          Alcotest.test_case
+            "second dynamic shared array rejected"
+            `Quick
+            test_two_dynamic_shared_rejected;
+          Alcotest.test_case
+            "static DShared keeps non-extern decl"
+            `Quick
+            test_static_dshared_markers;
         ] );
     ]

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -1613,6 +1613,156 @@ let test_f32_asin_via_f64 () =
   assert_contains ptx "sqrt.rn.f64" ;
   assert_contains ptx "cvt.rn.f32.f64"
 
+(** Per-thread local array: create_array n Local lowers to SLet (arr,
+    EArrayCreate (elt, n, Local), ...). Declaration in the .local state space,
+    64-bit base address, typed ld.local/st.local accesses. *)
+let test_local_array_markers () =
+  let out = make_var "out" (TVec TFloat32) in
+  let tmp = make_var "tmp" (TArray (TFloat32, Local)) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( tmp,
+            EArrayCreate (TFloat32, EConst (CInt32 16l), Local),
+            SSeq
+              [
+                SAssign
+                  ( LArrayElem ("tmp", EConst (CInt32 0l)),
+                    ECast (TFloat32, EVar tid) );
+                SAssign
+                  ( LArrayElem ("out", EVar tid),
+                    EArrayRead ("tmp", EConst (CInt32 0l)) );
+              ] ) )
+  in
+  let k =
+    base_kernel
+      "local_arr"
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx ".local .align 4 .b32 tmp[16];" ;
+  assert_contains ptx "mov.u64" ;
+  assert_contains ptx "st.local.f32" ;
+  assert_contains ptx "ld.local.f32"
+
+(** 8-byte elements get .align 8 .b64 local declarations. *)
+let test_local_array_int64_markers () =
+  let out = make_var "out" (TVec TInt64) in
+  let tmp = make_var "tmp" (TArray (TInt64, Local)) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( tmp,
+            EArrayCreate (TInt64, EConst (CInt32 8l), Local),
+            SSeq
+              [
+                SAssign (LArrayElem ("tmp", EVar tid), EConst (CInt64 7L));
+                SAssign
+                  (LArrayElem ("out", EVar tid), EArrayRead ("tmp", EVar tid));
+              ] ) )
+  in
+  let k =
+    base_kernel
+      "local_arr64"
+      [DParam (out, Some {arr_elttype = TInt64; arr_memspace = Global})]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx ".local .align 8 .b64 tmp[8];" ;
+  assert_contains ptx "st.local.s64" ;
+  assert_contains ptx "ld.local.s64"
+
+(** A DLocal declaration of array type has no size and can never allocate
+    storage: it must be rejected fail-closed (previously it fell through to a
+    bare uninitialized u64 register — dangling-pointer PTX). *)
+let test_dlocal_array_rejected () =
+  let out = make_var "out" (TVec TInt32) in
+  let arr = make_var "scratch" (TArray (TInt32, Local)) in
+  let k =
+    {
+      (base_kernel
+         "dlocal_arr"
+         [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+         (SAssign (LArrayElem ("out", EConst (CInt32 0l)), EConst (CInt32 1l)))
+         [])
+      with
+      kern_locals = [DLocal (arr, None)];
+    }
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ -> Alcotest.fail "DLocal of array type should raise Ptx_codegen_error"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error msg ->
+      if not (contains msg "scratch" && contains msg "create_array") then
+        Alcotest.fail
+          (Printf.sprintf
+             "DLocal array rejection must name the variable and the \
+              workaround; got: %s"
+             msg)
+
+(** Non-literal local array sizes are rejected (per-thread stack allocations
+    must be static). *)
+let test_local_array_dynamic_size_rejected () =
+  let out = make_var "out" (TVec TInt32) in
+  let tmp = make_var "tmp" (TArray (TInt32, Local)) in
+  let n = make_var "n" TInt32 in
+  let body =
+    SLet
+      ( tmp,
+        EArrayCreate (TInt32, EVar n, Local),
+        SAssign (LArrayElem ("out", EConst (CInt32 0l)), EConst (CInt32 1l)) )
+  in
+  let k =
+    base_kernel
+      "local_dyn"
+      [
+        DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global});
+        DParam (n, None);
+      ]
+      body
+      []
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ -> Alcotest.fail "non-literal local array size should be rejected"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
+(** PTX has no atom.local: atomics on a per-thread local array are rejected. *)
+let test_atomic_on_local_array_rejected () =
+  let out = make_var "out" (TVec TInt32) in
+  let tmp = make_var "tmp" (TArray (TInt32, Local)) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( tmp,
+            EArrayCreate (TInt32, EConst (CInt32 4l), Local),
+            SExpr
+              (EIntrinsic
+                 ( ["Sarek_stdlib"; "Gpu"],
+                   "atomic_add_int32",
+                   [EVar tmp; EVar tid; EConst (CInt32 1l)] )) ) )
+  in
+  let k =
+    base_kernel
+      "local_atomic"
+      [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+      body
+      []
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ -> Alcotest.fail "atomic on local array should be rejected"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
 let () =
   Alcotest.run
     "ptx_snapshot"
@@ -1775,5 +1925,25 @@ let () =
             "f64-payload variant vector param rejected"
             `Quick
             test_f64_variant_param_rejected;
+          Alcotest.test_case
+            "local array emits .local decl + ld/st.local"
+            `Quick
+            test_local_array_markers;
+          Alcotest.test_case
+            "int64 local array gets .align 8 .b64 decl"
+            `Quick
+            test_local_array_int64_markers;
+          Alcotest.test_case
+            "DLocal of array type is rejected fail-closed"
+            `Quick
+            test_dlocal_array_rejected;
+          Alcotest.test_case
+            "non-literal local array size rejected"
+            `Quick
+            test_local_array_dynamic_size_rejected;
+          Alcotest.test_case
+            "atomic on per-thread local array rejected"
+            `Quick
+            test_atomic_on_local_array_rejected;
         ] );
     ]


### PR DESCRIPTION
Campaign items L6+L7, stacked on #230. Both hardware-verified under ZLUDA (RX 7900 XTX).

- **Local arrays (L7):** step 0 closes a silent safety gap — `DLocal` of array type previously fell through to a bare uninitialized u64 register (dangling-pointer PTX, no error); now fail-closed with a precise message. Then the real feature: `.local .align A .bXX name[n]` declarations + typed `ld.local`/`st.local` through the same layout machinery (third memspace alongside global/shared; helper inlining propagates it; `atom.local` doesn't exist → precise rejection). Register promotion for const-indexed small arrays documented as a future pass.
- **Dynamic shared (L6):** `DShared size=None` → `.extern .shared .align A .bXX name[];` — **at module scope**, which is empirically load-bearing: ZLUDA's `cuModuleLoadData` rejects the function-scope form. Host plumbing (`Execute.run_vectors ?shared_mem → cuLaunchKernel sharedMemBytes`) verified already complete. One dynamic region per kernel (raw-CUDA semantics); a second is rejected naming both arrays.
- **Hardware probes:** dynamic-shared block reversal and per-thread local fill/sum both execute green under ZLUDA (skip cleanly without a driver).
- Sanctioned test change: formal conformance AC-3 pinned the pre-support rejection of dynamic shared; it now asserts the new contract (module-scope extern + single-region invariant). The Rocq theorems model static DShared only — unaffected.
- Findings for follow-up: the CUDA-C backend emits `__shared__ T name[];` without `extern` for the dynamic case (pre-existing bug); the PPX sizeless `let%shared` still lowers to a block_dim-sized EArrayCreate that needs host-side size computation to ride this feature (PPX/Execute surface work, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)