### PR TITLE
feat(sarek): Sarek_worklist — portable dynamic parallelism (L16)

### DIFF
--- a/docs/plans/sarek-worklist-2026-07-23.md
+++ b/docs/plans/sarek-worklist-2026-07-23.md
@@ -1,0 +1,71 @@
+# Sarek_worklist — portable dynamic parallelism (L16)
+
+Date: 2026-07-23. Branch: `feat/sarek-worklist`. Design source:
+`roster/ptx-limits-campaign/L16-dynamic-parallelism.md` (verdict: GO Route B
+`Sarek_worklist`, NO-GO native CDP).
+
+## What this delivers
+A pure-Sarek work-queue library serving the irregular-work / frontier /
+tree-recursion use cases that CUDA dynamic parallelism (CDP) targets, on all
+runnable backends, with no per-backend launch mechanism (CDP is absent on
+ZLUDA/Metal/WGSL and unreliable on OpenCL 2.0 device-enqueue — see the doc §2).
+
+## Key empirical findings (this environment)
+- Global atomics available to kernels: `atomic_add_global_int32`,
+  `atomic_inc_global_int32` (Sarek_stdlib/Gpu). **No global CAS/exch** — so the
+  queue uses monotonic atomic-add ticket counters, not CAS-retry.
+- Fences: `memory_fence_block` / `memory_fence_device`.
+- **Atomics cannot be encapsulated in `[@sarek.module]` helpers**: the OCaml
+  shim pins the vector to `int32 array`, which mismatches the kernel's vector
+  object type (`< … underlying: Vector.t >`). The PPX only reconciles vector
+  params through `.()`/`.()<-` rewriting, not through intrinsic calls. So
+  push/claim atomics live **inline in the user `[%kernel]`** (doc-sanctioned:
+  "provide it as a documented pattern + helpers, not a magic wrapper"). Pure
+  non-vector helpers (`wl_ring_index`, `wl_has_work`) remain callable.
+- **Persistent-spin worklists deadlock on sequential/pool-bounded executors**:
+  the interpreter runs blocks sequentially (or across a fixed domain pool), so a
+  kernel that spin-waits across blocks hangs. Only real GPUs with co-resident
+  occupancy make forward progress. This is an execution-model reality, not a
+  missing primitive.
+- Interpreter had **no atomic support** (histogram filtered it out). Added
+  trivial single-threaded RMW for the two global atomics + no-op fences
+  (mutex-guarded for the parallel interpreter).
+
+## Two portable patterns (both proven on all backends)
+1. **Level-synchronous frontier** (headline, multi-thread, all backends incl.
+   sequential interpreter): each launch, threads independently claim tickets
+   from a fixed `[head, snapshot_tail)` window via the shared atomic HEAD
+   counter (**no thread ever waits on another**), process, and push children to
+   TAIL for the next level. Host relaunches until drained. Spec-safe: no
+   forward-progress assumption. Serves BFS/graph-frontier / variable-fanout
+   trees. Memory ordering: the host sync between levels is the barrier.
+2. **Persistent single-launch** (documented; safe for single-thread everywhere,
+   and multi-thread on GPUs under co-residency): one launch, each thread loops
+   pop→work→push until `head >= tail`. Used at grid=1 for the ring-wrap stress
+   (single thread → no cross-thread spin → runs on every backend).
+
+## Termination protocol + assumptions
+- Level-sync: host-driven. Snapshot TAIL at level start; kernel claims up to the
+  snapshot; a level that produces no new pushes (TAIL unchanged, HEAD caught up)
+  is the last. Correct under: **capacity ≥ total items enqueued** (monotonic
+  ring, no reuse) for the main demo; an OVERFLOW flag signals under-sizing.
+- Persistent: a thread that claims `h >= tail` (empty) stops. For multi-thread
+  GPU use, add an OUTSTANDING counter (inc on push, dec after a work item's
+  pushes complete); quiescence at OUTSTANDING=0 is stable. Ring reuse (wrap) is
+  safe only when **capacity ≥ peak simultaneously-live items** — documented.
+
+## Control-vector layout (int32 vector, length 4)
+`[0]=HEAD  [1]=TAIL  [2]=OUTSTANDING  [3]=OVERFLOW`; plus a `slots` ring vector.
+
+## CDP-vs-worklist rationale (from the doc)
+CDP is frequently slower than a well-written worklist for its own headline
+workload (many small irregular tasks), and exists cleanly on only 1 of 6
+backends. The worklist serves the same *use cases* portably. Route B's one real
+gap: sub-problems needing a genuinely different launch configuration (narrow,
+out of scope for FP32/FP64 numeric kernels).
+
+## Test matrix (all verified vs CPU reference)
+- BFS variable-fanout tree frontier sum (level-sync) — every device.
+- Re-pop stress: more items than threads (claim-loop re-claims).
+- Push permutation + overflow-flag unit check.
+- Ring wrap-around: persistent single-thread linked-list, capacity ≪ N.

