### PR TITLE
feat(ppx): S2 record-field static tag erasure (device path)

### DIFF
--- a/sarek/ppx/Sarek_tag_erasure.ml
+++ b/sarek/ppx/Sarek_tag_erasure.ml
@@ -38,14 +38,19 @@
  * a whole variant value rather than only as a `match` scrutinee - is
  * conservatively left tagged, exactly today's behaviour.
  *
- * NOT implemented (deferred to a follow-up tier, see the design doc's
- * "Implementation findings" section): erasing a variant-typed *record field*
- * (the layout-unblock headline of SS0/SS8). Empirically that requires threading
- * a rewritten record type through every occurrence AND reconciling with the
- * `[@@sarek.type]` declaration that the Interpreter and host marshalling
- * consume by field position - substantially more than an expression rewrite,
- * and it regresses a currently-working backend if attempted as a pure
- * expression rewrite.
+ * Scoped tier S2 (this file, below the S1 section): erasing a variant-typed
+ * *record field* - the layout-unblock headline of SS0/SS8. Rather than reconcile
+ * the `[@@sarek.type]` declaration (consumed by field POSITION by the
+ * Interpreter and host marshalling), S2 SYNTHESIZES a device-only all-scalar
+ * record with POSITIONAL fields ([_0], [_1], ..) - mirroring L13's `_tup_*`
+ * tuple synthesis - so no declaration reconciliation and no runtime
+ * registration are needed: positional fields resolve without a registry entry
+ * (Sarek_ir_interp_eval.positional_field_index), and threading a nominal
+ * `TRecord` type (not a tuple, which falls back to the int32 placeholder in
+ * Sarek_lower_ir.elttype_of_typ) into the binding gives every struct-based
+ * backend a correct type. See the S2 section header for the exact scope and the
+ * empirical backend matrix this unblocks (Interpreter/Vulkan reject the layout,
+ * OpenCL the field read, CUDA emits malformed code; only Native tolerated it).
  ******************************************************************************)
 
 open Sarek_types
@@ -193,6 +198,291 @@ let reduce_matches (id : int) (cname : string)
   go body
 
 (* -------------------------------------------------------------------------- *)
