### PR TITLE
fix(ppx): reject vector-of-tuple/function kernel parameters

### DIFF
--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -705,6 +705,21 @@ let lower_param (p : tparam) : Ir.decl =
       Ppxlib.Location.raise_errorf
         ~loc:Ppxlib.Location.none
         "Function-typed kernel parameters are not supported."
+  | TVec t | TArr (t, _) -> (
+      (* A vector/array of tuples or functions would silently collapse to
+         TInt32 in elttype_of_typ (wrong stride, garbage layout) — reject
+         at the formal-parameter boundary like the bare cases above. *)
+      match repr t with
+      | TTuple _ ->
+          Ppxlib.Location.raise_errorf
+            ~loc:Ppxlib.Location.none
+            "Vectors of tuples are not supported as kernel parameters; declare \
+             a record type with [@@sarek.type] instead."
+      | TFun _ ->
+          Ppxlib.Location.raise_errorf
+            ~loc:Ppxlib.Location.none
+            "Vectors of functions are not supported as kernel parameters."
+      | _ -> ())
   | _ -> ()) ;
   let elt = elttype_of_typ p.tparam_type in
   let v =

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -705,20 +705,23 @@ let lower_param (p : tparam) : Ir.decl =
       Ppxlib.Location.raise_errorf
         ~loc:Ppxlib.Location.none
         "Function-typed kernel parameters are not supported."
-  | TVec t | TArr (t, _) -> (
+  | (TVec t | TArr (t, _)) as container -> (
       (* A vector/array of tuples or functions would silently collapse to
          TInt32 in elttype_of_typ (wrong stride, garbage layout) — reject
          at the formal-parameter boundary like the bare cases above. *)
+      let kind = match container with TArr _ -> "Arrays" | _ -> "Vectors" in
       match repr t with
       | TTuple _ ->
           Ppxlib.Location.raise_errorf
             ~loc:Ppxlib.Location.none
-            "Vectors of tuples are not supported as kernel parameters; declare \
-             a record type with [@@sarek.type] instead."
+            "%s of tuples are not supported as kernel parameters; declare a \
+             record type with [@@sarek.type] instead."
+            kind
       | TFun _ ->
           Ppxlib.Location.raise_errorf
             ~loc:Ppxlib.Location.none
-            "Vectors of functions are not supported as kernel parameters."
+            "%s of functions are not supported as kernel parameters."
+            kind
       | _ -> ())
   | _ -> ()) ;
   let elt = elttype_of_typ p.tparam_type in


### PR DESCRIPTION
Safety fix found by the L13 (tuple vectors) design investigation: `('a * 'b) vector` kernel parameters type-check and then **silently collapse to TInt32** in `elttype_of_typ` — wrong stride, garbage element layout, and no diagnostic at all unless the kernel body happens to touch a tuple value (the bare-`TTuple` guard in `lower_param` never fires for the vector case). This is a latent silent-miscompile, independent of whether tuple vectors ever get implemented (design doc: GO on structural-record auto-generation, tracked separately).

The guard now rejects vectors/arrays of tuples and of functions at the formal-parameter boundary with the `[@@sarek.type]` record workaround named, matching the existing bare-case rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for vector and array parameter types.
  * Invalid tuple- or function-element types are now rejected with clear errors instead of being processed with incorrect layout and stride behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->