### PR TITLE
feat(sarek): static tag erasure for kernel-local variant slots (L14 scoped tier)

### DIFF
--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -87,8 +87,8 @@ let elttype_prim_tag (e : Ir.elttype) : string option =
     match on [Sarek_types.typ] directly, NOT via [elttype_of_typ]: that
     conversion maps [TTuple]/[TFun] to a placeholder [Ir.TInt32] (see its NOTE),
     so routing the primitivity check through it would silently accept nested
-    tuples or function components as int32 fields and synthesize a wrong
-    layout. Returns the component's IR type iff it is a supported scalar. *)
+    tuples or function components as int32 fields and synthesize a wrong layout.
+    Returns the component's IR type iff it is a supported scalar. *)
 let prim_component_elttype (t : typ) : Ir.elttype option =
   match repr t with
   | TPrim TInt32 -> Some Ir.TInt32

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -1684,6 +1684,16 @@ let expand_kernel ~ctxt payload : expression =
             Sarek_debug.log_to_file "  step 6: tailrec transform done" ;
             Sarek_debug.log_exit "transform_kernel" ;
 
+            (* 6b. Static tag erasure (L14, scoped tier) - device path only.
+               Erase statically-known variant tags from kernel-local slots
+               before lowering; [native_kernel] captured above keeps the tag
+               and stays the OCaml reference. See Sarek_tag_erasure.ml. *)
+            Sarek_debug.log_to_file "  step 6b: tag erasure start" ;
+            Sarek_debug.log_enter "erase_tags" ;
+            let tkernel = Sarek_tag_erasure.erase_tags tkernel in
+            Sarek_debug.log_to_file "  step 6b: tag erasure done" ;
+            Sarek_debug.log_exit "erase_tags" ;
+
             (* 7. Lower to Sarek_ir *)
             let kern_name = Option.value ~default:"anon" tkernel.tkern_name in
             Sarek_debug.log_to_file

