### PR TITLE
fix(glsl): C-truncated integer Mod on Vulkan via single-eval sarek_smod helper

### DIFF
--- a/benchmarks/descriptions/generated/matrix_mul_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_generated.md
@@ -72,10 +72,12 @@ layout(push_constant) uniform PushConstants {
 #define n pc.n
 #define k pc.k
 
+int sarek_smod(int a, int b) { return a - b * (a / b); }
+
 void main() {
   int tid = int(gl_GlobalInvocationID.x);
   int row = (tid / n);
-  int col = (tid % n);
+  int col = sarek_smod(tid, n);
   if (((row < m) ? (col < n) : false)) {
     precise float sum = 0.0;
     for (int i = 0; i <= (k - 1); i++) {

--- a/benchmarks/descriptions/generated/transpose_naive_generated.md
+++ b/benchmarks/descriptions/generated/transpose_naive_generated.md
@@ -63,11 +63,13 @@ layout(push_constant) uniform PushConstants {
 #define width pc.width
 #define height pc.height
 
+int sarek_smod(int a, int b) { return a - b * (a / b); }
+
 void main() {
   int tid = int(gl_GlobalInvocationID.x);
   int n = (width * height);
   if ((tid < n)) {
-    int col = (tid % width);
+    int col = sarek_smod(tid, width);
     int row = (tid / width);
     int in_idx = ((row * width) + col);
     int out_idx = ((col * height) + row);

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -207,24 +207,19 @@ let rec gen_expr buf = function
       (* Integer remainder with C (dividend-signed, truncated) semantics.
          GLSL's [%] is undefined for negative operands and lowers to OpSMod
          (divisor-signed) on RADV, so [-7 % 2] yields +1 instead of C's -1.
-         Reconstruct C's [rem] as [a - b * (a / b)]: GLSL integer [/] truncates
-         toward zero (verified: the signed-arith probe's quotients already match
-         Int32.div on Vulkan), so this recovers the dividend's sign and matches
-         OCaml Int32.rem / the interpreter / PTX rem.s32 / OpenCL [%]. Type-
-         agnostic: signed int32 and int64 both use truncating [/]. Float [mod]
-         never reaches this arm (the frontend lowers it to the [fmod]/[mod]
-         intrinsic, not [Ir.Mod]). Operands are re-emitted, which is safe
-         because Sarek IR expressions are pure (no side effects); see
-         [Sarek_ir_types.expr]. *)
-      Buffer.add_char buf '(' ;
+         Delegate to the [sarek_smod] helper (emitted in the preamble by
+         [gen_smod_helper]) rather than inlining [a - b * (a / b)]: a GLSL
+         function call evaluates each argument exactly once, so operands that
+         carry side effects (a value-returning atomic intrinsic, an effectful
+         helper call) fire once - inlining the arithmetic form would emit each
+         operand twice and double any such effect. Float [mod] never reaches
+         this arm (the frontend lowers it to the [fmod]/[mod] intrinsic, not
+         [Ir.Mod]). *)
+      Buffer.add_string buf "sarek_smod(" ;
       gen_expr buf e1 ;
-      Buffer.add_string buf " - " ;
+      Buffer.add_string buf ", " ;
       gen_expr buf e2 ;
-      Buffer.add_string buf " * (" ;
-      gen_expr buf e1 ;
-      Buffer.add_string buf " / " ;
-      gen_expr buf e2 ;
-      Buffer.add_string buf "))"
+      Buffer.add_char buf ')'
   | EBinop (op, e1, e2) ->
       Buffer.add_char buf '(' ;
       gen_expr buf e1 ;
@@ -356,8 +351,8 @@ and gen_binop = function
   | Sub -> " - "
   | Mul -> " * "
   | Div -> " / "
-  (* [Mod] is intercepted by [gen_expr] with a C-truncated form; this arm is
-     unreachable and kept only for match exhaustiveness. *)
+  (* [Mod] is intercepted by [gen_expr] and lowered to the [sarek_smod] helper
+     call; this arm is unreachable and kept only for match exhaustiveness. *)
   | Mod -> " % "
   | Eq -> " == "
   | Ne -> " != "
@@ -1024,6 +1019,31 @@ let gen_shared_decls buf (decls : (string * elttype * expr) list) =
     Buffer.add_char buf '\n'
   end
 
+(** Emit the [sarek_smod] integer-remainder helper when the kernel uses [mod].
+
+    Integer [Mod] is lowered (in [gen_expr]) to a call to this helper rather
+    than to the GLSL [%] operator: [%] is undefined for negative operands and
+    lowers to OpSMod (divisor-signed) on RADV, giving [-7 % 2 = +1] instead of
+    C's [-1]. The helper computes the C-truncated, dividend-signed remainder as
+    [a - b * (a / b)]; GLSL integer [/] truncates toward zero, so the result
+    carries the dividend's sign and matches OCaml [Int32.rem] / the interpreter
+    / PTX [rem.s32] / OpenCL [%]. Routing through a function (not inlining the
+    arithmetic) guarantees each operand is evaluated exactly once - critical for
+    operands with side effects (value-returning atomics, effectful helper calls)
+    that are legal integer expressions and reach the [Mod] node unguarded.
+
+    [int]-only for now: int64 on the Vulkan backend is unwired (no
+    [GL_ARB_gpu_shader_int64] extension is emitted anywhere), so an int64 kernel
+    already fails to compile independently of [mod]. If int64 Vulkan lands, add
+    an [int64_t sarek_smod(int64_t, int64_t)] overload here (GLSL resolves the
+    overload by argument type at the call site) and gate the extension on int64
+    usage, mirroring the float64 path in [glsl_header]. *)
+let gen_smod_helper buf (k : kernel) =
+  if Sarek_ir_analysis.kernel_uses_int_mod k then
+    Buffer.add_string
+      buf
+      "int sarek_smod(int a, int b) { return a - b * (a / b); }\n\n"
+
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
 *)
@@ -1071,6 +1091,10 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
   (* Generate shared declarations at module scope (GLSL requirement) *)
   let shared_decls = collect_shared_decls k.kern_body in
   gen_shared_decls buf shared_decls ;
+
+  (* Emit the integer-remainder helper (before user helpers, which may call
+     it) when the kernel uses [mod]. *)
+  gen_smod_helper buf k ;
 
   (* Generate helper functions *)
   List.iter (gen_helper_func ~pc_names buf) k.kern_funcs ;
@@ -1161,6 +1185,10 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   (* Generate shared declarations at module scope (GLSL requirement) *)
   let shared_decls = collect_shared_decls k.kern_body in
   gen_shared_decls buf shared_decls ;
+
+  (* Emit the integer-remainder helper (before user helpers, which may call
+     it) when the kernel uses [mod]. *)
+  gen_smod_helper buf k ;
 
   (* Generate helper functions *)
   List.iter (gen_helper_func ~pc_names buf) k.kern_funcs ;

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -203,6 +203,28 @@ let rec gen_expr buf = function
   | EConst (CBool false) -> Buffer.add_string buf "false"
   | EConst CUnit -> Buffer.add_string buf "/* unit */"
   | EVar v -> Buffer.add_string buf (escape_glsl_name v.var_name)
+  | EBinop (Mod, e1, e2) ->
+      (* Integer remainder with C (dividend-signed, truncated) semantics.
+         GLSL's [%] is undefined for negative operands and lowers to OpSMod
+         (divisor-signed) on RADV, so [-7 % 2] yields +1 instead of C's -1.
+         Reconstruct C's [rem] as [a - b * (a / b)]: GLSL integer [/] truncates
+         toward zero (verified: the signed-arith probe's quotients already match
+         Int32.div on Vulkan), so this recovers the dividend's sign and matches
+         OCaml Int32.rem / the interpreter / PTX rem.s32 / OpenCL [%]. Type-
+         agnostic: signed int32 and int64 both use truncating [/]. Float [mod]
+         never reaches this arm (the frontend lowers it to the [fmod]/[mod]
+         intrinsic, not [Ir.Mod]). Operands are re-emitted, which is safe
+         because Sarek IR expressions are pure (no side effects); see
+         [Sarek_ir_types.expr]. *)
+      Buffer.add_char buf '(' ;
+      gen_expr buf e1 ;
+      Buffer.add_string buf " - " ;
+      gen_expr buf e2 ;
+      Buffer.add_string buf " * (" ;
+      gen_expr buf e1 ;
+      Buffer.add_string buf " / " ;
+      gen_expr buf e2 ;
+      Buffer.add_string buf "))"
   | EBinop (op, e1, e2) ->
       Buffer.add_char buf '(' ;
       gen_expr buf e1 ;
@@ -334,6 +356,8 @@ and gen_binop = function
   | Sub -> " - "
   | Mul -> " * "
   | Div -> " / "
+  (* [Mod] is intercepted by [gen_expr] with a C-truncated form; this arm is
+     unreachable and kept only for match exhaustiveness. *)
   | Mod -> " % "
   | Eq -> " == "
   | Ne -> " != "

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -28,6 +28,14 @@ end)
 (** Current kernel's variant definitions (set during generate) *)
 let current_variants : (string * (string * elttype list) list) list ref = ref []
 
+(** Name of the integer-remainder helper ([sarek_smod] by default) for the
+    current kernel, set per-kernel during generate by {!compute_smod_name} so it
+    cannot collide with a user identifier. Both the declaration
+    ({!gen_smod_helper}) and the call site ({!gen_expr}'s [Mod] arm) read this,
+    guaranteeing they agree. Mirrors the per-kernel {!current_variants} state.
+*)
+let current_smod_name = ref "sarek_smod"
+
 (** Helper function vector parameter indices - maps function name to set of
     parameter indices that are vectors. In GLSL, vectors cannot be passed as
     function parameters, so these must be filtered out at call sites. *)
@@ -215,7 +223,8 @@ let rec gen_expr buf = function
          operand twice and double any such effect. Float [mod] never reaches
          this arm (the frontend lowers it to the [fmod]/[mod] intrinsic, not
          [Ir.Mod]). *)
-      Buffer.add_string buf "sarek_smod(" ;
+      Buffer.add_string buf !current_smod_name ;
+      Buffer.add_char buf '(' ;
       gen_expr buf e1 ;
       Buffer.add_string buf ", " ;
       gen_expr buf e2 ;
@@ -1035,14 +1044,58 @@ let gen_shared_decls buf (decls : (string * elttype * expr) list) =
     [int]-only for now: int64 on the Vulkan backend is unwired (no
     [GL_ARB_gpu_shader_int64] extension is emitted anywhere), so an int64 kernel
     already fails to compile independently of [mod]. If int64 Vulkan lands, add
-    an [int64_t sarek_smod(int64_t, int64_t)] overload here (GLSL resolves the
+    an [int64_t <name>(int64_t, int64_t)] overload here (GLSL resolves the
     overload by argument type at the call site) and gate the extension on int64
-    usage, mirroring the float64 path in [glsl_header]. *)
+    usage, mirroring the float64 path in [glsl_header].
+
+    The helper name is [!current_smod_name] (see {!compute_smod_name}), not a
+    literal, so it cannot collide with a user param or helper identifier. *)
 let gen_smod_helper buf (k : kernel) =
   if Sarek_ir_analysis.kernel_uses_int_mod k then
     Buffer.add_string
       buf
-      "int sarek_smod(int a, int b) { return a - b * (a / b); }\n\n"
+      (Printf.sprintf
+         "int %s(int a, int b) { return a - b * (a / b); }\n\n"
+         !current_smod_name)
+
+(** Choose a collision-safe name for the integer-remainder helper of kernel [k].
+
+    The helper is declared at GLSL top level and called from expressions, so its
+    name must avoid every identifier sharing that scope. Two collision sources
+    (both observed by CodeRabbit on PR #255):
+
+    - {b param names}: a scalar param becomes a push-constant alias
+      [#define <name> pc.<name>], which would macro-expand the helper
+      declaration and every call; a vector param becomes the storage-buffer
+      array identifier [<name>]. Both use [escape_glsl_name].
+    - {b helper-function names}: emitted verbatim as [hf.hf_name] (see
+      {!gen_helper_func}); a user helper named [sarek_smod] would duplicate the
+      symbol.
+
+    If the default [sarek_smod] is taken, return the first free [sarek_smod_1],
+    [sarek_smod_2], ... Local ([SLet]) names are function-scoped, not top-level,
+    and are left to the future reserved-prefix policy noted in the impl brief
+    (the same class already affects the [sarek_<arr>_length] intrinsic name). *)
+let compute_smod_name (k : kernel) : string =
+  let reserved : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (fun decl ->
+      match decl with
+      | DParam (v, _) ->
+          Hashtbl.replace reserved (escape_glsl_name v.var_name) ()
+      | _ -> ())
+    k.kern_params ;
+  List.iter
+    (fun (hf : helper_func) -> Hashtbl.replace reserved hf.hf_name ())
+    k.kern_funcs ;
+  let base = "sarek_smod" in
+  if not (Hashtbl.mem reserved base) then base
+  else
+    let rec find i =
+      let cand = Printf.sprintf "%s_%d" base i in
+      if Hashtbl.mem reserved cand then find (i + 1) else cand
+    in
+    find 1
 
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
@@ -1051,6 +1104,7 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
     =
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
+  current_smod_name := compute_smod_name k ;
   let buf = Buffer.create 1024 in
   Buffer.add_string
     buf
@@ -1136,6 +1190,7 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
     ~(types : (string * (string * elttype) list) list) (k : kernel) : string =
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
+  current_smod_name := compute_smod_name k ;
   (* Use variant types directly from kernel IR *)
   current_variants := k.kern_variants ;
 

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -921,3 +921,22 @@
  (alias runtest)
  (action
   (run %{dep:test_glsl_mod_single_eval.exe})))
+
+(executable
+ (name test_glsl_mod_name_collision)
+ (modules test_glsl_mod_name_collision)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  test_helpers
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_glsl_mod_name_collision.exe})))

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -902,3 +902,22 @@
  (alias runtest)
  (action
   (run %{dep:test_ptx_signed_arith.exe})))
+
+(executable
+ (name test_glsl_mod_single_eval)
+ (modules test_glsl_mod_single_eval)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  test_helpers
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_glsl_mod_single_eval.exe})))

