### PR TITLE
fix(glsl): exact bit-level copysign for f32/f64 on Vulkan

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -36,6 +36,13 @@ let current_variants : (string * (string * elttype list) list) list ref = ref []
 *)
 let current_smod_name = ref "sarek_smod"
 
+(** Name of the sign-copy helper ([sarek_copysign] by default) for the current
+    kernel, set per-kernel during generate by {!compute_copysign_name} so it
+    cannot collide with a user identifier. Both the declaration
+    ({!gen_copysign_helper}) and the call site ({!gen_intrinsic}'s [copysign]
+    arm) read this, guaranteeing they agree. Mirrors {!current_smod_name}. *)
+let current_copysign_name = ref "sarek_copysign"
+
 (** Helper function vector parameter indices - maps function name to set of
     parameter indices that are vectors. In GLSL, vectors cannot be passed as
     function parameters, so these must be filtered out at call sites. *)
@@ -424,6 +431,26 @@ and gen_intrinsic buf path name args =
   in
   if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"] then
     gen_glsl_polyfill buf name args
+  else if name = "copysign" then (
+    (* GLSL has no [copysign] builtin under any name, and [abs(x)*sign(y)] is
+       wrong for [y=0] (GLSL [sign(0)=0]) and the [x=0]/NaN sign-transfer edge
+       cases. Lower to the bit-level [sarek_copysign] helper emitted in the
+       preamble by [gen_copysign_helper], ahead of both the pure registry
+       (which would emit the raw un-suffixed [copysign(...)] for
+       [Float32.copysign]) and the unqualified match arms (where
+       [Float64.copysign] would fall through to the raw-name fallback and emit
+       the swizzle-parsed [Float64.copysign(...)] that glslang rejects).
+       Routing through a function (not inlining the bit twiddling) evaluates
+       each argument exactly once — the same single-eval guarantee as the
+       [sarek_smod] helper. *)
+    Buffer.add_string buf !current_copysign_name ;
+    Buffer.add_char buf '(' ;
+    List.iteri
+      (fun i e ->
+        if i > 0 then Buffer.add_string buf ", " ;
+        gen_expr buf e)
+      args ;
+    Buffer.add_char buf ')')
   else
     (* For path-qualified intrinsics, query the pure registry first.
      Float32.sin -> sin on GLSL (GLSL uses un-suffixed names). *)
@@ -1076,7 +1103,7 @@ let gen_smod_helper buf (k : kernel) =
     [sarek_smod_2], ... Local ([SLet]) names are function-scoped, not top-level,
     and are left to the future reserved-prefix policy noted in the impl brief
     (the same class already affects the [sarek_<arr>_length] intrinsic name). *)
