### PR TITLE
harden(worklist): guard level-sync frontier push against silent overflow

### DIFF
--- a/sarek/Sarek_worklist/Sarek_worklist.ml
+++ b/sarek/Sarek_worklist/Sarek_worklist.ml
@@ -61,7 +61,10 @@
  *            let s = mut off.(u) in
  *            while s < off.(u + 1l) do
  *              let t = atomic_add_global_int32 ctrl 1l 1l in
- *              slots.(wl_ring_index cap t) <- idx.(s) ;
+ *              let head = atomic_add_global_int32 ctrl 0l 0l in
+ *              if t - head >= cap then
+ *                (let _ = atomic_add_global_int32 ctrl 3l 1l in ())  (* OVERFLOW *)
+ *              else slots.(wl_ring_index cap t) <- idx.(s) ;
  *              s := s + 1l
  *            done ;
  *            i := i + stride
@@ -76,8 +79,12 @@
  *
  * CAPACITY / TERMINATION CONTRACT (honest limits)
  *   - Level-sync main use: size capacity >= total items ever enqueued (the ring
- *     never reuses a slot, so ordering can never corrupt). The OVERFLOW flag is
- *     set if a push finds the ring full; the host checks {!Host.overflow}.
+ *     never reuses a slot, so ordering can never corrupt). Every push is guarded
+ *     ([t - head >= cap] -> set OVERFLOW instead of writing to a live slot), so
+ *     an under-sized ring is FLAGGED via {!Host.overflow} rather than silently
+ *     clobbering live data. Once OVERFLOW is set the run's result is undefined
+ *     (items were dropped) — treat a nonzero {!Host.overflow} as "grow capacity
+ *     and re-run", exactly like the {!push_guarded} pattern.
  *   - Ring reuse (wrap) is correct only when capacity >= peak simultaneously-
  *     live items, so a slot is always consumed before its ticket laps it.
  *   - This is NOT a drop-in for arbitrary CDP: workers are homogeneous (same

--- a/sarek/tests/e2e/test_worklist.ml
+++ b/sarek/tests/e2e/test_worklist.ml
@@ -56,7 +56,11 @@ let frontier_kernel =
         let e = child_off.(u + 1l) in
         while s < e do
           let t = atomic_add_global_int32 ctrl 1l 1l in
-          slots.(wl_ring_index cap t) <- child_idx.(s) ;
+          let head = atomic_add_global_int32 ctrl 0l 0l in
+          if t - head >= cap then
+            let _ = atomic_add_global_int32 ctrl 3l 1l in
+            ()
+          else slots.(wl_ring_index cap t) <- child_idx.(s) ;
           s := s + 1l
         done ;
         i := i + stride


### PR DESCRIPTION
L16 follow-up (from the termination review of #236). The level-sync frontier push wrote to the ring unconditionally, so an under-sized frontier ring would silently clobber a still-live slot — the worst failure mode. It now matches the proven `push_guarded` pattern: `t - head >= cap` sets the OVERFLOW flag instead of writing. Under-sizing is now loud (`Host.overflow != 0`) rather than silent corruption; the capacity contract in the module doc is clarified (nonzero overflow ⇒ grow-and-re-run, results undefined once items were dropped).

Correctly-sized scenarios are unchanged (the guard never fires when `t-head < cap`) — the full worklist e2e (frontier500/tiny13/overflow/wrap) passes on all 7 device configs including CUDA/PTX under ZLUDA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent worklist ring-buffer writes when capacity is exhausted.
  * Overflow is now detected and reported instead of overwriting active entries.
  * Updated behavior may drop items when capacity is insufficient; callers can increase capacity and rerun for a valid result.
* **Documentation**
  * Clarified capacity requirements, overflow reporting, and termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->