--- a/sarek/tests/e2e/test_glsl_mod_name_collision.ml
+++ b/sarek/tests/e2e/test_glsl_mod_name_collision.ml
@@ -1,0 +1,152 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E regression: the GLSL integer-[mod] helper name must not collide with a
+ * user identifier (CodeRabbit Major on PR #255).
+ *
+ * The GLSL backend lowers integer [Mod] to a call to a top-level helper
+ * (default name [sarek_smod]). A scalar kernel parameter emits a push-constant
+ * alias [#define <name> pc.<name>]; if a param is literally named [sarek_smod],
+ * that macro would rewrite the helper declaration [int sarek_smod(...)] to
+ * [int pc.sarek_smod(...)] - invalid GLSL, shader fails to compile. The fix
+ * (Sarek_ir_glsl.compute_smod_name) renames the helper to a fresh, non-colliding
+ * name ([sarek_smod_1], ...) used at both the declaration and every call site.
+ *
+ * This kernel does exactly that: a scalar divisor parameter NAMED [sarek_smod],
+ * used as the right operand of [mod]. If the collision were unhandled the
+ * Vulkan shader would not compile and the backend could not launch. Results are
+ * compared bit-for-bit against OCaml [Int32.rem] on every backend that runs.
+ *
+ * Run with (surfaces the CUDA device too):
+ *   LD_LIBRARY_PATH=$HOME/opt/zluda \
+ *     dune exec sarek/tests/e2e/test_glsl_mod_name_collision.exe
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Test_helpers.Benchmarks.init_backends ()
+
+(* The divisor parameter is deliberately named [sarek_smod] - the same name as
+   the default remainder helper - to force the collision path. A negative
+   divisor also re-checks the dividend-signed C remainder. *)
+let collision_kernel =
+  [%kernel
+    fun (a : int32 vector)
+        (r : int32 vector)
+        (sarek_smod : int32)
+        (n : int32) ->
+      let open Std in
+      let gid = global_thread_id in
+      if gid < n then r.(gid) <- a.(gid) mod sarek_smod]
+
+let dividends = [|-7l; 7l; -100l; 100l; -1l; 0l; 123l; -123l|]
+
+let divisor = -3l
+
+let n = Array.length dividends
+
+let run_on_device (dev : Device.t) ir =
+  let a = Vector.create Vector.int32 n in
+  let r = Vector.create Vector.int32 n in
+  for i = 0 to n - 1 do
+    Vector.set a i dividends.(i) ;
+    Vector.set r i 0l
+  done ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Execute.Vec a; Execute.Vec r; Execute.Int32 divisor; Execute.Int n]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  Vector.to_array r
+
+let verify got_r =
+  let bad = ref 0 in
+  for i = 0 to n - 1 do
+    let expected = Int32.rem dividends.(i) divisor in
+    if got_r.(i) <> expected then begin
+      if !bad < 5 then
+        Printf.printf
+          "    mismatch @%d: %ld mod %ld got %ld exp %ld\n%!"
+          i
+          dividends.(i)
+          divisor
+          got_r.(i)
+          expected ;
+      incr bad
+    end
+  done ;
+  !bad
+
+let is_native (dev : Device.t) =
+  dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
+
+(* Gate native/interpreter (oracle) AND Vulkan: the collision this test pins is
+   GLSL-specific, so a Vulkan device that is present must both LAUNCH (an
+   unhandled collision makes the shader fail to compile) and match Int32.rem.
+   Treating a Vulkan launch failure as a mere skip would mask the exact
+   regression - so for a present Vulkan device, failure is hard. PTX/OpenCL do
+   not use the GLSL helper; they stay report-only for infra robustness. *)
+let is_gated (dev : Device.t) = is_native dev || dev.Device.framework = "Vulkan"
+
+let () =
+  let _, kirc = collision_kernel in
+  let ir =
+    match kirc.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "collision kernel has no IR"
+  in
+  let devs = Device.init () in
+  print_endline
+    "=== GLSL mod-helper name-collision E2E (param named sarek_smod) ===" ;
+  let native_ran = ref false in
+  let failed = ref false in
+  Array.iter
+    (fun (dev : Device.t) ->
+      let native = is_native dev in
+      let gated = is_gated dev in
+      try
+        let got_r = run_on_device dev ir in
+        let bad = verify got_r in
+        Printf.printf
+          "  %-11s %-40s %s (%d/%d ok)\n%!"
+          dev.Device.framework
+          dev.Device.name
+          (if bad = 0 then "PASS" else "FAIL")
+          (n - bad)
+          n ;
+        if bad <> 0 then failed := true ;
+        if native then native_ran := true
+      with e ->
+        Printf.printf
+          "  %-11s %-40s %s (%s)\n%!"
+          dev.Device.framework
+          dev.Device.name
+          (if gated then "ERROR" else "SKIP (backend could not launch)")
+          (Printexc.to_string e) ;
+        (* A GLSL compile failure from an unhandled name collision surfaces here
+           as a Vulkan launch failure - gated (hard fail), since Vulkan is the
+           backend this regression targets. *)
+        if gated then failed := true)
+    devs ;
+  if not !native_ran then begin
+    print_endline
+      "test_glsl_mod_name_collision: FAILED - no native/interpreter device ran" ;
+    exit 1
+  end ;
+  if !failed then begin
+    print_endline "test_glsl_mod_name_collision: FAILED" ;
+    exit 1
+  end ;
+  print_endline "test_glsl_mod_name_collision: PASSED"

--- a/sarek/tests/e2e/test_glsl_mod_single_eval.ml
+++ b/sarek/tests/e2e/test_glsl_mod_single_eval.ml
@@ -1,0 +1,135 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E positive control: integer [Mod] evaluates each operand exactly ONCE.
+ *
+ * The GLSL/Vulkan backend lowers signed integer [Mod] to a C-truncated
+ * remainder. The naive rewrite [a - b * (a / b)] re-emits both operands, so an
+ * operand carrying a side effect - a value-returning atomic, an effectful
+ * helper call - would fire TWICE (silent double mutation + wrong result).
+ * Every other backend single-evaluates [%]; the fix routes GLSL [Mod] through
+ * a [sarek_smod(a, b)] helper call, and a GLSL function evaluates each argument
+ * exactly once, so the effect fires once.
+ *
+ * This test is the red-on-mutation control for that guarantee. The mod operand
+ * is an INLINE global-atomic increment (returns the old counter value); the
+ * remainder result is stored so the atomic cannot be dead-code eliminated. Each
+ * of [n] threads runs the kernel once, so:
+ *   - single evaluation  => counter ends at n   (PASS)
+ *   - double evaluation  => counter ends at 2*n (FAIL - catches the naive form)
+ * The final counter is order-independent (a sum of increments), so the witness
+ * is deterministic regardless of thread scheduling.
+ *
+ * Run with (surfaces the CUDA device too):
+ *   LD_LIBRARY_PATH=$HOME/opt/zluda \
+ *     dune exec sarek/tests/e2e/test_glsl_mod_single_eval.exe
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Gpu = Sarek_stdlib.Gpu
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Test_helpers.Benchmarks.init_backends ()
+
+(* r.(gid) = (atomic_add_global counter[0] 1) mod 1000. The atomic call is the
+   left operand of [mod] directly (not let-bound), so a Mod lowering that
+   re-emits its operands fires the atomic twice per thread. *)
+let single_eval_kernel =
+  [%kernel
+    fun (counter : int32 vector) (r : int32 vector) (n : int32) ->
+      let open Std in
+      let open Gpu in
+      let gid = global_thread_id in
+      if gid < n then r.(gid) <- atomic_add_global_int32 counter 0 1l mod 1000l]
+
+let block_size = 256
+
+let n = 4096 (* multiple of block_size: 16 blocks x 256 threads *)
+
+let run_on_device (dev : Device.t) ir =
+  let counter = Vector.create Vector.int32 1 in
+  let r = Vector.create Vector.int32 n in
+  Vector.set counter 0 0l ;
+  for i = 0 to n - 1 do
+    Vector.set r i 0l
+  done ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Execute.Vec counter; Execute.Vec r; Execute.Int n]
+    ~block:(Execute.dims1d block_size)
+    ~grid:(Execute.dims1d (n / block_size))
+    () ;
+  Transfer.flush dev ;
+  Int32.to_int (Vector.get counter 0)
+
+(* Gate the backends whose atomics we can execute and read back here: the
+   GLSL/Vulkan backend this fix targets, plus the CUDA/PTX and OpenCL GPU
+   backends and the native/interpreter oracles. A backend that runs but
+   double-counts is a hard failure. A GPU backend that cannot launch for infra
+   reasons is reported only. *)
+let is_native (dev : Device.t) =
+  dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
+
+let () =
+  let _, kirc = single_eval_kernel in
+  let ir =
+    match kirc.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "single_eval kernel has no IR"
+  in
+  let devs = Device.init () in
+  print_endline "=== integer Mod single-evaluation E2E (atomic operand) ===" ;
+  Printf.printf
+    "  expect final counter = n = %d (2*n = %d means double-eval)\n%!"
+    n
+    (2 * n) ;
+  let native_ran = ref false in
+  let failed = ref false in
+  Array.iter
+    (fun (dev : Device.t) ->
+      let native = is_native dev in
+      try
+        let got = run_on_device dev ir in
+        let ok = got = n in
+        Printf.printf
+          "  %-11s %-40s %s (counter=%d)\n%!"
+          dev.Device.framework
+          dev.Device.name
+          (if ok then "PASS" else "FAIL")
+          got ;
+        if not ok then failed := true ;
+        if native then native_ran := true
+      with e ->
+        let msg =
+          match e with
+          | Sarek_backend_error.Backend_error.Backend_error t ->
+              Sarek_backend_error.Backend_error.to_string t
+          | e -> Printexc.to_string e
+        in
+        Printf.printf
+          "  %-11s %-40s %s (%s)\n%!"
+          dev.Device.framework
+          dev.Device.name
+          (if native then "ERROR" else "SKIP (backend could not launch)")
+          msg ;
+        if native then failed := true)
+    devs ;
+  if not !native_ran then begin
+    print_endline
+      "test_glsl_mod_single_eval: FAILED - no native/interpreter device ran" ;
+    exit 1
+  end ;
+  if !failed then begin
+    print_endline "test_glsl_mod_single_eval: FAILED" ;
+    exit 1
+  end ;
+  print_endline "test_glsl_mod_single_eval: PASSED"

