### PR TITLE
feat(sarek): tuple-typed vectors (L13)

### DIFF
--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -68,6 +68,70 @@ let rec elttype_of_typ (ty : typ) : Ir.elttype =
          not supported. Annotate the parameter with a concrete type (e.g. \
          float32, int32)."
 
+(* L13: tuple-typed vector elements. A tuple used as a vector element type is
+   lowered to a synthesized packed record with positional fields [_0], [_1],
+   ..., reusing the record/aggregate codegen path unchanged (the layout is
+   computed by Sarek_ir_layout, byte-for-byte identically on host and device).
+   Only scalar-primitive components are supported in this tier; nested tuples,
+   records, vectors or functions as components are rejected. *)
+let elttype_prim_tag (e : Ir.elttype) : string option =
+  match e with
+  | Ir.TInt32 -> Some "int32"
+  | Ir.TInt64 -> Some "int64"
+  | Ir.TFloat32 -> Some "float32"
+  | Ir.TFloat64 -> Some "float64"
+  | Ir.TBool -> Some "bool"
+  | _ -> None
+
+let tuple_field_name i = Printf.sprintf "_%d" i
+
+(** Mangled nominal name of the record synthesized for a tuple shape, e.g.
+    [_tup_float32_int32] for [float32 * int32]. Kept in sync with the host-side
+    [Sarek_tuple_vec] builder so both agree on the element identity. *)
+let tuple_record_name (comps : Ir.elttype list) : string =
+  "_tup"
+  ^ String.concat
+      ""
+      (List.map
+         (fun e ->
+           match elttype_prim_tag e with Some t -> "_" ^ t | None -> "_x")
+         comps)
+
+(** Synthesized record fields (positional [_0.._n]) for a tuple's component
+    types. Raises if any component is not a scalar primitive. *)
+let tuple_record_fields (tys : typ list) : string * (string * Ir.elttype) list =
+  let comps = List.map elttype_of_typ tys in
+  List.iter
+    (fun e ->
+      if elttype_prim_tag e = None then
+        Ppxlib.Location.raise_errorf
+          ~loc:Ppxlib.Location.none
+          "Tuple-typed vector elements support only scalar components \
+           (float32/float64/int32/int64/bool); nested tuples, records, vectors \
+           or functions inside a vector-element tuple are not supported.")
+    comps ;
+  let name = tuple_record_name comps in
+  (name, List.mapi (fun i e -> (tuple_field_name i, e)) comps)
+
+let tuple_tmp_counter = ref 0
+
+(** Is [t] a tuple whose components are all scalar primitives (the shape we
+    synthesize a record for)? *)
+let is_primitive_tuple (t : typ) : bool =
+  match repr t with
+  | TTuple tys ->
+      List.for_all (fun t -> elttype_prim_tag (elttype_of_typ t) <> None) tys
+  | _ -> false
+
+(** Element IR type of a vector whose element is [t]; a tuple element becomes
+    its synthesized record, everything else is the ordinary mapping. *)
+let vector_elem_elttype (t : typ) : Ir.elttype =
+  match repr t with
+  | TTuple tys ->
+      let name, fields = tuple_record_fields tys in
+      Ir.TRecord (name, fields)
+  | _ -> elttype_of_typ t
+
 (** Convert Sarek_types.memspace to Sarek_ir_ppx.memspace *)
 let memspace_of_memspace (mem : Sarek_types.memspace) : Ir.memspace =
   match mem with
@@ -494,7 +558,31 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
       end ;
       let args = match arg with None -> [] | Some e -> [lower_expr state e] in
       Ir.EVariant (ty_name, constr, args)
-  | TETuple exprs -> Ir.ETuple (List.map (lower_expr state) exprs)
+  | TETuple exprs -> (
+      (* L13: a tuple literal whose components are scalar primitives is lowered
+         to the same synthesized record ([_0], [_1], ...) used for tuple vector
+         elements. This carries the nominal type name so struct-based backends
+         (OpenCL/GLSL/CUDA/Metal) emit a typed compound literal rather than a
+         bare, type-less brace initializer, and it matches what a tuple vector
+         slot stores. Non-primitive tuples keep the generic [Ir.ETuple]. *)
+      match repr te.ty with
+      | TTuple tys
+        when List.for_all
+               (fun t -> elttype_prim_tag (elttype_of_typ t) <> None)
+               tys ->
+          let comps = List.map elttype_of_typ tys in
+          let name = tuple_record_name comps in
+          if not (Hashtbl.mem state.types name) then
+            Hashtbl.add
+              state.types
+              name
+              (List.mapi (fun i e -> (tuple_field_name i, e)) comps) ;
+          Ir.ERecord
+            ( name,
+              List.mapi
+                (fun i e -> (tuple_field_name i, lower_expr state e))
+                exprs )
+      | _ -> Ir.ETuple (List.map (lower_expr state) exprs))
   | TEGlobalRef (name, ty) ->
       let v = make_var name 0 ty false in
       Ir.EVar v
@@ -604,6 +692,43 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
           lower_stmt state body )
   | TEWhile (cond, body) ->
       Ir.SWhile (lower_expr state cond, lower_stmt state body)