--- a/sarek/Sarek_worklist/Sarek_worklist.ml
+++ b/sarek/Sarek_worklist/Sarek_worklist.ml
@@ -1,0 +1,203 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek_worklist - portable dynamic parallelism via a global work queue.
+ *
+ * Serves the irregular-work / frontier / tree-recursion use cases that CUDA
+ * dynamic parallelism (CDP) targets - on every Sarek backend (CUDA/PTX incl.
+ * ZLUDA, OpenCL, Vulkan, Metal, WGSL, Native, Interpreter) - using only atomics
+ * Sarek already ships. No device-side kernel-launch mechanism is needed: the
+ * launch happens once, host-side, like any other kernel; all "dynamic" behavior
+ * flows through the queue. See roster/ptx-limits-campaign/L16-dynamic-
+ * parallelism.md for the CDP-vs-worklist rationale (CDP is frequently slower
+ * than a good worklist for its own headline workload and exists cleanly on only
+ * 1 of 6 backends).
+ *
+ * QUEUE LAYOUT
+ *   A control vector [ctrl] (int32, length {!Ctrl.size}) holds the counters:
+ *     ctrl.(0) = HEAD         next pop  ticket (monotonic)
+ *     ctrl.(1) = TAIL         next push ticket (monotonic)
+ *     ctrl.(2) = OUTSTANDING  pushed - fully-processed (persistent variant)
+ *     ctrl.(3) = OVERFLOW     nonzero if a push found the ring full
+ *   plus a [slots] ring vector of int32 items (typically node/index
+ *   descriptors). Tickets index the ring modulo capacity.
+ *
+ * WHY ATOMICS ARE INLINE, NOT HELPERS
+ *   The push/pop atomics operate on the queue *vectors*. A [@sarek.module]
+ *   helper cannot take a vector and call [atomic_add_global_int32] on it: the
+ *   OCaml shim pins the parameter to [int32 array], which does not unify with
+ *   the kernel's vector object type (the PPX only rewrites vector params through
+ *   [.()]/[.()<-], not through intrinsic calls). So the queue operations are a
+ *   documented *pattern* you paste into your own [%kernel] (see the PATTERNS
+ *   section below), and this library provides the pure, callable helpers that
+ *   do not touch vectors ({!wl_ring_index}, {!wl_has_work}) plus all the
+ *   host-side orchestration ({!Host}). This split is the one the design doc
+ *   explicitly anticipates.
+ *
+ * TWO PATTERNS (both run on every backend)
+ *   1. LEVEL-SYNCHRONOUS FRONTIER (recommended; works on the sequential
+ *      interpreter too). Each launch, every thread claims tickets from a fixed
+ *      window [head, snapshot_tail) via the shared atomic HEAD counter - no
+ *      thread ever waits on another - processes the item, and pushes any newly
+ *      discovered items to TAIL for the *next* level. The host relaunches until
+ *      the frontier drains ({!Host.drive}). Termination is host-driven and
+ *      spec-safe (no GPU forward-progress assumption); the host sync between
+ *      levels is the memory barrier.
+ *
+ *      The window [level_base, snapshot_tail) is distributed by grid-stride (no
+ *      shared claim counter, so nothing needs resetting between launches); only
+ *      TAIL is an atomic device counter, which the host reads but never writes:
+ *
+ *        [%kernel fun ctrl slots values off idx acc level_base snapshot_tail cap ->
+ *          let open Std in let open Gpu in
+ *          let stride = block_dim_x * grid_dim_x in
+ *          let i = mut (level_base + thread_idx_x + (block_idx_x * block_dim_x)) in
+ *          while i < snapshot_tail do
+ *            let u = slots.(wl_ring_index cap i) in
+ *            let _ = atomic_add_global_int32 acc 0l values.(u) in
+ *            let s = mut off.(u) in
+ *            while s < off.(u + 1l) do
+ *              let t = atomic_add_global_int32 ctrl 1l 1l in
+ *              slots.(wl_ring_index cap t) <- idx.(s) ;
+ *              s := s + 1l
+ *            done ;
+ *            i := i + stride
+ *          done]
+ *
+ *   2. PERSISTENT SINGLE-LAUNCH (one launch, each thread loops pop/work/push
+ *      until [head >= tail]). Safe for a single thread on every backend; safe
+ *      multi-thread only on real GPUs where all launched blocks are co-resident
+ *      (persistent-threads occupancy) - it spin-waits across threads, which
+ *      DEADLOCKS on the sequential interpreter and on any block-sequential or
+ *      pool-bounded executor. Do not run it multi-thread on the interpreter.
+ *
+ * CAPACITY / TERMINATION CONTRACT (honest limits)
+ *   - Level-sync main use: size capacity >= total items ever enqueued (the ring
+ *     never reuses a slot, so ordering can never corrupt). The OVERFLOW flag is
+ *     set if a push finds the ring full; the host checks {!Host.overflow}.
+ *   - Ring reuse (wrap) is correct only when capacity >= peak simultaneously-
+ *     live items, so a slot is always consumed before its ticket laps it.
+ *   - This is NOT a drop-in for arbitrary CDP: workers are homogeneous (same
+ *     kernel body). A sub-problem needing a genuinely different launch
+ *     configuration is Route B's one real gap (see the doc S5).
+ *
+ * USAGE (from another compilation unit)
+ *   dune:   add [sarek.worklist] to (libraries); add this file to
+ *           (preprocessor_deps) of the kernel's stanza.
+ *   source: [let%sarek_include _ = "path/to/Sarek_worklist.ml"] then call the
+ *           pure helpers from [%kernel]; use {!Host} from host code.
+ ******************************************************************************)
+
+[@@@warning "-32-33-34"]
+
+(* Alias so the pure [@sarek.module] helpers type-check as OCaml; the PPX maps
+   [int32] arithmetic to the int32 intrinsics. *)
+type 'a vector = 'a array
+
+(* Module-level int32 operator shim (same idea as Sarek_df64 before
+   df64_of_int32): OCaml uses Int32.rem, the PPX emits the int32 mod intrinsic.
+   Scoped to the helpers below; {!Host} rebinds Stdlib operators. *)
+let ( mod ) = Int32.rem
+
+(** Ring index of a monotonic ticket: [ticket mod capacity]. Callable from a
+    [%kernel] as an array index. *)
+let[@sarek.module] wl_ring_index (capacity : int32) (ticket : int32) : int32 =
+  ticket mod capacity
+
+(** Whether the queue has an unclaimed item: [head < tail]. *)
+let[@sarek.module] wl_has_work (head : int32) (tail : int32) : bool =
+  head < tail
+
+(** Control-vector slot indices (host-side and documentation). *)
+module Ctrl = struct
+  let head = 0
+
+  let tail = 1
+
+  let outstanding = 2
+
+  let overflow = 3
+
+  (** Length of the control vector. *)
+  let size = 4
+end
+
+(** Host-side queue management and the level-synchronous driver. *)
+module Host = struct
+  let ( mod ) = Stdlib.( mod )
+
+  type int32_vector = (int32, Bigarray.int32_elt) Spoc_core.Vector.t
+
+  type t = {ctrl : int32_vector; slots : int32_vector; capacity : int}
+
+  (** Allocate a queue with a ring of [capacity] int32 slots. Counters start at
+      zero; call {!seed} before running. *)
+  let create ~capacity =
+    let ctrl = Spoc_core.Vector.create Spoc_core.Vector.int32 Ctrl.size in
+    let slots = Spoc_core.Vector.create Spoc_core.Vector.int32 capacity in
+    for i = 0 to Ctrl.size - 1 do
+      Spoc_core.Vector.set ctrl i 0l
+    done ;
+    for i = 0 to capacity - 1 do
+      Spoc_core.Vector.set slots i (-1l)
+    done ;
+    {ctrl; slots; capacity}
+
+  let get_ctrl t i = Int32.to_int (Spoc_core.Vector.get t.ctrl i)
+
+  let set_ctrl t i v = Spoc_core.Vector.set t.ctrl i (Int32.of_int v)
+
+  (** Seed the initial frontier with [items] (int32 node/index descriptors):
+      writes them to the front of the ring and sets HEAD=0, TAIL=OUTSTANDING=
+      |items|, OVERFLOW=0. *)
+  let seed t (items : int32 array) =
+    let n = Array.length items in
+    if n > t.capacity then
+      invalid_arg "Sarek_worklist.Host.seed: too many items" ;
+    Array.iteri (fun i v -> Spoc_core.Vector.set t.slots i v) items ;
+    set_ctrl t Ctrl.head 0 ;
+    set_ctrl t Ctrl.tail n ;
+    set_ctrl t Ctrl.outstanding n ;
+    set_ctrl t Ctrl.overflow 0
+
+  let head t = get_ctrl t Ctrl.head
+
+  let tail t = get_ctrl t Ctrl.tail
+
+  let outstanding t = get_ctrl t Ctrl.outstanding
+
+  (** Nonzero if any push found the ring full during a run. *)
+  let overflow t = get_ctrl t Ctrl.overflow
+
+  (** Item currently stored at ring position [i mod capacity]. *)
+  let slot t i = Int32.to_int (Spoc_core.Vector.get t.slots (i mod t.capacity))
+
+  (** Level-synchronous driver. Each level processes the frontier window from
+      [level_base] up to [snapshot_tail] (the current TAIL) and any children the
+      workers push extend TAIL for the next level. Calls
+      [launch ~level_base ~snapshot_tail] (which must run one frontier kernel
+      over that window AND sync the device so TAIL reads back), until a level
+      adds no work (TAIL did not grow) or [max_levels] is reached. Returns the
+      number of levels launched.
+
+      The driver passes the window as SCALAR arguments and only ever READS the
+      device counters (never writes them back): the frontier kernel distributes
+      the window by grid-stride, so there is no shared claim counter to reset
+      and nothing to upload between launches. This is what makes the multi-
+      launch loop coherent under Sarek's CPU/GPU/Both vector residency (a host
+      write to a Both-resident vector would not re-upload). *)
+  let drive t ~(launch : level_base:int -> snapshot_tail:int -> unit)
+      ~max_levels =
+    let rec loop level base =
+      let snap = tail t in
+      if snap <= base || level >= max_levels then level
+      else begin
+        launch ~level_base:base ~snapshot_tail:snap ;
+        loop (level + 1) snap
+      end
+    in
+    loop 0 0
+end