--- a/sarek/tests/e2e/test_ptx_signed_arith.ml
+++ b/sarek/tests/e2e/test_ptx_signed_arith.ml
@@ -68,7 +68,22 @@ let cases =
     (-1l, 2l);
     (0l, 5l);
     (-999l, -13l);
+    (* Divisor magnitude 1: remainder is always 0, so a divisor-signed vs
+       dividend-signed remainder cannot be told apart on these - they pin the
+       [b = +/-1] edge of the GLSL [a - b*(a/b)] reconstruction (a/b = a, so
+       the remainder must collapse to exactly 0) rather than the sign. *)
+    (42l, 1l);
+    (-42l, 1l);
+    (7l, -1l);
+    (-7l, -1l);
   |]
+
+(* NOTE: [INT_MIN / -1] (and its remainder) is deliberately absent. It is
+   undefined behaviour for signed division on every target here (the true
+   quotient +2^31 is not representable in int32) and is a pre-existing Div
+   concern independent of this Mod fix - adding it would test div overflow, not
+   remainder sign. INT_MIN paired with +3 above already exercises the sign bit
+   through the remainder path. *)
 
 let n = Array.length cases
 

--- a/sarek/tests/e2e/test_ptx_signed_arith.ml
+++ b/sarek/tests/e2e/test_ptx_signed_arith.ml
@@ -16,9 +16,11 @@
  * under-tests.
  *
  * Integer div/rem is exact, so results are compared bit-for-bit against
