### PR TITLE
Tier 1a: SoA custom-vector storage + pinned host-memory API

### DIFF
--- a/benchmarks/bench_pinned_transfer.ml
+++ b/benchmarks/bench_pinned_transfer.ml
@@ -1,0 +1,160 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Tier 1a benchmark: pinned (page-locked) vs pageable host memory.
+ *
+ * Measures H2D and D2H bandwidth for host<->device transfers at several sizes,
+ * using the *blocking* cuMemcpyHtoD/DtoH path (the same path every SPOC
+ * transfer uses today). Pinned host memory lets the driver DMA directly
+ * instead of staging through an internal pageable bounce buffer, so it is the
+ * cheapest transfer-bandwidth lever and the prerequisite for async overlap.
+ *
+ * CUDA-backend only (runs under ZLUDA on the RX 7900 XTX):
+ *   LD_LIBRARY_PATH=$HOME/opt/zluda \
+ *     dune exec --root . benchmarks/bench_pinned_transfer.exe
+ *
+ * The pinned host-memory APIs (cuMemAllocHost / cuMemHostRegister) are probed
+ * for support at startup. When the active driver does not implement them
+ * (ZLUDA v7-preview.3 returns CUDA_ERROR_OTHER for both), the benchmark still
+ * reports pageable bandwidth and states that the pinned comparison is
+ * unavailable on this driver. Exits 0 (skips cleanly) with no CUDA device.
+ ******************************************************************************)
+
+open Ctypes
+module Cuda = Sarek_cuda.Cuda_api
+module Berr = Sarek_backend_error.Backend_error
+
+let iters = 30
+
+let warmup = 5
+
+(* Transfer sizes in bytes. *)
+let sizes_mb = [1; 4; 16; 64; 256]
+
+let bytes_of_mb mb = mb * 1024 * 1024
+
+(* Median of a float array (robust against the occasional scheduling spike). *)
+let median arr =
+  let a = Array.copy arr in
+  Array.sort Float.compare a ;
+  let n = Array.length a in
+  if n = 0 then 0.0
+  else if n mod 2 = 1 then a.(n / 2)
+  else (a.((n / 2) - 1) +. a.(n / 2)) /. 2.0
+
+let time_median f =
+  for _ = 1 to warmup do
+    f ()
+  done ;
+  let samples =
+    Array.init iters (fun _ ->
+        let t0 = Unix.gettimeofday () in
+        f () ;
+        (Unix.gettimeofday () -. t0) *. 1000.0)
+  in
+  median samples
+
+(* GB/s from milliseconds for [bytes] moved. *)
+let gbps bytes ms =
+  if ms <= 0.0 then 0.0 else float_of_int bytes /. (ms /. 1000.0) /. 1.0e9
+
+(* Does the active driver implement pinned host memory? A single tiny
+   cuMemAllocHost tells us; ZLUDA returns CUDA_ERROR_OTHER. *)
+let pinned_supported () =
+  try
+    let p = Cuda.Memory.alloc_host 4096 in
+    Cuda.Memory.free_host p ;
+    true
+  with Berr.Backend_error _ -> false
+
+type row = {
+  mb : int;
+  h2d : float;
+  d2h : float;
+  h2d_pin : float option;
+  d2h_pin : float option;
+}
+
+let bench_size dev ~pinned mb =
+  let bytes = bytes_of_mb mb in
+  let dbuf = Cuda.Memory.alloc_custom dev ~size:bytes ~elem_size:1 in
+  let page = allocate_n uint8_t ~count:bytes in
+  let page_ptr = to_voidp page in
+  let h2d_fn src_ptr () =
+    Cuda.Memory.host_ptr_to_device ~src_ptr ~byte_size:bytes ~dst:dbuf ;
+    Cuda.Device.synchronize dev
+  in
+  let d2h_fn dst_ptr () =
+    Cuda.Memory.device_to_host_ptr ~src:dbuf ~dst_ptr ~byte_size:bytes ;
+    Cuda.Device.synchronize dev
+  in
+  let h2d = gbps bytes (time_median (h2d_fn page_ptr)) in
+  let d2h = gbps bytes (time_median (d2h_fn page_ptr)) in
+  let h2d_pin, d2h_pin =
+    if not pinned then (None, None)
+    else begin
+      let pin = Cuda.Memory.alloc_host bytes in
+      let hp = gbps bytes (time_median (h2d_fn pin.Cuda.Memory.host_ptr)) in
+      let dp = gbps bytes (time_median (d2h_fn pin.Cuda.Memory.host_ptr)) in
+      Cuda.Memory.free_host pin ;
+      (Some hp, Some dp)
+    end
+  in
+  Cuda.Memory.free dbuf ;
+  {mb; h2d; d2h; h2d_pin; d2h_pin}
+
+let print_table ~pinned rows =
+  if pinned then begin
+    Printf.printf
+      "\n%-8s | %-18s | %-18s | %-9s\n"
+      "size"
+      "H2D GB/s (pg/pin)"
+      "D2H GB/s (pg/pin)"
+      "speedup" ;
+    Printf.printf "%s\n" (String.make 63 '-') ;
+    List.iter
+      (fun r ->
+        let hp = Option.value ~default:0.0 r.h2d_pin in
+        let dp = Option.value ~default:0.0 r.d2h_pin in
+        Printf.printf
+          "%5dMB  | %7.2f / %7.2f  | %7.2f / %7.2f  | %.2fx/%.2fx\n"
+          r.mb
+          r.h2d
+          hp
+          r.d2h
+          dp
+          (hp /. r.h2d)
+          (dp /. r.d2h))
+      rows
+  end
+  else begin
+    Printf.printf "\n%-8s | %-12s | %-12s\n" "size" "H2D GB/s" "D2H GB/s" ;
+    Printf.printf "%s\n" (String.make 38 '-') ;
+    List.iter
+      (fun r -> Printf.printf "%5dMB  | %10.2f | %10.2f\n" r.mb r.h2d r.d2h)
+      rows
+  end
+
+let () =
+  Cuda.Device.init () ;
+  if Cuda.Device.count () = 0 then (
+    print_endline "bench_pinned_transfer: no CUDA device present - SKIPPED" ;
+    exit 0) ;
+  let dev = Cuda.Device.get 0 in
+  Cuda.Device.set_current dev ;
+  Printf.printf
+    "=== Pinned vs pageable host-memory transfer (device: %s) ===\n%!"
+    dev.Cuda.Device.name ;
+  let pinned = pinned_supported () in
+  if not pinned then
+    Printf.printf
+      "NOTE: this driver does not implement pinned host memory \
+       (cuMemAllocHost/cuMemHostRegister return CUDA_ERROR_OTHER; observed on \
+       ZLUDA v7-preview.3). Reporting pageable bandwidth only; the pinned \
+       comparison requires a driver with pinned-memory support.\n\
+       %!" ;
+  let rows = List.map (bench_size dev ~pinned) sizes_mb in
+  print_table ~pinned rows

