### PR TITLE
L12: Tier-0 defunctionalization of function values in Sarek kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,8 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tuple_param.cma > "$$out" 2>&1; if grep -q "Tuple-typed kernel parameters are not supported" "$$out"; then echo "  PASS: tuple param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing function-typed kernel parameter rejection..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_param.cma > "$$out" 2>&1; if grep -q "Function-typed kernel parameters are not supported" "$$out"; then echo "  PASS: function param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing escaping function-value rejection (L12 defunctionalization)..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_escape.cma > "$$out" 2>&1; if grep -q "Function value escapes" "$$out"; then echo "  PASS: escaping function value rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "All negative tests checked (see KNOWN-ISSUE line above for the one non-blocking gap, if any)"
 
 

--- a/sarek/ppx/Sarek_defunc.ml
+++ b/sarek/ppx/Sarek_defunc.ml
@@ -54,15 +54,6 @@ let is_fun_typed (e : texpr) : bool =
 
 let is_fun_ty (t : typ) : bool = match repr t with TFun _ -> true | _ -> false
 
-(** An expression cheap enough to duplicate without changing evaluation
-    semantics (no side effects, no re-computation cost worth a temporary). *)
-let is_atomic (e : texpr) : bool =
-  match e.te with
-  | TEVar _ | TEUnit | TEBool _ | TEInt _ | TEInt32 _ | TEInt64 _ | TEFloat _
-  | TEDouble _ | TEIntrinsicConst _ | TEGlobalRef _ ->
-      true
-  | _ -> false
-
 (* -------------------------------------------------------------------------- *)
 (* Core rewrite                                                               *)
 (* -------------------------------------------------------------------------- *)
@@ -194,43 +185,16 @@ and rewrite_fexpr (fenv : (int, texpr) Hashtbl.t) (fe : texpr) : texpr =
          as a leaf and lowering/codegen will handle or reject it as today. *)
       rewrite fenv fe
 
-(* Does this selector branch (so that duplicating the arguments across its
-   leaves would re-evaluate them)? *)
-and is_branching (sel : texpr) : bool =
-  match sel.te with
-  | TEIf _ | TEMatch _ -> true
-  | TELet (_, _, _, b) | TEOpen (_, b) -> is_branching b
-  | TESeq es -> (
-      match List.rev es with last :: _ -> is_branching last | [] -> false)
-  | _ -> false
-
-(* Push [args] down to every leaf of [sel], producing an expression of type
-   [ty]. If [sel] branches, bind non-atomic arguments to fresh temporaries
-   first so they are evaluated exactly once. *)
+(* Push [args] down to every leaf of a selector. The selector's branches
+   (if/match arms) are mutually exclusive, so at runtime exactly one leaf
+   executes and each argument is evaluated exactly as many times as in the
+   source `f args` -- distribution duplicates arguments only *textually*, never
+   at runtime, so no fresh temporaries are needed. This also keeps the result a
+   plain expression (introducing `let` bindings here would place a
+   statement-only form in expression position and break lowering). *)
 and distribute_app (sel : texpr) (args : texpr list) (ty : typ) (loc : loc) :
     texpr =