- * OCaml's Int32.div/Int32.rem (no tolerance). Native, Interpreter and
- * CUDA/PTX are hard-gated; the Vulkan backend has a pre-existing signed-mod
- * divergence (see [is_gated]) and is reported only.
+ * OCaml's Int32.div/Int32.rem (no tolerance). Native, Interpreter, CUDA/PTX
+ * and Vulkan are all hard-gated (see [is_gated]). Vulkan's signed-mod
+ * divergence - GLSL [%] returns a divisor-signed remainder on RADV - was
+ * fixed by lowering integer [Mod] to the C-truncated form [a - b*(a/b)] in
+ * Sarek_ir_glsl.ml; this probe now gates that fix.
  *
  * Run with (surfaces the CUDA device):
  *   LD_LIBRARY_PATH=$HOME/opt/zluda \
@@ -120,18 +122,20 @@ let verify got_q got_r =
 let is_native (dev : Device.t) =
   dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
 
-(* Backends whose signed remainder this PR fixes/claims C semantics for: the
-   PTX emitter (audit H1) plus the interpreter and native oracle. A wrong
-   result from one of these is a hard failure.
+(* Backends whose signed remainder is claimed to have C semantics: the PTX
+   emitter (audit H1), the interpreter and native oracle, AND the Vulkan/GLSL
+   backend. A wrong result from any of these is a hard failure.
 
-   NOT gated: the Vulkan backend lowers integer Mod to the GLSL [%] operator
+   Vulkan is now gated: integer [Mod] used to lower to the GLSL [%] operator
    (Sarek_ir_glsl.ml), which on RADV returns a remainder with the DIVISOR's
-   sign (OpSMod-like) instead of C's dividend sign - so [-7 mod 2] yields +1,
-   not -1. That is a genuine pre-existing Vulkan codegen bug this probe
-   surfaces, but it is out of scope for this PTX/interpreter PR; it is
-   reported here (see stdout) and left for a dedicated GLSL-backend fix. *)
+   sign (OpSMod-like) instead of C's dividend sign - so [-7 mod 2] yielded +1,
+   not -1. That backend gap is fixed by emitting the C-truncated form
+   [a - b*(a/b)] (GLSL integer [/] truncates toward zero), so the Vulkan rows
+   must now match Int32.rem bit-for-bit like every other gated backend. *)
 let is_gated (dev : Device.t) =
