### PR TITLE
feat(real64): single-source dual lowering via [%kernel.real64] (palier B)

### DIFF
--- a/sarek/Sarek_real64/Sarek_real64.ml
+++ b/sarek/Sarek_real64/Sarek_real64.ml
@@ -58,6 +58,14 @@
  *   materialisation, dispatch, readback) is what makes the two bodies feel
  *   like one abstraction to the caller. See sarek/tests/e2e/test_real64.ml
  *   for the canonical usage.
+ *
+ * AUTHORING KERNELS (palier B - single source)
+ *   [%kernel.real64 ...] removes the hand-written pair: author the compute
+ *   ONCE over an abstract `real64 vector` element type with the intersection
+ *   op set (+. -. *. /. and sqrt), and the PPX expands the SAME AST twice into
+ *   the (native, fallback) pair above. {!kernel_ir} picks the IR matching a
+ *   device's substrate. Transcendentals are rejected at expansion (df64 has
+ *   none). See sarek/tests/e2e/test_real64_single_source.ml.
  ******************************************************************************)
 
 module Device = Spoc_core.Device
@@ -112,6 +120,28 @@ let substrate_for ?force (dev : Device.t) : substrate =
     but works for anything). *)
 let select (s : substrate) ~(native : 'a) ~(fallback : 'a) : 'a =
   match s with Native_f64 -> native | Fallback_df64 -> fallback
