### PR TITLE
feat: multi-arg variant payloads on all backends + interpreter tuple vectors

### DIFF
--- a/sarek/interp/Sarek_ir_interp.ml
+++ b/sarek/interp/Sarek_ir_interp.ml
@@ -399,6 +399,56 @@ type exec_writeback =
       (module Spoc_framework.Typed_value.EXEC_VECTOR) * value array
       -> exec_writeback
 
+(* Tuple vector elements (L13) reach the interpreter as a [COMPOSITE_TYPE] whose
+   [fields] descriptor list is empty but whose [to_bytes]/[of_bytes] marshal the
+   raw device-layout element bytes. The tuple-shape byte layout (per-field type
+   and offset) is resolved from [Sarek_tuple_vec], the single authority that
+   built the host vector, and used to decode those bytes into a positional
+   [VRecord] (fields [_0], [_1], ...) and re-encode them on writeback. *)
+let value_of_bytes (b : bytes) (fl : Sarek_tuple_vec.field_layout) : value =
+  let off = fl.Sarek_tuple_vec.fl_offset in
+  match fl.Sarek_tuple_vec.fl_elttype with
+  | Sarek_ir_types.TFloat32 ->
+      VFloat32 (Int32.float_of_bits (Bytes.get_int32_le b off))
+  | Sarek_ir_types.TFloat64 ->
+      VFloat64 (Int64.float_of_bits (Bytes.get_int64_le b off))
+  | Sarek_ir_types.TInt32 -> VInt32 (Bytes.get_int32_le b off)
+  | Sarek_ir_types.TInt64 -> VInt64 (Bytes.get_int64_le b off)
+  | Sarek_ir_types.TBool -> VBool (Bytes.get_int8 b off <> 0)
+  | _ ->
+      Interp_error.raise_error
+        (Unsupported_operation
+           {
+             operation = "value_of_bytes";
+             reason = "unsupported tuple component type";
+           })
+
+let bytes_of_shape (shape : Sarek_tuple_vec.shape) (fields : value array) :
+    bytes =
+  let b = Bytes.make shape.Sarek_tuple_vec.sh_size '\000' in
+  List.iteri
+    (fun idx fl ->
+      let off = fl.Sarek_tuple_vec.fl_offset in
+      let v = if idx < Array.length fields then fields.(idx) else VUnit in
+      match fl.Sarek_tuple_vec.fl_elttype with
+      | Sarek_ir_types.TFloat32 ->
+          Bytes.set_int32_le b off (Int32.bits_of_float (to_float32 v))
+      | Sarek_ir_types.TFloat64 ->
+          Bytes.set_int64_le b off (Int64.bits_of_float (to_float64 v))
+      | Sarek_ir_types.TInt32 -> Bytes.set_int32_le b off (to_int32 v)
+      | Sarek_ir_types.TInt64 -> Bytes.set_int64_le b off (to_int64 v)
+      | Sarek_ir_types.TBool ->
+          Bytes.set_int8 b off (if to_bool v then 1 else 0)
+      | _ ->
+          Interp_error.raise_error
+            (Unsupported_operation
+               {
+                 operation = "bytes_of_shape";
+                 reason = "unsupported tuple component type";
+               }))
+    shape.Sarek_tuple_vec.sh_fields ;
+  b
+
 let value_of_typed_value (tv : Spoc_framework.Typed_value.typed_value) : value =
   match tv with
   | TV_Scalar (SV ((module S), x)) -> (
@@ -411,7 +461,15 @@ let value_of_typed_value (tv : Spoc_framework.Typed_value.typed_value) : value =
           Interp_error.raise_error
             (Unsupported_operation
                {operation = "value_of_typed_value"; reason = "PBytes scalar"}))
-  | TV_Composite (CV ((module C), _x)) -> VRecord (C.name, [||])
+  | TV_Composite (CV ((module C), x)) -> (
+      match Sarek_tuple_vec.lookup_shape C.name with
+      | Some shape ->
+          let b = C.to_bytes x in
+          VRecord
+            ( C.name,
+              Array.of_list
+                (List.map (value_of_bytes b) shape.Sarek_tuple_vec.sh_fields) )
+      | None -> VRecord (C.name, [||]))
 
 let typed_value_of_value (type a)
     (module V : Spoc_framework.Typed_value.EXEC_VECTOR with type elt = a)
