### PR TITLE
feat(typer): polymorphic bare float literals (default float32)

### DIFF
--- a/formal/type-safety/test/test_type_safety_conformance.ml
+++ b/formal/type-safety/test/test_type_safety_conformance.ml
@@ -194,7 +194,9 @@ let ncmp_of_coq (r : M.infer_result) : ncmp =
 
 (* --- project the real Sarek_types.typ --------------------------------------- *)
 let rec ncmp_of_typ (t : Sarek_types.typ) : ncmp =
-  match t with
+  (* Follow unification links: after L17b defaulting a float literal's type is a
+     [TVar] linked to [Float32], not a bare [TReg Float32]. *)
+  match Sarek_types.repr t with
   | Sarek_types.TPrim Sarek_types.TInt32 -> NInt32
   | Sarek_types.TReg Sarek_types.Float32 -> NFloat32
   | Sarek_types.TPrim Sarek_types.TBool -> NBool
@@ -367,8 +369,17 @@ let test_differential =
     (fun (env, e) ->
       let coq_result = ncmp_of_coq (M.infer_type env e) in
       let real_result =
-        ncmp_of_real
-          (Sarek_typer.infer (real_env_of_coq env) (real_expr_of_coq e))
+        (* L17b: a bare float literal is now typed as a fresh tvar that defaults
+           to float32 when unconstrained. The production engine performs that
+           defaulting inside [infer_kernel]; this harness calls [infer]
+           directly, so we reproduce the exact same language rule here — clear
+           the per-run literal registry, infer, then unify every still-unbound
+           literal tvar with float32 before projecting. This keeps the Rocq
+           model (ELit (LFloat _) -> RFloat32) correct and untouched. *)
+        Sarek_types.clear_float_literals () ;
+        let r = Sarek_typer.infer (real_env_of_coq env) (real_expr_of_coq e) in
+        Sarek_types.default_float_literals () ;
+        ncmp_of_real r
       in
       if coq_result = real_result then true
       else begin

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -502,7 +502,12 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
   | TEInt i -> Ir.EConst (Ir.CInt32 (Int32.of_int i))
   | TEInt32 i -> Ir.EConst (Ir.CInt32 i)
   | TEInt64 i -> Ir.EConst (Ir.CInt64 i)
-  | TEFloat f -> Ir.EConst (Ir.CFloat32 f)
+  | TEFloat f -> (
+      (* L17b: a bare float literal is lowered by its resolved type — float64 if
+         context unified it to Float64, float32 otherwise (the default). *)
+      match repr te.ty with
+      | TReg Float64 -> Ir.EConst (Ir.CFloat64 f)
+      | _ -> Ir.EConst (Ir.CFloat32 f))
   | TEDouble f -> Ir.EConst (Ir.CFloat64 f)
   | TEVar (name, id) -> (
       match repr te.ty with

--- a/sarek/ppx/Sarek_typer.ml
+++ b/sarek/ppx/Sarek_typer.ml
@@ -79,6 +79,11 @@ let check_integer t loc =
   match repr t with
   | TPrim TInt32 -> Ok ()
   | TReg (Int64 | Int) -> Ok ()
+  | TVar {contents = Unbound (id, _)} when is_float_literal_id id ->
+      (* L17b: a bare float literal must never satisfy an integer requirement,
+         e.g. [1.0 land x] stays a compile error even though the literal is an
+         (as-yet unbound) tvar. *)
+      Error [Type_mismatch {expected = t_int32; got = t; loc}]
   | TVar _ -> Ok ()
   | t -> Error [Type_mismatch {expected = t_int32; got = t; loc}]
 
@@ -200,7 +205,14 @@ let infer_literal (loc : Sarek_ast.loc) (expr : expr_desc) : texpr result =
   | EInt i -> Ok (mk_texpr (TEInt i) t_int32 loc)
   | EInt32 i -> Ok (mk_texpr (TEInt32 i) t_int32 loc)
   | EInt64 i -> Ok (mk_texpr (TEInt64 i) t_int64 loc)
-  | EFloat f -> Ok (mk_texpr (TEFloat f) t_float32 loc)
+  | EFloat f ->
+      (* L17b: a bare float literal is polymorphic — a fresh tvar that unifies
+         with its context and defaults to float32 if left unconstrained. The
+         tvar is recorded so it can be guarded (never an integer) and defaulted
+         after kernel inference. *)
+      let tv = fresh_tvar () in
+      register_float_literal tv ;
+      Ok (mk_texpr (TEFloat f) tv loc)
   | EDouble f -> Ok (mk_texpr (TEDouble f) t_float64 loc)
   | _ ->
       error
@@ -945,6 +957,8 @@ and is_intrinsic_fun name env =
 
 (** Type a complete kernel *)
 let infer_kernel (env : t) (kernel : Sarek_ast.kernel) : tkernel result =
+  (* L17b: start each kernel with an empty bare-float-literal registry. *)
+  clear_float_literals () ;
   (* Register type declarations first *)
   let rec add_type_decls env acc = function
     | [] -> Ok (List.rev acc, env)
@@ -1145,6 +1159,10 @@ let infer_kernel (env : t) (kernel : Sarek_ast.kernel) : tkernel result =
   in
   let* tparams, env' = add_params env_after_mods 0 [] kernel.kern_params in
   let* tbody, _ = infer env' kernel.kern_body in
+  (* L17b: any bare float literal that context never constrained defaults to
+     float32. Runs before the typed AST is handed to the lowering / defunc /
+     tag-erasure passes, so those never see an unbound literal-origin tvar. *)
+  default_float_literals () ;
   Ok
     {
       tkern_name = kernel.kern_name;

--- a/sarek/ppx/Sarek_types.ml
+++ b/sarek/ppx/Sarek_types.ml
@@ -72,12 +72,54 @@ let fresh_tvar_id () = Atomic.fetch_and_add tvar_counter 1
 let fresh_tvar ?(level = 0) () : typ =
   TVar (ref (Unbound (fresh_tvar_id (), level)))
 
+(** {1 Polymorphic bare float literals (L17b)}
+
+    A bare float literal (e.g. [1.0]) is typed as a fresh unification variable
+    instead of being hard-typed [float32], so it can unify with its context
+    (e.g. a [float64] binding). Two invariants make this safe:
+
+    - a float-literal tvar may only ever resolve to a floating-point type
+      ([float32]/[float64]) — it must never unify with an integer or other
+      concrete type (enforced in {!unify} via {!float_literal_can_link});
+    - any float-literal tvar left unconstrained after kernel inference is
+      defaulted to [float32] (see {!default_float_literals}), so [float32] stays
+      the GPGPU default.
+
+    The registry is process-global but scoped per kernel: it is cleared at the
+    start of each [infer_kernel] and whenever the tvar counter is reset. IDs are
+    monotonic within a kernel so no stale collision is possible. *)
+
+(** IDs of tvars that originate from bare float literals. *)
+let float_literal_ids : (int, unit) Hashtbl.t = Hashtbl.create 16
+
+(** The float-literal tvars in creation order, used for defaulting. *)
+let float_literal_tvars : typ list ref = ref []
+
+(** Clear the float-literal registry (called per kernel). *)
+let clear_float_literals () =
+  Hashtbl.clear float_literal_ids ;
+  float_literal_tvars := []
+
+(** Is [id] the id of a float-literal-origin tvar? *)
+let is_float_literal_id (id : int) : bool = Hashtbl.mem float_literal_ids id
+
 (** Reset the type variable counter (for testing) *)
-let reset_tvar_counter () = Atomic.set tvar_counter 0
+let reset_tvar_counter () =
+  Atomic.set tvar_counter 0 ;
+  clear_float_literals ()
 
 (** Follow links to get the actual type *)
 let rec repr (t : typ) : typ =
   match t with TVar {contents = Link t'} -> repr t' | t -> t
+
+(** Record a fresh float-literal tvar so it can be guarded and later defaulted.
+    (See the L17b registry section above.) *)
+let register_float_literal (t : typ) : unit =
+  match repr t with
+  | TVar {contents = Unbound (id, _)} ->
+      Hashtbl.replace float_literal_ids id () ;
+      float_literal_tvars := t :: !float_literal_tvars
+  | _ -> ()
 
 (** Check if a type variable occurs in a type (for occurs check) *)
 let rec occurs (id : int) (t : typ) : bool =
@@ -100,6 +142,13 @@ let rec occurs (id : int) (t : typ) : bool =
 (** Unification error *)
 type unify_error = Cannot_unify of typ * typ | Occurs_check of int * typ
 
+(** A float-literal tvar may only link to a floating-point type or to another
+    type variable (which will itself carry the constraint). Linking it to any
+    other concrete type (int32, int64, bool, records, ...) is a type error — a
+    bare float literal is never an integer. *)
+let float_literal_can_link (t : typ) : bool =
+  match repr t with TReg (Float32 | Float64) | TVar _ -> true | _ -> false
+
 (** Unify two types *)
 let rec unify (t1 : typ) (t2 : typ) : (unit, unify_error) result =
   let t1 = repr t1 and t2 = repr t2 in
@@ -112,11 +161,17 @@ let rec unify (t1 : typ) (t2 : typ) : (unit, unify_error) result =
     | TVar ({contents = Unbound (id, level1)} as r), t
     | t, TVar ({contents = Unbound (id, level1)} as r) ->
         if occurs id t then Error (Occurs_check (id, t))
+        else if is_float_literal_id id && not (float_literal_can_link t) then
+          (* L17b: a bare-float-literal tvar cannot become a non-float type. *)
+          Error (Cannot_unify (TVar r, t))
         else begin
           (* Update level for let-polymorphism *)
           (match t with
           | TVar {contents = Unbound (_, level2)} ->
-              r := Unbound (id, min level1 level2)
+              r := Unbound (id, min level1 level2) ;
+              (* Propagate the float-literal constraint onto the tvar that
+                 becomes the representative after linking. *)
+              if is_float_literal_id id then register_float_literal t
           | _ -> ()) ;
           r := Link t ;
           Ok ()
@@ -265,6 +320,21 @@ let t_int64 = TReg Int64
 let t_int = TReg Int
 
 let t_char = TReg Char
+
+(** Default every still-unconstrained float-literal tvar to [float32]. Called
+    once after kernel inference: literal-origin tvars that context never
+    resolved (e.g. an unconstrained [let z = 1.0]) become [float32], preserving
+    the GPGPU default. Already-resolved literals (unified to [float64] by
+    context, or to [float32]) are left untouched. Non-literal tvars are never in
+    the registry, so the polymorphic-kernel-parameter guard in
+    [Sarek_lower_ir.elttype_of_typ] keeps firing for them. *)
+let default_float_literals () =
+  List.iter
+    (fun t ->
+      match repr t with
+      | TVar {contents = Unbound _} -> ignore (unify t t_float32)
+      | _ -> ())
+    !float_literal_tvars
 
 (** {1 Type Predicates}
 

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -758,3 +758,26 @@
  (alias runtest)
  (action
   (run %{dep:test_soa_aos_equiv.exe})))
+
+; L17b polymorphic bare float literals: bare (unsuffixed) literals inferred as
+; float64 from an f64 context, executed on all devices vs an OCaml f64 reference.
+
+(executable
+ (name test_bare_float_infers_f64)
+ (modules test_bare_float_infers_f64)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek.float64
+  sarek_ir
+  spoc_core
+  test_helpers
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_bare_float_infers_f64.exe})))

--- a/sarek/tests/e2e/test_bare_float_infers_f64.ml
+++ b/sarek/tests/e2e/test_bare_float_infers_f64.ml
@@ -1,0 +1,149 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for L17b: polymorphic bare float literals.
+ *
+ * This kernel mixes bare, UNSUFFIXED float literals (`2.0`, `1.0`, `0.0`) into
+ * a float64 computation. Under the old rule a bare literal was hard-typed
+ * float32 and `f64_value *. 2.0` failed to unify (see the note in
+ * test_bare_float_kernel_arith.ml / test_float64_kernel_arith.ml). With L17b a
+ * bare literal is a fresh tvar that unifies with its context, so here every
+ * literal infers float64 from the surrounding f64 arithmetic - no `G` suffix
+ * anywhere in the body.
+ *
+ * Two load-bearing halves:
+ * (i)  the lowered IR uses float64 (kernel_uses_float64 = true) - proves the
+ *      bare literals were inferred as f64 and did NOT default to f32;
+ * (ii) the kernel executes and matches a pure-OCaml binary64 reference on
+ *      every available device (native/interpreter gate the test; GPU devices
+ *      with fp64 support are compared within tolerance and reported).
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Benchmarks = Test_helpers.Benchmarks
+
+let () = Benchmarks.init ()
+
+(* Bare literals only (0.0, 2.0, 1.0) - each infers float64 from the f64 vector
+   context. `x` starts life as a bare-literal `mut 0.0` whose tvar is pinned to
+   float64 by the `inp.(tid) *. 2.0` assignment. *)
+let bare_f64_kernel =
+  [%kernel
+    fun (out : float64 vector) (inp : float64 vector) (n : int32) ->
+      let open Std in
+      let tid = global_thread_id in
+      if tid < n then begin
+        let x = mut 0.0 in
+        x := inp.(tid) *. 2.0 ;
+        out.(tid) <- x +. 1.0
+      end]
+
+let n = 64
+
+let inp_of i = (float_of_int i *. 0.5) -. 8.0
+
+let ocaml_reference v = (v *. 2.0) +. 1.0
+
+let run_on_device (dev : Device.t) ir =
+  let out = Vector.create Vector.float64 n in
+  let inp = Vector.create Vector.float64 n in
+  for i = 0 to n - 1 do
+    Vector.set inp i (inp_of i) ;
+    Vector.set out i 0.0
+  done ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Execute.Vec out; Execute.Vec inp; Execute.Int n]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  Vector.to_array out
+
+let verify ~exact got =
+  let tol = if exact then 0.0 else 1e-9 in
+  let bad = ref 0 in
+  for i = 0 to n - 1 do
+    let expected = ocaml_reference (inp_of i) in
+    if Stdlib.abs_float (got.(i) -. expected) > tol then begin
+      if !bad < 5 then
+        Printf.printf
+          "    mismatch @%d: got=%.15g ref=%.15g\n%!"
+          i
+          got.(i)
+          expected ;
+      incr bad
+    end
+  done ;
+  !bad
+
+let is_native (dev : Device.t) =
+  dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
+
+let () =
+  let _, kirc = bare_f64_kernel in
+  let ir =
+    match kirc.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "bare-f64 kernel has no IR"
+  in
+  (* (i) The bare literals must have been inferred float64. If they had defaulted
+     to float32 the whole kernel would collapse to the f32 path. *)
+  if not (Sarek_ir_analysis.kernel_uses_float64 ir) then begin
+    print_endline
+      "test_bare_float_infers_f64: FAILED - kernel_uses_float64 = false (bare \
+       literals did not infer float64 from context)" ;
+    exit 1
+  end ;
+  let devs = Device.init () in
+  Printf.printf "=== bare float literals inferred as float64 ===\n%!" ;
+  let native_ok = ref false in
+  let native_failed = ref false in
+  Array.iter
+    (fun (dev : Device.t) ->
+      let native = is_native dev in
+      if native || Device.allows_fp64 dev then begin
+        try
+          let got = run_on_device dev ir in
+          let bad = verify ~exact:native got in
+          Printf.printf
+            "  %-10s %-24s %s (%d/%d ok)\n%!"
+            dev.Device.framework
+            dev.Device.name
+            (if bad = 0 then "PASS" else "FAIL")
+            (n - bad)
+            n ;
+          if native then begin
+            native_ok := true ;
+            if bad <> 0 then native_failed := true
+          end
+        with e ->
+          Printf.printf
+            "  %-10s %-24s ERROR (%s)\n%!"
+            dev.Device.framework
+            dev.Device.name
+            (Printexc.to_string e) ;
+          if native then native_failed := true
+      end)
+    devs ;
+  if not !native_ok then begin
+    print_endline
+      "test_bare_float_infers_f64: FAILED - no native/interpreter device ran \
+       the kernel" ;
+    exit 1
+  end ;
+  if !native_failed then begin
+    print_endline "test_bare_float_infers_f64: FAILED" ;
+    exit 1
+  end ;
+  print_endline "test_bare_float_infers_f64: PASSED"