-  if is_branching sel then begin
-    (* Bind non-atomic args once. *)
-    let binds = ref [] in
-    let args' =
-      List.map
-        (fun a ->
-          if is_atomic a then a
-          else begin
-            let id = fresh_var_id () in
-            let name = Printf.sprintf "__df_arg%d" id in
-            binds := (name, id, a) :: !binds ;
-            mk_texpr (TEVar (name, id)) a.ty a.te_loc
-          end)
-        args
-    in
-    let dispatched = push_args sel args' ty loc in
-    List.fold_left
-      (fun acc (name, id, v) -> mk_texpr (TELet (name, id, v, acc)) ty loc)
-      dispatched
-      !binds
-  end
-  else push_args sel args ty loc
+  push_args sel args ty loc
 
 (* Recursively descend a selector's spine, applying [args] at each leaf. *)
 and push_args (sel : texpr) (args : texpr list) (ty : typ) (loc : loc) : texpr =

--- a/sarek/ppx/Sarek_defunc.ml
+++ b/sarek/ppx/Sarek_defunc.ml
@@ -1,0 +1,390 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek PPX - Defunctionalization pass (Tier 0)
+ *
+ * Typed-AST -> typed-AST rewrite that runs between monomorphization
+ * (Sarek_mono) and lowering (Sarek_lower_ir). It eliminates first-class
+ * function *values* that are bound to `let` variables inside a kernel or
+ * helper body, so that lowering never has to emit an `EApp` whose callee is
+ * anything other than a directly-named helper.
+ *
+ * Design: L12-defunctionalization.md (roster/ptx-limits-campaign). This
+ * implements the capture-free Tier 0 subset via *application distribution*
+ * rather than a synthesized Reynolds tag variant:
+ *
+ *   - `let f = g in ... f x ...`         (single static candidate, L12 4.1)
+ *       -> the binding is dropped and every `f a...` becomes `g a...`,
+ *          i.e. a direct named call that lowering already handles.
+ *
+ *   - `let f = if c then g else h in f x` (genuinely runtime-dynamic, L12 4.2)
+ *       -> the application is *distributed into the selector's leaves*:
+ *          `if c then g x else h x`. Only direct named calls remain; no
+ *          function value ever reaches lowering and no tag variant is
+ *          synthesized, so every backend's existing `if`/`match` + direct
+ *          call paths handle it with zero emitter changes.
+ *
+ * This covers the two headline examples in L12 1 (the ones that fail today
+ * with "EApp to unknown function" / "EApp with non-variable callee"). It is
+ * capture-free: the candidate leaves must be named helpers (module
+ * `[@sarek.module]` functions or kernel-local `let rec` helpers), never a
+ * lambda closing over kernel-local state. Scalar captures (L12 Tier 1),
+ * aggregate captures (Tier 2) and specialization of higher-order *helper
+ * parameters* (`sort ~cmp:my_less`) are out of scope for this milestone and
+ * documented as follow-ups in the design doc.
+ *
+ * Escape rules (L12 5): after rewriting, any residual function-typed value
+ * sitting in a position that has no runtime representation (record field,
+ * tuple/vector element, variant payload, created-array element, or an
+ * assignment/return value) is reported as `Function_value_escapes` with a
+ * source location, instead of being left to fail with an opaque codegen
+ * message three passes downstream.
+ ******************************************************************************)
+
+open Sarek_ast
+open Sarek_types
+open Sarek_typed_ast
+
+(** Is the top constructor of this expression's type a function type? *)
+let is_fun_typed (e : texpr) : bool =
+  match repr e.ty with TFun _ -> true | _ -> false
+
+let is_fun_ty (t : typ) : bool = match repr t with TFun _ -> true | _ -> false
+
+(** An expression cheap enough to duplicate without changing evaluation
+    semantics (no side effects, no re-computation cost worth a temporary). *)
+let is_atomic (e : texpr) : bool =
+  match e.te with
+  | TEVar _ | TEUnit | TEBool _ | TEInt _ | TEInt32 _ | TEInt64 _ | TEFloat _
+  | TEDouble _ | TEIntrinsicConst _ | TEGlobalRef _ ->
+      true
+  | _ -> false
+
+(* -------------------------------------------------------------------------- *)
+(* Core rewrite                                                               *)
+(* -------------------------------------------------------------------------- *)
+
+(* [fenv] maps the variable id of a function-typed `let` binding to the
+   (already-rewritten) selector expression it was bound to. A selector is a
+   texpr whose "leaves" (reached through if/match/let/open/seq spines) are the
+   concrete callee expressions to apply the arguments to. *)
+
+let rec rewrite (fenv : (int, texpr) Hashtbl.t) (e : texpr) : texpr =
+  match e.te with
+  (* Drop a function-typed let binding, recording its selector so uses of the
+     bound variable resolve to it. *)
+  | TELet (_name, id, value, body) when is_fun_typed value ->
+      let sel = rewrite_fexpr fenv value in
+      Hashtbl.replace fenv id sel ;
+      let body' = rewrite fenv body in
+      Hashtbl.remove fenv id ;
+      body'
+  (* Application: resolve the callee to a selector and distribute. *)
+  | TEApp (callee, args) ->
+      let args' = List.map (rewrite fenv) args in
+      let sel = resolve_callee fenv callee in
+      distribute_app sel args' e.ty e.te_loc
+  (* A bare use of a function-typed local (not in callee position) has no
+     runtime representation under Tier 0 -- report it as an escape. *)
+  | TEVar (name, id) when is_fun_typed e && Hashtbl.mem fenv id ->
+      Sarek_error.raise_error
+        (Sarek_error.Function_value_escapes
+           ( Printf.sprintf
+               "function value '%s' is used where no runtime representation \
+                exists (it may only be applied to arguments)"
+               name,
+             e.ty,
+             e.te_loc ))
+  | _ -> {e with te = rewrite_desc fenv e.te}
+
+(* Structural recursion for every constructor that is not special-cased in
+   [rewrite]. Mirrors Sarek_mono.apply_subst_expr's shape. *)
+and rewrite_desc (fenv : (int, texpr) Hashtbl.t) (te : texpr_desc) : texpr_desc
+    =
+  let r = rewrite fenv in
+  match te with
+  | TEUnit | TEBool _ | TEInt _ | TEInt32 _ | TEInt64 _ | TEFloat _ | TEDouble _
+  | TEGlobalRef _ | TENative _ | TEIntrinsicConst _ | TEVar _ ->
+      te
+  | TEVecGet (v, i) -> TEVecGet (r v, r i)
+  | TEVecSet (v, i, x) -> TEVecSet (r v, r i, r x)
+  | TEArrGet (a, i) -> TEArrGet (r a, r i)
+  | TEArrSet (a, i, x) -> TEArrSet (r a, r i, r x)
+  | TEFieldGet (rec_, f, idx) -> TEFieldGet (r rec_, f, idx)
+  | TEFieldSet (rec_, f, idx, v) -> TEFieldSet (r rec_, f, idx, r v)
+  | TEBinop (op, a, b) -> TEBinop (op, r a, r b)
+  | TEUnop (op, a) -> TEUnop (op, r a)
+  | TEApp (fn, args) -> TEApp (r fn, List.map r args)
+  | TEAssign (n, id, v) -> TEAssign (n, id, r v)
+  | TELet (n, id, v, b) -> TELet (n, id, r v, r b)
+  | TELetRec (n, id, params, fn_body, cont) ->
+      TELetRec (n, id, params, r fn_body, r cont)
+  | TELetMut (n, id, v, b) -> TELetMut (n, id, r v, r b)
+  | TEIf (c, t, e) -> TEIf (r c, r t, Option.map r e)
+  | TEFor (v, id, lo, hi, dir, body) -> TEFor (v, id, r lo, r hi, dir, r body)
+  | TEWhile (c, b) -> TEWhile (r c, r b)
+  | TESeq es -> TESeq (List.map r es)
+  | TEMatch (s, cases) -> TEMatch (r s, List.map (fun (p, b) -> (p, r b)) cases)
+  | TERecord (n, fields) ->
+      TERecord (n, List.map (fun (f, e) -> (f, r e)) fields)
+  | TEConstr (tn, cn, arg) -> TEConstr (tn, cn, Option.map r arg)
+  | TETuple es -> TETuple (List.map r es)
+  | TEReturn e -> TEReturn (r e)
+  | TECreateArray (size, t, m) -> TECreateArray (r size, t, m)
+  | TEPragma (opts, body) -> TEPragma (opts, r body)
+  | TEIntrinsicFun (ref, c, args) -> TEIntrinsicFun (ref, c, List.map r args)
+  | TELetShared (n, id, t, size, b) ->
+      TELetShared (n, id, t, Option.map r size, r b)
+  | TESuperstep (n, d, step, cont) -> TESuperstep (n, d, r step, r cont)
+  | TEOpen (path, body) -> TEOpen (path, r body)
+
+(* Resolve the callee of an application to a fully-rewritten selector. *)
+and resolve_callee (fenv : (int, texpr) Hashtbl.t) (callee : texpr) : texpr =
+  match callee.te with
+  | TEVar (_, id) when Hashtbl.mem fenv id -> Hashtbl.find fenv id
+  | (TEIf _ | TEMatch _ | TELet _ | TEOpen _ | TESeq _) when is_fun_typed callee
+    ->
+      rewrite_fexpr fenv callee
+  | _ -> rewrite fenv callee
+
+(* Rewrite a function-valued expression into a selector: conditions and
+   scrutinees are rewritten normally; the function-typed result positions are
+   rewritten recursively; TEVar leaves are resolved through [fenv]. *)
+and rewrite_fexpr (fenv : (int, texpr) Hashtbl.t) (fe : texpr) : texpr =
+  match fe.te with
+  | TEVar (_, id) when Hashtbl.mem fenv id -> Hashtbl.find fenv id
+  | TEVar _ -> fe (* named helper leaf *)
+  | TEIf (c, t, Some el) ->
+      {
+        fe with
+        te =
+          TEIf
+            (rewrite fenv c, rewrite_fexpr fenv t, Some (rewrite_fexpr fenv el));
+      }
+  | TEMatch (s, cases) ->
+      {
+        fe with
+        te =
+          TEMatch
+            ( rewrite fenv s,
+              List.map (fun (p, b) -> (p, rewrite_fexpr fenv b)) cases );
+      }
+  | TELet (n, id, v, b) when not (is_fun_typed v) ->
+      {fe with te = TELet (n, id, rewrite fenv v, rewrite_fexpr fenv b)}
+  | TELet (_n, id, v, b) ->
+      (* nested function-typed let inside a selector: register and drop *)
+      let sel = rewrite_fexpr fenv v in
+      Hashtbl.replace fenv id sel ;
+      let b' = rewrite_fexpr fenv b in
+      Hashtbl.remove fenv id ;
+      b'
+  | TEOpen (path, b) -> {fe with te = TEOpen (path, rewrite_fexpr fenv b)}
+  | TESeq es -> (
+      match List.rev es with
+      | [] -> fe
+      | last :: rest_rev ->
+          let init = List.rev_map (rewrite fenv) rest_rev in
+          {fe with te = TESeq (init @ [rewrite_fexpr fenv last])})
+  | _ ->
+      (* Not a recognized function-value shape (e.g. a helper parameter used
+         directly). Leave it to the normal rewrite; distribution will keep it
+         as a leaf and lowering/codegen will handle or reject it as today. *)
+      rewrite fenv fe
+
+(* Does this selector branch (so that duplicating the arguments across its
+   leaves would re-evaluate them)? *)
+and is_branching (sel : texpr) : bool =
+  match sel.te with
+  | TEIf _ | TEMatch _ -> true
+  | TELet (_, _, _, b) | TEOpen (_, b) -> is_branching b
+  | TESeq es -> (
+      match List.rev es with last :: _ -> is_branching last | [] -> false)
+  | _ -> false
+
+(* Push [args] down to every leaf of [sel], producing an expression of type
+   [ty]. If [sel] branches, bind non-atomic arguments to fresh temporaries
+   first so they are evaluated exactly once. *)
+and distribute_app (sel : texpr) (args : texpr list) (ty : typ) (loc : loc) :
+    texpr =
+  if is_branching sel then begin
+    (* Bind non-atomic args once. *)
+    let binds = ref [] in
+    let args' =
+      List.map
+        (fun a ->
+          if is_atomic a then a
+          else begin
+            let id = fresh_var_id () in
+            let name = Printf.sprintf "__df_arg%d" id in
+            binds := (name, id, a) :: !binds ;
+            mk_texpr (TEVar (name, id)) a.ty a.te_loc
+          end)
+        args
+    in
+    let dispatched = push_args sel args' ty loc in
+    List.fold_left
+      (fun acc (name, id, v) -> mk_texpr (TELet (name, id, v, acc)) ty loc)
+      dispatched
+      !binds
+  end
+  else push_args sel args ty loc
+
+(* Recursively descend a selector's spine, applying [args] at each leaf. *)
+and push_args (sel : texpr) (args : texpr list) (ty : typ) (loc : loc) : texpr =
+  match sel.te with
+  | TEIf (c, t, Some el) ->
+      mk_texpr
+        (TEIf (c, push_args t args ty loc, Some (push_args el args ty loc)))
+        ty
+        loc
+  | TEMatch (s, cases) ->
+      mk_texpr
+        (TEMatch (s, List.map (fun (p, b) -> (p, push_args b args ty loc)) cases))
+        ty
+        loc
+  | TELet (n, id, v, b) ->
+      mk_texpr (TELet (n, id, v, push_args b args ty loc)) ty loc
+  | TEOpen (path, b) -> mk_texpr (TEOpen (path, push_args b args ty loc)) ty loc
+  | TESeq es -> (
+      match List.rev es with
+      | [] -> mk_texpr (TEApp (sel, args)) ty loc
+      | last :: rest_rev ->
+          let init = List.rev rest_rev in
+          mk_texpr (TESeq (init @ [push_args last args ty loc])) ty loc)
+  | _ ->
+      (* Leaf: a directly-named callee. *)
+      mk_texpr (TEApp (sel, args)) ty loc
+
+(* -------------------------------------------------------------------------- *)
+(* Escape-rule validation (L12 5)                                            *)
+(* -------------------------------------------------------------------------- *)
+
+let escape (what : string) (t : typ) (loc : loc) : 'a =
+  Sarek_error.raise_error
+    (Sarek_error.Function_value_escapes
+       ( Printf.sprintf
+           "a function value cannot appear as %s (no runtime representation)"
+           what,
+         t,
+         loc ))
+
+(* Walk the rewritten AST and reject any function-typed value that survives in
+   a position with no runtime representation. A function-typed node is only
+   legal as the immediate callee of an application. *)
+let rec check_expr (e : texpr) : unit =
+  (match e.te with
+  | TERecord (_, fields) ->
+      List.iter
+        (fun (_, fe) ->
+          if is_fun_typed fe then escape "a record field" fe.ty fe.te_loc)
+        fields
+  | TETuple es ->
+      List.iter
+        (fun te ->
+          if is_fun_typed te then escape "a tuple element" te.ty te.te_loc)
+        es
+  | TEConstr (_, _, Some arg) ->
+      if is_fun_typed arg then escape "a variant payload" arg.ty arg.te_loc
+  | TEReturn re ->
+      if is_fun_typed re then escape "a return value" re.ty re.te_loc
+  | TEVecSet (_, _, v) ->
+      if is_fun_typed v then escape "a vector element" v.ty v.te_loc
+  | TEArrSet (_, _, v) ->
+      if is_fun_typed v then escape "an array element" v.ty v.te_loc
+  | TEAssign (_, _, v) ->
+      if is_fun_typed v then escape "an assigned value" v.ty v.te_loc
+  | TECreateArray (_, t, _) ->
+      if is_fun_ty t then escape "an array element type" t e.te_loc
+  | _ -> ()) ;
+  (* Recurse. The callee child of an application is legally function-typed, so
+     skip it and only descend into the arguments. *)
+  match e.te with
+  | TEApp (_callee, args) -> List.iter check_expr args
+  | _ -> iter_children check_expr e
+
+and iter_children (f : texpr -> unit) (e : texpr) : unit =
+  match e.te with
+  | TEUnit | TEBool _ | TEInt _ | TEInt32 _ | TEInt64 _ | TEFloat _ | TEDouble _
+  | TEGlobalRef _ | TENative _ | TEIntrinsicConst _ | TEVar _ ->
+      ()
+  | TEVecGet (a, b) | TEArrGet (a, b) | TEBinop (_, a, b) | TEWhile (a, b) ->
+      f a ;
+      f b
+  | TEVecSet (a, b, c) | TEArrSet (a, b, c) ->
+      f a ;
+      f b ;
+      f c
+  | TEFieldGet (a, _, _)
+  | TEUnop (_, a)
+  | TEReturn a
+  | TEPragma (_, a)
+  | TEOpen (_, a) ->
+      f a
+  | TEFieldSet (a, _, _, b) ->
+      f a ;
+      f b
+  | TEApp (fn, args) ->
+      f fn ;
+      List.iter f args
+  | TEAssign (_, _, v) -> f v
+  | TELet (_, _, v, b) | TELetMut (_, _, v, b) ->
+      f v ;
+      f b
+  | TELetRec (_, _, _, fn_body, cont) ->
+      f fn_body ;
+      f cont
+  | TEIf (c, t, e) ->
+      f c ;
+      f t ;
+      Option.iter f e
+  | TEFor (_, _, lo, hi, _, body) ->
+      f lo ;
+      f hi ;
+      f body
+  | TESeq es | TETuple es -> List.iter f es
+  | TEMatch (s, cases) ->
+      f s ;
+      List.iter (fun (_, b) -> f b) cases
+  | TERecord (_, fields) -> List.iter (fun (_, e) -> f e) fields
+  | TEConstr (_, _, arg) -> Option.iter f arg
+  | TECreateArray (size, _, _) -> f size
+  | TEIntrinsicFun (_, _, args) -> List.iter f args
+  | TELetShared (_, _, _, size, b) ->
+      Option.iter f size ;
+      f b
+  | TESuperstep (_, _, step, cont) ->
+      f step ;
+      f cont
+
+(* -------------------------------------------------------------------------- *)
+(* Entry point                                                                *)
+(* -------------------------------------------------------------------------- *)
+
+let rewrite_body (body : texpr) : texpr =
+  let fenv : (int, texpr) Hashtbl.t = Hashtbl.create 8 in
+  let body' = rewrite fenv body in
+  check_expr body' ;
+  body'
+
+let defunctionalize (kernel : tkernel) : tkernel =
+  let module_items' =
+    List.map
+      (function
+        | TMFun (name, is_rec, params, body) ->
+            (* A helper whose parameter is itself function-typed is a
+               higher-order helper (specialization case, L12 4.3 / 4.1). That
+               is out of scope for this Tier-0 milestone; leave its body
+               untouched so the existing lowering behavior is unchanged. *)
+            if List.exists (fun p -> is_fun_ty p.tparam_type) params then
+              TMFun (name, is_rec, params, body)
+            else TMFun (name, is_rec, params, rewrite_body body)
+        | TMConst _ as item -> item)
+      kernel.tkern_module_items
+  in
+  let body' = rewrite_body kernel.tkern_body in
+  if is_fun_ty kernel.tkern_return_type then
+    escape "a kernel return type" kernel.tkern_return_type kernel.tkern_loc ;
+  {kernel with tkern_module_items = module_items'; tkern_body = body'}

--- a/sarek/ppx/Sarek_defunc.ml
+++ b/sarek/ppx/Sarek_defunc.ml
@@ -48,11 +48,10 @@ open Sarek_ast
 open Sarek_types
 open Sarek_typed_ast
 
-(** Is the top constructor of this expression's type a function type? *)
-let is_fun_typed (e : texpr) : bool =
-  match repr e.ty with TFun _ -> true | _ -> false
-
 let is_fun_ty (t : typ) : bool = match repr t with TFun _ -> true | _ -> false
+
+(** Is the top constructor of this expression's type a function type? *)
+let is_fun_typed (e : texpr) : bool = is_fun_ty e.ty
 
 (* -------------------------------------------------------------------------- *)
 (* Core rewrite                                                               *)

--- a/sarek/ppx/Sarek_error.ml
+++ b/sarek/ppx/Sarek_error.ml
@@ -47,6 +47,7 @@ type error =
   | Unknown_variant_type of string * loc
   | Expression_needs_statement_context of string * loc
   | Invalid_lvalue of loc
+  | Function_value_escapes of string * typ * loc
 
 (** Get the location from an error *)
 let error_loc = function
@@ -81,6 +82,7 @@ let error_loc = function
   | Unknown_variant_type (_, loc) -> loc
   | Expression_needs_statement_context (_, loc) -> loc
   | Invalid_lvalue loc -> loc
+  | Function_value_escapes (_, _, loc) -> loc
 
 (** Pretty print an error *)
 let pp_error fmt = function
@@ -189,6 +191,15 @@ let pp_error fmt = function
         fmt
         "Invalid left-hand side of assignment. Expected variable, field \
          access, or array element"
+  | Function_value_escapes (msg, t, _) ->
+      Format.fprintf
+        fmt
+        "Function value escapes: %s. Offending type: %a. Function values in \
+         kernels must be bound to a `let` and applied directly (they have no \
+         runtime representation)."
+        msg
+        pp_typ
+        t
 
 (** Convert error to string *)
 let error_to_string e = Format.asprintf "%a" pp_error e

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -1665,6 +1665,16 @@ let expand_kernel ~ctxt payload : expression =
             Sarek_debug.log_to_file "  step 5: monomorphization done" ;
             Sarek_debug.log_exit "monomorphize" ;
 
+            (* 5b. Defunctionalization pass (Tier 0) - eliminate first-class
+               function values bound to `let` variables by distributing
+               applications into if/match selectors, so lowering only ever
+               sees directly-named callees. See Sarek_defunc.ml. *)
+            Sarek_debug.log_to_file "  step 5b: defunctionalization start" ;
+            Sarek_debug.log_enter "defunctionalize" ;
+            let tkernel = Sarek_defunc.defunctionalize tkernel in
+            Sarek_debug.log_to_file "  step 5b: defunctionalization done" ;
+            Sarek_debug.log_exit "defunctionalize" ;
+
             (* 6. Tail recursion elimination pass (for GPU code) *)
             (* Keep original kernel for native OCaml which handles recursion *)
             let native_kernel = tkernel in

--- a/sarek/ppx/dune
+++ b/sarek/ppx/dune
@@ -25,6 +25,7 @@
   Sarek_quote_ir
   Sarek_ir_ppx
   Sarek_mono
+  Sarek_defunc
   Sarek_debug
   Sarek_tailrec_analysis
   Sarek_tailrec_elim

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -640,3 +640,21 @@
  (alias runtest)
  (action
   (run %{dep:test_float64_kernel_arith.exe})))
+
+; L12 Tier-0 defunctionalization E2E (Sarek_defunc). Self-verifying against a
+; pure-OCaml reference on every available device (Native/Interpreter always,
+; plus any GPU backend present). int32-only, no custom types.
+
+(executable
+ (name test_defunc)
+ (modules test_defunc)
+ (libraries sarek sarek.stdlib sarek_ir spoc_core test_helpers unix)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_defunc.exe})))

--- a/sarek/tests/e2e/test_defunc.ml
+++ b/sarek/tests/e2e/test_defunc.ml
@@ -36,11 +36,10 @@ module Transfer = Spoc_core.Transfer
 open Sarek
 module Std = Sarek_stdlib.Std
 
-let () =
-  Sarek_cuda.Cuda_plugin.init () ;
-  Sarek_opencl.Opencl_plugin.init () ;
-  Sarek_native.Native_plugin.init () ;
-  Sarek_interpreter.Interpreter_plugin.init ()
+(* Backend init goes through the shared conditional loader so this test
+   stays buildable when optional GPU plugins (CUDA/OpenCL/Vulkan/Metal) are
+   absent, and enumerates every backend that IS present. *)
+let () = Test_helpers.Benchmarks.init ()
 
 (* Case 1: static single candidate. `let f = addf` resolves to one helper. *)
 let static_kernel =

--- a/sarek/tests/e2e/test_defunc.ml
+++ b/sarek/tests/e2e/test_defunc.ml
@@ -1,0 +1,176 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for L12 Tier-0 defunctionalization (Sarek_defunc).
+ *
+ * Exercises the two capabilities the pass unlocks, end-to-end, on every
+ * available device, self-verifying against a pure-OCaml reference:
+ *
+ *   1. Static single candidate:  `let f = addf in ... f x 1l`
+ *      The function-valued binding resolves to a single named helper; the
+ *      pass drops the binding and calls `addf` directly.
+ *
+ *   2. Genuinely runtime-dynamic: `let f = if op = 0l then addf else mulf in
+ *                                  ... f x x`
+ *      `op` is a *runtime kernel parameter*, so the choice cannot be resolved
+ *      at compile time. The pass distributes the application into the `if`
+ *      branches -> `if op = 0l then addf x x else mulf x x`. No function value
+ *      reaches lowering and no tag variant is synthesized, so every backend
+ *      handles it with its existing `if` + direct-call paths (zero emitter
+ *      changes). Both kernels would fail to compile before L12 with
+ *      "EApp to unknown function 'f'".
+ *
+ * The candidate leaves are kernel-local `let`-bound helpers (a Tier-0
+ * candidate class per L12 6). Only int32 vectors + scalars are used (no
+ * custom types), so the kernels run on the always-available
+ * Native/Interpreter backends and on every GPU backend without the
+ * custom-vector caveats that gate test_klet_variant.
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+open Sarek
+module Std = Sarek_stdlib.Std
+
+let () =
+  Sarek_cuda.Cuda_plugin.init () ;
+  Sarek_opencl.Opencl_plugin.init () ;
+  Sarek_native.Native_plugin.init () ;
+  Sarek_interpreter.Interpreter_plugin.init ()
+
+(* Case 1: static single candidate. `let f = addf` resolves to one helper. *)
+let static_kernel =
+  [%kernel
+    let open Std in
+    let addf (a : int32) (b : int32) : int32 = a + b in
+    fun (data : int32 vector) (out : int32 vector) ->
+      let idx = global_idx_x in
+      let f = addf in
+      out.(idx) <- f data.(idx) 1l]
+
+(* Case 2: runtime-dynamic dispatch. `op` is a kernel parameter, so the
+   selection is only known at runtime. *)
+let dynamic_kernel =
+  [%kernel
+    let open Std in
+    let addf (a : int32) (b : int32) : int32 = a + b in
+    let mulf (a : int32) (b : int32) : int32 = a * b in
+    fun (data : int32 vector) (op : int32) (out : int32 vector) ->
+      let idx = global_idx_x in
+      let f = if op = 0l then addf else mulf in
+      out.(idx) <- f data.(idx) data.(idx)]
+
+let n = 1024
+
+let block_size = 256
+
+let ir_of kernel =
+  let _, kirc = kernel in
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let make_data () =
+  let data = Vector.create Vector.int32 n in
+  for i = 0 to n - 1 do
+    Vector.set data i (Int32.of_int (i mod 97))
+  done ;
+  data
+
+(* Returns true if this device produced correct results for both kernels. *)
+let run_on_device dev =
+  Printf.printf
+    "--- device: %s (%s) ---\n%!"
+    dev.Device.name
+    dev.Device.framework ;
+  let block = Execute.dims1d block_size in
+  let grid = Execute.dims1d (n / block_size) in
+  let ok = ref true in
+
+  (* Case 1: static. out[i] = data[i] + 1 *)
+  let data = make_data () in
+  let out = Vector.create Vector.int32 n in
+  Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of static_kernel)
+    ~args:[Execute.Vec data; Execute.Vec out]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  for i = 0 to n - 1 do
+    let expected = Int32.add (Vector.get data i) 1l in
+    let got = Vector.get out i in
+    if got <> expected then begin
+      if !ok then
+        Printf.printf
+          "  [static] FAIL at %d: got %ld expected %ld\n%!"
+          i
+          got
+          expected ;
+      ok := false
+    end
+  done ;
+  if !ok then Printf.printf "  [static] PASS\n%!" ;
+
+  (* Case 2: dynamic, both selectors. op=0 -> add (x+x), op=1 -> mul (x*x) *)
+  let run_dynamic op reference =
+    let data = make_data () in
+    let out = Vector.create Vector.int32 n in
+    Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of dynamic_kernel)
+      ~args:[Execute.Vec data; Execute.Int32 (Int32.of_int op); Execute.Vec out]
+      ~block
+      ~grid
+      () ;
+    Transfer.flush dev ;
+    let dyn_ok = ref true in
+    for i = 0 to n - 1 do
+      let x = Vector.get data i in
+      let expected = reference x in
+      let got = Vector.get out i in
+      if got <> expected then begin
+        if !dyn_ok then
+          Printf.printf
+            "  [dynamic op=%d] FAIL at %d: got %ld expected %ld\n%!"
+            op
+            i
+            got
+            expected ;
+        dyn_ok := false ;
+        ok := false
+      end
+    done ;
+    if !dyn_ok then Printf.printf "  [dynamic op=%d] PASS\n%!" op
+  in
+  run_dynamic 0 (fun x -> Int32.add x x) ;
+  run_dynamic 1 (fun x -> Int32.mul x x) ;
+  !ok
+
+let () =
+  print_endline "=== L12 Tier-0 defunctionalization E2E ===" ;
+  let devs =
+    Device.init
+      ~frameworks:["CUDA"; "OpenCL"; "Vulkan"; "Metal"; "Native"; "Interpreter"]
+      ()
+  in
+  if Array.length devs = 0 then begin
+    print_endline "No device found - nothing to run" ;
+    exit 0
+  end ;
+  let all_ok = ref true in
+  Array.iter (fun dev -> if not (run_on_device dev) then all_ok := false) devs ;
+  print_endline "" ;
+  if !all_ok then begin
+    print_endline "test_defunc: PASS (all devices)" ;
+    exit 0
+  end
+  else begin
+    print_endline "test_defunc: FAIL" ;
+    exit 1
+  end

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -16,6 +16,7 @@
 ; - test_inline_node_exhaustion: "Inlining produced N nodes (limit: 10000)"
 ; - test_tuple_param: "Tuple-typed kernel parameters are not supported"
 ; - test_fun_param: "Function-typed kernel parameters are not supported"
