### PR TITLE
fix(doc): resolve odoc duplicate-rule collision on Spoc_core

### DIFF
--- a/sarek/core_js_exec/dune
+++ b/sarek/core_js_exec/dune
@@ -6,6 +6,14 @@
 ;
 ; The interpreter stack is the SINGLE source in ../interp/, pulled in via
 ; copy_files and recompiled here against the jsoo Spoc_core (no literal copies).
+;
+; This is an INTERNAL jsoo build shim, not a public API. It is intentionally a
+; private library (no public_name): being (wrapped false) it exposes a top-level
+; `Spoc_core` shim module, which would otherwise collide in package `sarek`'s odoc
+; output with the genuine public `Spoc_core` from the `sarek.core` library
+; ("Multiple rules generated for .../sarek/Spoc_core/index.html"). Keeping it
+; private (and thus out of @doc/@install) resolves the collision without changing
+; the wrapped-false layout the jsoo Execute smoke test depends on.
 
 (copy_files ../interp/*.ml)
 
@@ -13,7 +21,6 @@
 
 (library
  (name spoc_core_exec_js)
- (public_name sarek.core_exec_js)
  (wrapped false)
  (libraries spoc_framework spoc_core_base sarek_ir sarek_registry)
  (modules


### PR DESCRIPTION
## Root cause

`dune build @doc` failed:

```
Error: Multiple rules generated for _build/default/_doc/_html/sarek/Spoc_core/index.html
Error: Multiple rules generated for _build/default/_doc/_odocls/sarek/spoc_core.odocl
```

Two libraries in package **`sarek`** both emitted a top-level `Spoc_core` odoc unit, so dune generated two rules for the same doc target:

| Library | dune name | public_name | wrapping | exposes `Spoc_core` |
|---|---|---|---|---|
| runtime core | `spoc_core` | `sarek.core` | wrapped | wrapper module `Spoc_core` (the real public API) |
| jsoo Execute shim | `spoc_core_exec_js` | `sarek.core_exec_js` | **`wrapped false`** | explicit top-level `Spoc_core` shim module |

Because `spoc_core_exec_js` is `(wrapped false)`, every module it lists — including its `Spoc_core` shim — becomes a package-top-level odoc unit under `sarek`, colliding with the genuine `Spoc_core` from `sarek.core`.

The shim **must stay `wrapped false`**: `sarek/execute/jsoo/dune` copies `Execute.ml` and compiles it against this library, relying on `open Spoc_core` and bare `Sarek_ir_interp` resolving to top-level modules. Wrapping it or renaming the module would break that jsoo smoke build.

## Fix

Make `spoc_core_exec_js` a **private library** by dropping its `public_name` (`sarek/core_js_exec/dune`). It is an internal jsoo build shim, not public API, so it should be neither installed nor documented. `@doc` only documents public libraries, so this removes the shim's `Spoc_core` from the doc set and clears the collision — without touching the `wrapped false` layout the jsoo consumer depends on. The genuine public `Spoc_core` (from `sarek.core`) remains fully documented.

This is minimal (one dune stanza, one field removed), principled (correctly excludes an internal lib from doc/install rather than hiding docs or disabling `@doc`), and does not touch any source logic.

## Verification

- `dune build @doc` — **green, exit 0**, no "Multiple rules generated"; only 41 pre-existing odoc doc-comment warnings (`unresolvedroot(...)`, ambiguous-reference) remain, all unrelated.
- `dune build @install` — green (exit 0).
- `dune runtest` — green (all tests pass).
- `dune build @fmt` — the two failures (`sarek/interp/Sarek_float32.ml` doc-comment ordering, `sarek/tests/unit/test_ir_layout.ml`) are **pre-existing** (reproduced on the base branch with my change stashed) and in source files outside this change's scope; the edited dune file is fmt-clean.

odoc was installable in the switch, so the full `@doc` pipeline was verified green end-to-end.

## `retarget-prs.yml` verdict: benign, no fix

`.github/workflows/retarget-prs.yml` is well-formed and correct:
- triggers only on `pull_request: [closed]` and gates the job with `if: github.event.pull_request.merged == true` — it is skipped (not failed) on non-merge closes and never runs on normal branch CI, so it cannot cause the docs build failure;
- gracefully no-ops (`console.log` + `return`) when there are no dependent PRs;
- wraps each retarget in `try/catch`, so a single failed retarget cannot fail the job;
- declares the correct `permissions: pull-requests: write, contents: read` for `pulls.update` + `issues.createComment`, and uses valid `actions/github-script@v7`.

Nothing to fix; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal JavaScript execution components to remain private and avoid naming conflicts.
  * Preserved the existing execution behavior and compatibility with JavaScript smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->