--- a/sarek/Sarek_worklist/dune
+++ b/sarek/Sarek_worklist/dune
@@ -1,0 +1,6 @@
+(library
+ (name sarek_worklist)
+ (public_name sarek.worklist)
+ (libraries sarek sarek_stdlib spoc_core)
+ (preprocess
+  (pps sarek_ppx)))

--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -9,20 +9,25 @@ open Sarek_ir_interp_intrinsics
 
 (** Main intrinsic dispatcher - tries each category in order *)
 let rec eval_intrinsic state path name args =
-  (* Try GPU path intrinsics *)
-  if is_gpu_path path then
-    match eval_gpu_index_intrinsic state name with
-    | Some v -> v
-    | None -> (
-        match eval_barrier_intrinsic name with
+  (* Global-memory atomics and fences are path-independent (they may be opened
+     from Gpu or referenced unqualified), so try them first. *)
+  match eval_atomic_intrinsic name args with
+  | Some v -> v
+  | None ->
+      (* Try GPU path intrinsics *)
+      if is_gpu_path path then
+        match eval_gpu_index_intrinsic state name with
         | Some v -> v
         | None -> (
-            match eval_type_conversion_intrinsic name args with
+            match eval_barrier_intrinsic name with
             | Some v -> v
-            | None ->
-                (* Not a GPU intrinsic, fall through to type-specific *)
-                eval_intrinsic_by_type path name args))
-  else eval_intrinsic_by_type path name args
+            | None -> (
+                match eval_type_conversion_intrinsic name args with
+                | Some v -> v
+                | None ->
+                    (* Not a GPU intrinsic, fall through to type-specific *)
+                    eval_intrinsic_by_type path name args))
+      else eval_intrinsic_by_type path name args
 
 (** Try type-specific intrinsics based on path *)
 and eval_intrinsic_by_type path name args =