@@ -443,10 +501,26 @@ let array_to_exec_vector (module V : Spoc_framework.Typed_value.EXEC_VECTOR)
   let len = min (Array.length arr) V.length in
   for i = 0 to len - 1 do
     match arr.(i) with
-    | VRecord _ as vrec -> (
+    | VRecord (name, fields) as vrec -> (
         match Sarek_type_helpers.lookup_typed V.type_id with
         | Some (module H) -> V.set_typed i (H.from_value vrec)
-        | None -> ())
+        | None -> (
+            (* Tuple vector element (L13): re-encode the positional record to
+               raw element bytes via the resolved shape layout, then round-trip
+               through the composite's [of_bytes] to set the element. *)
+            match Sarek_tuple_vec.lookup_shape name with
+            | Some shape -> (
+                match V.get i with
+                | Spoc_framework.Typed_value.TV_Composite (CV ((module C), _))
+                  ->
+                    let b = bytes_of_shape shape fields in
+                    V.set
+                      i
+                      (Spoc_framework.Typed_value.TV_Composite
+                         (Spoc_framework.Typed_value.CV
+                            ((module C), C.of_bytes b)))
+                | _ -> ())
+            | None -> ()))
     | scalar -> (
         match typed_value_of_value (module V) scalar with
         | Some tv -> V.set i tv

--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -7,6 +7,20 @@ open Sarek_ir_types
 open Sarek_ir_interp_value
 open Sarek_ir_interp_intrinsics
 
+(** Positional tuple-field index for a synthesized [_tup_*] record: ["_0"] ->
+    [Some 0], ["_12"] -> [Some 12], any other name -> [None]. Used to resolve
+    tuple-element field access without a record-registry entry. *)
+let positional_field_index (field : string) : int option =
+  let n = String.length field in
+  if n >= 2 && field.[0] = '_' then begin
+    let rec all_digits i =
+      i >= n || (field.[i] >= '0' && field.[i] <= '9' && all_digits (i + 1))
+    in
+    if all_digits 1 then int_of_string_opt (String.sub field 1 (n - 1))
+    else None
+  end
+  else None
+
 (** Main intrinsic dispatcher - tries each category in order *)
 let rec eval_intrinsic state path name args =
   (* Global-memory atomics and fences are path-independent (they may be opened
@@ -106,6 +120,22 @@ and eval_composite_expr state env = function
       | VRecord (type_name, fields) as vrec -> (
           match Sarek_type_helpers.lookup type_name with
           | Some h -> h.get_field vrec field
+          | None when positional_field_index field <> None ->
+              (* Synthesized tuple records (L13, [_tup_*]) use positional field
+                 names [_0], [_1], ...; resolve the index directly rather than
+                 through the record registry, which never holds these. *)
+              let idx = Option.get (positional_field_index field) in
+              if idx < Array.length fields then fields.(idx)
+              else
+                Interp_error.raise_error
+                  (Pattern_match_failure
+                     {
+                       context =
+                         Printf.sprintf
+                           "Positional field %s out of range in %s"
+                           field
+                           type_name;
+                     })
           | None ->
               let field_infos = Sarek_registry.record_fields type_name in
               let rec find_idx i = function

--- a/sarek/interp/dune
+++ b/sarek/interp/dune
@@ -7,7 +7,7 @@
 (library
  (name sarek_interp)
  (public_name sarek.interp)
- (libraries sarek_ir spoc_core spoc_framework sarek_registry)
+ (libraries sarek_ir spoc_core spoc_framework sarek_registry sarek_tuple_vec)
  (modules
   Sarek_float32
   Sarek_value

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -45,9 +45,7 @@ let rec elttype_of_typ (ty : typ) : Ir.elttype =
       Ir.TVariant
         ( name,
           List.map
-            (fun (n, ty_opt) ->
-              ( n,
-                match ty_opt with None -> [] | Some ty -> [elttype_of_typ ty] ))
+            (fun (n, ty_opt) -> (n, constr_payload_elttypes ty_opt))
             constrs )
   (* NOTE: TTuple/TFun are NOT rejected here even though this is where the
      original bug report pointed. This function converts the type of *any*
@@ -67,6 +65,31 @@ let rec elttype_of_typ (ty : typ) : Ir.elttype =
         "Kernel parameter type is a type variable — polymorphic kernels are \
          not supported. Annotate the parameter with a concrete type (e.g. \
          float32, int32)."
+
+(** Flatten a variant constructor's payload type into its IR field list. A
+    multi-argument constructor ([MkPair of float32 * float32]) carries a tuple
+    payload type; it is FLATTENED to one IR field per component
+    ([TFloat32; TFloat32]) so it lines up field-for-field with the multi-binder
+    pattern ([PConstr ("MkPair", ["x"; "y"])]) and the flat [_0/_1] tagged-union
+    payload every source generator already emits. A single, non-tuple payload
+    stays one field. Only scalar-primitive tuple components flatten; any other
+    tuple keeps the (placeholder) single-field mapping. *)
+and constr_payload_elttypes (ty_opt : typ option) : Ir.elttype list =
+  match ty_opt with
+  | None -> []
+  | Some ty -> (
+      match repr ty with
+      | TTuple tys when List.for_all is_scalar_prim_typ tys ->
+          List.map elttype_of_typ tys
+      | _ -> [elttype_of_typ ty])
+
+(** Scalar-primitive predicate on a source [typ], matching the component set
+    accepted for flattened tuple payloads (mirrors [prim_component_elttype]). *)
+and is_scalar_prim_typ (t : typ) : bool =
+  match repr t with
+  | TPrim TInt32 | TPrim TBool | TReg Int64 | TReg Float32 | TReg Float64 ->
+      true
+  | _ -> false
 
 (* L13: tuple-typed vector elements. A tuple used as a vector element type is
    lowered to a synthesized packed record with positional fields [_0], [_1],
@@ -564,17 +587,27 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
         | TVariant (_, constrs) ->
             let constr_types =
               List.map
-                (fun (cname, ty_opt) ->
-                  ( cname,
-                    match ty_opt with
-                    | None -> []
-                    | Some ty -> [elttype_of_typ ty] ))
+                (fun (cname, ty_opt) -> (cname, constr_payload_elttypes ty_opt))
                 constrs
             in
             Hashtbl.add state.variants ty_name constr_types
         | _ -> ()
       end ;
-      let args = match arg with None -> [] | Some e -> [lower_expr state e] in
+      (* Flatten a multi-argument constructor's tuple payload into one IR
+         argument per component, matching the flattened field registration
+         above and the multi-binder pattern side. A literal tuple whose
+         components are all scalar primitives is the shape the typer produces
+         for [MkPair (a, b)]; everything else stays a single argument. *)
+      let args =
+        match arg with
+        | None -> []
+        | Some {te = TETuple comps; ty = tup_ty; _}
+          when match repr tup_ty with
+               | TTuple tys -> List.for_all is_scalar_prim_typ tys
+               | _ -> false ->
+            List.map (lower_expr state) comps
+        | Some e -> [lower_expr state e]
+      in
       Ir.EVariant (ty_name, constr, args)
   | TETuple exprs -> (
       (* L13: a tuple literal whose components are scalar primitives is lowered

--- a/sarek/tests/e2e/test_static_tag_erasure.ml
+++ b/sarek/tests/e2e/test_static_tag_erasure.ml
@@ -217,16 +217,12 @@ let () =
       let r = float_of_int (i + 1) in
       (r *. r) +. r) ;
   run_behaviour "nullary(erasable)" nullary_kirc ~reference:(fun _ -> 1.0) ;
-  (* Multi-arg constructor payloads are a PRE-EXISTING gap everywhere except
-     Native: the Interpreter crashes (List.iter2) and every source generator
-     (CUDA/PTX, OpenCL, Vulkan) returns generate_source None — unrelated to
-     erasure. The retained-tag assertion above is the real check here;
-     behaviour is gated only where the construct executes today (Native). *)
-  run_behaviour
-    "multiarg-payload(control)"
-    multiarg_kirc
-    ~must:(fun fw -> fw = "Native")
-    ~reference:(fun i ->
+  (* Multi-arg constructor payloads: the constructor's tuple payload is
+     FLATTENED to one field per component end-to-end (Sarek_lower_ir), so it
+     lines up with the multi-binder pattern and the flat [_0/_1] tagged-union
+     payload every backend emits. Now executes on every backend, so the gate
+     is the default (all frameworks must pass). *)
+  run_behaviour "multiarg-payload(control)" multiarg_kirc ~reference:(fun i ->
       let a = float_of_int (i + 1) in
       a +. (a +. a)) ;
   Printf.printf

--- a/sarek/tests/e2e/test_tuple_vector.ml
+++ b/sarek/tests/e2e/test_tuple_vector.ml
@@ -13,10 +13,11 @@
  * and writes a modified tuple element back; results are checked against a pure
  * OCaml reference on every available device.
  *
- * Device support tier: CUDA/PTX, OpenCL, Vulkan and Native must pass. The
- * Interpreter path additionally needs value-model unification (its tuple/record
- * representation and helper registration) and is recorded as a follow-up; it is
- * reported as NOT-YET-SUPPORTED rather than treated as a failure.
+ * Device support tier: CUDA/PTX, OpenCL, Vulkan, Native AND the Interpreter
+ * must pass. The Interpreter decodes a tuple element from the raw composite
+ * bytes into a positional record ([_0], [_1], ...) using the shape layout
+ * resolved from [Sarek_tuple_vec], and re-encodes it on writeback — the same
+ * value model the record/aggregate path already uses.
  ******************************************************************************)
 
 module Vector = Spoc_core.Vector
@@ -46,12 +47,10 @@ let tuple_copy_kirc =
         let tid = thread_idx_x + (block_dim_x * block_idx_x) in
         if tid < n then match src.(tid) with a, b -> dst.(tid) <- (a +. 1.0, b)]
 
-(* Devices where the tuple-vector capability must work in this tier. The
-   Interpreter is a documented follow-up and reported (not failed) when it
-   cannot run. *)
+(* Devices where the tuple-vector capability must work in this tier. *)
 let must_pass fw =
   match fw with
-  | "CUDA" | "OpenCL" | "Vulkan" | "Metal" | "Native" -> true
+  | "CUDA" | "OpenCL" | "Vulkan" | "Metal" | "Native" | "Interpreter" -> true
   | _ -> false
 
 let () =

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -136,12 +136,52 @@ let descriptor_by_name (name : string) : 'a Vector.custom_type =
        ^ "'; build it on the host (e.g. Sarek_tuple_vec.pair ...) before \
           running the kernel.")
 
+(* Value-model-neutral description of a tuple element's byte layout, keyed by
+   the mangled shape name. The Interpreter (which represents a tuple element as
+   a positional record of boxed scalars, not as a native OCaml tuple) resolves a
+   shape here to decode the raw element bytes exposed by the host composite
+   bridge into per-field scalar values and re-encode them on writeback. This
+   keeps the dependency one-directional: the Interpreter depends on this module,
+   never the reverse. *)
+type field_layout = {
+  fl_name : string;
+  fl_elttype : Sarek_ir_types.elttype;
+  fl_offset : int;
+}
+
+type shape = {sh_name : string; sh_size : int; sh_fields : field_layout list}
+
+let shape_registry : (string, shape) Hashtbl.t = Hashtbl.create 16
+
+(** [lookup_shape name] returns the registered byte layout of the tuple shape
+    [name] (e.g. ["_tup_float32_int32"]), or [None] if no [pair]/[triple] has
+    built it yet. *)
+let lookup_shape (name : string) : shape option =
+  Hashtbl.find_opt shape_registry name
+
+(* Build a [shape] from a laid-out field list and record it. Called only from
+   within the [memoize] critical section (which already holds
+   [registry_mutex]), so it must not re-acquire the lock. *)
+let register_shape_of rl name fields =
+  let sh_fields =
+    List.map
+      (fun (fname, elttype) ->
+        {fl_name = fname; fl_elttype = elttype; fl_offset = offset_of rl fname})
+      fields
+  in
+  if not (Hashtbl.mem shape_registry name) then
+    Hashtbl.replace
+      shape_registry
+      name
+      {sh_name = name; sh_size = rl.Layout.rl_size; sh_fields}
+
 (** [pair a b] is the [custom_type] for a [(a, b)] tuple vector element. *)
 let pair (a : 'a component) (b : 'b component) : ('a * 'b) Vector.custom_type =
   let name = mangled_name [a.c_tag; b.c_tag] in
   memoize name @@ fun () ->
   let fields = [(field_name 0, a.c_elttype); (field_name 1, b.c_elttype)] in
   let rl = layout_of fields name in
+  register_shape_of rl name fields ;
   let size = rl.Layout.rl_size in
   let o0 = offset_of rl (field_name 0) in
   let o1 = offset_of rl (field_name 1) in
@@ -175,6 +215,7 @@ let triple (a : 'a component) (b : 'b component) (c : 'c component) :
     ]
   in
   let rl = layout_of fields name in
+  register_shape_of rl name fields ;
   let size = rl.Layout.rl_size in
   let o0 = offset_of rl (field_name 0) in
   let o1 = offset_of rl (field_name 1) in

--- a/sarek/tuple_vec/Sarek_tuple_vec.mli
+++ b/sarek/tuple_vec/Sarek_tuple_vec.mli
@@ -42,3 +42,21 @@ val triple :
     same [Type_id] the host vector carries. Raises if the shape was never built
     on the host. Not normally called directly. *)
 val descriptor_by_name : string -> 'a Vector.custom_type
+
+(** Byte layout of one positional field ([_0], [_1], ...) of a tuple element. *)
+type field_layout = {
+  fl_name : string;
+  fl_elttype : Sarek_ir_types.elttype;
+  fl_offset : int;
+}
+
+(** The byte layout of a tuple-shape element: total size and per-field layout,
+    taken from the shared layout authority so it matches the raw element bytes
+    the host composite bridge marshals. *)
+type shape = {sh_name : string; sh_size : int; sh_fields : field_layout list}
+
+(** [lookup_shape name] returns the registered byte layout of the tuple shape
+    [name] (e.g. ["_tup_float32_int32"]), or [None] if no [pair]/[triple] has
+    instantiated it yet. Used by the Interpreter to decode/encode tuple vector
+    elements without depending on the interpreter's value model. *)
+val lookup_shape : string -> shape option

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -102,6 +102,31 @@ let gen_variant_def_glsl ~type_of_elttype buf (name, constrs) =
       Buffer.add_string buf (Printf.sprintf "const int %s = %d;\n" cname i))
     constrs ;
   Buffer.add_char buf '\n' ;
+  (* GLSL forbids anonymous nested struct definitions inside a struct, so a
+     multi-field (flattened tuple) payload is hoisted to a named struct type
+     [<mangled>_<cname>_payload { T0 _0; T1 _1; ... }] declared before the
+     variant struct; the member and all accesses keep the [<cname>_v._N] shape
+     shared with the other backends. *)
+  let payload_struct_name cname =
+    Printf.sprintf "%s_%s_payload" mangled cname
+  in
+  List.iter
+    (fun (cname, args) ->
+      match args with
+      | [] | [_] -> ()
+      | _ ->
+          Buffer.add_string
+            buf
+            (Printf.sprintf "struct %s {" (payload_struct_name cname)) ;
+          List.iteri
+            (fun i ty ->
+              if i > 0 then Buffer.add_string buf " " ;
+              Buffer.add_string
+                buf
+                (Printf.sprintf " %s _%d;" (type_of_elttype ty) i))
+            args ;
+          Buffer.add_string buf " };\n")
+    constrs ;
   (* Struct with tag and union-like data *)
   Buffer.add_string buf (Printf.sprintf "struct %s {\n  int tag;\n" mangled) ;
   let has_payload = List.exists (fun (_, args) -> args <> []) constrs in
@@ -116,16 +141,9 @@ let gen_variant_def_glsl ~type_of_elttype buf (name, constrs) =
               buf
               (Printf.sprintf "  %s %s_v;\n" (type_of_elttype ty) cname)
         | _ ->
-            (* Multiple args - generate struct *)
-            Buffer.add_string buf (Printf.sprintf "  struct { ") ;
-            List.iteri
-              (fun i ty ->
-                if i > 0 then Buffer.add_string buf " " ;
-                Buffer.add_string
-                  buf
-                  (Printf.sprintf "%s _%d;" (type_of_elttype ty) i))
-              args ;
-            Buffer.add_string buf (Printf.sprintf " } %s_v;\n" cname))
+            Buffer.add_string
+              buf
+              (Printf.sprintf "  %s %s_v;\n" (payload_struct_name cname) cname))
       constrs
   end ;
   Buffer.add_string buf "};\n\n" ;


### PR DESCRIPTION
Closes two expressivity gaps in the Sarek OCaml GPU DSL. All work verified on a
real GPU: ZLUDA (CUDA/PTX on RX 7900 XTX) + OpenCL + Vulkan validation, plus
Native and both Interpreter devices.

## Gap 1 — multi-arg variant constructor payloads on all backends

`type t = MkPair of float32 * float32` with `match s with MkPair (x,y) -> ...`
previously executed only on Native; the Interpreter crashed (`List.iter2`
arity) and CUDA/PTX, OpenCL and Vulkan bailed.

Root cause was purely in lowering: `MkPair (a,b)` lowered to a **single**
tuple-typed payload while the pattern produced **two** binders. Every source
generator (CUDA/OpenCL/Metal/GLSL) and the interpreter's `SMatch` were already
built for the **flattened** N-field representation (`struct { T0 _0; T1 _1; }`,
N-arg `make_` constructors, `._0/._1` match binding). So the canonical fix is to
flatten the constructor's tuple payload to one IR field per component
end-to-end in `Sarek_lower_ir` (registration + argument lowering). Layout is
byte-identical (inline struct vs record) and the variant here is a kernel-local,
never marshalled — no layout-authority change (`Sarek_ir_layout` / Rocq
untouched).

One backend-specific fix: GLSL forbids anonymous nested structs, so a flattened
multi-field payload is hoisted to a named `<type>_<ctor>_payload` struct
(accesses keep the `_v._N` shape).

`test_static_tag_erasure` multiarg-payload control now passes on every backend;
the `~must` gate is widened from Native-only to all frameworks.

## Gap 2 — interpreter tuple vectors (L13 follow-up)

`(float32 * int32) vector` failed on the Interpreter with `Unknown record type:
_tup_float32_int32`: the tuple element arrived as a `COMPOSITE_TYPE` with an
empty `fields` descriptor (but raw device-layout bytes), so the interpreter
produced an empty `VRecord`.

Added a value-model-neutral **shape registry** to `Sarek_tuple_vec` (mangled
name → per-field elttype + byte offset + size), populated by `pair`/`triple`.
The interpreter now depends on `sarek_tuple_vec` (one-directional, as directed)
and uses the shape to decode the composite bytes into a positional `VRecord`
(`_0`, `_1`, …) and re-encode on writeback. `ERecordField` resolves `_N`
positional fields directly.

`test_tuple_vector`: both Interpreter devices now PASS (9 passed, 0
not-yet-supported); Interpreter added to the must-pass tier.

## Test matrix (per device)

| Test | Interp seq | Interp par | Native | CUDA/PTX gpu | CUDA/PTX cpu | OpenCL gpu | OpenCL cpu | Vulkan gpu | Vulkan cpu |
|------|-----------|-----------|--------|-----|-----|-----|-----|-----|-----|
| test_static_tag_erasure (multiarg) | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
| test_tuple_vector | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS |

Full `dune runtest sarek/tests` is green (incl. the variant/record
no-regression suite: test_klet_variant, test_registered_variant,
test_ktype_record, test_complex_types, test_nested_types). `dune build @install`
and `@fmt` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