+
+(** {1 Single-source kernels (palier B)}
+
+    A [%kernel.real64 ...] kernel is authored ONCE over an abstract
+    [real64 vector] element type and expands to the pair [(native, fallback)] -
+    the same two lowered [%kernel] values palier A authored by hand. Each
+    element is a [(closure, kirc)] pair; {!kernel_ir} picks the one matching a
+    device's substrate, ready to hand to [Sarek.Execute.run_vectors]. *)
+
+(** Extract the lowered IR from one lowered kernel value. *)
+let ir_of_kernel (_, kirc) =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "Sarek_real64: kernel has no lowered IR"
+
+(** Pick the IR variant matching [substrate] from the [(native, fallback)] pair
+    produced by [%kernel.real64]. *)
+let kernel_ir (substrate : substrate) (native_k, fallback_k) =
+  select
+    substrate
+    ~native:(ir_of_kernel native_k)
+    ~fallback:(ir_of_kernel fallback_k)
 
 (** {1 Uniform host vectors}
 

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -1920,29 +1920,61 @@ module Real64_lowering = struct
     end
 
   (* Inject a [let open M in] around the innermost function body so the
-     substrate's ops resolve exactly as in a hand-written body. *)
-  let rec open_in_body ~loc modname e =
-    match e.pexp_desc with
-    | Pexp_fun (lbl, def, pat, body) ->
+     substrate's ops (df64_* helpers, float64 operators) resolve exactly as in
+     a hand-written body.
+
+     Done in the frozen Ast_502 representation via the repo's own converters
+     (Sarek_parse_helpers.expression_{to,of}_502), mirroring how
+     collect_fun_params walks the fun chain. This is version-robust: the
+     ambient ppxlib AST merged [Pexp_fun] into [Pexp_function] in 5.2+, but
+     Ast_502 always exposes [Pexp_function (params, _, Pfunction_body body)]. *)
+  let open_in_body modname (e : expression) : expression =
+    let module P = Astlib.Ast_502.Parsetree in
+    let module A = Astlib.Ast_502.Asttypes in
+    let mk_open (body : P.expression) : P.expression =
+      let loc = body.P.pexp_loc in
+      let md : P.module_expr =
         {
-          e with
-          pexp_desc = Pexp_fun (lbl, def, pat, open_in_body ~loc modname body);
+          P.pmod_desc = P.Pmod_ident {txt = Longident.Lident modname; loc};
+          P.pmod_loc = loc;
+          P.pmod_attributes = [];
         }
-    | _ ->
-        let mod_ident =
-          Ast_builder.Default.pmod_ident ~loc {txt = Lident modname; loc}
-        in
-        Ast_builder.Default.pexp_open
-          ~loc
-          (Ast_builder.Default.open_infos ~loc ~expr:mod_ident ~override:Fresh)
-          e
+      in
+      let od : P.open_declaration =
+        {
+          P.popen_expr = md;
+          P.popen_override = A.Fresh;
+          P.popen_loc = loc;
+          P.popen_attributes = [];
+        }
+      in
+      {body with P.pexp_desc = P.Pexp_open (od, body)}
+    in
+    let rec wrap (fn : P.expression) : P.expression =
+      match fn.P.pexp_desc with
+      | P.Pexp_function (params, constr, P.Pfunction_body body) ->
+          let body' =
+            match body.P.pexp_desc with
+            (* nested [fun a -> fun b -> ...]: descend to the real body *)
+            | P.Pexp_function _ -> wrap body
+            | _ -> mk_open body
+          in
+          {
+            fn with
+            P.pexp_desc =
+              P.Pexp_function (params, constr, P.Pfunction_body body');
+          }
+      (* not a function: expand_kernel will report "Kernel must be a function" *)
+      | _ -> fn
+    in
+    let e502 = Sarek_parse_helpers.expression_to_502 e in
+    Sarek_parse_helpers.expression_of_502 (wrap e502)
 
   let build_variant ~(expr_map : Ast_traverse.map) ~replacement ~open_mod
       (payload : expression) =
-    let loc = payload.pexp_loc in
     let e = expr_map#expression payload in
     let e = (subst_type replacement)#expression e in
-    open_in_body ~loc open_mod e
+    open_in_body open_mod e
 end
 
 (** [%kernel.real64 ...] - single-source dual lowering (palier B). See the

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -1761,6 +1761,221 @@ let kernel_extension =
     Ast_pattern.(single_expr_payload __)
     expand_kernel
 
+(* ==========================================================================
+   Single-source real64 kernels ([%kernel.real64 ...], palier B)
+
+   Authors write ONE kernel body over an abstract [real64 vector] element type
+   using +. -. *. /. and sqrt. The extension expands the SAME surface AST TWICE
+   - once as a native IEEE-754 float64 kernel, once as a df64 double-float
+   kernel - and returns the pair [(native, fallback)]. Both variants are then
+   the ordinary [%kernel] outputs Sarek_real64.select / kernel_ir already know
+   how to consume: no IR or codegen change, everything downstream is reused.
+
+   The df64 substitution maps arithmetic operators and sqrt to the df64 helper
+   calls, G-suffix literals to df64 records, the element type to Sarek_df64.df64,
+   and REJECTS constructs df64 lacks (transcendentals) with a clear error. The
+   native substitution maps sqrt to Float64.sqrt and rejects the same
+   unsupported set (real64 promises neither path more than the intersection).
+   ========================================================================== *)
+module Real64_lowering = struct
+  (* real64's op set is the INTERSECTION of the native-f64 and df64 substrates.
+     df64 has no transcendentals, so reject them at expansion rather than
+     lowering only one variant of the pair. *)
+  let unsupported_ops =
+    [
+      "sin";
+      "cos";
+      "tan";
+      "asin";
+      "acos";
+      "atan";
+      "atan2";
+      "sinh";
+      "cosh";
+      "tanh";
+      "exp";
+      "expm1";
+      "log";
+      "log2";
+      "log10";
+      "log1p";
+      "pow";
+      "**";
+      "cbrt";
+      "hypot";
+      "fabs";
+      "floor";
+      "ceil";
+      "round";
+      "trunc";
+    ]
+
+  let arith_fn = function
+    | "+." -> Some "df64_add"
+    | "-." -> Some "df64_sub"
+    | "*." -> Some "df64_mul"
+    | "/." -> Some "df64_div"
+    | _ -> None
+
+  (* real64 element type -> concrete substrate element type in every core-type
+     position (kernel param annotations, let-bound annotations, ...). *)
+  let subst_type (replacement : Longident.t) =
+    object
+      inherit Ast_traverse.map as super
+
+      method! core_type ct =
+        let ct = super#core_type ct in
+        match ct.ptyp_desc with
+        | Ptyp_constr ({txt = Lident "real64"; loc}, args) ->
+            {ct with ptyp_desc = Ptyp_constr ({txt = replacement; loc}, args)}
+        | _ -> ct
+    end
+
+  let ident ~loc name =
+    Ast_builder.Default.pexp_ident ~loc {txt = Lident name; loc}
+
+  let reject_unsupported ~loc op =
+    Location.raise_errorf
+      ~loc
+      "[%%kernel.real64]: operation '%s' is not part of the real64 contract. \
+       real64 exposes only +. -. *. /. and sqrt (the intersection of the \
+       native-f64 and df64 fallback substrates; the df64 fallback has no \
+       transcendentals)."
+      op
+
+  (* df64 fallback body: operators and sqrt become df64 helper calls, G-suffix
+     literals become df64 records, transcendentals are rejected. *)
+  let df64_expr =
+    object (self)
+      inherit Ast_traverse.map as super
+
+      method! expression e =
+        let loc = e.pexp_loc in
+        match e.pexp_desc with
+        | Pexp_apply
+            ( {pexp_desc = Pexp_ident {txt = Lident op; _}; _},
+              [(Nolabel, a); (Nolabel, b)] )
+          when arith_fn op <> None ->
+            let fn = Option.get (arith_fn op) in
+            Ast_builder.Default.eapply
+              ~loc
+              (ident ~loc fn)
+              [self#expression a; self#expression b]
+        | Pexp_apply
+            ( {pexp_desc = Pexp_ident {txt = Lident "sqrt"; _}; _},
+              [(Nolabel, x)] ) ->
+            Ast_builder.Default.eapply
+              ~loc
+              (ident ~loc "df64_sqrt")
+              [self#expression x]
+        | Pexp_apply
+            ({pexp_desc = Pexp_ident {txt = Lident op; loc = oloc}; _}, _)
+          when List.mem op unsupported_ops ->
+            reject_unsupported ~loc:oloc op
+        | Pexp_constant (Pconst_float (s, (Some 'g' | Some 'G'))) ->
+            (* Faithful two-float32 split of the binary64 literal into a df64
+               record {hi; lo}: hi carries the leading ~24 bits, lo the next. *)
+            let round_f32 x = Int32.float_of_bits (Int32.bits_of_float x) in
+            let x = float_of_string s in
+            let hi = round_f32 x in
+            let lo = round_f32 (x -. hi) in
+            let flit v =
+              Ast_builder.Default.pexp_constant
+                ~loc
+                (Pconst_float (Printf.sprintf "%h" v, None))
+            in
+            Ast_builder.Default.pexp_record
+              ~loc
+              [
+                ({txt = Lident "hi"; loc}, flit hi);
+                ({txt = Lident "lo"; loc}, flit lo);
+              ]
+              None
+        | _ -> super#expression e
+    end
+
+  (* Native f64 body: sqrt -> Float64.sqrt, transcendentals rejected. Operators
+     and G-suffix literals lower unchanged (float64). *)
+  let native_expr =
+    object (self)
+      inherit Ast_traverse.map as super
+
+      method! expression e =
+        let loc = e.pexp_loc in
+        match e.pexp_desc with
+        | Pexp_apply
+            ( {pexp_desc = Pexp_ident {txt = Lident "sqrt"; _}; _},
+              [(Nolabel, x)] ) ->
+            Ast_builder.Default.eapply
+              ~loc
+              (Ast_builder.Default.pexp_ident
+                 ~loc
+                 {txt = Ldot (Lident "Float64", "sqrt"); loc})
+              [self#expression x]
+        | Pexp_apply
+            ({pexp_desc = Pexp_ident {txt = Lident op; loc = oloc}; _}, _)
+          when List.mem op unsupported_ops ->
+            reject_unsupported ~loc:oloc op
+        | _ -> super#expression e
+    end
+
+  (* Inject a [let open M in] around the innermost function body so the
+     substrate's ops resolve exactly as in a hand-written body. *)
+  let rec open_in_body ~loc modname e =
+    match e.pexp_desc with
+    | Pexp_fun (lbl, def, pat, body) ->
+        {
+          e with
+          pexp_desc = Pexp_fun (lbl, def, pat, open_in_body ~loc modname body);
+        }
+    | _ ->
+        let mod_ident =
+          Ast_builder.Default.pmod_ident ~loc {txt = Lident modname; loc}
+        in
+        Ast_builder.Default.pexp_open
+          ~loc
+          (Ast_builder.Default.open_infos ~loc ~expr:mod_ident ~override:Fresh)
+          e
+
+  let build_variant ~(expr_map : Ast_traverse.map) ~replacement ~open_mod
+      (payload : expression) =
+    let loc = payload.pexp_loc in
+    let e = expr_map#expression payload in
+    let e = (subst_type replacement)#expression e in
+    open_in_body ~loc open_mod e
+end
+
+(** [%kernel.real64 ...] - single-source dual lowering (palier B). See the
+    [Real64_lowering] module comment above. Returns the [(native, fallback)]
+    kernel pair; consume it with {!Sarek_real64.kernel_ir}. *)
+let expand_kernel_real64 ~ctxt (payload : expression) : expression =
+  let loc = payload.pexp_loc in
+  let native =
+    Real64_lowering.build_variant
+      ~expr_map:Real64_lowering.native_expr
+      ~replacement:(Lident "float64")
+      ~open_mod:"Sarek_float64"
+      payload
+  in
+  let fallback =
+    Real64_lowering.build_variant
+      ~expr_map:Real64_lowering.df64_expr
+      ~replacement:(Ldot (Lident "Sarek_df64", "df64"))
+      ~open_mod:"Sarek_df64"
+      payload
+  in
+  let native_k = expand_kernel ~ctxt native in
+  let fallback_k = expand_kernel ~ctxt fallback in
+  [%expr [%e native_k], [%e fallback_k]]
+
+(** The [%kernel.real64 ...] extension for expressions (palier B). *)
+let kernel_real64_extension =
+  Extension.V3.declare
+    "kernel.real64"
+    Extension.Context.expression
+    Ast_pattern.(single_expr_payload __)
+    expand_kernel_real64
+
 (* Register top-level Sarek type declarations *)
 let expand_sarek_type ~ctxt payload =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
@@ -2023,6 +2238,7 @@ let () =
       sarek_type_rule;
       sarek_type_private_rule;
       Context_free.Rule.extension kernel_extension;
+      Context_free.Rule.extension kernel_real64_extension;
       Context_free.Rule.extension sarek_include_extension;
       (* NOTE: %sarek_intrinsic and %sarek_extend are handled by sarek_ppx_intrinsic *)
     ]

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -781,3 +781,33 @@
  (alias runtest)
  (action
   (run %{dep:test_bare_float_infers_f64.exe})))
+
+; Palier B: single-source real64 kernel ([%kernel.real64]). ONE authored body
+; expands to both the native-f64 and df64 lowerings; same op-check coverage as
+; test_real64, both substrates forced on every device.
+
+(executable
+ (name test_real64_single_source)
+ (modules test_real64_single_source)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek.df64
+  sarek.float64
+  sarek.real64
+  spoc_core
+  test_helpers
+  unix
+  sarek_backend_error)
+ (preprocessor_deps
+  (file ../../Sarek_df64/Sarek_df64.ml))
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_real64_single_source.exe})))
+

--- a/sarek/tests/e2e/test_real64_single_source.ml
+++ b/sarek/tests/e2e/test_real64_single_source.ml
@@ -1,0 +1,204 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for SINGLE-SOURCE Sarek_real64 (palier B).
+ *
+ * Palier A authored a real64 kernel as a hand-written PAIR: an f64 body over
+ * `float64 vector` and a df64 body over `Sarek_df64.df64 vector`, kept in sync
+ * by the author. This test proves palier B: the compute is written ONCE
+ * against an abstract `real64 vector` element type with the intersection op
+ * set (+. -. *. /. and sqrt), and [%kernel.real64] expands it to BOTH lowered
+ * variants automatically. Real64.kernel_ir then picks the IR matching the
+ * device substrate - exactly the plumbing palier A used.
+ *
+ * Coverage mirrors test_real64.ml op-for-op: on EVERY available device it runs
+ * two passes -
+ *   1. the device's DEFAULT substrate (native f64 where supported, else df64);
+ *   2. the df64 fallback FORCED, so the emulation lowering runs even on fp64
+ *      hardware -
+ * and checks elementwise add / sub / mul / div / sqrt against an OCaml binary64
+ * reference computed from the exact values the device saw. Tolerances follow
+ * the substrate's honest contract (identical to test_real64's [tol_for]).
+ ******************************************************************************)
+
+[@@@warning "-32-33-34-69"]
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Execute = Sarek.Execute
+module Real64 = Sarek_real64
+
+type float32 = float
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+let () = Test_helpers.Benchmarks.init ()
+
+(* df64 [@sarek.module] ops for the fallback lowering of the single source. *)
+let%sarek_include _ = "../../Sarek_df64/Sarek_df64.ml"
+
+(* ========== ONE kernel body, authored against abstract real64 ============== *)
+
+(* Written once over `real64 vector` with the intersection op set. The PPX
+   expands this SAME AST twice: once as native IEEE-754 float64 (operators
+   unchanged, sqrt -> Float64.sqrt) and once as the df64 double-float fallback
+   (+. -> df64_add, sqrt -> df64_sqrt, element type -> Sarek_df64.df64). *)
+let real64_ops_kernel =
+  [%kernel.real64
+    fun (a : real64 vector)
+        (b : real64 vector)
+        (c : real64 vector)
+        (add_o : real64 vector)
+        (sub_o : real64 vector)
+        (mul_o : real64 vector)
+        (div_o : real64 vector)
+        (sqrt_o : real64 vector)
+        (nn : int32) ->
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < nn then begin
+        let x = a.(tid) in
+        let y = b.(tid) in
+        add_o.(tid) <- x +. y ;
+        sub_o.(tid) <- x -. y ;
+        mul_o.(tid) <- x *. y ;
+        div_o.(tid) <- x /. y ;
+        sqrt_o.(tid) <- sqrt c.(tid)
+      end]
+
+(* ========== Inputs and reference (identical to test_real64.ml) ============= *)
+
+let n = 4096
+
+let inputs =
+  Random.init 0x5ea1 ;
+  let logu emin emax =
+    let e = emin +. Random.float (emax -. emin) in
+    let m = 1.0 +. Random.float 9.0 in
+    let s = if Random.bool () then 1.0 else -1.0 in
+    s *. m *. (10.0 ** e)
+  in
+  let a = Array.init n (fun _ -> logu (-6.0) 6.0) in
+  let b = Array.init n (fun _ -> logu (-3.0) 3.0) in
+  (a, b)
+
+let rel_error got expected =
+  if expected = 0.0 then Stdlib.abs_float got
+  else Stdlib.abs_float ((got -. expected) /. expected)
+
+let f32_tol = 0x1p-22
+
+let tol_for ~(substrate : Real64.substrate) ~framework ~op =
+  match substrate with
+  | Real64.Native_f64 -> 1e-12
+  | Real64.Fallback_df64 -> (
+      let base = match op with "add" | "sub" -> 0x1p-47 | _ -> 0x1p-46 in
+      match (framework, op) with
+      | "Native", _ -> f32_tol
+      | "Vulkan", ("mul" | "div") -> f32_tol
+      | _ -> base)
+
+(* ========== One pass on one device with one substrate ===================== *)
+
+let failures = ref 0
+
+let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
+  let a_data, b_data = inputs in
+  let mk () = Real64.create_vector substrate n in
+  let a = mk () and b = mk () and c = mk () in
+  let add_o = mk () and sub_o = mk () and mul_o = mk () in
+  let div_o = mk () and sqrt_o = mk () in
+  for i = 0 to n - 1 do
+    Real64.vset a i a_data.(i) ;
+    Real64.vset b i b_data.(i) ;
+    (* Dedicated nonnegative input for sqrt (avoids an abs intrinsic, which
+       does not lower on GLSL). *)
+    Real64.vset c i (Stdlib.abs_float a_data.(i))
+  done ;
+  (* The whole point of palier B: ONE authored kernel, IR picked per device. *)
+  let ir = Real64.kernel_ir substrate real64_ops_kernel in
+  let block = Execute.dims1d 256 in
+  let grid = Execute.dims1d ((n + 255) / 256) in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:
+      [
+        Real64.arg_of a;
+        Real64.arg_of b;
+        Real64.arg_of c;
+        Real64.arg_of add_o;
+        Real64.arg_of sub_o;
+        Real64.arg_of mul_o;
+        Real64.arg_of div_o;
+        Real64.arg_of sqrt_o;
+        Execute.Int n;
+      ]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let framework = dev.Device.framework in
+  let worst = Hashtbl.create 8 in
+  let check op got expected =
+    let err =
+      if Float.is_nan got then Float.infinity else rel_error got expected
+    in
+    let prev = try Hashtbl.find worst op with Not_found -> 0.0 in
+    if err > prev then Hashtbl.replace worst op err
+  in
+  for i = 0 to n - 1 do
+    let x = Real64.vget a i and y = Real64.vget b i in
+    let cx = Real64.vget c i in
+    check "add" (Real64.vget add_o i) (x +. y) ;
+    check "sub" (Real64.vget sub_o i) (x -. y) ;
+    check "mul" (Real64.vget mul_o i) (x *. y) ;
+    check "div" (Real64.vget div_o i) (x /. y) ;
+    check "sqrt" (Real64.vget sqrt_o i) (Stdlib.sqrt cx)
+  done ;
+  Printf.printf
+    "  [%s / %s]\n%!"
+    framework
+    (Real64.string_of_substrate substrate) ;
+  List.iter
+    (fun op ->
+      let err = try Hashtbl.find worst op with Not_found -> 0.0 in
+      let tol = tol_for ~substrate ~framework ~op in
+      let ok = err <= tol in
+      if not ok then incr failures ;
+      Printf.printf
+        "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
+        op
+        err
+        tol
+        (if ok then "PASS" else "FAIL"))
+    ["add"; "sub"; "mul"; "div"; "sqrt"]
+
+(* ========== Main ========== *)
+
+let () =
+  let devs = Device.init () in
+  if Array.length devs = 0 then begin
+    print_endline "No devices found - SKIPPED" ;
+    exit 0
+  end ;
+  Array.iter
+    (fun (dev : Device.t) ->
+      Printf.printf
+        "Device: %s [%s]  fp64=%b\n%!"
+        dev.Device.name
+        dev.Device.framework
+        (Device.allows_fp64 dev) ;
+      run_pass dev ~substrate:(Real64.substrate_for dev) ;
+      run_pass
+        dev
+        ~substrate:(Real64.substrate_for ~force:Real64.Fallback_df64 dev))
+    devs ;
+  if !failures = 0 then print_endline "test_real64_single_source PASSED"
+  else begin
+    Printf.printf "test_real64_single_source FAILED (%d failures)\n" !failures ;
+    exit 1
+  end


