### PR TITLE
fix(ppx): local tuple bindings emit real structs on struct backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_param.cma > "$$out" 2>&1; if grep -q "Function-typed kernel parameters are not supported" "$$out"; then echo "  PASS: function param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing non-primitive local tuple rejection..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tuple_local_nonprim.cma > "$$out" 2>&1; if grep -q "Tuple values support only scalar components" "$$out"; then echo "  PASS: non-primitive local tuple rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing non-primitive tuple destructure rejection (non-variable scrutinee)..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tuple_destructure_nonprim.cma > "$$out" 2>&1; if grep -q "Tuple values support only scalar components" "$$out"; then echo "  PASS: non-primitive tuple destructure rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing escaping function-value rejection (L12 defunctionalization)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_escape.cma > "$$out" 2>&1; if grep -q "Function value escapes" "$$out"; then echo "  PASS: escaping function value rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing reserved-prefix rejection (kernel param sarek_smod)..."

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,8 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tuple_param.cma > "$$out" 2>&1; if grep -q "Tuple-typed kernel parameters are not supported" "$$out"; then echo "  PASS: tuple param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing function-typed kernel parameter rejection..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_param.cma > "$$out" 2>&1; if grep -q "Function-typed kernel parameters are not supported" "$$out"; then echo "  PASS: function param rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing non-primitive local tuple rejection..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tuple_local_nonprim.cma > "$$out" 2>&1; if grep -q "Tuple values support only scalar components" "$$out"; then echo "  PASS: non-primitive local tuple rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing escaping function-value rejection (L12 defunctionalization)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_fun_escape.cma > "$$out" 2>&1; if grep -q "Function value escapes" "$$out"; then echo "  PASS: escaping function value rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing reserved-prefix rejection (kernel param sarek_smod)..."

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -135,6 +135,19 @@ let tuple_record_name (comps : Ir.elttype list) : string =
            match elttype_prim_tag e with Some t -> "_" ^ t | None -> "_x")
          comps)
 
+(** The single located error raised for any tuple whose components are not all
+    scalar primitives — shared by the vector-element path, the kernel-local slot
+    path ({!slot_elttype_of_typ}), and the match-scrutinee guard in
+    {!lower_stmt}. [loc] should be the offending source expression when known
+    ([Ppxlib.Location.none] otherwise). *)
+let raise_tuple_component_error ~loc : 'a =
+  Ppxlib.Location.raise_errorf
+    ~loc
+    "Tuple values support only scalar components \
+     (float32/float64/int32/int64/bool); nested tuples, records, vectors or \
+     functions as tuple components are not supported (applies to vector \
+     elements, kernel-local tuple bindings and tuple match scrutinees)."
+
 (** Synthesized record fields (positional [_0.._n]) for a tuple's component
     types. Raises if any component is not a scalar primitive. *)
 let tuple_record_fields (tys : typ list) : string * (string * Ir.elttype) list =
@@ -143,14 +156,7 @@ let tuple_record_fields (tys : typ list) : string * (string * Ir.elttype) list =
       (fun t ->
         match prim_component_elttype t with
         | Some e -> e
-        | None ->
-            Ppxlib.Location.raise_errorf
-              ~loc:Ppxlib.Location.none
-              "Tuple values support only scalar components \
-               (float32/float64/int32/int64/bool); nested tuples, records, \
-               vectors or functions as tuple components are not supported \
-               (applies to both vector elements and kernel-local tuple \
-               bindings).")
+        | None -> raise_tuple_component_error ~loc:Ppxlib.Location.none)
       tys
   in
   let name = tuple_record_name comps in
@@ -708,6 +714,13 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
       (* No else branch - only valid for unit-returning expressions *)
       Ir.EIf (lower_expr state cond, lower_expr state then_, Ir.EConst Ir.CUnit)
   (* Match as expression *)
+  | TEMatch (e, _)
+    when (match repr e.ty with TTuple _ -> true | _ -> false)
+         && not (is_primitive_tuple e.ty) ->
+      (* Same non-primitive tuple-scrutinee guard as the statement path (see
+         {!lower_stmt}); reachable when a non-primitive tuple match is used in
+         value position. *)
+      raise_tuple_component_error ~loc:(Sarek_ast.loc_to_ppxlib e.te_loc)
   | TEMatch (e, cases) ->
       let ir_cases =
         List.map