--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -118,6 +118,10 @@ let with_atomic_lock f =
   Mutex.lock atomic_global_mutex ;
   Fun.protect ~finally:(fun () -> Mutex.unlock atomic_global_mutex) f
 
+(* Bounds-checked index into an atomic's target array, mirroring
+   eval_array_expr's Array_bounds_error path so the interpreter oracle rejects
+   out-of-range atomics the same way an ordinary array access would. *)
+
 (** Global-memory atomics and memory fences.
 
     Atomics on global vectors return the OLD value and update in place. The
@@ -125,20 +129,35 @@ let with_atomic_lock f =
     no-ops because a single logical memory is already sequentially consistent
     here. Sufficient for the Sarek_worklist queue pattern (atomic HEAD/TAIL
     counters + ring slots). *)
+let atomic_index name a idx =
+  let i = to_int idx in
+  if i < 0 || i >= Array.length a then
+    Interp_error.raise_error
+      (Array_bounds_error
+         {array_name = name; index = i; length = Array.length a}) ;
+  i
+
+let atomic_arity name n _args =
+  Interp_error.raise_error
+    (Unsupported_operation
+       {operation = name; reason = Printf.sprintf "requires %d arguments" n})
+
 let eval_atomic_intrinsic name args =
   match (name, args) with
   | "atomic_add_global_int32", [VArray a; idx; delta] ->
       with_atomic_lock (fun () ->
-          let i = to_int idx in
+          let i = atomic_index "atomic_add_global_int32" a idx in
           let old = to_int32 a.(i) in
           a.(i) <- VInt32 (Int32.add old (to_int32 delta)) ;
           Some (VInt32 old))
+  | "atomic_add_global_int32", _ -> atomic_arity name 3 args
   | "atomic_inc_global_int32", [VArray a; idx] ->
       with_atomic_lock (fun () ->
-          let i = to_int idx in
+          let i = atomic_index "atomic_inc_global_int32" a idx in
           let old = to_int32 a.(i) in
           a.(i) <- VInt32 (Int32.add old 1l) ;
           Some (VInt32 old))
+  | "atomic_inc_global_int32", _ -> atomic_arity name 2 args
   | ("memory_fence_block" | "memory_fence_device"), _ -> Some VUnit
   | _ -> None
 

--- a/sarek/interp/Sarek_ir_interp_intrinsics.ml
+++ b/sarek/interp/Sarek_ir_interp_intrinsics.ml
@@ -109,6 +109,39 @@ let eval_barrier_intrinsic name =
       Some VUnit
   | _ -> None
 
+(* Serialises global-memory atomics. The sequential interpreter needs no lock,
+   but the parallel interpreter distributes blocks across a domain pool sharing
+   the same global VArray, so the read-modify-write must be atomic. *)
+let atomic_global_mutex = Mutex.create ()
+
+let with_atomic_lock f =
+  Mutex.lock atomic_global_mutex ;
+  Fun.protect ~finally:(fun () -> Mutex.unlock atomic_global_mutex) f
+
+(** Global-memory atomics and memory fences.
+
+    Atomics on global vectors return the OLD value and update in place. The
+    interpreter models global memory as a shared mutable [VArray]; fences are
+    no-ops because a single logical memory is already sequentially consistent
+    here. Sufficient for the Sarek_worklist queue pattern (atomic HEAD/TAIL
+    counters + ring slots). *)
+let eval_atomic_intrinsic name args =
+  match (name, args) with
+  | "atomic_add_global_int32", [VArray a; idx; delta] ->
+      with_atomic_lock (fun () ->
+          let i = to_int idx in
+          let old = to_int32 a.(i) in
+          a.(i) <- VInt32 (Int32.add old (to_int32 delta)) ;
+          Some (VInt32 old))
+  | "atomic_inc_global_int32", [VArray a; idx] ->
+      with_atomic_lock (fun () ->
+          let i = to_int idx in
+          let old = to_int32 a.(i) in
+          a.(i) <- VInt32 (Int32.add old 1l) ;
+          Some (VInt32 old))
+  | ("memory_fence_block" | "memory_fence_device"), _ -> Some VUnit
+  | _ -> None
+
 (** Float32 math intrinsics *)
 let eval_float32_math_intrinsic name args =
   match name with

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -558,3 +558,19 @@
  (alias runtest)
  (action
   (run %{dep:test_df64.exe})))