+  | TEMatch (e, [({tpat = TPTuple pats; _}, body)])
+    when is_primitive_tuple e.ty
+         && List.for_all
+              (fun p ->
+                match p.tpat with TPVar _ | TPAny -> true | _ -> false)
+              pats ->
+      (* L13: a single-arm tuple-pattern match is not a variant dispatch; the
+         C-like backends (OpenCL/GLSL/CUDA/Metal) would otherwise emit a bogus
+         [switch (x.tag)]. Rewrite it to a record destructure: bind the
+         scrutinee once, then bind each component to its [_i] field. This works
+         uniformly on every backend (field access is already supported). *)
+      let rec_elt = vector_elem_elttype e.ty in
+      incr tuple_tmp_counter ;
+      let tmp_name = Printf.sprintf "__sarek_tup_%d" !tuple_tmp_counter in
+      let tmp_var : Ir.var =
+        {
+          var_name = tmp_name;
+          var_id = - !tuple_tmp_counter;
+          var_type = rec_elt;
+          var_mutable = false;
+        }
+      in
+      let body_ir = lower_stmt state body in
+      let bound =
+        List.fold_right
+          (fun (i, p) acc ->
+            match p.tpat with
+            | TPVar (name, id) ->
+                let field =
+                  Ir.ERecordField (Ir.EVar tmp_var, tuple_field_name i)
+                in
+                Ir.SLet (make_var name id p.tpat_ty false, field, acc)
+            | _ -> acc)
+          (List.mapi (fun i p -> (i, p)) pats)
+          body_ir
+      in
+      Ir.SLet (tmp_var, lower_expr state e, bound)
   | TEMatch (e, cases) ->
       let ir_cases =
         List.map
@@ -705,26 +830,39 @@ let lower_param (p : tparam) : Ir.decl =
       Ppxlib.Location.raise_errorf
         ~loc:Ppxlib.Location.none
         "Function-typed kernel parameters are not supported."
-  | (TVec t | TArr (t, _)) as container -> (
-      (* A vector/array of tuples or functions would silently collapse to
-         TInt32 in elttype_of_typ (wrong stride, garbage layout) — reject
-         at the formal-parameter boundary like the bare cases above. *)
-      let kind = match container with TArr _ -> "Arrays" | _ -> "Vectors" in
+  | TArr (t, _) -> (
+      (* An array of tuples or functions would silently collapse to TInt32 in
+         elttype_of_typ (wrong stride, garbage layout) — reject at the
+         formal-parameter boundary. (L13: local-array-of-tuple aggregate
+         support is a follow-up; only global vector elements are lowered.) *)
       match repr t with
       | TTuple _ ->
           Ppxlib.Location.raise_errorf
             ~loc:Ppxlib.Location.none
-            "%s of tuples are not supported as kernel parameters; declare a \
-             record type with [@@sarek.type] instead."
-            kind
+            "Arrays of tuples are not supported as kernel parameters; declare \
+             a record type with [@@sarek.type] instead, or use a vector."
       | TFun _ ->
           Ppxlib.Location.raise_errorf
             ~loc:Ppxlib.Location.none
-            "%s of functions are not supported as kernel parameters."
-            kind
+            "Arrays of functions are not supported as kernel parameters."
+      | _ -> ())
+  | TVec t -> (
+      match repr t with
+      | TFun _ ->
+          Ppxlib.Location.raise_errorf
+            ~loc:Ppxlib.Location.none
+            "Vectors of functions are not supported as kernel parameters."
+      | TTuple tys ->
+          (* L13: a vector of tuples is lowered to a vector of the synthesized
+             packed record; validate the components eagerly for a clear error. *)
+          ignore (tuple_record_fields tys)
       | _ -> ())
   | _ -> ()) ;