--- a/sarek/ppx/Sarek_tag_erasure.ml
+++ b/sarek/ppx/Sarek_tag_erasure.ml
@@ -1,0 +1,226 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek PPX - Static tag erasure (campaign item L14, scoped tier)
+ *
+ * Typed-AST -> typed-AST rewrite that runs after defunctionalization
+ * (Sarek_defunc) / tail-recursion elimination and BEFORE lowering
+ * (Sarek_lower_ir), on the DEVICE-lowered kernel only: the un-erased
+ * [native_kernel] captured earlier in Sarek_ppx keeps the tag and stays the
+ * OCaml reference path. See roster/ptx-limits-campaign/L14-static-tag-erasure.md.
+ *
+ * The tag stays in the typed AST for typing / OCaml-side exhaustiveness
+ * checking; this pass erases it for code generation wherever the live
+ * constructor of a variant-typed *storage slot* is statically determined -
+ * the slot is written exactly once by a literal constructor application
+ * ([TEConstr]) and is only ever read as the scrutinee of a [match]. This is
+ * case-of-known-constructor / iota-reduction applied to the storage
+ * representation of a value whose constructor identity is invariant, which is
+ * a standard, decades-old compiler technique (design doc SS7).
+ *
+ * Scoped tier implemented here (S1): a variant-typed plain (immutable)
+ * kernel-local `let` binding, so there is exactly one write site by
+ * construction:
+ *
+ *     let s = C payload in ... match s with .. | C x -> rhs | .. ...
+ *  ~> let s = payload   in ... let x = s in rhs ...            (unary)
+ *     let s = C         in ... match s with .. | C -> rhs | .. ...
+ *  ~>                       ... rhs ...                         (nullary, drop)
+ *
+ * The tag store and the whole branch chain disappear from every backend's
+ * emitted code (observable in the IR / CUDA-C / PTX), and behaviour is
+ * unchanged: the reduced form runs the C-arm unconditionally, binding the
+ * payload for the unary case. Anything with a runtime-selected constructor - a
+ * mutable slot, a value from a `TEIf`/`TEMatch`/helper call, or a slot read as
+ * a whole variant value rather than only as a `match` scrutinee - is
+ * conservatively left tagged, exactly today's behaviour.
+ *
+ * NOT implemented (deferred to a follow-up tier, see the design doc's
+ * "Implementation findings" section): erasing a variant-typed *record field*
+ * (the layout-unblock headline of SS0/SS8). Empirically that requires threading
+ * a rewritten record type through every occurrence AND reconciling with the
+ * `[@@sarek.type]` declaration that the Interpreter and host marshalling
+ * consume by field position - substantially more than an expression rewrite,
+ * and it regresses a currently-working backend if attempted as a pure
+ * expression rewrite.
+ ******************************************************************************)
+
+open Sarek_types
+open Sarek_typed_ast
+
+let is_variant_ty (t : typ) : bool =
+  match repr t with TVariant _ -> true | _ -> false
+
+(* -------------------------------------------------------------------------- *)
+(* Generic structural map / iter over the typed AST (mirrors the shape of     *)
+(* Sarek_defunc.rewrite_desc / iter_children).                                *)
+(* -------------------------------------------------------------------------- *)
+
+let map_desc (f : texpr -> texpr) (te : texpr_desc) : texpr_desc =
+  match te with
+  | TEUnit | TEBool _ | TEInt _ | TEInt32 _ | TEInt64 _ | TEFloat _ | TEDouble _
+  | TEGlobalRef _ | TENative _ | TEIntrinsicConst _ | TEVar _ ->
+      te
+  | TEVecGet (v, i) -> TEVecGet (f v, f i)
+  | TEVecSet (v, i, x) -> TEVecSet (f v, f i, f x)
+  | TEArrGet (a, i) -> TEArrGet (f a, f i)
+  | TEArrSet (a, i, x) -> TEArrSet (f a, f i, f x)
+  | TEFieldGet (r, fld, idx) -> TEFieldGet (f r, fld, idx)
+  | TEFieldSet (r, fld, idx, v) -> TEFieldSet (f r, fld, idx, f v)
+  | TEBinop (op, a, b) -> TEBinop (op, f a, f b)
+  | TEUnop (op, a) -> TEUnop (op, f a)
+  | TEApp (fn, args) -> TEApp (f fn, List.map f args)
+  | TEAssign (n, id, v) -> TEAssign (n, id, f v)
+  | TELet (n, id, v, b) -> TELet (n, id, f v, f b)
+  | TELetRec (n, id, ps, fn_body, cont) ->
+      TELetRec (n, id, ps, f fn_body, f cont)
+  | TELetMut (n, id, v, b) -> TELetMut (n, id, f v, f b)
+  | TEIf (c, t, e) -> TEIf (f c, f t, Option.map f e)
+  | TEFor (v, id, lo, hi, dir, body) -> TEFor (v, id, f lo, f hi, dir, f body)
+  | TEWhile (c, b) -> TEWhile (f c, f b)
+  | TESeq es -> TESeq (List.map f es)
+  | TEMatch (s, cases) -> TEMatch (f s, List.map (fun (p, b) -> (p, f b)) cases)
+  | TERecord (n, fields) ->
+      TERecord (n, List.map (fun (fl, e) -> (fl, f e)) fields)
+  | TEConstr (tn, cn, arg) -> TEConstr (tn, cn, Option.map f arg)
+  | TETuple es -> TETuple (List.map f es)
+  | TEReturn e -> TEReturn (f e)
+  | TECreateArray (size, t, m) -> TECreateArray (f size, t, m)
+  | TEPragma (opts, body) -> TEPragma (opts, f body)
+  | TEIntrinsicFun (r, c, args) -> TEIntrinsicFun (r, c, List.map f args)
+  | TELetShared (n, id, t, size, b) ->
+      TELetShared (n, id, t, Option.map f size, f b)
+  | TESuperstep (n, d, step, cont) -> TESuperstep (n, d, f step, f cont)
+  | TEOpen (path, body) -> TEOpen (path, f body)
+
+let iter_children (f : texpr -> unit) (e : texpr) : unit =
+  ignore
+    (map_desc
+       (fun c ->
+         f c ;
+         c)
+       e.te)
+
+let map_children (f : texpr -> texpr) (e : texpr) : texpr =
+  {e with te = map_desc f e.te}
+
+(* -------------------------------------------------------------------------- *)
+(* Eligibility + reduction, keyed on a slot variable id                       *)
+(* -------------------------------------------------------------------------- *)
+
+let is_slot_var (id : int) (e : texpr) : bool =
+  match e.te with TEVar (_, i) -> i = id | _ -> false
+
+let is_ctor_case (cname : string) ((p, _) : tpattern * texpr) : bool =
+  match p.tpat with TPConstr (_, cn, _) -> cn = cname | _ -> false
+
+(* Every read of the slot variable is the scrutinee of a `match` that has an
+   explicit arm for [cname]. Any other use of the variable (which would need
+   the whole tagged value) makes the slot ineligible. Variable ids are globally
+   unique (Sarek_typed_ast.fresh_var_id), so there is no shadowing to handle. *)
+let uses_all_reducible (id : int) (cname : string) (body : texpr) : bool =
+  let ok = ref true in
+  let rec go (e : texpr) : unit =
+    match e.te with
+    | TEVar (_, i) when i = id -> ok := false (* bare use outside scrutinee *)
+    | TEMatch (scrut, cases) when is_slot_var id scrut ->
+        if not (List.exists (is_ctor_case cname) cases) then ok := false ;
+        List.iter (fun (_, rhs) -> go rhs) cases
+    | _ -> iter_children go e
+  in
+  go body ;
+  !ok
+
+(* Substitute [repl] for every occurrence of variable [pid]. Used to inline the
+   payload-typed slot variable in place of a constructor pattern's bound
+   variable, so no fresh `let` is introduced in what may be an expression
+   position (Sarek treats `let` as statement-only in some contexts - see the
+   note in Sarek_defunc.distribute_app). [repl] is always a bare variable read,
+   so substitution never duplicates work. *)
+let subst_var (pid : int) (repl : texpr) (e : texpr) : texpr =
+  let rec go (e : texpr) : texpr =
+    match e.te with TEVar (_, i) when i = pid -> repl | _ -> map_children go e
+  in
+  go e
+
+(* Replace every `match <slot> with .. | C pat -> rhs | ..` by the C-arm: [rhs]
+   with the bound pattern variable substituted by [accessor] (the slot re-read
+   at the payload type) for a unary constructor, or [rhs] alone for a nullary
+   one. Recurses into the kept arm so nested reads reduce too. *)
+let reduce_matches (id : int) (cname : string)
+    (accessor : (unit -> texpr) option) (body : texpr) : texpr =
+  let rec go (e : texpr) : texpr =
+    match e.te with
+    | TEMatch (scrut, cases) when is_slot_var id scrut -> (
+        let pat, rhs =
+          match List.find_opt (is_ctor_case cname) cases with
+          | Some (p, rhs) -> (
+              match p.tpat with
+              | TPConstr (_, _, arg) -> (arg, rhs)
+              | _ -> (None, rhs))
+          | None -> (None, e)
+          (* unreachable: guarded by uses_all_reducible *)
+        in
+        let rhs' = go rhs in
+        match (pat, accessor) with
+        | Some {tpat = TPVar (_, pid); _}, Some mk -> subst_var pid (mk ()) rhs'
+        | _ -> {rhs' with ty = e.ty})
+    | _ -> map_children go e
+  in
+  go body
+
+(* -------------------------------------------------------------------------- *)
+(* Core rewrite                                                               *)
+(* -------------------------------------------------------------------------- *)
+
+let rewrite_body (body : texpr) : texpr =
+  let rec rewrite (e : texpr) : texpr =
+    match e.te with
+    | TELet (name, id, value, body)
+      when is_variant_ty value.ty
+           && match value.te with TEConstr _ -> true | _ -> false -> (
+        match value.te with
+        | TEConstr (_tyname, cname, arg) when uses_all_reducible id cname body
+          -> (
+            match arg with
+            | None ->
+                (* nullary: drop the binding, reduce every match to its arm *)
+                reduce_matches id cname None (rewrite body)
+            | Some payload ->
+                (* unary: retype the binding to the payload; each match arm
+                   binds its pattern var to the (now payload-typed) slot. *)
+                let payload' = rewrite payload in
+                let accessor () = {payload' with te = TEVar (name, id)} in
+                let body' =
+                  reduce_matches id cname (Some accessor) (rewrite body)
+                in
+                {
+                  te = TELet (name, id, payload', body');
+                  ty = body'.ty;
+                  te_loc = e.te_loc;
+                })
+        | _ -> map_children rewrite e)
+    | _ -> map_children rewrite e
+  in
+  rewrite body
+
+(* -------------------------------------------------------------------------- *)
+(* Entry point                                                                *)
+(* -------------------------------------------------------------------------- *)
+
+let erase_tags (kernel : tkernel) : tkernel =
+  let module_items' =
+    List.map
+      (function
+        | TMFun (n, r, ps, b) -> TMFun (n, r, ps, rewrite_body b)
+        | TMConst _ as it -> it)
+      kernel.tkern_module_items
+  in
+  {
+    kernel with
+    tkern_module_items = module_items';
+    tkern_body = rewrite_body kernel.tkern_body;
+  }

--- a/sarek/ppx/Sarek_tag_erasure.ml
+++ b/sarek/ppx/Sarek_tag_erasure.ml
@@ -114,8 +114,22 @@ let map_children (f : texpr -> texpr) (e : texpr) : texpr =
 let is_slot_var (id : int) (e : texpr) : bool =
   match e.te with TEVar (_, i) -> i = id | _ -> false
 
+(* A constructor arm is reducible only when its payload pattern binds through
+   the forms [reduce_matches] actually substitutes: no payload (nullary), a
+   single [TPVar], or a binder-free [TPAny] (`C _ -> ...`). Compound payload
+   patterns (a multi-arg constructor's [TPTuple], nested [TPConstr], ...) would
+   have their binders silently dropped by the reduction, so they make the arm -
+   and therefore the slot - ineligible and the tag is retained. *)
+let is_reducible_payload (arg : tpattern option) : bool =
+  match arg with
+  | None -> true
+  | Some {tpat = TPVar _; _} | Some {tpat = TPAny; _} -> true
+  | Some _ -> false
+
 let is_ctor_case (cname : string) ((p, _) : tpattern * texpr) : bool =
-  match p.tpat with TPConstr (_, cn, _) -> cn = cname | _ -> false
+  match p.tpat with
+  | TPConstr (_, cn, arg) -> cn = cname && is_reducible_payload arg
+  | _ -> false
 
 (* Every read of the slot variable is the scrutinee of a `match` that has an
    explicit arm for [cname]. Any other use of the variable (which would need
@@ -161,8 +175,14 @@ let reduce_matches (id : int) (cname : string)
               match p.tpat with
               | TPConstr (_, _, arg) -> (arg, rhs)
               | _ -> (None, rhs))
-          | None -> (None, e)
-          (* unreachable: guarded by uses_all_reducible *)
+          | None ->
+              (* Guarded by uses_all_reducible; if a future eligibility-check
+                 change breaks that invariant, fail loudly rather than
+                 re-entering this same branch forever via [go e]. *)
+              failwith
+                "Sarek_tag_erasure.reduce_matches: no reducible arm for the \
+                 slot's constructor (invariant violated: uses_all_reducible \
+                 should have made this slot ineligible)"
         in
         let rhs' = go rhs in
         match (pat, accessor) with

--- a/sarek/ppx/dune
+++ b/sarek/ppx/dune
@@ -26,6 +26,7 @@
   Sarek_ir_ppx
   Sarek_mono
   Sarek_defunc
+  Sarek_tag_erasure
   Sarek_debug
   Sarek_tailrec_analysis
   Sarek_tailrec_elim

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -695,3 +695,37 @@
  (alias runtest)
  (action
   (run %{dep:test_tuple_vector.exe})))
+
+; L14 static tag erasure E2E (Sarek_tag_erasure). A variant-typed kernel-local
+; slot written once by a literal constructor and read only as a match scrutinee
+; has its tag/branch erased for codegen. Self-verifying: (1) emitted CUDA-C
+; carries no tag/switch for the erasable kernels but does for a runtime-selected
+; control, and (2) behaviour matches a pure-OCaml reference on every device
+; (Native/Interpreter always, plus any GPU backend present).
+
+(executable
+ (name test_static_tag_erasure)
+ (modules test_static_tag_erasure)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  sarek.codegen
+  spoc_core
+  test_helpers
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_static_tag_erasure.exe})))

--- a/sarek/tests/e2e/test_static_tag_erasure.ml
+++ b/sarek/tests/e2e/test_static_tag_erasure.ml
@@ -70,7 +70,8 @@ let nullary_kirc =
    pattern is a tuple of binders, which the S1 reduction does not substitute —
    the arm is ineligible and the tag must be RETAINED (erasing it would drop
    the tuple binders and emit malformed code). Result: a + 2a with a = src.(tid). *)
