### PR TITLE
feat(glsl): close the unknown-intrinsic fallback hole — located error + log10 polyfill

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -395,24 +395,45 @@ and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
     [cbrt] uses [sign(x)*pow(abs(x),...)] rather than bare [pow] because GLSL's
     [pow] is undefined for a negative base. [log10] is derived from the natural
     [log] builtin: GLSL exposes [log] (base e) and [log2] but no base-10 form,
-    so [log10(x) = log(x)/log(10)]; the [log(10.0)] divisor is a compile-time
-    constant every GLSL compiler folds. Routing [log10] through here (ahead of
-    the pure registry) is required: [log10] IS present in the pure-registry
+    so [log10(x) = log(x)/log(10)]. Routing [log10] through here (ahead of the
+    pure registry) is required: [log10] IS present in the pure-registry
     float32/float64 tables and would otherwise emit the raw un-suffixed
     [log10(...)] that glslang rejects — the same latent-invalid-GLSL class as
-    [fabs]/[copysign] (#246/#256). *)
-and gen_glsl_polyfill buf name args =
+    [fabs]/[copysign] (#246/#256).
+
+    [is_f64] carries the operand precision (derived from the intrinsic path — a
+    [Float64] component). It governs the precision of any numeric LITERAL that a
+    builtin then computes on: on the [double] route the literal must carry the
+    GLSL double suffix (GLSL 4.5 §4.1.4), otherwise it defaults to [float] and
+    pins the result to single precision even where the [double] overload of the
+    surrounding builtin exists. The suffix is spelled lowercase [lf] to match
+    the generator's own [EConst (CFloat64 _)] output (see {!gen_expr}); GLSL
+    accepts [lf] and [LF] interchangeably, so a single casing keeps every double
+    literal in the emitted shader uniform. This bites exactly the two polyfills
+    that feed a literal into a transcendental / irrational computation:
+    - [log10]: [log(10.0)] — an irrational, evaluated by the [float] [log]
+      overload; [log(10.0lf)] uses the [double] overload.
+    - [cbrt]: the exponent [1.0/3.0] — a non-terminating fraction; [1.0/3.0] is
+      a [float] division (~7 digits), [1.0lf/3.0lf] a [double] one. [hypot] (no
+      literal), [expm1] and [log1p] (their only literal is [1.0], which is
+      exactly representable and promotes to [double] losslessly, and is never
+      itself the argument of a builtin) are precision-safe as-is and left
+      byte-for-byte unchanged so their existing goldens do not move. *)
+and gen_glsl_polyfill buf ~is_f64 name args =
+  let flit s = if is_f64 then s ^ "lf" else s in
   match (name, args) with
   | "log10", [x] ->
       Buffer.add_string buf "(log(" ;
       gen_expr buf x ;
-      Buffer.add_string buf ") / log(10.0))"
+      Buffer.add_string buf (Printf.sprintf ") / log(%s))" (flit "10.0"))
   | "cbrt", [x] ->
       Buffer.add_string buf "(sign(" ;
       gen_expr buf x ;
       Buffer.add_string buf ") * pow(abs(" ;
       gen_expr buf x ;
-      Buffer.add_string buf "), 1.0 / 3.0))"
+      Buffer.add_string
+        buf
+        (Printf.sprintf "), %s / %s))" (flit "1.0") (flit "3.0"))
   | "hypot", [x; y] ->
       Buffer.add_string buf "sqrt((" ;
       gen_expr buf x ;
@@ -441,7 +462,12 @@ and gen_intrinsic buf path name args =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
   if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"; "log10"] then
-    gen_glsl_polyfill buf name args
+    (* A [Float64] path component marks the double-precision route; the plain
+       [Float32]/[Math.Float32] and unqualified (core-primitive, f32-typed)
+       spellings stay single-precision. This mirrors how the pure registry keys
+       the same intrinsics by their [Float64] vs [Float32] module path. *)
+    let is_f64 = List.mem "Float64" path in
+    gen_glsl_polyfill buf ~is_f64 name args
   else if name = "copysign" then (
     (* GLSL has no [copysign] builtin under any name, and [abs(x)*sign(y)] is
        wrong for [y=0] (GLSL [sign(0)=0]) and the [x=0]/NaN sign-transfer edge

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -386,16 +386,27 @@ and gen_binop = function
 
 and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
 
-(** GLSL has no [cbrt]/[hypot]/[expm1]/[log1p] builtins under any name (unlike
-    [fabs]/[rsqrt]/[atan2], which are simple renames — see
+(** GLSL has no [cbrt]/[hypot]/[expm1]/[log1p]/[log10] builtins under any name
+    (unlike [fabs]/[rsqrt]/[atan2], which are simple renames — see
     [Sarek_pure_registry.glsl_override_name]). These need a multi-token
     expression instead of a function-name substitution, so they're special-cased
     here ahead of both the unqualified match arms and the pure registry,
     applying uniformly to qualified (Float32.cbrt) and unqualified calls alike.
     [cbrt] uses [sign(x)*pow(abs(x),...)] rather than bare [pow] because GLSL's
-    [pow] is undefined for a negative base. *)
+    [pow] is undefined for a negative base. [log10] is derived from the natural
+    [log] builtin: GLSL exposes [log] (base e) and [log2] but no base-10 form,
+    so [log10(x) = log(x)/log(10)]; the [log(10.0)] divisor is a compile-time
+    constant every GLSL compiler folds. Routing [log10] through here (ahead of
+    the pure registry) is required: [log10] IS present in the pure-registry
+    float32/float64 tables and would otherwise emit the raw un-suffixed
+    [log10(...)] that glslang rejects — the same latent-invalid-GLSL class as
+    [fabs]/[copysign] (#246/#256). *)
 and gen_glsl_polyfill buf name args =
   match (name, args) with
+  | "log10", [x] ->
+      Buffer.add_string buf "(log(" ;
+      gen_expr buf x ;
+      Buffer.add_string buf ") / log(10.0))"
   | "cbrt", [x] ->
       Buffer.add_string buf "(sign(" ;
       gen_expr buf x ;
@@ -429,7 +440,7 @@ and gen_intrinsic buf path name args =
   let full_name =
     match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
   in
-  if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"] then
+  if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"; "log10"] then
     gen_glsl_polyfill buf name args
   else if name = "copysign" then (
     (* GLSL has no [copysign] builtin under any name, and [abs(x)*sign(y)] is
@@ -622,15 +633,25 @@ and gen_intrinsic buf path name args =
               (match args with [e] -> gen_expr buf e | _ -> ()) ;
               Buffer.add_char buf ')'
           | _ ->
-              (* Unknown intrinsic - emit as function call *)
-              Buffer.add_string buf full_name ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')')
+              (* No GLSL lowering for this intrinsic. Unlike CUDA/OpenCL/Metal,
+                 GLSL does NOT fall back to [Sarek_registry] (the FFI registry):
+                 its device closures only branch CUDA-vs-OpenCL and have no GLSL
+                 arm, so consulting it would splice OpenCL C — [get_global_id],
+                 [barrier(CLK_LOCAL_MEM_FENCE)], [(float)] casts — into GLSL,
+                 which glslang rejects just as cryptically as the old behaviour
+                 of emitting the raw OCaml path [full_name(...)] ("vector
+                 swizzle too long"). Raise a located error naming the intrinsic
+                 and backend instead — strictly better than emitting garbage.
+
+                 To give a future intrinsic a real GLSL lowering, extend one of
+                 (a) [Sarek_pure_registry.glsl_override_name] for a plain rename,
+                 (b) [gen_glsl_polyfill] above for a multi-token expression, or
+                 (c) an explicit match arm here. The pure registry is already
+                 GLSL-parameterised (it receives [~framework:"GLSL"]), so no
+                 registry-type change is needed and existing registrations are
+                 untouched. *)
+              Codegen_error.raise_error
+                (Codegen_error.unknown_intrinsic full_name))
 
 (** {1 L-value Generation} *)
 

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -42,3 +42,10 @@
  (libraries sarek_ir sarek_codegen alcotest)
  (instrumentation
   (backend bisect_ppx)))
+
+(test
+ (name test_glsl_intrinsic_fallback)
+ (modules test_glsl_intrinsic_fallback)
+ (libraries sarek_ir sarek_codegen sarek_backend_error alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -259,6 +259,53 @@ let float64_abs_float_path_kernel () =
     []
     body
 
+(* Float64.log10 / Float64.cbrt: the polyfill must emit the divisor / exponent
+   literal with the GLSL [lf] double suffix (10.0lf, 1.0lf/3.0lf) so the constant
+   is evaluated at double precision. The plain Float32 goldens (float32_log10_path
+   / float32_cbrt_path) keep the un-suffixed literal — that path-awareness is the
+   guarantee under test here. *)
+let float64_log10_path_kernel () =
+  let a = make_var "a" (TVec TFloat64) in
+  let b = make_var "b" (TVec TFloat64) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float64"], "log10", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float64_log10_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
+    ]
+    []
+    body
+
+let float64_cbrt_path_kernel () =
+  let a = make_var "a" (TVec TFloat64) in
+  let b = make_var "b" (TVec TFloat64) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float64"], "cbrt", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float64_cbrt_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
+    ]
+    []
+    body
+
 (* Float64.copysign has no GLSL builtin (and is absent from
    Sarek_pure_registry.float64_list), so pre-fix it fell through to the raw-name
    fallback and emitted [Float64.copysign(...)], which glslang parses as a
@@ -1538,6 +1585,54 @@ let () =
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = (log(a[idx]) / log(10.0));\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float64_log10_path"
+    "#version 450\n\
+     #extension GL_ARB_gpu_shader_fp64 : require\n\n\
+     // Sarek-generated compute shader: float64_log10_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  double a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  double b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = (log(a[idx]) / log(10.0lf));\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float64_cbrt_path"
+    "#version 450\n\
+     #extension GL_ARB_gpu_shader_fp64 : require\n\n\
+     // Sarek-generated compute shader: float64_cbrt_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  double a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  double b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = (sign(a[idx]) * pow(abs(a[idx]), 1.0lf / 3.0lf));\n\
      }\n"
 
 let glsl_only_kernels () =
@@ -1553,6 +1648,8 @@ let glsl_only_kernels () =
     ("float32_expm1_path", float32_expm1_path_kernel ());
     ("float32_log1p_path", float32_log1p_path_kernel ());
     ("float32_log10_path", float32_log10_path_kernel ());
+    ("float64_log10_path", float64_log10_path_kernel ());
+    ("float64_cbrt_path", float64_cbrt_path_kernel ());
   ]
 
 let glsl_only_tests () =

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -441,6 +441,33 @@ let float32_log1p_path_kernel () =
     []
     body
 
+(** Kernel 5i: path-qualified [Float32.log10]. GLSL exposes [log]/[log2] but no
+    base-10 builtin, so — like cbrt/hypot/expm1/log1p — it needs a multi-token
+    polyfill [log(x)/log(10.0)]. Unlike those four, [log10] IS present in the
+    pure-registry float32/float64 tables, so without the polyfill it would
+    resolve to the invalid raw [log10(...)]. CUDA/OpenCL/Metal have a native
+    [log10] builtin, so only a glsl_only golden is needed. *)
+let float32_log10_path_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EIntrinsic (["Float32"], "log10", [EArrayRead ("a", EVar idx)]) ) )
+  in
+  empty_kernel
+    "float32_log10_path"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
 (** Kernel 6: bounds-check with if-expression. WGSL-specific: exercises EIf
     which must emit [select(else, then, cond)] (no ternary in WGSL). fun (a :
     float32 vec) (b : float32 vec) (n : int32) -> let i = global_thread_id in
@@ -1488,6 +1515,29 @@ let () =
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = log(1.0 + (a[idx]));\n\
+     }\n" ;
+
+  register_golden
+    "glsl"
+    "float32_log10_path"
+    "#version 450\n\n\
+     // Sarek-generated compute shader: float32_log10_path\n\
+     layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n\
+     layout(std430, set=0, binding = 0) buffer Buffer_a {\n\
+    \  float a[];\n\
+     };\n\
+     layout(std430, set=0, binding = 1) buffer Buffer_b {\n\
+    \  float b[];\n\
+     };\n\
+     layout(push_constant) uniform PushConstants {\n\
+    \  int a_len;\n\
+    \  int b_len;\n\
+     } pc;\n\n\
+     #define a_len pc.a_len\n\
+     #define b_len pc.b_len\n\n\
+     void main() {\n\
+    \  int idx = int(gl_GlobalInvocationID.x);\n\
+    \  b[idx] = (log(a[idx]) / log(10.0));\n\
      }\n"
 
 let glsl_only_kernels () =
@@ -1502,6 +1552,7 @@ let glsl_only_kernels () =
     ("float32_hypot_path", float32_hypot_path_kernel ());
     ("float32_expm1_path", float32_expm1_path_kernel ());
     ("float32_log1p_path", float32_log1p_path_kernel ());
+    ("float32_log10_path", float32_log10_path_kernel ());
   ]
 
 let glsl_only_tests () =

--- a/sarek/tests/codegen_golden/test_glsl_intrinsic_fallback.ml
+++ b/sarek/tests/codegen_golden/test_glsl_intrinsic_fallback.ml
@@ -1,0 +1,138 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * IR-level unit test for the GLSL intrinsic-dispatch fallback (task
+ * [glsl-ffi-fallback]; class opened by #246 abs_float / #256 copysign).
+ *
+ * Two guarantees are pinned here:
+ *
+ * 1. NEGATIVE — an intrinsic with no GLSL lowering must raise a located
+ *    [Backend_error (Codegen {backend = "Vulkan"; Unknown_intrinsic {name}})]
+ *    naming the intrinsic, NOT emit the raw OCaml path [full_name(...)] that
+ *    glslang rejects cryptically ("vector swizzle too long"). This covers every
+ *    fall-through name in the brief inventory (warp/subgroup ops, atomic-int
+ *    variants, [_f64] primitives, int bit-ops, memory fences).
+ *
+ * 2. POSITIVE — [log10], which IS present in the pure-registry float32/float64
+ *    tables (so it "resolves" but to the non-existent GLSL builtin [log10]),
+ *    must be polyfilled to [(log(x) / log(10.0))] for both the path-qualified
+ *    and the unqualified spelling.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Glsl = Sarek_codegen.Sarek_ir_glsl
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* A minimal kernel: c.[idx] <- <intr>(a.[idx]) with a float32 in/out pair.
+   [idx] is a bare literal so the body itself never introduces another
+   intrinsic that could mask the one under test. *)
+let kernel_calling ~path ~name ~arity =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let arg = EArrayRead ("a", EConst (CInt32 0l)) in
+  let args = List.init arity (fun _ -> arg) in
+  {
+    kern_name = "fallback_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body =
+      SAssign
+        (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic (path, name, args));
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let generate k = Glsl.generate_with_types ~types:[] k
+
+(* --- 1. Negative: unhandled intrinsics raise a located error --- *)
+
+(* (path, name, arity) — a representative slice of the fall-through inventory. *)
+let unhandled =
+  [
+    ([], "warp_shuffle", 2);
+    ([], "warp_vote_all", 1);
+    ([], "atomic_cas_int32", 3);
+    ([], "atomic_xor_int32", 2);
+    ([], "clz_int32", 1);
+    ([], "popcount_int32", 1);
+    ([], "abs_int32", 1);
+    ([], "memory_fence_block", 0);
+    ([], "sin_f64", 1);
+    ([], "min_int32", 2);
+  ]
+
+let test_unhandled_raises (path, name, arity) () =
+  let full_name =
+    match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
+  in
+  match generate (kernel_calling ~path ~name ~arity) with
+  | (_ : string) ->
+      Alcotest.failf
+        "expected Unknown_intrinsic for %S but generation succeeded"
+        full_name
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Codegen
+           {backend; error = Backend_error.Unknown_intrinsic {name = got}}) ->
+      Alcotest.(check string) "backend is Vulkan" "Vulkan" backend ;
+      Alcotest.(check string) "error names the intrinsic" full_name got
+
+(* --- 2. Positive: log10 is polyfilled, never emitted as a raw name --- *)
+
+(* Dependency-free substring test (avoids pulling in the [str] library). *)
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+let test_log10 ~path ~label () =
+  let glsl = generate (kernel_calling ~path ~name:"log10" ~arity:1) in
+  let contains needle = string_contains ~haystack:glsl ~needle in
+  Alcotest.(check bool)
+    (label ^ ": emits (log(..)/log(10.0)) polyfill")
+    true
+    (contains "log(" && contains "/ log(10.0)") ;
+  Alcotest.(check bool)
+    (label ^ ": no raw log10( token")
+    false
+    (contains "log10(")
+
+let () =
+  let open Alcotest in
+  run
+    "GLSL intrinsic fallback"
+    [
+      ( "unhandled-intrinsic-errors",
+        List.map
+          (fun ((_, name, _) as spec) ->
+            test_case name `Quick (test_unhandled_raises spec))
+          unhandled );
+      ( "log10-polyfill",
+        [
+          test_case "unqualified" `Quick (test_log10 ~path:[] ~label:"log10");
+          test_case
+            "Float32-qualified"
+            `Quick
+            (test_log10 ~path:["Float32"] ~label:"Float32.log10");
+          test_case
+            "Float64-qualified"
+            `Quick
+            (test_log10 ~path:["Float64"] ~label:"Float64.log10");
+        ] );
+    ]

--- a/sarek/tests/codegen_golden/test_glsl_intrinsic_fallback.ml
+++ b/sarek/tests/codegen_golden/test_glsl_intrinsic_fallback.ml
@@ -101,13 +101,21 @@ let string_contains ~haystack ~needle =
   in
   nl = 0 || loop 0
 
-let test_log10 ~path ~label () =
+let test_log10 ~path ~is_f64 ~label () =
   let glsl = generate (kernel_calling ~path ~name:"log10" ~arity:1) in
   let contains needle = string_contains ~haystack:glsl ~needle in
+  (* The divisor literal must carry the GLSL [lf] double suffix on the Float64
+     route and must NOT on the f32 route (else the divisor is pinned to single
+     precision — the CodeRabbit #259 finding). *)
+  let divisor = if is_f64 then "log(10.0lf)" else "log(10.0)" in
   Alcotest.(check bool)
-    (label ^ ": emits (log(..)/log(10.0)) polyfill")
+    (label ^ ": emits (log(x) / " ^ divisor ^ ") polyfill")
     true
-    (contains "log(" && contains "/ log(10.0)") ;
+    (contains "log(" && contains ("/ " ^ divisor)) ;
+  Alcotest.(check bool)
+    (label ^ ": f32 divisor carries no lf suffix")
+    is_f64
+    (contains "10.0lf") ;
   Alcotest.(check bool)
     (label ^ ": no raw log10( token")
     false
@@ -125,14 +133,17 @@ let () =
           unhandled );
       ( "log10-polyfill",
         [
-          test_case "unqualified" `Quick (test_log10 ~path:[] ~label:"log10");
+          test_case
+            "unqualified"
+            `Quick
+            (test_log10 ~path:[] ~is_f64:false ~label:"log10");
           test_case
             "Float32-qualified"
             `Quick
-            (test_log10 ~path:["Float32"] ~label:"Float32.log10");
+            (test_log10 ~path:["Float32"] ~is_f64:false ~label:"Float32.log10");
           test_case
             "Float64-qualified"
             `Quick
-            (test_log10 ~path:["Float64"] ~label:"Float64.log10");
+            (test_log10 ~path:["Float64"] ~is_f64:true ~label:"Float64.log10");
         ] );
     ]


### PR DESCRIPTION
Structural fix for the class behind #246/#256: the GLSL generator's default arm emitted unknown intrinsic names VERBATIM (raw OCaml paths → cryptic glslang 'vector swizzle too long').

Research finding that shaped the design: the FFI registry has NO GLSL branch (its device closures are CUDA/OpenCL C only) — consulting it would splice OpenCL C into GLSL. So:
- Default arm now raises a located `Backend_error (Codegen {backend="Vulkan"; Unknown_intrinsic{name}})` — no garbage GLSL can ever be emitted (all 4 leak vectors audited: EApp user helpers unaffected, lvalues, pure-registry expansion, polyfill arity).
- Full audit of all 59 pure-registry entries against GLSL 4.5: `log10` was the only invalid resolution → single-eval change-of-base polyfill (golden + e2e PASS on 6 fp64 devices).
- ~40 core primitives without GLSL lowering (warp/subgroup, atomic-int variants, _f64 prims, bit ops, fences) now error cleanly — all previously emitted broken GLSL; codegen is lazy per-backend so CUDA/OpenCL users are untouched (verified via the plugin compile path).
- 13-case fallback test (both classes) + golden; 41/41 goldens unchanged.

Follow-up filed: Vulkan_plugin's pre-existing `with _ -> None` swallows the located message at runtime (tracked separately).

Pipeline (full): research → spec → plan → implement → review GO → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GLSL `log10` support by polyfilling `log10(x)` via natural-log math.
  * Ensures correct precision for Float32 and Float64 variants (including the appropriate constant literal).

* **Bug Fixes**
  * Improved handling of unsupported GLSL intrinsics so shader generation fails with a clear, correctly identified error instead of producing invalid output.

* **Tests**
  * Added new golden and Alcotest coverage for `log10` lowering and for unsupported intrinsic error reporting.
  * Extended existing golden snapshots for new `log10` kernel paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->