+; - test_fun_escape: "Function value escapes"
 
 (library
  (name neg_test_convention_kernel_fail)
@@ -119,6 +120,17 @@
 (library
  (name neg_test_fun_param)
  (modules test_fun_param)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+(library
+ (name neg_test_fun_escape)
+ (modules test_fun_escape)
  (libraries sarek sarek.stdlib sarek.ppx.lib)
  (preprocess
   (pps sarek_ppx))

--- a/sarek/tests/negative/test_fun_escape.ml
+++ b/sarek/tests/negative/test_fun_escape.ml
@@ -1,0 +1,26 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile (L12 escape rule, Sarek_defunc):
+   a function value bound to `let f` is returned from the kernel body instead
+   of being applied to arguments. Tier-0 defunctionalization has no runtime
+   representation for an escaping function value, so this is rejected with a
+   `Function_value_escapes` diagnostic ("Function value escapes: ...") rather
+   than an opaque codegen failure downstream. *)
+
+module Std = Sarek_stdlib.Std
+
+let () =
+  let bad_kernel =
+    [%kernel
+      let open Std in
+      let addf (a : int32) (b : int32) : int32 = a + b in
+      let mulf (a : int32) (b : int32) : int32 = a * b in
+      fun (op : int32) ->
+        let f = if op = 0l then addf else mulf in
+        f]
+  in
+  ignore bad_kernel ;
+  print_endline "This should not print - test should have failed to compile"


### PR DESCRIPTION
Implements **L12 Tier 0** (design: `roster/ptx-limits-campaign/L12-defunctionalization.md`): a typed-AST→typed-AST pass (`sarek/ppx/Sarek_defunc.ml`) spliced between monomorphization and lowering that eliminates first-class function *values* bound to `let` variables in kernel/helper bodies.

Before this, the two headline patterns from the design doc §1 fail at codegen with `EApp to unknown function 'f'` / `EApp with non-variable callee`. Now they compile and run:

- `let f = g in f x`  → direct call `g x` (single static candidate, §4.1)
- `let f = if c then g else h in f x` → `if c then g x else h x` (genuinely runtime-dynamic, §4.2)

## Approach — distribution, not a tag variant
The pass distributes the application into the selector's `if`/`match` leaves rather than synthesizing a Reynolds tag variant. Since the §5 escape rules keep a Tier-0 function value in callee position only, distribution is complete for the capture-free world and needs **zero new IR and zero emitter changes** — it reuses ordinary `if`/`match`-expression + direct-call lowering that every backend already has. `if`/`match` arms are mutually exclusive, so arguments are never re-evaluated.

## Escape rules (§5)
New `Function_value_escapes` error: a function-typed value in a record field, tuple/vector element, variant payload, created-array element, assignment, return, or bare non-callee position is rejected with a located diagnostic instead of an opaque downstream failure. Negative test `test_fun_escape`.

## Test matrix — `sarek/tests/e2e/test_defunc.ml` (self-verifying vs OCaml reference)

| Backend | static | dynamic op=0 | dynamic op=1 |
|---|---|---|---|
| CUDA/PTX — RX 7900 XTX (ZLUDA) | PASS | PASS | PASS |
| CUDA/PTX — Ryzen (ZLUDA) | PASS | PASS | PASS |
| OpenCL — RX 7900 XTX / Ryzen | PASS | PASS | PASS |
| Vulkan — RADV NAVI31 / RAPHAEL | PASS | PASS | PASS |
| Native | PASS | PASS | PASS |
| Interpreter (seq + parallel) | PASS | PASS | PASS |

This empirically confirms the design's "zero emitter changes" claim on the real PTX path plus every other available backend.

## Gates
- `dune build @install` clean
- `dune build @fmt` clean on all changed files (pre-existing drift in `Sarek_float32.ml` / `test_ir_layout.ml` untouched)
- `dune runtest sarek/tests` fully green (no regression)
- GPU validated under ZLUDA on CUDA/PTX + OpenCL + Vulkan

## Deferred (documented follow-ups, not started)
- Higher-order **helper-parameter** specialization (`sort ~cmp:my_less`, §4.1/§4.3) — a separable Sarek_mono-style helper-duplication pass; not needed for the headline examples.
- Tier 1 scalar captures / Tier 2 aggregate captures — as designed.

Also surfaced (not fixed, out of scope): a pre-existing typer bug where a `[@sarek.module]` helper doing int32 `+` mis-unifies float32/int32 when used in a kernel (reproduces on a direct call, no function value involved). The test uses kernel-local helpers to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tier-0 defunctionalization stage to support kernels using locally selected function values, including both static and runtime-dependent selections.
* **Bug Fixes**
  * Improved diagnostics and rejection for escaping function-value usage, preventing invalid IR/codegen paths.
* **Tests**
  * Added an end-to-end defunctionalization test executed across available backends.
  * Added negative compilation coverage for escaping function values, including Makefile verification and Dune integration in the negative test profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->