+(* S2: variant-typed record FIELD erasure (device path, layout unblock)        *)
+(*                                                                             *)
+(* An immutable kernel-local record binding                                    *)
+(*                                                                             *)
+(*   let r = { ..; f = C payload; .. } in .. match r.f with .. | C x -> rhs .. *)
+(*                                                                             *)
+(* whose variant-typed field [f] is written by a *literal* constructor [C]     *)
+(* with a substitutable payload, and every read of which is only the scrutinee *)
+(* of a [match] with a reducible [C]-arm, is rewritten on the DEVICE path to a *)
+(* synthesized all-scalar record with POSITIONAL fields ([_0], [_1], ..),      *)
+(* mirroring L13's tuple synthesis (Sarek_lower_ir.tuple_record_fields):       *)
+(*                                                                             *)
+(*   let r = { _0 = payload; _1 = .. } in .. let x = r._0 in rhs ..            *)
+(*                                                                             *)
+(* The variant field's tag/branch is erased exactly as S1 does for a slot, and *)
+(* the record loses its nested variant entirely. That is what unblocks the     *)
+(* backends that reject a nested-variant record field today (empirically:      *)
+(* Interpreter and Vulkan/GLSL reject the layout, OpenCL rejects the field     *)
+(* read, CUDA emits a malformed constructor). Positional [_i] fields need no   *)
+(* runtime registry entry — the interpreter resolves them by position          *)
+(* (Sarek_ir_interp_eval.positional_field_index) — and an all-scalar record    *)
+(* threads through elttype_of_typ as a proper nominal struct (a *tuple*-typed  *)
+(* binding would fall back to the int32 placeholder, so we synthesize a named  *)
+(* record, not a tuple). The native path keeps the original record             *)
+(* (native_kernel is captured before this pass), so the [@@sarek.type]         *)
+(* declaration and host marshalling stay untouched.                            *)
+(*                                                                             *)
+(* Scope (conservative, same spirit as S1): a plain immutable kernel-local     *)
+(* [let]-bound record literal; EVERY variant field is erasable (literal ctor + *)
+(* substitutable payload + all reads are reducible match scrutinees); every    *)
+(* kept field and every erased unary payload is a scalar primitive; the record *)
+(* value never escapes as a whole (only field reads of it appear). Anything    *)
+(* else leaves the record entirely untouched (today's behaviour).              *)
+(* -------------------------------------------------------------------------- *)
+
+let is_scalar_prim (t : typ) : bool =
+  match repr t with
+  | TPrim (TInt32 | TBool) | TReg (Int64 | Float32 | Float64 | Int) -> true
+  | _ -> false
+
+(* C-identifier-safe tag for a scalar type, used to mangle the synthesized
+   record name. Two erased records of identical shape share a name and hence a
+   single emitted struct, which is sound (structural). *)
+let typ_tag (t : typ) : string =
+  match repr t with
+  | TPrim TInt32 -> "int32"
+  | TPrim TBool -> "bool"
+  | TReg Int64 -> "int64"
+  | TReg Float32 -> "float32"
+  | TReg Float64 -> "float64"
+  | TReg Int -> "int"
+  | _ -> "x"
+
+let pos_field_name (i : int) : string = Printf.sprintf "_%d" i
+
+(* Per-field plan for an eligible record binding. Slots (the positional fields
+   of the synthesized record) are numbered in source field order; a nullary
+   erased field carries no data and is dropped, so it consumes no slot. *)
+type field_plan =
+  | FKeep of int * typ  (** kept scalar field -> positional slot, its type *)
+  | FUnary of int * typ * string
+      (** erased unary field -> slot, payload type, constructor name *)
+  | FNullary of string  (** erased nullary field -> dropped, constructor name *)
+
+(* Classify every field of a record literal. Returns [None] (whole record
+   ineligible) if any field is a variant not written by a reducible literal
+   constructor, or a kept/payload field that is not a scalar primitive.
+   Requires at least one surviving slot and at least one erased variant. *)
+let plan_fields (fields : (string * texpr) list) :
+    (string * field_plan) list option =
+  let exception Bail in
+  try
+    let slot = ref 0 in
+    let next () =
+      let i = !slot in
+      incr slot ;
+      i
+    in
+    let plan =
+      List.map
+        (fun (fname, (fexpr : texpr)) ->
+          match repr fexpr.ty with
+          | TVariant _ -> (
+              match fexpr.te with
+              | TEConstr (_, cname, None) -> (fname, FNullary cname)
+              | TEConstr (_, cname, Some payload) when is_scalar_prim payload.ty
+                ->
+                  (fname, FUnary (next (), repr payload.ty, cname))
+              | _ -> raise Bail)
+          | t when is_scalar_prim t -> (fname, FKeep (next (), t))
+          | _ -> raise Bail)
+        fields
+    in
+    let has_variant =
+      List.exists
+        (function _, (FUnary _ | FNullary _) -> true | _ -> false)
+        plan
+    in
+    if !slot = 0 || not has_variant then None else Some plan
+  with Bail -> None
+
+(* Constructor name of an erased variant field, if [fname] is one. *)
+let variant_field_ctor (plan : (string * field_plan) list) (fname : string) :
+    string option =
+  match List.assoc_opt fname plan with
+  | Some (FUnary (_, _, c)) | Some (FNullary c) -> Some c
+  | _ -> None
+
+(* Is [scrut] a read [r.fname] of record variable [rid]? Returns the field. *)
+let field_read_of (rid : int) (e : texpr) : string option =
+  match e.te with
+  | TEFieldGet ({te = TEVar (_, i); _}, fname, _) when i = rid -> Some fname
+  | _ -> None
+
+(* Body-usage eligibility: every occurrence of [rid] is a field read; every
+   read of an erased variant field is a match scrutinee whose match has a
+   reducible arm for that field's constructor; the record never escapes whole.
+   Mirrors S1's uses_all_reducible, keyed on field reads instead of the slot
+   variable. *)
+let record_body_eligible (rid : int) (plan : (string * field_plan) list)
+    (body : texpr) : bool =
+  let ok = ref true in
+  let rec go (e : texpr) : unit =
+    match e.te with
+    | TEVar (_, i) when i = rid -> ok := false (* whole-record escape *)
+    | TEMatch (scrut, cases) -> (
+        match
+          Option.bind (field_read_of rid scrut) (variant_field_ctor plan)
+        with
+        | Some cname ->
+            if not (List.exists (is_ctor_case cname) cases) then ok := false ;
+            List.iter (fun (_, rhs) -> go rhs) cases (* skip the scrutinee *)
+        | None -> iter_children go e)
+    | TEFieldGet ({te = TEVar (_, i); _}, fname, _) when i = rid -> (
+        (* A field read reached here is NOT an erased-variant match scrutinee. *)
+        match variant_field_ctor plan fname with
+        | Some _ ->
+            ok := false (* bare variant-field read needs the whole value *)
+        | None -> () (* scalar field read: fine; do not recurse into the var *))
+    | _ -> iter_children go e
+  in
+  go body ;
+  !ok
+
+(* An active record-erasure context: everything the body rewrite needs. *)
+type rec_ctx = {
+  rc_rid : int;
+  rc_rname : string;
+  rc_synth_ty : typ;
+  rc_plan : (string * field_plan) list;
+  rc_loc : Sarek_ast.loc;
+}
+
+(* Find the [match] arm for [cname] (guaranteed reducible by eligibility) and
+   return its payload pattern and rhs. *)
+let find_ctor_arm (cname : string) (cases : (tpattern * texpr) list) :
+    tpattern option * texpr =
+  match List.find_opt (is_ctor_case cname) cases with
+  | Some (p, rhs) -> (
+      match p.tpat with TPConstr (_, _, arg) -> (arg, rhs) | _ -> (None, rhs))
+  | None ->
+      failwith
+        "Sarek_tag_erasure.find_ctor_arm: no reducible arm for the record \
+         field's constructor (invariant violated: record_body_eligible should \
+         have made this record ineligible)"
+
+(* Build a positional field read [r._i : ty] on the synthesized record. *)
+let mk_field_read (rc : rec_ctx) (slot : int) (ty : typ) : texpr =
+  let rrec =
+    {
+      te = TEVar (rc.rc_rname, rc.rc_rid);
+      ty = rc.rc_synth_ty;
+      te_loc = rc.rc_loc;
+    }
+  in
+  {te = TEFieldGet (rrec, pos_field_name slot, slot); ty; te_loc = rc.rc_loc}
+
+(* Try to erase a record binding. Returns the rewritten [TELet] on success, or
+   [None] to leave it untouched. [descend] is the recursion used for the
+   payload expressions and to continue the general rewrite. *)
+let rec try_erase_record (ctxs : rec_ctx list) (name : string) (id : int)
+    (value : texpr) (body : texpr) (te_loc : Sarek_ast.loc) : texpr option =
+  match value.te with
+  | TERecord (_, fields) -> (
+      match plan_fields fields with
+      | Some plan when record_body_eligible id plan body ->
+          (* Survivors in slot order (source order over kept/unary fields). *)
+          let survivors =
+            List.filter_map
+              (fun (fname, (fexpr : texpr)) ->
+                match List.assoc fname plan with
+                | FKeep (slot, ty) -> Some (slot, descend ctxs fexpr, ty)
+                | FUnary (slot, ty, _) ->
+                    let payload =
+                      match fexpr.te with
+                      | TEConstr (_, _, Some p) -> p
+                      | _ -> assert false
+                    in
+                    Some (slot, descend ctxs payload, ty)
+                | FNullary _ -> None)
+              fields
+          in
+          let survivors =
+            List.sort (fun (a, _, _) (b, _, _) -> compare a b) survivors
+          in
+          let synth_name =
+            "_erec"
+            ^ String.concat
+                ""
+                (List.map (fun (_, _, ty) -> "_" ^ typ_tag ty) survivors)
+          in
+          let field_tys =
+            List.map (fun (slot, _, ty) -> (pos_field_name slot, ty)) survivors
+          in
+          let synth_ty = TRecord (synth_name, field_tys) in
+          let value_fields =
+            List.map (fun (slot, e, _) -> (pos_field_name slot, e)) survivors
+          in
+          let value' =
+            {
+              te = TERecord (synth_name, value_fields);
+              ty = synth_ty;
+              te_loc = value.te_loc;
+            }
+          in
+          let rc =
+            {
+              rc_rid = id;
+              rc_rname = name;
+              rc_synth_ty = synth_ty;
+              rc_plan = plan;
+              rc_loc = value.te_loc;
+            }
+          in
+          let body' = descend (rc :: ctxs) body in
+          Some {te = TELet (name, id, value', body'); ty = body'.ty; te_loc}
+      | _ -> None)
+  | _ -> None
+
+(* The unified S2 traversal, carrying the active record-erasure contexts. It (a)
+   reduces each erased variant field's match to its constructor arm (binding the
+   arm's payload variable to the positional field read), (b) remaps every
+   kept-field read to its positional slot, and (c) attempts a fresh erasure at
+   every [let]-bound record literal, so S2 recurses into and composes with
+   nested erasable records. Everything else recurses structurally. *)
+and descend (ctxs : rec_ctx list) (e : texpr) : texpr =
+  let find_ctx rid = List.find_opt (fun rc -> rc.rc_rid = rid) ctxs in
+  match e.te with
+  | TELet (name, id, value, body) -> (
+      match try_erase_record ctxs name id value body e.te_loc with
+      | Some e' -> e'
+      | None -> map_children (descend ctxs) e)
+  | TEMatch (scrut, cases) -> (
+      match scrut.te with
+      | TEFieldGet ({te = TEVar (_, i); _}, fname, _) -> (
+          match find_ctx i with
+          | Some rc when variant_field_ctor rc.rc_plan fname <> None -> (
+              match List.assoc fname rc.rc_plan with
+              | FUnary (slot, pty, cname) -> (
+                  let arg, rhs = find_ctor_arm cname cases in
+                  let rhs' = descend ctxs rhs in
+                  match arg with
+                  | Some {tpat = TPVar (_, pid); _} ->
+                      subst_var pid (mk_field_read rc slot pty) rhs'
+                  | _ -> {rhs' with ty = e.ty})
+              | FNullary cname ->
+                  let _, rhs = find_ctor_arm cname cases in
+                  {(descend ctxs rhs) with ty = e.ty}
+              | FKeep _ -> map_children (descend ctxs) e)
+          | _ -> map_children (descend ctxs) e)
+      | _ -> map_children (descend ctxs) e)
+  | TEFieldGet ({te = TEVar (_, i); _}, fname, _) -> (
+      match find_ctx i with
+      | Some rc -> (
+          match List.assoc_opt fname rc.rc_plan with
+          | Some (FKeep (slot, ty)) -> mk_field_read rc slot ty
+          | _ ->
+              map_children (descend ctxs) e
+              (* variant-field bare read: eligibility bars it *))
+      | None -> map_children (descend ctxs) e)
+  | _ -> map_children (descend ctxs) e
+
+let erase_record_fields (body : texpr) : texpr = descend [] body
+
+(* -------------------------------------------------------------------------- *)
 (* Core rewrite                                                               *)
 (* -------------------------------------------------------------------------- *)
 
@@ -231,16 +521,23 @@ let rewrite_body (body : texpr) : texpr =
 (* Entry point                                                                *)
 (* -------------------------------------------------------------------------- *)
 
+(* Erase variant record fields (S2) first, then variant slots (S1). The two are
+   orthogonal — S2 rewrites [let r = {..}] record bindings into all-scalar
+   synthesized records, S1 rewrites [let s = C ..] variant-slot bindings — and
+   S2 only ever turns a variant field read into a scalar field read, never
+   producing a new variant slot, so the composition is confluent. *)
+let transform_body (b : texpr) : texpr = rewrite_body (erase_record_fields b)
+
 let erase_tags (kernel : tkernel) : tkernel =
   let module_items' =
     List.map
       (function
-        | TMFun (n, r, ps, b) -> TMFun (n, r, ps, rewrite_body b)
+        | TMFun (n, r, ps, b) -> TMFun (n, r, ps, transform_body b)
         | TMConst _ as it -> it)
       kernel.tkern_module_items
   in
   {
     kernel with
     tkern_module_items = module_items';
-    tkern_body = rewrite_body kernel.tkern_body;
+    tkern_body = transform_body kernel.tkern_body;
   }

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -811,3 +811,38 @@
  (action
   (run %{dep:test_real64_single_source.exe})))
 
+; L14 S2: record-field static tag erasure. A kernel-local record whose
+; variant-typed field is written by a literal constructor and read only as a
+; match scrutinee is lowered to a synthesized all-scalar record ([_erec_*]),
+; erasing the nested variant and unblocking every backend. Self-verifying:
+; emitted CUDA-C carries no tag and the synthesized record for the erasable
+; kernels, keeps the tag for a runtime-selected control, and leaves a
+; variant-free record untouched; behaviour matches a pure-OCaml reference on
+; every device (Native-only for the retained control).
+
+(executable
+ (name test_record_field_tag_erasure)
+ (modules test_record_field_tag_erasure)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  sarek.codegen
+  spoc_core
+  test_helpers
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_record_field_tag_erasure.exe})))

--- a/sarek/tests/e2e/test_record_field_tag_erasure.ml
+++ b/sarek/tests/e2e/test_record_field_tag_erasure.ml
@@ -1,0 +1,286 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * L14 S2 - E2E test for record-field static tag erasure (device path).
+ *
+ * A kernel-local immutable record whose variant-typed FIELD is written by a
+ * literal constructor with a substitutable payload, and read only as a `match`
+ * scrutinee, has that field's tag erased: the record is lowered to a
+ * synthesized all-scalar record with positional fields ([_0], [_1], ..)
+ * (Sarek_tag_erasure S2, device path only). This unblocks the backends that
+ * reject a nested-variant record field today. Empirically (recorded when this
+ * test was written, RX 7900 XTX host), a record with a variant field FAILS
+ * before erasure on Interpreter and Vulkan (record layout rejected) and on
+ * OpenCL (variant field read rejected), with malformed CUDA-C; only the Native
+ * OCaml path tolerates it. After S2 every backend runs it.
+ *
+ * Self-verifying on two axes:
+ *   1. OBSERVABLE erasure in the emitted device source (CUDA-C, generated from
+ *      the lowered IR, no device needed):
+ *        - erasable kernels carry NO variant tag/switch/enum and DO carry the
+ *          synthesized [_erec_*] record (proof the field was erased, not just
+ *          absent);
+ *        - an all-scalar record (no variant field) is left untouched: no tag
+ *          and NO [_erec_*] (the pass does not gratuitously rewrite records);
+ *        - a record whose variant field's constructor is runtime-selected keeps
+ *          its tag (proof the pass stays conservative).
+ *   2. BEHAVIOURAL equivalence vs a pure-OCaml reference. Erasable kernels run
+ *      on EVERY available device. The runtime-selected control retains a
+ *      variant record field, which only the Native path can execute (that is
+ *      the very limitation S2 removes for the erasable case), so its behaviour
+ *      is checked on Native alone as the correctness oracle.
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module Device = Spoc_core.Device
+module Transfer = Spoc_core.Transfer
+
+[@@@warning "-32"]
+
+let () = Test_helpers.Benchmarks.init ()
+
+type float32 = float
+
+(* A variant used as an init-time tag inside a record field. *)
+type shape = Circle of float32 | Square of float32 [@@sarek.type]
+
+(* A record with a variant-typed field [kind] and a scalar field [scale]. *)
+type cell = {kind : shape; scale : float32} [@@sarek.type]
+
+(* A nullary-constructor variant, and a record carrying it as a tag field. *)
+type mode = Fast | Slow [@@sarek.type]
+
+type job = {sel : mode; load : float32} [@@sarek.type]
+
+(* A plain all-scalar record: no variant field, so S2 must leave it alone. *)
+type vec2 = {vx : float32; vy : float32} [@@sarek.type]
+
+(* ERASABLE, unary field: `kind = Circle src.(tid)`, matched, never taken as a
+   whole value. Result: (v*v)*scale = (v*v)*2 with v = src.(tid). *)
+let unary_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let c = {kind = Circle src.(tid); scale = 2.0} in
+          let base = match c.kind with Circle r -> r *. r | Square x -> x in
+          dst.(tid) <- base *. c.scale
+        end]
+
+(* ERASABLE, nullary field: `sel = Fast` is dropped entirely; the scalar field
+   [load] survives. Result: v + 1.0 with v = src.(tid). *)
+let nullary_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let j = {sel = Fast; load = src.(tid)} in
+          match j.sel with
+          | Fast -> dst.(tid) <- j.load +. 1.0
+          | Slow -> dst.(tid) <- j.load
+        end]
+
+(* NEGATIVE CONTROL (no variant field): a plain scalar record must be left as
+   its original named record (NOT rewritten to [_erec_*]) and runs everywhere.
+   Result: vx*vy = (v)*(v+1). *)
+let allscalar_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let p = {vx = src.(tid); vy = src.(tid) +. 1.0} in
+          dst.(tid) <- p.vx *. p.vy
+        end]
+
+(* NEGATIVE CONTROL (runtime-selected field): the variant field's constructor
+   is chosen at runtime, so the slot is NOT statically known and the field's
+   tag must be RETAINED. This retains a variant record field, which only the
+   Native path executes; behaviour is checked on Native as the oracle. *)
+let runtime_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let c =
+            {
+              kind =
+                (if tid mod 2 = 0 then Circle src.(tid) else Square src.(tid));
+              scale = 2.0;
+            }
+          in
+          match c.kind with
+          | Circle r -> dst.(tid) <- r *. c.scale
+          | Square x -> dst.(tid) <- x *. c.scale
+        end]
+
+let ir_of name kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith ("no IR for " ^ name)
+
+(* ---- Axis 1: observable erasure in the emitted device source ------------- *)
+
+let contains hay needle =
+  let nh = String.length needle and h = String.length hay in
+  let rec go i =
+    if i + nh > h then false
+    else if String.sub hay i nh = needle then true
+    else go (i + 1)
+  in
+  go 0
+
+let mentions_tag src =
+  contains src "switch (" || contains src ".tag" || contains src "enum "
+
+let observable_ok = ref true
+
+let check_emitted name kirc ~expect_tag ~expect_erec =
+  let src = Sarek_codegen.Sarek_ir_cuda.generate (ir_of name kirc) in
+  let has_tag = mentions_tag src in
+  let has_erec = contains src "_erec" in
+  let ok = has_tag = expect_tag && has_erec = expect_erec in
+  if not ok then observable_ok := false ;
+  Printf.printf
+    "  emitted[%s]: tag %s (exp %s), _erec %s (exp %s) -> %s\n%!"
+    name
+    (if has_tag then "present" else "absent")
+    (if expect_tag then "present" else "absent")
+    (if has_erec then "present" else "absent")
+    (if expect_erec then "present" else "absent")
+    (if ok then "OK" else "MISMATCH") ;
+  if not ok then begin
+    print_endline "  ---- emitted CUDA-C ----" ;
+    print_endline src
+  end
+
+(* ---- Axis 2: behavioural equivalence ------------------------------------- *)
+
+let all_must fw =
+  match fw with
+  | "CUDA" | "OpenCL" | "Vulkan" | "Metal" | "Native" | "Interpreter" -> true
+  | _ -> false
+
+let native_only fw = fw = "Native"
+
+let any_failure = ref false
+
+(* Initialise every backend ONCE and share the device set across kernels: each
+   [Device.init] spins up a fresh Vulkan instance, and repeated init/teardown
+   churn has been observed to crash RADV, so we avoid re-initialising per run. *)
+let devs =
+  Device.init
+    ~frameworks:["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"]
+    ()
+
+let run_behaviour ~must name kirc ~reference =
+  Printf.printf "runtime[%s]:\n%!" name ;
+  if Array.length devs = 0 then
+    print_endline "  no devices - codegen-only (behaviour skipped)"
+  else
+    Array.iter
+      (fun dev ->
+        let fw = dev.Device.framework in
+        Printf.printf "  [%s] %s: %!" fw dev.Device.name ;
+        try
+          let n = 64 in
+          let src = Vector.create Vector.float32 n in
+          let dst = Vector.create Vector.float32 n in
+          for i = 0 to n - 1 do
+            Vector.set src i (float_of_int (i + 1)) ;
+            Vector.set dst i 0.0
+          done ;
+          let threads = min 64 n in
+          let grid_x = (n + threads - 1) / threads in
+          Sarek.Execute.run_vectors
+            ~device:dev
+            ~block:(Sarek.Execute.dims1d threads)
+            ~grid:(Sarek.Execute.dims1d grid_x)
+            ~ir:(ir_of name kirc)
+            ~args:
+              [
+                Sarek.Execute.Vec src;
+                Sarek.Execute.Vec dst;
+                Sarek.Execute.Int32 (Int32.of_int n);
+              ]
+            () ;
+          Transfer.flush dev ;
+          let ok = ref true in
+          for i = 0 to n - 1 do
+            let got = Vector.get dst i and exp = reference i in
+            if abs_float (got -. exp) > 1e-2 then begin
+              ok := false ;
+              if i < 4 then
+                Printf.printf "\n    mismatch@%d got %.3f exp %.3f%!" i got exp
+            end
+          done ;
+          if !ok then print_endline "PASSED"
+          else begin
+            if must fw then any_failure := true ;
+            print_endline "FAILED"
+          end
+        with e ->
+          if must fw then any_failure := true ;
+          Printf.printf
+            "%s %s\n%!"
+            (if must fw then "ERROR"
+             else "SKIP (backend lacks nested-variant record field)")
+            (Printexc.to_string e))
+      devs
+
+let () =
+  print_endline "=== L14 S2 record-field tag erasure E2E ===" ;
+  print_endline "-- emitted-code snapshots --" ;
+  check_emitted "unary(erasable)" unary_kirc ~expect_tag:false ~expect_erec:true ;
+  check_emitted
+    "nullary(erasable)"
+    nullary_kirc
+    ~expect_tag:false
+    ~expect_erec:true ;
+  check_emitted
+    "all-scalar(untouched)"
+    allscalar_kirc
+    ~expect_tag:false
+    ~expect_erec:false ;
+  check_emitted
+    "runtime-selected(control)"
+    runtime_kirc
+    ~expect_tag:true
+    ~expect_erec:false ;
+  print_endline "-- behaviour vs pure-OCaml reference --" ;
+  run_behaviour ~must:all_must "unary(erasable)" unary_kirc ~reference:(fun i ->
+      let v = float_of_int (i + 1) in
+      v *. v *. 2.0) ;
+  run_behaviour
+    ~must:all_must
+    "nullary(erasable)"
+    nullary_kirc
+    ~reference:(fun i -> float_of_int (i + 1) +. 1.0) ;
+  run_behaviour
+    ~must:all_must
+    "all-scalar(untouched)"
+    allscalar_kirc
+    ~reference:(fun i ->
+      let v = float_of_int (i + 1) in
+      v *. (v +. 1.0)) ;
+  run_behaviour
+    ~must:native_only
+    "runtime-selected(control)"
+    runtime_kirc
+    ~reference:(fun i -> float_of_int (i + 1) *. 2.0) ;
+  Printf.printf
+    "\n=== observable=%s behaviour=%s ===\n"
+    (if !observable_ok then "OK" else "FAIL")
+    (if !any_failure then "FAIL" else "OK") ;
+  if !observable_ok && not !any_failure then
+    print_endline "test_record_field_tag_erasure PASSED"
+  else begin
+    print_endline "test_record_field_tag_erasure FAILED" ;
+    exit 1
+  end


