### PR TITLE
feat(real64): portable ~double precision (native f64 / df64 fallback) for Sarek kernels

### DIFF
--- a/sarek/Sarek_real64/Sarek_real64.ml
+++ b/sarek/Sarek_real64/Sarek_real64.ml
@@ -74,9 +74,9 @@ let to_float (x : real64) : float = x
 (** {1 Host reference arithmetic}
 
     Plain binary64 operations on real64 values, for building references and
-    doing host-side combination of results. These are NOT the device ops
-    (those live in the two substrates); they are the "what a correct answer
-    looks like" oracle. *)
+    doing host-side combination of results. These are NOT the device ops (those
+    live in the two substrates); they are the "what a correct answer looks like"
+    oracle. *)
 
 let add (a : real64) (b : real64) : real64 = a +. b
 
@@ -100,26 +100,26 @@ let string_of_substrate = function
   | Fallback_df64 -> "fallback-df64"
 
 (** Substrate a device would use by default: native f64 iff it reports fp64
-    support, df64 otherwise. Pass [~force] to override (used by tests to run
-    the df64 fallback even on fp64-capable hardware, so both lowering paths are
+    support, df64 otherwise. Pass [~force] to override (used by tests to run the
+    df64 fallback even on fp64-capable hardware, so both lowering paths are
     exercised everywhere). *)
 let substrate_for ?force (dev : Device.t) : substrate =
   match force with
   | Some s -> s
   | None -> if Device.allows_fp64 dev then Native_f64 else Fallback_df64
 
-(** Pick one of two per-substrate values (typically the two lowered kernel
-    IRs, but works for anything). *)
+(** Pick one of two per-substrate values (typically the two lowered kernel IRs,
+    but works for anything). *)
 let select (s : substrate) ~(native : 'a) ~(fallback : 'a) : 'a =
   match s with Native_f64 -> native | Fallback_df64 -> fallback
 
 (** {1 Uniform host vectors}
 
     A [real64_vector] hides whether the underlying storage is a float64 vector
-    (native path) or a df64 struct vector (fallback). Callers always
-    read/write plain doubles; encoding/decoding to the df64 pair is done here.
-    [arg] is the ready-to-pass kernel argument (the same physical vector
-    run_vectors transfers to/from the device). *)
+    (native path) or a df64 struct vector (fallback). Callers always read/write
+    plain doubles; encoding/decoding to the df64 pair is done here. [arg] is the
+    ready-to-pass kernel argument (the same physical vector run_vectors
+    transfers to/from the device). *)
 type real64_vector = {
   arg : Sarek.Execute.vector_arg;
   set : int -> float -> unit;

--- a/sarek/Sarek_real64/Sarek_real64.ml
+++ b/sarek/Sarek_real64/Sarek_real64.ml
@@ -1,0 +1,165 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek Real64 - portable "~double precision on every device"
+ *
+ * [real64] is a user-facing abstraction meaning "give me roughly double
+ * precision, whatever the device can do". It selects, PER DEVICE at launch
+ * time, between two concrete substrates that already ship in Sarek:
+ *
+ *   - Native float64 (sarek.float64) on devices that report fp64 support
+ *     (Device.allows_fp64 = true): the real IEEE-754 binary64 path - native
+ *     `double` locals, native `+. -. *. /.`, `Float64.sqrt`, etc.
+ *
+ *   - df64 double-float fallback (sarek.df64) on devices WITHOUT native fp64:
+ *     a pair of float32 carrying ~2x float32 precision, implemented in pure
+ *     Sarek and therefore runnable on every backend.
+ *
+ * The selection is done here, on the host, from the device capability flag;
+ * the two substrates are materialised as two separately-lowered kernels and
+ * the matching one is picked at launch (see {!substrate_for} / {!select}).
+ *
+ * HOST REPRESENTATION
+ *   On the host a real64 value is just an OCaml [float] (binary64). Vectors
+ *   are created through {!create_vector}, which picks the device-appropriate
+ *   storage (a plain float64 vector for the native path, a df64 struct vector
+ *   for the fallback) and exposes a uniform double-precision get/set so caller
+ *   code never sees the representation.
+ *
+ * PRECISION CONTRACT (honest, per substrate)
+ *   - Native f64 path  : full IEEE-754 binary64 (~2^-52 relative), i.e.
+ *     at-least-f64-comparable precision. This is the existing, fully-working
+ *     f64 kernel path (writable f64 literals via the `G` suffix since PR #240).
+ *   - df64 fallback    : ~2^-47..2^-46 relative on backends with IEEE-exact
+ *     float32 + fma (OpenCL, CUDA/PTX, Interpreter) - "significantly better
+ *     than f32, near-f64". Exponent range is that of float32, NOT binary64,
+ *     and results are NOT bit-exact with binary64. On Native the error-free
+ *     transformations collapse to plain f32 storage precision (~2^-24), and
+ *     on Vulkan mul/div currently degrade likewise (see Sarek_df64 for the
+ *     full per-backend table). These are the df64 contract's known
+ *     deviations, inherited verbatim.
+ *
+ * EXPOSED OPERATION SET
+ *   The op set is the INTERSECTION of what both substrates provide:
+ *   of_float / to_float, add / sub / mul / div, and sqrt. df64 has no
+ *   transcendentals (sin/cos/exp/log/...), so real64 does NOT expose them -
+ *   promising them would be a lie on the fallback path.
+ *
+ * AUTHORING KERNELS (palier A - see the deviation note below)
+ *   A single [%kernel] produces ONE lowered IR with ONE concrete element
+ *   type, so a real64 kernel is authored as a PAIR: a native-f64 body (over
+ *   `float64 vector`, using Float64 ops) and a df64 body (over
+ *   `Sarek_df64.df64 vector`, using the df64 ops pulled in with
+ *   %sarek_include). Both are built once; {!select} picks the IR to launch
+ *   from the device's substrate. The host plumbing here (vector
+ *   materialisation, dispatch, readback) is what makes the two bodies feel
+ *   like one abstraction to the caller. See sarek/tests/e2e/test_real64.ml
+ *   for the canonical usage.
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+
+(** A real64 value on the host is a binary64 float. *)
+type real64 = float
+
+(** Identity host conversions - the host always carries full binary64. *)
+let of_float (x : float) : real64 = x
+
+let to_float (x : real64) : float = x
+
+(** {1 Host reference arithmetic}
+
+    Plain binary64 operations on real64 values, for building references and
+    doing host-side combination of results. These are NOT the device ops
+    (those live in the two substrates); they are the "what a correct answer
+    looks like" oracle. *)
+
+let add (a : real64) (b : real64) : real64 = a +. b
+
+let sub (a : real64) (b : real64) : real64 = a -. b
+
+let mul (a : real64) (b : real64) : real64 = a *. b
+
+let div (a : real64) (b : real64) : real64 = a /. b
+
+let sqrt (a : real64) : real64 = Stdlib.sqrt a
+
+(** {1 Substrate selection} *)
+
+(** The two concrete lowerings [real64] can take on a device. *)
+type substrate =
+  | Native_f64  (** native IEEE-754 binary64 (device has fp64) *)
+  | Fallback_df64  (** double-float emulation (device lacks fp64) *)
+
+let string_of_substrate = function
+  | Native_f64 -> "native-f64"
+  | Fallback_df64 -> "fallback-df64"
+
+(** Substrate a device would use by default: native f64 iff it reports fp64
+    support, df64 otherwise. Pass [~force] to override (used by tests to run
+    the df64 fallback even on fp64-capable hardware, so both lowering paths are
+    exercised everywhere). *)
+let substrate_for ?force (dev : Device.t) : substrate =
+  match force with
+  | Some s -> s
+  | None -> if Device.allows_fp64 dev then Native_f64 else Fallback_df64
+
+(** Pick one of two per-substrate values (typically the two lowered kernel
+    IRs, but works for anything). *)
+let select (s : substrate) ~(native : 'a) ~(fallback : 'a) : 'a =
+  match s with Native_f64 -> native | Fallback_df64 -> fallback
+
+(** {1 Uniform host vectors}
+
+    A [real64_vector] hides whether the underlying storage is a float64 vector
+    (native path) or a df64 struct vector (fallback). Callers always
+    read/write plain doubles; encoding/decoding to the df64 pair is done here.
+    [arg] is the ready-to-pass kernel argument (the same physical vector
+    run_vectors transfers to/from the device). *)
+type real64_vector = {
+  arg : Sarek.Execute.vector_arg;
+  set : int -> float -> unit;
+  get : int -> float;
+  length : int;
+}
+
+(** Create an [n]-element real64 vector in the storage matching [substrate]. *)
+let create_vector (substrate : substrate) (n : int) : real64_vector =
+  match substrate with
+  | Native_f64 ->
+      let v = Vector.create Vector.float64 n in
+      {
+        arg = Sarek.Execute.Vec v;
+        set = (fun i x -> Vector.set v i x);
+        get = (fun i -> Vector.get v i);
+        length = n;
+      }
+  | Fallback_df64 ->
+      let v = Vector.create_custom Sarek_df64.df64_custom n in
+      {
+        arg = Sarek.Execute.Vec v;
+        set = (fun i x -> Vector.set v i (Sarek_df64.Host.encode x));
+        get = (fun i -> Sarek_df64.Host.decode (Vector.get v i));
+        length = n;
+      }
+
+let vset (rv : real64_vector) (i : int) (x : float) : unit = rv.set i x
+
+let vget (rv : real64_vector) (i : int) : float = rv.get i
+
+let vlength (rv : real64_vector) : int = rv.length
+
+let arg_of (rv : real64_vector) : Sarek.Execute.vector_arg = rv.arg
+
+(** {1 Substrate re-exports for kernel authors}
+
+    The fallback kernel body pulls df64 ops in with
+    [let%sarek_include _ = ".../Sarek_df64.ml"] and [let open Sarek_df64 in];
+    the native body uses [Float64]. Re-exported here for discoverability. *)
+
+module Df64 = Sarek_df64
+module Float64 = Sarek_float64.Float64

--- a/sarek/Sarek_real64/dune
+++ b/sarek/Sarek_real64/dune
@@ -1,0 +1,4 @@
+(library
+ (name sarek_real64)
+ (public_name sarek.real64)
+ (libraries sarek sarek_stdlib sarek_df64 sarek_float64 spoc_core))

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -560,6 +560,30 @@
   (run %{dep:test_df64.exe})))
 
 (executable
+ (name test_real64)
+ (modules test_real64)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek.df64
+  sarek.float64
+  sarek.real64
+  spoc_core
+  test_helpers
+  unix)
+ (preprocessor_deps
+  (file ../../Sarek_df64/Sarek_df64.ml))
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_real64.exe})))
+
+(executable
  (name test_worklist)
  (modules test_worklist)
  (libraries sarek sarek.stdlib sarek.worklist spoc_core test_helpers unix)

--- a/sarek/tests/e2e/test_real64.ml
+++ b/sarek/tests/e2e/test_real64.ml
@@ -1,0 +1,251 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for Sarek_real64 - portable "~double precision on every device".
+ *
+ * real64 selects, per device, between two concrete lowerings:
+ *   - native IEEE-754 binary64 (Sarek_float64) on fp64-capable devices, and
+ *   - the df64 double-float fallback (Sarek_df64) on devices without fp64.
+ *
+ * Because a single [%kernel] lowers to ONE concrete element type, the compute
+ * is authored as a PAIR - a float64 body and a df64 body - and Sarek_real64
+ * picks the matching IR at launch (Real64.select) and materialises the
+ * device-appropriate vector storage (Real64.create_vector). To the test
+ * driver both paths look identical: fill/read plain doubles, launch, compare.
+ *
+ * On EVERY available device this runs TWO passes:
+ *   1. the device's DEFAULT substrate (native f64 where supported, else df64);
+ *   2. the df64 fallback FORCED (Real64.substrate_for ~force:Fallback_df64),
+ *      so the emulation lowering path is exercised even on fp64 hardware.
+ *
+ * Each pass checks elementwise add / sub / mul / div / sqrt against an OCaml
+ * binary64 reference computed from the exact values the device saw (the df64
+ * path stores inputs at ~48-bit precision, so the oracle reads them back).
+ * Tolerances follow the substrate's honest contract (see [tol_for]).
+ ******************************************************************************)
+
+[@@@warning "-32-33-34-69"]
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Execute = Sarek.Execute
+module Real64 = Sarek_real64
+
+type float32 = float
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+let () = Test_helpers.Benchmarks.init ()
+
+(* df64 [@sarek.module] ops for the fallback kernel body. *)
+let%sarek_include _ = "../../Sarek_df64/Sarek_df64.ml"
+
+(* ========== The two lowered kernel bodies (one algorithm, two substrates) == *)
+
+(* Native f64 body: real IEEE-754 binary64. Float64 ops + `G`-suffix literals. *)
+let f64_ops_kernel =
+  [%kernel
+    fun (a : float64 vector)
+        (b : float64 vector)
+        (c : float64 vector)
+        (add_o : float64 vector)
+        (sub_o : float64 vector)
+        (mul_o : float64 vector)
+        (div_o : float64 vector)
+        (sqrt_o : float64 vector)
+        (nn : int32) ->
+      let open Sarek_float64 in
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < nn then begin
+        let x = a.(tid) in
+        let y = b.(tid) in
+        add_o.(tid) <- x +. y ;
+        sub_o.(tid) <- x -. y ;
+        mul_o.(tid) <- x *. y ;
+        div_o.(tid) <- x /. y ;
+        sqrt_o.(tid) <- Float64.sqrt c.(tid)
+      end]
+
+(* df64 fallback body: double-float over pairs of float32. Same algorithm. *)
+let df64_ops_kernel =
+  [%kernel
+    fun (a : Sarek_df64.df64 vector)
+        (b : Sarek_df64.df64 vector)
+        (c : Sarek_df64.df64 vector)
+        (add_o : Sarek_df64.df64 vector)
+        (sub_o : Sarek_df64.df64 vector)
+        (mul_o : Sarek_df64.df64 vector)
+        (div_o : Sarek_df64.df64 vector)
+        (sqrt_o : Sarek_df64.df64 vector)
+        (nn : int32) ->
+      let open Sarek_df64 in
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < nn then begin
+        let x = a.(tid) in
+        let y = b.(tid) in
+        add_o.(tid) <- df64_add x y ;
+        sub_o.(tid) <- df64_sub x y ;
+        mul_o.(tid) <- df64_mul x y ;
+        div_o.(tid) <- df64_div x y ;
+        sqrt_o.(tid) <- df64_sqrt c.(tid)
+      end]
+
+let ir_of (_, kirc) =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+(* ========== Inputs and reference ========== *)
+
+let n = 4096
+
+let inputs =
+  Random.init 0x5ea1 ;
+  let logu emin emax =
+    let e = emin +. Random.float (emax -. emin) in
+    let m = 1.0 +. Random.float 9.0 in
+    let s = if Random.bool () then 1.0 else -1.0 in
+    s *. m *. (10.0 ** e)
+  in
+  let a = Array.init n (fun _ -> logu (-6.0) 6.0) in
+  let b = Array.init n (fun _ -> logu (-3.0) 3.0) in
+  (a, b)
+
+let rel_error got expected =
+  if expected = 0.0 then Stdlib.abs_float got
+  else Stdlib.abs_float ((got -. expected) /. expected)
+
+(* Per-op relative tolerance for a (substrate, framework). Native f64 gets the
+   full binary64 contract; df64 follows Sarek_df64's per-backend table (Native
+   and Vulkan mul/div collapse to f32 storage precision - a documented,
+   inherited deviation, not a silent widening). *)
+let f32_tol = 0x1p-22
+
+let tol_for ~(substrate : Real64.substrate) ~framework ~op =
+  match substrate with
+  | Real64.Native_f64 -> 1e-12
+  | Real64.Fallback_df64 -> (
+      let base =
+        match op with
+        | "add" | "sub" -> 0x1p-47
+        | _ -> 0x1p-46 (* mul / div / sqrt *)
+      in
+      match (framework, op) with
+      | "Native", _ -> f32_tol
+      | "Vulkan", ("mul" | "div") -> f32_tol
+      | _ -> base)
+
+(* ========== One pass on one device with one substrate ========== *)
+
+let failures = ref 0
+
+let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
+  let a_data, b_data = inputs in
+  let mk () = Real64.create_vector substrate n in
+  let a = mk () and b = mk () and c = mk () in
+  let add_o = mk () and sub_o = mk () and mul_o = mk () in
+  let div_o = mk () and sqrt_o = mk () in
+  for i = 0 to n - 1 do
+    Real64.vset a i a_data.(i) ;
+    Real64.vset b i b_data.(i) ;
+    (* Dedicated nonnegative input for sqrt (avoids an abs intrinsic, which
+       does not lower on GLSL). *)
+    Real64.vset c i (Stdlib.abs_float a_data.(i))
+  done ;
+  let ir =
+    Real64.select
+      substrate
+      ~native:(ir_of f64_ops_kernel)
+      ~fallback:(ir_of df64_ops_kernel)
+  in
+  let block = Execute.dims1d 256 in
+  let grid = Execute.dims1d ((n + 255) / 256) in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:
+      [
+        Real64.arg_of a;
+        Real64.arg_of b;
+        Real64.arg_of c;
+        Real64.arg_of add_o;
+        Real64.arg_of sub_o;
+        Real64.arg_of mul_o;
+        Real64.arg_of div_o;
+        Real64.arg_of sqrt_o;
+        Execute.Int n;
+      ]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let framework = dev.Device.framework in
+  let worst = Hashtbl.create 8 in
+  let check op got expected =
+    let err =
+      if Float.is_nan got then Float.infinity else rel_error got expected
+    in
+    let prev = try Hashtbl.find worst op with Not_found -> 0.0 in
+    if err > prev then Hashtbl.replace worst op err
+  in
+  for i = 0 to n - 1 do
+    (* Reference from the values the device actually saw (df64 stores inputs
+       at ~48-bit precision; vget decodes them exactly). *)
+    let x = Real64.vget a i and y = Real64.vget b i in
+    let cx = Real64.vget c i in
+    check "add" (Real64.vget add_o i) (x +. y) ;
+    check "sub" (Real64.vget sub_o i) (x -. y) ;
+    check "mul" (Real64.vget mul_o i) (x *. y) ;
+    check "div" (Real64.vget div_o i) (x /. y) ;
+    check "sqrt" (Real64.vget sqrt_o i) (Stdlib.sqrt cx)
+  done ;
+  Printf.printf
+    "  [%s / %s]\n%!"
+    framework
+    (Real64.string_of_substrate substrate) ;
+  List.iter
+    (fun op ->
+      let err = try Hashtbl.find worst op with Not_found -> 0.0 in
+      let tol = tol_for ~substrate ~framework ~op in
+      let ok = err <= tol in
+      if not ok then incr failures ;
+      Printf.printf
+        "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
+        op
+        err
+        tol
+        (if ok then "PASS" else "FAIL"))
+    ["add"; "sub"; "mul"; "div"; "sqrt"]
+
+(* ========== Main ========== *)
+
+let () =
+  let devs = Device.init () in
+  if Array.length devs = 0 then begin
+    print_endline "No devices found - SKIPPED" ;
+    exit 0
+  end ;
+  Array.iter
+    (fun (dev : Device.t) ->
+      Printf.printf
+        "Device: %s [%s]  fp64=%b\n%!"
+        dev.Device.name
+        dev.Device.framework
+        (Device.allows_fp64 dev) ;
+      (* Pass 1: the device's default substrate. *)
+      run_pass dev ~substrate:(Real64.substrate_for dev) ;
+      (* Pass 2: force the df64 fallback, so the emulation lowering path runs
+         on EVERY device including fp64-capable ones. *)
+      run_pass
+        dev
+        ~substrate:(Real64.substrate_for ~force:Real64.Fallback_df64 dev))
+    devs ;
+  if !failures = 0 then print_endline "test_real64 PASSED"
+  else begin
+    Printf.printf "test_real64 FAILED (%d failures)\n" !failures ;
+    exit 1
+  end


### PR DESCRIPTION
## What

Introduces **`real64`** (new library `sarek.real64`), a user-facing abstraction meaning *"give me ~double precision on every device"*. Per device, at launch time, it selects between two substrates that already ship in Sarek:

- **Native IEEE-754 binary64** (`sarek.float64`) on fp64-capable devices (`Device.allows_fp64 = true`) — the real double path (native `double`, `+. -. *. /.`, `Float64.sqrt`).
- **df64 double-float fallback** (`sarek.df64`) on devices without native fp64 — pairs of float32, pure-Sarek, runs on every backend.

Selection is host-side off the existing capability flag `Device.allows_fp64`.

### API (`Sarek_real64`)
- `real64 = float`; `of_float` / `to_float`; host reference `add/sub/mul/div/sqrt`.
- `substrate` (`Native_f64 | Fallback_df64`), `substrate_for ?force dev`, `select ~native ~fallback`.
- `real64_vector`: uniform double get/set (`vset`/`vget`) over device-appropriate storage (float64 vector vs df64 struct vector) + a ready-to-launch `arg_of`.

The exposed op set is the **intersection** of both substrates: `of_float/to_float, +, -, *, /, sqrt`. No transcendentals — df64 has none, so promising them would be a lie on the fallback.

### Precision contract (honest)
- Native f64: full binary64 (~2^-52), "at least f64-comparable".
- df64: ~2^-47..2^-46 on OpenCL/CUDA-PTX/Interpreter ("significantly better than f32, near-f64"); float32 exponent range; **not** bit-exact with binary64. Collapses to f32 storage precision (~2^-24) on Native and for mul/div on Vulkan — Sarek_df64's documented, inherited deviations.

## Test — `sarek/tests/e2e/test_real64.ml` (wired into `runtest`)

Same add/sub/mul/div/sqrt algorithm authored as a native-f64 kernel and a df64 kernel; driven through Sarek_real64 (uniform vectors + `select`). **Two passes per device**: (1) default substrate, (2) **df64 fallback forced**, so the emulation lowering path runs even on fp64 hardware. Each op checked against an OCaml binary64 reference read back from the values the device actually saw, with per-substrate/per-framework tolerances.

## Validation (GPU, RX 7900 XTX)

`dune build @install`, `dune fmt` (clean on new files), `dune runtest sarek/tests` all green.

Device × substrate matrix — **all PASS**:

| Device (framework) | native-f64 | df64 fallback (forced) |
|---|---|---|
| CUDA/PTX (ZLUDA, RX 7900 XTX) | PASS | PASS |
| CUDA/PTX (ZLUDA, iGPU) | PASS | PASS |
| Vulkan (RADV NAVI31) | PASS | PASS |
| Vulkan (RADV iGPU) | PASS | PASS |
| OpenCL (fp64=false → df64 default) | n/a | PASS |
| Native | PASS | PASS (f32-level) |
| Interpreter | PASS | PASS |

ZLUDA run: `LD_LIBRARY_PATH=$HOME/opt/zluda ./…/test_real64.exe` → `test_real64 PASSED`, 90 op-checks PASS, exit 0.

## Deviation / follow-up (palier A)

A single `[%kernel]` lowers to **one** concrete element type, so the compute is authored as a **pair** (an f64 body + a df64 body) and `select` picks the IR at launch. The host plumbing makes the two bodies feel like one abstraction to the caller, but a true single-source dual-lowering (one kernel AST → both variants, resolved per-device at JIT codegen via a `real64` IR type) is left as follow-up — it needs IR/codegen surgery across all backends and would balloon this PR.

Minor: `sqrt` takes a dedicated nonnegative input rather than an abs intrinsic, because `Float64.abs_float` has no GLSL lowering (emits the raw OCaml path) — a pre-existing backend gap, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)