### PR TITLE
Fix arithmetic operations and float fmod for PTX backend (audit M1-M9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Test alias coverage guard
         run: ./scripts/check-test-alias-coverage.sh
@@ -170,6 +172,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,24 @@ jobs:
           - true
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Test alias coverage guard
+        run: ./scripts/check-test-alias-coverage.sh
+
+      - name: Formal proofs admit gate
+        run: |
+          # The formal projects claim 0 admits; fail if an Admitted/admit/Axiom
+          # sneaks into a .v file (comments don't match the line-anchored regex).
+          if grep -rnE '^[[:space:]]*(Admitted\.|admit\.|Axiom[[:space:]])' formal --include='*.v'; then
+            echo "::error::Admitted/admit/Axiom found in formal/ .v files (0-admit invariant violated)"
+            exit 1
+          fi
+          echo "OK: no Admitted/admit/Axiom in formal/ .v files"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -137,6 +151,7 @@ jobs:
 
   check-generated-code:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,23 @@ jobs:
       - name: Formal proofs admit gate
         run: |
           # The formal projects claim 0 admits; fail if an Admitted/admit/Axiom
-          # sneaks into a .v file (comments don't match the line-anchored regex).
-          if grep -rnE '^[[:space:]]*(Admitted\.|admit\.|Axiom[[:space:]])' formal --include='*.v'; then
-            echo "::error::Admitted/admit/Axiom found in formal/ .v files (0-admit invariant violated)"
+          # sneaks into a .v file. Word-boundary regex with optional space
+          # before the terminating dot catches bulleted tactics (`- admit.`),
+          # same-line sequences (`Proof. Admitted.`) and `Axiom(`/`Axioms`.
+          # Note: `Parameter` remains a sanctioned escape hatch (see
+          # AGpuSemantics.v) - this gate enforces the textual invariant only;
+          # full assurance needs a proof-building CI job (tracked follow-up).
+          set +e
+          ls formal/*/theories/*.v >/dev/null 2>&1 || { echo "::error::admit gate could not find formal .v files"; exit 1; }
+          matches=$(grep -rnE "(^|[^[:alnum:]_'])((Admitted|admit)[[:space:]]*\.|Axioms?([[:space:]]|\())" formal --include='*.v')
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "$matches"
+            echo "::error::Admitted/admit/Axiom found in formal/ .v files"
+            exit 1
+          elif [ "$rc" -ge 2 ]; then
+            echo "::error::admit gate grep failed (rc=$rc)"
             exit 1
           fi
           echo "OK: no Admitted/admit/Axiom in formal/ .v files"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,50 @@
-## Unreleased
+## 2026-07
+
+### Added
+
+- Direct PTX emitter completion: records/variants with aligned C-ABI layout,
+  match, helper-function inlining, static + dynamic `.shared`, `.local`
+  arrays, full atomic set (CAS, wrapping inc/dec, 64-bit add/exch), f64
+  softmath (trig, exp/log family, hypot, …), scalar cast matrix
+- `Sarek_worklist` — portable dynamic-parallelism (work-queue) library
+- `Sarek_gemm` — portable tiled SGEMM library for shared-memory backends
+- `Sarek_df64` — float-float extended-precision arithmetic in pure Sarek
+- Portable float64: `G`-suffix float64 literals, `sarek.real64` host
+  plumbing, complete interpreter float64 math oracle
+- Tier-0 defunctionalization pass (first-class kernel-local functions)
+- Tuple-typed vectors on device and Native paths (shared shape registry)
+- Static tag erasure for kernel-local variant slots
+- Aligned C-ABI aggregate host layout (L8), with the `PtxLayout.v` formal
+  model restated for the aligned ABI (0 admits)
+- float32 `fma` intrinsic on all backends; GLSL `precise` qualifier on
+  float locals
+- ZLUDA/AMD support for the CUDA/PTX backend (PTX launch ABI fix)
+- T3-SEMANTIC milestone lock for both formal projects; conformance +
+  mutation tests wired into `dune runtest`
+
+### Fixed
+
+- Indexed kernel-argument container with strict launch validation, honored
+  across all six backends (out-of-order/sparse `set_arg` now correct)
+- Unambiguous, collision-resistant compile-cache keys (kernel name included,
+  digest-per-field); CUDA kernel-cache eviction on context destroy
+- e2e test alias actually executes tests; vacuous tests now assert real
+  results; negative suite runs in CI
+- Vulkan push-constant scalar binding by logical index; 64-bit write
+  alignment; buffer-index validation
+- Benchmark dashboard HTML escaping at all sinks (stored-XSS hardening)
+- CPU data kept authoritative after Interpreter runs
+
+## 2026-06
+
+### Added
+
+- CUDA backend split into CUDA/PTX and CUDA/C devices (PTX is the default)
+- `.shared` (DShared) emission in the PTX backend with formal spec
+  (`specs/ptx-dshared-formal.md`)
+- T3-SEMANTIC theorem work for the convergence-safety and type-safety
+  formal projects
+- WGSL/WebGPU codegen backend, in-browser playground and Learn course
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_param.cma > "$$out" 2>&1; if grep -q "Function-typed kernel parameters are not supported" "$$out"; then echo "  PASS: function param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing escaping function-value rejection (L12 defunctionalization)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_escape.cma > "$$out" 2>&1; if grep -q "Function value escapes" "$$out"; then echo "  PASS: escaping function value rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing unregistered record field-type rejection (aligned ABI safety)..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_unregistered_field.cma > "$$out" 2>&1; if grep -qE "unknown (size|alignment) for field type" "$$out"; then echo "  PASS: unregistered field type rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "All negative tests checked (see KNOWN-ISSUE line above for the one non-blocking gap, if any)"
 
 

--- a/README.md
+++ b/README.md
@@ -91,35 +91,32 @@ GPU Backends:
 └── sarek-metal/   Apple Metal backend
 
 Experimental:
-└── sarek/codegen/Sarek_ir_ptx.ml   Direct PTX emitter (spike)
+└── sarek/codegen/Sarek_ir_ptx.ml   Direct PTX emitter (experimental)
 ```
 
 ## Experimental Features
 
 ### PTX Direct Emitter (`Sarek_ir_ptx`)
 
-> ⚠️ **Experimental — incomplete, not production-ready.**
+> ⚠️ **Experimental — validated on real hardware, not yet exercised by CI on GPUs.**
 
-`Sarek_ir_ptx` is a spike-level PTX code generator that emits NVIDIA PTX directly from Sarek IR, bypassing NVRTC entirely.
+`Sarek_ir_ptx` emits NVIDIA PTX directly from Sarek IR, bypassing NVRTC entirely. It is the default device path of the CUDA backend (`Cuda_ptx_plugin`); the NVRTC/C path remains available as `Cuda_c_plugin`.
 
 **What works:**
-- Basic scalar and vector kernels (float32/int32 arithmetic, global memory loads/stores, barriers)
-- Thread ID / block ID / grid ID registers
-- Parameterised SM target (`?sm_target`, default `sm_86`)
-- `Cuda_api.Kernel.load_from_ptx` loads the PTX via `cuModuleLoadData` — automatically adapts the `.target` to the device's actual SM, so `sm_86` PTX runs on older hardware (tested: GTX 1070, sm_61)
-- End-to-end test in `sarek-cuda/test/test_ptx_external.ml`
+- Scalar and vector kernels (int32/int64, float32/float64), global loads/stores, barriers
+- Records and variants with the aligned C-ABI aggregate layout (proven in `formal/codegen-ptx/theories/PtxLayout.v`), match expressions, static tag erasure
+- Helper functions via `EApp` inlining (`sarek.inline` budget-controlled)
+- Static and dynamic shared memory (`.shared`, module-scope `extern .shared`), per-thread `.local` arrays
+- Atomics: add/min/max/and/or/xor/exch, CAS, wrapping inc/dec, 64-bit add/exch
+- float64 softmath library (trig, exp/log family, hypot, fma, …) with an interpreter oracle
+- Parameterised SM target (`?sm_target`, default `sm_86`); `Cuda_api.Kernel.load_from_ptx` adapts `.target` to the device's actual SM (tested: GTX 1070, sm_61; AMD RX 7900 XTX via ZLUDA)
 
-**What is missing (known gaps):**
-- Records and variants (`TRecord`, `TVariant`) — struct layout not implemented
-- Helper / device functions (`kern_funcs`, `EApp`) — `.func` directive
-- Match expressions (`EMatch`, `SMatch`) — depends on variant lowering
-- `EArrayLen` on local/shared arrays (parameter arrays are supported)
-- Shared memory (`__shared__` / `.shared`) — not yet emitted
-- Full CI integration and ptxas validation gate
+**Known gaps:**
+- The formal proofs cover the aggregate byte layout and a scalar statement/expression fragment of a Rocq-side model; the production emitter is conformance-tested against that model, not extracted from it
+- No `ptxas` validation gate or GPU execution in CI yet — GPU validation is manual
+- Warp-level primitives are modeled in the IR but not emitted by any backend yet
 
-**Intended purpose:** foundation for formal verification of the CUDA backend. Proving `Sarek_ir_ptx.ml` produces semantically correct PTX (against a Rocq PTX semantics) is the target of the planned `cuda-semantics` formal project.
-
-See `docs/plans/ptx-spike-findings.md` for the full PTX subset analysis.
+**Intended purpose:** foundation for formal verification of the CUDA backend, developed in `formal/codegen-ptx/` alongside `specs/ptx-records-variants.md` and `specs/ptx-dshared-formal.md`.
 
 ## Installation
 
@@ -151,7 +148,7 @@ For NVIDIA GPUs, especially newer architectures:
 
 #### AMD GPUs via ZLUDA
 
-The CUDA backend also runs on AMD GPUs through [ZLUDA](https://github.com/vosen/ZLUDA), a CUDA implementation on top of ROCm. ZLUDA ships the CUDA driver API but not NVRTC, so only the CUDA/PTX backend (the default) is available — kernels that fall back to the CUDA/C backend (records, variants) will not run.
+The CUDA backend also runs on AMD GPUs through [ZLUDA](https://github.com/vosen/ZLUDA), a CUDA implementation on top of ROCm. ZLUDA ships the CUDA driver API but not NVRTC, so only the CUDA/PTX backend (the default) is available. Records, variants, match expressions and shared memory are all supported by the PTX emitter, so typical Sarek kernels run unmodified; only kernels that explicitly select the CUDA/C (NVRTC) backend will not run.
 
 ```bash
 # Prerequisites: ROCm (tested with 7.2) and a supported AMD GPU (e.g. RDNA3)
@@ -343,9 +340,8 @@ If OpenCL is not detecting your device, ensure you have the appropriate ICD (Ins
 ## Documentation
 
 - [GitHub Pages](http://mathiasbourgoin.github.io/Sarek/) - User guides, tutorials, and API docs
-- [ARCHITECTURE.md](ARCHITECTURE.md) - System architecture and design
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
-- [PROJECT_STATUS.md](PROJECT_STATUS.md) - Current project status
+- [CHANGES.md](CHANGES.md) - Changelog
 - [Backend Documentation](sarek-cuda/) - Individual backend READMEs
 
 For API documentation, see inline comments and README files in each package directory.

--- a/benchmarks/descriptions/generated/mandelbrot_generated.md
+++ b/benchmarks/descriptions/generated/mandelbrot_generated.md
@@ -10,13 +10,13 @@ extern "C" {
 __global__ void sarek_kern(int* __restrict__ output, int sarek_output_length, int width, int height, int max_iter) {
   int px = (threadIdx.x + blockIdx.x * blockDim.x);
   int py = (threadIdx.y + blockIdx.y * blockDim.y);
-  if (((px < width) && (py < height))) {
+  if (((px < width) ? (py < height) : 0)) {
     float x0 = ((4.0f * ((float)(px) / (float)(width))) - 2.5f);
     float y0 = ((3.0f * ((float)(py) / (float)(height))) - 1.5f);
     float x = 0.0f;
     float y = 0.0f;
     int iter = 0;
-    while (((((x * x) + (y * y)) <= 4.0f) && (iter < max_iter))) {
+    while (((((x * x) + (y * y)) <= 4.0f) ? (iter < max_iter) : 0)) {
       float xtemp = (((x * x) - (y * y)) + x0);
       y = (((2.0f * x) * y) + y0);
       x = xtemp;
@@ -34,13 +34,13 @@ __global__ void sarek_kern(int* __restrict__ output, int sarek_output_length, in
 __kernel void sarek_kern(__global int* restrict output, int sarek_output_length, int width, int height, int max_iter) {
   int px = get_global_id(0);
   int py = get_global_id(1);
-  if (((px < width) && (py < height))) {
+  if (((px < width) ? (py < height) : 0)) {
     float x0 = ((4.0f * ((float)(px) / (float)(width))) - 2.5f);
     float y0 = ((3.0f * ((float)(py) / (float)(height))) - 1.5f);
     float x = 0.0f;
     float y = 0.0f;
     int iter = 0;
-    while (((((x * x) + (y * y)) <= 4.0f) && (iter < max_iter))) {
+    while (((((x * x) + (y * y)) <= 4.0f) ? (iter < max_iter) : 0)) {
       float xtemp = (((x * x) - (y * y)) + x0);
       y = (((2.0f * x) * y) + y0);
       x = xtemp;
@@ -77,13 +77,13 @@ layout(push_constant) uniform PushConstants {
 void main() {
   int px = int(gl_GlobalInvocationID.x);
   int py = int(gl_GlobalInvocationID.y);
-  if (((px < width) && (py < height))) {
+  if (((px < width) ? (py < height) : false)) {
     precise float x0 = ((4.0 * (float(px) / float(width))) - 2.5);
     precise float y0 = ((3.0 * (float(py) / float(height))) - 1.5);
     precise float x = 0.0;
     precise float y = 0.0;
     int iter = 0;
-    while (((((x * x) + (y * y)) <= 4.0) && (iter < max_iter))) {
+    while (((((x * x) + (y * y)) <= 4.0) ? (iter < max_iter) : false)) {
       precise float xtemp = (((x * x) - (y * y)) + x0);
       y = (((2.0 * x) * y) + y0);
       x = xtemp;
@@ -108,13 +108,13 @@ uint3 __metal_tpg [[threads_per_threadgroup]],
 uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int px = __metal_gid.x;
   int py = __metal_gid.y;
-  if (((px < width) && (py < height))) {
+  if (((px < width) ? (py < height) : 0)) {
     float x0 = ((4.0f * ((float)(px) / (float)(width))) - 2.5f);
     float y0 = ((3.0f * ((float)(py) / (float)(height))) - 1.5f);
     float x = 0.0f;
     float y = 0.0f;
     int iter = 0;
-    while (((((x * x) + (y * y)) <= 4.0f) && (iter < max_iter))) {
+    while (((((x * x) + (y * y)) <= 4.0f) ? (iter < max_iter) : 0)) {
       float xtemp = (((x * x) - (y * y)) + x0);
       y = (((2.0f * x) * y) + y0);
       x = xtemp;

--- a/benchmarks/descriptions/generated/matrix_mul_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_generated.md
@@ -11,7 +11,7 @@ __global__ void sarek_kern(float* __restrict__ a, int sarek_a_length, float* __r
   int tid = (threadIdx.x + blockIdx.x * blockDim.x);
   int row = (tid / n);
   int col = (tid % n);
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : 0)) {
     float sum = 0.0f;
     for (int i = 0; i <= (k - 1); i++) {
       sum = (sum + (a[((row * k) + i)] * b[((i * n) + col)]));
@@ -29,7 +29,7 @@ __kernel void sarek_kern(__global float* restrict a, int sarek_a_length, __globa
   int tid = get_global_id(0);
   int row = (tid / n);
   int col = (tid % n);
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : 0)) {
     float sum = 0.0f;
     for (int i = 0; i <= (k - 1); i++) {
       sum = (sum + (a[((row * k) + i)] * b[((i * n) + col)]));
@@ -76,7 +76,7 @@ void main() {
   int tid = int(gl_GlobalInvocationID.x);
   int row = (tid / n);
   int col = (tid % n);
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : false)) {
     precise float sum = 0.0;
     for (int i = 0; i <= (k - 1); i++) {
       sum = (sum + (a[((row * k) + i)] * b[((i * n) + col)]));
@@ -101,7 +101,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int tid = __metal_gid.x;
   int row = (tid / n);
   int col = (tid % n);
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : 0)) {
     float sum = 0.0f;
     for (int i = 0; i <= (k - 1); i++) {
       sum = (sum + (a[((row * k) + i)] * b[((i * n) + col)]));

--- a/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
@@ -20,7 +20,7 @@ __global__ void sarek_kern(float* __restrict__ a, int sarek_a_length, float* __r
   for (int t = 0; t <= (num_tiles - 1); t++) {
     {
       int a_col = ((t * tile_size) + tx);
-      if (((row < m) && (a_col < k))) {
+      if (((row < m) ? (a_col < k) : 0)) {
         tile_a[((ty * tile_size) + tx)] = a[((row * k) + a_col)];
       } else {
         tile_a[((ty * tile_size) + tx)] = 0.0f;
@@ -29,7 +29,7 @@ __global__ void sarek_kern(float* __restrict__ a, int sarek_a_length, float* __r
     __syncthreads();
     {
       int b_row = ((t * tile_size) + ty);
-      if (((b_row < k) && (col < n))) {
+      if (((b_row < k) ? (col < n) : 0)) {
         tile_b[((ty * tile_size) + tx)] = b[((b_row * n) + col)];
       } else {
         tile_b[((ty * tile_size) + tx)] = 0.0f;
@@ -43,7 +43,7 @@ __global__ void sarek_kern(float* __restrict__ a, int sarek_a_length, float* __r
     }
     __syncthreads();
   }
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : 0)) {
     c[((row * n) + col)] = sum;
   }
 }
@@ -66,7 +66,7 @@ __kernel void sarek_kern(__global float* restrict a, int sarek_a_length, __globa
   for (int t = 0; t <= (num_tiles - 1); t++) {
     {
       int a_col = ((t * tile_size) + tx);
-      if (((row < m) && (a_col < k))) {
+      if (((row < m) ? (a_col < k) : 0)) {
         tile_a[((ty * tile_size) + tx)] = a[((row * k) + a_col)];
       } else {
         tile_a[((ty * tile_size) + tx)] = 0.0f;
@@ -75,7 +75,7 @@ __kernel void sarek_kern(__global float* restrict a, int sarek_a_length, __globa
     barrier(CLK_LOCAL_MEM_FENCE);
     {
       int b_row = ((t * tile_size) + ty);
-      if (((b_row < k) && (col < n))) {
+      if (((b_row < k) ? (col < n) : 0)) {
         tile_b[((ty * tile_size) + tx)] = b[((b_row * n) + col)];
       } else {
         tile_b[((ty * tile_size) + tx)] = 0.0f;
@@ -89,7 +89,7 @@ __kernel void sarek_kern(__global float* restrict a, int sarek_a_length, __globa
     }
     barrier(CLK_LOCAL_MEM_FENCE);
   }
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : 0)) {
     c[((row * n) + col)] = sum;
   }
 }
@@ -143,7 +143,7 @@ void main() {
   for (int t = 0; t <= (num_tiles - 1); t++) {
     {
       int a_col = ((t * tile_size) + tx);
-      if (((row < m) && (a_col < k))) {
+      if (((row < m) ? (a_col < k) : false)) {
         tile_a[((ty * tile_size) + tx)] = a[((row * k) + a_col)];
       } else {
         tile_a[((ty * tile_size) + tx)] = 0.0;
@@ -152,7 +152,7 @@ void main() {
     barrier();
     {
       int b_row = ((t * tile_size) + ty);
-      if (((b_row < k) && (col < n))) {
+      if (((b_row < k) ? (col < n) : false)) {
         tile_b[((ty * tile_size) + tx)] = b[((b_row * n) + col)];
       } else {
         tile_b[((ty * tile_size) + tx)] = 0.0;
@@ -166,7 +166,7 @@ void main() {
     }
     barrier();
   }
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : false)) {
     c[((row * n) + col)] = sum;
   }
 }
@@ -196,7 +196,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   for (int t = 0; t <= (num_tiles - 1); t++) {
     {
       int a_col = ((t * tile_size) + tx);
-      if (((row < m) && (a_col < k))) {
+      if (((row < m) ? (a_col < k) : 0)) {
         tile_a[((ty * tile_size) + tx)] = a[((row * k) + a_col)];
       } else {
         tile_a[((ty * tile_size) + tx)] = 0.0f;
@@ -205,7 +205,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
     threadgroup_barrier(mem_flags::mem_threadgroup);
     {
       int b_row = ((t * tile_size) + ty);
-      if (((b_row < k) && (col < n))) {
+      if (((b_row < k) ? (col < n) : 0)) {
         tile_b[((ty * tile_size) + tx)] = b[((b_row * n) + col)];
       } else {
         tile_b[((ty * tile_size) + tx)] = 0.0f;
@@ -219,7 +219,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
   }
-  if (((row < m) && (col < n))) {
+  if (((row < m) ? (col < n) : 0)) {
     c[((row * n) + col)] = sum;
   }
 }

--- a/benchmarks/descriptions/generated/transpose_tiled_generated.md
+++ b/benchmarks/descriptions/generated/transpose_tiled_generated.md
@@ -17,7 +17,7 @@ __global__ void sarek_kern(float* __restrict__ input, int sarek_input_length, fl
   int read_col = (block_col + tx);
   int read_row = (block_row + ty);
   {
-    if (((read_col < width) && (read_row < height))) {
+    if (((read_col < width) ? (read_row < height) : 0)) {
       int read_idx = ((read_row * width) + read_col);
       int tile_idx = ((ty * 17) + tx);
       tile[tile_idx] = input[read_idx];
@@ -27,7 +27,7 @@ __global__ void sarek_kern(float* __restrict__ input, int sarek_input_length, fl
   int write_col = (block_row + tx);
   int write_row = (block_col + ty);
   {
-    if (((write_col < height) && (write_row < width))) {
+    if (((write_col < height) ? (write_row < width) : 0)) {
       int tile_idx = ((tx * 17) + ty);
       int write_idx = ((write_row * height) + write_col);
       output[write_idx] = tile[tile_idx];
@@ -51,7 +51,7 @@ __kernel void sarek_kern(__global float* restrict input, int sarek_input_length,
   int read_col = (block_col + tx);
   int read_row = (block_row + ty);
   {
-    if (((read_col < width) && (read_row < height))) {
+    if (((read_col < width) ? (read_row < height) : 0)) {
       int read_idx = ((read_row * width) + read_col);
       int tile_idx = ((ty * 17) + tx);
       tile[tile_idx] = input[read_idx];
@@ -61,7 +61,7 @@ __kernel void sarek_kern(__global float* restrict input, int sarek_input_length,
   int write_col = (block_row + tx);
   int write_row = (block_col + ty);
   {
-    if (((write_col < height) && (write_row < width))) {
+    if (((write_col < height) ? (write_row < width) : 0)) {
       int tile_idx = ((tx * 17) + ty);
       int write_idx = ((write_row * height) + write_col);
       output[write_idx] = tile[tile_idx];
@@ -109,7 +109,7 @@ void main() {
   int read_col = (block_col + tx);
   int read_row = (block_row + ty);
   {
-    if (((read_col < width) && (read_row < height))) {
+    if (((read_col < width) ? (read_row < height) : false)) {
       int read_idx = ((read_row * width) + read_col);
       int tile_idx = ((ty * 17) + tx);
       tile[tile_idx] = inputv[read_idx];
@@ -119,7 +119,7 @@ void main() {
   int write_col = (block_row + tx);
   int write_row = (block_col + ty);
   {
-    if (((write_col < height) && (write_row < width))) {
+    if (((write_col < height) ? (write_row < width) : false)) {
       int tile_idx = ((tx * 17) + ty);
       int write_idx = ((write_row * height) + write_col);
       outputv[write_idx] = tile[tile_idx];
@@ -150,7 +150,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int read_col = (block_col + tx);
   int read_row = (block_row + ty);
   {
-    if (((read_col < width) && (read_row < height))) {
+    if (((read_col < width) ? (read_row < height) : 0)) {
       int read_idx = ((read_row * width) + read_col);
       int tile_idx = ((ty * 17) + tx);
       tile[tile_idx] = input[read_idx];
@@ -160,7 +160,7 @@ uint3 __metal_num_groups [[threadgroups_per_grid]]) {
   int write_col = (block_row + tx);
   int write_row = (block_col + ty);
   {
-    if (((write_col < height) && (write_row < width))) {
+    if (((write_col < height) ? (write_row < width) : 0)) {
       int tile_idx = ((tx * 17) + ty);
       int write_idx = ((write_row * height) + write_col);
       output[write_idx] = tile[tile_idx];

--- a/sarek-opencl/Opencl_plugin_base.ml
+++ b/sarek-opencl/Opencl_plugin_base.ml
@@ -227,12 +227,16 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
       {kernel; program; device_id = device.id}
 
     let compile_cached device ~name ~source =
+      (* Compile_cache.make_key gives the same collision-resistant,
+         digest-per-field encoding every other backend uses (the July 2026
+         cache-key standardization missed this hand-rolled join - audit
+         finding; a ':' in a kernel name could shift bytes between fields). *)
       let key =
-        Printf.sprintf
-          "%d:%s:%s"
-          device.Opencl_api.Device.id
-          name
-          (Digest.string source |> Digest.to_hex)
+        Spoc_framework.Compile_cache.make_key
+          ~device:(string_of_int device.Opencl_api.Device.id)
+          ~name
+          ~source
+          ()
       in
       match Hashtbl.find_opt cache key with
       | Some k -> k

--- a/sarek/Sarek_gemm/Sarek_gemm.ml
+++ b/sarek/Sarek_gemm/Sarek_gemm.ml
@@ -179,10 +179,10 @@ module Host = struct
   let grid ~m ~n =
     Sarek.Execute.dims2d ((n + tile - 1) / tile) ((m + tile - 1) / tile)
 
-  (** Shared-memory footprint of the kernel's two float32 tiles, for
-      occupancy estimation only. The kernel declares its tiles with
-      [let%shared] (STATIC shared memory), so launches do NOT need to pass
-      [~shared_mem] - passing it merely reserves the same bytes again as an
-      unused dynamic region (audit finding L5). *)
+  (** Shared-memory footprint of the kernel's two float32 tiles, for occupancy
+      estimation only. The kernel declares its tiles with [let%shared] (STATIC
+      shared memory), so launches do NOT need to pass [~shared_mem] - passing it
+      merely reserves the same bytes again as an unused dynamic region (audit
+      finding L5). *)
   let shared_mem_bytes = 2 * tile * tile * 4
 end

--- a/sarek/Sarek_gemm/Sarek_gemm.ml
+++ b/sarek/Sarek_gemm/Sarek_gemm.ml
@@ -179,6 +179,10 @@ module Host = struct
   let grid ~m ~n =
     Sarek.Execute.dims2d ((n + tile - 1) / tile) ((m + tile - 1) / tile)
 
-  (** Dynamic shared-memory bytes: two float32 tiles. *)
+  (** Shared-memory footprint of the kernel's two float32 tiles, for
+      occupancy estimation only. The kernel declares its tiles with
+      [let%shared] (STATIC shared memory), so launches do NOT need to pass
+      [~shared_mem] - passing it merely reserves the same bytes again as an
+      unused dynamic region (audit finding L5). *)
   let shared_mem_bytes = 2 * tile * tile * 4
 end

--- a/sarek/Sarek_worklist/Sarek_worklist.ml
+++ b/sarek/Sarek_worklist/Sarek_worklist.ml
@@ -200,7 +200,12 @@ module Host = struct
       ~max_levels =
     let rec loop level base =
       let snap = tail t in
-      if snap <= base || level >= max_levels then level
+      (* Stop at the first overflow (audit finding M8): once OVERFLOW is
+         set, TAIL counts tickets whose ring slot was never written - still
+         the -1 seed - and the next level would feed -1 to the kernel as a
+         node index (out-of-bounds device reads on poisoned data). The
+         caller observes {!overflow} > 0 and re-runs with a larger ring. *)
+      if snap <= base || level >= max_levels || overflow t > 0 then level
       else begin
         launch ~level_base:base ~snapshot_tail:snap ;
         loop (level + 1) snap

--- a/sarek/codegen/Sarek_ir_ptx.ml
+++ b/sarek/codegen/Sarek_ir_ptx.ml
@@ -13,13 +13,15 @@
  *   Sarek_ir_ptx_stmt    - statement emitter
  *   Sarek_ir_ptx_kernel  - kernel-level generation entry points
  *
- * Known gaps (documented in docs/plans/ptx-spike-findings.md):
- *   - Records / TRecord: layout would need a struct-to-offset mapping
- *   - Variants / TVariant: tagged-union lowering is non-trivial in PTX
- *   - EMatch / SMatch: depends on variant lowering
- *   - Helper functions / kern_funcs: .func directive; callable from kernel
- *   - EArrayLen: needs (ptr, len) pair tracking in env
- *   - EApp: device function calls via .func; not yet implemented
+ * Supported: records/variants (aligned C-ABI layout, see PtxLayout.v),
+ * EMatch/SMatch, helper functions via EApp inlining, EArrayLen on parameter
+ * arrays (local/shared arrays fall back to another backend), static and
+ * dynamic .shared, per-thread .local arrays, atomics (incl. CAS and 64-bit
+ * forms), f64 softmath.
+ *
+ * Known gaps:
+ *   - No ptxas validation gate in CI; GPU validation is manual
+ *   - Warp-level primitives modeled in the IR but not emitted
  ******************************************************************************)
 
 open Sarek_ir_types

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1293,7 +1293,7 @@ and emit_intrinsic_native buf alloc env path name args : string =
      the element size (2 for 32-bit, 3 for 64-bit elements) — the stride
      must match the atom width or neighbouring elements alias. Returns the
      PTX space name and the address register. *)
-  let atomic_addr ~global_only ~elt_shift arr r_idx =
+  let atomic_addr ~intr ~global_only ~elt_shift arr r_idx =
     let r_base = env_lookup env arr.var_name in
     (* PTX has no atom.local — and per-thread memory needs no atomics. *)
     (match arr_space_of alloc arr.var_name with
@@ -1301,7 +1301,40 @@ and emit_intrinsic_native buf alloc env path name args : string =
         unsupported
           ("atomic operation on per-thread local array '" ^ arr.var_name
          ^ "' (atomics require shared or global memory)")
+    | Some SpaceShared when global_only ->
+        (* A *_global_* atomic on a shared array would use the 32-bit
+           shared-window offset as a 64-bit global address — silent
+           corruption (audit finding M5). *)
+        unsupported
+          (intr ^ ": '" ^ arr.var_name
+         ^ "' is a shared array; use the non-global atomic form")
     | Some SpaceShared | None -> ()) ;
+    (* The intrinsic's hardwired stride must match the array's element
+       width: atomic_add_int32 on an int64/f64 vector would index with a
+       4-byte stride into 8-byte elements — silent corruption of
+       neighbouring elements (audit finding M5). *)
+    (let elt = infer_elt_type alloc arr.var_name in
+     let width_shift =
+       match elt with
+       | TInt32 | TFloat32 | TBool -> Some 2
+       | TInt64 | TFloat64 -> Some 3
+       | _ -> None
+     in
+     match width_shift with
+     | Some w when w <> elt_shift ->
+         unsupported
+           (Printf.sprintf
+              "%s: array '%s' has %d-byte elements but this atomic addresses \
+               %d-byte elements; use the matching-width atomic"
+              intr
+              arr.var_name
+              (1 lsl w)
+              (1 lsl elt_shift))
+     | Some _ -> ()
+     | None ->
+         unsupported
+           (intr ^ ": atomics require a scalar int/float element type, but '"
+          ^ arr.var_name ^ "' has an aggregate element type")) ;
     let is_shared =
       (not global_only) && arr_space_of alloc arr.var_name = Some SpaceShared
     in
@@ -1343,7 +1376,7 @@ and emit_intrinsic_native buf alloc env path name args : string =
           end
           else (op, r_val0)
         in
-        let space, r_addr = atomic_addr ~global_only ~elt_shift arr r_idx in
+        let space, r_addr = atomic_addr ~intr ~global_only ~elt_shift arr r_idx in
         let r_old = new_atom_result result in
         emit buf "atom.%s.%s%s %s, [%s], %s;" space op ty r_old r_addr r_val ;
         r_old
@@ -1361,7 +1394,7 @@ and emit_intrinsic_native buf alloc env path name args : string =
         check_atom_operand intr result r_cmp ;
         check_atom_operand intr result r_val ;
         let space, r_addr =
-          atomic_addr ~global_only:false ~elt_shift arr r_idx
+          atomic_addr ~intr ~global_only:false ~elt_shift arr r_idx
         in
         let r_old = new_atom_result result in
         emit
@@ -1389,7 +1422,7 @@ and emit_intrinsic_native buf alloc env path name args : string =
     match args with
     | [EVar arr; idx_e] ->
         let r_idx = emit_expr buf alloc env idx_e in
-        let space, r_addr = atomic_addr ~global_only ~elt_shift:2 arr r_idx in
+        let space, r_addr = atomic_addr ~intr ~global_only ~elt_shift:2 arr r_idx in
         let r_lim = new_u32 alloc in
         emit buf "mov.u32 %s, 0xffffffff;" r_lim ;
         let r_old = new_u32 alloc in

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -902,12 +902,15 @@ and emit_binop buf alloc env op e1 e2 : string =
         emit buf "div.approx.f32 %s, %s, %s;" r r1 r2 ;
         r)
       else if is_u64 r1 then (
+        (* Sarek int64 is signed: div.u64 on negative operands is silently
+           wrong ((-7)/2 = huge). add/sub/mul are sign-agnostic in two's
+           complement; div/rem are not (audit finding H1). *)
         let r = new_u64 alloc in
-        emit buf "div.u64 %s, %s, %s;" r r1 r2 ;
+        emit buf "div.s64 %s, %s, %s;" r r1 r2 ;
         r)
       else
         let r = new_u32 alloc in
-        emit buf "div.u32 %s, %s, %s;" r r1 r2 ;
+        emit buf "div.s32 %s, %s, %s;" r r1 r2 ;
         r
   | Mod ->
       (* Float Mod is C fmod: x - trunc(x/y)*y, result sign follows the
@@ -937,12 +940,14 @@ and emit_binop buf alloc env op e1 e2 : string =
         emit buf "fma.rn.f32 %s, %s, %s, %s;" r nt r2 r1 ;
         r)
       else if is_u64 r1 then (
+        (* Signed rem, matching C's % (result sign follows the dividend),
+           the interpreter's Int64.rem, and every C-family backend. *)
         let r = new_u64 alloc in
-        emit buf "rem.u64 %s, %s, %s;" r r1 r2 ;
+        emit buf "rem.s64 %s, %s, %s;" r r1 r2 ;
         r)
       else
         let r = new_u32 alloc in
-        emit buf "rem.u32 %s, %s, %s;" r r1 r2 ;
+        emit buf "rem.s32 %s, %s, %s;" r r1 r2 ;
         r
   | Eq ->
       let p = new_pred alloc in

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1376,7 +1376,9 @@ and emit_intrinsic_native buf alloc env path name args : string =
           end
           else (op, r_val0)
         in
-        let space, r_addr = atomic_addr ~intr ~global_only ~elt_shift arr r_idx in
+        let space, r_addr =
+          atomic_addr ~intr ~global_only ~elt_shift arr r_idx
+        in
         let r_old = new_atom_result result in
         emit buf "atom.%s.%s%s %s, [%s], %s;" space op ty r_old r_addr r_val ;
         r_old
@@ -1422,7 +1424,9 @@ and emit_intrinsic_native buf alloc env path name args : string =
     match args with
     | [EVar arr; idx_e] ->
         let r_idx = emit_expr buf alloc env idx_e in
-        let space, r_addr = atomic_addr ~intr ~global_only ~elt_shift:2 arr r_idx in
+        let space, r_addr =
+          atomic_addr ~intr ~global_only ~elt_shift:2 arr r_idx
+        in
         let r_lim = new_u32 alloc in
         emit buf "mov.u32 %s, 0xffffffff;" r_lim ;
         let r_old = new_u32 alloc in

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -285,6 +285,131 @@ let rec zero_binding buf (b : binding) : unit =
       emit buf "mov.u32 %s, 0;" tag_reg ;
       List.iter (fun (_, bs) -> List.iter (zero_binding buf) bs) ctors
 
+(** Exact C-semantics fmod (audit finding M1): the single-pass
+    [x - trunc(x/y)*y] formula is only exact while the quotient fits the
+    mantissa; beyond 2^53 (f64) / 2^24 (f32) the rounded quotient carries
+    absolute error >> 1 and the result can leave [0, |y|) or flip sign.
+    This emits an iterative reduction instead:
+
+    - outer loop: while |r| >= |y|, subtract trunc(r/y)*y via a single fma
+      (each round shrinks |r| by ~2^-mantissa, so it terminates in <= ~20
+      rounds for f64 / ~6 for f32; once |r| < |y| the quotient truncates
+      to 0 and further rounds are exact no-ops);
+    - overflow branch: if r/y overflows to inf (huge x with tiny/subnormal
+      y), reduce against y * 2^k (k = 1022 f64 / 126 f32, exact scaling and
+      still a multiple of y, so congruence mod y is preserved), retrying
+      with a larger scale while the scaled quotient is still inf;
+    - sign fix: the last fma can land one |y| past zero on the wrong side;
+      one conditional +/-|y| restores the dividend's sign, and a final
+      copysign fixes the sign of a +/-0 result;
+    - domain guard: y = 0, y = NaN, |x| = inf and x = NaN all produce NaN
+      (C fmod contract); x mod inf = x falls out naturally.
+
+    Validated bit-exact against OCaml's [Float.rem] (C fmod) on 200k
+    full-exponent-range fuzz cases including subnormals and the
+    overflow-scaling path (see commit message). *)
+let emit_float_fmod buf alloc ~is64 rx ry : string =
+  let newf () = if is64 then new_f64 alloc else new_f32 alloc in
+  let s = if is64 then "f64" else "f32" in
+  let const b64 b32 =
+    if is64 then Printf.sprintf "0D%016LX" b64 else Printf.sprintf "0F%08lX" b32
+  in
+  let c_inf = const 0x7FF0000000000000L 0x7F800000l in
+  let c_nan = const 0x7FF8000000000000L 0x7FC00000l in
+  (* 2^1022 / 2^126: largest power-of-two scale that keeps y * scale exact
+     and finite for every y small enough to make x/y overflow. *)
+  let c_scale = const 0x7FD0000000000000L 0x7E800000l in
+  let c_zero = const 0L 0l in
+  let rz = newf () in
+  emit buf "mov.%s %s, %s;" s rz c_zero ;
+  let rinf = newf () in
+  emit buf "mov.%s %s, %s;" s rinf c_inf ;
+  let rscale = newf () in
+  emit buf "mov.%s %s, %s;" s rscale c_scale ;
+  let ay = newf () in
+  emit buf "abs.%s %s, %s;" s ay ry ;
+  let ax = newf () in
+  emit buf "abs.%s %s, %s;" s ax rx ;
+  let r = newf () in
+  emit buf "mov.%s %s, %s;" s r rx ;
+  let l_outer = new_label alloc in
+  let l_scale = new_label alloc in
+  let l_scale_loop = new_label alloc in
+  let l_fix = new_label alloc in
+  (* Domain guard: ay > 0 rejects y = 0 and y = NaN; ax < inf rejects
+     x = +/-inf and x = NaN. *)
+  let p_y = new_pred alloc in
+  emit buf "setp.gt.%s %s, %s, %s;" s p_y ay rz ;
+  let p_x = new_pred alloc in
+  emit buf "setp.lt.%s %s, %s, %s;" s p_x ax rinf ;
+  let p_ok = new_pred alloc in
+  emit buf "and.pred %s, %s, %s;" p_ok p_y p_x ;
+  emit buf "@%s bra %s;" p_ok l_outer ;
+  emit buf "mov.%s %s, %s;" s r c_nan ;
+  emit buf "bra %s;" l_fix ;
+  emit_label buf l_outer ;
+  let ar = newf () in
+  emit buf "abs.%s %s, %s;" s ar r ;
+  let p_done = new_pred alloc in
+  emit buf "setp.lt.%s %s, %s, %s;" s p_done ar ay ;
+  emit buf "@%s bra %s;" p_done l_fix ;
+  let q = newf () in
+  emit buf "div.rn.%s %s, %s, %s;" s q r ry ;
+  let aq = newf () in
+  emit buf "abs.%s %s, %s;" s aq q ;
+  let p_qinf = new_pred alloc in
+  emit buf "setp.eq.%s %s, %s, %s;" s p_qinf aq rinf ;
+  emit buf "@%s bra %s;" p_qinf l_scale ;
+  let t = newf () in
+  emit buf "cvt.rzi.%s.%s %s, %s;" s s t q ;
+  let nt = newf () in
+  emit buf "neg.%s %s, %s;" s nt t ;
+  emit buf "fma.rn.%s %s, %s, %s, %s;" s r nt ry r ;
+  emit buf "bra %s;" l_outer ;
+  emit_label buf l_scale ;
+  let ys = newf () in
+  emit buf "mov.%s %s, %s;" s ys ry ;
+  emit_label buf l_scale_loop ;
+  emit buf "mul.%s %s, %s, %s;" s ys ys rscale ;
+  let q2 = newf () in
+  emit buf "div.rn.%s %s, %s, %s;" s q2 r ys ;
+  let aq2 = newf () in
+  emit buf "abs.%s %s, %s;" s aq2 q2 ;
+  let p_q2inf = new_pred alloc in
+  emit buf "setp.eq.%s %s, %s, %s;" s p_q2inf aq2 rinf ;
+  emit buf "@%s bra %s;" p_q2inf l_scale_loop ;
+  let t2 = newf () in
+  emit buf "cvt.rzi.%s.%s %s, %s;" s s t2 q2 ;
+  let nt2 = newf () in
+  emit buf "neg.%s %s, %s;" s nt2 t2 ;
+  emit buf "fma.rn.%s %s, %s, %s, %s;" s r nt2 ys r ;
+  emit buf "bra %s;" l_outer ;
+  emit_label buf l_fix ;
+  let p_rn = new_pred alloc in
+  emit buf "setp.lt.%s %s, %s, %s;" s p_rn r rz ;
+  let p_xp = new_pred alloc in
+  emit buf "setp.ge.%s %s, %s, %s;" s p_xp rx rz ;
+  let p_c1 = new_pred alloc in
+  emit buf "and.pred %s, %s, %s;" p_c1 p_rn p_xp ;
+  let p_rp = new_pred alloc in
+  emit buf "setp.gt.%s %s, %s, %s;" s p_rp r rz ;
+  let p_xn = new_pred alloc in
+  emit buf "setp.lt.%s %s, %s, %s;" s p_xn rx rz ;
+  let p_c2 = new_pred alloc in
+  emit buf "and.pred %s, %s, %s;" p_c2 p_rp p_xn ;
+  let c = newf () in
+  emit buf "selp.%s %s, %s, %s, %s;" s c ay rz p_c1 ;
+  let nay = newf () in
+  emit buf "neg.%s %s, %s;" s nay ay ;
+  emit buf "selp.%s %s, %s, %s, %s;" s c nay c p_c2 ;
+  emit buf "add.%s %s, %s, %s;" s r r c ;
+  (* copysign d, a, b = |b| with a's sign: post-fix sign(r) already matches
+     sign(x) for r <> 0, so this only normalizes the sign of a zero result
+     (fmod(-x, y) must return -0 when the remainder is exact). *)
+  let res = newf () in
+  emit buf "copysign.%s %s, %s, %s;" s res rx r ;
+  res
+
 (** {1 Expression emitter}
 
     Returns the PTX register name holding the result. Emits instructions into
@@ -928,32 +1053,11 @@ and emit_binop buf alloc env op e1 e2 : string =
         emit buf "div.s32 %s, %s, %s;" r r1 r2 ;
         r
   | Mod ->
-      (* Float Mod is C fmod: x - trunc(x/y)*y, result sign follows the
-         dividend x. OCaml's Float.rem has the same contract (it is C fmod),
-         so this matches mod_float on the host. rn-rounded div (not the fast
-         .approx form): the trunc snaps the quotient to an integer, so the
-         quotient's rounding error only shows within 1 ulp of an integer
-         boundary; the final fma is a single rounding. *)
-      if is_f64 r1 then (
-        let q = new_f64 alloc in
-        emit buf "div.rn.f64 %s, %s, %s;" q r1 r2 ;
-        let t = new_f64 alloc in
-        emit buf "cvt.rzi.f64.f64 %s, %s;" t q ;
-        let nt = new_f64 alloc in
-        emit buf "neg.f64 %s, %s;" nt t ;
-        let r = new_f64 alloc in
-        emit buf "fma.rn.f64 %s, %s, %s, %s;" r nt r2 r1 ;
-        r)
-      else if is_f32 r1 then (
-        let q = new_f32 alloc in
-        emit buf "div.rn.f32 %s, %s, %s;" q r1 r2 ;
-        let t = new_f32 alloc in
-        emit buf "cvt.rzi.f32.f32 %s, %s;" t q ;
-        let nt = new_f32 alloc in
-        emit buf "neg.f32 %s, %s;" nt t ;
-        let r = new_f32 alloc in
-        emit buf "fma.rn.f32 %s, %s, %s, %s;" r nt r2 r1 ;
-        r)
+      (* Float Mod is C fmod (exact for all finite inputs, result sign
+         follows the dividend). Lowered by emit_float_fmod's iterative
+         reduction - see its doc comment (audit finding M1). *)
+      if is_f64 r1 then emit_float_fmod buf alloc ~is64:true r1 r2
+      else if is_f32 r1 then emit_float_fmod buf alloc ~is64:false r1 r2
       else if is_u64 r1 then (
         (* Signed rem, matching C's % (result sign follows the dividend),
            the interpreter's Int64.rem, and every C-family backend. *)

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -908,8 +908,13 @@ and emit_binop buf alloc env op e1 e2 : string =
         emit buf "div.rn.f64 %s, %s, %s;" r r1 r2 ;
         r)
       else if is_f32 r1 then (
+        (* Correctly-rounded division (audit finding M2): div.approx.f32 is
+           ~2 ulp and badly wrong at exponent extremes, which made PTX the
+           least-accurate backend for ordinary /. and eroded Sarek_df64's
+           error budget. Fast approximate division stays available to
+           intrinsics that are already approximate (tan, tanh). *)
         let r = new_f32 alloc in
-        emit buf "div.approx.f32 %s, %s, %s;" r r1 r2 ;
+        emit buf "div.rn.f32 %s, %s, %s;" r r1 r2 ;
         r)
       else if is_u64 r1 then (
         (* Sarek int64 is signed: div.u64 on negative operands is silently

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -343,17 +343,27 @@ let rec emit_expr buf alloc (env : env) (expr : expr) : string =
         emit buf "neg.s32 %s, %s;" r r_src ;
         r
   | EUnop (Not, e) ->
+      (* Bools are u32 0/1 post-typer, but be class-aware so a 64-bit
+         operand cannot produce invalid setp.eq.u32-on-%rd PTX (H2). *)
       let r_src = emit_expr buf alloc env e in
+      let is_u64 r = String.length r >= 3 && r.[1] = 'r' && r.[2] = 'd' in
       let p = new_pred alloc in
-      emit buf "setp.eq.u32 %s, %s, 0;" p r_src ;
+      if is_u64 r_src then emit buf "setp.eq.s64 %s, %s, 0;" p r_src
+      else emit buf "setp.eq.u32 %s, %s, 0;" p r_src ;
       let r = new_u32 alloc in
       emit buf "selp.u32 %s, 1, 0, %s;" r p ;
       r
   | EUnop (BitNot, e) ->
       let r_src = emit_expr buf alloc env e in
-      let r = new_u32 alloc in
-      emit buf "not.b32 %s, %s;" r r_src ;
-      r
+      let is_u64 r = String.length r >= 3 && r.[1] = 'r' && r.[2] = 'd' in
+      if is_u64 r_src then (
+        let r = new_u64 alloc in
+        emit buf "not.b64 %s, %s;" r r_src ;
+        r)
+      else
+        let r = new_u32 alloc in
+        emit buf "not.b32 %s, %s;" r r_src ;
+        r
   | EArrayRead (arr_name, idx_expr) ->
       let r_base = env_lookup env arr_name in
       let r_idx = emit_expr buf alloc env idx_expr in
@@ -949,51 +959,31 @@ and emit_binop buf alloc env op e1 e2 : string =
         let r = new_u32 alloc in
         emit buf "rem.s32 %s, %s, %s;" r r1 r2 ;
         r
-  | Eq ->
+  | Eq | Ne | Lt | Le | Gt | Ge ->
+      (* Comparison family, class-aware (audit finding H2): the old code
+         fell through to setp.*.u32/s32 even on %rd (64-bit) operands,
+         which is invalid PTX and fails at module load. Sarek ints are
+         signed, so the integer forms are s32/s64 (sign matters for
+         Lt/Le/Gt/Ge; for Eq/Ne it is irrelevant but harmless). *)
+      let cmp =
+        match op with
+        | Eq -> "eq"
+        | Ne -> "ne"
+        | Lt -> "lt"
+        | Le -> "le"
+        | Gt -> "gt"
+        | Ge -> "ge"
+        | _ -> assert false
+      in
+      let ty =
+        if is_f64 r1 then "f64"
+        else if is_f32 r1 then "f32"
+        else if is_u64 r1 then "s64"
+        else if cmp = "eq" || cmp = "ne" then "u32"
+        else "s32"
+      in
       let p = new_pred alloc in
-      if is_f64 r1 then emit buf "setp.eq.f64 %s, %s, %s;" p r1 r2
-      else if is_f32 r1 then emit buf "setp.eq.f32 %s, %s, %s;" p r1 r2
-      else emit buf "setp.eq.u32 %s, %s, %s;" p r1 r2 ;
-      let r = new_u32 alloc in
-      emit buf "selp.u32 %s, 1, 0, %s;" r p ;
-      r
-  | Ne ->
-      let p = new_pred alloc in
-      if is_f64 r1 then emit buf "setp.ne.f64 %s, %s, %s;" p r1 r2
-      else if is_f32 r1 then emit buf "setp.ne.f32 %s, %s, %s;" p r1 r2
-      else emit buf "setp.ne.u32 %s, %s, %s;" p r1 r2 ;
-      let r = new_u32 alloc in
-      emit buf "selp.u32 %s, 1, 0, %s;" r p ;
-      r
-  | Lt ->
-      let p = new_pred alloc in
-      if is_f64 r1 then emit buf "setp.lt.f64 %s, %s, %s;" p r1 r2
-      else if is_f32 r1 then emit buf "setp.lt.f32 %s, %s, %s;" p r1 r2
-      else emit buf "setp.lt.s32 %s, %s, %s;" p r1 r2 ;
-      let r = new_u32 alloc in
-      emit buf "selp.u32 %s, 1, 0, %s;" r p ;
-      r
-  | Le ->
-      let p = new_pred alloc in
-      if is_f64 r1 then emit buf "setp.le.f64 %s, %s, %s;" p r1 r2
-      else if is_f32 r1 then emit buf "setp.le.f32 %s, %s, %s;" p r1 r2
-      else emit buf "setp.le.s32 %s, %s, %s;" p r1 r2 ;
-      let r = new_u32 alloc in
-      emit buf "selp.u32 %s, 1, 0, %s;" r p ;
-      r
-  | Gt ->
-      let p = new_pred alloc in
-      if is_f64 r1 then emit buf "setp.gt.f64 %s, %s, %s;" p r1 r2
-      else if is_f32 r1 then emit buf "setp.gt.f32 %s, %s, %s;" p r1 r2
-      else emit buf "setp.gt.s32 %s, %s, %s;" p r1 r2 ;
-      let r = new_u32 alloc in
-      emit buf "selp.u32 %s, 1, 0, %s;" r p ;
-      r
-  | Ge ->
-      let p = new_pred alloc in
-      if is_f64 r1 then emit buf "setp.ge.f64 %s, %s, %s;" p r1 r2
-      else if is_f32 r1 then emit buf "setp.ge.f32 %s, %s, %s;" p r1 r2
-      else emit buf "setp.ge.s32 %s, %s, %s;" p r1 r2 ;
+      emit buf "setp.%s.%s %s, %s, %s;" cmp ty p r1 r2 ;
       let r = new_u32 alloc in
       emit buf "selp.u32 %s, 1, 0, %s;" r p ;
       r
@@ -1324,9 +1314,18 @@ and emit_intrinsic_native buf alloc env path name args : string =
             r)
         else if is_f32_reg rb || is_f64_reg rb then mismatch ()
         else
-          let r = new_u32 alloc in
-          emit buf "%s.s32 %s, %s, %s;" op r ra rb ;
-          r
+          let is_u64 r = String.length r >= 3 && r.[1] = 'r' && r.[2] = 'd' in
+          if is_u64 ra then (
+            if not (is_u64 rb) then mismatch ()
+            else
+              let r = new_u64 alloc in
+              emit buf "%s.s64 %s, %s, %s;" op r ra rb ;
+              r)
+          else if is_u64 rb then mismatch ()
+          else
+            let r = new_u32 alloc in
+            emit buf "%s.s32 %s, %s, %s;" op r ra rb ;
+            r
     | _ -> unsupported (intr ^ " arity != 2")
   in
   (* Unary same-type float rounding via cvt (rmi = floor, rpi = ceil). *)

--- a/sarek/codegen/Sarek_ir_ptx_softmath.ml
+++ b/sarek/codegen/Sarek_ir_ptx_softmath.ml
@@ -275,6 +275,15 @@ let inv_fact k =
 (** exp(x): n = rint(x·log2 e) (as floor(·+0.5)); r = x − n·ln2 (hi/lo split, 2
     fma); degree-12 Taylor on r ∈ [−ln2/2, ln2/2] (truncation ≈ 1.7e-16
     relative); scale by 2^n via exponent-field construction (n+1023) << 52. *)
+(* Saturation bounds for the 2^n exponent-field construction: n must stay in
+   [-1022, 1024] or (n + 1023) << 52 wraps into the sign/exponent bits and
+   returns garbage instead of 0/inf (audit finding M3). log(max_float) =
+   709.7827...; below -708 the true result is subnormal and this tier
+   flushes to zero (documented: no gradual underflow). *)
+let exp_hi_cut = 709.782712893384
+
+let exp_lo_cut = -708.0
+
 let exp_body x =
   let nf = fvar "nf" in
   let r_hi = fvar "r_hi" in
@@ -283,7 +292,8 @@ let exp_body x =
   let n = ivar "n" in
   (* c12 … c3, then c2 = 1/2 as the Horner constant term. *)
   let coeffs = List.init 10 (fun i -> inv_fact (12 - i)) in
-  let_ nf (floor_ (fma (EVar x) (f64 log2_e) (f64 0.5)))
+  let core =
+    let_ nf (floor_ (fma (EVar x) (f64 log2_e) (f64 0.5)))
   @@ let_ r_hi (fma (EVar nf) (f64 (-.ln2_hi)) (EVar x))
   @@ let_ r (fma (EVar nf) (f64 (-.ln2_lo)) (EVar r_hi))
   (* exp(r) = 1 + r·(1 + r·(1/2 + r/6 + …)) *)
@@ -294,6 +304,12 @@ let exp_body x =
   @@ SReturn
        (fma (EVar p) (EVar r) (f64 1.0)
        *! unbits (shl (to_i64 (EVar n +! i32 1023)) 52))
+  in
+  SIf
+    ( EVar x <! f64 exp_lo_cut,
+      SReturn (f64 0.0),
+      Some
+        (SIf (EVar x >! f64 exp_hi_cut, SReturn (f64 infinity), Some core)) )
 
 (** log(x): exponent extract + mantissa normalized to [√2/2, √2), then
     log(m) = 2·atanh(s) with s = (m−1)/(m+1): odd Taylor to s¹⁵ (truncation
@@ -615,7 +631,8 @@ let expm1_body x =
   let e = fvar "e" in
   let n = ivar "n" in
   let e2 = fvar "e2" in
-  let_ nf (floor_ (fma (EVar x) (f64 log2_e) (f64 0.5)))
+  let core =
+    let_ nf (floor_ (fma (EVar x) (f64 log2_e) (f64 0.5)))
   @@ let_ hi (fma (EVar nf) (f64 (-.ln2_hi)) (EVar x))
   @@ let_ lo (EVar nf *! f64 ln2_lo)
   @@ let_ xr (EVar hi -! EVar lo)
@@ -644,6 +661,14 @@ let expm1_body x =
                    (f64 1.0 -! (EVar e2 -! EVar xr))
                    (unbits (shl (to_i64 (EVar n +! i32 1023)) 52))
                    (f64 (-1.0)))) )
+  in
+  (* Same exponent-field saturation as exp (audit finding M3): below the
+     cut expm1 = -1 to within 1 ulp; above, +inf. *)
+  SIf
+    ( EVar x <! f64 exp_lo_cut,
+      SReturn (f64 (-1.0)),
+      Some
+        (SIf (EVar x >! f64 exp_hi_cut, SReturn (f64 infinity), Some core)) )
 
 (** log1p(x): fdlibm 5.3 s_log1p.c — u = 1 + x with the rounding correction
     c = (k > 0 ? 1 − (u − x) : x − (u − 1))/u, u's mantissa normalized to

--- a/sarek/codegen/Sarek_ir_ptx_softmath.ml
+++ b/sarek/codegen/Sarek_ir_ptx_softmath.ml
@@ -272,14 +272,15 @@ let inv_fact k =
 
 (** {1 Helper bodies} *)
 
-(** exp(x): n = rint(x·log2 e) (as floor(·+0.5)); r = x − n·ln2 (hi/lo split, 2
-    fma); degree-12 Taylor on r ∈ [−ln2/2, ln2/2] (truncation ≈ 1.7e-16
-    relative); scale by 2^n via exponent-field construction (n+1023) << 52. *)
 (* Saturation bounds for the 2^n exponent-field construction: n must stay in
    [-1022, 1024] or (n + 1023) << 52 wraps into the sign/exponent bits and
    returns garbage instead of 0/inf (audit finding M3). log(max_float) =
    709.7827...; below -708 the true result is subnormal and this tier
    flushes to zero (documented: no gradual underflow). *)
+
+(** exp(x): n = rint(x·log2 e) (as floor(·+0.5)); r = x − n·ln2 (hi/lo split, 2
+    fma); degree-12 Taylor on r ∈ [−ln2/2, ln2/2] (truncation ≈ 1.7e-16
+    relative); scale by 2^n via exponent-field construction (n+1023) << 52. *)
 let exp_hi_cut = 709.782712893384
 
 let exp_lo_cut = -708.0
@@ -294,22 +295,22 @@ let exp_body x =
   let coeffs = List.init 10 (fun i -> inv_fact (12 - i)) in
   let core =
     let_ nf (floor_ (fma (EVar x) (f64 log2_e) (f64 0.5)))
-  @@ let_ r_hi (fma (EVar nf) (f64 (-.ln2_hi)) (EVar x))
-  @@ let_ r (fma (EVar nf) (f64 (-.ln2_lo)) (EVar r_hi))
-  (* exp(r) = 1 + r·(1 + r·(1/2 + r/6 + …)) *)
-  @@ let_
-       p
-       (fma (horner (EVar r) ~coeffs ~last:(inv_fact 2)) (EVar r) (f64 1.0))
-  @@ let_ n (to_i32 (EVar nf))
-  @@ SReturn
-       (fma (EVar p) (EVar r) (f64 1.0)
-       *! unbits (shl (to_i64 (EVar n +! i32 1023)) 52))
+    @@ let_ r_hi (fma (EVar nf) (f64 (-.ln2_hi)) (EVar x))
+    @@ let_ r (fma (EVar nf) (f64 (-.ln2_lo)) (EVar r_hi))
+    (* exp(r) = 1 + r·(1 + r·(1/2 + r/6 + …)) *)
+    @@ let_
+         p
+         (fma (horner (EVar r) ~coeffs ~last:(inv_fact 2)) (EVar r) (f64 1.0))
+    @@ let_ n (to_i32 (EVar nf))
+    @@ SReturn
+         (fma (EVar p) (EVar r) (f64 1.0)
+         *! unbits (shl (to_i64 (EVar n +! i32 1023)) 52))
   in
   SIf
     ( EVar x <! f64 exp_lo_cut,
       SReturn (f64 0.0),
-      Some
-        (SIf (EVar x >! f64 exp_hi_cut, SReturn (f64 infinity), Some core)) )
+      Some (SIf (EVar x >! f64 exp_hi_cut, SReturn (f64 infinity), Some core))
+    )
 
 (** log(x): exponent extract + mantissa normalized to [√2/2, √2), then
     log(m) = 2·atanh(s) with s = (m−1)/(m+1): odd Taylor to s¹⁵ (truncation
@@ -633,42 +634,42 @@ let expm1_body x =
   let e2 = fvar "e2" in
   let core =
     let_ nf (floor_ (fma (EVar x) (f64 log2_e) (f64 0.5)))
-  @@ let_ hi (fma (EVar nf) (f64 (-.ln2_hi)) (EVar x))
-  @@ let_ lo (EVar nf *! f64 ln2_lo)
-  @@ let_ xr (EVar hi -! EVar lo)
-  @@ let_ c (EVar hi -! EVar xr -! EVar lo)
-  @@ let_ hfx (f64 0.5 *! EVar xr)
-  @@ let_ hxs (EVar xr *! EVar hfx)
-  @@ let_
-       r1
-       (fma
-          (EVar hxs)
-          (horner (EVar hxs) ~coeffs:expm1_q_coeffs ~last:expm1_q1)
-          (f64 1.0))
-  @@ let_ t (fma (EVar r1) (neg (EVar hfx)) (f64 3.0))
-  @@ let_
-       e
-       (EVar hxs
-       *! ((EVar r1 -! EVar t) /! fma (neg (EVar xr)) (EVar t) (f64 6.0)))
-  @@ let_ n (to_i32 (EVar nf))
-  @@ SIf
-       ( EVar n =! i32 0,
-         SReturn (EVar xr -! ((EVar xr *! EVar e) -! EVar hxs)),
-         Some
-           (let_ e2 ((EVar xr *! (EVar e -! EVar c)) -! EVar c -! EVar hxs)
-           @@ SReturn
-                (fma
-                   (f64 1.0 -! (EVar e2 -! EVar xr))
-                   (unbits (shl (to_i64 (EVar n +! i32 1023)) 52))
-                   (f64 (-1.0)))) )
+    @@ let_ hi (fma (EVar nf) (f64 (-.ln2_hi)) (EVar x))
+    @@ let_ lo (EVar nf *! f64 ln2_lo)
+    @@ let_ xr (EVar hi -! EVar lo)
+    @@ let_ c (EVar hi -! EVar xr -! EVar lo)
+    @@ let_ hfx (f64 0.5 *! EVar xr)
+    @@ let_ hxs (EVar xr *! EVar hfx)
+    @@ let_
+         r1
+         (fma
+            (EVar hxs)
+            (horner (EVar hxs) ~coeffs:expm1_q_coeffs ~last:expm1_q1)
+            (f64 1.0))
+    @@ let_ t (fma (EVar r1) (neg (EVar hfx)) (f64 3.0))
+    @@ let_
+         e
+         (EVar hxs
+         *! ((EVar r1 -! EVar t) /! fma (neg (EVar xr)) (EVar t) (f64 6.0)))
+    @@ let_ n (to_i32 (EVar nf))
+    @@ SIf
+         ( EVar n =! i32 0,
+           SReturn (EVar xr -! ((EVar xr *! EVar e) -! EVar hxs)),
+           Some
+             (let_ e2 ((EVar xr *! (EVar e -! EVar c)) -! EVar c -! EVar hxs)
+             @@ SReturn
+                  (fma
+                     (f64 1.0 -! (EVar e2 -! EVar xr))
+                     (unbits (shl (to_i64 (EVar n +! i32 1023)) 52))
+                     (f64 (-1.0)))) )
   in
   (* Same exponent-field saturation as exp (audit finding M3): below the
      cut expm1 = -1 to within 1 ulp; above, +inf. *)
   SIf
     ( EVar x <! f64 exp_lo_cut,
       SReturn (f64 (-1.0)),
-      Some
-        (SIf (EVar x >! f64 exp_hi_cut, SReturn (f64 infinity), Some core)) )
+      Some (SIf (EVar x >! f64 exp_hi_cut, SReturn (f64 infinity), Some core))
+    )
 
 (** log1p(x): fdlibm 5.3 s_log1p.c — u = 1 + x with the rounding correction
     c = (k > 0 ? 1 − (u − x) : x − (u − 1))/u, u's mantissa normalized to

--- a/sarek/framework/Framework_registry.ml
+++ b/sarek/framework/Framework_registry.ml
@@ -73,10 +73,18 @@ let find_backend name =
 (** List all registered plugin names *)
 let names () = Hashtbl.to_seq_keys plugins |> List.of_seq
 
-(** List all available plugins (those where is_available returns true) *)
+(** List all available plugins (those where is_available returns true).
+
+    A probe failure counts as unavailable, but only for ordinary exceptions:
+    asynchronous/fatal ones (Out_of_memory, Stack_overflow, signals) must
+    propagate - swallowing them turned real failures into silent
+    "no backends found" (audit finding). *)
 let available () =
   Hashtbl.to_seq_values plugins
-  |> Seq.filter (fun (module P : S) -> try P.is_available () with _ -> false)
+  |> Seq.filter (fun (module P : S) ->
+         try P.is_available () with
+         | (Out_of_memory | Stack_overflow) as fatal -> raise fatal
+         | _ -> false)
   |> List.of_seq
 
 (** List all available full backends *)

--- a/sarek/framework/Framework_registry.ml
+++ b/sarek/framework/Framework_registry.ml
@@ -77,14 +77,14 @@ let names () = Hashtbl.to_seq_keys plugins |> List.of_seq
 
     A probe failure counts as unavailable, but only for ordinary exceptions:
     asynchronous/fatal ones (Out_of_memory, Stack_overflow, signals) must
-    propagate - swallowing them turned real failures into silent
-    "no backends found" (audit finding). *)
+    propagate - swallowing them turned real failures into silent "no backends
+    found" (audit finding). *)
 let available () =
   Hashtbl.to_seq_values plugins
   |> Seq.filter (fun (module P : S) ->
-         try P.is_available () with
-         | (Out_of_memory | Stack_overflow) as fatal -> raise fatal
-         | _ -> false)
+      try P.is_available () with
+      | (Out_of_memory | Stack_overflow) as fatal -> raise fatal
+      | _ -> false)
   |> List.of_seq
 
 (** List all available full backends *)

--- a/sarek/framework/Framework_registry.ml
+++ b/sarek/framework/Framework_registry.ml
@@ -79,19 +79,20 @@ let names () = Hashtbl.to_seq_keys plugins |> List.of_seq
     asynchronous/fatal ones (Out_of_memory, Stack_overflow, signals) must
     propagate - swallowing them turned real failures into silent "no backends
     found" (audit finding). *)
+let probe_available (is_available : unit -> bool) : bool =
+  try is_available () with
+  | (Out_of_memory | Stack_overflow | Sys.Break) as fatal -> raise fatal
+  | _ -> false
+
 let available () =
   Hashtbl.to_seq_values plugins
-  |> Seq.filter (fun (module P : S) ->
-      try P.is_available () with
-      | (Out_of_memory | Stack_overflow) as fatal -> raise fatal
-      | _ -> false)
+  |> Seq.filter (fun (module P : S) -> probe_available P.is_available)
   |> List.of_seq
 
 (** List all available full backends *)
 let available_backends () =
   Hashtbl.to_seq_values backends
-  |> Seq.filter (fun (module B : BACKEND) ->
-      try B.is_available () with _ -> false)
+  |> Seq.filter (fun (module B : BACKEND) -> probe_available B.is_available)
   |> List.of_seq
 
 (** Get the best available backend (highest priority) *)
@@ -99,7 +100,7 @@ let best_backend () =
   let available =
     Hashtbl.to_seq backends
     |> Seq.filter (fun (_name, (module B : BACKEND)) ->
-        try B.is_available () with _ -> false)
+        probe_available B.is_available)
     |> List.of_seq
   in
   match available with

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -213,8 +213,7 @@ let eval_binop op v1 v2 =
       | VFloat32 a, VFloat32 b -> VFloat32 (F32.to_float32 (Float.rem a b))
       | VFloat64 a, VFloat64 b -> VFloat64 (Float.rem a b)
       | VFloat32 _, _ | _, VFloat32 _ ->
-          VFloat32
-            (F32.to_float32 (Float.rem (to_float32 v1) (to_float32 v2)))
+          VFloat32 (F32.to_float32 (Float.rem (to_float32 v1) (to_float32 v2)))
       | VFloat64 _, _ | _, VFloat64 _ ->
           VFloat64 (Float.rem (to_float64 v1) (to_float64 v2))
       | VInt64 _, _ | _, VInt64 _ ->

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -207,6 +207,16 @@ let eval_binop op v1 v2 =
       | _ -> VInt32 (Int32.div (to_int32 v1) (to_int32 v2)))
   | Mod -> (
       match (v1, v2) with
+      (* Float Mod is C fmod on every backend; Float.rem is C fmod. The
+         float arms were missing entirely (audit follow-up to M1/M4): float
+         operands were truncated to ints before the rem. *)
+      | VFloat32 a, VFloat32 b -> VFloat32 (F32.to_float32 (Float.rem a b))
+      | VFloat64 a, VFloat64 b -> VFloat64 (Float.rem a b)
+      | VFloat32 _, _ | _, VFloat32 _ ->
+          VFloat32
+            (F32.to_float32 (Float.rem (to_float32 v1) (to_float32 v2)))
+      | VFloat64 _, _ | _, VFloat64 _ ->
+          VFloat64 (Float.rem (to_float64 v1) (to_float64 v2))
       | VInt64 _, _ | _, VInt64 _ ->
           VInt64 (Int64.rem (to_int64 v1) (to_int64 v2))
       | _ -> VInt32 (Int32.rem (to_int32 v1) (to_int32 v2)))

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -218,6 +218,8 @@ let eval_binop op v1 v2 =
       | VFloat64 a, VFloat64 b -> VBool (a < b)
       | VFloat32 _, _ | _, VFloat32 _ -> VBool (to_float32 v1 < to_float32 v2)
       | VFloat64 _, _ | _, VFloat64 _ -> VBool (to_float64 v1 < to_float64 v2)
+      | VInt64 _, _ | _, VInt64 _ ->
+          VBool (Int64.compare (to_int64 v1) (to_int64 v2) < 0)
       | _ -> VBool (to_int32 v1 < to_int32 v2))
   | Le -> (
       match (v1, v2) with
@@ -225,6 +227,8 @@ let eval_binop op v1 v2 =
       | VFloat64 a, VFloat64 b -> VBool (a <= b)
       | VFloat32 _, _ | _, VFloat32 _ -> VBool (to_float32 v1 <= to_float32 v2)
       | VFloat64 _, _ | _, VFloat64 _ -> VBool (to_float64 v1 <= to_float64 v2)
+      | VInt64 _, _ | _, VInt64 _ ->
+          VBool (Int64.compare (to_int64 v1) (to_int64 v2) <= 0)
       | _ -> VBool (to_int32 v1 <= to_int32 v2))
   | Gt -> (
       match (v1, v2) with
@@ -232,6 +236,8 @@ let eval_binop op v1 v2 =
       | VFloat64 a, VFloat64 b -> VBool (a > b)
       | VFloat32 _, _ | _, VFloat32 _ -> VBool (to_float32 v1 > to_float32 v2)
       | VFloat64 _, _ | _, VFloat64 _ -> VBool (to_float64 v1 > to_float64 v2)
+      | VInt64 _, _ | _, VInt64 _ ->
+          VBool (Int64.compare (to_int64 v1) (to_int64 v2) > 0)
       | _ -> VBool (to_int32 v1 > to_int32 v2))
   | Ge -> (
       match (v1, v2) with
@@ -239,21 +245,40 @@ let eval_binop op v1 v2 =
       | VFloat64 a, VFloat64 b -> VBool (a >= b)
       | VFloat32 _, _ | _, VFloat32 _ -> VBool (to_float32 v1 >= to_float32 v2)
       | VFloat64 _, _ | _, VFloat64 _ -> VBool (to_float64 v1 >= to_float64 v2)
+      | VInt64 _, _ | _, VInt64 _ ->
+          VBool (Int64.compare (to_int64 v1) (to_int64 v2) >= 0)
       | _ -> VBool (to_int32 v1 >= to_int32 v2))
   | And -> VBool (to_bool v1 && to_bool v2)
   | Or -> VBool (to_bool v1 || to_bool v2)
-  | Shl -> VInt32 (Int32.shift_left (to_int32 v1) (to_int v2))
-  | Shr ->
+  | Shl -> (
+      match v1 with
+      | VInt64 a -> VInt64 (Int64.shift_left a (to_int v2))
+      | _ -> VInt32 (Int32.shift_left (to_int32 v1) (to_int v2)))
+  | Shr -> (
       (* Arithmetic (sign-extending) shift, matching every codegen backend:
          CUDA/OpenCL/Metal/GLSL/WGSL emit plain [>>] on a signed int type,
-         and PTX emits shr.s32. [lsr] is lowered to a separate expression
-         tree in Sarek_lower_ir.ml precisely because this node is
+         and PTX emits shr.s32/shr.s64. [lsr] is lowered to a separate
+         expression tree in Sarek_lower_ir.ml precisely because this node is
          arithmetic - see G phase 1 in
          briefs/fix-critical-semantics-evidence.md. *)
-      VInt32 (Int32.shift_right (to_int32 v1) (to_int v2))
-  | BitAnd -> VInt32 (Int32.logand (to_int32 v1) (to_int32 v2))
-  | BitOr -> VInt32 (Int32.logor (to_int32 v1) (to_int32 v2))
-  | BitXor -> VInt32 (Int32.logxor (to_int32 v1) (to_int32 v2))
+      match v1 with
+      | VInt64 a -> VInt64 (Int64.shift_right a (to_int v2))
+      | _ -> VInt32 (Int32.shift_right (to_int32 v1) (to_int v2)))
+  | BitAnd -> (
+      match (v1, v2) with
+      | VInt64 _, _ | _, VInt64 _ ->
+          VInt64 (Int64.logand (to_int64 v1) (to_int64 v2))
+      | _ -> VInt32 (Int32.logand (to_int32 v1) (to_int32 v2)))
+  | BitOr -> (
+      match (v1, v2) with
+      | VInt64 _, _ | _, VInt64 _ ->
+          VInt64 (Int64.logor (to_int64 v1) (to_int64 v2))
+      | _ -> VInt32 (Int32.logor (to_int32 v1) (to_int32 v2)))
+  | BitXor -> (
+      match (v1, v2) with
+      | VInt64 _, _ | _, VInt64 _ ->
+          VInt64 (Int64.logxor (to_int64 v1) (to_int64 v2))
+      | _ -> VInt32 (Int32.logxor (to_int32 v1) (to_int32 v2)))
 
 let eval_unop op v =
   match op with
@@ -264,7 +289,10 @@ let eval_unop op v =
       | VInt64 n -> VInt64 (Int64.neg n)
       | _ -> VInt32 (Int32.neg (to_int32 v)))
   | Not -> VBool (not (to_bool v))
-  | BitNot -> VInt32 (Int32.lognot (to_int32 v))
+  | BitNot -> (
+      match v with
+      | VInt64 a -> VInt64 (Int64.lognot a)
+      | _ -> VInt32 (Int32.lognot (to_int32 v)))
 
 (** {1 Intrinsics} *)
 

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -533,6 +533,18 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
         (lower_expr state a)
         (lower_expr state b)
         (elttype_of_typ te.ty)
+  | TEBinop (And, a, b) ->
+      (* Short-circuit && (audit finding H3): a strict Ir.And evaluates both
+         operands eagerly on the PTX and Interpreter backends while the
+         C-family backends emit C's short-circuiting &&, so the classic
+         [i < n && a.(i) > 0.] bounds guard read out of bounds on PTX and
+         raised on the Interpreter. Lowering to EIf gives every backend
+         short-circuit semantics (the PTX EIf emitter already refuses to
+         evaluate memory-reading/effectful branches speculatively). *)
+      Ir.EIf (lower_expr state a, lower_expr state b, Ir.EConst (Ir.CBool false))
+  | TEBinop (Or, a, b) ->
+      (* Short-circuit || - see the && case above. *)
+      Ir.EIf (lower_expr state a, Ir.EConst (Ir.CBool true), lower_expr state b)
   | TEBinop (op, a, b) ->
       Ir.EBinop (ir_binop op te.ty, lower_expr state a, lower_expr state b)
   | TEUnop (op, a) -> Ir.EUnop (ir_unop op, lower_expr state a)

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -120,7 +120,12 @@ let type_align_registry : (string, int) Hashtbl.t = Hashtbl.create 16
    positive power of two (4 or 8) here; [a <= 1] is the identity. *)
 let align_up off a = if a <= 1 then off else (off + a - 1) / a * a
 
-(* Get size of a type, checking registry for custom types *)
+(* Get size of a type, checking registry for custom types.
+
+   Unknown or non-simple field types are a HARD ERROR, not a silent 4-byte
+   default: these sizes feed the aligned host ABI (L8), and a wrong
+   size/alignment silently desynchronizes host bytes from the device layout
+   (audit finding M6). *)
 let get_type_size_from_core_type (ct : core_type) : int =
   match ct.ptyp_desc with
   | Ptyp_constr ({txt = Lident "int32"; _}, _) -> 4
@@ -129,10 +134,23 @@ let get_type_size_from_core_type (ct : core_type) : int =
   | Ptyp_constr ({txt = Lident "float"; _}, _) -> 4 (* GPU float32 *)
   | Ptyp_constr ({txt = Lident "float64"; _}, _) -> 8
   | Ptyp_constr ({txt = Lident "int"; _}, _) -> 4
+  | Ptyp_constr ({txt = Lident "bool"; _}, _) -> 4
+  | Ptyp_constr ({txt = Lident "unit"; _}, _) -> 4
   | Ptyp_constr ({txt = Lident type_name; _}, _) -> (
       (* Check if it's a known custom type *)
-      try Hashtbl.find type_size_registry type_name with Not_found -> 4)
-  | _ -> 4
+      try Hashtbl.find type_size_registry type_name
+      with Not_found ->
+        Location.raise_errorf
+          ~loc:ct.ptyp_loc
+          "sarek: unknown size for field type '%s' - register it with \
+           [%%ktype] before using it as a record/variant field (a silent \
+           default would corrupt the host/device layout)"
+          type_name)
+  | _ ->
+      Location.raise_errorf
+        ~loc:ct.ptyp_loc
+        "sarek: unsupported field type in a GPU record/variant - only scalar \
+         types and [%%ktype]-registered names are supported here"
 
 (* Natural alignment of a field type, mirroring Sarek_ir_layout.elttype_align:
    4 for 32-bit scalars, 8 for int64/float64, and the registered alignment for a
@@ -145,9 +163,22 @@ let get_type_align_from_core_type (ct : core_type) : int =
   | Ptyp_constr ({txt = Lident "float"; _}, _) -> 4 (* GPU float32 *)
   | Ptyp_constr ({txt = Lident "float64"; _}, _) -> 8
   | Ptyp_constr ({txt = Lident "int"; _}, _) -> 4
+  | Ptyp_constr ({txt = Lident "bool"; _}, _) -> 4
+  | Ptyp_constr ({txt = Lident "unit"; _}, _) -> 4
   | Ptyp_constr ({txt = Lident type_name; _}, _) -> (
-      try Hashtbl.find type_align_registry type_name with Not_found -> 4)
-  | _ -> 4
+      try Hashtbl.find type_align_registry type_name
+      with Not_found ->
+        Location.raise_errorf
+          ~loc:ct.ptyp_loc
+          "sarek: unknown alignment for field type '%s' - register it with \
+           [%%ktype] before using it as a record/variant field (a silent \
+           default would corrupt the host/device layout)"
+          type_name)
+  | _ ->
+      Location.raise_errorf
+        ~loc:ct.ptyp_loc
+        "sarek: unsupported field type in a GPU record/variant - only scalar \
+         types and [%%ktype]-registered names are supported here"
 
 (* Aligned immediate-field offset table for a record: each field placed at the
    next offset satisfying its natural alignment. Returns (name, offset, type)

--- a/sarek/ppx/Sarek_tag_erasure.ml
+++ b/sarek/ppx/Sarek_tag_erasure.ml
@@ -136,6 +136,30 @@ let is_ctor_case (cname : string) ((p, _) : tpattern * texpr) : bool =
   | TPConstr (_, cn, arg) -> cn = cname && is_reducible_payload arg
   | _ -> false
 
+(* Could this arm match a value built with constructor [cname]? A wildcard or
+   variable pattern matches anything; a constructor pattern matches only its
+   own constructor; anything else on a variant scrutinee is treated
+   conservatively as matching. Used to detect arms that shadow the [cname] arm
+   under OCaml's first-match-wins semantics. *)
+let arm_matches_ctor (cname : string) ((p, _) : tpattern * texpr) : bool =
+  match p.tpat with
+  | TPAny | TPVar _ -> true
+  | TPConstr (_, cn, _) -> cn = cname
+  | _ -> true
+
+(* The reduction keeps the first arm satisfying [is_ctor_case]; that is only
+   correct if no earlier arm would also match a [cname] value at runtime.
+   Otherwise `match s with _ -> a | C x -> b` (first-match-wins => [a]) would be
+   miscompiled to [b]. Returns true when the [cname] arm is reachable. *)
+let ctor_arm_reachable (cname : string) (cases : (tpattern * texpr) list) : bool
+    =
+  let rec go = function
+    | [] -> true (* no cname arm at all; caller's List.exists handles that *)
+    | case :: _ when is_ctor_case cname case -> true
+    | case :: rest -> if arm_matches_ctor cname case then false else go rest
+  in
+  go cases
+
 (* Every read of the slot variable is the scrutinee of a `match` that has an
    explicit arm for [cname]. Any other use of the variable (which would need
    the whole tagged value) makes the slot ineligible. Variable ids are globally
@@ -146,7 +170,10 @@ let uses_all_reducible (id : int) (cname : string) (body : texpr) : bool =
     match e.te with
     | TEVar (_, i) when i = id -> ok := false (* bare use outside scrutinee *)
     | TEMatch (scrut, cases) when is_slot_var id scrut ->
-        if not (List.exists (is_ctor_case cname) cases) then ok := false ;
+        if
+          (not (List.exists (is_ctor_case cname) cases))
+          || not (ctor_arm_reachable cname cases)
+        then ok := false ;
         List.iter (fun (_, rhs) -> go rhs) cases
     | _ -> iter_children go e
   in

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -414,6 +414,7 @@
 
 (rule
  (alias runtest)
+ (enabled_if %{lib-available:sarek_vulkan})
  (action
   (run %{dep:test_vulkan_interleaved_push_constants.exe})))
 

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -372,7 +372,8 @@
   test_pragma.exe
   test_barrier_converged.exe
   test_superstep.exe
-  test_inline_pragma.exe))
+  test_inline_pragma.exe
+  test_ppx_scan_failure_warning.exe))
 
 ; Build-gate the compile-only tests under default `runtest` too, so a
 ; compile regression still fails CI, without executing them (this is the
@@ -388,7 +389,33 @@
   test_pragma.exe
   test_barrier_converged.exe
   test_superstep.exe
-  test_inline_pragma.exe))
+  test_inline_pragma.exe
+  test_ppx_scan_failure_warning.exe))
+
+; Regression tests wired to executing runtest rules (found unwired by
+; scripts/check-test-alias-coverage.sh - the guard added after the 2026-07
+; vacuous-e2e fix). test_vulkan_interleaved_push_constants self-skips
+; without a Vulkan device.
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_native_create_array.exe})))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_native_downto.exe})))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_bare_float_is_float32.exe})))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_vulkan_interleaved_push_constants.exe})))
 
 ; e2e-gpu alias: requires an actual GPU backend (no Native/Interpreter
 ; fallback path exists in the test). Not part of default `runtest`.

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -874,3 +874,31 @@
  (alias runtest)
  (action
   (run %{dep:test_record_field_tag_erasure.exe})))
+
+; H1 signed int32 div/rem hardware probe. Plain DSL [/] and [mod] on int32
+; run against OCaml Int32.div/Int32.rem on every available device (Native /
+; Interpreter always, plus CUDA/PTX under ZLUDA and any other GPU backend).
+; A wrong result from any device that ran is a hard failure - this is the
+; executed proof of the div.s32/rem.s32 retarget the snapshot only asserts.
+; Run with:
+;   LD_LIBRARY_PATH=$HOME/opt/zluda \
+;     dune exec sarek/tests/e2e/test_ptx_signed_arith.exe
+
+(executable
+ (name test_ptx_signed_arith)
+ (modules test_ptx_signed_arith)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  test_helpers
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_ptx_signed_arith.exe})))

--- a/sarek/tests/e2e/test_ptx_signed_arith.ml
+++ b/sarek/tests/e2e/test_ptx_signed_arith.ml
@@ -1,0 +1,188 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E hardware probe for signed integer division / remainder (audit H1).
+ *
+ * Sarek int32 is signed on every backend, but the PTX emitter used to lower
+ * integer Div/Mod to [div.u32]/[rem.u32]. On negative operands that returns
+ * silent garbage - e.g. (-7)/2 = 2147483644 instead of -3. The snapshot test
+ * (test_ptx_snapshot.ml) asserts the emitted instruction is now [div.s32]/
+ * [rem.s32]; this test proves the RESULT on real hardware by running the
+ * kernel through every available backend - crucially CUDA/PTX under ZLUDA,
+ * the class of semantics a text snapshot cannot catch and that hardware CI
+ * under-tests.
+ *
+ * Integer div/rem is exact, so results are compared bit-for-bit against
+ * OCaml's Int32.div/Int32.rem (no tolerance). Native, Interpreter and
+ * CUDA/PTX are hard-gated; the Vulkan backend has a pre-existing signed-mod
+ * divergence (see [is_gated]) and is reported only.
+ *
+ * Run with (surfaces the CUDA device):
+ *   LD_LIBRARY_PATH=$HOME/opt/zluda \
+ *     dune exec sarek/tests/e2e/test_ptx_signed_arith.exe
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Test_helpers.Benchmarks.init_backends ()
+
+(* q.(tid) = a.(tid) / b.(tid), r.(tid) = a.(tid) mod b.(tid). Plain DSL [/]
+   and [mod] on int32 -> Ir.Div / Ir.Mod, the operators the H1 fix retargets
+   to the signed PTX forms. *)
+let signed_divrem_kernel =
+  [%kernel
+    fun (a : int32 vector)
+        (b : int32 vector)
+        (q : int32 vector)
+        (r : int32 vector)
+        (n : int32) ->
+      let open Std in
+      let tid = global_thread_id in
+      if tid < n then begin
+        q.(tid) <- a.(tid) / b.(tid) ;
+        r.(tid) <- a.(tid) mod b.(tid)
+      end]
+
+(* A spread that stresses sign combinations: negative/positive dividends and
+   divisors, including the (-7)/2 witness from the audit finding. *)
+let cases =
+  [|
+    (-7l, 2l);
+    (7l, -2l);
+    (-7l, -2l);
+    (7l, 2l);
+    (-2147483648l, 3l) (* INT_MIN, exercises the sign bit *);
+    (-100l, 7l);
+    (100l, -7l);
+    (-1l, 2l);
+    (0l, 5l);
+    (-999l, -13l);
+  |]
+
+let n = Array.length cases
+
+let run_on_device (dev : Device.t) ir =
+  let a = Vector.create Vector.int32 n in
+  let b = Vector.create Vector.int32 n in
+  let q = Vector.create Vector.int32 n in
+  let r = Vector.create Vector.int32 n in
+  for i = 0 to n - 1 do
+    let av, bv = cases.(i) in
+    Vector.set a i av ;
+    Vector.set b i bv ;
+    Vector.set q i 0l ;
+    Vector.set r i 0l
+  done ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:
+      [
+        Execute.Vec a; Execute.Vec b; Execute.Vec q; Execute.Vec r; Execute.Int n;
+      ]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  (Vector.to_array q, Vector.to_array r)
+
+let verify got_q got_r =
+  let bad = ref 0 in
+  for i = 0 to n - 1 do
+    let av, bv = cases.(i) in
+    let eq = Int32.div av bv in
+    let er = Int32.rem av bv in
+    if got_q.(i) <> eq || got_r.(i) <> er then begin
+      if !bad < 5 then
+        Printf.printf
+          "    mismatch @%d: %ld/%ld got q=%ld r=%ld exp q=%ld r=%ld\n%!"
+          i
+          av
+          bv
+          got_q.(i)
+          got_r.(i)
+          eq
+          er ;
+      incr bad
+    end
+  done ;
+  !bad
+
+let is_native (dev : Device.t) =
+  dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
+
+(* Backends whose signed remainder this PR fixes/claims C semantics for: the
+   PTX emitter (audit H1) plus the interpreter and native oracle. A wrong
+   result from one of these is a hard failure.
+
+   NOT gated: the Vulkan backend lowers integer Mod to the GLSL [%] operator
+   (Sarek_ir_glsl.ml), which on RADV returns a remainder with the DIVISOR's
+   sign (OpSMod-like) instead of C's dividend sign - so [-7 mod 2] yields +1,
+   not -1. That is a genuine pre-existing Vulkan codegen bug this probe
+   surfaces, but it is out of scope for this PTX/interpreter PR; it is
+   reported here (see stdout) and left for a dedicated GLSL-backend fix. *)
+let is_gated (dev : Device.t) =
+  is_native dev || dev.Device.framework = "CUDA/PTX"
+
+let () =
+  let _, kirc = signed_divrem_kernel in
+  let ir =
+    match kirc.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "signed div/rem kernel has no IR"
+  in
+  let devs = Device.init () in
+  print_endline "=== H1 signed int32 div/rem E2E (negative operands) ===" ;
+  let native_ran = ref false in
+  let failed = ref false in
+  Array.iter
+    (fun (dev : Device.t) ->
+      let native = is_native dev in
+      let gated = is_gated dev in
+      try
+        let got_q, got_r = run_on_device dev ir in
+        let bad = verify got_q got_r in
+        Printf.printf
+          "  %-11s %-40s %s (%d/%d ok)%s\n%!"
+          dev.Device.framework
+          dev.Device.name
+          (if bad = 0 then "PASS" else if gated then "FAIL" else "DIVERGES")
+          (n - bad)
+          n
+          (if bad <> 0 && not gated then " [known out-of-scope backend gap]"
+           else "") ;
+        (* Integer div/rem is exact, so a gated backend that ran must match
+           bit-for-bit. Non-gated backends (Vulkan) are reported only. *)
+        if bad <> 0 && gated then failed := true ;
+        if native then native_ran := true
+      with e ->
+        Printf.printf
+          "  %-11s %-40s %s (%s)\n%!"
+          dev.Device.framework
+          dev.Device.name
+          (if native then "ERROR" else "SKIP (backend could not launch)")
+          (Printexc.to_string e) ;
+        (* Native/Interpreter must always run; a GPU backend that cannot even
+           launch for infra reasons is only reported (a wrong RESULT from a
+           backend that DID run is always a hard failure - see above). *)
+        if native then failed := true)
+    devs ;
+  if not !native_ran then begin
+    print_endline
+      "test_ptx_signed_arith: FAILED - no native/interpreter device ran" ;
+    exit 1
+  end ;
+  if !failed then begin
+    print_endline "test_ptx_signed_arith: FAILED" ;
+    exit 1
+  end ;
+  print_endline "test_ptx_signed_arith: PASSED"

--- a/sarek/tests/e2e/test_sarek_gemm.ml
+++ b/sarek/tests/e2e/test_sarek_gemm.ml
@@ -109,7 +109,6 @@ let run_tiled dev a_arr b_arr c_init ~m ~n ~k ~alpha ~beta =
     ~args:(args a b c ~m ~n ~k ~alpha ~beta)
     ~block:(GH.block ())
     ~grid:(GH.grid ~m ~n)
-    ~shared_mem:GH.shared_mem_bytes
     () ;
   Transfer.flush dev ;
   let t1 = Unix.gettimeofday () in

--- a/sarek/tests/e2e/test_static_tag_erasure.ml
+++ b/sarek/tests/e2e/test_static_tag_erasure.ml
@@ -31,6 +31,13 @@ module Transfer = Spoc_core.Transfer
 
 [@@@warning "-32"]
 
+(* -11 (redundant-case): the arm-order-shadowed control kernel below is a
+   deliberately redundant match (`_ -> .. | Circle r -> ..`) - exactly the
+   shape that must NOT be tag-erased. OCaml's own redundancy checker is the
+   first line of defense against it; suppressing the warning here lets the
+   test drive the erasure pass's own guard (audit finding M7) directly. *)
+[@@@warning "-11"]
+
 let () = Test_helpers.Benchmarks.init ()
 
 type float32 = float
@@ -82,6 +89,22 @@ let multiarg_kirc =
           match s with
           | MkPair (x, y) -> dst.(tid) <- x +. y
           | MkOne x -> dst.(tid) <- x
+        end]
+
+(* NEGATIVE CONTROL (arm-order shadowing): the wildcard arm precedes the
+   Circle arm, so first-match-wins makes the runtime result the WILDCARD arm
+   (v +. 100.), not the Circle arm. Erasing to the Circle arm would miscompile
+   to v *. v (audit finding M7). The slot must stay ineligible and the tag be
+   retained; behaviour must equal the wildcard arm. *)
+let shadowed_kirc =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let s = Circle src.(tid) in
+          dst.(tid) <-
+            (match s with _ -> src.(tid) +. 100.0 | Circle r -> r *. r)
         end]
 
 (* NEGATIVE CONTROL: the live constructor is chosen at runtime, so the slot is
@@ -212,11 +235,34 @@ let () =
   check_emitted "nullary(erasable)" nullary_kirc ~expect_tag:false ;
   check_emitted "runtime-selected(control)" retained_kirc ~expect_tag:true ;
   check_emitted "multiarg-payload(control)" multiarg_kirc ~expect_tag:true ;
+  (* Arm-order shadowing (M7): a wildcard-first match compiles to a ternary,
+     not a switch, so the crude tag heuristic does not apply. The specific
+     regression to guard is erasure rewriting the match to the (unreachable)
+     Circle arm [r *. r]; assert instead that the emitted device code keeps
+     the wildcard arm [+ 100]. *)
+  let shadowed_src =
+    Sarek_codegen.Sarek_ir_cuda.generate (ir_of "shadowed" shadowed_kirc)
+  in
+  let shadowed_ok = contains shadowed_src "100" in
+  if not shadowed_ok then observable_ok := false ;
+  Printf.printf
+    "  emitted[arm-order-shadowed(control)]: wildcard arm %s -> %s\n%!"
+    (if shadowed_ok then "kept" else "ERASED to Circle arm")
+    (if shadowed_ok then "OK" else "MISMATCH") ;
   print_endline "-- behaviour vs pure-OCaml reference --" ;
   run_behaviour "unary(erasable)" unary_kirc ~reference:(fun i ->
       let r = float_of_int (i + 1) in
       (r *. r) +. r) ;
   run_behaviour "nullary(erasable)" nullary_kirc ~reference:(fun _ -> 1.0) ;
+  (* Gated to Native/Interpreter: the retained tagged match on a variant with a
+     wildcard arm is a pre-existing device-codegen gap (OpenCL/Vulkan return
+     generate_source None), unrelated to erasure. Native+Interpreter are the
+     oracle proving erasure did not miscompile to the Circle arm. *)
+  run_behaviour
+    "arm-order-shadowed(control)"
+    shadowed_kirc
+    ~must:(fun fw -> fw = "Native" || fw = "Interpreter")
+    ~reference:(fun i -> float_of_int (i + 1) +. 100.0) ;
   (* Multi-arg constructor payloads: the constructor's tuple payload is
      FLATTENED to one field per component end-to-end (Sarek_lower_ir), so it
      lines up with the multi-binder pattern and the flat [_0/_1] tagged-union

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -17,6 +17,18 @@
 ; - test_tuple_param: "Tuple-typed kernel parameters are not supported"
 ; - test_fun_param: "Function-typed kernel parameters are not supported"
 ; - test_fun_escape: "Function value escapes"
+; - test_unregistered_field: "unknown size/alignment for field type"
+
+(library
+ (name neg_test_unregistered_field)
+ (modules test_unregistered_field)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
 
 (library
  (name neg_test_convention_kernel_fail)

--- a/sarek/tests/negative/test_unregistered_field.ml
+++ b/sarek/tests/negative/test_unregistered_field.ml
@@ -1,0 +1,18 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test type declaration that should FAIL to compile:
+   - [my_meters] is not a [@@sarek.type]-registered type and not a scalar, so
+     using it as a GPU record field must be a hard PPX error. Before the fix
+     (audit finding M6) the PPX silently assumed size/align 4/4, which
+     desynchronizes the host byte layout from the device's aligned ABI. *)
+
+type my_meters = float
+
+type bad_record = {distance : my_meters; count : int32} [@@sarek.type]
+
+let () =
+  ignore (fun (r : bad_record) -> r.count) ;
+  print_endline "This should not print - test should have failed to compile"

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -58,7 +58,7 @@
 
 (test
  (name test_ptx_snapshot)
- (libraries sarek.codegen alcotest))
+ (libraries sarek.codegen alcotest unix))
 
 ; Software f64 transcendentals for PTX: IR-level accuracy vs the OCaml stdlib
 ; (pure scalar evaluation of the helper bodies — CPU-only, no device needed)

--- a/sarek/tests/unit/test_f64_softmath.ml
+++ b/sarek/tests/unit/test_f64_softmath.ml
@@ -205,9 +205,9 @@ let test_exp () =
   check_unary "exp" Stdlib.exp ~domains:[(-2.0, 2.0); (-700.0, 700.0)]
 
 (** Out-of-domain saturation (audit finding M3): the (n + 1023) << 52 scale
-    construction used to wrap into the sign/exponent bits outside
-    [-708, 709.78] and return garbage (exp -1000 came back huge). Now it
-    flushes to 0 / -1 / +inf per the documented tier. *)
+    construction used to wrap into the sign/exponent bits outside [-708, 709.78]
+    and return garbage (exp -1000 came back huge). Now it flushes to 0 / -1 /
+    +inf per the documented tier. *)
 let test_exp_expm1_saturation () =
   let hname name =
     match Sarek_codegen.Sarek_ir_ptx_softmath.helper_name name with

--- a/sarek/tests/unit/test_f64_softmath.ml
+++ b/sarek/tests/unit/test_f64_softmath.ml
@@ -204,6 +204,28 @@ let check_unary name ?(tol = 1e-12) ~domains reference =
 let test_exp () =
   check_unary "exp" Stdlib.exp ~domains:[(-2.0, 2.0); (-700.0, 700.0)]
 
+(** Out-of-domain saturation (audit finding M3): the (n + 1023) << 52 scale
+    construction used to wrap into the sign/exponent bits outside
+    [-708, 709.78] and return garbage (exp -1000 came back huge). Now it
+    flushes to 0 / -1 / +inf per the documented tier. *)
+let test_exp_expm1_saturation () =
+  let hname name =
+    match Sarek_codegen.Sarek_ir_ptx_softmath.helper_name name with
+    | Some h -> h
+    | None -> Alcotest.fail ("no softmath helper for " ^ name)
+  in
+  let exp_h = hname "exp" and expm1_h = hname "expm1" in
+  let checkf label want got =
+    if got <> want then
+      Alcotest.failf "%s: expected %.17g, got %.17g" label want got
+  in
+  checkf "exp(-1000)" 0.0 (call1 exp_h (-1000.0)) ;
+  checkf "exp(-750)" 0.0 (call1 exp_h (-750.0)) ;
+  checkf "exp(710)" infinity (call1 exp_h 710.0) ;
+  checkf "exp(1e10)" infinity (call1 exp_h 1e10) ;
+  checkf "expm1(-1000)" (-1.0) (call1 expm1_h (-1000.0)) ;
+  checkf "expm1(710)" infinity (call1 expm1_h 710.0)
+
 let test_log () =
   check_unary
     "log"
@@ -365,6 +387,10 @@ let () =
       ( "accuracy",
         [
           Alcotest.test_case "exp" `Quick test_exp;
+          Alcotest.test_case
+            "exp/expm1 saturation"
+            `Quick
+            test_exp_expm1_saturation;
           Alcotest.test_case "log" `Quick test_log;
           Alcotest.test_case "sin" `Quick test_sin;
           Alcotest.test_case "cos" `Quick test_cos;

--- a/sarek/tests/unit/test_ir_interp.ml
+++ b/sarek/tests/unit/test_ir_interp.ml
@@ -240,7 +240,10 @@ let test_binop_int64_compare_above_bit31 () =
      compare 0 > 0 = false. Also covers Lt/Le/Ge via the same arms. *)
   let env = make_env () in
   let state = make_state () in
-  let big = 4294967296L (* 2^32: truncates to 0l *) in
+  let big =
+    4294967296L
+    (* 2^32: truncates to 0l *)
+  in
   let check_cmp op a b expected label =
     let expr = EBinop (op, EConst (CInt64 a), EConst (CInt64 b)) in
     match eval_expr state env expr with

--- a/sarek/tests/unit/test_ir_interp.ml
+++ b/sarek/tests/unit/test_ir_interp.ml
@@ -234,6 +234,50 @@ let test_binop_shr_negative_is_arithmetic () =
   | VInt32 n -> check int32 "(-16) shr 2 is arithmetic" (-4l) n
   | _ -> fail "expected VInt32"
 
+let test_binop_int64_compare_above_bit31 () =
+  (* Regression (2026-07 audit M4): int64 comparisons used to route through
+     to_int32, truncating operands. 2^32 > 0 must hold; truncated it would
+     compare 0 > 0 = false. Also covers Lt/Le/Ge via the same arms. *)
+  let env = make_env () in
+  let state = make_state () in
+  let big = 4294967296L (* 2^32: truncates to 0l *) in
+  let check_cmp op a b expected label =
+    let expr = EBinop (op, EConst (CInt64 a), EConst (CInt64 b)) in
+    match eval_expr state env expr with
+    | VBool r -> check bool label expected r
+    | _ -> fail "expected VBool"
+  in
+  check_cmp Gt big 0L true "2^32 > 0" ;
+  check_cmp Lt 0L big true "0 < 2^32" ;
+  check_cmp Le big 0L false "2^32 <= 0 is false" ;
+  check_cmp Ge Int64.min_int Int64.max_int false "min_int64 >= max_int64" ;
+  check_cmp Lt Int64.min_int Int64.max_int true "min_int64 < max_int64"
+
+let test_binop_int64_bitwise_and_shift () =
+  (* Regression (2026-07 audit M4): 64-bit shift/bitwise ops used to truncate
+     to 32 bits, diverging from the PTX/CUDA/OpenCL backends' 64-bit ops. *)
+  let env = make_env () in
+  let state = make_state () in
+  let eval e = eval_expr state env e in
+  (match eval (EBinop (Shl, EConst (CInt64 1L), EConst (CInt32 40l))) with
+  | VInt64 n -> check int64 "1L shl 40" 1099511627776L n
+  | _ -> fail "expected VInt64") ;
+  (match
+     eval (EBinop (Shr, EConst (CInt64 (-1099511627776L)), EConst (CInt32 40l)))
+   with
+  | VInt64 n -> check int64 "arithmetic shr 40" (-1L) n
+  | _ -> fail "expected VInt64") ;
+  (match
+     eval
+       (EBinop
+          (BitAnd, EConst (CInt64 0xFF00000000L), EConst (CInt64 0x0F00000000L)))
+   with
+  | VInt64 n -> check int64 "band above bit31" 0x0F00000000L n
+  | _ -> fail "expected VInt64") ;
+  (match eval (EUnop (BitNot, EConst (CInt64 0L))) with
+  | VInt64 n -> check int64 "bnot 0L" (-1L) n
+  | _ -> fail "expected VInt64")
+
 let test_binop_eq () =
   let env = make_env () in
   let state = make_state () in
@@ -386,6 +430,14 @@ let () =
           test_case "add" `Quick test_binop_add;
           test_case "multiply" `Quick test_binop_mul;
           test_case "less_than" `Quick test_binop_lt;
+          test_case
+            "int64_compare_above_bit31"
+            `Quick
+            test_binop_int64_compare_above_bit31;
+          test_case
+            "int64_bitwise_and_shift"
+            `Quick
+            test_binop_int64_bitwise_and_shift;
           test_case "equals" `Quick test_binop_eq;
           test_case
             "shr_negative_is_arithmetic"

--- a/sarek/tests/unit/test_ir_interp.ml
+++ b/sarek/tests/unit/test_ir_interp.ml
@@ -296,6 +296,28 @@ let test_binop_int64_bitwise_and_shift () =
   | VBool b -> check bool "mixed 0l < 2^32" true b
   | _ -> fail "expected VBool"
 
+let test_binop_float_mod_is_fmod () =
+  (* Regression (audit M1 follow-up): float Mod had no float arms and
+     truncated operands to ints. It must be C fmod (Float.rem). *)
+  let env = make_env () in
+  let state = make_state () in
+  (match
+     eval_expr
+       state
+       env
+       (EBinop (Mod, EConst (CFloat64 1e17), EConst (CFloat64 3.0)))
+   with
+  | VFloat64 f -> check (float 0.0) "1e17 fmod 3" 1.0 f
+  | _ -> fail "expected VFloat64") ;
+  match
+    eval_expr
+      state
+      env
+      (EBinop (Mod, EConst (CFloat64 (-7.5)), EConst (CFloat64 2.0)))
+  with
+  | VFloat64 f -> check (float 0.0) "-7.5 fmod 2 keeps dividend sign" (-1.5) f
+  | _ -> fail "expected VFloat64"
+
 let test_binop_eq () =
   let env = make_env () in
   let state = make_state () in
@@ -457,6 +479,7 @@ let () =
             `Quick
             test_binop_int64_bitwise_and_shift;
           test_case "equals" `Quick test_binop_eq;
+          test_case "float_mod_is_fmod" `Quick test_binop_float_mod_is_fmod;
           test_case
             "shr_negative_is_arithmetic"
             `Quick

--- a/sarek/tests/unit/test_ir_interp.ml
+++ b/sarek/tests/unit/test_ir_interp.ml
@@ -276,7 +276,25 @@ let test_binop_int64_bitwise_and_shift () =
   | _ -> fail "expected VInt64") ;
   (match eval (EUnop (BitNot, EConst (CInt64 0L))) with
   | VInt64 n -> check int64 "bnot 0L" (-1L) n
-  | _ -> fail "expected VInt64")
+  | _ -> fail "expected VInt64") ;
+  (match
+     eval
+       (EBinop
+          (BitOr, EConst (CInt64 0xF000000000L), EConst (CInt64 0x0F00000000L)))
+   with
+  | VInt64 n -> check int64 "bor above bit31" 0xFF00000000L n
+  | _ -> fail "expected VInt64") ;
+  (match
+     eval
+       (EBinop
+          (BitXor, EConst (CInt64 0xFF00000000L), EConst (CInt64 0x0F00000000L)))
+   with
+  | VInt64 n -> check int64 "bxor above bit31" 0xF000000000L n
+  | _ -> fail "expected VInt64") ;
+  (* Mixed-width promotion arm: VInt32 promotes to Int64 for the compare. *)
+  match eval (EBinop (Lt, EConst (CInt32 0l), EConst (CInt64 4294967296L))) with
+  | VBool b -> check bool "mixed 0l < 2^32" true b
+  | _ -> fail "expected VBool"
 
 let test_binop_eq () =
   let env = make_env () in

--- a/sarek/tests/unit/test_lower_ir.ml
+++ b/sarek/tests/unit/test_lower_ir.ml
@@ -355,6 +355,28 @@ let eval_int32_binop op a b =
   let ir_expr = Sarek_lower_ir.lower_expr state texpr in
   eval_ir_int32 ir_expr
 
+(* Audit finding H3: && / || must lower to short-circuit EIf, not a strict
+   Ir.And/Ir.Or - the strict form evaluated both operands eagerly on PTX and
+   the Interpreter (out-of-bounds reads in the classic bounds-guard idiom)
+   while the C backends short-circuited. *)
+let test_and_or_lower_to_short_circuit_eif () =
+  let ty = Sarek_types.(TPrim TBool) in
+  let mk te = Sarek_typed_ast.{te; ty; te_loc = Sarek_ast.dummy_loc} in
+  let texpr op =
+    mk (Sarek_typed_ast.TEBinop (op, mk (TEBool true), mk (TEBool false)))
+  in
+  let state = Sarek_lower_ir.create_state (Hashtbl.create 1) in
+  (match Sarek_lower_ir.lower_expr state (texpr Sarek_ast.And) with
+  | Ir.EIf (_, _, Ir.EConst (Ir.CBool false)) -> ()
+  | Ir.EBinop (Ir.And, _, _) ->
+      Alcotest.fail "&& lowered to strict Ir.And (evaluates both operands)"
+  | _ -> Alcotest.fail "&& lowered to unexpected IR shape") ;
+  match Sarek_lower_ir.lower_expr state (texpr Sarek_ast.Or) with
+  | Ir.EIf (_, Ir.EConst (Ir.CBool true), _) -> ()
+  | Ir.EBinop (Ir.Or, _, _) ->
+      Alcotest.fail "|| lowered to strict Ir.Or (evaluates both operands)"
+  | _ -> Alcotest.fail "|| lowered to unexpected IR shape"
+
 let test_lsr_negative_is_logical () =
   (* (-16) lsr 2 = 1073741820, NOT (-16) asr 2 = -4 *)
   let result = eval_int32_binop Sarek_ast.Lsr (-16l) 2l in
@@ -615,6 +637,10 @@ let () =
             "lsr positive matches asr"
             `Quick
             test_lsr_positive_matches_asr;
+          Alcotest.test_case
+            "&&/|| lower to short-circuit EIf"
+            `Quick
+            test_and_or_lower_to_short_circuit_eif;
           Alcotest.test_case
             "lsr raises on non-trivial operand"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -550,10 +550,10 @@ let test_atomic_cas_incdec_wide_markers () =
   (* 8-byte addressing stride for the 64-bit forms *)
   assert_contains ptx ", 3;"
 
-(** Float Mod lowers to exact C fmod via emit_float_fmod's iterative
-    reduction (audit finding M1): rn-rounded div + cvt.rzi + fma per round,
-    inside a branch loop, with an overflow-scaling branch and a final
-    sign fix (selp) + copysign zero-sign normalization — for f32 and f64. *)
+(** Float Mod lowers to exact C fmod via emit_float_fmod's iterative reduction
+    (audit finding M1): rn-rounded div + cvt.rzi + fma per round, inside a
+    branch loop, with an overflow-scaling branch and a final sign fix (selp) +
+    copysign zero-sign normalization — for f32 and f64. *)
 let test_float_mod_fmod_markers () =
   let fa = make_var "fa" (TVec TFloat32) in
   let da = make_var "da" (TVec TFloat64) in
@@ -600,11 +600,11 @@ let test_float_mod_fmod_markers () =
   assert_contains ptx "selp.f64" ;
   assert_contains ptx "selp.f32"
 
-(** Integer Div/Mod are SIGNED (audit finding H1): Sarek int32/int64 are
-    signed everywhere (interpreter uses Int32.div/Int64.div, C backends emit
-    / and % on signed types), so PTX must emit div.s32/s64 and rem.s32/s64.
-    The old div.u32/u64, rem.u32/u64 silently returned garbage for negative
-    operands ((-7)/2 = 2147483644). *)
+(** Integer Div/Mod are SIGNED (audit finding H1): Sarek int32/int64 are signed
+    everywhere (interpreter uses Int32.div/Int64.div, C backends emit / and % on
+    signed types), so PTX must emit div.s32/s64 and rem.s32/s64. The old
+    div.u32/u64, rem.u32/u64 silently returned garbage for negative operands
+    ((-7)/2 = 2147483644). *)
 let test_int_div_rem_signed_markers () =
   let ia = make_var "ia" (TVec TInt32) in
   let la = make_var "la" (TVec TInt64) in
@@ -624,12 +624,11 @@ let test_int_div_rem_signed_markers () =
                 EBinop (Mod, EArrayRead ("ia", EVar tid), EConst (CInt32 3l)) );
             SAssign
               ( LArrayElem ("la", EVar tid),
-                EBinop
-                  (Div, EArrayRead ("la", EVar tid), EConst (CInt64 (-2L))) );
+                EBinop (Div, EArrayRead ("la", EVar tid), EConst (CInt64 (-2L)))
+              );
             SAssign
               ( LArrayElem ("la", EVar tid),
-                EBinop (Mod, EArrayRead ("la", EVar tid), EConst (CInt64 3L))
-              );
+                EBinop (Mod, EArrayRead ("la", EVar tid), EConst (CInt64 3L)) );
           ] )
   in
   let k =
@@ -652,9 +651,9 @@ let test_int_div_rem_signed_markers () =
   if contains ptx "rem.u32" || contains ptx "rem.u64" then
     Alcotest.fail "unsigned rem emitted for signed Sarek int"
 
-(** Plain f32 division is correctly rounded (audit finding M2): the generic
-    Div binop must emit div.rn.f32, not the ~2-ulp div.approx.f32 (which
-    remains reserved for already-approximate intrinsics like tan/tanh). *)
+(** Plain f32 division is correctly rounded (audit finding M2): the generic Div
+    binop must emit div.rn.f32, not the ~2-ulp div.approx.f32 (which remains
+    reserved for already-approximate intrinsics like tan/tanh). *)
 let test_f32_div_correctly_rounded () =
   let out = make_var "out" (TVec TFloat32) in
   let a = make_var "a" (TVec TFloat32) in
@@ -675,9 +674,9 @@ let test_f32_div_correctly_rounded () =
   if contains ptx "div.approx.f32" then
     Alcotest.fail "plain f32 division must not use div.approx.f32"
 
-(** Int64 comparison family, Not/BitNot and min/max must be class-aware
-    (audit finding H2): the old code emitted setp.*.s32 / not.b32 / min.s32
-    on %rd (64-bit) registers - invalid PTX, rejected at module load. *)
+(** Int64 comparison family, Not/BitNot and min/max must be class-aware (audit
+    finding H2): the old code emitted setp.*.s32 / not.b32 / min.s32 on %rd
+    (64-bit) registers - invalid PTX, rejected at module load. *)
 let test_int64_compare_minmax_markers () =
   let la = make_var "la" (TVec TInt64) in
   let out = make_var "out" (TVec TInt32) in
@@ -698,9 +697,7 @@ let test_int64_compare_minmax_markers () =
                 SAssign
                   ( LArrayElem ("out", EVar tid),
                     EBinop (Eq, EVar x, EConst (CInt64 42L)) );
-                SAssign
-                  ( LArrayElem ("la", EVar tid),
-                    EUnop (BitNot, EVar x) );
+                SAssign (LArrayElem ("la", EVar tid), EUnop (BitNot, EVar x));
                 SAssign
                   ( LArrayElem ("la", EVar tid),
                     EIntrinsic ([], "min", [EVar x; EConst (CInt64 7L)]) );
@@ -808,10 +805,10 @@ let test_atomic_width_mismatch_rejected () =
   | _ -> Alcotest.fail "int32 value into atom.add.u64 should be rejected"
   | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
 
-(** Audit finding M5: the intrinsic's hardwired 4/8-byte stride must match
-    the array's element width — atomic_add_int32 on an int64 vector would
-    corrupt neighbouring elements; and a *_global_* atomic on a shared
-    array would use the 32-bit shared-window offset as a global address. *)
+(** Audit finding M5: the intrinsic's hardwired 4/8-byte stride must match the
+    array's element width — atomic_add_int32 on an int64 vector would corrupt
+    neighbouring elements; and a *_global_* atomic on a shared array would use
+    the 32-bit shared-window offset as a global address. *)
 let test_atomic_stride_and_space_rejected () =
   let tid = make_var "tid" TInt32 in
   let gen_with body params =

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -808,6 +808,53 @@ let test_atomic_width_mismatch_rejected () =
   | _ -> Alcotest.fail "int32 value into atom.add.u64 should be rejected"
   | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
 
+(** Audit finding M5: the intrinsic's hardwired 4/8-byte stride must match
+    the array's element width — atomic_add_int32 on an int64 vector would
+    corrupt neighbouring elements; and a *_global_* atomic on a shared
+    array would use the 32-bit shared-window offset as a global address. *)
+let test_atomic_stride_and_space_rejected () =
+  let tid = make_var "tid" TInt32 in
+  let gen_with body params =
+    base_kernel "atomic_bad" params body [] |> Sarek_ir_ptx.generate
+  in
+  (* 4-byte atomic on an 8-byte-element array: rejected. *)
+  let lacc = make_var "lacc" (TVec TInt64) in
+  let body32on64 =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SExpr
+          (EIntrinsic
+             ( ["Sarek_stdlib"; "Gpu"],
+               "atomic_add_int32",
+               [EVar lacc; EVar tid; EConst (CInt32 1l)] )) )
+  in
+  (match
+     gen_with
+       body32on64
+       [DParam (lacc, Some {arr_elttype = TInt64; arr_memspace = Global})]
+   with
+  | _ -> Alcotest.fail "4-byte atomic on 8-byte elements should be rejected"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()) ;
+  (* *_global_* atomic on a shared array: rejected. *)
+  let sacc = make_var "sacc" TInt32 in
+  let body_global_on_shared =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( sacc,
+            EArrayCreate (TInt32, EConst (CInt32 32l), Shared),
+            SExpr
+              (EIntrinsic
+                 ( ["Sarek_stdlib"; "Gpu"],
+                   "atomic_add_global_int32",
+                   [EVar sacc; EVar tid; EConst (CInt32 1l)] )) ) )
+  in
+  match gen_with body_global_on_shared [] with
+  | _ -> Alcotest.fail "global-form atomic on shared array should be rejected"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
 (** Check that [ptx] does NOT contain [marker]. *)
 let assert_absent ptx marker ~why =
   let mlen = String.length marker in
@@ -2039,6 +2086,10 @@ let () =
             "width-mismatched atomic value is rejected"
             `Quick
             test_atomic_width_mismatch_rejected;
+          Alcotest.test_case
+            "stride/space-mismatched atomics are rejected"
+            `Quick
+            test_atomic_stride_and_space_rejected;
           Alcotest.test_case
             "float Mod lowers to fmod (div.rn + cvt.rzi + fma)"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -2037,6 +2037,123 @@ let test_static_dshared_markers () =
     ~why:"statically-sized shared array must not be extern" ;
   assert_contains ptx "st.shared.s32"
 
+(** ptxas validation gate (audit finding M9): the substring markers above prove
+    which instructions were emitted, but not that the module ASSEMBLES. When the
+    CUDA toolkit's [ptxas] is on PATH, assemble the PTX of the regression
+    kernels (vector_add, signed div/rem, int64 comparisons) and fail if ptxas
+    rejects it — this is exactly the check that catches an invalid-PTX class of
+    bug (e.g. a 32-bit instruction on a 64-bit register) with no GPU required.
+    Skips cleanly when ptxas is absent (CPU-only CI). *)
+let ptxas_available =
+  lazy
+    (match Unix.system "command -v ptxas >/dev/null 2>&1" with
+    | Unix.WEXITED 0 -> true
+    | _ -> false)
+
+let assemble_ok ptx =
+  let base = Filename.temp_file "sarek_ptx_" "" in
+  let src = base ^ ".ptx" in
+  let obj = base ^ ".cubin" in
+  let oc = open_out src in
+  output_string oc ptx ;
+  close_out oc ;
+  let cmd =
+    Printf.sprintf
+      "ptxas --compile-only -o %s %s 2>%s.err"
+      (Filename.quote obj)
+      (Filename.quote src)
+      (Filename.quote base)
+  in
+  let rc = Unix.system cmd in
+  let err =
+    try
+      let ic = open_in (base ^ ".err") in
+      let n = in_channel_length ic in
+      let s = really_input_string ic n in
+      close_in ic ;
+      s
+    with _ -> ""
+  in
+  List.iter
+    (fun f -> try Sys.remove f with _ -> ())
+    [src; obj; base; base ^ ".err"] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error err
+
+let test_ptxas_assembles () =
+  if not (Lazy.force ptxas_available) then
+    Printf.printf "  SKIP: ptxas not on PATH (CPU-only environment)\n%!"
+  else begin
+    let ia = make_var "ia" (TVec TInt32) in
+    let la = make_var "la" (TVec TInt64) in
+    let out = make_var "out" (TVec TInt32) in
+    let tid = make_var "tid" TInt32 in
+    let x = make_var "x" TInt64 in
+    let div_body =
+      SLet
+        ( tid,
+          EIntrinsic ([], "global_thread_id", []),
+          SSeq
+            [
+              SAssign
+                ( LArrayElem ("ia", EVar tid),
+                  EBinop
+                    (Div, EArrayRead ("ia", EVar tid), EConst (CInt32 (-2l))) );
+              SAssign
+                ( LArrayElem ("la", EVar tid),
+                  EBinop
+                    (Div, EArrayRead ("la", EVar tid), EConst (CInt64 (-2L))) );
+            ] )
+    in
+    let cmp_body =
+      SLet
+        ( tid,
+          EIntrinsic ([], "global_thread_id", []),
+          SLet
+            ( x,
+              EArrayRead ("la", EVar tid),
+              SSeq
+                [
+                  SAssign
+                    ( LArrayElem ("out", EVar tid),
+                      EBinop (Lt, EVar x, EConst (CInt64 0L)) );
+                  SAssign
+                    ( LArrayElem ("la", EVar tid),
+                      EIntrinsic ([], "min", [EVar x; EConst (CInt64 7L)]) );
+                ] ) )
+    in
+    let kernels =
+      [
+        ("vector_add", make_vector_add_kernel ());
+        ( "int_div_rem_signed",
+          base_kernel
+            "int_div_rem"
+            [
+              DParam (ia, Some {arr_elttype = TInt32; arr_memspace = Global});
+              DParam (la, Some {arr_elttype = TInt64; arr_memspace = Global});
+            ]
+            div_body
+            [] );
+        ( "int64_compare",
+          base_kernel
+            "int64_cmp"
+            [
+              DParam (la, Some {arr_elttype = TInt64; arr_memspace = Global});
+              DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global});
+            ]
+            cmp_body
+            [] );
+      ]
+    in
+    List.iter
+      (fun (name, k) ->
+        match assemble_ok (Sarek_ir_ptx.generate k) with
+        | Ok () -> Printf.printf "  ptxas OK: %s\n%!" name
+        | Error err ->
+            Alcotest.fail
+              (Printf.sprintf "ptxas rejected kernel %s:\n%s" name err))
+      kernels
+  end
+
 let () =
   Alcotest.run
     "ptx_snapshot"
@@ -2047,6 +2164,10 @@ let () =
             "vector_add PTX contains canonical markers"
             `Quick
             test_vector_add_markers;
+          Alcotest.test_case
+            "ptxas assembles regression kernels (skips if ptxas absent)"
+            `Quick
+            test_ptxas_assembles;
           Alcotest.test_case
             "native math emits min/max/cvt.rmi/cvt.rpi/rsqrt"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -592,6 +592,58 @@ let test_float_mod_fmod_markers () =
   assert_contains ptx "neg.f64" ;
   assert_contains ptx "fma.rn.f64"
 
+(** Integer Div/Mod are SIGNED (audit finding H1): Sarek int32/int64 are
+    signed everywhere (interpreter uses Int32.div/Int64.div, C backends emit
+    / and % on signed types), so PTX must emit div.s32/s64 and rem.s32/s64.
+    The old div.u32/u64, rem.u32/u64 silently returned garbage for negative
+    operands ((-7)/2 = 2147483644). *)
+let test_int_div_rem_signed_markers () =
+  let ia = make_var "ia" (TVec TInt32) in
+  let la = make_var "la" (TVec TInt64) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SSeq
+          [
+            SAssign
+              ( LArrayElem ("ia", EVar tid),
+                EBinop (Div, EArrayRead ("ia", EVar tid), EConst (CInt32 (-2l)))
+              );
+            SAssign
+              ( LArrayElem ("ia", EVar tid),
+                EBinop (Mod, EArrayRead ("ia", EVar tid), EConst (CInt32 3l)) );
+            SAssign
+              ( LArrayElem ("la", EVar tid),
+                EBinop
+                  (Div, EArrayRead ("la", EVar tid), EConst (CInt64 (-2L))) );
+            SAssign
+              ( LArrayElem ("la", EVar tid),
+                EBinop (Mod, EArrayRead ("la", EVar tid), EConst (CInt64 3L))
+              );
+          ] )
+  in
+  let k =
+    base_kernel
+      "int_div_rem"
+      [
+        DParam (ia, Some {arr_elttype = TInt32; arr_memspace = Global});
+        DParam (la, Some {arr_elttype = TInt64; arr_memspace = Global});
+      ]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "div.s32" ;
+  assert_contains ptx "rem.s32" ;
+  assert_contains ptx "div.s64" ;
+  assert_contains ptx "rem.s64" ;
+  if contains ptx "div.u32" || contains ptx "div.u64" then
+    Alcotest.fail "unsigned div emitted for signed Sarek int" ;
+  if contains ptx "rem.u32" || contains ptx "rem.u64" then
+    Alcotest.fail "unsigned rem emitted for signed Sarek int"
+
 (** ECast scalar-matrix coverage: bool casts normalize to a u32 0/1 via
     setp+selp (float sources use unordered neu so NaN -> 1, matching C); i32 ->
     i64 sign-extends (cvt.s64.s32); i64 -> i32 truncates (cvt.u32.u64). *)
@@ -1911,6 +1963,10 @@ let () =
             "float Mod lowers to fmod (div.rn + cvt.rzi + fma)"
             `Quick
             test_float_mod_fmod_markers;
+          Alcotest.test_case
+            "integer Div/Mod emit signed div.s32/s64 rem.s32/s64"
+            `Quick
+            test_int_div_rem_signed_markers;
           Alcotest.test_case
             "ECast matrix: bool setp/selp + i32<->i64 cvt pairs"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -644,6 +644,29 @@ let test_int_div_rem_signed_markers () =
   if contains ptx "rem.u32" || contains ptx "rem.u64" then
     Alcotest.fail "unsigned rem emitted for signed Sarek int"
 
+(** Plain f32 division is correctly rounded (audit finding M2): the generic
+    Div binop must emit div.rn.f32, not the ~2-ulp div.approx.f32 (which
+    remains reserved for already-approximate intrinsics like tan/tanh). *)
+let test_f32_div_correctly_rounded () =
+  let out = make_var "out" (TVec TFloat32) in
+  let a = make_var "a" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let av = EArrayRead ("a", EVar tid) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          (LArrayElem ("out", EVar tid), EBinop (Div, av, EConst (CFloat32 3.0)))
+      )
+  in
+  let mk v = DParam (v, Some {arr_elttype = TFloat32; arr_memspace = Global}) in
+  let k = base_kernel "f32_div" [mk out; mk a] body [] in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "div.rn.f32" ;
+  if contains ptx "div.approx.f32" then
+    Alcotest.fail "plain f32 division must not use div.approx.f32"
+
 (** Int64 comparison family, Not/BitNot and min/max must be class-aware
     (audit finding H2): the old code emitted setp.*.s32 / not.b32 / min.s32
     on %rd (64-bit) registers - invalid PTX, rejected at module load. *)
@@ -2020,6 +2043,10 @@ let () =
             "int64 compare/not/min emit 64-bit forms"
             `Quick
             test_int64_compare_minmax_markers;
+          Alcotest.test_case
+            "plain f32 division emits div.rn.f32"
+            `Quick
+            test_f32_div_correctly_rounded;
           Alcotest.test_case
             "ECast matrix: bool setp/selp + i32<->i64 cvt pairs"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -644,6 +644,55 @@ let test_int_div_rem_signed_markers () =
   if contains ptx "rem.u32" || contains ptx "rem.u64" then
     Alcotest.fail "unsigned rem emitted for signed Sarek int"
 
+(** Int64 comparison family, Not/BitNot and min/max must be class-aware
+    (audit finding H2): the old code emitted setp.*.s32 / not.b32 / min.s32
+    on %rd (64-bit) registers - invalid PTX, rejected at module load. *)
+let test_int64_compare_minmax_markers () =
+  let la = make_var "la" (TVec TInt64) in
+  let out = make_var "out" (TVec TInt32) in
+  let tid = make_var "tid" TInt32 in
+  let x = make_var "x" TInt64 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( x,
+            EArrayRead ("la", EVar tid),
+            SSeq
+              [
+                SAssign
+                  ( LArrayElem ("out", EVar tid),
+                    EBinop (Lt, EVar x, EConst (CInt64 0L)) );
+                SAssign
+                  ( LArrayElem ("out", EVar tid),
+                    EBinop (Eq, EVar x, EConst (CInt64 42L)) );
+                SAssign
+                  ( LArrayElem ("la", EVar tid),
+                    EUnop (BitNot, EVar x) );
+                SAssign
+                  ( LArrayElem ("la", EVar tid),
+                    EIntrinsic ([], "min", [EVar x; EConst (CInt64 7L)]) );
+              ] ) )
+  in
+  let k =
+    base_kernel
+      "int64_cmp"
+      [
+        DParam (la, Some {arr_elttype = TInt64; arr_memspace = Global});
+        DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global});
+      ]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "setp.lt.s64" ;
+  assert_contains ptx "setp.eq.s64" ;
+  assert_contains ptx "not.b64" ;
+  assert_contains ptx "min.s64" ;
+  if contains ptx "setp.lt.s32" || contains ptx "not.b32" then
+    Alcotest.fail "32-bit instruction emitted for 64-bit operand"
+
 (** ECast scalar-matrix coverage: bool casts normalize to a u32 0/1 via
     setp+selp (float sources use unordered neu so NaN -> 1, matching C); i32 ->
     i64 sign-extends (cvt.s64.s32); i64 -> i32 truncates (cvt.u32.u64). *)
@@ -1967,6 +2016,10 @@ let () =
             "integer Div/Mod emit signed div.s32/s64 rem.s32/s64"
             `Quick
             test_int_div_rem_signed_markers;
+          Alcotest.test_case
+            "int64 compare/not/min emit 64-bit forms"
+            `Quick
+            test_int64_compare_minmax_markers;
           Alcotest.test_case
             "ECast matrix: bool setp/selp + i32<->i64 cvt pairs"
             `Quick

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -550,8 +550,10 @@ let test_atomic_cas_incdec_wide_markers () =
   (* 8-byte addressing stride for the 64-bit forms *)
   assert_contains ptx ", 3;"
 
-(** Float Mod lowers to C fmod: x − trunc(x/y)·y via rn-rounded div, cvt.rzi
-    trunc, neg and a single fma — for both f32 and f64. *)
+(** Float Mod lowers to exact C fmod via emit_float_fmod's iterative
+    reduction (audit finding M1): rn-rounded div + cvt.rzi + fma per round,
+    inside a branch loop, with an overflow-scaling branch and a final
+    sign fix (selp) + copysign zero-sign normalization — for f32 and f64. *)
 let test_float_mod_fmod_markers () =
   let fa = make_var "fa" (TVec TFloat32) in
   let da = make_var "da" (TVec TFloat64) in
@@ -587,10 +589,16 @@ let test_float_mod_fmod_markers () =
   assert_contains ptx "cvt.rzi.f32.f32" ;
   assert_contains ptx "neg.f32" ;
   assert_contains ptx "fma.rn.f32" ;
+  assert_contains ptx "copysign.f32" ;
   assert_contains ptx "div.rn.f64" ;
   assert_contains ptx "cvt.rzi.f64.f64" ;
   assert_contains ptx "neg.f64" ;
-  assert_contains ptx "fma.rn.f64"
+  assert_contains ptx "fma.rn.f64" ;
+  assert_contains ptx "copysign.f64" ;
+  (* loop + overflow-scale + sign-fix structure *)
+  assert_contains ptx "and.pred" ;
+  assert_contains ptx "selp.f64" ;
+  assert_contains ptx "selp.f32"
 
 (** Integer Div/Mod are SIGNED (audit finding H1): Sarek int32/int64 are
     signed everywhere (interpreter uses Int32.div/Int64.div, C backends emit

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -112,23 +112,25 @@ let registry_mutex = Mutex.create ()
 
 let memoize name (build : unit -> 'a Vector.custom_type) : 'a Vector.custom_type
     =
-  match Hashtbl.find_opt registry name with
-  | Some obj -> Obj.obj obj
-  | None ->
-      Mutex.protect registry_mutex (fun () ->
-          match Hashtbl.find_opt registry name with
-          | Some obj -> Obj.obj obj
-          | None ->
-              let custom = build () in
-              Hashtbl.replace registry name (Obj.repr custom) ;
-              custom)
+  (* No unlocked fast path: a lock-free [find_opt] racing a [replace] on a
+     non-atomic Hashtbl is a data race under OCaml 5 (audit finding L1).
+     Registration is rare and the table tiny, so taking the mutex on every
+     lookup is cheap and makes every access happens-before ordered. *)
+  Mutex.protect registry_mutex (fun () ->
+      match Hashtbl.find_opt registry name with
+      | Some obj -> Obj.obj obj
+      | None ->
+          let custom = build () in
+          Hashtbl.replace registry name (Obj.repr custom) ;
+          custom)
 
 (** [descriptor_by_name name] returns the canonical [custom_type] previously
     registered for the mangled shape [name] (built by [pair]/[triple]). Used by
     generated Native kernel code to obtain the host-shared [Type_id]. Raises if
     the shape was never instantiated on the host. *)
 let descriptor_by_name (name : string) : 'a Vector.custom_type =
-  match Hashtbl.find_opt registry name with
+  match Mutex.protect registry_mutex (fun () -> Hashtbl.find_opt registry name)
+  with
   | Some obj -> Obj.obj obj
   | None ->
       failwith

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -160,7 +160,10 @@ let shape_registry : (string, shape) Hashtbl.t = Hashtbl.create 16
     [name] (e.g. ["_tup_float32_int32"]), or [None] if no [pair]/[triple] has
     built it yet. *)
 let lookup_shape (name : string) : shape option =
-  Hashtbl.find_opt shape_registry name
+  (* Locked: register_shape_of writes under [registry_mutex]; an unlocked read
+     could race a concurrent first-time registration on the mutable Hashtbl
+     (interpreter workers look shapes up while the host may still register). *)
+  Mutex.protect registry_mutex (fun () -> Hashtbl.find_opt shape_registry name)
 
 (* Build a [shape] from a laid-out field list and record it. Called only from
    within the [memoize] critical section (which already holds

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -129,7 +129,8 @@ let memoize name (build : unit -> 'a Vector.custom_type) : 'a Vector.custom_type
     generated Native kernel code to obtain the host-shared [Type_id]. Raises if
     the shape was never instantiated on the host. *)
 let descriptor_by_name (name : string) : 'a Vector.custom_type =
-  match Mutex.protect registry_mutex (fun () -> Hashtbl.find_opt registry name)
+  match
+    Mutex.protect registry_mutex (fun () -> Hashtbl.find_opt registry name)
   with
   | Some obj -> Obj.obj obj
   | None ->

--- a/scripts/check-test-alias-coverage.sh
+++ b/scripts/check-test-alias-coverage.sh
@@ -49,6 +49,13 @@ for form in toplevel_forms(src):
 # alias deps list FOO.exe directly - both match).
 referenced = set(re.findall(r"([A-Za-z0-9_]+)\.exe", src))
 
+if not declared:
+    print(f"ERROR: no executables parsed from {path} - parser broken or file restructured")
+    sys.exit(2)
+if src.count("(") != src.count(")"):
+    print(f"ERROR: unbalanced parentheses after comment-stripping in {path} - parser assumptions violated")
+    sys.exit(2)
+
 missing = sorted(declared - referenced)
 if missing:
     for exe in missing:

--- a/scripts/check-test-alias-coverage.sh
+++ b/scripts/check-test-alias-coverage.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Guard against silently-unwired test executables (the "vacuous e2e" failure
+# mode fixed in 2026-07: an (executable) with no run rule builds green but
+# never executes). Fails if any executable declared in sarek/tests/e2e/dune
+# is not referenced by at least one alias/rule in that file — i.e. every
+# test binary must be classified: runtest (executing or build-gated),
+# compile-only, e2e-gpu, or e2e-manual.
+set -euo pipefail
+
+DUNE_FILE="sarek/tests/e2e/dune"
+[ -f "$DUNE_FILE" ] || { echo "ERROR: $DUNE_FILE not found (run from repo root)"; exit 2; }
+
+python3 - "$DUNE_FILE" <<'PYEOF'
+import re, sys
+
+path = sys.argv[1]
+src = open(path).read()
+# Strip line comments so names mentioned in prose don't count as wiring.
+src = re.sub(r";[^\n]*", "", src)
+
+# Parse top-level s-expressions.
+def toplevel_forms(s):
+    forms, depth, start = [], 0, None
+    for i, c in enumerate(s):
+        if c == "(":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0 and start is not None:
+                forms.append(s[start : i + 1])
+                start = None
+    return forms
+
+declared = set()
+for form in toplevel_forms(src):
+    head = form[1:].split(None, 1)[0] if form[1:].split(None, 1) else ""
+    if head == "executables":
+        m = re.search(r"\(names((?:[^()])*)\)", form)
+        if m:
+            declared.update(m.group(1).split())
+    elif head == "executable":
+        m = re.search(r"\(name\s+([A-Za-z0-9_]+)\s*\)", form)
+        if m:
+            declared.add(m.group(1))
+
+# Referenced names: every FOO.exe token (rule run actions use %{dep:FOO.exe},
+# alias deps list FOO.exe directly - both match).
+referenced = set(re.findall(r"([A-Za-z0-9_]+)\.exe", src))
+
+missing = sorted(declared - referenced)
+if missing:
+    for exe in missing:
+        print(f"UNWIRED: {exe} is declared in {path} but referenced by no alias or run rule")
+    print()
+    print("Every test executable must be attached to an alias: runtest (executing")
+    print("via (rule (alias runtest) (action (run ...))) or build-gated),")
+    print("compile-only, e2e-gpu, or e2e-manual. See the comment block in")
+    print(f"{path} and briefs/make-tests-actually-run-impl-notes.md.")
+    sys.exit(1)
+
+print(f"OK: all {len(declared)} e2e test executables are wired to an alias")
+PYEOF


### PR DESCRIPTION
## Summary

This PR addresses multiple correctness issues in the PTX code generator and interpreter discovered during a comprehensive audit. The changes fix signed integer division/remainder, implement exact C-semantics floating-point modulo, correct float32 division rounding, and add class-aware instruction selection for 64-bit operands.

## Key Changes

### Floating-Point Modulo (Audit M1)
- Replaced naive single-pass `x - trunc(x/y)*y` formula with iterative reduction in `emit_float_fmod`
- Handles overflow cases where quotient exceeds mantissa precision (>2^53 for f64, >2^24 for f32)
- Implements overflow-scaling branch using power-of-two scaling to preserve congruence mod y
- Adds sign correction and copysign normalization for ±0 results
- Validated bit-exact against OCaml's `Float.rem` on 200k fuzz cases including subnormals

### Signed Integer Arithmetic (Audit H1)
- Changed `div.u32/u64` → `div.s32/s64` for integer division (Sarek ints are signed everywhere)
- Changed `rem.u32/u64` → `rem.s32/s64` for integer remainder
- Fixes silent garbage results for negative operands (e.g., (-7)/2 was returning huge values)
- Updated interpreter's `eval_binop` to use `Int32.div/Int64.div` and `Int32.rem/Int64.rem`

### Float32 Division Accuracy (Audit M2)
- Changed `div.approx.f32` → `div.rn.f32` for generic division operator
- Reserves `div.approx.f32` for already-approximate intrinsics (tan, tanh)
- Fixes ~2 ulp error and exponent-extreme inaccuracy in the old approximate form

### Class-Aware Instruction Selection (Audit H2)
- Added register-width detection for `Not` and `BitNot` unary operators
- Emits `setp.eq.s64` / `not.b64` for 64-bit registers instead of invalid 32-bit instructions
- Prevents PTX module load failures from mismatched instruction/register classes

### Softmath Saturation Bounds (Audit M3)
- Added domain guards to `exp` and `expm1` helpers to prevent exponent-field wrapping
- Flushes underflow to 0 and overflow to ±inf outside [-708, 709.78] range
- Prevents garbage results from (n + 1023) << 52 construction wrapping into sign bits

### Interpreter Fixes (Audit M4)
- Fixed int64 comparisons (Lt, Le, Gt, Ge) to use full 64-bit values instead of truncating to 32 bits
- Fixed int64 bitwise operations (Shl, Shr, BitAnd, BitOr, BitXor) to operate on full 64-bit values
- Added missing float arms to Mod operator (was truncating floats to ints)

### Type Size Registry Validation (Audit M6)
- Changed PPX type-size lookup to hard-error on unknown types instead of silent 4-byte default
- Prevents host/device layout desynchronization for unregistered field types
- Added explicit size entries for bool and unit types

### Tag Erasure Safety (Audit M7)
- Added `arm_matches_ctor` check to detect arm-order shadowing in variant matches
- Prevents incorrect erasure when wildcard/variable patterns precede constructor patterns
- Keeps tags when earlier arms would shadow the target constructor at runtime

### Short-Circuit Evaluation (Audit H3)
- Changed `&&` and `||` lowering from strict `Ir.And/Ir.Or` to short-circuit `EIf`
- Fixes out-of-bounds reads in bounds-guard idioms on PTX and Interpreter backends
- Aligns with C backend behavior

### Test Infrastructure
- Added `scripts/check-test-alias-coverage.sh` to guard against unwired test executables
-

https://claude.ai/code/session_01Xn7LY69qVpLhPpS7BfP65M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correctness for floating remainder/modulo, 64-bit comparisons/bitwise/shift, signed division/modulo, and more valid PTX emission.
  * Fixed short-circuit lowering for `&&`/`||` and strengthened atomic min/max/intrinsic validation.
* **New Features**
  * Added a signed PTX arithmetic regression test and expanded GEMM/PTX-related coverage.
* **Documentation**
  * Refreshed PTX emitter and ZLUDA installation guidance, and updated released documentation links.
* **Tests & Quality**
  * Expanded e2e/unit/negative tests, added PTXAS validation gates, and improved test-alias wiring checks.
* **Chores**
  * Tightened CI build constraints and updated job timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->