--- a/benchmarks/bench_soa_aos.ml
+++ b/benchmarks/bench_soa_aos.ml
@@ -1,0 +1,193 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Tier 1a benchmark: AoS vs SoA memory-bound single-field access.
+ *
+ * A wide 8-field record ([wide], 32-byte stride) is read one field at a time
+ * by a copy kernel — the textbook uncoalesced case. AoS stores the record
+ * packed, so consecutive threads' reads of field [f0] are 32 bytes apart
+ * (1/8 bus efficiency); SoA stores [f0] in its own contiguous float32 buffer,
+ * restoring full coalescing. The SoA input is produced from the AoS buffer via
+ * the host transpose (Spoc_core.Soa.scatter), then fed to a plain scalar
+ * kernel.
+ *
+ * Reports median kernel time (excludes the one-time H2D upload; transfers are
+ * amortised across [iters]) and effective single-field bandwidth for both
+ * layouts. GPU device preferred.
+ *
+ *   LD_LIBRARY_PATH=$HOME/opt/zluda \
+ *     dune exec --root . benchmarks/bench_soa_aos.exe
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Soa = Spoc_core.Soa
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+type float32 = float
+
+type wide = {
+  f0 : float32;
+  f1 : float32;
+  f2 : float32;
+  f3 : float32;
+  f4 : float32;
+  f5 : float32;
+  f6 : float32;
+  f7 : float32;
+}
+[@@sarek.type]
+
+(* AoS: bind the record, use one field. *)
+let aos_kernel =
+  snd
+    [%kernel
+      fun (pts : wide vector) (out : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then
+          let p = pts.(tid) in
+          out.(tid) <- p.f0]
+
+(* SoA: read the field's own contiguous array. *)
+let soa_kernel =
+  snd
+    [%kernel
+      fun (f0 : float32 vector) (out : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then out.(tid) <- f0.(tid)]
+
+let ir_of kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let iters = 50
+
+let warmup = 10
+
+let median arr =
+  let a = Array.copy arr in
+  Array.sort Float.compare a ;
+  let n = Array.length a in
+  if n = 0 then 0.0 else a.(n / 2)
+
+let plan =
+  Soa.plan
+    ~name:"wide"
+    Sarek_ir_types.
+      [
+        ("f0", TFloat32);
+        ("f1", TFloat32);
+        ("f2", TFloat32);
+        ("f3", TFloat32);
+        ("f4", TFloat32);
+        ("f5", TFloat32);
+        ("f6", TFloat32);
+        ("f7", TFloat32);
+      ]
+
+let time_kernel dev ~ir ~args ~block ~grid =
+  for _ = 1 to warmup do
+    Sarek.Execute.run_vectors ~device:dev ~ir ~args ~block ~grid () ;
+    Transfer.flush dev
+  done ;
+  let samples =
+    Array.init iters (fun _ ->
+        let t0 = Unix.gettimeofday () in
+        Sarek.Execute.run_vectors ~device:dev ~ir ~args ~block ~grid () ;
+        Transfer.flush dev ;
+        (Unix.gettimeofday () -. t0) *. 1000.0)
+  in
+  median samples
+
+let run dev n =
+  let threads = 256 in
+  let grid_x = (n + threads - 1) / threads in
+  let block = Sarek.Execute.dims1d threads in
+  let grid = Sarek.Execute.dims1d grid_x in
+  (* AoS source. *)
+  let pts = Vector.create_custom wide_custom n in
+  for i = 0 to n - 1 do
+    let v = float_of_int i in
+    Vector.set
+      pts
+      i
+      {f0 = v; f1 = v; f2 = v; f3 = v; f4 = v; f5 = v; f6 = v; f7 = v}
+  done ;
+  (* SoA: scatter, keep only the f0 leaf for the read. *)
+  let leaves = Array.init 8 (fun _ -> Vector.create Vector.float32 n) in
+  Soa.scatter
+    plan
+    ~aos:(Vector.to_ctypes_ptr pts)
+    ~length:n
+    ~leaves:(Array.map Vector.to_ctypes_ptr leaves) ;
+  let out_a = Vector.create Vector.float32 n in
+  let out_s = Vector.create Vector.float32 n in
+  let t_aos =
+    time_kernel
+      dev
+      ~ir:(ir_of aos_kernel)
+      ~args:
+        [Sarek.Execute.Vec pts; Sarek.Execute.Vec out_a; Sarek.Execute.Int n]
+      ~block
+      ~grid
+  in
+  let t_soa =
+    time_kernel
+      dev
+      ~ir:(ir_of soa_kernel)
+      ~args:
+        [
+          Sarek.Execute.Vec leaves.(0);
+          Sarek.Execute.Vec out_s;
+          Sarek.Execute.Int n;
+        ]
+      ~block
+      ~grid
+  in
+  (t_aos, t_soa)
+
+(* Effective single-field bandwidth: n elements read (4B) + n written (4B). *)
+let field_gbps n ms =
+  if ms <= 0.0 then 0.0 else float_of_int (n * 4 * 2) /. (ms /. 1000.0) /. 1.0e9
+
+let () =
+  Benchmark_backends.Backend_loader.init () ;
+  let devs = Device.all () in
+  if Array.length devs = 0 then (
+    print_endline "bench_soa_aos: no device - SKIPPED" ;
+    exit 0) ;
+  let dev =
+    match Array.find_opt Device.is_gpu devs with
+    | Some d -> d
+    | None -> devs.(0)
+  in
+  Printf.printf
+    "=== AoS vs SoA single-field copy (device: %s, 8-field record, 32B stride) \
+     ===\n\
+     %!"
+    dev.Device.name ;
+  Printf.printf
+    "%-10s | %-14s | %-14s | %-8s\n"
+    "N"
+    "AoS ms (GB/s)"
+    "SoA ms (GB/s)"
+    "speedup" ;
+  Printf.printf "%s\n" (String.make 54 '-') ;
+  List.iter
+    (fun n ->
+      let t_aos, t_soa = run dev n in
+      Printf.printf
+        "%-10d | %6.3f (%5.1f) | %6.3f (%5.1f) | %.2fx\n%!"
+        n
+        t_aos
+        (field_gbps n t_aos)
+        t_soa
+        (field_gbps n t_soa)
+        (if t_soa > 0.0 then t_aos /. t_soa else 0.0))
+    [1 lsl 18; 1 lsl 20; 1 lsl 22; 1 lsl 24]

--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -127,6 +127,13 @@
  (preprocess
   (pps sarek_ppx)))
 
+; Tier 1a: pinned vs pageable host-memory transfer (CUDA/ZLUDA only)
+
+(executable
+ (name bench_pinned_transfer)
+ (modules bench_pinned_transfer)
+ (libraries sarek_cuda ctypes unix))
+
 ; Data aggregation and analysis tools
 
 (executable

--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -127,6 +127,17 @@
  (preprocess
   (pps sarek_ppx)))
 
+; Tier 1a: AoS vs SoA memory-bound single-field access
+
+(executable
+ (name bench_soa_aos)
+ (modules bench_soa_aos)
+ (libraries sarek sarek_stdlib sarek_ir spoc_core benchmark_backends unix)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
 ; Tier 1a: pinned vs pageable host-memory transfer (CUDA/ZLUDA only)
 
 (executable

--- a/docs/optimization/tier1a-soa-pinned-handoff.md
+++ b/docs/optimization/tier1a-soa-pinned-handoff.md
@@ -1,0 +1,133 @@
+# Tier 1a implementation notes — SoA + pinned memory
+
+_Implemented 2026-07-23 on branch `feat/soa-pinned-tier1a`. This records what
+shipped, the correctness/benchmark evidence, and the precise Tier 1b handoff._
+
+Companion to [opt-spoc-runtime.md](opt-spoc-runtime.md) §1 (SoA) and §2 (pinned).
+Scope was runtime/layout/host side only; the PTX emitter
+(`sarek/codegen/Sarek_ir_ptx_*`) was **not** touched (Tier 1b territory).
+
+## What shipped
+
+### SoA (structure-of-arrays) — host layout + transpose
+
+- **`Spoc_core.Soa`** (`sarek/core/Soa.ml{,i}`): an opt-in SoA storage plan and
+  the host-side AoS↔SoA transpose.
+  - `plan` / `plan_of_elttype` derive the leaf layout by **reusing
+    `Sarek_ir_layout.record_layout`** — the same leaf enumeration the emitter
+    and PPX already use, so SoA offsets/sizes/stride match the AoS byte layout
+    by construction. v1 accepts **flat records only**; nested records,
+    variants, and array/vector fields are rejected with `Soa.Unsupported`
+    (variants have no well-defined per-tag SoA split — see opt-spoc-runtime §1
+    verdict).
+  - `scatter` / `gather` do a bit-preserving transpose between one packed AoS
+    ctypes buffer and N per-leaf contiguous buffers (4/8-byte word copy; any
+    scalar leaf types).
+  - Deliberately layered **below `Vector`** (operates on raw `unit Ctypes.ptr`),
+    so each SoA leaf can just be an ordinary scalar `Vector`. That reuses the
+    existing scalar transfer / allocation / (future) pinned path with **zero
+    backend or codegen change** — the N-scalar-vector bundle *is* the SoA
+    storage for the host+transfer tier.
+
+- The one place the roadmap flagged as genuinely harder — growing kernel arity
+  so a single custom-vector argument lowers to N base pointers — is **not** done
+  here because it is emitter-side. See the handoff below.
+
+### Pinned (page-locked) host memory — CUDA backend API
+
+- **`Cuda_bindings`**: added `cuMemHostRegister_v2` / `cuMemHostUnregister`
+  (the `cuMemAllocHost_v2` / `cuMemFreeHost` bindings already existed, as the
+  prior exploration pass found).
+- **`Cuda_api.Memory`**: `alloc_host` / `free_host` (driver-allocated
+  page-locked buffers) and `register_host` / `unregister_host` (page-lock in
+  place). The raw pointer feeds the existing
+  `host_ptr_to_device` / `device_to_host_ptr` blocking-memcpy path unchanged.
+
+## Correctness matrix (`sarek/tests/e2e/test_soa_aos_equiv`)
+
+AoS and SoA kernels compute the same per-element value and match a pure-OCaml
+reference. Verified PASS on **every** device present:
+
+| Framework | Device | Result |
+|---|---|---|
+| CUDA/PTX (ZLUDA) | RX 7900 XTX | PASS |
+| CUDA/PTX (ZLUDA) | Ryzen 9 7950X | PASS |
+| OpenCL | RX 7900 XTX (RADV/radeonsi) | PASS |
+| OpenCL | Ryzen 9 7950X | PASS |
+| Vulkan | RX 7900 XTX (RADV NAVI31) | PASS |
+| Vulkan | Ryzen 9 7950X | PASS |
+| Native | CPU (32 cores) | PASS |
+| Interpreter | CPU (seq + parallel) | PASS |
+
+Plus `sarek/tests/unit/test_soa` (host, no device): plan offsets/sizes/stride
+for `point3d` and a mixed-width `{i32;f64}` record, nested/non-record
+rejection, and a bit-identical AoS→SoA→AoS round-trip.
+
+## Benchmark numbers
+
+### SoA vs AoS single-field access (`benchmarks/bench_soa_aos`)
+
+Memory-bound copy reading one field of an 8-field (32-byte-stride) record.
+RX 7900 XTX under ZLUDA (median of 50 runs, effective single-field GB/s):
+
+| N | AoS ms (GB/s) | SoA ms (GB/s) | speedup |
+|---|---|---|---|
+| 262 144 | 0.052 (40.3) | 0.043 (48.9) | 1.21x |
+| 1 048 576 | 0.066 (127.5) | 0.052 (161.4) | 1.27x |
+| 4 194 304 | 0.344 (97.5) | 0.049 (683.2) | **7.00x** |
+| 16 777 216 | 0.789 (170.1) | 0.193 (695.9) | **4.09x** |
+
+SoA restores near-peak bandwidth (~680–700 GB/s effective) once the problem is
+large enough to be bandwidth-bound; AoS stays throttled at ~100–170 GB/s by the
+8× uncoalesced stride. Small N is launch-overhead-bound (~1.2×). Numbers have
+run-to-run variance; the large-N coalescing win is the stable signal.
+
+### Pinned vs pageable transfer (`benchmarks/bench_pinned_transfer`)
+
+**Blocked on the environment.** ZLUDA v7-preview.3 implements neither
+`cuMemAllocHost` nor `cuMemHostRegister` — both return `CUDA_ERROR_OTHER`. The
+benchmark probes for support and, finding none, reports pageable bandwidth only
+(RX 7900 XTX): ~28 GB/s H2D/D2H at ≥16 MB, dropping to ~10 GB/s at 1 MB. The
+pinned API is correct CUDA per the driver docs; the ~2× pinned-vs-pageable
+comparison simply cannot be measured on this hardware/driver and needs a stock
+NVIDIA driver (or a ZLUDA build that implements pinned host memory).
+
+## Tier 1b handoff — device-side single-vector SoA (emitter)
+
+The host+transfer tier above lets a user *manually* run SoA today (bundle N
+scalar vectors, transpose with `Soa`). To make a **single** custom-vector value
+transparently SoA-backed — so kernel source keeps writing `pts.(i).x` and the
+compiler lowers it to coalesced per-leaf loads — needs three emitter-side
+changes, all in files this task was scoped **out** of:
+
+1. **Kernel signature** (`sarek/codegen/Sarek_ir_ptx_kernel.ml:69-93`): a
+   custom-vector parameter currently lowers to `(ptr, len)`. Under SoA it must
+   lower to `(ptr_0, …, ptr_{N-1}, len)` — N base pointers sharing one length.
+   This is the ABI-arity change flagged in opt-spoc-runtime §1.2(c) and touches
+   `Kernel_args` / `RSA_Buffer` / `bind_to_kargs` binding
+   (`sarek/core/Transfer.ml`) to bind N buffers per vector argument.
+2. **Element addressing** (`sarek/codegen/Sarek_ir_ptx_mem.ml`):
+   `emit_agg_elem_addr` + `emit_field_load/store`'s byte-offset folding is
+   *deleted* for the SoA case and replaced by, per leaf, the plain scalar-array
+   addressing that already exists in the same file (`mul.wide.u32 idx,
+   leaf_size; add.u64 r_base_leaf`). A record-of-N-scalars becomes N
+   independent coalesced scalar accesses with a shared index — **less** emitter
+   code, not more.
+3. **Storage variant** (`sarek/core_base/Spoc_core_base`): a `Custom_storage_soa`
+   host-storage variant holding the N leaf sub-buffers, so `Vector.create
+   ~layout:SoA` can pick it and `Transfer` can alloc/transfer/free N device
+   buffers. `Soa.plan` already provides the exact leaf list this needs; the SoA
+   scatter/gather here becomes the host get/set path.
+
+Guardrails to preserve (already reflected in `Soa`): flat records only for v1;
+AoS stays the compatible default (external `.cu`/`.ptx` via `Execute.run_source`
+are hand-written against the packed layout); whole-record-copy kernels can
+regress under SoA (N cache lines vs 1) so the layout must stay an explicit,
+workload-driven per-vector choice, never a blanket default flip.
+
+## Files
+
+- `sarek/core/Soa.ml`, `sarek/core/Soa.mli`
+- `sarek-cuda/Cuda_bindings.ml`, `sarek-cuda/Cuda_api.ml` (`Memory` pinned API)
+- `sarek/tests/unit/test_soa.ml`, `sarek/tests/e2e/test_soa_aos_equiv.ml`
+- `benchmarks/bench_soa_aos.ml`, `benchmarks/bench_pinned_transfer.ml`

--- a/sarek-cuda/Cuda_api.ml
+++ b/sarek-cuda/Cuda_api.ml
@@ -351,6 +351,46 @@ module Memory = struct
     Device.set_current buf.device ;
     let bytes = Unsigned.Size_t.of_int (buf.size * buf.elem_size) in
     check "cuMemsetD8" (cuMemsetD8 buf.ptr (Unsigned.UChar.of_int value) bytes)
+
+  (** {2 Pinned (page-locked) host memory}
+
+      Page-locked host buffers let the driver DMA straight to/from the device
+      without staging through an internal pageable bounce buffer, roughly
+      doubling H2D/D2H bandwidth on PCIe-class links, and are the hard
+      prerequisite for true async transfers (a pageable [cuMemcpy*Async]
+      silently degrades to synchronous). Two shapes are exposed:
+
+      - {!alloc_host}/{!free_host} — driver-allocated page-locked memory
+        ([cuMemAllocHost]); the returned raw pointer is fed to
+        {!host_ptr_to_device}/{!device_to_host_ptr} exactly like any other host
+        pointer.
+      - {!register_host}/{!unregister_host} — page-lock an {e existing} host
+        allocation in place ([cuMemHostRegister]); no allocation-path change,
+        but the caller owns page-alignment and the register/unregister cost. *)
+
+  type pinned_host = {host_ptr : unit ptr; bytes : int}
+
+  (** Allocate [bytes] of page-locked host memory. Must be released with
+      {!free_host}, never [Stdlib]/[free]. *)
+  let alloc_host bytes =
+    let pp = allocate (ptr void) null in
+    check "cuMemAllocHost" (cuMemAllocHost pp (Unsigned.Size_t.of_int bytes)) ;
+    {host_ptr = !@pp; bytes}
+
+  let free_host ph = check "cuMemFreeHost" (cuMemFreeHost ph.host_ptr)
+
+  (** Page-lock [bytes] at an existing host pointer (flags = 0: portable,
+      non-mapped). Pair with {!unregister_host}. *)
+  let register_host ptr bytes =
+    check
+      "cuMemHostRegister"
+      (cuMemHostRegister
+         (to_voidp ptr)
+         (Unsigned.Size_t.of_int bytes)
+         (Unsigned.UInt.of_int 0))
+
+  let unregister_host ptr =
+    check "cuMemHostUnregister" (cuMemHostUnregister (to_voidp ptr))
 end
 
 (** {1 Stream Management} *)

--- a/sarek-cuda/Cuda_bindings.ml
+++ b/sarek-cuda/Cuda_bindings.ml
@@ -257,6 +257,21 @@ let cuMemFreeHost_lazy =
 
 let cuMemFreeHost ptr = Lazy.force cuMemFreeHost_lazy ptr
 
+(* Page-lock an existing host allocation in place (no copy). [flags] is 0 for
+   the default portable/non-mapped registration. *)
+let cuMemHostRegister_lazy =
+  foreign_cuda_lazy
+    "cuMemHostRegister_v2"
+    (ptr void @-> size_t @-> uint @-> returning cu_result)
+
+let cuMemHostRegister ptr size flags =
+  Lazy.force cuMemHostRegister_lazy ptr size flags
+
+let cuMemHostUnregister_lazy =
+  foreign_cuda_lazy "cuMemHostUnregister" (ptr void @-> returning cu_result)
+
+let cuMemHostUnregister ptr = Lazy.force cuMemHostUnregister_lazy ptr
+
 let cuMemGetInfo_lazy =
   foreign_cuda_lazy
     "cuMemGetInfo_v2"

--- a/sarek/core/Soa.ml
+++ b/sarek/core/Soa.ml
@@ -1,0 +1,119 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* See Soa.mli for the design rationale. *)
+
+module Layout = Sarek_ir_layout
+module Helpers = Vector_types.Custom_helpers
+
+type leaf = {
+  path : string;
+  ty : Sarek_ir_types.elttype;
+  aos_offset : int;
+  size : int;
+}
+
+type plan = {name : string; leaves : leaf list; aos_stride : int}
+
+exception Unsupported of string
+
+let reject_non_flat name fields =
+  List.iter
+    (fun (fname, ty) ->
+      match (ty : Sarek_ir_types.elttype) with
+      | TInt32 | TInt64 | TFloat32 | TFloat64 | TBool | TUnit -> ()
+      | TRecord _ ->
+          raise
+            (Unsupported
+               (Printf.sprintf
+                  "nested-record field %S in %S: v1 SoA supports flat records \
+                   only"
+                  fname
+                  name))
+      | TVariant _ ->
+          raise
+            (Unsupported
+               (Printf.sprintf
+                  "variant field %S in %S: variants have no well-defined SoA \
+                   split"
+                  fname
+                  name))
+      | TArray _ | TVec _ ->
+          raise
+            (Unsupported
+               (Printf.sprintf
+                  "array/vector field %S in %S unsupported"
+                  fname
+                  name)))
+    fields
+
+let plan ~name fields =
+  reject_non_flat name fields ;
+  match Layout.record_layout ~type_name:name fields with
+  | Error e -> raise (Unsupported (Layout.layout_error_message e))
+  | Ok rl ->
+      let leaves =
+        List.map
+          (fun (l : Layout.leaf) ->
+            {
+              path = l.leaf_path;
+              ty = l.leaf_type;
+              aos_offset = l.leaf_offset;
+              size = l.leaf_size;
+            })
+          rl.rl_leaves
+      in
+      {name; leaves; aos_stride = rl.rl_size}
+
+let plan_of_elttype (t : Sarek_ir_types.elttype) =
+  match t with
+  | TRecord (name, fields) -> plan ~name fields
+  | _ -> raise (Unsupported "SoA plan requires a record (TRecord) element type")
+
+let num_leaves p = List.length p.leaves
+
+let aos_bytes p ~length = length * p.aos_stride
+
+(* Bit-preserving copy of one [size]-byte scalar. All Sarek scalar leaves are
+   4 or 8 bytes; the byte-loop is a defensive fallback. *)
+let copy_word ~size ~src ~src_off ~dst ~dst_off =
+  match size with
+  | 4 -> Helpers.write_int32 dst dst_off (Helpers.read_int32 src src_off)
+  | 8 -> Helpers.write_int64 dst dst_off (Helpers.read_int64 src src_off)
+  | _ ->
+      (* Defensive fallback (no Sarek scalar hits this): plain byte copy. *)
+      for b = 0 to size - 1 do
+        let s = Ctypes.(from_voidp uint8_t src +@ (src_off + b)) in
+        let d = Ctypes.(from_voidp uint8_t dst +@ (dst_off + b)) in
+        Ctypes.(d <-@ !@s)
+      done
+
+let scatter p ~aos ~length ~leaves =
+  List.iteri
+    (fun k leaf ->
+      let dst = leaves.(k) in
+      for i = 0 to length - 1 do
+        copy_word
+          ~size:leaf.size
+          ~src:aos
+          ~src_off:((i * p.aos_stride) + leaf.aos_offset)
+          ~dst
+          ~dst_off:(i * leaf.size)
+      done)
+    p.leaves
+
+let gather p ~leaves ~length ~aos =
+  List.iteri
+    (fun k leaf ->
+      let src = leaves.(k) in
+      for i = 0 to length - 1 do
+        copy_word
+          ~size:leaf.size
+          ~src
+          ~src_off:(i * leaf.size)
+          ~dst:aos
+          ~dst_off:((i * p.aos_stride) + leaf.aos_offset)
+      done)
+    p.leaves

--- a/sarek/core/Soa.mli
+++ b/sarek/core/Soa.mli
@@ -1,0 +1,79 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Structure-of-Arrays (SoA) storage for custom-type vectors — host side.
+ *
+ * Tier 1a headline item (host/transfer/accessor half). A custom-type vector
+ * (e.g. a [point3d = {x;y;z}] vector) is stored packed AoS today, which forces
+ * an N-way-strided (1/N-efficiency) uncoalesced device access whenever a kernel
+ * touches only one field. SoA stores each scalar leaf in its own contiguous
+ * buffer, restoring full coalescing for single-field access.
+ *
+ * This module provides the storage *plan* (reusing the leaf enumeration
+ * [Sarek_ir_layout] already computes) and the host-side AoS<->SoA transpose.
+ * It is deliberately layered below {!Vector}: it operates on raw ctypes
+ * pointers, so the caller can transpose between a custom (AoS) vector's host
+ * buffer and an array of scalar (SoA leaf) vectors, then transfer each leaf
+ * with the ordinary scalar path — no new backend or codegen support needed.
+ *
+ * The device-side consumption of a SoA vector (lowering [pts.(i).x] to N base
+ * pointers + coalesced scalar loads) requires PTX-emitter changes and is the
+ * Tier 1b handoff; see docs/optimization/opt-spoc-runtime.md.
+ ******************************************************************************)
+
+(** One scalar leaf of a flattened record: its dotted path, scalar type, byte
+    offset within the packed AoS element, and scalar byte size. *)
+type leaf = {
+  path : string;
+  ty : Sarek_ir_types.elttype;
+  aos_offset : int;
+  size : int;
+}
+
+(** A SoA storage plan for a flat record type. [aos_stride] is the packed AoS
+    element size in bytes (the stride between consecutive elements in AoS). *)
+type plan = {name : string; leaves : leaf list; aos_stride : int}
+
+(** Raised when a type is not a v1-supported SoA target (non-record, or a record
+    with a nested-record / variant / array field — flat records only for v1). *)
+exception Unsupported of string
+
+(** Build a SoA plan from a record's named fields. Reuses
+    {!Sarek_ir_layout.record_layout} for leaf offsets/sizes/stride. Every field
+    must be a scalar; nested records, variants and arrays are rejected with
+    {!Unsupported}. *)
+val plan : name:string -> (string * Sarek_ir_types.elttype) list -> plan
+
+(** [plan_of_elttype t] requires [t] to be a [TRecord]. *)
+val plan_of_elttype : Sarek_ir_types.elttype -> plan
+
+(** Number of scalar leaves (= number of SoA sub-buffers / kernel base pointers
+    a SoA vector of this type needs). *)
+val num_leaves : plan -> int
+
+(** Total bytes an AoS buffer of [length] elements occupies
+    ([length * aos_stride]). *)
+val aos_bytes : plan -> length:int -> int
+
+(** [scatter plan ~aos ~length ~leaves] copies each element's field values from
+    the packed AoS buffer [aos] into the per-leaf contiguous buffers [leaves]
+    ([leaves.(k)] receives the k-th leaf, in {!plan.leaves} order).
+    Bit-preserving copy; works for any scalar leaf types. *)
+val scatter :
+  plan ->
+  aos:unit Ctypes.ptr ->
+  length:int ->
+  leaves:unit Ctypes.ptr array ->
+  unit
+
+(** Inverse of {!scatter}: gather per-leaf SoA buffers back into a packed AoS
+    buffer. *)
+val gather :
+  plan ->
+  leaves:unit Ctypes.ptr array ->
+  length:int ->
+  aos:unit Ctypes.ptr ->
+  unit

--- a/sarek/core/dune
+++ b/sarek/core/dune
@@ -22,6 +22,7 @@
   Vector_types
   Vector_transfer
   Vector
+  Soa
   Gpu_memory
   Transfer
   Profiling

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -729,3 +729,32 @@
  (alias runtest)
  (action
   (run %{dep:test_static_tag_erasure.exe})))
+
+; Tier 1a SoA correctness: AoS and SoA kernels produce identical values on
+; every device (Spoc_core.Soa host transpose + scalar transfer path).
+
+(executable
+ (name test_soa_aos_equiv)
+ (modules test_soa_aos_equiv)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  test_helpers
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_soa_aos_equiv.exe})))