@@ -836,6 +849,20 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
           body_ir
       in
       Ir.SLet (tmp_var, lower_expr state e, bound)
+  | TEMatch (e, _)
+    when (match repr e.ty with TTuple _ -> true | _ -> false)
+         && not (is_primitive_tuple e.ty) ->
+      (* A tuple-typed match scrutinee that did NOT take the primitive
+         single-arm destructure path above is a NON-PRIMITIVE tuple (nested
+         tuple / record / vector / function component), reachable with a
+         non-variable scrutinee that never passes through [slot_elttype_of_typ]
+         (e.g. [let ((a, b), c) = ((x, y), z) in ...], which the parser desugars
+         to this match, or the equivalent [match] spelling). Without this guard
+         it would lower to [Ir.ETuple] + an [SMatch] and die as a confusing
+         backend C error ([switch ((...).tag)]). Raise the same located
+         tuple-component error the slot path raises. Only tuple scrutinees reach
+         here; variant matches have a [TVariant] scrutinee and fall through. *)
+      raise_tuple_component_error ~loc:(Sarek_ast.loc_to_ppxlib e.te_loc)
   | TEMatch (e, cases) ->
       let ir_cases =
         List.map

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -146,10 +146,11 @@ let tuple_record_fields (tys : typ list) : string * (string * Ir.elttype) list =
         | None ->
             Ppxlib.Location.raise_errorf
               ~loc:Ppxlib.Location.none
-              "Tuple-typed vector elements support only scalar components \
+              "Tuple values support only scalar components \
                (float32/float64/int32/int64/bool); nested tuples, records, \
-               vectors or functions inside a vector-element tuple are not \
-               supported.")
+               vectors or functions as tuple components are not supported \
+               (applies to both vector elements and kernel-local tuple \
+               bindings).")
       tys
   in
   let name = tuple_record_name comps in
@@ -164,9 +165,17 @@ let is_primitive_tuple (t : typ) : bool =
   | TTuple tys -> List.for_all (fun t -> prim_component_elttype t <> None) tys
   | _ -> false
 
-(** Element IR type of a vector whose element is [t]; a tuple element becomes
-    its synthesized record, everything else is the ordinary mapping. *)
-let vector_elem_elttype (t : typ) : Ir.elttype =
+(** IR type for a value that occupies a *data slot* — a vector element, or a
+    kernel-local binding ([let]/[match]-bound). A primitive-component tuple
+    becomes its synthesized positional record ([_tup_*], fields [_0.._n]) so the
+    struct backends (CUDA/OpenCL/GLSL/Metal) emit the right compound type
+    instead of the [elttype_of_typ] placeholder [int] (see that function's
+    NOTE); every other type uses the ordinary mapping. A non-primitive tuple
+    raises the located tuple-component error via {!tuple_record_fields},
+    mirroring vector-of-tuple scope. This is the sole difference from
+    {!elttype_of_typ}: the placeholder there stays intact for genuinely non-data
+    flows (function-typed helper bindings), while data uses route here. *)
+let slot_elttype_of_typ (t : typ) : Ir.elttype =
   match repr t with
   | TTuple tys ->
       let name, fields = tuple_record_fields tys in
@@ -318,6 +327,24 @@ let fresh_id state =
   state.next_var_id <- id + 1 ;
   id
 
+(** Register the synthesized [_tup_*] record for a primitive-component tuple in
+    the codegen types table, so a kernel-local slot typed by that record (see
+    {!make_var}/{!slot_elttype_of_typ}) has its [struct] definition emitted.
+    Idempotent; a no-op for non-tuple or non-primitive-tuple types (the latter
+    is rejected at the slot-typing site by {!tuple_record_fields}). The
+    realistic data sources for a local tuple (a tuple literal, an [if]/[match]
+    whose branches are tuple literals, a tuple-typed vector element) already
+    register it elsewhere; this call makes the binding site self-sufficient
+    regardless. *)
+let register_tuple_type (state : state) (ty : typ) : unit =
+  match repr ty with
+  | TTuple tys when List.for_all (fun t -> prim_component_elttype t <> None) tys
+    ->
+      let name, fields = tuple_record_fields tys in
+      if not (Hashtbl.mem state.types name) then
+        Hashtbl.add state.types name fields
+  | _ -> ()
+
 (** Convert Sarek_ast.binop to Sarek_ir_ppx.binop *)
 let ir_binop (op : binop) (_ty : typ) : Ir.binop =
   match op with