--- a/sarek/tests/unit/test_typer.ml
+++ b/sarek/tests/unit/test_typer.ml
@@ -36,6 +36,8 @@ let int32_expr i = mk_expr (EInt32 i)
 
 let float_expr f = mk_expr (EFloat f)
 
+let double_expr f = mk_expr (EDouble f)
+
 let bool_expr b = mk_expr (EBool b)
 
 let var_expr s = mk_expr (EVar s)
@@ -73,6 +75,9 @@ let check_infer_ok msg env expr expected_typ =
   reset_var_id_counter () ;
   match infer env expr with
   | Ok (te, _) ->
+      (* L17b: bare float literals infer to unconstrained tvars; mirror the
+         kernel behaviour by defaulting them to float32 before comparing. *)
+      default_float_literals () ;
       if types_equal te.ty expected_typ then ()
       else
         Alcotest.failf
@@ -453,6 +458,70 @@ let test_kernel_type_decl_record () =
         "kernel with type decl failed: %s"
         (String.concat ", " (List.map Sarek_error.error_to_string errs))
 
+(* ------------------------------------------------------------------ *)
+(* L17b: polymorphic bare float literals                              *)
+(* ------------------------------------------------------------------ *)
+
+(* An unconstrained bare float literal `let z = 1.0 in z` defaults to float32. *)
+let test_float_literal_defaults_f32 () =
+  let env = with_stdlib empty in
+  let expr = let_expr "z" None (float_expr 1.0) (var_expr "z") in
+  check_infer_ok "let z = 1.0 in z defaults to float32" env expr t_float32
+
+(* A bare float literal unifies with an f64 context:
+   `let x = 0.0 in x *. 2.0G` infers float64 without suffixing every literal. *)
+let test_float_literal_infers_f64_from_context () =
+  reset_tvar_counter () ;
+  reset_var_id_counter () ;
+  let env = with_stdlib empty in
+  let body = binop_expr Mul (var_expr "x") (double_expr 2.0) in
+  let expr = mk_expr (ELetMut ("x", None, float_expr 0.0, body)) in
+  match infer env expr with
+  | Ok (te, _) ->
+      default_float_literals () ;
+      if types_equal te.ty t_float64 then ()
+      else
+        Alcotest.failf
+          "expected float64 (inferred from *. 2.0G), got %s"
+          (typ_to_string te.ty)
+  | Error errors ->
+      Alcotest.failf
+        "let x = 0.0 in x *. 2.0G: type error: %s"
+        (String.concat ", " (List.map Sarek_error.error_to_string errors))
+
+(* A bare float literal must not satisfy an integer op: `1.0 land x` is still a
+   compile error even though the literal is (transiently) an unbound tvar. *)
+let test_float_literal_not_integer () =
+  reset_tvar_counter () ;
+  reset_var_id_counter () ;
+  let env = with_stdlib empty in
+  let info =
+    {
+      vi_type = t_int32;
+      vi_mutable = false;
+      vi_is_param = true;
+      vi_index = 0;
+      vi_is_vec = false;
+    }
+  in
+  let env = add_var "x" info env in
+  let expr = binop_expr Land (float_expr 1.0) (var_expr "x") in
+  check_infer_error "1.0 land x must fail (float is not an integer)" env expr
+
+(* Existing f32 behaviour is unchanged: two bare literals added together are
+   float32, and a float literal added to an int is still a type error. *)
+let test_float_literal_f32_unchanged () =
+  let env = with_stdlib empty in
+  check_infer_ok
+    "1.0 +. 2.0 is float32"
+    env
+    (binop_expr Add (float_expr 1.0) (float_expr 2.0))
+    t_float32 ;
+  check_infer_error
+    "1 + 2.0 is still a type error"
+    env
+    (binop_expr Add (int_expr 1) (float_expr 2.0))
+
 (* Test variable type inference *)
 let test_var_lookup () =
   let env = with_stdlib empty in
