### PR TITLE
feat(gemm): Sarek_gemm — portable shared-memory tiled SGEMM (pure Sarek, FMA)

### DIFF
--- a/sarek/Sarek_gemm/Sarek_gemm.ml
+++ b/sarek/Sarek_gemm/Sarek_gemm.ml
@@ -1,0 +1,184 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek_gemm - portable shared-memory tiled SGEMM (single-precision GEMM).
+ *
+ * Computes C = alpha * A * B + beta * C for row-major float32 matrices, in
+ * PURE Sarek (FMA accumulation, no tensor cores), on every Sarek backend that
+ * supports block-shared memory: CUDA/PTX (incl. ZLUDA), OpenCL, Vulkan, Metal,
+ * Native. (The sequential Interpreter has no shared-memory model - see BACKEND
+ * LIMITATIONS - so the tiled kernel is not run there, exactly like the reduce
+ * and naive/tiled matmul e2e tests.)
+ *
+ * This is the FMA baseline for campaign item L15. A later step (L15b) will
+ * optionally accelerate the inner tile product with tensor-core mma; the API
+ * is kept so that fast path can slot behind it (see API / L15b HOOK below).
+ *
+ * TILING SCHEME  (classic BLOCK x BLOCK, one output element per thread)
+ *   The output C is partitioned into {!tile} x {!tile} blocks; one thread block
+ *   of {!tile} x {!tile} threads computes one output block. Thread (tx,ty)
+ *   owns C[row,col] with row = ty + tile*block_idx_y, col = tx + tile*block_idx_x.
+ *   Marching along K in steps of {!tile}:
+ *     1. superstep LOAD  - each thread cooperatively loads one element of the
+ *        current A tile and one of the current B tile into shared memory,
+ *        zero-filling the halo when the global index is out of range. The
+ *        implicit barrier at the end of the superstep publishes both tiles to
+ *        the whole block.
+ *     2. superstep COMPUTE - each thread accumulates the {!tile}-long dot
+ *        product of its shared A row and shared B column into a private
+ *        register with {!gemm_fma_f32} (fused multiply-add). The implicit
+ *        barrier at the end guarantees every thread is done reading the tiles
+ *        before the next iteration's LOAD overwrites them.
+ *   After the K loop, the guarded thread writes alpha*acc + beta*C_old.
+ *   Two barriers per K step (one per superstep) - the classic tiled count.
+ *
+ * TILE SIZE  (default 16 -> {!tile})
+ *   16x16 = 256 threads/block and 2 * 16*16 * 4 B = 2 KiB shared memory - a
+ *   safe, portable default (well under the 16-48 KiB/block and 1024 thread/
+ *   block limits every backend here exposes). Larger tiles (e.g. 32 -> 8 KiB,
+ *   1024 threads) raise arithmetic intensity / reuse but cut the number of
+ *   resident blocks per multiprocessor (occupancy) and can exceed the work-
+ *   group size on CPU-class OpenCL/Native devices. The shared-array extents are
+ *   compile-time literals in a Sarek kernel, so the tile is fixed per kernel
+ *   value: this library ships the 16x16 kernel and a matching {!Host} launch
+ *   config; a different tile is a one-line edit of the two shared literals plus
+ *   [tile_size] (see PATTERN) and the {!Host.tile} constant.
+ *
+ * BOUNDARY HANDLING  (non-multiple-of-tile dimensions)
+ *   M, N, K need NOT be multiples of {!tile} and the matrices need NOT be
+ *   padded. The LOAD superstep guards every global read (row<M, col<N, and the
+ *   K index < K) and writes 0.0 into the shared tile on a miss, so out-of-range
+ *   lanes contribute a genuine zero to the dot product; the final store is
+ *   guarded by row<M && col<N. Zero-padding the tile - not the matrix - is what
+ *   makes an arbitrary shape correct with no host-side copy. This is the
+ *   classic GEMM boundary bug when omitted, so it is tested explicitly (see
+ *   sarek/tests/e2e/test_sarek_gemm.ml: exact-multiple, non-multiple, and
+ *   rectangular M<>N<>K cases).
+ *
+ * NUMERICS
+ *   Tiled accumulation sums the K products in a different ORDER than a naive
+ *   row*col loop (block by block), and FMA fuses each product-add with a single
+ *   rounding. Results therefore match a naive/CPU reference within a float32
+ *   epsilon, NOT bit-for-bit. Callers must compare with a tolerance (the e2e
+ *   test uses a relative epsilon scaled by K).
+ *
+ * BACKEND LIMITATIONS
+ *   - Interpreter: no block-shared-memory / barrier model (sequential executor);
+ *     the tiled kernel is not run there. Use a naive kernel for the Interpreter.
+ *   - All of CUDA/PTX (ZLUDA), OpenCL, Vulkan, Native provide __shared__ /
+ *     local / shared / emulated tiles and a block barrier, and run this kernel.
+ *
+ * USAGE (from another compilation unit - same split as Sarek_worklist)
+ *   dune:   add [sarek.gemm] to (libraries); add this file to
+ *           (preprocessor_deps) of the kernel's stanza.
+ *   source: [let%sarek_include _ = "path/to/Sarek_gemm.ml"] to reuse the pure
+ *           {!gemm_fma_f32} helper from your own [%kernel]; OR use the ready
+ *           kernel value {!sgemm_tiled_kernel} directly and {!Host} for the
+ *           launch configuration (see the e2e test for the full flow).
+ *
+ * API / L15b HOOK
+ *   The stable surface L15b (tensor-core mma) extends is:
+ *     - {!gemm_fma_f32}     the element multiply-accumulate (swap for an mma
+ *                           fragment op, or add [gemm_fma_f16]/df64 twins - the
+ *                           kernel body is unchanged around it);
+ *     - {!sgemm_tiled_kernel}  the (a b c m n k alpha beta) kernel value - an
+ *                           mma fast path is a sibling kernel value with the
+ *                           SAME argument shape, so {!Host} and every caller
+ *                           are reused unchanged;
+ *     - {!Host}             tile constant + block/grid/shared-mem launch config,
+ *                           parameterised by the element type only.
+ ******************************************************************************)
+
+[@@@warning "-32-33-34"]
+
+(* Alias so the pure [@sarek.module] helper type-checks as OCaml; inside a
+   [%kernel] the same [float32] resolves to the device 32-bit float. *)
+type float32 = float
+
+(* OCaml-level binding of [fma] (as in Sarek_df64): the body below compiles as
+   plain OCaml, while the PPX maps the bare [fma] call to the device fused-
+   multiply-add intrinsic (fmaf / fma) inside a kernel. The plain-OCaml version
+   runs at binary64 precision and is not a bit-faithful float32 reference. *)
+let fma = Float.fma
+
+(** Element multiply-accumulate: [acc + a * b] with a single rounding (FMA). The
+    one op L15b swaps for a tensor-core fragment multiply-accumulate. *)
+let[@sarek.module] gemm_fma_f32 (acc : float32) (a : float32) (b : float32) :
+    float32 =
+  fma a b acc
+
+(* ========================================================================= *)
+(* Directly-usable tiled SGEMM kernel value (float32, tile = 16).            *)
+(*                                                                            *)
+(* PATTERN: to retile, this is exactly the body to paste into your own       *)
+(* [%kernel] - change the two [let%shared ... = 256l] extents to tile*tile   *)
+(* and [tile_size] to the new tile (and {!Host.tile} to match).              *)
+(* ========================================================================= *)
+
+(** Tiled SGEMM: [c := alpha * a * b + beta * c] for row-major float32 [a]
+    (MxK), [b] (KxN), [c] (MxN). Launch with {!Host}. Tile is 16x16. *)
+let sgemm_tiled_kernel =
+  [%kernel
+    fun (a : float32 vector)
+        (b : float32 vector)
+        (c : float32 vector)
+        (m : int32)
+        (n : int32)
+        (k : int32)
+        (alpha : float32)
+        (beta : float32) ->
+      let%shared (tile_a : float32) = 256l in
+      let%shared (tile_b : float32) = 256l in
+      let tx = thread_idx_x in
+      let ty = thread_idx_y in
+      let row = ty + (block_dim_y * block_idx_y) in
+      let col = tx + (block_dim_x * block_idx_x) in
+      let tile_size = 16l in
+      let num_tiles = (k + tile_size - 1l) / tile_size in
+      let sum = mut 0.0 in
+      for t = 0 to num_tiles - 1l do
+        let%superstep load =
+          let a_col = (t * tile_size) + tx in
+          if row < m && a_col < k then
+            tile_a.((ty * tile_size) + tx) <- a.((row * k) + a_col)
+          else tile_a.((ty * tile_size) + tx) <- 0.0 ;
+          let b_row = (t * tile_size) + ty in
+          if b_row < k && col < n then
+            tile_b.((ty * tile_size) + tx) <- b.((b_row * n) + col)
+          else tile_b.((ty * tile_size) + tx) <- 0.0
+        in
+        let%superstep _compute =
+          for i = 0 to tile_size - 1l do
+            sum :=
+              gemm_fma_f32
+                sum
+                tile_a.((ty * tile_size) + i)
+                tile_b.((i * tile_size) + tx)
+          done
+        in
+        ()
+      done ;
+      if row < m && col < n then
+        c.((row * n) + col) <- (alpha *. sum) +. (beta *. c.((row * n) + col))]
+
+(** Host-side launch configuration for {!sgemm_tiled_kernel}. Kept element-type-
+    agnostic so an f64/df64 or L15b mma kernel reuses it by construction. *)
+module Host = struct
+  (** Tile edge. MUST equal the kernel's shared extent (tile*tile) and
+      [tile_size] literal; 16 -> 256 threads/block, 2 KiB shared. *)
+  let tile = 16
+
+  (** Block dimensions: one thread per output element of a tile. *)
+  let block () = Sarek.Execute.dims2d tile tile
+
+  (** Grid dimensions covering an MxN output (ceil-div, so partial edge blocks
+      are launched and masked by the kernel's boundary guards). *)
+  let grid ~m ~n =
+    Sarek.Execute.dims2d ((n + tile - 1) / tile) ((m + tile - 1) / tile)
+
+  (** Dynamic shared-memory bytes: two float32 tiles. *)
+  let shared_mem_bytes = 2 * tile * tile * 4
+end

--- a/sarek/Sarek_gemm/dune
+++ b/sarek/Sarek_gemm/dune
@@ -1,0 +1,6 @@
+(library
+ (name sarek_gemm)
+ (public_name sarek.gemm)
+ (libraries sarek sarek_stdlib spoc_core)
+ (preprocess
+  (pps sarek_ppx)))

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -574,3 +574,19 @@
  (alias runtest)
  (action
   (run %{dep:test_worklist.exe})))
+
+(executable
+ (name test_sarek_gemm)
+ (modules test_sarek_gemm)
+ (libraries sarek sarek.stdlib sarek.gemm spoc_core test_helpers unix)
+ (preprocessor_deps
+  (file ../../Sarek_gemm/Sarek_gemm.ml))
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_sarek_gemm.exe})))