+
+(executable
+ (name test_worklist)
+ (modules test_worklist)
+ (libraries sarek sarek.stdlib sarek.worklist spoc_core test_helpers unix)
+ (preprocessor_deps
+  (file ../../Sarek_worklist/Sarek_worklist.ml))
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_worklist.exe})))

--- a/sarek/tests/e2e/test_worklist.ml
+++ b/sarek/tests/e2e/test_worklist.ml
@@ -1,0 +1,342 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for Sarek_worklist - portable dynamic parallelism.
+ *
+ * The library source is compiled to device code by the Sarek PPX and pulled in
+ * with %sarek_include, so the SAME source runs on every backend - including
+ * CUDA/PTX under ZLUDA. Scenarios (each verified against a CPU reference on
+ * every available device):
+ *   A. BFS variable-fanout tree frontier sum (level-synchronous, Host.drive).
+ *      With far fewer threads than nodes it also proves the claim-loop re-pops.
+ *   B. Deterministic tiny tree (order-independent sum, hand-checked).
+ *   C. Push with a small ring -> OVERFLOW flag set; non-dropped items correct.
+ *   D. Ring wrap-around: persistent single-thread linked list, capacity << N.
+ ******************************************************************************)
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Gpu = Sarek_stdlib.Gpu
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module WL = Sarek_worklist
+
+let%sarek_include _ = "../../Sarek_worklist/Sarek_worklist.ml"
+
+(* ============================ kernels ============================ *)
+
+(* One level of a variable-fanout BFS frontier. Each thread claims tickets from
+   [0, snapshot_tail) via the shared HEAD counter, adds the node value to a
+   global accumulator, and pushes the node's children to TAIL for the next
+   level. Uses the callable pure helper wl_ring_index. *)
+let frontier_kernel =
+  [%kernel
+    fun (ctrl : int32 vector)
+        (slots : int32 vector)
+        (values : int32 vector)
+        (child_off : int32 vector)
+        (child_idx : int32 vector)
+        (acc : int32 vector)
+        (level_base : int32)
+        (snapshot_tail : int32)
+        (cap : int32) ->
+      let open Std in
+      let open Gpu in
+      let open Sarek_worklist in
+      let stride = block_dim_x * grid_dim_x in
+      let i = mut (level_base + thread_idx_x + (block_idx_x * block_dim_x)) in
+      while i < snapshot_tail do
+        let u = slots.(wl_ring_index cap i) in
+        let _ = atomic_add_global_int32 acc 0l values.(u) in
+        let s = mut child_off.(u) in
+        let e = child_off.(u + 1l) in
+        while s < e do
+          let t = atomic_add_global_int32 ctrl 1l 1l in
+          slots.(wl_ring_index cap t) <- child_idx.(s) ;
+          s := s + 1l
+        done ;
+        i := i + stride
+      done]
+
+(* Each thread pushes one item into a ring that may be too small; a bounds-check
+   against HEAD sets the OVERFLOW flag instead of clobbering a live slot. *)
+let push_guarded_kernel =
+  [%kernel
+    fun (ctrl : int32 vector)
+        (slots : int32 vector)
+        (input : int32 vector)
+        (n : int32)
+        (cap : int32) ->
+      let open Std in
+      let open Gpu in
+      let open Sarek_worklist in
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < n then begin
+        let t = atomic_add_global_int32 ctrl 1l 1l in
+        let head = atomic_add_global_int32 ctrl 0l 0l in
+        if t - head >= cap then
+          let _ = atomic_add_global_int32 ctrl 3l 1l in
+          ()
+        else slots.(wl_ring_index cap t) <- input.(tid)
+      end]
+
+(* Persistent single-launch traversal of a linked list by ONE thread: pop, sum,
+   push the (single) successor, until the queue drains. A tiny ring wraps
+   many times; live set is always 1 so no live slot is ever overwritten. *)
+let persistent_wrap_kernel =
+  [%kernel
+    fun (ctrl : int32 vector)
+        (slots : int32 vector)
+        (values : int32 vector)
+        (nxt : int32 vector)
+        (acc : int32 vector)
+        (cap : int32) ->
+      let open Std in
+      let open Gpu in
+      let open Sarek_worklist in
+      let cont = mut 1l in
+      while cont = 1l do
+        let tl = ctrl.(1) in
+        let h = atomic_add_global_int32 ctrl 0l 1l in
+        if h >= tl then cont := 0l
+        else begin
+          let u = slots.(wl_ring_index cap h) in
+          let _ = atomic_add_global_int32 acc 0l values.(u) in
+          let c = nxt.(u) in
+          if c >= 0l then begin
+            let t = atomic_add_global_int32 ctrl 1l 1l in
+            slots.(wl_ring_index cap t) <- c
+          end
+        end
+      done]
+
+let ir_of (_, kirc) =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "no IR"
+
+(* ============================ host helpers ============================ *)
+
+type tree = {
+  n : int;
+  values : int32 array;
+  child_off : int32 array; (* length n+1 *)
+  child_idx : int32 array;
+}
+
+(* Build a variable-fanout tree over nodes [0, n): node i gets [i mod max_fan]
+   children taken from the not-yet-assigned nodes, so every node is reachable
+   from root 0 exactly once (a genuine tree). *)
+let build_tree n ~max_fan =
+  let fan = Array.make n 0 in
+  let next = ref 1 in
+  for i = 0 to n - 1 do
+    (* At least one child (varying 1..max_fan) until all nodes are placed, so
+       the root really expands and every node is reachable exactly once. *)
+    let want = 1 + (i mod max_fan) in
+    let f = if !next >= n then 0 else min want (n - !next) in
+    fan.(i) <- f ;
+    next := !next + f
+  done ;
+  let child_off = Array.make (n + 1) 0l in
+  let child_idx = Array.make (n - 1) 0l in
+  let cursor = ref 1 in
+  let pos = ref 0 in
+  for i = 0 to n - 1 do
+    child_off.(i) <- Int32.of_int !pos ;
+    for _ = 1 to fan.(i) do
+      child_idx.(!pos) <- Int32.of_int !cursor ;
+      incr cursor ;
+      incr pos
+    done
+  done ;
+  child_off.(n) <- Int32.of_int !pos ;
+  let values = Array.init n (fun i -> Int32.of_int (i + 1)) in
+  {n; values; child_off; child_idx}
+
+(* CPU reference: BFS from root 0, summing visited node values. Mirrors the
+   kernel's queue semantics exactly (order-independent result). *)
+let cpu_frontier_sum tree =
+  let q = Queue.create () in
+  Queue.push 0 q ;
+  let sum = ref 0 in
+  while not (Queue.is_empty q) do
+    let u = Queue.pop q in
+    sum := !sum + Int32.to_int tree.values.(u) ;
+    let s = Int32.to_int tree.child_off.(u) in
+    let e = Int32.to_int tree.child_off.(u + 1) in
+    for k = s to e - 1 do
+      Queue.push (Int32.to_int tree.child_idx.(k)) q
+    done
+  done ;
+  !sum
+
+let vec_of_int32_array a =
+  let v = Vector.create Vector.int32 (Array.length a) in
+  Array.iteri (fun i x -> Vector.set v i x) a ;
+  v
+
+(* ============================ scenarios ============================ *)
+
+(* A/B: run the level-synchronous frontier on [tree]; return the summed value.
+   [threads] is deliberately small to force claim-loop re-pops. *)
+let run_frontier dev tree ~threads =
+  let cap = (2 * tree.n) + 8 in
+  let q = WL.Host.create ~capacity:cap in
+  WL.Host.seed q [|0l|] ;
+  let values = vec_of_int32_array tree.values in
+  let child_off = vec_of_int32_array tree.child_off in
+  let child_idx =
+    if Array.length tree.child_idx = 0 then Vector.create Vector.int32 1
+    else vec_of_int32_array tree.child_idx
+  in
+  let acc = Vector.create Vector.int32 1 in
+  Vector.set acc 0 0l ;
+  let ir = ir_of frontier_kernel in
+  let launch ~level_base ~snapshot_tail =
+    Execute.run_vectors
+      ~device:dev
+      ~ir
+      ~args:
+        [
+          Execute.Vec q.WL.Host.ctrl;
+          Execute.Vec q.WL.Host.slots;
+          Execute.Vec values;
+          Execute.Vec child_off;
+          Execute.Vec child_idx;
+          Execute.Vec acc;
+          Execute.Int level_base;
+          Execute.Int snapshot_tail;
+          Execute.Int cap;
+        ]
+      ~block:(Execute.dims1d threads)
+      ~grid:(Execute.dims1d 1)
+      () ;
+    Transfer.flush dev
+  in
+  let _levels = WL.Host.drive q ~launch ~max_levels:(tree.n + 2) in
+  Transfer.flush dev ;
+  let got = Int32.to_int (Vector.get acc 0) in
+  (got, WL.Host.overflow q)
+
+(* C: push [n] items into a ring of [cap] < n; expect the overflow flag set and
+   every non-dropped slot to hold a distinct input value. *)
+let run_overflow dev =
+  let n = 256 in
+  let cap = 64 in
+  let input =
+    vec_of_int32_array (Array.init n (fun i -> Int32.of_int (i + 1)))
+  in
+  let q = WL.Host.create ~capacity:cap in
+  WL.Host.seed q [||] ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of push_guarded_kernel)
+    ~args:
+      [
+        Execute.Vec q.WL.Host.ctrl;
+        Execute.Vec q.WL.Host.slots;
+        Execute.Vec input;
+        Execute.Int n;
+        Execute.Int cap;
+      ]
+    ~block:(Execute.dims1d 64)
+    ~grid:(Execute.dims1d 4)
+    () ;
+  Transfer.flush dev ;
+  let overflow = WL.Host.overflow q in
+  (* Distinct, in-range values in the ring; count them. *)
+  let seen = Array.make (n + 1) false in
+  let distinct = ref true in
+  for i = 0 to cap - 1 do
+    let v = Int32.to_int (Vector.get q.WL.Host.slots i) in
+    if v >= 1 && v <= n then (
+      if seen.(v) then distinct := false ;
+      seen.(v) <- true)
+  done ;
+  overflow > 0 && !distinct
+
+(* D: persistent single-thread linked-list traversal with a tiny wrapping ring. *)
+let run_wrap dev =
+  let n = 50 in
+  let cap = 4 in
+  let values =
+    vec_of_int32_array (Array.init n (fun i -> Int32.of_int (i + 1)))
+  in
+  let nxt =
+    vec_of_int32_array
+      (Array.init n (fun i -> if i = n - 1 then -1l else Int32.of_int (i + 1)))
+  in
+  let acc = Vector.create Vector.int32 1 in
+  Vector.set acc 0 0l ;
+  let q = WL.Host.create ~capacity:cap in
+  WL.Host.seed q [|0l|] ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of persistent_wrap_kernel)
+    ~args:
+      [
+        Execute.Vec q.WL.Host.ctrl;
+        Execute.Vec q.WL.Host.slots;
+        Execute.Vec values;
+        Execute.Vec nxt;
+        Execute.Vec acc;
+        Execute.Int cap;
+      ]
+    ~block:(Execute.dims1d 1)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  let got = Int32.to_int (Vector.get acc 0) in
+  let expected = n * (n + 1) / 2 in
+  got = expected && WL.Host.overflow q = 0
+
+(* ============================ driver ============================ *)
+
+let () =
+  Test_helpers.Benchmarks.init () ;
+  let devices = Device.init () in
+  (* deterministic tiny tree (B): root + explicit small fanout *)
+  let big = build_tree 500 ~max_fan:4 in
+  let tiny = build_tree 13 ~max_fan:3 in
+  let exp_big = cpu_frontier_sum big in
+  let exp_tiny = cpu_frontier_sum tiny in
+  (* Sanity: the tree must fully expand (every node reachable), else the sums
+     would be vacuous. Full sum = n(n+1)/2. *)
+  assert (exp_big = big.n * (big.n + 1) / 2) ;
+  assert (exp_tiny = tiny.n * (tiny.n + 1) / 2) ;
+  let all_ok = ref true in
+  Array.iter
+    (fun dev ->
+      let label =
+        Printf.sprintf "%s (%s)" dev.Device.name dev.Device.framework
+      in
+      let check name ok =
+        if not ok then all_ok := false ;
+        Printf.sprintf "%s=%b" name ok
+      in
+      let results =
+        try
+          let sb, ob = run_frontier dev big ~threads:32 in
+          let st, ot = run_frontier dev tiny ~threads:8 in
+          [
+            check "frontier500" (sb = exp_big && ob = 0);
+            check "tiny13" (st = exp_tiny && ot = 0);
+            check "overflow" (run_overflow dev);
+            check "wrap" (run_wrap dev);
+          ]
+        with e ->
+          all_ok := false ;
+          [Printf.sprintf "EXN=%s" (Printexc.to_string e)]
+      in
+      Printf.printf "  %-54s : %s\n" label (String.concat " " results))
+    devices ;
+  Printf.printf "  (reference: frontier500=%d tiny13=%d)\n" exp_big exp_tiny ;
+  if !all_ok then print_endline "test_worklist PASSED"
+  else (
+    print_endline "test_worklist FAILED" ;
+    exit 1)