-type pair_pt = MkPair of float32 * float32 [@@sarek.type]
+type pair_pt = MkPair of float32 * float32 | MkOne of float32
+[@@sarek.type]
 
 let multiarg_kirc =
   snd
@@ -79,7 +80,9 @@ let multiarg_kirc =
         let tid = thread_idx_x + (block_dim_x * block_idx_x) in
         if tid < n then begin
           let s = MkPair (src.(tid), src.(tid) +. src.(tid)) in
-          match s with MkPair (x, y) -> dst.(tid) <- x +. y
+          match s with
+          | MkPair (x, y) -> dst.(tid) <- x +. y
+          | MkOne x -> dst.(tid) <- x
         end]
 
 (* NEGATIVE CONTROL: the live constructor is chosen at runtime, so the slot is

--- a/sarek/tests/e2e/test_static_tag_erasure.ml
+++ b/sarek/tests/e2e/test_static_tag_erasure.ml
@@ -70,8 +70,7 @@ let nullary_kirc =
    pattern is a tuple of binders, which the S1 reduction does not substitute —
    the arm is ineligible and the tag must be RETAINED (erasing it would drop
    the tuple binders and emit malformed code). Result: a + 2a with a = src.(tid). *)
-type pair_pt = MkPair of float32 * float32 | MkOne of float32
-[@@sarek.type]
+type pair_pt = MkPair of float32 * float32 | MkOne of float32 [@@sarek.type]
 
 let multiarg_kirc =
   snd