### PR DESCRIPTION
## Summary

Palier B: kernel authors write a `real64` compute **once**, against an abstract `real64 vector` element type, and get **both** lowered variants automatically. This eliminates palier A's hand-written pair (an f64 body + a df64 body kept in sync by the author, see `test_real64.ml`).

## Option chosen: Option 1 (PPX double-expansion) — no IR/codegen change

The new `[%kernel.real64 ...]` extension in `Sarek_ppx.ml` rewrites the surface payload for each substrate and calls the **existing** `expand_kernel` twice, returning the `(native, fallback)` pair the palier-A `select` plumbing already consumes. Nothing downstream (IR, the 5 backends, interp, `substrate_for`/`create_vector`) changed.

Per-variant rewrite:
- **df64 fallback**: `+. -. *. /.` → `df64_add/sub/mul/div`, `sqrt` → `df64_sqrt`, element type → `Sarek_df64.df64`, G-suffix literals → faithful two-float32 `{hi; lo}` records, transcendentals → **clear expansion error** (df64 has none).
- **native f64**: `sqrt` → `Float64.sqrt`, same unsupported set rejected; operators + G-literals lower unchanged. 
- Each variant wrapped in the matching `let open` so ops resolve exactly as a hand-written body.

`Sarek_real64.kernel_ir substrate (native, fallback)` picks the IR per device.

## Test matrix

`test_real64_single_source.ml` ports `test_real64`'s compute to the single-source form — same op-check coverage (add/sub/mul/div/sqrt vs binary64 oracle), both substrates forced on every device.

**9 devices × 2 substrates × 5 ops = 90 op-checks, all PASS.** Max-rel-err is **byte-identical** to palier A's hand-written pair (verified by diff). Devices: ZLUDA CUDA/PTX (7900 XTX + CPU), OpenCL (fp64=false), Vulkan (RADV), Native, Interpreter ×2.

## Gates
- `dune build @install` clean; `@fmt` clean on changed files (drift files untouched).
- `dune runtest sarek/tests` fully green.
- Transcendental rejection verified with a probe (removed).

## Follow-ups
- G-suffix literal → df64 record uses an exact 2×f32 split; bare (polymorphic) literals flow through each variant unchanged — real64 literals should use the `G` suffix.
- Option 2 (IR-level `real64` type) remains the maximal design; not needed — Option 1 hit no wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)