-  let elt = elttype_of_typ p.tparam_type in
+  let elt =
+    match repr p.tparam_type with
+    | TVec t -> Ir.TVec (vector_elem_elttype t)
+    | _ -> elttype_of_typ p.tparam_type
+  in
   let v =
     {
       Ir.var_name = p.tparam_name;
@@ -735,7 +873,7 @@ let lower_param (p : tparam) : Ir.decl =
   in
   if p.tparam_is_vec then
     let elem_ty =
-      match repr p.tparam_type with TVec t -> elttype_of_typ t | _ -> elt
+      match repr p.tparam_type with TVec t -> vector_elem_elttype t | _ -> elt
     in
     Ir.DParam (v, Some {arr_elttype = elem_ty; arr_memspace = Ir.Global})
   else Ir.DParam (v, None)
@@ -772,7 +910,19 @@ let lower_kernel (kernel : tkernel) : Ir.kernel * string list =
         List.iter (fun (_, t) -> register_types_from_typ t) fields
     | TVec elem_ty -> register_types_from_typ elem_ty
     | TArr (elem_ty, _) -> register_types_from_typ elem_ty
-    | TTuple tys -> List.iter register_types_from_typ tys
+    | TTuple tys ->
+        (* L13: register the synthesized record for a tuple aggregate so the
+           codegen types table knows its field layout, mirroring records. *)
+        let comps = List.map elttype_of_typ tys in
+        if List.for_all (fun e -> elttype_prim_tag e <> None) comps then begin
+          let name = tuple_record_name comps in
+          if not (Hashtbl.mem state.types name) then
+            Hashtbl.add
+              state.types
+              name
+              (List.mapi (fun i e -> (tuple_field_name i, e)) comps)
+        end ;
+        List.iter register_types_from_typ tys
     | _ -> ()
   in
   List.iter

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -83,6 +83,21 @@ let elttype_prim_tag (e : Ir.elttype) : string option =
   | Ir.TBool -> Some "bool"
   | _ -> None
 
+(** Scalar-primitive check on the SOURCE type of a tuple component. This must
+    match on [Sarek_types.typ] directly, NOT via [elttype_of_typ]: that
+    conversion maps [TTuple]/[TFun] to a placeholder [Ir.TInt32] (see its NOTE),
+    so routing the primitivity check through it would silently accept nested
+    tuples or function components as int32 fields and synthesize a wrong
+    layout. Returns the component's IR type iff it is a supported scalar. *)
+let prim_component_elttype (t : typ) : Ir.elttype option =
+  match repr t with
+  | TPrim TInt32 -> Some Ir.TInt32
+  | TPrim TBool -> Some Ir.TBool
+  | TReg Int64 -> Some Ir.TInt64
+  | TReg Float32 -> Some Ir.TFloat32
+  | TReg Float64 -> Some Ir.TFloat64
+  | _ -> None
+
 let tuple_field_name i = Printf.sprintf "_%d" i
 
 (** Mangled nominal name of the record synthesized for a tuple shape, e.g.
@@ -100,16 +115,20 @@ let tuple_record_name (comps : Ir.elttype list) : string =
 (** Synthesized record fields (positional [_0.._n]) for a tuple's component
     types. Raises if any component is not a scalar primitive. *)
 let tuple_record_fields (tys : typ list) : string * (string * Ir.elttype) list =
-  let comps = List.map elttype_of_typ tys in
-  List.iter
-    (fun e ->
-      if elttype_prim_tag e = None then
-        Ppxlib.Location.raise_errorf
-          ~loc:Ppxlib.Location.none
-          "Tuple-typed vector elements support only scalar components \
-           (float32/float64/int32/int64/bool); nested tuples, records, vectors \
-           or functions inside a vector-element tuple are not supported.")
-    comps ;
+  let comps =
+    List.map
+      (fun t ->
+        match prim_component_elttype t with
+        | Some e -> e
+        | None ->
+            Ppxlib.Location.raise_errorf
+              ~loc:Ppxlib.Location.none
+              "Tuple-typed vector elements support only scalar components \
+               (float32/float64/int32/int64/bool); nested tuples, records, \
+               vectors or functions inside a vector-element tuple are not \
+               supported.")
+      tys
+  in
   let name = tuple_record_name comps in
   (name, List.mapi (fun i e -> (tuple_field_name i, e)) comps)
 
@@ -119,8 +138,7 @@ let tuple_tmp_counter = ref 0
     synthesize a record for)? *)
 let is_primitive_tuple (t : typ) : bool =
   match repr t with
-  | TTuple tys ->
-      List.for_all (fun t -> elttype_prim_tag (elttype_of_typ t) <> None) tys
+  | TTuple tys -> List.for_all (fun t -> prim_component_elttype t <> None) tys
   | _ -> false
 
 (** Element IR type of a vector whose element is [t]; a tuple element becomes
@@ -567,10 +585,15 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
          slot stores. Non-primitive tuples keep the generic [Ir.ETuple]. *)
       match repr te.ty with
       | TTuple tys
-        when List.for_all
-               (fun t -> elttype_prim_tag (elttype_of_typ t) <> None)
-               tys ->
-          let comps = List.map elttype_of_typ tys in
+        when List.for_all (fun t -> prim_component_elttype t <> None) tys ->
+          let comps =
+            List.map
+              (fun t ->
+                match prim_component_elttype t with
+                | Some e -> e
+                | None -> assert false (* guarded above *))
+              tys
+          in
           let name = tuple_record_name comps in
           if not (Hashtbl.mem state.types name) then
             Hashtbl.add
@@ -912,16 +935,24 @@ let lower_kernel (kernel : tkernel) : Ir.kernel * string list =
     | TArr (elem_ty, _) -> register_types_from_typ elem_ty
     | TTuple tys ->
         (* L13: register the synthesized record for a tuple aggregate so the
-           codegen types table knows its field layout, mirroring records. *)
-        let comps = List.map elttype_of_typ tys in
-        if List.for_all (fun e -> elttype_prim_tag e <> None) comps then begin
-          let name = tuple_record_name comps in
-          if not (Hashtbl.mem state.types name) then
-            Hashtbl.add
-              state.types
-              name
-              (List.mapi (fun i e -> (tuple_field_name i, e)) comps)
-        end ;
+           codegen types table knows its field layout, mirroring records.
+           Primitivity is checked on the SOURCE types (prim_component_elttype),
+           never via elttype_of_typ, whose TTuple/TFun placeholder would let a
+           nested tuple register as an int32 field. *)
+        (match
+           List.map prim_component_elttype tys |> fun opts ->
+           if List.for_all Option.is_some opts then
+             Some (List.map Option.get opts)
+           else None
+         with
+        | Some comps ->
+            let name = tuple_record_name comps in
+            if not (Hashtbl.mem state.types name) then
+              Hashtbl.add
+                state.types
+                name
+                (List.mapi (fun i e -> (tuple_field_name i, e)) comps)
+        | None -> ()) ;
         List.iter register_types_from_typ tys
     | _ -> ()
   in

--- a/sarek/ppx/Sarek_native_gen_base.ml
+++ b/sarek/ppx/Sarek_native_gen_base.ml
@@ -127,18 +127,49 @@ let gen_variable ~loc ~ctx (name : string) (id : int) : expression =
     [%expr ![%e var_e]]
   else var_e
 
+(* L13: a synthesized tuple-shape record (name starting with [_tup]) has no
+   [<name>_custom] binding — its canonical descriptor lives in the process-wide
+   Sarek_tuple_vec registry, shared with the host so both carry the same
+   Type_id. Emit a runtime lookup instead of an unbound identifier. *)
+let is_tuple_shape_name name =
+  String.length name >= 4 && String.sub name 0 4 = "_tup"
+
+(* Tag of a tuple component type on the Native path. Restricted to the exact
+   component types Sarek_tuple_vec builds (matching OCaml element types) so the
+   registry lookup is type-sound: float32/float64 (float), int32 (int32),
+   int64 (int64). Other component types have no host builder and stay
+   Native-unsupported. *)
+let tuple_component_tag (t : typ) : string option =
+  match repr t with
+  | TReg Float32 -> Some "float32"
+  | TReg Float64 -> Some "float64"
+  | TPrim TInt32 -> Some "int32"
+  | TReg Int64 -> Some "int64"
+  | _ -> None
+
+let tuple_shape_name (tys : typ list) : string option =
+  let tags = List.map tuple_component_tag tys in
+  if List.for_all Option.is_some tags then
+    Some
+      ("_tup" ^ String.concat "" (List.map (fun t -> "_" ^ Option.get t) tags))
+  else None
+
 let custom_descriptor_expr ?current_module ~loc type_name =