--- a/sarek/tests/e2e/test_static_tag_erasure.ml
+++ b/sarek/tests/e2e/test_static_tag_erasure.ml
@@ -1,0 +1,207 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * L14 — E2E test for static tag erasure (scoped tier, S1).
+ *
+ * A variant-typed kernel-local slot written exactly once by a literal
+ * constructor and read only as a `match` scrutinee has its tag and branch
+ * chain erased at code-generation time (Sarek_tag_erasure), on the device
+ * path only. This test is self-verifying on two axes:
+ *
+ *   1. OBSERVABLE erasure: the emitted device source (CUDA-C, generated
+ *      directly from the lowered IR — no device required) for the erasable
+ *      kernel contains no variant tag, `switch`, or `enum`, whereas a
+ *      NEGATIVE-CONTROL kernel whose constructor is genuinely runtime-selected
+ *      still carries the tag/branch. This proves the pass erases when safe and
+ *      stays conservative otherwise (it is not blindly stripping variants).
+ *
+ *   2. BEHAVIOURAL equivalence: on every available device the erasable kernels
+ *      (a nullary and a unary constructor slot) compute exactly the pure-OCaml
+ *      reference. The un-erased Native path (Sarek keeps the tag for native
+ *      codegen) acts as an independent oracle alongside the hand-written
+ *      reference.
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module Device = Spoc_core.Device
+module Transfer = Spoc_core.Transfer
+
+[@@@warning "-32"]
+
+let () = Test_helpers.Benchmarks.init ()
+
+type float32 = float
+
+(* A variant that is morally an init-time tag in these kernels: constructed
+   once, never a live dispatch. *)
+type shape = Circle of float32 | Square of float32 [@@sarek.type]
+
+type flag = On | Off [@@sarek.type]
+
+(* Erasable, unary: `let s = Circle src.(tid)` — literal constructor, matched
+   twice, never used as a whole value. Result: v^2 + v with v = src.(tid). *)
+let unary_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let s = Circle src.(tid) in
+          let sq = match s with Circle r -> r *. r | Square x -> x in
+          dst.(tid) <- (match s with Circle r -> sq +. r | Square _ -> sq)
+        end]
+
+(* Erasable, nullary: `let f = On` — the tag and branch vanish entirely.
+   Result: 1.0 for On, 2.0 for Off (always On here). [src] is unused. *)
+let nullary_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let f = On in
+          match f with On -> dst.(tid) <- 1.0 | Off -> dst.(tid) <- 2.0
+        end]
+
+(* NEGATIVE CONTROL: the live constructor is chosen at runtime, so the slot is
+   NOT erasable and the tag/branch must be retained. *)
+let retained_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let s =
+            if tid mod 2 = 0 then Circle src.(tid) else Square src.(tid)
+          in
+          match s with
+          | Circle r -> dst.(tid) <- r *. r
+          | Square x -> dst.(tid) <- x
+        end]
+
+let ir_of name kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith ("no IR for " ^ name)
+
+(* ---- Axis 1: observable erasure in the emitted device source ------------- *)
+
+let contains hay needle =
+  let nh = String.length needle and h = String.length hay in
+  let rec go i =
+    if i + nh > h then false
+    else if String.sub hay i nh = needle then true
+    else go (i + 1)
+  in
+  go 0
+
+let mentions_tag src =
+  contains src "switch (" || contains src ".tag" || contains src "enum "
+
+let observable_ok = ref true
+
+let check_emitted name kirc ~expect_tag =
+  let src = Sarek_codegen.Sarek_ir_cuda.generate (ir_of name kirc) in
+  let has = mentions_tag src in
+  let ok = has = expect_tag in
+  if not ok then observable_ok := false ;
+  Printf.printf
+    "  emitted[%s]: tag/branch %s (expected %s) -> %s\n%!"
+    name
+    (if has then "present" else "absent")
+    (if expect_tag then "present" else "absent")
+    (if ok then "OK" else "MISMATCH") ;
+  if not ok then begin
+    print_endline "  ---- emitted CUDA-C ----" ;
+    print_endline src
+  end
+
+(* ---- Axis 2: behavioural equivalence on every device --------------------- *)
+
+let must_pass fw =
+  match fw with
+  | "CUDA" | "OpenCL" | "Vulkan" | "Metal" | "Native" | "Interpreter" -> true
+  | _ -> false
+
+let any_failure = ref false
+
+let run_behaviour name kirc ~reference =
+  Printf.printf "runtime[%s]:\n%!" name ;
+  let devs =
+    Device.init
+      ~frameworks:["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"]
+      ()
+  in
+  if Array.length devs = 0 then
+    print_endline "  no devices — codegen-only (behaviour skipped)"
+  else
+    Array.iter
+      (fun dev ->
+        let fw = dev.Device.framework in
+        Printf.printf "  [%s] %s: %!" fw dev.Device.name ;
+        try
+          let n = 64 in
+          let src = Vector.create Vector.float32 n in
+          let dst = Vector.create Vector.float32 n in
+          for i = 0 to n - 1 do
+            Vector.set src i (float_of_int (i + 1)) ;
+            Vector.set dst i 0.0
+          done ;
+          let threads = min 64 n in
+          let grid_x = (n + threads - 1) / threads in
+          Sarek.Execute.run_vectors
+            ~device:dev
+            ~block:(Sarek.Execute.dims1d threads)
+            ~grid:(Sarek.Execute.dims1d grid_x)
+            ~ir:(ir_of name kirc)
+            ~args:
+              [
+                Sarek.Execute.Vec src;
+                Sarek.Execute.Vec dst;
+                Sarek.Execute.Int32 (Int32.of_int n);
+              ]
+            () ;
+          Transfer.flush dev ;
+          let ok = ref true in
+          for i = 0 to n - 1 do
+            let got = Vector.get dst i and exp = reference i in
+            if abs_float (got -. exp) > 1e-2 then begin
+              ok := false ;
+              if i < 4 then
+                Printf.printf "\n    mismatch@%d got %.3f exp %.3f%!" i got exp
+            end
+          done ;
+          if !ok then print_endline "PASSED"
+          else begin
+            if must_pass fw then any_failure := true ;
+            print_endline "FAILED"
+          end
+        with e ->
+          if must_pass fw then any_failure := true ;
+          Printf.printf "ERROR %s\n%!" (Printexc.to_string e))
+      devs
+
+let () =
+  print_endline "=== L14 static tag erasure E2E ===" ;
+  print_endline "-- emitted-code snapshots --" ;
+  check_emitted "unary(erasable)" unary_kirc ~expect_tag:false ;
+  check_emitted "nullary(erasable)" nullary_kirc ~expect_tag:false ;
+  check_emitted "runtime-selected(control)" retained_kirc ~expect_tag:true ;
+  print_endline "-- behaviour vs pure-OCaml reference --" ;
+  run_behaviour "unary(erasable)" unary_kirc ~reference:(fun i ->
+      let r = float_of_int (i + 1) in
+      (r *. r) +. r) ;
+  run_behaviour "nullary(erasable)" nullary_kirc ~reference:(fun _ -> 1.0) ;
+  Printf.printf
+    "\n=== observable=%s behaviour=%s ===\n"
+    (if !observable_ok then "OK" else "FAIL")
+    (if !any_failure then "FAIL" else "OK") ;
+  if !observable_ok && not !any_failure then
+    print_endline "test_static_tag_erasure PASSED"
+  else begin
+    print_endline "test_static_tag_erasure FAILED" ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_static_tag_erasure.ml
+++ b/sarek/tests/e2e/test_static_tag_erasure.ml
@@ -66,6 +66,22 @@ let nullary_kirc =
           match f with On -> dst.(tid) <- 1.0 | Off -> dst.(tid) <- 2.0
         end]
 