-let compute_smod_name (k : kernel) : string =
+let compute_collision_safe_name (k : kernel) ~(base : string) : string =
   let reserved : (string, unit) Hashtbl.t = Hashtbl.create 16 in
   List.iter
     (fun decl ->
@@ -1088,7 +1115,6 @@ let compute_smod_name (k : kernel) : string =
   List.iter
     (fun (hf : helper_func) -> Hashtbl.replace reserved hf.hf_name ())
     k.kern_funcs ;
-  let base = "sarek_smod" in
   if not (Hashtbl.mem reserved base) then base
   else
     let rec find i =
@@ -1096,6 +1122,57 @@ let compute_smod_name (k : kernel) : string =
       if Hashtbl.mem reserved cand then find (i + 1) else cand
     in
     find 1
+
+let compute_smod_name (k : kernel) : string =
+  compute_collision_safe_name k ~base:"sarek_smod"
+
+(** Choose a collision-safe name for the sign-copy helper of kernel [k]. Same
+    scope and collision rules as {!compute_smod_name} (see its doc); the two
+    helpers use distinct bases ([sarek_smod] / [sarek_copysign]) so they never
+    collide with each other, only with user param/helper identifiers. *)
+let compute_copysign_name (k : kernel) : string =
+  compute_collision_safe_name k ~base:"sarek_copysign"
+
+(** Emit the [sarek_copysign] sign-copy helper when the kernel uses [copysign].
+
+    GLSL has no [copysign] builtin. The exact, branch-free lowering transfers
+    the IEEE-754 sign bit of [y] onto the magnitude of [x] via integer bit ops,
+    correct for every input including [±0] (where [abs(x)*sign(y)] fails, since
+    GLSL [sign(0)=0]) and NaN sign transfer.
+
+    Two overloads are emitted, resolved by argument type at the call site:
+
+    - [float]: always emitted when [copysign] is used. [floatBitsToUint] /
+      [uintBitsToFloat] are core since GLSL 3.30, so this needs no extension.
+    - [double]: emitted only when the kernel also uses float64, because it uses
+      [unpackDouble2x32] / [packDouble2x32] and the [double] type itself, all
+      gated behind [GL_ARB_gpu_shader_fp64] — the extension [glsl_header]
+      already emits under the same [kernel_uses_float64] condition. A
+      [Float64.copysign] kernel is float64 by construction, so its call always
+      finds the double overload; the (then-unused) float overload is harmless
+      dead code. A [Float32.copysign]-only kernel gets just the float overload.
+
+    The helper name is [!current_copysign_name] (see {!compute_copysign_name}),
+    not a literal, so it cannot collide with a user param or helper identifier.
+*)
+let gen_copysign_helper buf (k : kernel) =
+  if Sarek_ir_analysis.kernel_uses_copysign k then begin
+    Buffer.add_string
+      buf
+      (Printf.sprintf
+         "float %s(float x, float y) { return \
+          uintBitsToFloat((floatBitsToUint(x) & 0x7FFFFFFFu) | \
+          (floatBitsToUint(y) & 0x80000000u)); }\n\n"
+         !current_copysign_name) ;
+    if Sarek_ir_analysis.kernel_uses_float64 k then
+      Buffer.add_string
+        buf
+        (Printf.sprintf
+           "double %s(double x, double y) { uvec2 ux = unpackDouble2x32(x); \
+            uvec2 uy = unpackDouble2x32(y); ux.y = (ux.y & 0x7FFFFFFFu) | \
+            (uy.y & 0x80000000u); return packDouble2x32(ux); }\n\n"
+           !current_copysign_name)
+  end
 
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
@@ -1105,6 +1182,7 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
   current_smod_name := compute_smod_name k ;
+  current_copysign_name := compute_copysign_name k ;
   let buf = Buffer.create 1024 in
   Buffer.add_string
     buf
@@ -1150,6 +1228,10 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
      it) when the kernel uses [mod]. *)
   gen_smod_helper buf k ;
 
+  (* Emit the sign-copy helper (before user helpers, which may call it) when
+     the kernel uses [copysign]. *)
+  gen_copysign_helper buf k ;
+
   (* Generate helper functions *)
   List.iter (gen_helper_func ~pc_names buf) k.kern_funcs ;
 
@@ -1191,6 +1273,7 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
   current_smod_name := compute_smod_name k ;
+  current_copysign_name := compute_copysign_name k ;
   (* Use variant types directly from kernel IR *)
   current_variants := k.kern_variants ;
 
@@ -1244,6 +1327,10 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   (* Emit the integer-remainder helper (before user helpers, which may call
      it) when the kernel uses [mod]. *)
   gen_smod_helper buf k ;
+
+  (* Emit the sign-copy helper (before user helpers, which may call it) when
+     the kernel uses [copysign]. *)
+  gen_copysign_helper buf k ;
 
   (* Generate helper functions *)
   List.iter (gen_helper_func ~pc_names buf) k.kern_funcs ;

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -259,6 +259,68 @@ let float64_abs_float_path_kernel () =
     []
     body
 
+(* Float64.copysign has no GLSL builtin (and is absent from
+   Sarek_pure_registry.float64_list), so pre-fix it fell through to the raw-name
+   fallback and emitted [Float64.copysign(...)], which glslang parses as a
+   swizzle on a [Float64] variable and rejects. It must lower to a call to the
+   bit-level [sarek_copysign] helper (emitted in the preamble). See
+   Sarek_ir_glsl.ml. *)
+let float64_copysign_path_kernel () =
+  let a = make_var "a" (TVec TFloat64) in
+  let b = make_var "b" (TVec TFloat64) in
+  let c = make_var "c" (TVec TFloat64) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("c", EVar idx),
+            EIntrinsic
+              ( ["Float64"],
+                "copysign",
+                [EArrayRead ("a", EVar idx); EArrayRead ("b", EVar idx)] ) ) )
+  in
+  empty_kernel
+    "float64_copysign_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      DParam (c, Some {arr_elttype = TFloat64; arr_memspace = Global});
+    ]
+    []
+    body
+
+(* Float32.copysign resolves through the pure registry to the raw un-suffixed
+   [copysign(...)] (no GLSL builtin), so it too must lower to the
+   [sarek_copysign] helper — here the float overload only, as the kernel is not
+   float64. *)
+let float32_copysign_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("c", EVar idx),
+            EIntrinsic
+              ( ["Float32"],
+                "copysign",
+                [EArrayRead ("a", EVar idx); EArrayRead ("b", EVar idx)] ) ) )
+  in
+  empty_kernel
+    "float32_copysign_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
 let float32_atan2_path_kernel () =
   let a = make_var "a" (TVec TFloat32) in
   let b = make_var "b" (TVec TFloat32) in