-  let parts = String.split_on_char '.' type_name in
-  match List.rev parts with
-  | name :: modules ->
-      let modules = List.rev modules in
-      let modules =
-        match (current_module, modules) with
-        | Some current, [m] when String.equal current m -> []
-        | _ -> modules
-      in
-      evar_qualified ~loc modules (name ^ "_custom")
-  | [] -> failwith "custom_descriptor_expr: empty type name"
+  if is_tuple_shape_name type_name then
+    let name_str = Ast_builder.Default.estring ~loc type_name in
+    [%expr Sarek_tuple_vec.descriptor_by_name [%e name_str]]
+  else
+    let parts = String.split_on_char '.' type_name in
+    match List.rev parts with
+    | name :: modules ->
+        let modules = List.rev modules in
+        let modules =
+          match (current_module, modules) with
+          | Some current, [m] when String.equal current m -> []
+          | _ -> modules
+        in
+        evar_qualified ~loc modules (name ^ "_custom")
+    | [] -> failwith "custom_descriptor_expr: empty type name"
 
 let is_inline_type inline_types type_name =
   match inline_types with
@@ -185,6 +216,14 @@ let vector_type_id_expr ?current_module ?inline_types
         [%expr
           [%e custom_descriptor_expr ?current_module ~loc type_name]
             .Spoc_core.Vector.vector_type_id]
+  | TTuple tys when Option.is_some (tuple_shape_name tys) ->
+      [%expr
+        [%e
+          custom_descriptor_expr
+            ?current_module
+            ~loc
+            (Option.get (tuple_shape_name tys))]
+          .Spoc_core.Vector.vector_type_id]
   | _ -> [%expr failwith "unsupported vector type identity"]
 
 let custom_type_id_expr ?current_module ?inline_types
@@ -198,4 +237,12 @@ let custom_type_id_expr ?current_module ?inline_types
         [%expr
           [%e custom_descriptor_expr ?current_module ~loc type_name]
             .Spoc_core.Vector.type_id]
+  | TTuple tys when Option.is_some (tuple_shape_name tys) ->
+      [%expr
+        [%e
+          custom_descriptor_expr
+            ?current_module
+            ~loc
+            (Option.get (tuple_shape_name tys))]
+          .Spoc_core.Vector.type_id]
   | _ -> [%expr failwith "unsupported custom type identity"]

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -51,7 +51,8 @@
    from
    (sarek_metal -> backend_metal.available.ml)
    (-> backend_metal.unavailable.ml))
-  unix))
+  unix
+  sarek_backend_error))
 
 (executables
  (names
@@ -140,7 +141,8 @@
   registered_defs
   spoc_core
   test_helpers
-  unix)
+  unix
+  sarek_backend_error)
  (preprocessor_deps registered_defs.ml)
  (preprocess
   (pps sarek_ppx))
@@ -570,7 +572,8 @@
   sarek.real64
   spoc_core
   test_helpers
-  unix)
+  unix
+  sarek_backend_error)
  (preprocessor_deps
   (file ../../Sarek_df64/Sarek_df64.ml))
  (preprocess
@@ -632,7 +635,8 @@
   sarek_ir
   spoc_core
   test_helpers
-  unix)
+  unix
+  sarek_backend_error)
  (preprocess
   (pps sarek_ppx)))
 
@@ -658,3 +662,36 @@
  (alias runtest)
  (action
   (run %{dep:test_defunc.exe})))
+
+; L13 tuple-typed vectors E2E ((float32 * int32) vector). Builds the host
+; custom_type with sarek.tuple_vec, runs a read-modify-write kernel on every
+; available device, checks against a pure-OCaml reference. GPU devices
+; (CUDA/PTX under ZLUDA, Vulkan, OpenCL) must pass; Native/Interpreter are
+; reported NOT-YET-SUPPORTED (host/kernel Type_id identity and interpreter
+; value-model unification are follow-ups — see L13 design doc).
+
+(executable
+ (name test_tuple_vector)
+ (modules test_tuple_vector)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  sarek.tuple_vec
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_tuple_vector.exe})))

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -666,9 +666,9 @@
 ; L13 tuple-typed vectors E2E ((float32 * int32) vector). Builds the host
 ; custom_type with sarek.tuple_vec, runs a read-modify-write kernel on every
 ; available device, checks against a pure-OCaml reference. GPU devices