+(* NEGATIVE CONTROL (compound payload): a multi-arg constructor's payload
+   pattern is a tuple of binders, which the S1 reduction does not substitute —
+   the arm is ineligible and the tag must be RETAINED (erasing it would drop
+   the tuple binders and emit malformed code). Result: a + 2a with a = src.(tid). *)
+type pair_pt = MkPair of float32 * float32 [@@sarek.type]
+
+let multiarg_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let s = MkPair (src.(tid), src.(tid) +. src.(tid)) in
+          match s with MkPair (x, y) -> dst.(tid) <- x +. y
+        end]
+
 (* NEGATIVE CONTROL: the live constructor is chosen at runtime, so the slot is
    NOT erasable and the tag/branch must be retained. *)
 let retained_kirc =
@@ -128,7 +144,7 @@ let must_pass fw =
 
 let any_failure = ref false
 
-let run_behaviour name kirc ~reference =
+let run_behaviour ?(must = must_pass) name kirc ~reference =
   Printf.printf "runtime[%s]:\n%!" name ;
   let devs =
     Device.init
@@ -176,12 +192,15 @@ let run_behaviour name kirc ~reference =
           done ;
           if !ok then print_endline "PASSED"
           else begin
-            if must_pass fw then any_failure := true ;
+            if must fw then any_failure := true ;
             print_endline "FAILED"
           end
         with e ->