-  is_native dev || dev.Device.framework = "CUDA/PTX"
+  is_native dev
+  || dev.Device.framework = "CUDA/PTX"
+  || dev.Device.framework = "Vulkan"
 
 let () =
   let _, kirc = signed_divrem_kernel in
@@ -161,7 +165,7 @@ let () =
           (if bad <> 0 && not gated then " [known out-of-scope backend gap]"
            else "") ;
         (* Integer div/rem is exact, so a gated backend that ran must match
-           bit-for-bit. Non-gated backends (Vulkan) are reported only. *)
+           bit-for-bit. A non-gated backend that diverges is reported only. *)
         if bad <> 0 && gated then failed := true ;
         if native then native_ran := true
       with e ->

--- a/spoc/ir/Sarek_ir_analysis.ml
+++ b/spoc/ir/Sarek_ir_analysis.ml
@@ -211,3 +211,79 @@ let kernel_uses_atomics k =
   || List.exists decl_uses_atomics k.kern_locals
   || stmt_uses_atomics k.kern_body
   || List.exists helper_uses_atomics k.kern_funcs
+
+(** {1 Integer-remainder detection}
+
+    [EBinop (Mod, _, _)] is always integer remainder — float [mod] is lowered to
+    the [fmod]/[mod] intrinsic (an [EIntrinsic]), never to [Ir.Mod]. Backends
+    that cannot lower [%] directly (e.g. GLSL, whose [%] is undefined for
+    negative operands) use this to decide whether to emit a remainder helper. *)
+let rec expr_uses_int_mod = function
+  | EBinop (Mod, _, _) -> true
+  | EConst _ | EVar _ -> false
+  | EBinop (_, e1, e2) -> expr_uses_int_mod e1 || expr_uses_int_mod e2
+  | EUnop (_, e) -> expr_uses_int_mod e
+  | EArrayRead (_, idx) -> expr_uses_int_mod idx
+  | EArrayReadExpr (base, idx) ->
+      expr_uses_int_mod base || expr_uses_int_mod idx
+  | ERecordField (e, _) -> expr_uses_int_mod e
+  | EIntrinsic (_, _, args) -> List.exists expr_uses_int_mod args
+  | ECast (_, e) -> expr_uses_int_mod e
+  | ETuple exprs -> List.exists expr_uses_int_mod exprs
+  | EApp (fn, args) ->
+      expr_uses_int_mod fn || List.exists expr_uses_int_mod args
+  | ERecord (_, fields) ->
+      List.exists (fun (_, e) -> expr_uses_int_mod e) fields
+  | EVariant (_, _, args) -> List.exists expr_uses_int_mod args
+  | EArrayLen _ -> false
+  | EArrayCreate (_, size, _) -> expr_uses_int_mod size
+  | EIf (cond, then_, else_) ->
+      expr_uses_int_mod cond || expr_uses_int_mod then_
+      || expr_uses_int_mod else_
+  | EMatch (scrutinee, cases) ->
+      expr_uses_int_mod scrutinee
+      || List.exists (fun (_, e) -> expr_uses_int_mod e) cases
+
+let lvalue_uses_int_mod = function
+  | LVar _ -> false
+  | LArrayElem (_, idx) -> expr_uses_int_mod idx
+  | LArrayElemExpr (base, idx) ->
+      expr_uses_int_mod base || expr_uses_int_mod idx
+  | LRecordField _ -> false
+
+let rec stmt_uses_int_mod = function
+  | SAssign (lv, e) -> lvalue_uses_int_mod lv || expr_uses_int_mod e
+  | SSeq stmts -> List.exists stmt_uses_int_mod stmts
+  | SIf (cond, then_, else_) ->
+      expr_uses_int_mod cond || stmt_uses_int_mod then_
+      || Option.fold ~none:false ~some:stmt_uses_int_mod else_
+  | SWhile (cond, body) -> expr_uses_int_mod cond || stmt_uses_int_mod body
+  | SFor (_, lo, hi, _, body) ->
+      expr_uses_int_mod lo || expr_uses_int_mod hi || stmt_uses_int_mod body
+  | SMatch (scrutinee, cases) ->
+      expr_uses_int_mod scrutinee
+      || List.exists (fun (_, s) -> stmt_uses_int_mod s) cases
+  | SReturn e | SExpr e -> expr_uses_int_mod e
+  | SBarrier | SWarpBarrier | SEmpty | SMemFence -> false
+  | SLet (_, e, body) | SLetMut (_, e, body) ->
+      expr_uses_int_mod e || stmt_uses_int_mod body
+  | SPragma (_, body) | SBlock body -> stmt_uses_int_mod body
+  (* Inline native GPU code is opaque text; assume it may contain a remainder
+     so a helper it references is still emitted. *)
+  | SNative _ -> true
+
+let decl_uses_int_mod = function
+  | DParam _ -> false
+  | DLocal (_, init) -> Option.fold ~none:false ~some:expr_uses_int_mod init
+  | DShared (_, _, size) -> Option.fold ~none:false ~some:expr_uses_int_mod size
+
+let helper_uses_int_mod hf = stmt_uses_int_mod hf.hf_body
+
+(** Check if a kernel uses integer remainder anywhere: locals initializers,
+    body, and helper functions. Helper bodies are walked explicitly (a helper
+    may use [mod] even when the top-level body does not). *)
+let kernel_uses_int_mod k =
+  List.exists decl_uses_int_mod k.kern_params
+  || List.exists decl_uses_int_mod k.kern_locals
+  || stmt_uses_int_mod k.kern_body
+  || List.exists helper_uses_int_mod k.kern_funcs