-; (CUDA/PTX under ZLUDA, Vulkan, OpenCL) must pass; Native/Interpreter are
-; reported NOT-YET-SUPPORTED (host/kernel Type_id identity and interpreter
-; value-model unification are follow-ups — see L13 design doc).
+; (CUDA/PTX under ZLUDA, Vulkan, OpenCL) AND Native must pass; only the
+; Interpreter is reported NOT-YET-SUPPORTED (its evaluator's tuple
+; value-model unification is a follow-up — see L13 design doc).
 
 (executable
  (name test_tuple_vector)

--- a/sarek/tests/e2e/test_tuple_vector.ml
+++ b/sarek/tests/e2e/test_tuple_vector.ml
@@ -1,0 +1,165 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * L13 — E2E test for tuple-typed vectors: [(float32 * int32) vector].
+ *
+ * A tuple vector element is lowered to a synthesized packed record (fields
+ * _0, _1) and consumed by the existing record/aggregate codegen. The host
+ * builds the matching [custom_type] with [Sarek_tuple_vec], so the same bytes
+ * are marshalled on both sides. The kernel reads a tuple element (via [match])
+ * and writes a modified tuple element back; results are checked against a pure
+ * OCaml reference on every available device.
+ *
+ * Device support tier: the GPU/device path (CUDA/PTX, OpenCL, Vulkan) works
+ * from the inline record layout alone. The Native and Interpreter paths
+ * additionally need host/kernel Type_id identity and interpreter value-model
+ * unification and are recorded as follow-ups; they are reported as
+ * NOT-YET-SUPPORTED here rather than treated as failures.
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module Device = Spoc_core.Device
+module Transfer = Spoc_core.Transfer
+
+[@@@warning "-32"]
+
+let () =
+  Sarek_native.Native_plugin.init () ;
+  Sarek_interpreter.Interpreter_plugin.init () ;
+  Sarek_cuda.Cuda_plugin.init () ;
+  Sarek_opencl.Opencl_plugin.init () ;
+  Sarek_vulkan.Vulkan_plugin.init ()
+
+type float32 = float
+
+(* Kernel: dst[i] = (src[i]._0 +. 1.0, src[i]._1) — reads and writes both
+   components of the tuple element, exercising field offsets for a mixed
+   (float32, int32) layout. *)
+let tuple_copy_kirc =
+  snd
+    [%kernel
+      fun (src : (float32 * int32) vector)
+          (dst : (float32 * int32) vector)
+          (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then match src.(tid) with a, b -> dst.(tid) <- (a +. 1.0, b)]
+
+(* Devices where the tuple-vector capability is expected to be fully supported
+   in this tier. *)
+let gpu_supported fw =
+  match fw with "CUDA" | "OpenCL" | "Vulkan" | "Metal" -> true | _ -> false
+
+let () =
+  print_endline "=== L13 tuple-vector E2E: (float32 * int32) vector ===" ;
+  let devs =
+    Device.init
+      ~frameworks:["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"]
+      ()
+  in
+  if Array.length devs = 0 then begin
+    print_endline "No runtime devices found - build/lowering test passed" ;
+    exit 0
+  end ;
+
+  let n = 64 in
+  let tup =
+    Sarek_tuple_vec.pair Sarek_tuple_vec.float32 Sarek_tuple_vec.int32
+  in
+  (* Pure OCaml reference. *)
+  let ref_src i = (float_of_int i, Int32.of_int (n - i)) in
+  let ref_dst i =
+    let a, b = ref_src i in
+    (a +. 1.0, b)
+  in
+
+  let any_failure = ref false in
+  let pass_count = ref 0 in
+  let unsupported = ref 0 in
+  Array.iter
+    (fun dev ->
+      let fw = dev.Device.framework in
+      Printf.printf "runtime [%s] %s: %!" fw dev.Device.name ;
+      let run () =
+        let src = Vector.create_custom tup n in
+        let dst = Vector.create_custom tup n in
+        for i = 0 to n - 1 do
+          Vector.set src i (ref_src i) ;
+          Vector.set dst i (0.0, 0l)
+        done ;
+        let threads = min 64 n in
+        let grid_x = (n + threads - 1) / threads in
+        let ir =
+          match tuple_copy_kirc.Sarek.Kirc_types.body_ir with
+          | Some ir -> ir
+          | None -> failwith "Kernel has no IR"
+        in
+        Sarek.Execute.run_vectors
+          ~device:dev
+          ~block:(Sarek.Execute.dims1d threads)
+          ~grid:(Sarek.Execute.dims1d grid_x)
+          ~ir
+          ~args:
+            [
+              Sarek.Execute.Vec src;
+              Sarek.Execute.Vec dst;
+              Sarek.Execute.Int32 (Int32.of_int n);
+            ]
+          () ;
+        Transfer.flush dev ;
+        let ok = ref true in
+        for i = 0 to n - 1 do
+          let ea, eb = ref_dst i in
+          let da, db = Vector.get dst i in
+          if abs_float (da -. ea) > 1e-3 || db <> eb then begin
+            ok := false ;
+            if i < 5 then
+              Printf.printf
+                "\n  Mismatch at %d: got (%.2f, %ld) expected (%.2f, %ld)%!"
+                i
+                da
+                db
+                ea
+                eb
+          end
+        done ;
+        !ok
+      in
+      try
+        if run () then begin
+          incr pass_count ;
+          print_endline "PASSED"
+        end
+        else if gpu_supported fw then begin
+          any_failure := true ;
+          print_endline "FAILED"
+        end
+        else begin
+          incr unsupported ;
+          print_endline "NOT-YET-SUPPORTED (result mismatch; see L13 findings)"
+        end
+      with e ->
+        let msg =
+          match e with
+          | Sarek_backend_error.Backend_error.Backend_error err ->
+              Sarek_backend_error.Backend_error.to_string err
+          | e -> Printexc.to_string e
+        in
+        if gpu_supported fw then begin
+          any_failure := true ;
+          Printf.printf "FAIL (%s)\n%!" msg
+        end
+        else begin
+          incr unsupported ;
+          Printf.printf
+            "NOT-YET-SUPPORTED (%s; see L13 findings)\n%!"
+            (Printexc.to_string e)
+        end)
+    devs ;
+  Printf.printf
+    "\n=== tuple-vector: %d passed, %d not-yet-supported ===\n"
+    !pass_count
+    !unsupported ;
+  if !any_failure then exit 1

--- a/sarek/tests/e2e/test_tuple_vector.ml
+++ b/sarek/tests/e2e/test_tuple_vector.ml
@@ -13,11 +13,10 @@
  * and writes a modified tuple element back; results are checked against a pure
  * OCaml reference on every available device.
  *
- * Device support tier: the GPU/device path (CUDA/PTX, OpenCL, Vulkan) works
- * from the inline record layout alone. The Native and Interpreter paths
- * additionally need host/kernel Type_id identity and interpreter value-model
- * unification and are recorded as follow-ups; they are reported as
- * NOT-YET-SUPPORTED here rather than treated as failures.
+ * Device support tier: CUDA/PTX, OpenCL, Vulkan and Native must pass. The
+ * Interpreter path additionally needs value-model unification (its tuple/record
+ * representation and helper registration) and is recorded as a follow-up; it is
+ * reported as NOT-YET-SUPPORTED rather than treated as a failure.
  ******************************************************************************)
 
 module Vector = Spoc_core.Vector
@@ -47,10 +46,13 @@ let tuple_copy_kirc =
         let tid = thread_idx_x + (block_dim_x * block_idx_x) in
         if tid < n then match src.(tid) with a, b -> dst.(tid) <- (a +. 1.0, b)]
 