-          if must_pass fw then any_failure := true ;
-          Printf.printf "ERROR %s\n%!" (Printexc.to_string e))
+          if must fw then any_failure := true ;
+          Printf.printf
+            "%s %s\n%!"
+            (if must fw then "ERROR" else "SKIP (backend lacks the construct)")
+            (Printexc.to_string e))
       devs
 
 let () =
@@ -190,11 +209,24 @@ let () =
   check_emitted "unary(erasable)" unary_kirc ~expect_tag:false ;
   check_emitted "nullary(erasable)" nullary_kirc ~expect_tag:false ;
   check_emitted "runtime-selected(control)" retained_kirc ~expect_tag:true ;
+  check_emitted "multiarg-payload(control)" multiarg_kirc ~expect_tag:true ;
   print_endline "-- behaviour vs pure-OCaml reference --" ;
   run_behaviour "unary(erasable)" unary_kirc ~reference:(fun i ->
       let r = float_of_int (i + 1) in
       (r *. r) +. r) ;
   run_behaviour "nullary(erasable)" nullary_kirc ~reference:(fun _ -> 1.0) ;
+  (* Multi-arg constructor payloads are a PRE-EXISTING gap everywhere except
+     Native: the Interpreter crashes (List.iter2) and every source generator
+     (CUDA/PTX, OpenCL, Vulkan) returns generate_source None — unrelated to
+     erasure. The retained-tag assertion above is the real check here;
+     behaviour is gated only where the construct executes today (Native). *)
+  run_behaviour
+    "multiarg-payload(control)"
+    multiarg_kirc
+    ~must:(fun fw -> fw = "Native")
+    ~reference:(fun i ->
+      let a = float_of_int (i + 1) in
+      a +. (a +. a)) ;
   Printf.printf
     "\n=== observable=%s behaviour=%s ===\n"
     (if !observable_ok then "OK" else "FAIL")