--- a/sarek/tests/e2e/test_sarek_gemm.ml
+++ b/sarek/tests/e2e/test_sarek_gemm.ml
@@ -1,0 +1,291 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for Sarek_gemm - shared-memory tiled SGEMM (pure Sarek, FMA).
+ *
+ * The ready kernel value Sarek_gemm.sgemm_tiled_kernel is exercised on every
+ * available shared-memory backend (Native + CUDA/PTX incl. ZLUDA + OpenCL +
+ * Vulkan; the Interpreter has no shared-memory model and is skipped, like the
+ * matmul/reduce e2e tests), and cross-checked against a CPU reference GEMM and
+ * against a naive one-element-per-thread kernel.
+ *
+ * Cases (all verified vs CPU reference within a float32 relative epsilon):
+ *   - tiny hand-checkable 2x2 (known product) and 3x3 (identity);
+ *   - EXACT multiple of the tile (32x32x32);
+ *   - NON-multiple of the tile (boundary: 30x30x30, 17x17x17);
+ *   - rectangular M<>N<>K (37x50x23);
+ *   - large / many blocks (128x96x160);
+ *   - alpha/beta: C := alpha*A*B + beta*C with alpha=2, beta=3.
+ * Plus tiled-vs-naive agreement and a (non-gating) tiled-vs-naive perf note.
+ ******************************************************************************)
+
+open Sarek
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module GH = Sarek_gemm.Host
+
+(* ========================== CPU reference ========================== *)
+
+(* c := alpha * a * b + beta * c, row-major, a: MxK, b: KxN, c: MxN. *)
+let cpu_gemm a b c ~m ~n ~k ~alpha ~beta =
+  let out = Array.make (m * n) 0.0 in
+  for row = 0 to m - 1 do
+    for col = 0 to n - 1 do
+      let sum = ref 0.0 in
+      for i = 0 to k - 1 do
+        sum := !sum +. (a.((row * k) + i) *. b.((i * n) + col))
+      done ;
+      out.((row * n) + col) <- (alpha *. !sum) +. (beta *. c.((row * n) + col))
+    done
+  done ;
+  out
+
+(* ========================== naive GPU kernel ========================== *)
+
+(* One thread per output element; same C := alpha*A*B + beta*C contract, for
+   cross-checking the tiled kernel and the perf-ratio note. *)
+let sgemm_naive_kernel =
+  [%kernel
+    fun (a : float32 vector)
+        (b : float32 vector)
+        (c : float32 vector)
+        (m : int32)
+        (n : int32)
+        (k : int32)
+        (alpha : float32)
+        (beta : float32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      let row = tid / n in
+      let col = tid mod n in
+      if row < m && col < n then begin
+        let sum = mut 0.0 in
+        for i = 0 to k - 1l do
+          sum := sum +. (a.((row * k) + i) *. b.((i * n) + col))
+        done ;
+        c.((row * n) + col) <- (alpha *. sum) +. (beta *. c.((row * n) + col))
+      end]
+
+let ir_of (_, kirc) =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "no IR"
+
+let tiled_ir = ir_of Sarek_gemm.sgemm_tiled_kernel
+
+let naive_ir = ir_of sgemm_naive_kernel
+
+(* ========================== host runners ========================== *)
+
+let vec_of a =
+  let v = Vector.create Vector.float32 (Array.length a) in
+  Array.iteri (fun i x -> Vector.set v i x) a ;
+  v
+
+let args a b c ~m ~n ~k ~alpha ~beta =
+  [
+    Execute.Vec a;
+    Execute.Vec b;
+    Execute.Vec c;
+    Execute.Int32 (Int32.of_int m);
+    Execute.Int32 (Int32.of_int n);
+    Execute.Int32 (Int32.of_int k);
+    Execute.Float32 alpha;
+    Execute.Float32 beta;
+  ]
+
+(* Run the tiled kernel; returns (result array, elapsed_ms). c_init seeds C
+   (for the beta term). *)
+let run_tiled dev a_arr b_arr c_init ~m ~n ~k ~alpha ~beta =
+  let a = vec_of a_arr and b = vec_of b_arr and c = vec_of c_init in
+  let t0 = Unix.gettimeofday () in
+  Execute.run_vectors
+    ~device:dev
+    ~ir:tiled_ir
+    ~args:(args a b c ~m ~n ~k ~alpha ~beta)
+    ~block:(GH.block ())
+    ~grid:(GH.grid ~m ~n)
+    ~shared_mem:GH.shared_mem_bytes
+    () ;
+  Transfer.flush dev ;
+  let t1 = Unix.gettimeofday () in
+  (Vector.to_array c, (t1 -. t0) *. 1000.0)
+
+let run_naive dev a_arr b_arr c_init ~m ~n ~k ~alpha ~beta =
+  let a = vec_of a_arr and b = vec_of b_arr and c = vec_of c_init in
+  let block_sz = 256 in
+  let grid_sz = ((m * n) + block_sz - 1) / block_sz in
+  let t0 = Unix.gettimeofday () in
+  Execute.run_vectors
+    ~device:dev
+    ~ir:naive_ir
+    ~args:(args a b c ~m ~n ~k ~alpha ~beta)
+    ~block:(Execute.dims1d block_sz)
+    ~grid:(Execute.dims1d grid_sz)
+    () ;
+  Transfer.flush dev ;
+  let t1 = Unix.gettimeofday () in
+  (Vector.to_array c, (t1 -. t0) *. 1000.0)
+
+(* ========================== verification ========================== *)
+
+(* Tiled accumulation order differs from naive, so compare within a relative
+   epsilon scaled by K (accumulated float32 rounding), not bit-exact. *)
+let close_enough ~k result expected =
+  let n = Array.length expected in
+  let eps = 1e-4 +. (float_of_int k *. 1e-6) in
+  let bad = ref 0 in
+  for i = 0 to n - 1 do
+    let e = expected.(i) and g = result.(i) in
+    let tol = eps *. (1.0 +. abs_float e) in
+    if abs_float (e -. g) > tol then begin
+      if !bad < 4 then
+        Printf.printf "    mismatch @%d: expected %.6f got %.6f\n" i e g ;
+      incr bad
+    end
+  done ;
+  !bad = 0
+
+(* Deterministic pseudo-random-ish fill in [-1,1], reproducible per shape. *)
+let fill rows cols seed =
+  Array.init (rows * cols) (fun i ->
+      let x =
+        float_of_int ((((i * 1103515245) + seed + 12345) mod 1000) - 500)
+      in
+      x /. 500.0)
+
+(* ========================== named cases ========================== *)
+
+type case = {
+  name : string;
+  m : int;
+  n : int;
+  k : int;
+  alpha : float;
+  beta : float;
+}
+
+let cases =
+  [
+    {
+      name = "exact-multiple 32x32x32";
+      m = 32;
+      n = 32;
+      k = 32;
+      alpha = 1.0;
+      beta = 0.0;
+    };
+    {
+      name = "boundary 30x30x30";
+      m = 30;
+      n = 30;
+      k = 30;
+      alpha = 1.0;
+      beta = 0.0;
+    };
+    {
+      name = "boundary 17x17x17";
+      m = 17;
+      n = 17;
+      k = 17;
+      alpha = 1.0;
+      beta = 0.0;
+    };
+    {
+      name = "rectangular 37x50x23";
+      m = 37;
+      n = 50;
+      k = 23;
+      alpha = 1.0;
+      beta = 0.0;
+    };
+    {
+      name = "large 128x96x160";
+      m = 128;
+      n = 96;
+      k = 160;
+      alpha = 1.0;
+      beta = 0.0;
+    };
+    {
+      name = "alpha/beta 40x24x33";
+      m = 40;
+      n = 24;
+      k = 33;
+      alpha = 2.0;
+      beta = 3.0;
+    };
+  ]
+
+let run_case dev {name; m; n; k; alpha; beta} =
+  let a = fill m k 1 and b = fill k n 2 in
+  let c_init = fill m n 3 in
+  let expected = cpu_gemm a b c_init ~m ~n ~k ~alpha ~beta in
+  let tiled, _ = run_tiled dev a b c_init ~m ~n ~k ~alpha ~beta in
+  let ref_ok = close_enough ~k tiled expected in
+  (* Cross-check tiled vs naive on the same inputs. *)
+  let naive, _ = run_naive dev a b c_init ~m ~n ~k ~alpha ~beta in
+  let cross_ok = close_enough ~k tiled naive in
+  if not (ref_ok && cross_ok) then
+    Printf.printf "    [%s] ref_ok=%b cross_ok=%b\n" name ref_ok cross_ok ;
+  ref_ok && cross_ok
+
+(* Tiny hand-checkable products (also boundary: smaller than a tile). *)
+let run_hand_checked dev =
+  (* 2x2: [[1,2],[3,4]] * [[5,6],[7,8]] = [[19,22],[43,50]] *)
+  let a = [|1.; 2.; 3.; 4.|] and b = [|5.; 6.; 7.; 8.|] in
+  let c0 = Array.make 4 0.0 in
+  let got2, _ = run_tiled dev a b c0 ~m:2 ~n:2 ~k:2 ~alpha:1.0 ~beta:0.0 in
+  let exp2 = [|19.; 22.; 43.; 50.|] in
+  let ok2 = close_enough ~k:2 got2 exp2 in
+  (* 3x3: A * I = A *)
+  let a3 = Array.init 9 (fun i -> float_of_int (i + 1)) in
+  let id3 = [|1.; 0.; 0.; 0.; 1.; 0.; 0.; 0.; 1.|] in
+  let c0' = Array.make 9 0.0 in
+  let got3, _ = run_tiled dev a3 id3 c0' ~m:3 ~n:3 ~k:3 ~alpha:1.0 ~beta:0.0 in
+  let ok3 = close_enough ~k:3 got3 a3 in
+  if not (ok2 && ok3) then
+    Printf.printf "    hand-checked ok2=%b ok3=%b\n" ok2 ok3 ;
+  ok2 && ok3
+
+(* ========================== driver ========================== *)
+
+let () =
+  Test_helpers.Benchmarks.init () ;
+  let devices = Device.init () in
+  let all_ok = ref true in
+  Array.iter
+    (fun dev ->
+      let fw = dev.Device.framework in
+      let label = Printf.sprintf "%s (%s)" dev.Device.name fw in
+      if fw = "Interpreter" then
+        Printf.printf "  %-48s : SKIP (no shared memory)\n" label
+      else begin
+        Printf.printf "  %s\n" label ;
+        let ok =
+          try
+            let hand = run_hand_checked dev in
+            let cs = List.map (fun c -> (c.name, run_case dev c)) cases in
+            List.iter
+              (fun (nm, ok) ->
+                Printf.printf
+                  "    %-24s : %s\n"
+                  nm
+                  (if ok then "OK" else "FAIL"))
+              (("hand-checked 2x2/3x3", hand) :: cs) ;
+            hand && List.for_all snd cs
+          with e ->
+            Printf.printf "    EXN: %s\n" (Printexc.to_string e) ;
+            false
+        in
+        if not ok then all_ok := false
+      end)
+    devices ;
+  if !all_ok then print_endline "test_sarek_gemm PASSED"
+  else (
+    print_endline "test_sarek_gemm FAILED" ;
+    exit 1)

--- a/sarek/tests/e2e/test_sarek_gemm.ml
+++ b/sarek/tests/e2e/test_sarek_gemm.ml
@@ -252,6 +252,48 @@ let run_hand_checked dev =
     Printf.printf "    hand-checked ok2=%b ok3=%b\n" ok2 ok3 ;
   ok2 && ok3
 
+(* ========================== perf note (non-gating) ========================== *)
+
+let median xs =
+  let a = Array.of_list xs in
+  Array.sort compare a ;
+  a.(Array.length a / 2)
+
+let best_of ~iters run =
+  let ts = ref [] in
+  for _ = 1 to iters do
+    let _, t = run () in
+    ts := t :: !ts
+  done ;
+  median !ts
+
+let perf_note dev =
+  (* Bigger, compute-bound square on GPUs where tiling actually pays; a modest
+     size on CPU-class devices to keep the note fast. Non-gating. *)
+  let dim = match dev.Device.framework with "Native" -> 384 | _ -> 1024 in
+  let m, n, k = (dim, dim, dim) in
+  let a = fill m k 7 and b = fill k n 9 in
+  let c0 = Array.make (m * n) 0.0 in
+  let _ = run_tiled dev a b c0 ~m ~n ~k ~alpha:1.0 ~beta:0.0 in
+  (* warm-up *)
+  let _ = run_naive dev a b c0 ~m ~n ~k ~alpha:1.0 ~beta:0.0 in
+  let tt =
+    best_of ~iters:5 (fun () ->
+        run_tiled dev a b c0 ~m ~n ~k ~alpha:1.0 ~beta:0.0)
+  in
+  let tn =
+    best_of ~iters:5 (fun () ->
+        run_naive dev a b c0 ~m ~n ~k ~alpha:1.0 ~beta:0.0)
+  in
+  let ratio = if tt > 0.0 then tn /. tt else 0.0 in
+  Printf.printf
+    "    perf %d^3 (median of 5): tiled=%.3fms naive=%.3fms (tiled speedup \
+     %.2fx)\n"
+    dim
+    tt
+    tn
+    ratio
+
 (* ========================== driver ========================== *)
 
 let () =
@@ -277,6 +319,7 @@ let () =
                   nm
                   (if ok then "OK" else "FAIL"))
               (("hand-checked 2x2/3x3", hand) :: cs) ;
