### PR TITLE
fix(test): pass the PTX module's .target to ptxas (--gpu-name)

### DIFF
--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -58,7 +58,7 @@
 
 (test
  (name test_ptx_snapshot)
- (libraries sarek.codegen alcotest unix))
+ (libraries sarek.codegen alcotest unix str))
 
 ; Software f64 transcendentals for PTX: IR-level accuracy vs the OCaml stdlib
 ; (pure scalar evaluation of the helper bodies — CPU-only, no device needed)

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -2057,9 +2057,21 @@ let assemble_ok ptx =
   let oc = open_out src in
   output_string oc ptx ;
   close_out oc ;
+  (* ptxas assumes a low default SM and rejects any PTX whose [.target] is
+     higher ("SM version specified by .target is higher than default SM
+     version assumed"), so extract the module's own target and pass it
+     explicitly via --gpu-name. *)
+  let gpu_name =
+    let target_re = Str.regexp "\\.target[ \t]+\\(sm_[0-9]+\\)" in
+    try
+      ignore (Str.search_forward target_re ptx 0) ;
+      Str.matched_group 1 ptx
+    with Not_found -> "sm_86"
+  in
   let cmd =
     Printf.sprintf
-      "ptxas --compile-only -o %s %s 2>%s.err"
+      "ptxas --compile-only --gpu-name %s -o %s %s 2>%s.err"
+      (Filename.quote gpu_name)
       (Filename.quote obj)
       (Filename.quote src)
       (Filename.quote base)


### PR DESCRIPTION
The ptxas assembly gate added in #252 fails on any machine with a real CUDA toolkit: `ptxas --compile-only` without `-arch` assumes its low default SM and rejects the emitted `.target sm_86` ("SM version specified by .target is higher than default SM version assumed").

Fix: extract the `.target sm_XX` from the PTX under test and pass it via `--gpu-name`. Verified on this machine with CUDA 13.3's ptxas (/opt/cuda/bin): the gate now assembles all regression kernels — `[OK] codegen 1 ptxas assembles regression kernels`. Full `dune runtest sarek/tests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)