### PR TITLE
fix(glsl): lower Float64.abs_float to GLSL abs()

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -465,7 +465,13 @@ and gen_intrinsic buf path name args =
                   gen_expr buf e)
                 args ;
               Buffer.add_char buf ')'
-          | "fabs" ->
+          | "fabs" | "abs_float" ->
+              (* GLSL has no [fabs]; its abs() has an fp64 overload under
+                 GL_ARB_gpu_shader_fp64 (enabled on the f64 path). [abs_float]
+                 (Float64.abs_float) reaches here rather than via the pure
+                 registry — it is absent from [float64_list] because that list's
+                 generic template would emit the raw name on CUDA/OpenCL, which
+                 need [fabs]. See spoc/ir/Sarek_pure_registry.ml. *)
               Buffer.add_string buf "abs" ;
               Buffer.add_char buf '(' ;
               List.iteri

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -234,6 +234,31 @@ let float32_abs_float_path_kernel () =
     []
     body
 
+(* Float64.abs_float reaches the GLSL generator's hardcoded match arm (it is
+   absent from Sarek_pure_registry.float64_list), and must lower to abs() — not
+   the raw Float64.abs_float(...) that glslang rejects. See Sarek_ir_glsl.ml. *)
+let float64_abs_float_path_kernel () =
+  let a = make_var "a" (TVec TFloat64) in
+  let b = make_var "b" (TVec TFloat64) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float64"], "abs_float", [EArrayRead ("a", EVar idx)])
+          ) )
+  in
+  empty_kernel
+    "float64_abs_float_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
+    ]
+    []
+    body
+
 let float32_atan2_path_kernel () =
   let a = make_var "a" (TVec TFloat32) in
   let b = make_var "b" (TVec TFloat32) in
@@ -1190,6 +1215,30 @@ let () =
 
   register_golden
     "glsl"
+    "float64_abs_float_path"
+    "#version 450\n\
+     #extension GL_ARB_gpu_shader_fp64 : require\n\n\
+     // Sarek-generated compute shader: float64_abs_float_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  double a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  double b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = abs(a[idx]);\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
     "float32_atan2_path"
     "#version 450\n\n\
      // Sarek-generated compute shader: float32_atan2_path\n\
@@ -1317,6 +1366,7 @@ let glsl_only_kernels () =
   [
     ("float32_rsqrt_path", float32_rsqrt_path_kernel ());
     ("float32_abs_float_path", float32_abs_float_path_kernel ());
+    ("float64_abs_float_path", float64_abs_float_path_kernel ());
     ("float32_atan2_path", float32_atan2_path_kernel ());
     ("float32_cbrt_path", float32_cbrt_path_kernel ());
     ("float32_hypot_path", float32_hypot_path_kernel ());


### PR DESCRIPTION
## Problem

`Float64.abs_float` had no GLSL lowering. On Vulkan the generator fell through to its default arm and emitted the raw OCaml path `Float64.abs_float(...)`, which glslang rejects — it parses the unknown call as a vector swizzle:

```
ERROR: 'abs_float' : vector swizzle too long
```

## Root cause

The asymmetry is in the GLSL backend's dispatch:

- `abs_float` is intentionally **absent** from `Sarek_pure_registry.float64_list` — that list's generic template would emit the raw name, and CUDA/OpenCL need `fabs`. So the pure-registry lookup misses.
- CUDA/OpenCL/Metal recover in their default arm via the FFI registry (`Sarek_registry`), which the stdlib populates with `fabs` from `Float64.abs_float`'s `{device = dev "fabs" "fabs"}` declaration.
- The **GLSL** generator has no `Sarek_registry` fallback, so an unhandled name is emitted verbatim.

## Fix

Add `abs_float` to the GLSL generator's existing `fabs -> abs` match arm (one-liner, mirrors the established pattern). `GL_ARB_gpu_shader_fp64` is already required on the f64 path and `abs()` has an fp64 overload, so `double abs()` compiles.

## Verification

- **Red-on-mutation** on RX 7900 XTX (RADV NAVI31): `abs_float` SKIP (glslang error) before → **PASS** after.
- `test_float64_math_intrinsics` e2e (`EIntrinsic (["Float64"], "abs_float", …)` vs OCaml reference):

  | Device | abs_float |
  |---|---|
  | Vulkan — RX 7900 XTX (RADV NAVI31) | PASS |
  | Vulkan — RADV RAPHAEL_MENDOCINO | PASS |
  | CPU Interpreter (Sequential) | PASS |
  | CPU Interpreter (Parallel) | PASS |
  | CPU Native | SKIP (pre-existing: hand-built IR has no native fn — affects all functions, not abs_float) |

- New deterministic golden `glsl/float64_abs_float_path` in `test_codegen_golden` locks in `b[idx] = abs(a[idx]);`.
- `dune build @install` clean; `dune runtest sarek/tests` green; `@fmt` clean on touched files.

## Follow-ups (out of scope)

- **`Float64.copysign` is broken on GLSL/Vulkan the same way** — not in `float64_list`, no polyfill, no hardcoded GLSL arm. glslang rejects `copysign(...)` (`vector swizzle too long`). It needs a multi-token polyfill, not a rename (`abs(x)*sign(y)` mishandles `y = 0`), so it is deliberately left for a dedicated change. Confirmed failing in the e2e report on both Vulkan devices.
- The deeper asymmetry — GLSL lacking the `Sarek_registry` FFI fallback that CUDA/OpenCL/Metal have — is the structural reason such names slip through. Worth considering a shared fallback rather than per-name arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GLSL code generation for floating-point absolute-value operations, including path-qualified float64 operations.
  - Ensures generated shaders use the appropriate absolute-value behavior for supported floating-point configurations.

- **Tests**
  - Added coverage and golden-output validation for float64 absolute-value operations in GLSL.
  - Added a shader verification case requiring the appropriate 64-bit floating-point support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->