### PR DESCRIPTION
## Sarek_worklist — portable dynamic parallelism (campaign item L16)

Implements **Route B** from `roster/ptx-limits-campaign/L16-dynamic-parallelism.md`
(verdict: GO `Sarek_worklist`, NO-GO native CDP). A pure-Sarek global work-queue
that delivers the **irregular-work / frontier / tree-recursion** use cases CUDA
dynamic parallelism (CDP) targets — on every backend, built only on the atomics
already on main. No device-side kernel-launch mechanism is used (CDP is absent on
ZLUDA/Metal/WGSL and unreliable on OpenCL 2.0 device-enqueue across the real
vendor matrix — doc §2).

### CDP-vs-worklist rationale (from the doc)
CDP is frequently *slower* than a good worklist for its own headline workload
(many small irregular tasks) and exists cleanly on only 1 of 6 backends. The
worklist serves the same **use cases** portably, with all "dynamic" behavior
flowing through the queue rather than a launch primitive. Route B's one real gap:
sub-problems needing a genuinely different launch configuration (narrow; out of
scope for FP32/FP64 numeric kernels).

### API delivered
- **Callable pure helpers** (`[@sarek.module]`, usable from any `[%kernel]`):
  `wl_ring_index` (ticket → ring slot), `wl_has_work` (head < tail).