@@ -1239,6 +1301,72 @@ let () =
 
   register_golden
     "glsl"
+    "float64_copysign_path"
+    "#version 450\n\
+     #extension GL_ARB_gpu_shader_fp64 : require\n\n\
+     // Sarek-generated compute shader: float64_copysign_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  double a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  double b[];\n\
+     };\n\
+     layout(std430, set=0, binding = 2) buffer Buffer_c {\n\
+    \  double c[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+    \  int c_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\
+     #define c_len pc.c_len\n\n\
+     float sarek_copysign(float x, float y) { return \
+     uintBitsToFloat((floatBitsToUint(x) & 0x7FFFFFFFu) | (floatBitsToUint(y) \
+     & 0x80000000u)); }\n\n\
+     double sarek_copysign(double x, double y) { uvec2 ux = \
+     unpackDouble2x32(x); uvec2 uy = unpackDouble2x32(y); ux.y = (ux.y & \
+     0x7FFFFFFFu) | (uy.y & 0x80000000u); return packDouble2x32(ux); }\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  c[idx] = sarek_copysign(a[idx], b[idx]);\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_copysign_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_copysign_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(std430, set=0, binding = 2) buffer Buffer_c {\n\
+    \  float c[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+    \  int c_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\
+     #define c_len pc.c_len\n\n\
+     float sarek_copysign(float x, float y) { return \
+     uintBitsToFloat((floatBitsToUint(x) & 0x7FFFFFFFu) | (floatBitsToUint(y) \
+     & 0x80000000u)); }\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  c[idx] = sarek_copysign(a[idx], b[idx]);\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
     "float32_atan2_path"
     "#version 450\n\n\
      // Sarek-generated compute shader: float32_atan2_path\n\
@@ -1367,6 +1495,8 @@ let glsl_only_kernels () =
     ("float32_rsqrt_path", float32_rsqrt_path_kernel ());
     ("float32_abs_float_path", float32_abs_float_path_kernel ());
     ("float64_abs_float_path", float64_abs_float_path_kernel ());
+    ("float64_copysign_path", float64_copysign_path_kernel ());
+    ("float32_copysign_path", float32_copysign_path_kernel ());
     ("float32_atan2_path", float32_atan2_path_kernel ());
     ("float32_cbrt_path", float32_cbrt_path_kernel ());
     ("float32_hypot_path", float32_hypot_path_kernel ());

--- a/sarek/tests/e2e/test_float64_math_intrinsics.ml
+++ b/sarek/tests/e2e/test_float64_math_intrinsics.ml
@@ -277,7 +277,32 @@ let binary_specs =
     {
       b_name = "copysign";
       b_ocaml = Stdlib.copysign;
-      b_gen = (fun i -> (bounded (-3.0) 3.0 i, bounded (-3.0) 3.0 (i + 11)));
+      (* Edge-case coverage vs the OCaml [Stdlib.copysign] reference, tol 0.0
+         (copysign is exact — a pure sign-bit transfer). [x] is forced nonzero
+         so the sign-transfer result has detectable magnitude, then [y] cycles
+         through both signed zeros and both nonzero signs. The [y = ±0.0] rows
+         are the discriminating ones: the naive [abs(x)*sign(y)] lowering gives
+         [|x|*0 = 0] there (GLSL [sign(0)=0]), so it would report [0.0] where C
+         copysign requires [±|x|] — caught here as a magnitude mismatch. The
+         bit-level helper transfers [y]'s sign bit exactly, including for
+         [-0.0]. *)
+      b_gen =
+        (fun i ->
+          let x =
+            let v = bounded (-3.0) 3.0 i in
+            if v = 0.0 then 1.5 else v
+          in
+          let y =
+            match i mod 6 with
+            | 0 -> 0.0 (* +0.0 -> +|x| *)
+            | 1 -> -0.0 (* -0.0 -> -|x| (naive abs*sign would give 0) *)
+            | 2 -> 2.5
+            | 3 -> -2.5
+            | 4 ->
+                float_of_int (i - 128) (* spans both signs across the range *)
+            | _ -> bounded (-3.0) 3.0 (i + 11)
+          in
+          (x, y));
       b_tol = 0.0;
     };
   ]