+            (try perf_note dev with _ -> ()) ;
             hand && List.for_all snd cs
           with e ->
             Printf.printf "    EXN: %s\n" (Printexc.to_string e) ;


### PR DESCRIPTION
## Summary

Campaign item **L15 STEP 1**: a well-tested, portable shared-memory-tiled matrix-multiply (SGEMM) in **pure Sarek** — FMA accumulation, no tensor cores. This is the baseline that L15b will optionally accelerate with tensor-core `mma`; the API is shaped so that fast path slots behind it unchanged.

New library `sarek/Sarek_gemm/` (`sarek.gemm`) + e2e test `sarek/tests/e2e/test_sarek_gemm.ml`, following the `Sarek_worklist` / `Sarek_df64` `[@sarek.module]` conventions and dune layout.

Computes `C = alpha * A * B + beta * C` for row-major float32 matrices.

## Tiling scheme + tile size

Classic BLOCK×BLOCK, one output element per thread. Output C is partitioned into `tile×tile` blocks; a block of `tile×tile` threads computes one output block. Marching along K in steps of `tile`:
1. **LOAD** superstep — each thread cooperatively loads one A-tile and one B-tile element into shared memory (implicit barrier publishes both tiles);
2. **COMPUTE** superstep — each thread accumulates the tile-length dot product into a private register via `gemm_fma_f32` (fused multiply-add); implicit barrier before the next LOAD overwrites the tiles.