- **`Host`** (host-side): `create ~capacity`, `seed`, counter readers
  (`head`/`tail`/`outstanding`/`overflow`/`slot`), and **`drive`** — the
  level-synchronous relaunch loop.
- **Documented kernel patterns** for push/pop. The queue atomics live *inline in
  the user kernel*, not inside a helper: a `[@sarek.module]` helper cannot carry
  a vector into an atomic intrinsic (the OCaml shim pins the param to `int32
  array`, which does not unify with the kernel's vector object type — the PPX
  only reconciles vector params through `.()`/`.()<-` rewriting). This is the
  split the doc explicitly anticipates.

### Termination protocol + assumptions (the hard, honest part)
- **Level-synchronous (recommended, verified everywhere incl. the sequential
  interpreter):** each launch distributes a `[level_base, snapshot_tail)` window
  by **grid-stride** — no thread ever waits on another. Children are pushed to
  TAIL (the only atomic device counter) for the next level; the host relaunches
  until TAIL stops growing. The window bounds are passed as **scalar args and the
  host only ever reads device counters, never writes them back** — required for
  multi-launch coherence under Sarek's CPU/GPU/Both vector residency. Spec-safe:
  no GPU forward-progress assumption; the host sync between levels is the memory
  barrier. Correct when **capacity ≥ total items enqueued** (monotonic ring, no
  reuse); the OVERFLOW flag signals under-sizing.