--- a/spoc/ir/Sarek_ir_analysis.ml
+++ b/spoc/ir/Sarek_ir_analysis.ml
@@ -244,12 +244,16 @@ let rec expr_uses_int_mod = function
       expr_uses_int_mod scrutinee
       || List.exists (fun (_, e) -> expr_uses_int_mod e) cases
 
-let lvalue_uses_int_mod = function
+let rec lvalue_uses_int_mod = function
   | LVar _ -> false
   | LArrayElem (_, idx) -> expr_uses_int_mod idx
   | LArrayElemExpr (base, idx) ->
       expr_uses_int_mod base || expr_uses_int_mod idx
-  | LRecordField _ -> false
+  (* Recurse into the nested lvalue: its array index may carry a [mod], e.g.
+     [arr.(j mod n).field <- v]. A non-recursive arm would miss it and skip
+     emitting the [sarek_smod] helper the emitted index references. Mirrors
+     [lvalue_uses_atomics]. *)
+  | LRecordField (lv, _) -> lvalue_uses_int_mod lv
 
 let rec stmt_uses_int_mod = function
   | SAssign (lv, e) -> lvalue_uses_int_mod lv || expr_uses_int_mod e

--- a/spoc/ir/test/test_sarek_ir_analysis.ml
+++ b/spoc/ir/test/test_sarek_ir_analysis.ml
@@ -576,6 +576,76 @@ let test_kernel_uses_atomics_snative () =
   assert (kernel_uses_atomics k_native = true) ;
   print_endline "  kernel_uses_atomics via SNative (conservative): OK"
 