@@ -358,12 +385,16 @@ let lower_memspace = function
   | Shared -> Ir.Shared
   | Global -> Ir.Global
 
-(** Create a var from typed var info *)
+(** Create a var from typed var info. Uses {!slot_elttype_of_typ} (not the bare
+    {!elttype_of_typ}) so a kernel-local binding of primitive-tuple type is
+    typed by its synthesized [_tup_*] record rather than the placeholder [int] —
+    the struct backends then declare and read the slot as the right compound
+    type. Function-typed references still fall through to the placeholder. *)
 let make_var name id ty mutable_ : Ir.var =
   {
     var_name = name;
     var_id = id;
-    var_type = elttype_of_typ ty;
+    var_type = slot_elttype_of_typ ty;
     var_mutable = mutable_;
   }
 
@@ -740,9 +771,11 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
               body_ir )
       (* Normal let binding *)
       | _ ->
+          register_tuple_type state value.ty ;
           let v = make_var name id value.ty false in
           Ir.SLet (v, lower_expr state value, lower_stmt state body))
   | TELetMut (name, id, value, body) ->
+      register_tuple_type state value.ty ;
       let v = make_var name id value.ty true in
       Ir.SLetMut (v, lower_expr state value, lower_stmt state body)
   | TELetRec (name, _id, params, fn_body, cont) ->
@@ -776,7 +809,8 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
          [switch (x.tag)]. Rewrite it to a record destructure: bind the
          scrutinee once, then bind each component to its [_i] field. This works
          uniformly on every backend (field access is already supported). *)
-      let rec_elt = vector_elem_elttype e.ty in
+      register_tuple_type state e.ty ;
+      let rec_elt = slot_elttype_of_typ e.ty in
       incr tuple_tmp_counter ;
       let tmp_name = Printf.sprintf "__sarek_tup_%d" !tuple_tmp_counter in
       let tmp_var : Ir.var =
@@ -933,7 +967,7 @@ let lower_param (p : tparam) : Ir.decl =
   | _ -> ()) ;
   let elt =
     match repr p.tparam_type with
-    | TVec t -> Ir.TVec (vector_elem_elttype t)
+    | TVec t -> Ir.TVec (slot_elttype_of_typ t)
     | _ -> elttype_of_typ p.tparam_type
   in
   let v =
@@ -946,7 +980,7 @@ let lower_param (p : tparam) : Ir.decl =
   in
   if p.tparam_is_vec then
     let elem_ty =
-      match repr p.tparam_type with TVec t -> vector_elem_elttype t | _ -> elt
+      match repr p.tparam_type with TVec t -> slot_elttype_of_typ t | _ -> elt
     in
     Ir.DParam (v, Some {arr_elttype = elem_ty; arr_memspace = Ir.Global})
   else Ir.DParam (v, None)

--- a/sarek/ppx/Sarek_parse.ml
+++ b/sarek/ppx/Sarek_parse.ml
@@ -403,6 +403,26 @@ and parse_binop_or_app_form (expr : expression) (op : string) (e1 : expression)
 (** Extract body for let binding arm *)
 and parse_let_form (pvb_pat : pattern) (pvb_expr : expression)
     (body : expression) : Sarek_ast.expr_desc =