--- a/sarek/tests/e2e/test_soa_aos_equiv.ml
+++ b/sarek/tests/e2e/test_soa_aos_equiv.ml
@@ -1,0 +1,167 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Tier 1a SoA correctness: AoS and SoA produce identical values on every
+ * device.
+ *
+ * A [point3d] custom (AoS) vector is filled with source data. The host-side
+ * SoA transpose (Spoc_core.Soa.scatter) derives three contiguous float32 leaf
+ * vectors (xs/ys/zs) from that AoS buffer. Two kernels compute the same
+ * per-element reduction x+y+z:
+ *   - AoS kernel reads the whole record  [let p = pts.(tid) in p.x+p.y+p.z]
+ *   - SoA kernel reads three scalar arrays [xs.(tid)+ys.(tid)+zs.(tid)]
+ * The two device results must match each other and a pure-OCaml reference, on
+ * every available device (Native/Interpreter always, plus any GPU backend).
+ *
+ * This exercises the SoA storage plan + transpose + (scalar) transfer path
+ * end-to-end. Device-side SoA addressing of a single custom vector value is
+ * the Tier 1b emitter handoff and is not exercised here.
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Soa = Spoc_core.Soa
+module Benchmarks = Test_helpers.Benchmarks
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+type float32 = float
+
+type point3d = {x : float32; y : float32; z : float32} [@@sarek.type]
+
+let aos_kernel =
+  snd
+    [%kernel
+      fun (pts : point3d vector) (out : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then
+          let p = pts.(tid) in
+          out.(tid) <- p.x +. p.y +. p.z]
+
+let soa_kernel =
+  snd
+    [%kernel
+      fun (xs : float32 vector)
+          (ys : float32 vector)
+          (zs : float32 vector)
+          (out : float32 vector)
+          (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then out.(tid) <- xs.(tid) +. ys.(tid) +. zs.(tid)]
+
+let ir_of kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let run_device dev n =
+  let threads = min 128 n in
+  let grid_x = (n + threads - 1) / threads in
+  let block = Sarek.Execute.dims1d threads in
+  let grid = Sarek.Execute.dims1d grid_x in
+  (* Source data + AoS vector. *)
+  let src = Vector.create_custom point3d_custom n in
+  for i = 0 to n - 1 do
+    Vector.set
+      src
+      i
+      {
+        x = float_of_int i;
+        y = (float_of_int i *. 0.5) +. 1.0;
+        z = float_of_int (n - i);
+      }
+  done ;
+  (* SoA leaves derived from the AoS buffer via the host transpose. *)
+  let plan =
+    Soa.plan
+      ~name:"point3d"
+      Sarek_ir_types.[("x", TFloat32); ("y", TFloat32); ("z", TFloat32)]
+  in
+  let xs = Vector.create Vector.float32 n in
+  let ys = Vector.create Vector.float32 n in
+  let zs = Vector.create Vector.float32 n in
+  Soa.scatter
+    plan
+    ~aos:(Vector.to_ctypes_ptr src)
+    ~length:n
+    ~leaves:
+      [|
+        Vector.to_ctypes_ptr xs;
+        Vector.to_ctypes_ptr ys;
+        Vector.to_ctypes_ptr zs;
+      |] ;
+  (* AoS kernel. *)
+  let out_aos = Vector.create Vector.float32 n in
+  Sarek.Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of aos_kernel)
+    ~args:
+      [Sarek.Execute.Vec src; Sarek.Execute.Vec out_aos; Sarek.Execute.Int n]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  (* SoA kernel. *)
+  let out_soa = Vector.create Vector.float32 n in
+  Sarek.Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of soa_kernel)
+    ~args:
+      [
+        Sarek.Execute.Vec xs;
+        Sarek.Execute.Vec ys;
+        Sarek.Execute.Vec zs;
+        Sarek.Execute.Vec out_soa;
+        Sarek.Execute.Int n;
+      ]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  (out_aos, out_soa, src)
+
+let () =
+  Benchmarks.init () ;
+  let n = 1024 in
+  let devs = Device.all () in
+  if Array.length devs = 0 then (
+    print_endline "test_soa_aos_equiv: no device - SKIPPED" ;
+    exit 0) ;
+  let any_failure = ref false in
+  Array.iter
+    (fun dev ->
+      Printf.printf
+        "SoA/AoS equiv [%s] %s: %!"
+        dev.Device.framework
+        dev.Device.name ;
+      try
+        let out_aos, out_soa, src = run_device dev n in
+        let ok = ref true in
+        for i = 0 to n - 1 do
+          let p = Vector.get src i in
+          let reference = p.x +. p.y +. p.z in
+          let a = Vector.get out_aos i in
+          let s = Vector.get out_soa i in
+          if abs_float (a -. s) > 1e-4 || abs_float (a -. reference) > 1e-3 then (
+            ok := false ;
+            if i < 5 then
+              Printf.printf
+                "\n  Mismatch at %d: aos=%f soa=%f ref=%f%!"
+                i
+                a
+                s
+                reference)
+        done ;
+        if !ok then print_endline "PASSED"
+        else (
+          any_failure := true ;
+          print_endline "FAILED")
+      with e ->
+        any_failure := true ;
+        Printf.printf "FAIL (%s)\n%!" (Printexc.to_string e))
+    devs ;
+  if !any_failure then exit 1

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -83,3 +83,9 @@
 (test
  (name test_ppx_scan_diagnostics)
  (libraries sarek_ppx alcotest))