+(** {1 expr_uses_int_mod / kernel_uses_int_mod Tests} *)
+
+let test_expr_uses_int_mod () =
+  let no_mod = EBinop (Add, EConst (CInt32 1l), EConst (CInt32 2l)) in
+  assert (expr_uses_int_mod no_mod = false) ;
+  let direct_mod = EBinop (Mod, EConst (CInt32 7l), EConst (CInt32 2l)) in
+  assert (expr_uses_int_mod direct_mod = true) ;
+  (* Nested: [mod] buried inside an otherwise ordinary expression. *)
+  let nested_mod = EBinop (Add, EConst (CInt32 1l), direct_mod) in
+  assert (expr_uses_int_mod nested_mod = true) ;
+  print_endline "  expr_uses_int_mod: OK"
+
+(** Regression pin (finding: [lvalue_uses_int_mod] must recurse through
+    [LRecordField]). [LRecordField] wraps a NESTED lvalue whose array index can
+    carry a [mod], e.g. [arr.(j mod n).field <- v]. A non-recursive arm returned
+    false, so the GLSL backend would emit a [sarek_smod(...)] call from the
+    lvalue index while [kernel_uses_int_mod] wrongly reported false and skipped
+    emitting the helper — an undefined-function shader compile failure. *)
+let test_lvalue_uses_int_mod () =
+  let mod_idx = EBinop (Mod, EConst (CInt32 7l), EConst (CInt32 2l)) in
+  assert (
+    lvalue_uses_int_mod
+      (LVar {var_name = "x"; var_id = 0; var_type = TInt32; var_mutable = true})
+    = false) ;
+  assert (lvalue_uses_int_mod (LArrayElem ("arr", EConst (CInt32 0l))) = false) ;
+  assert (lvalue_uses_int_mod (LArrayElem ("arr", mod_idx)) = true) ;
+  assert (
+    lvalue_uses_int_mod (LArrayElemExpr (EConst (CInt32 0l), mod_idx)) = true) ;
+  (* The load-bearing shape: [mod] only inside an LRecordField-wrapped index. *)
+  assert (
+    lvalue_uses_int_mod (LRecordField (LArrayElem ("arr", mod_idx), "field"))
+    = true) ;
+  print_endline "  lvalue_uses_int_mod: OK"
+
+(** The only [mod] in the kernel is inside an [SAssign] lvalue whose index is
+    wrapped in [LRecordField] ([arr.(j mod n).field <- v]) — the exact shape
+    that a non-recursive [lvalue_uses_int_mod] would miss. *)
+let test_kernel_uses_int_mod_in_record_field_lvalue () =
+  let mod_idx = EBinop (Mod, EConst (CInt32 7l), EConst (CInt32 2l)) in
+  let k_lvalue_mod : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LRecordField (LArrayElem ("arr", mod_idx), "field"),
+            EConst (CInt32 5l) );
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_int_mod k_lvalue_mod = true) ;
+  let k_none : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body = SEmpty;
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_int_mod k_none = false) ;
+  print_endline "  kernel_uses_int_mod via record-field lvalue: OK"
+
 (** {1 Main} *)
 
 let () =