--- a/spoc/ir/Sarek_ir_analysis.ml
+++ b/spoc/ir/Sarek_ir_analysis.ml
@@ -291,3 +291,93 @@ let kernel_uses_int_mod k =
   || List.exists decl_uses_int_mod k.kern_locals
   || stmt_uses_int_mod k.kern_body
   || List.exists helper_uses_int_mod k.kern_funcs
+
+(** {1 copysign detection}
+
+    [copysign] is not a dedicated IR node (unlike [Mod]); it is an ordinary
+    [EIntrinsic (path, "copysign", [x; y])] emitted for [Float32.copysign] and
+    [Float64.copysign]. GLSL has no [copysign] builtin under any name, and
+    [abs(x)*sign(y)] is wrong for [y=0] (GLSL [sign(0)=0] zeroes the result,
+    whereas C [copysign(x, ±0) = ±|x|]) and for the [x=0]/NaN sign-transfer edge
+    cases. The GLSL backend therefore lowers it to a bit-level [sarek_copysign]
+    helper emitted in the preamble; this predicate decides whether that helper
+    is emitted. Mirrors [kernel_uses_int_mod]. *)
+let is_copysign_intrinsic_name name = String.equal name "copysign"
+
+let rec expr_uses_copysign = function
+  | EIntrinsic (_, name, args) ->
+      is_copysign_intrinsic_name name || List.exists expr_uses_copysign args
+  | EConst _ | EVar _ -> false
+  | EBinop (_, e1, e2) -> expr_uses_copysign e1 || expr_uses_copysign e2
+  | EUnop (_, e) -> expr_uses_copysign e
+  | EArrayRead (_, idx) -> expr_uses_copysign idx
+  | EArrayReadExpr (base, idx) ->
+      expr_uses_copysign base || expr_uses_copysign idx
+  | ERecordField (e, _) -> expr_uses_copysign e
+  | ECast (_, e) -> expr_uses_copysign e
+  | ETuple exprs -> List.exists expr_uses_copysign exprs
+  | EApp (fn, args) ->
+      expr_uses_copysign fn || List.exists expr_uses_copysign args
+  | ERecord (_, fields) ->
+      List.exists (fun (_, e) -> expr_uses_copysign e) fields
+  | EVariant (_, _, args) -> List.exists expr_uses_copysign args
+  | EArrayLen _ -> false
+  | EArrayCreate (_, size, _) -> expr_uses_copysign size
+  | EIf (cond, then_, else_) ->
+      expr_uses_copysign cond || expr_uses_copysign then_
+      || expr_uses_copysign else_
+  | EMatch (scrutinee, cases) ->
+      expr_uses_copysign scrutinee
+      || List.exists (fun (_, e) -> expr_uses_copysign e) cases
+
+(** Recurse into the nested lvalue: its array index may carry a [copysign]
+    result cast to an int index, e.g.
+    [arr.(int_of_float (copysign ...)).field <- v]. A non-recursive
+    [LRecordField] arm would miss it and skip emitting the [sarek_copysign]
+    helper the emitted index references. Mirrors [lvalue_uses_int_mod] — the
+    round-3 LRecordField lesson. *)
+let rec lvalue_uses_copysign = function
+  | LVar _ -> false
+  | LArrayElem (_, idx) -> expr_uses_copysign idx
+  | LArrayElemExpr (base, idx) ->
+      expr_uses_copysign base || expr_uses_copysign idx
+  | LRecordField (lv, _) -> lvalue_uses_copysign lv
+
+let rec stmt_uses_copysign = function
+  | SAssign (lv, e) -> lvalue_uses_copysign lv || expr_uses_copysign e
+  | SSeq stmts -> List.exists stmt_uses_copysign stmts
+  | SIf (cond, then_, else_) ->
+      expr_uses_copysign cond || stmt_uses_copysign then_
+      || Option.fold ~none:false ~some:stmt_uses_copysign else_
+  | SWhile (cond, body) -> expr_uses_copysign cond || stmt_uses_copysign body
+  | SFor (_, lo, hi, _, body) ->
+      expr_uses_copysign lo || expr_uses_copysign hi || stmt_uses_copysign body
+  | SMatch (scrutinee, cases) ->
+      expr_uses_copysign scrutinee
+      || List.exists (fun (_, s) -> stmt_uses_copysign s) cases
+  | SReturn e | SExpr e -> expr_uses_copysign e
+  | SBarrier | SWarpBarrier | SEmpty | SMemFence -> false
+  | SLet (_, e, body) | SLetMut (_, e, body) ->
+      expr_uses_copysign e || stmt_uses_copysign body
+  | SPragma (_, body) | SBlock body -> stmt_uses_copysign body
+  (* Inline native GPU code is opaque text; assume it may reference a copysign
+     helper so the helper it references is still emitted. Mirrors
+     [stmt_uses_int_mod]. *)
+  | SNative _ -> true
+
+let decl_uses_copysign = function
+  | DParam _ -> false
+  | DLocal (_, init) -> Option.fold ~none:false ~some:expr_uses_copysign init
+  | DShared (_, _, size) ->
+      Option.fold ~none:false ~some:expr_uses_copysign size
+
+let helper_uses_copysign hf = stmt_uses_copysign hf.hf_body
+
+(** Check if a kernel uses [copysign] anywhere: locals initializers, body, and
+    helper functions. Helper bodies are walked explicitly (a helper may use
+    [copysign] even when the top-level body does not). *)
+let kernel_uses_copysign k =
+  List.exists decl_uses_copysign k.kern_params
+  || List.exists decl_uses_copysign k.kern_locals
+  || stmt_uses_copysign k.kern_body
+  || List.exists helper_uses_copysign k.kern_funcs