- **Persistent single-launch (documented, for GPUs / single-thread):** one
  launch, each thread loops pop→work→push until `head ≥ tail`. Safe single-thread
  on every backend; safe multi-thread only on real GPUs under persistent-threads
  co-residency. It spin-waits across threads, so it **deadlocks on the sequential
  interpreter and any pool-bounded executor** — documented, not run multi-thread
  there. Ring reuse (wrap) is correct only when **capacity ≥ peak live items**.

### Per-backend e2e results (all verified vs CPU reference)
`test_worklist` runs 4 scenarios on every device. Result on this machine:

| Backend | frontier(500) | tiny(13) | overflow | wrap |
|---|---|---|---|---|
| **CUDA/PTX — RX 7900 XTX [ZLUDA]** | ✅ | ✅ | ✅ | ✅ |
| **CUDA/PTX — Ryzen CPU [ZLUDA]** | ✅ | ✅ | ✅ | ✅ |
| OpenCL — RX 7900 XTX | ✅ | ✅ | ✅ | ✅ |
| OpenCL — Ryzen CPU | ✅ | ✅ | ✅ | ✅ |
| Vulkan — RADV NAVI31 | ✅ | ✅ | ✅ | ✅ |
| Vulkan — Ryzen CPU | ✅ | ✅ | ✅ | ✅ |
| Native (32-core) | ✅ | ✅ | ✅ | ✅ |
| Interpreter (sequential) | ✅ | ✅ | ✅ | ✅ |
| Interpreter (parallel) | ✅ | ✅ | ✅ | ✅ |

CUDA/PTX verified under `LD_LIBRARY_PATH=~/opt/zluda`. **Metal / WGSL:** no
runtime on this Linux/AMD host, so not executed; the kernels use only int32 +
global atomics + loops, which the Metal and WGSL emitters already handle.

### Stress results
- **More items than threads:** 32-thread grid over 500 tree nodes → the
  grid-stride loop re-pops; sum verified.
- **Ring wrap-around:** persistent single-thread linked list, capacity **4** over
  **50** nodes → ring wraps ~12×, live set always 1, sum = 1275 correct, overflow
  flag stays 0.

### Perf note
One launch per BFS *level* (host-side counter read + relaunch), not one per work
item — the host cost is amortized over a whole frontier, exactly the "enough work
per launch" regime the doc identifies (§1). All other work is plain atomics on
device memory. No CDP per-child launch overhead.

### Missing-primitive findings (follow-ups)
- **No global CAS/exch** (`atomic_cas_int32` is `Local`-only). The queue is built
  on monotonic `atomic_add` ticket counters instead of CAS-retry — sufficient
  here, but a conditional claim (non-blocking pop without over-claim) would need
  a global CAS.
- **Atomics can't be encapsulated in `[@sarek.module]` helpers** (vector-type
  unification, see above) — a PPX limitation, not a runtime one.
- The **interpreter had no atomic support**; this PR adds global add/inc + fences
  (mutex-guarded RMW). A follow-up could extend it to the shared-memory atomics
  so `test_histogram` can drop its `no_interpreter` filter.

### Gates
`dune build @install`, unit runtest, and e2e runtest (`test_df64` + `test_worklist`)
all green; new files fmt/odoc-clean. (Note: `sarek/interp/Sarek_float32.ml` has
pre-existing ocamlformat drift on `main`, unrelated to this PR — left untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `sarek.worklist` library implementing a portable dynamic work queue with frontier (level-synchronous) and persistent traversal patterns.
  * Introduced queue control counters, ring-buffer slot management, and host-side driving/initialization.
  * Added interpreter support for global-memory atomics (add/inc) and treated memory fences as no-ops.
* **Tests**
  * Added an end-to-end `test_worklist` suite covering frontier expansion, overflow behavior, ring wrap-around, and persistent draining across backends.
* **Documentation**
  * Added a new work-queue execution/termination and validation plan for “Sarek_worklist.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->