### PR TITLE
feat(interp): math intrinsics for the reference oracle (integrates #218)

### DIFF
--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -156,7 +156,8 @@ let eval_float32_math_intrinsic name args =
                {operation = "atan"; reason = "requires 1 argument"}))
   | "atan2" -> (
       match args with
-      | arg1 :: arg2 :: _ -> Some (VFloat32 (F32.atan2 (to_float32 arg1) (to_float32 arg2)))
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat32 (F32.atan2 (to_float32 arg1) (to_float32 arg2)))
       | _ ->
           Interp_error.raise_error
             (Unsupported_operation
@@ -304,11 +305,13 @@ let eval_float64_math_intrinsic name args =
                {operation = "atan (float64)"; reason = "requires 1 argument"}))
   | "atan2" -> (
       match args with
-      | arg1 :: arg2 :: _ -> Some (VFloat64 (atan2 (to_float64 arg1) (to_float64 arg2)))
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (atan2 (to_float64 arg1) (to_float64 arg2)))
       | _ ->
           Interp_error.raise_error
             (Unsupported_operation
-               {operation = "atan2 (float64)"; reason = "requires 2 arguments"}))
+               {operation = "atan2 (float64)"; reason = "requires 2 arguments"})
+      )
   | "sinh" -> (
       match args with
       | arg :: _ -> Some (VFloat64 (sinh (to_float64 arg)))
@@ -404,6 +407,64 @@ let eval_float64_math_intrinsic name args =
             (Unsupported_operation
                {operation = "of_int (float64)"; reason = "requires 1 argument"})
       )
+  | "expm1" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (Float.expm1 (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "expm1 (float64)"; reason = "requires 1 argument"}))
+  | "log10" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (Float.log10 (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "log10 (float64)"; reason = "requires 1 argument"}))
+  | "log1p" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (Float.log1p (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "log1p (float64)"; reason = "requires 1 argument"}))
+  | "rsqrt" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (1.0 /. Float.sqrt (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "rsqrt (float64)"; reason = "requires 1 argument"}))
+  | "abs_float" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (Float.abs (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {
+                 operation = "abs_float (float64)";
+                 reason = "requires 1 argument";
+               }))
+  | "hypot" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (Float.hypot (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "hypot (float64)"; reason = "requires 2 arguments"})
+      )
+  | "copysign" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (Float.copy_sign (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {
+                 operation = "copysign (float64)";
+                 reason = "requires 2 arguments";
+               }))
   | _ -> None
 
 (** Int32 math intrinsics *)

--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -133,6 +133,55 @@ let eval_float32_math_intrinsic name args =
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "tan"; reason = "requires 1 argument"}))
+  | "asin" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.asin (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "asin"; reason = "requires 1 argument"}))
+  | "acos" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.acos (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "acos"; reason = "requires 1 argument"}))
+  | "atan" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.atan (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan"; reason = "requires 1 argument"}))
+  | "atan2" -> (
+      match args with
+      | arg1 :: arg2 :: _ -> Some (VFloat32 (F32.atan2 (to_float32 arg1) (to_float32 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan2"; reason = "requires 2 arguments"}))
+  | "sinh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.sinh (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "sinh"; reason = "requires 1 argument"}))
+  | "cosh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.cosh (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "cosh"; reason = "requires 1 argument"}))
+  | "tanh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat32 (F32.tanh (to_float32 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "tanh"; reason = "requires 1 argument"}))
   | "sqrt" -> (
       match args with
       | arg :: _ -> Some (VFloat32 (F32.sqrt (to_float32 arg)))

--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -358,6 +358,44 @@ let eval_float64_math_intrinsic name args =
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "abs (float64)"; reason = "requires 1 argument"}))
+  | "floor" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (floor (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "floor (float64)"; reason = "requires 1 argument"}))
+  | "ceil" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (ceil (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "ceil (float64)"; reason = "requires 1 argument"}))
+  | "pow" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (Float.pow (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "pow (float64)"; reason = "requires 2 arguments"}))
+  | "min" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (min (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "min (float64)"; reason = "requires 2 arguments"}))
+  | "max" -> (
+      match args with
+      | arg1 :: arg2 :: _ ->
+          Some (VFloat64 (max (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "max (float64)"; reason = "requires 2 arguments"}))
   | "of_int" -> (
       match args with
       | arg :: _ -> Some (VFloat64 (Float.of_int (to_int arg)))

--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -274,6 +274,62 @@ let eval_float64_math_intrinsic name args =
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "cos (float64)"; reason = "requires 1 argument"}))
+  | "tan" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (tan (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "tan (float64)"; reason = "requires 1 argument"}))
+  | "asin" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (asin (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "asin (float64)"; reason = "requires 1 argument"}))
+  | "acos" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (acos (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "acos (float64)"; reason = "requires 1 argument"}))
+  | "atan" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (atan (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan (float64)"; reason = "requires 1 argument"}))
+  | "atan2" -> (
+      match args with
+      | arg1 :: arg2 :: _ -> Some (VFloat64 (atan2 (to_float64 arg1) (to_float64 arg2)))
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "atan2 (float64)"; reason = "requires 2 arguments"}))
+  | "sinh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (sinh (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "sinh (float64)"; reason = "requires 1 argument"}))
+  | "cosh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (cosh (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "cosh (float64)"; reason = "requires 1 argument"}))
+  | "tanh" -> (
+      match args with
+      | arg :: _ -> Some (VFloat64 (tanh (to_float64 arg)))
+      | [] ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {operation = "tanh (float64)"; reason = "requires 1 argument"}))
   | "sqrt" -> (
       match args with
       | arg :: _ -> Some (VFloat64 (sqrt (to_float64 arg)))


### PR DESCRIPTION
Integrates community PR #218 by @matburnx (Matéo Boury) — approved by CodeRabbit and the repo owner but blocked from merge by a stale CI check and an unpushable fork branch. Cherry-picked verbatim onto current main (authorship preserved on the three original commits), plus one completion commit.

Closes the Interpreter backend's math coverage so the **reference oracle** matches the Float64 surface implemented on the GPU backends by the softmath work (#227/#229):

- **From #218 (matburnx):** f32 asin/acos/atan/atan2/sinh/cosh/tanh and f64 sin/cos/tan/asin/acos/atan/atan2/sinh/cosh/tanh/min/max/floor/ceil/pow.
- **Completion (this branch):** the 7 the e2e report still errored on — f64 expm1/log10/log1p/rsqrt/abs_float/hypot/copysign.

**Reference-oracle correctness** was the review's paramount concern (a wrong mapping silently corrupts every GPU-vs-reference comparison). Every mapping was verified; `copysign` argument order was checked against `nvcc -ptx` ground truth and the interpreter agrees with the PTX backend. One regression caught and fixed in review: the completion edit had accidentally dropped the pre-existing `Float64.of_int` arm (restored, verified).

Behavioral proof: on the Interpreter device, `test_float64_math_intrinsics` now shows **43 PASS / 0 ERROR** for the Float64 surface (was erroring on the whole inverse-trig/hyperbolic set + the 7 above). Full `dune runtest` green.

Known follow-up: the 7 completion functions were added to the f64 block only, not f32 (asymmetric; the f32 e2e does not currently require them).

Co-authored-by: Matéo Boury <matboury@proton.me>

🤖 Generated with [Claude Code](https://claude.com/claude-code)