Two barriers per K step (the classic count) via `let%superstep`.

**Default tile = 16×16** → 256 threads/block, 2·16·16·4 = 2 KiB shared. Safe/portable (well under every backend's shared-mem and 1024-thread/block limits). Larger tiles raise reuse but cut occupancy and can exceed CPU-class work-group sizes. Shared extents are compile-time literals in a Sarek kernel, so the tile is fixed per kernel value: the library ships the 16×16 kernel + matching `Host` launch config; a different tile is a one-line edit of the two shared literals + `tile_size` + `Host.tile` (documented as PATTERN).

## Boundary handling

M, N, K need **not** be multiples of the tile and the matrices need **no** padding. The LOAD superstep guards every global read (`row<M`, `col<N`, K-index `<K`) and writes `0.0` into the shared tile on a miss, so out-of-range lanes contribute a genuine zero; the final store is guarded by `row<M && col<N`. Zero-padding the *tile*, not the matrix. This is the classic GEMM boundary bug when omitted, so it is tested explicitly.

## Per-backend + ZLUDA correctness

Verified vs a CPU reference GEMM (K-scaled float32 relative epsilon — tiled accumulation order + FMA fusion differ from naive, so **not** bit-exact) and cross-checked against a naive one-element-per-thread kernel. Cases: hand-checkable 2×2 (known product `[[19,22],[43,50]]`) and 3×3 (identity); exact-multiple 32³; **non-multiple boundary 30³ and 17³**; rectangular 37×50×23; large many-block 128×96×160; alpha/beta (alpha=2, beta=3).

All PASS on:
- **CUDA/PTX via ZLUDA** (RX 7900 XTX + CPU) — `LD_LIBRARY_PATH=$HOME/opt/zluda`
- **OpenCL** (rusticl: RX 7900 XTX + Ryzen CPU)
- **Vulkan** (RADV: RX 7900 XTX + Ryzen CPU)
- **Native** (32-core CPU)
- **Interpreter**: SKIP — no shared-memory/barrier model (same as the reduce/matmul e2e tests).

## Tiled-vs-naive perf (non-gating, end-to-end incl. transfers)

median-of-5, 1024³ on GPUs / 384³ on CPU:

| Device | tiled | naive | speedup |
|---|---|---|---|
| RX 7900 XTX (ZLUDA CUDA/PTX) | 2.28 ms | 4.91 ms | **2.15x** |
| RX 7900 XTX (OpenCL) | 2.21 ms | 4.48 ms | 2.02x |
| RX 7900 XTX (Vulkan) | 3.48 ms | 4.97 ms | 1.43x |
| Ryzen (OpenCL) | 24.8 ms | 111.9 ms | 4.51x |
| Native (384³) | 336 ms | 366 ms | 1.09x |

## API shape (so L15b can extend it)

- `gemm_fma_f32` — the element multiply-accumulate `[@sarek.module]` helper; L15b swaps it for a tensor-core fragment op (or adds f16/df64 twins) with the kernel body unchanged around it.
- `sgemm_tiled_kernel` — the ready `(a b c m n k alpha beta)` kernel value; an mma fast path is a sibling kernel value with the **same argument shape**, so `Host` and every caller are reused unchanged.
- `Host` — tile constant + block/grid/shared-mem launch config, element-type-agnostic.

**L15b (tensor-core mma) slots behind this API** — no caller changes.

## Gates

`dune build @install`, e2e `dune runtest`, and `ocamlformat --check` all green. ≤50-line functions, CECILL-B headers.

Do **not** merge — review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable, tiled float32 matrix multiplication with support for `C = αAB + βC`.
  * Added automatic launch configuration for tile dimensions, grid coverage, and shared memory.
  * Published the GEMM functionality as a reusable library.

* **Tests**
  * Added end-to-end validation across available device backends and varied matrix sizes.
  * Added hand-checked correctness cases and comparative performance reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->