+  (* A tuple-pattern let ([let (a, b) = e in body]) is not a named binding;
+     desugar it to the single-arm tuple [match] the lowering already handles as
+     a positional-record destructure ([let ..], line ~800 of
+     Sarek_lower_ir.ml). This is the [let]-pattern half of local tuple support;
+     [match] was already covered directly. Constraints on the pattern (e.g.
+     [let ((a, b) : t) = e]) unwrap to the inner tuple. *)
+  let rec is_tuple_pattern (p : pattern) =
+    match p.ppat_desc with
+    | Ppat_tuple _ -> true
+    | Ppat_constraint (p, _) -> is_tuple_pattern p
+    | _ -> false
+  in
+  if is_tuple_pattern pvb_pat then
+    Sarek_ast.EMatch
+      ( parse_expression pvb_expr,
+        [(parse_pattern pvb_pat, parse_expression body)] )
+  else parse_named_let_form pvb_pat pvb_expr body
+
+and parse_named_let_form (pvb_pat : pattern) (pvb_expr : expression)
+    (body : expression) : Sarek_ast.expr_desc =
   let name =
     match extract_name_from_pattern pvb_pat with
     | Some n -> n

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -964,3 +964,38 @@
  (alias runtest)
  (action
   (run %{dep:test_reserved_prefix_positive.exe})))
+
+; local-tuple E2E: kernel-LOCAL primitive tuple bindings (let-bound literal,
+; let-pattern / match destructure, tuple through an if-branch, mixed
+; float32*int32) lowered to the L13 synthesized [_tup_*] positional record.
+; Axis 1 asserts the emitted CUDA/OpenCL/GLSL declares the slot with the
+; struct type (not the placeholder int); Axis 2 runs every position on every
+; available device (Native/Interpreter always, plus any GPU backend) against a
+; pure-OCaml reference. Self-verifying: exits nonzero on any mismatch.
+
+(executable
+ (name test_local_tuple)
+ (modules test_local_tuple)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  sarek.codegen
+  spoc_core
+  test_helpers
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_local_tuple.exe})))