@@ -717,4 +786,23 @@ let () =
             test_vec_access_wrong_index;
         ] );
       ("sequence", [Alcotest.test_case "seq" `Quick test_seq]);
+      ( "float literals (L17b)",
+        [
+          Alcotest.test_case
+            "unconstrained defaults f32"
+            `Quick
+            test_float_literal_defaults_f32;
+          Alcotest.test_case
+            "infers f64 from context"
+            `Quick
+            test_float_literal_infers_f64_from_context;
+          Alcotest.test_case
+            "not an integer (1.0 land x)"
+            `Quick
+            test_float_literal_not_integer;
+          Alcotest.test_case
+            "f32 behaviour unchanged"
+            `Quick
+            test_float_literal_f32_unchanged;
+        ] );
     ]


### PR DESCRIPTION
## Part 1 — L17b: polymorphic bare float literal (default float32)

A bare float literal (e.g. `1.0`) in `[%kernel]` was hard-typed `float32`. It is
now typed as a fresh unification variable that unifies with its context and
defaults to `float32` only when left unconstrained. This makes
`let x : float64 = ... in x *. 2.0` work without suffixing every literal with
`G`, while keeping `float32` as the GPGPU default.

### Design (as validated in the L17 report)
- **`Sarek_typer.infer_literal` (`EFloat`)** — each bare float literal is a fresh
  `TVar`, recorded in a per-kernel registry (`register_float_literal`).
- **`Sarek_typer.infer_kernel`** — clears the registry on entry; after inference
  completes, `default_float_literals ()` unifies every still-unbound registered
  tvar with `t_float32`. Runs before the typed AST reaches the lowering /
  defunc / tag-erasure passes, so those never see an unbound literal-origin tvar.
  Only literal-origin tvars are defaulted — the polymorphic-kernel-param guard in
  `Sarek_lower_ir.elttype_of_typ` (raises on unbound `TVar`) keeps firing for
  non-literal tvars.
- **`Sarek_lower_ir` (`TEFloat`)** — lowered by `repr te.ty`: `CFloat64` if the
  literal resolved to `Float64`, `CFloat32` otherwise.
- **Integer guard** — `check_integer` now rejects float-literal tvars, so
  `1.0 land x` stays a compile error even though the literal is transiently an
  unbound tvar.

### Deviation from the brief (stronger guard)
The brief scoped the integer guard to "the binop integer path". I additionally
added a guard inside `unify` (`float_literal_can_link`): a float-literal tvar may
only ever link to a floating-point type or another tvar — never to a concrete
non-float type. This was necessary because:
1. the existing `test_binop_add_mismatch` requires `1 + 2.0` to remain a type
   error, and a purely binop-path guard would let the literal tvar silently
   unify with `int32`;
2. permitting a float-literal tvar to become `int32` would then lower a
   `CFloat32` constant into an `int32` slot — a wrong-width codegen bug.
The guard is a no-op for every non-literal tvar, so pre-existing polymorphism
(e.g. `[@sarek.module]` `identity`) is unaffected.

### Tests
- `test_typer.ml`: four new unit tests — unconstrained defaults f32; infers f64
  from context (`let x = 0.0 in x *. 2.0G`); `1.0 land x` still errors; f32
  behaviour unchanged (`1.0 +. 2.0` = f32, `1 + 2.0` still an error). The shared
  `check_infer_ok` helper now defaults float literals before comparing, mirroring
  kernel behaviour.
- `test_bare_float_infers_f64.ml` (e2e): a kernel mixing bare unsuffixed literals
  into a float64 computation; asserts the lowered IR uses float64 and matches an
  OCaml binary64 reference on every device.

### Test matrix (all green)
- `dune build --root . @install` — clean.
- `@fmt` — clean on all touched files (the two pre-existing drift files
  `Sarek_float32.ml` / `test_ir_layout.ml` were deliberately left untouched).
- `dune runtest --root . sarek/tests` — fully green.
- New e2e on all devices (ZLUDA + Vulkan): CUDA/PTX (RX 7900 XTX + CPU),
  Vulkan (NAVI31 + CPU), Native, Interpreter (seq + parallel) — 64/64 each, PASS.

## Part 2 — `[@sarek.module]` int32 helper mis-unification: NOT REPRODUCED

I could not reproduce the reported bug (a `[@sarek.module]` helper doing int32
`+` mis-unifying float32/int32 when called from a kernel), and did not ship a
speculative fix.

What I tried:
- **`infer_kernel`-level probes** (the module-item inference path named in the
  brief) across many shapes: annotated-int32 helper, unannotated polymorphic
  `a + b`, bare-int-literal `x + 1`, and the same helper used at int32 then
  float32 (and float32 then int32) in one kernel. Every module-helper shape
  behaves **identically** to the kernel-local `let`/`ELetRec` equivalent. The
  only error observed was the *legitimate* `Cannot unify int32 and float32` when
  an int32-param helper is deliberately called with a float32 argument.
- **Real-ppx probes**: an int32-arithmetic `[@sarek.module]` helper cannot be
  written as valid OCaml (`x + 1l` / `a + b` on `int32` is rejected by the OCaml
  native-fallback checker, since the helper body is plain OCaml, not rewritten
  DSL). Forcing `int` params/return instead collides with the int32-backed
  vector `set` (`int -> int32`). This int/int32 OCaml-shadow friction is real but
  is a separate ergonomic issue, is not a Sarek *inference* bug, and does not
  match the "float32/int32 at inference" description.

Diagnosis: with the current tree the module-item inference path is consistent
with the local path; the reported symptom does not manifest. It may have been
already resolved, mis-described, or dependent on a specific helper shape not
captured in the report. Recommend the reporter supply the exact failing helper +
kernel source so it can be turned into a regression test. Part 1 ships alone, as
the brief permits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bare decimal literals now adapt to their surrounding floating-point context, including Float64 operations.
  - Unconstrained decimal literals continue to default to Float32.
  - Integer-only operations now reject bare decimal literals with a clear type error.

- **Bug Fixes**
  - Corrected generated code so Float64 literals remain Float64 instead of being narrowed to Float32.

- **Tests**
  - Added coverage for Float32 defaults, Float64 inference, invalid integer usage, and end-to-end Float64 execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->