--- a/spoc/ir/test/test_sarek_ir_analysis.ml
+++ b/spoc/ir/test/test_sarek_ir_analysis.ml
@@ -646,6 +646,147 @@ let test_kernel_uses_int_mod_in_record_field_lvalue () =
   assert (kernel_uses_int_mod k_none = false) ;
   print_endline "  kernel_uses_int_mod via record-field lvalue: OK"
 
+(** {1 expr_uses_copysign / kernel_uses_copysign Tests} *)
+
+let test_is_copysign_intrinsic_name () =
+  assert (is_copysign_intrinsic_name "copysign" = true) ;
+  assert (is_copysign_intrinsic_name "copysignf" = false) ;
+  assert (is_copysign_intrinsic_name "sin" = false) ;
+  assert (is_copysign_intrinsic_name "" = false) ;
+  print_endline "  is_copysign_intrinsic_name: OK"
+
+let test_expr_uses_copysign () =
+  let non_copysign =
+    EIntrinsic (["Float64"], "hypot", [EConst (CFloat64 1.0)])
+  in
+  assert (expr_uses_copysign non_copysign = false) ;
+  let direct_copysign =
+    EIntrinsic
+      ( ["Float64"],
+        "copysign",
+        [EConst (CFloat64 1.0); EConst (CFloat64 (-2.0))] )
+  in
+  assert (expr_uses_copysign direct_copysign = true) ;
+  (* Float32-qualified copysign is detected too (name-based, path-agnostic). *)
+  let f32_copysign =
+    EIntrinsic
+      ( ["Float32"],
+        "copysign",
+        [EConst (CFloat32 1.0); EConst (CFloat32 (-2.0))] )
+  in
+  assert (expr_uses_copysign f32_copysign = true) ;
+  (* Nested: copysign buried inside an otherwise ordinary expression. *)
+  let nested = EBinop (Add, EConst (CFloat64 1.0), direct_copysign) in
+  assert (expr_uses_copysign nested = true) ;
+  print_endline "  expr_uses_copysign: OK"
+
+(** Regression pin (round-3 LRecordField lesson): [lvalue_uses_copysign] must
+    recurse through [LRecordField]. A non-recursive arm would return false when
+    a copysign result only appears inside an [LRecordField]-wrapped index, so
+    the GLSL backend would emit a [sarek_copysign(...)] call from the lvalue
+    index while [kernel_uses_copysign] wrongly reported false and skipped
+    emitting the helper — an undefined-function shader compile failure. *)
+let test_lvalue_uses_copysign () =
+  let cs_idx =
+    EIntrinsic
+      ( [],
+        "int_of_float",
+        [
+          EIntrinsic
+            ( ["Float64"],
+              "copysign",
+              [EConst (CFloat64 1.0); EConst (CFloat64 (-2.0))] );
+        ] )
+  in
+  assert (
+    lvalue_uses_copysign
+      (LVar {var_name = "x"; var_id = 0; var_type = TInt32; var_mutable = true})
+    = false) ;
+  assert (lvalue_uses_copysign (LArrayElem ("arr", EConst (CInt32 0l))) = false) ;
+  assert (lvalue_uses_copysign (LArrayElem ("arr", cs_idx)) = true) ;
+  assert (
+    lvalue_uses_copysign (LArrayElemExpr (EConst (CInt32 0l), cs_idx)) = true) ;
+  (* The load-bearing shape: copysign only inside an LRecordField-wrapped index. *)
+  assert (
+    lvalue_uses_copysign (LRecordField (LArrayElem ("arr", cs_idx), "field"))
+    = true) ;
+  print_endline "  lvalue_uses_copysign: OK"
+
+let test_kernel_uses_copysign_in_record_field_lvalue () =
+  let cs_idx =
+    EIntrinsic
+      ( [],
+        "int_of_float",
+        [
+          EIntrinsic
+            ( ["Float64"],
+              "copysign",
+              [EConst (CFloat64 1.0); EConst (CFloat64 (-2.0))] );
+        ] )
+  in
+  let k_lvalue_cs : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LRecordField (LArrayElem ("arr", cs_idx), "field"),
+            EConst (CInt32 5l) );
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_copysign k_lvalue_cs = true) ;
+  let k_none : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body = SEmpty;
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_copysign k_none = false) ;
+  print_endline "  kernel_uses_copysign via record-field lvalue: OK"
+
+(** Load-bearing case: the only copysign is reachable through [kern_funcs], not
+    [kern_body]. A body-only walk would wrongly report false. *)
+let test_kernel_uses_copysign_in_helper () =
+  let param : var =
+    {var_name = "x"; var_id = 0; var_type = TFloat64; var_mutable = false}
+  in
+  let hf_cs : helper_func =
+    {
+      hf_name = "f";
+      hf_params = [param];
+      hf_ret_type = TFloat64;
+      hf_body =
+        SReturn
+          (EIntrinsic
+             (["Float64"], "copysign", [EVar param; EConst (CFloat64 (-1.0))]));
+    }
+  in
+  let k : kernel =
+    {
+      kern_name = "test";
+      kern_params = [];
+      kern_locals = [];
+      kern_body = SEmpty;
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [hf_cs];
+      kern_native_fn = None;
+    }
+  in
+  assert (kernel_uses_copysign k = true) ;
+  print_endline "  kernel_uses_copysign via helper: OK"
+
 (** {1 Main} *)
 
 let () =