### PR DESCRIPTION
## Summary

Implements the **scoped tier** of campaign item **L14 — static tag erasure** (design: `roster/ptx-limits-campaign/L14-static-tag-erasure.md`). Keeps the variant tag in the typed AST (typing / OCaml-side exhaustiveness) and **erases it for code generation** wherever the live constructor of a variant-typed storage slot is statically determined.

New pass `sarek/ppx/Sarek_tag_erasure.ml` runs at `Sarek_ppx` step 6b (after tailrec, before lowering) on the **device-lowered kernel only** — the `native_kernel` captured earlier keeps the tag and stays an independent OCaml reference oracle.

### What it erases (S1 — variant-typed immutable kernel-local `let` slot)
A slot written exactly once by a literal `TEConstr` and read only as a `match` scrutinee has a statically-known constructor, so the pass applies case-of-known-constructor:
- **nullary** → drop the binding, collapse each match to its arm;
- **unary** → retype the binding to the payload and substitute the payload variable for the pattern variable (no new `let`, avoiding statement-only-in-expression-position lowering errors — the constraint `Sarek_defunc.distribute_app` documents).

The tag store and the whole branch chain disappear from the emitted IR / CUDA-C / PTX. Conservative by construction: mutable slots, runtime-selected constructors, and slots used as whole variant values are left tagged (exactly today's behaviour).

## Test matrix

New self-verifying `sarek/tests/e2e/test_static_tag_erasure.ml` (registered in the runtest alias):
- **Observable**: emitted CUDA-C for the erasable kernels carries no `switch`/`.tag`/`enum`, while a runtime-selected **negative control** still does.
- **Behavioural**: nullary + unary erasable kernels match a pure-OCaml reference on every device.

| Device | Result |
|---|---|
| Native | PASS |
| Interpreter (seq + parallel) | PASS |
| CUDA/PTX — RX 7900 XTX (ZLUDA) | PASS |
| OpenCL — RX 7900 XTX | PASS |
| Vulkan — RX 7900 XTX (RADV NAVI31) | PASS |

Full `dune runtest sarek/tests` green (incl. the critical variant/record suite: `test_klet_variant`, `test_registered_variant`, `test_ktype_record`, `test_ktype_mixed_align`, `test_complex_types`, `test_nested_types`). `@install` and `@fmt` clean. No changes to `Sarek_ir_layout.ml` or the Rocq layout proofs.

## Deviation from the design doc

The doc's **headline record-field layout-unblock** (§0/§8) is **deferred**, not shipped. Attempting it as a pure expression rewrite (per §4) empirically fails: the record value/binding/`TEFieldGet` types still carry the original variant-field `TRecord` (CUDA types the local as `void`), and the `[@@sarek.type]` declaration is consumed positionally by the Interpreter/host marshalling (field-index divergence → "index out of bounds"). A correct record-field tier needs record-type threading + declaration reconciliation, i.e. most of the §10 budget — captured in the doc's new "Implementation findings" section. Per the brief's "ship the coherent gate-passing subset" guidance, S1 lands standalone.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced generated device code for statically known variant values by removing unnecessary tags and branches.
  * Preserved tag handling when constructor choices are determined at runtime.

* **Bug Fixes**
  * Ensured optimized variant handling maintains the same kernel behavior across supported backends.

* **Tests**
  * Added end-to-end coverage validating generated code and runtime results across available CPU and GPU backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->