--- a/sarek/tests/e2e/test_local_tuple.ml
+++ b/sarek/tests/e2e/test_local_tuple.ml
@@ -1,0 +1,267 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for kernel-LOCAL tuple bindings.
+ *
+ * A local tuple value ([let p = (a, b) in ...], a tuple through an [if]-branch,
+ * a [let]/[match] destructure) is lowered to the L13 synthesized positional
+ * record ([_tup_*], fields [_0.._n]) — the SAME machinery vector-of-tuple
+ * elements already use. Before this fix a local tuple slot was typed by the
+ * [elttype_of_typ] placeholder ([int]), so struct backends emitted [int p]
+ * where a struct belonged: wrong code / codegen rejection on OpenCL/Vulkan,
+ * sometimes tolerated on CUDA. This test locks BOTH:
+ *
+ *   Axis 1 (codegen): the emitted CUDA-C / OpenCL-C / GLSL for each position
+ *     declares the local slot with the synthesized struct type and defines the
+ *     struct — never a bare scalar mistyping.
+ *   Axis 2 (behaviour): results match a pure-OCaml reference on every available
+ *     device — CUDA/PTX (under ZLUDA), OpenCL, Vulkan, Metal, Native AND the
+ *     Interpreter (its evaluator carries local tuples by value as positional
+ *     records, so no byte-layout host bridge is needed — the tuple never leaves
+ *     the kernel).
+ *
+ * Positions exercised: let-bound literal + match destructure (all-float32);
+ * let-pattern destructure (all-float32); tuple through an if-branch
+ * (all-float32); mixed (float32 * int32) with an int component consumed via
+ * [float_of_int]. All results land in a plain [float32 vector], so verification
+ * is a scalar float compare — the tuple is purely kernel-internal.
+ ******************************************************************************)
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Benchmarks = Test_helpers.Benchmarks
+
+type float32 = float
+
+(* A: let-bound tuple literal, consumed by a match destructure.
+   dst[i] = a + b  with (a, b) = (src[i], src[i] + 1) = 2*src[i] + 1 *)
+let k_match =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let open Std in
+        let tid = global_thread_id in
+        if tid < n then begin
+          let p = (src.(tid), src.(tid) +. 1.0) in
+          match p with a, b -> dst.(tid) <- a +. b
+        end]
+
+(* B: let-PATTERN destructure (desugars to a single-arm tuple match).
+   dst[i] = a + b  with (a, b) = (src[i], src[i] * 2) = 3*src[i] *)
+let k_letpat =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let open Std in
+        let tid = global_thread_id in
+        if tid < n then begin
+          let a, b = (src.(tid), src.(tid) *. 2.0) in
+          dst.(tid) <- a +. b
+        end]
+
+(* C: tuple produced by an if-branch, then destructured.
+   dst[i] = a + b  with (a, b) = (src[i], 1) if src[i] > 0 else (src[i], 2) *)
+let k_ifbranch =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let open Std in
+        let tid = global_thread_id in
+        if tid < n then begin
+          let p =
+            if src.(tid) >. 0.0 then (src.(tid), 1.0) else (src.(tid), 2.0)
+          in
+          match p with a, b -> dst.(tid) <- a +. b
+        end]
+
+(* D: mixed (float32 * int32) local tuple; the int component is consumed via
+   float_of_int, exercising a mixed-alignment layout.
+   dst[i] = a + float_of_int b  with (a, b) = (src[i], tid) *)
+let k_mixed =
+  snd
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let open Std in
+        let tid = global_thread_id in
+        if tid < n then begin
+          let p = (src.(tid), tid) in
+          match p with a, b -> dst.(tid) <- a +. float b
+        end]
+
+(* ---- OCaml references (must mirror the kernels exactly) ------------------ *)
+
+let ref_src i = float_of_int i -. 8.0 (* spans negative and positive for C *)
+
+let ref_match i = ref_src i +. (ref_src i +. 1.0)
+
+let ref_letpat i = ref_src i +. (ref_src i *. 2.0)
+
+let ref_ifbranch i = ref_src i +. if ref_src i > 0.0 then 1.0 else 2.0
+
+let ref_mixed i = ref_src i +. float_of_int i
+
+(* ---- Axis 1: emitted-source structural check ----------------------------- *)
+
+let ir_of name kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith ("no IR for " ^ name)
+
+let contains hay needle =
+  let nh = String.length needle and h = String.length hay in
+  let rec go i =
+    if i + nh > h then false
+    else if String.sub hay i nh = needle then true
+    else go (i + 1)
+  in
+  nh = 0 || go 0
+
+let codegen_ok = ref true
+
+(* The synthesized-record type name for the tuple shape of each kernel. *)
+let check_codegen name kirc ~struct_name =
+  let ir = ir_of name kirc in
+  let types = ir.Sarek_ir_types.kern_types in
+  let backends =
+    [
+      ("CUDA", Sarek_codegen.Sarek_ir_cuda.generate_with_types ~types ir);
+      ("OpenCL", Sarek_codegen.Sarek_ir_opencl.generate_with_types ~types ir);
+      ("GLSL", Sarek_codegen.Sarek_ir_glsl.generate_with_types ~types ir);
+    ]
+  in
+  List.iter
+    (fun (bk, src) ->
+      (* The synthesized struct must be defined AND used as the slot type; the
+         destructure tmp must never be mistyped as a bare scalar. *)
+      let has_struct = contains src struct_name in
+      let mistyped =
+        contains src ("int " ^ struct_name)
+        || contains src "int __sarek_tup"
+        || contains src "int p ="
+      in
+      if (not has_struct) || mistyped then begin
+        codegen_ok := false ;
+        Printf.printf
+          "  codegen[%s/%s]: FAIL (struct present=%b, mistyped=%b)\n%s\n%!"
+          name
+          bk
+          has_struct
+          mistyped
+          src
+      end
+      else Printf.printf "  codegen[%s/%s]: OK\n%!" name bk)
+    backends
+
+(* ---- Axis 2: behavioural equivalence on every device --------------------- *)
+
+let must_pass fw =
+  match fw with
+  | "CUDA" | "OpenCL" | "Vulkan" | "Metal" | "Native" | "Interpreter" -> true
+  | _ -> false
+
+let any_failure = ref false
+
+let pass_count = ref 0
+
+let run_kernel_on name kirc reff dev n =
+  let ir = ir_of name kirc in
+  let src = Vector.create Vector.float32 n in
+  let dst = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set src i (ref_src i) ;
+    Vector.set dst i (-999.0)
+  done ;
+  let threads = min 64 n in
+  let grid_x = (n + threads - 1) / threads in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~block:(Execute.dims1d threads)
+    ~grid:(Execute.dims1d grid_x)
+    ~args:[Execute.Vec src; Execute.Vec dst; Execute.Int32 (Int32.of_int n)]
+    () ;
+  Transfer.flush dev ;
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    let got = Vector.get dst i and exp = reff i in
+    if abs_float (got -. exp) > 1e-3 then begin
+      ok := false ;
+      if i < 5 then
+        Printf.printf
+          "\n    %s mismatch at %d: got %.3f expected %.3f%!"
+          name
+          i
+          got
+          exp
+    end
+  done ;
+  !ok
+
+let kernels =
+  [
+    ("match", k_match, ref_match);
+    ("letpat", k_letpat, ref_letpat);
+    ("ifbranch", k_ifbranch, ref_ifbranch);
+    ("mixed", k_mixed, ref_mixed);
+  ]
+
+let () =
+  print_endline "=== local-tuple E2E ===" ;
+  (* Axis 1 — codegen structural check (no device needed). *)
+  print_endline "-- emitted-source structural check --" ;
+  check_codegen "match" k_match ~struct_name:"_tup_float32_float32" ;
+  check_codegen "letpat" k_letpat ~struct_name:"_tup_float32_float32" ;
+  check_codegen "ifbranch" k_ifbranch ~struct_name:"_tup_float32_float32" ;
+  check_codegen "mixed" k_mixed ~struct_name:"_tup_float32_int32" ;
+  if not !codegen_ok then any_failure := true ;
+
+  (* Axis 2 — behaviour on every available device. *)
+  Benchmarks.init () ;
+  let devs =
+    Device.init
+      ~frameworks:["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"; "Metal"]
+      ()
+  in
+  if Array.length devs = 0 then
+    print_endline "No runtime devices — codegen axis only"
+  else begin
+    let n = 64 in
+    Array.iter
+      (fun dev ->
+        let fw = dev.Device.framework in
+        List.iter
+          (fun (name, kirc, reff) ->
+            Printf.printf "runtime [%s/%s]: %!" fw name ;
+            try
+              if run_kernel_on name kirc reff dev n then begin
+                incr pass_count ;
+                print_endline "PASSED"
+              end
+              else if must_pass fw then begin
+                any_failure := true ;
+                print_endline "FAILED"
+              end
+              else print_endline "skip (non-required)"
+            with e ->
+              let msg =
+                match e with
+                | Sarek_backend_error.Backend_error.Backend_error err ->
+                    Sarek_backend_error.Backend_error.to_string err
+                | e -> Printexc.to_string e
+              in
+              if must_pass fw then begin
+                any_failure := true ;
+                Printf.printf "FAIL (%s)\n%!" msg
+              end
+              else Printf.printf "skip (%s)\n%!" msg)
+          kernels)
+      devs
+  end ;
+  Printf.printf "\n=== local-tuple: %d runtime checks passed ===\n" !pass_count ;
+  if !any_failure then exit 1

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -16,6 +16,7 @@
 ; - test_inline_node_exhaustion: "Inlining produced N nodes (limit: 10000)"
 ; - test_tuple_param: "Tuple-typed kernel parameters are not supported"
 ; - test_tuple_local_nonprim: "Tuple values support only scalar components"