+
+; Tier 1a: host-side SoA layout/transpose round-trip (pure ctypes, no device)
+
+(test
+ (name test_soa)
+ (libraries spoc_core spoc.ir ctypes alcotest))

--- a/sarek/tests/unit/test_soa.ml
+++ b/sarek/tests/unit/test_soa.ml
@@ -1,0 +1,144 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Unit tests for the host-side SoA layout/transpose (Spoc_core.Soa).
+ * Pure ctypes buffers, no device — verifies plan derivation and that
+ * AoS -> SoA -> AoS round-trips bit-identically.
+ ******************************************************************************)
+
+module Soa = Spoc_core.Soa
+module Helpers = Spoc_core.Vector_types.Custom_helpers
+open Sarek_ir_types
+
+let alloc_bytes n = Ctypes.(to_voidp (allocate_n uint8_t ~count:n))
+
+let point3d =
+  TRecord ("point3d", [("x", TFloat32); ("y", TFloat32); ("z", TFloat32)])
+
+(* {a:int32; b:float64} — mixed width, exercises the 8-byte leaf and aligned
+   offsets (b lands at offset 8 under the aligned ABI, stride 16). *)
+let ab = TRecord ("ab", [("a", TInt32); ("b", TFloat64)])
+
+let test_plan_point3d () =
+  let p = Soa.plan_of_elttype point3d in
+  Alcotest.(check int) "num_leaves" 3 (Soa.num_leaves p) ;
+  Alcotest.(check int) "aos_stride" 12 p.Soa.aos_stride ;
+  let offs = List.map (fun (l : Soa.leaf) -> l.aos_offset) p.Soa.leaves in
+  Alcotest.(check (list int)) "offsets" [0; 4; 8] offs ;
+  let sizes = List.map (fun (l : Soa.leaf) -> l.size) p.Soa.leaves in
+  Alcotest.(check (list int)) "sizes" [4; 4; 4] sizes
+
+let test_plan_mixed () =
+  let p = Soa.plan_of_elttype ab in
+  Alcotest.(check int) "num_leaves" 2 (Soa.num_leaves p) ;
+  (* aligned ABI: int32 at 0, float64 aligned to 8, struct padded to 16 *)
+  Alcotest.(check int) "aos_stride" 16 p.Soa.aos_stride ;
+  let offs = List.map (fun (l : Soa.leaf) -> l.aos_offset) p.Soa.leaves in
+  Alcotest.(check (list int)) "offsets" [0; 8] offs
+
+let test_rejects () =
+  let nested = TRecord ("outer", [("p", point3d); ("w", TFloat32)]) in
+  Alcotest.check_raises
+    "nested record rejected"
+    (Soa.Unsupported
+       "nested-record field \"p\" in \"outer\": v1 SoA supports flat records \
+        only")
+    (fun () -> ignore (Soa.plan_of_elttype nested)) ;
+  Alcotest.check_raises
+    "non-record rejected"
+    (Soa.Unsupported "SoA plan requires a record (TRecord) element type")
+    (fun () -> ignore (Soa.plan_of_elttype TFloat32))
+
+(* Fill AoS[i] = {x=i, y=100+i, z=200+i}; scatter; check contiguous leaves;
+   gather back; check bit-identical. *)
+let test_roundtrip_point3d () =
+  let p = Soa.plan_of_elttype point3d in
+  let length = 257 in
+  let aos = alloc_bytes (Soa.aos_bytes p ~length) in
+  for i = 0 to length - 1 do
+    Helpers.write_float32 aos ((i * 12) + 0) (float_of_int i) ;
+    Helpers.write_float32 aos ((i * 12) + 4) (float_of_int (100 + i)) ;
+    Helpers.write_float32 aos ((i * 12) + 8) (float_of_int (200 + i))
+  done ;
+  let leaves = Array.init 3 (fun _ -> alloc_bytes (length * 4)) in
+  Soa.scatter p ~aos ~length ~leaves ;
+  (* Each leaf buffer must hold its field's values contiguously. *)
+  for i = 0 to length - 1 do
+    Alcotest.(check (float 0.0))
+      "leaf x"
+      (float_of_int i)
+      (Helpers.read_float32 leaves.(0) (i * 4)) ;
+    Alcotest.(check (float 0.0))
+      "leaf y"
+      (float_of_int (100 + i))
+      (Helpers.read_float32 leaves.(1) (i * 4)) ;
+    Alcotest.(check (float 0.0))
+      "leaf z"
+      (float_of_int (200 + i))
+      (Helpers.read_float32 leaves.(2) (i * 4))
+  done ;
+  (* Gather back into a fresh AoS buffer and compare bit-identical. *)
+  let aos2 = alloc_bytes (Soa.aos_bytes p ~length) in
+  Soa.gather p ~leaves ~length ~aos:aos2 ;
+  for i = 0 to (length * 12) - 1 do
+    let b1 = Ctypes.(!@(from_voidp uint8_t aos +@ i)) in
+    let b2 = Ctypes.(!@(from_voidp uint8_t aos2 +@ i)) in
+    Alcotest.(check int)
+      (Printf.sprintf "byte %d" i)
+      (Unsigned.UInt8.to_int b1)
+      (Unsigned.UInt8.to_int b2)
+  done
+
+let test_roundtrip_mixed () =
+  let p = Soa.plan_of_elttype ab in
+  let length = 64 in
+  let stride = p.Soa.aos_stride in
+  let aos = alloc_bytes (Soa.aos_bytes p ~length) in
+  for i = 0 to length - 1 do
+    Helpers.write_int32 aos ((i * stride) + 0) (Int32.of_int (i * 3)) ;
+    Helpers.write_float64 aos ((i * stride) + 8) (float_of_int i +. 0.5)
+  done ;
+  let leaves = [|alloc_bytes (length * 4); alloc_bytes (length * 8)|] in
+  Soa.scatter p ~aos ~length ~leaves ;
+  for i = 0 to length - 1 do
+    Alcotest.(check int32)
+      "leaf a"
+      (Int32.of_int (i * 3))
+      (Helpers.read_int32 leaves.(0) (i * 4)) ;
+    Alcotest.(check (float 0.0))
+      "leaf b"
+      (float_of_int i +. 0.5)
+      (Helpers.read_float64 leaves.(1) (i * 8))
+  done ;
+  let aos2 = alloc_bytes (Soa.aos_bytes p ~length) in
+  Soa.gather p ~leaves ~length ~aos:aos2 ;
+  for i = 0 to length - 1 do
+    Alcotest.(check int32)
+      "rt a"
+      (Helpers.read_int32 aos (i * stride))
+      (Helpers.read_int32 aos2 (i * stride)) ;
+    Alcotest.(check (float 0.0))
+      "rt b"
+      (Helpers.read_float64 aos ((i * stride) + 8))
+      (Helpers.read_float64 aos2 ((i * stride) + 8))
+  done
+
+let () =
+  Alcotest.run
+    "soa"
+    [
+      ( "plan",
+        [
+          Alcotest.test_case "point3d" `Quick test_plan_point3d;
+          Alcotest.test_case "mixed" `Quick test_plan_mixed;
+          Alcotest.test_case "rejects" `Quick test_rejects;
+        ] );
+      ( "roundtrip",
+        [
+          Alcotest.test_case "point3d" `Quick test_roundtrip_point3d;
+          Alcotest.test_case "mixed" `Quick test_roundtrip_mixed;
+        ] );
+    ]


### PR DESCRIPTION
Implements performance-roadmap **Tier 1a** (`docs/optimization/`): the host/layout/transfer half of SoA custom vectors and the pinned host-memory plumbing. Scoped to runtime + host + benchmarks; the PTX emitter (`Sarek_ir_ptx_*`) was deliberately not touched — the device-side single-vector SoA lowering is the documented Tier 1b handoff.

## SoA (structure-of-arrays)
- New `Spoc_core.Soa`: opt-in SoA storage plan (reuses `Sarek_ir_layout` leaf enumeration; flat records only for v1, variants/nested/arrays rejected) + bit-preserving host AoS↔SoA `scatter`/`gather`. Layered below `Vector` on raw ctypes ptrs, so each leaf is a plain scalar `Vector` reusing the existing scalar transfer path — zero backend/codegen change.
- Because each SoA leaf is an ordinary scalar vector, the SoA inputs run through existing kernels on **every** backend today.

## Pinned host memory
- Bound `cuMemHostRegister_v2`/`cuMemHostUnregister` (the `cuMemAllocHost_v2`/`cuMemFreeHost` bindings already existed).
- `Cuda_api.Memory`: `alloc_host`/`free_host` + `register_host`/`unregister_host`, feeding the existing blocking-memcpy path.

## Correctness (`test_soa_aos_equiv`, e2e)
AoS and SoA kernels produce identical values and match a CPU reference on **every device**: CUDA/PTX (ZLUDA), OpenCL, Vulkan, Native, Interpreter — GPU + CPU each. Plus `test_soa` unit (plan + bit-identical round-trip). Full `dune runtest sarek/tests` green; `@install` and `@fmt` (my files) clean.

## Benchmarks (RX 7900 XTX / ZLUDA)
**SoA vs AoS single-field copy** (8-field, 32B-stride record), effective single-field bandwidth:

| N | AoS GB/s | SoA GB/s | speedup |
|---|---|---|---|
| 262 144 | 40.3 | 48.9 | 1.21x |
| 1 048 576 | 127.5 | 161.4 | 1.27x |
| 4 194 304 | 97.5 | 683.2 | **7.00x** |
| 16 777 216 | 170.1 | 695.9 | **4.09x** |

**Pinned vs pageable** — blocked on environment: ZLUDA v7-preview.3 implements neither `cuMemAllocHost` nor `cuMemHostRegister` (both return `CUDA_ERROR_OTHER`). The benchmark probes support and reports pageable-only (~28 GB/s at ≥16 MB). The API is correct CUDA; the ~2× comparison needs a stock NVIDIA driver.

## Tier 1b handoff (emitter)
Device-side transparent SoA for a single custom-vector value needs 3 emitter-side changes (kernel arity → N base pointers, per-leaf coalesced addressing, `Custom_storage_soa` variant). Detailed in `docs/optimization/tier1a-soa-pinned-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)