-(* Devices where the tuple-vector capability is expected to be fully supported
-   in this tier. *)
-let gpu_supported fw =
-  match fw with "CUDA" | "OpenCL" | "Vulkan" | "Metal" -> true | _ -> false
+(* Devices where the tuple-vector capability must work in this tier. The
+   Interpreter is a documented follow-up and reported (not failed) when it
+   cannot run. *)
+let must_pass fw =
+  match fw with
+  | "CUDA" | "OpenCL" | "Vulkan" | "Metal" | "Native" -> true
+  | _ -> false
 
 let () =
   print_endline "=== L13 tuple-vector E2E: (float32 * int32) vector ===" ;
@@ -132,7 +134,7 @@ let () =
           incr pass_count ;
           print_endline "PASSED"
         end
-        else if gpu_supported fw then begin
+        else if must_pass fw then begin
           any_failure := true ;
           print_endline "FAILED"
         end
@@ -147,7 +149,7 @@ let () =
               Sarek_backend_error.Backend_error.to_string err
           | e -> Printexc.to_string e
         in
-        if gpu_supported fw then begin
+        if must_pass fw then begin
           any_failure := true ;
           Printf.printf "FAIL (%s)\n%!" msg
         end

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -101,14 +101,27 @@ let offset_of rl fname =
    so the coercion is sound. *)
 let registry : (string, Obj.t) Hashtbl.t = Hashtbl.create 16
 