+; - test_tuple_destructure_nonprim: "Tuple values support only scalar components"
 ; - test_fun_param: "Function-typed kernel parameters are not supported"
 ; - test_fun_escape: "Function value escapes"
 ; - test_unregistered_field: "unknown size/alignment for field type"
@@ -127,6 +128,17 @@
 (library
  (name neg_test_tuple_param)
  (modules test_tuple_param)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+(library
+ (name neg_test_tuple_destructure_nonprim)
+ (modules test_tuple_destructure_nonprim)
  (libraries sarek sarek.stdlib sarek.ppx.lib)
  (preprocess
   (pps sarek_ppx))

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -15,6 +15,7 @@
 ; - test_convention_kernel_fail2: "Cannot unify types"
 ; - test_inline_node_exhaustion: "Inlining produced N nodes (limit: 10000)"
 ; - test_tuple_param: "Tuple-typed kernel parameters are not supported"
+; - test_tuple_local_nonprim: "Tuple values support only scalar components"
 ; - test_fun_param: "Function-typed kernel parameters are not supported"
 ; - test_fun_escape: "Function value escapes"
 ; - test_unregistered_field: "unknown size/alignment for field type"
@@ -126,6 +127,17 @@
 (library
  (name neg_test_tuple_param)
  (modules test_tuple_param)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+(library
+ (name neg_test_tuple_local_nonprim)
+ (modules test_tuple_local_nonprim)
  (libraries sarek sarek.stdlib sarek.ppx.lib)
  (preprocess
   (pps sarek_ppx))

--- a/sarek/tests/negative/test_tuple_destructure_nonprim.ml
+++ b/sarek/tests/negative/test_tuple_destructure_nonprim.ml
@@ -1,0 +1,25 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile:
+   - A NON-PRIMITIVE tuple DESTRUCTURE with a non-variable scrutinee. The
+     scrutinee never passes through the kernel-local slot-typing path
+     (no make_var), so the rejection must come from the match-scrutinee guard
+     in Sarek_lower_ir.ml — NOT surface as a confusing backend C error
+     (`switch((...).tag)`). The let-pattern is desugared by the parser to the
+     single-arm tuple match this guard covers. *)
+
+let () =
+  let bad_kernel =
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let (a, b), c = ((src.(tid), src.(tid)), src.(tid)) in
+          dst.(tid) <- a +. b +. c
+        end]
+  in
+  ignore bad_kernel ;
+  print_endline "This should not print - test should have failed to compile"

--- a/sarek/tests/negative/test_tuple_local_nonprim.ml
+++ b/sarek/tests/negative/test_tuple_local_nonprim.ml
@@ -1,0 +1,24 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile:
+   - A kernel-LOCAL tuple binding whose component is itself a tuple (a
+     non-primitive component). Local primitive tuples are lowered to the
+     synthesized [_tup_*] record, but a non-primitive component must produce
+     the located tuple-component error (the same one vector-of-tuple elements
+     raise), NOT silently collapse to the placeholder int. *)
+
+let () =
+  let bad_kernel =
+    [%kernel
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let p = (src.(tid), (tid, tid)) in
+          match p with a, _ -> dst.(tid) <- a
+        end]
+  in
+  ignore bad_kernel ;
+  print_endline "This should not print - test should have failed to compile"

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -13,7 +13,7 @@
  * positional fields [_0], [_1], ... and its byte layout is taken from the
  * shared layout authority [Sarek_ir_layout], byte-for-byte identical to the
  * layout the device codegen computes for the synthesized record
- * ([Sarek_lower_ir.vector_elem_elttype]). Host [get]/[set] therefore marshal
+ * ([Sarek_lower_ir.slot_elttype_of_typ]). Host [get]/[set] therefore marshal
  * to/from exactly the bytes the kernel reads and writes on device.
  *
  * Scope (this tier): tuples of two or three scalar-primitive components,


### PR DESCRIPTION
Kernel-local tuples (`let p = (a,b)`) emitted an `int` placeholder slot initialized with a struct literal — CUDA tolerated it, OpenCL/GLSL rejected/miscompiled (found empirically in the L14-S2 review).

- Locals now reuse L13's synthesized `_tup_*` positional records: `slot_elttype_of_typ` (né `vector_elem_elttype`) maps primitive-component tuples to the nominal TRecord at every slot/read/destructure site; registration guaranteed at binding + destructure; the `TTuple→TInt32` placeholder stays for non-data flows and the polymorphic-param TVar guard is untouched.
- `let (a,b) = e in …` was a parse error — now desugars to a single-arm match (location-preserving; unsupported forms stay clean errors).
- Non-primitive tuples: located component error at BOTH the binding path and (review round-2) the destructure path with non-variable scrutinees — variant matches unaffected (TVariant guard). 3 negative tests.
- e2e: 4 positions (literal, match-destructure, let-pattern, if-branch) × codegen axis (CUDA/OpenCL/GLSL) + 36 runtime checks on Interpreter/Native/CUDA-PTX(ZLUDA)/OpenCL/Vulkan vs OCaml reference.
- Out of scope, documented: helper-returned tuples (loud backend type error, no silent path — PTX lacks device calls).

Pipeline (full): research → spec → plan → implement → review GO → polish (nested-scrutinee hole closed, doc ref, rebase on #260) → QA GO. ptxas 59/59 post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)