@@ -613,4 +683,7 @@ let () =
   test_lvalue_uses_atomics () ;
   test_kernel_uses_atomics_in_assign_lvalue () ;
   test_kernel_uses_atomics_snative () ;
+  test_expr_uses_int_mod () ;
+  test_lvalue_uses_int_mod () ;
+  test_kernel_uses_int_mod_in_record_field_lvalue () ;
   print_endline "All Sarek_ir_analysis tests passed!"


### PR DESCRIPTION
GLSL `%` lowers to OpSMod (divisor-signed) on RADV: `-7 mod 2` returned +1 instead of C/OCaml/PTX/OpenCL's dividend-signed -1 (found by #252's signed-arith probe, previously tolerated as DIVERGES).

**Fix (3 review rounds, roster pipeline):**
- `Ir.Mod` on GLSL now lowers to a preamble helper `int sarek_smod(int a, int b) { return a - b * (a / b); }` — function arguments evaluate exactly once, so effectful operands (value-returning atomics, helper calls) are safe. An inline `(a - b*(a/b))` rewrite was rejected in review: it double-fires atomics (proven by mutation: counter=8192 vs 4096, Vulkan-only flip).
- Helper emission gated on `Sarek_ir_analysis.kernel_uses_int_mod` (complete traversal incl. LRecordField-nested lvalue indices — round-3 fix + unit pin, red-on-mutation).
- Probe `test_ptx_signed_arith`: Vulkan flipped from reported-DIVERGES to gated must-pass; 14/14 (incl. b=±1, INT_MIN mod 3) on both RADV devices; INT_MIN/-1 documented as pre-existing signed-Div UB.
- New positive control `test_glsl_mod_single_eval`: atomic-as-mod-operand, counter=n on every device.

No PTX/OpenCL regression (14/14 under ZLUDA). Pipeline: implement→review(NO-GO)→implement→review(NO-GO)→implement→review GO→QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GLSL integer remainder semantics to match C/OCaml-style truncated, dividend-signed behavior for negative operands.
  * Prevented `mod` operands from being evaluated more than once, preserving results when operands have side effects.
  * Fixed signed remainder consistency across backends and avoided GLSL helper name collisions.
* **Tests**
  * Added e2e coverage for single-evaluation of `mod` with side effects and for backend-correct signed remainder edge cases.
  * Expanded IR analysis tests and kernel-level detection to cover integer remainder usage inside nested expressions and lvalue indices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->