@@ -686,4 +827,9 @@ let () =
   test_expr_uses_int_mod () ;
   test_lvalue_uses_int_mod () ;
   test_kernel_uses_int_mod_in_record_field_lvalue () ;
+  test_is_copysign_intrinsic_name () ;
+  test_expr_uses_copysign () ;
+  test_lvalue_uses_copysign () ;
+  test_kernel_uses_copysign_in_record_field_lvalue () ;
+  test_kernel_uses_copysign_in_helper () ;
   print_endline "All Sarek_ir_analysis tests passed!"


### PR DESCRIPTION
`Float64.copysign` emitted a raw OCaml path on GLSL (glslang: 'vector swizzle too long'); `Float32.copysign` resolved to a nonexistent GLSL builtin. Both Vulkan devices failed pre-fix (58/115 in the f64 e2e report).

Fix: bit-level `sarek_copysign` preamble helper (sign-bit transfer — exact for ±0/NaN, unlike `abs(x)*sign(y)` which zeroes on y=0). Two overloads under one collision-safe name: f32 (`floatBitsToUint`, core) always; f64 (`unpackDouble2x32`, sign masked on the high word) gated on `kernel_uses_float64` so f32-only shaders need no fp64 extension. Mirrors the #255 `sarek_smod` precedent: `kernel_uses_copysign` full traversal (incl. LRecordField recursion), shared `compute_collision_safe_name`, single-eval call site.

Post-fix: copysign PASS on both RADV devices (60/115); signed-zero rows discriminate at tol 0.0. Goldens assert byte-exact helper bodies. No cross-backend change (GLSL-only). Pipeline: implement → review GO (6/6 scopes) → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GLSL support for the `copysign` floating-point intrinsic.
  - Supports both 32-bit and 64-bit floating-point values.
  - Handles positive and negative zero correctly when copying signs.

- **Bug Fixes**
  - Prevented sign-copy operations from being miscompiled or affected by naming conflicts.

- **Tests**
  - Added coverage for qualified `copysign` usage and targeted zero/sign edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->