### PR DESCRIPTION
## Summary

Implements **L14 / S2** — erasing a statically-known variant-typed **record field**, the layout-unblock headline of the static-tag-erasure design. Builds on S1 (PR #245, variant-typed kernel-local slots).

An immutable kernel-local record whose variant field is written by a literal constructor with a substitutable payload, and read only as a `match` scrutinee, is lowered on the **device path only** to a synthesized all-scalar record with positional fields (`_0`, `_1`, …), mirroring L13's `_tup_*` tuple synthesis. The nested variant disappears entirely.

```
let c = { kind = Circle src.(tid); scale = 2.0 } in
let base = match c.kind with Circle r -> r *. r | Square x -> x in
dst.(tid) <- base *. c.scale
```
emits (CUDA-C, post-S2):
```c
_erec_float32_float32 c = (_erec_float32_float32){src[tid], 2.0f};
float base = (c._0 * c._0);
dst[tid] = (base * c._1);
```

## Empirical backend matrix (probe, RX 7900 XTX)

A record with a variant field, **before** S2:

| Backend | Before | After |
|---|---|---|
| Interpreter | FAIL (record layout rejected) | PASS |
| Vulkan | FAIL (layout rejected) | PASS |
| OpenCL | FAIL (variant field read) | PASS |
| CUDA/PTX (ZLUDA) | malformed emit | PASS |
| Native | PASS (real OCaml) | PASS |

This refines the S1 "Implementation findings" note, which assumed CUDA + host already tolerated nested-variant fields — the probe shows the unblock is broader.

## Design

- **Positional `_i` fields** need no runtime registry entry — the interpreter resolves them by position (`positional_field_index`), exactly like L13 tuples. No `[@@sarek.type]` declaration reconciliation, no runtime registration.
- **Nominal `TRecord` threaded into the binding** (not a tuple — `TTuple` falls back to the `int32` placeholder in `elttype_of_typ`, which is why local tuples break on strict backends), so every struct-based backend gets the correct type.
- **Device-only**: `native_kernel` (captured before the pass) keeps the original record, so `[@@sarek.type]` and host marshalling are untouched. No layout-authority (`Sarek_ir_layout` / Rocq) changes.

## Scope (conservative, same spirit as S1)

Plain immutable kernel-local `let`-bound record literal; **every** variant field erasable (literal ctor + substitutable payload + all reads are reducible match scrutinees); every kept field and unary payload a scalar primitive; the record never escapes as a whole value. Anything else is left untouched.

## Tests

New `sarek/tests/e2e/test_record_field_tag_erasure.ml`:
- **Emitted-code**: no tag + synthesized `_erec_*` for erasable unary/nullary; untouched (original record name, no `_erec_*`) for an all-scalar record; tag retained for a runtime-selected control.
- **Behaviour** vs pure-OCaml reference on every device; Native-only oracle for the retained control (its variant record field is the very case only Native can execute).

Gates: `dune build @install` clean; `@fmt` clean on changed files; `dune runtest sarek/tests` fully green (incl. S1 `test_static_tag_erasure` with its negative controls); new test green on Interpreter/Native/OpenCL/Vulkan and CUDA/PTX under ZLUDA.

Do **not** merge — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device-side optimization for records containing statically known variant fields.
  * Supports nested eligible records and simplifies matching on known variant values.
  * Preserves tagged representations when values are selected at runtime.

* **Tests**
  * Added end-to-end coverage across supported device backends.
  * Verifies generated device code and confirms behavior matches reference results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->