+(* Guards first-time registration: [find_opt] + [replace] is not atomic, and
+   two concurrent callers racing on the same shape would each build a fresh
+   [Type_id] with only one winning the registry slot — the loser's vector
+   would then fail the [Type_id.equal] check against the canonical descriptor
+   later resolved by generated Native code ([descriptor_by_name]). The mutex
+   makes build-and-insert single-winner; the double-check inside the critical
+   section resolves the race deterministically. *)
+let registry_mutex = Mutex.create ()
+
 let memoize name (build : unit -> 'a Vector.custom_type) : 'a Vector.custom_type
     =
   match Hashtbl.find_opt registry name with
   | Some obj -> Obj.obj obj
   | None ->
-      let custom = build () in
-      Hashtbl.replace registry name (Obj.repr custom) ;
-      custom
+      Mutex.protect registry_mutex (fun () ->
+          match Hashtbl.find_opt registry name with
+          | Some obj -> Obj.obj obj
+          | None ->
+              let custom = build () in
+              Hashtbl.replace registry name (Obj.repr custom) ;
+              custom)
 
 (** [descriptor_by_name name] returns the canonical [custom_type] previously
     registered for the mangled shape [name] (built by [pair]/[triple]). Used by

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -1,0 +1,152 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * L13 — Tuple-typed vectors (host side).
+ *
+ * OCaml tuples are structural, so there is no declaration site to hang
+ * [@@sarek.type] off and no PPX-generated [<name>_custom] to feed to
+ * [Vector.create_custom]. This module builds the missing [custom_type] values
+ * at runtime by composition: a tuple element is a packed record with
+ * positional fields [_0], [_1], ... and its byte layout is taken from the
+ * shared layout authority [Sarek_ir_layout], byte-for-byte identical to the
+ * layout the device codegen computes for the synthesized record
+ * ([Sarek_lower_ir.vector_elem_elttype]). Host [get]/[set] therefore marshal
+ * to/from exactly the bytes the kernel reads and writes on device.
+ *
+ * Scope (this tier): tuples of two or three scalar-primitive components. The
+ * device/GPU path (CUDA/PTX, OpenCL, Vulkan) consumes these directly. The
+ * Native and Interpreter execution paths additionally require host/kernel
+ * [Type_id] identity and interpreter value-model unification respectively and
+ * are follow-ups (see roster/ptx-limits-campaign/L13-tuple-vectors.md).
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module CH = Spoc_core.Vector.Custom_helpers
+module Layout = Sarek_ir_layout
+module Type_id = Sarek_ir_types.Type_id
+
+(** A scalar component of a tuple element: its IR element type (for layout) and
+    the typed raw-pointer read/write primitives used to marshal it at a byte
+    offset. *)
+type 'a component = {
+  c_elttype : Sarek_ir_types.elttype;
+  c_read : unit Ctypes.ptr -> int -> 'a;
+  c_write : unit Ctypes.ptr -> int -> 'a -> unit;
+  c_tag : string;
+}
+
+let float32 : float component =
+  {
+    c_elttype = Sarek_ir_types.TFloat32;
+    c_read = CH.read_float32;
+    c_write = CH.write_float32;
+    c_tag = "float32";
+  }
+
+let float64 : float component =
+  {
+    c_elttype = Sarek_ir_types.TFloat64;
+    c_read = CH.read_float64;
+    c_write = CH.write_float64;
+    c_tag = "float64";
+  }
+
+let int32 : int32 component =
+  {
+    c_elttype = Sarek_ir_types.TInt32;
+    c_read = CH.read_int32;
+    c_write = CH.write_int32;
+    c_tag = "int32";
+  }
+
+let int64 : int64 component =
+  {
+    c_elttype = Sarek_ir_types.TInt64;
+    c_read = CH.read_int64;
+    c_write = CH.write_int64;
+    c_tag = "int64";
+  }
+
+(** Mangled record name for a component tag list; kept in sync with
+    [Sarek_lower_ir.tuple_record_name] so host and device agree on the element
+    identity. *)
+let mangled_name (tags : string list) : string =
+  "_tup" ^ String.concat "" (List.map (fun t -> "_" ^ t) tags)
+
+let field_name i = Printf.sprintf "_%d" i
+
+let layout_of fields name =
+  match Layout.record_layout ~type_name:name fields with
+  | Ok rl -> rl
+  | Error e ->
+      failwith
+        ("Sarek_tuple_vec: could not lay out " ^ name ^ ": "
+        ^ Layout.layout_error_message e)
+
+let offset_of rl fname =
+  match List.assoc_opt fname rl.Layout.rl_fields with
+  | Some off -> off
+  | None -> failwith ("Sarek_tuple_vec: missing field offset for " ^ fname)
+
+(** [pair a b] is the [custom_type] for a [(a, b)] tuple vector element. *)
+let pair (a : 'a component) (b : 'b component) : ('a * 'b) Vector.custom_type =
+  let name = mangled_name [a.c_tag; b.c_tag] in
+  let fields = [(field_name 0, a.c_elttype); (field_name 1, b.c_elttype)] in
+  let rl = layout_of fields name in
+  let size = rl.Layout.rl_size in
+  let o0 = offset_of rl (field_name 0) in
+  let o1 = offset_of rl (field_name 1) in
+  {
+    Vector.elem_size = size;
+    type_id = Type_id.create ();
+    vector_type_id = Type_id.create ();
+    name;
+    get =
+      (fun ptr idx ->
+        let base = idx * size in
+        (a.c_read ptr (base + o0), b.c_read ptr (base + o1)));
+    set =
+      (fun ptr idx (x, y) ->
+        let base = idx * size in
+        a.c_write ptr (base + o0) x ;
+        b.c_write ptr (base + o1) y);
+  }
+
+(** [triple a b c] is the [custom_type] for a [(a, b, c)] tuple vector element.
+*)
+let triple (a : 'a component) (b : 'b component) (c : 'c component) :
+    ('a * 'b * 'c) Vector.custom_type =
+  let name = mangled_name [a.c_tag; b.c_tag; c.c_tag] in
+  let fields =
+    [
+      (field_name 0, a.c_elttype);
+      (field_name 1, b.c_elttype);
+      (field_name 2, c.c_elttype);
+    ]
+  in
+  let rl = layout_of fields name in
+  let size = rl.Layout.rl_size in
+  let o0 = offset_of rl (field_name 0) in
+  let o1 = offset_of rl (field_name 1) in
+  let o2 = offset_of rl (field_name 2) in
+  {
+    Vector.elem_size = size;
+    type_id = Type_id.create ();
+    vector_type_id = Type_id.create ();
+    name;
+    get =
+      (fun ptr idx ->
+        let base = idx * size in
+        ( a.c_read ptr (base + o0),
+          b.c_read ptr (base + o1),
+          c.c_read ptr (base + o2) ));
+    set =
+      (fun ptr idx (x, y, z) ->
+        let base = idx * size in
+        a.c_write ptr (base + o0) x ;
+        b.c_write ptr (base + o1) y ;
+        c.c_write ptr (base + o2) z);
+  }

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -16,11 +16,11 @@
  * ([Sarek_lower_ir.vector_elem_elttype]). Host [get]/[set] therefore marshal
  * to/from exactly the bytes the kernel reads and writes on device.
  *
- * Scope (this tier): tuples of two or three scalar-primitive components. The
- * device/GPU path (CUDA/PTX, OpenCL, Vulkan) consumes these directly. The
- * Native and Interpreter execution paths additionally require host/kernel
- * [Type_id] identity and interpreter value-model unification respectively and
- * are follow-ups (see roster/ptx-limits-campaign/L13-tuple-vectors.md).
+ * Scope (this tier): tuples of two or three scalar-primitive components,
+ * running on CUDA/PTX, OpenCL, Vulkan and Native. Native shares the [Type_id]
+ * with generated kernel code through the process-wide registry below. The
+ * Interpreter path needs value-model unification and is a follow-up (see
+ * roster/ptx-limits-campaign/L13-tuple-vectors.md).
  ******************************************************************************)
 
 module Vector = Spoc_core.Vector
@@ -91,9 +91,42 @@ let offset_of rl fname =
   | Some off -> off
   | None -> failwith ("Sarek_tuple_vec: missing field offset for " ^ fname)
 
+(* Process-global registry mapping a mangled tuple-shape name to its canonical
+   [custom_type]. A shape is instantiated once and shared: the host builds a
+   vector from it and the Native execution path looks up the very same
+   descriptor (via [descriptor_by_name], emitted by the native code generator),
+   so both sides carry the identical [Type_id] token that [vec_get_custom]
+   compares with [Type_id.equal]. The value is stored type-erased and recovered
+   at the call-site type; the mangled name uniquely determines the OCaml type,
+   so the coercion is sound. *)
+let registry : (string, Obj.t) Hashtbl.t = Hashtbl.create 16
+
+let memoize name (build : unit -> 'a Vector.custom_type) : 'a Vector.custom_type
+    =
+  match Hashtbl.find_opt registry name with
+  | Some obj -> Obj.obj obj
+  | None ->
+      let custom = build () in
+      Hashtbl.replace registry name (Obj.repr custom) ;
+      custom
+
+(** [descriptor_by_name name] returns the canonical [custom_type] previously
+    registered for the mangled shape [name] (built by [pair]/[triple]). Used by
+    generated Native kernel code to obtain the host-shared [Type_id]. Raises if
+    the shape was never instantiated on the host. *)
+let descriptor_by_name (name : string) : 'a Vector.custom_type =
+  match Hashtbl.find_opt registry name with
+  | Some obj -> Obj.obj obj
+  | None ->
+      failwith
+        ("Sarek_tuple_vec: no tuple custom_type registered for shape '" ^ name
+       ^ "'; build it on the host (e.g. Sarek_tuple_vec.pair ...) before \
+          running the kernel.")
+
 (** [pair a b] is the [custom_type] for a [(a, b)] tuple vector element. *)
 let pair (a : 'a component) (b : 'b component) : ('a * 'b) Vector.custom_type =
   let name = mangled_name [a.c_tag; b.c_tag] in
+  memoize name @@ fun () ->
   let fields = [(field_name 0, a.c_elttype); (field_name 1, b.c_elttype)] in
   let rl = layout_of fields name in
   let size = rl.Layout.rl_size in
@@ -120,6 +153,7 @@ let pair (a : 'a component) (b : 'b component) : ('a * 'b) Vector.custom_type =
 let triple (a : 'a component) (b : 'b component) (c : 'c component) :
     ('a * 'b * 'c) Vector.custom_type =
   let name = mangled_name [a.c_tag; b.c_tag; c.c_tag] in
+  memoize name @@ fun () ->
   let fields =
     [
       (field_name 0, a.c_elttype);

--- a/sarek/tuple_vec/Sarek_tuple_vec.mli
+++ b/sarek/tuple_vec/Sarek_tuple_vec.mli
@@ -1,0 +1,37 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** L13 — host-side [custom_type] builders for tuple-typed vector elements.
+
+    Build the [Spoc_core.Vector.custom_type] needed by [Vector.create_custom]
+    for a [('a * 'b) vector] (or 3-tuple), so tuples can be stored/read from the
+    host with OCaml tuple literals while the kernel manipulates them on device.
+    The byte layout is taken from the shared layout authority so it matches the
+    device element layout exactly. Only scalar-primitive components are
+    supported in this tier. *)
+
+module Vector = Spoc_core.Vector
+
+(** A scalar tuple component. *)
+type 'a component
+
+val float32 : float component
+
+val float64 : float component
+
+val int32 : int32 component
+
+val int64 : int64 component
+
+(** [pair a b] builds the custom type for a [(a, b)] tuple vector element. *)
+val pair : 'a component -> 'b component -> ('a * 'b) Vector.custom_type
+
+(** [triple a b c] builds the custom type for an [(a, b, c)] tuple vector
+    element. *)
+val triple :
+  'a component ->
+  'b component ->
+  'c component ->
+  ('a * 'b * 'c) Vector.custom_type

--- a/sarek/tuple_vec/Sarek_tuple_vec.mli
+++ b/sarek/tuple_vec/Sarek_tuple_vec.mli
@@ -35,3 +35,10 @@ val triple :
   'b component ->
   'c component ->
   ('a * 'b * 'c) Vector.custom_type
+
+(** [descriptor_by_name name] returns the canonical [custom_type] registered for
+    a mangled tuple-shape name (e.g. ["_tup_float32_int32"]) by a previous
+    [pair]/[triple] call. Generated Native kernel code uses this to obtain the
+    same [Type_id] the host vector carries. Raises if the shape was never built
+    on the host. Not normally called directly. *)
+val descriptor_by_name : string -> 'a Vector.custom_type

--- a/sarek/tuple_vec/dune
+++ b/sarek/tuple_vec/dune
@@ -1,0 +1,7 @@
+; L13 — host-side custom_type builders for tuple-typed vector elements.
+
+(library
+ (name sarek_tuple_vec)
+ (public_name sarek.tuple_vec)
+ (libraries spoc_core sarek_ir ctypes)
+ (preprocess no_preprocessing))


### PR DESCRIPTION
## Summary

Implements L13 — `('a * 'b) vector` tuple-typed vectors (Design A from the
validated design doc). A tuple vector element is lowered to a synthesized
packed record (positional fields `_0`, `_1`, ...), reusing the existing
record/aggregate codegen; the host builds the matching `custom_type` with a
new `sarek.tuple_vec` library, layout taken from the shared `Sarek_ir_layout`
authority so host and device agree byte-for-byte.

Before this, a tuple vector param was rejected by the `lower_param` guard (which
had already turned an earlier silent-`TInt32` miscompile into a clear error).

## What changed
- **`Sarek_lower_ir`**: accept `TVec (TTuple prims)`, map the element to
  `Ir.TRecord`; lower tuple literals to `Ir.ERecord` (typed compound literal
  for struct backends); rewrite a single-arm tuple-pattern `match` into
  field-access `let`s (the C-like backends otherwise mis-emit a variant
  `switch (x.tag)`); register the synthesized record in the codegen types table.
- **`sarek.tuple_vec`** (new lib): host `pair`/`triple` `custom_type` builders +
  a process-global shape registry so the Native path shares one `Type_id` with
  generated kernel code.
- **`Sarek_native_gen_base`**: resolve tuple-shape elements to the shared
  registry descriptor (restricted to float32/float64/int32/int64 components).
- **`sarek/tests/e2e/test_tuple_vector.ml`** (new): self-verifying vs a pure
  OCaml reference on every device.

## Test matrix (RX 7900 XTX host)
`(float32 * int32) vector` read-modify-write kernel, checked vs host reference:

| Device | Result |
|---|---|
| CUDA/PTX (ZLUDA) — GPU + CPU | PASS |
| OpenCL — GPU + CPU | PASS |
| Vulkan — GPU + CPU | PASS |
| Native | PASS |
| Interpreter | NOT-YET-SUPPORTED (value-model unification; documented follow-up) |

**7/7 must-pass devices green.** Full `dune runtest sarek/tests` green — no
regression. `@install` and `@fmt` clean on changed files.

## Follow-ups (see design doc §9)
Interpreter support (tuple/record value-model unification), non-primitive tuple
components, and `int`/`char`/`bool` components on Native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for vectors containing primitive tuples, including pairs and triples.
  - Added APIs for defining tuple vector element types using supported scalar components.
  - Added host/device layout handling for reading and writing tuple elements.
  - Added tuple vector execution coverage across supported backends.

- **Bug Fixes**
  - Improved tuple lowering and destructuring to preserve consistent memory layout and code generation.

- **Tests**
  - Added end-to-end validation for tuple vectors with floating-point and integer components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->