### PR TITLE
fix(interp): variant-typed record fields through the deriver value model

### DIFF
--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -464,18 +464,20 @@ let interp_array_to_vector : type a b.
       (* Custom types: convert VRecord to native OCaml values using helpers *)
       for i = 0 to len - 1 do
         match arr.(i) with
-        | Sarek_ir_interp.VRecord (type_name, _fields) as vrec -> (
+        | ( Sarek_ir_interp.VRecord (type_name, _)
+          | Sarek_ir_interp.VVariant (type_name, _, _) ) as v -> (
+            (* Both a record element (VRecord) and a standalone variant element
+               (VVariant) are decoded back to their native OCaml value through
+               the registered [@@sarek.type] helper. *)
             match Sarek_type_helpers.lookup_typed custom.Vector.type_id with
-            | Some (module H) ->
-                let native_record = H.from_value vrec in
-                Vector.set vec i native_record
+            | Some (module H) -> Vector.set vec i (H.from_value v)
             | None ->
                 Execute_error.raise_error
                   (Execute_error.Type_helper_not_found
                      {
                        type_name;
                        context =
-                         "sync_vector_back (record conversion from interpreter)";
+                         "sync_vector_back (custom conversion from interpreter)";
                      }))
         | _ -> () (* Skip other values *)
       done

--- a/sarek/interp/Sarek_ir_interp.ml
+++ b/sarek/interp/Sarek_ir_interp.ml
@@ -501,13 +501,26 @@ let array_to_exec_vector (module V : Spoc_framework.Typed_value.EXEC_VECTOR)
   let len = min (Array.length arr) V.length in
   for i = 0 to len - 1 do
     match arr.(i) with
-    | VVariant _ as vv -> (
+    | VVariant (type_name, _, _) as vv -> (
         (* Standalone variant vector element: the [@@sarek.type] variant helper
            decodes the [VVariant] back to the native constructor, then the
            composite's typed setter writes the [tag|payload] bytes. *)
         match Sarek_type_helpers.lookup_typed V.type_id with
         | Some (module H) -> V.set_typed i (H.from_value vv)
-        | None -> ())
+        | None ->
+            (* A [@@sarek.type] variant element always has a registered helper;
+               a missing one is a registration bug. Surface it (mirrors
+               Execute.interp_array_to_vector) rather than silently dropping the
+               write and producing wrong output. Unlike the VRecord arm there is
+               no tuple-shape fallback for variants. *)
+            Interp_error.raise_error
+              (Unsupported_operation
+                 {
+                   operation = "variant vector writeback";
+                   reason =
+                     "no registered [@@sarek.type] helper for variant element \
+                      type '" ^ type_name ^ "'";
+                 }))
     | VRecord (name, fields) as vrec -> (
         match Sarek_type_helpers.lookup_typed V.type_id with
         | Some (module H) -> V.set_typed i (H.from_value vrec)

--- a/sarek/interp/Sarek_ir_interp.ml
+++ b/sarek/interp/Sarek_ir_interp.ml
@@ -501,6 +501,13 @@ let array_to_exec_vector (module V : Spoc_framework.Typed_value.EXEC_VECTOR)
   let len = min (Array.length arr) V.length in
   for i = 0 to len - 1 do
     match arr.(i) with
+    | VVariant _ as vv -> (
+        (* Standalone variant vector element: the [@@sarek.type] variant helper
+           decodes the [VVariant] back to the native constructor, then the
+           composite's typed setter writes the [tag|payload] bytes. *)
+        match Sarek_type_helpers.lookup_typed V.type_id with
+        | Some (module H) -> V.set_typed i (H.from_value vv)
+        | None -> ())
     | VRecord (name, fields) as vrec -> (
         match Sarek_type_helpers.lookup_typed V.type_id with
         | Some (module H) -> V.set_typed i (H.from_value vrec)

--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -186,8 +186,24 @@ and eval_control_flow state env = function
         | [] ->
             Interp_error.raise_error
               (Pattern_match_failure {context = "EMatch"})
-        | (PConstr (name, _), body) :: rest ->
-            if Hashtbl.hash name mod 256 = tag then body else find_case rest
+        | (PConstr (name, vars), body) :: rest ->
+            if Hashtbl.hash name mod 256 = tag then begin
+              (* Bind the constructor's payload variables positionally, exactly
+                 as SMatch does, so an expression-position match on a variant
+                 (e.g. [let s = match c.kind with Shade f -> f]) can use the
+                 payload. Previously EMatch selected the arm but left payload
+                 vars unbound. *)
+              (match v with
+              | VVariant (_, _, args) ->
+                  List.iter2
+                    (fun vname arg ->
+                      Hashtbl.replace env.vars_by_name vname arg)
+                    vars
+                    args
+              | _ -> ()) ;
+              body
+            end
+            else find_case rest
         | (PWild, body) :: _ -> body
       in
       eval_expr state env (find_case cases)

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -87,6 +87,96 @@ let custom_descriptor_expr_of_lid ~loc lid =
       Ast_builder.Default.pexp_ident ~loc {txt = ident; loc}
   | [] -> Ast_builder.Default.evar ~loc "unknown_custom"
 
+(** Interpreter value-model converters, shared by the record and variant helper
+    generators ([generate_interp_helpers]).
+
+    [value_to_ocaml]: extract the OCaml scalar / nested-custom value of type
+    [ct] from a runtime [value] expression (used by record [from_values] field
+    converters and variant [from_value] payload reconstruction).
+
+    [value_from_ocaml]: wrap an OCaml scalar / nested-custom value of type [ct]
+    into the corresponding runtime [value] (used by record [to_values]/
+    [get_field] and variant [to_value]).
+
+    A nested custom type (record OR variant) is delegated to its registered
+    helper via [lookup_typed <ct>_custom.type_id]; the [value_to_ocaml] nested
+    arm accepts BOTH [VRecord] and [VVariant] — a variant-typed field is no
+    longer rejected with "expected record" (the L14-S2 PR #251 break). [what]
+    names the field/argument for error messages. *)
+let value_to_ocaml ~loc ~(what : string) (ct : core_type)
+    (value_expr : expression) : expression =
+  let estr s = Ast_builder.Default.estring ~loc s in
+  match ct.ptyp_desc with
+  | Ptyp_constr ({txt = Lident ("float32" | "float"); _}, _) ->
+      [%expr
+        match [%e value_expr] with
+        | Sarek.Sarek_value.VFloat32 f -> f
+        | Sarek.Sarek_value.VFloat64 f -> f
+        | _ -> failwith [%e estr (what ^ " expected float32, got wrong type")]]
+  | Ptyp_constr ({txt = Lident "float64"; _}, _) ->
+      [%expr
+        match [%e value_expr] with
+        | Sarek.Sarek_value.VFloat64 f -> f
+        | Sarek.Sarek_value.VFloat32 f -> f
+        | _ -> failwith [%e estr (what ^ " expected float64, got wrong type")]]
+  | Ptyp_constr ({txt = Lident ("int32" | "int"); _}, _) ->
+      [%expr
+        match [%e value_expr] with
+        | Sarek.Sarek_value.VInt32 n -> n
+        | _ -> failwith [%e estr (what ^ " expected int32, got wrong type")]]
+  | Ptyp_constr ({txt = Lident "int64"; _}, _) ->
+      [%expr
+        match [%e value_expr] with
+        | Sarek.Sarek_value.VInt64 n -> n
+        | _ -> failwith [%e estr (what ^ " expected int64, got wrong type")]]
+  | Ptyp_constr ({txt = Lident "bool"; _}, _) ->
+      [%expr
+        match [%e value_expr] with
+        | Sarek.Sarek_value.VBool b -> b
+        | _ -> failwith [%e estr (what ^ " expected bool")]]
+  | Ptyp_constr ({txt; _}, _) ->
+      let custom_type = String.concat "." (flatten_longident txt) in
+      let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
+      [%expr
+        match [%e value_expr] with
+        | (Sarek.Sarek_value.VRecord _ | Sarek.Sarek_value.VVariant _) as nested
+          -> (
+            match
+              Sarek.Sarek_type_helpers.lookup_typed
+                [%e custom_expr].Spoc_core.Vector.type_id
+            with
+            | Some (module H) -> H.from_value nested
+            | None ->
+                failwith [%e estr ("No helper for nested type " ^ custom_type)])
+        | _ -> failwith [%e estr (what ^ " expected record or variant")]]
+  | _ -> [%expr failwith [%e estr ("Unsupported field type: " ^ what)]]
+
+let value_from_ocaml ~loc ~(what : string) (ct : core_type)
+    (ocaml_expr : expression) : expression =
+  let estr s = Ast_builder.Default.estring ~loc s in
+  match ct.ptyp_desc with
+  | Ptyp_constr ({txt = Lident ("float32" | "float"); _}, _) ->
+      [%expr Sarek.Sarek_value.VFloat32 [%e ocaml_expr]]
+  | Ptyp_constr ({txt = Lident "float64"; _}, _) ->
+      [%expr Sarek.Sarek_value.VFloat64 [%e ocaml_expr]]
+  | Ptyp_constr ({txt = Lident ("int32" | "int"); _}, _) ->
+      [%expr Sarek.Sarek_value.VInt32 [%e ocaml_expr]]
+  | Ptyp_constr ({txt = Lident "int64"; _}, _) ->
+      [%expr Sarek.Sarek_value.VInt64 [%e ocaml_expr]]
+  | Ptyp_constr ({txt = Lident "bool"; _}, _) ->
+      [%expr Sarek.Sarek_value.VBool [%e ocaml_expr]]
+  | Ptyp_constr ({txt; _}, _) ->
+      let custom_type = String.concat "." (flatten_longident txt) in
+      let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
+      [%expr
+        match
+          Sarek.Sarek_type_helpers.lookup_typed
+            [%e custom_expr].Spoc_core.Vector.type_id
+        with
+        | Some (module H) -> H.to_value [%e ocaml_expr]
+        | None -> failwith [%e estr ("No helper for type " ^ custom_type)]]
+  | _ -> [%expr failwith [%e estr ("Unsupported field type: " ^ what)]]
+
 let rec core_type_to_sarek_type_expr ~loc (ct : core_type) =
   match ct.ptyp_desc with
   | Ptyp_constr ({txt; _}, args) ->
@@ -1168,96 +1258,11 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
               [%expr arr.([%e Ast_builder.Default.eint ~loc i])]
             in
             let converter =
-              match field_type.ptyp_desc with
-              | Ptyp_constr ({txt = Lident "float32"; _}, _)
-              | Ptyp_constr ({txt = Lident "float"; _}, _) ->
-                  [%expr
-                    match [%e array_access] with
-                    | Sarek.Sarek_value.VFloat32 f -> f
-                    | Sarek.Sarek_value.VFloat64 f -> f
-                    | _ ->
-                        failwith
-                          [%e
-                            Ast_builder.Default.estring
-                              ~loc
-                              ("Field '" ^ field_name
-                             ^ "' expected float32, got wrong type")]]
-              | Ptyp_constr ({txt = Lident "float64"; _}, _) ->
-                  [%expr
-                    match [%e array_access] with
-                    | Sarek.Sarek_value.VFloat64 f -> f
-                    | Sarek.Sarek_value.VFloat32 f -> f
-                    | _ ->
-                        failwith
-                          [%e
-                            Ast_builder.Default.estring
-                              ~loc
-                              ("Field '" ^ field_name
-                             ^ "' expected float64, got wrong type")]]
-              | Ptyp_constr ({txt = Lident "int32"; _}, _)
-              | Ptyp_constr ({txt = Lident "int"; _}, _) ->
-                  [%expr
-                    match [%e array_access] with
-                    | Sarek.Sarek_value.VInt32 n -> n
-                    | _ ->
-                        failwith
-                          [%e
-                            Ast_builder.Default.estring
-                              ~loc
-                              ("Field '" ^ field_name
-                             ^ "' expected int32, got wrong type")]]
-              | Ptyp_constr ({txt = Lident "int64"; _}, _) ->
-                  [%expr
-                    match [%e array_access] with
-                    | Sarek.Sarek_value.VInt64 n -> n
-                    | _ ->
-                        failwith
-                          [%e
-                            Ast_builder.Default.estring
-                              ~loc
-                              ("Field '" ^ field_name
-                             ^ "' expected int64, got wrong type")]]
-              | Ptyp_constr ({txt = Lident "bool"; _}, _) ->
-                  [%expr
-                    match [%e array_access] with
-                    | Sarek.Sarek_value.VBool b -> b
-                    | _ ->
-                        failwith
-                          [%e
-                            Ast_builder.Default.estring
-                              ~loc
-                              ("Field '" ^ field_name ^ "' expected bool")]]
-              | Ptyp_constr ({txt; _}, _) ->
-                  (* Nested custom type - recursively call its helper *)
-                  let custom_type = String.concat "." (flatten_longident txt) in
-                  let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
-                  [%expr
-                    match [%e array_access] with
-                    | Sarek.Sarek_value.VRecord _ as nested_vrec -> (
-                        match
-                          Sarek.Sarek_type_helpers.lookup_typed
-                            [%e custom_expr].Spoc_core.Vector.type_id
-                        with
-                        | Some (module H) -> H.from_value nested_vrec
-                        | None ->
-                            failwith
-                              [%e
-                                Ast_builder.Default.estring
-                                  ~loc
-                                  ("No helper for nested type " ^ custom_type)])
-                    | _ ->
-                        failwith
-                          [%e
-                            Ast_builder.Default.estring
-                              ~loc
-                              ("Field '" ^ field_name ^ "' expected record")]]
-              | _ ->
-                  [%expr
-                    failwith
-                      [%e
-                        Ast_builder.Default.estring
-                          ~loc
-                          ("Unsupported field type: " ^ field_name)]]
+              value_to_ocaml
+                ~loc
+                ~what:("Field '" ^ field_name ^ "'")
+                field_type
+                array_access
             in
             (Ast_builder.Default.Located.lident ~loc field_name, converter))
           labels
@@ -1279,47 +1284,11 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
               let field_access =
                 Ast_builder.Default.pexp_field ~loc [%expr record] field_lid
               in
-              let converter =
-                match ld.pld_type.ptyp_desc with
-                | Ptyp_constr ({txt = Lident "float32"; _}, _)
-                | Ptyp_constr ({txt = Lident "float"; _}, _) ->
-                    [%expr Sarek.Sarek_value.VFloat32 [%e field_access]]
-                | Ptyp_constr ({txt = Lident "float64"; _}, _) ->
-                    [%expr Sarek.Sarek_value.VFloat64 [%e field_access]]
-                | Ptyp_constr ({txt = Lident "int32"; _}, _)
-                | Ptyp_constr ({txt = Lident "int"; _}, _) ->
-                    [%expr Sarek.Sarek_value.VInt32 [%e field_access]]
-                | Ptyp_constr ({txt = Lident "int64"; _}, _) ->
-                    [%expr Sarek.Sarek_value.VInt64 [%e field_access]]
-                | Ptyp_constr ({txt = Lident "bool"; _}, _) ->
-                    [%expr Sarek.Sarek_value.VBool [%e field_access]]
-                | Ptyp_constr ({txt; _}, _) ->
-                    (* Nested custom type - use helper to convert *)
-                    let custom_type =
-                      String.concat "." (flatten_longident txt)
-                    in
-                    let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
-                    [%expr
-                      match
-                        Sarek.Sarek_type_helpers.lookup_typed
-                          [%e custom_expr].Spoc_core.Vector.type_id
-                      with
-                      | Some (module H) -> H.to_value [%e field_access]
-                      | None ->
-                          failwith
-                            [%e
-                              Ast_builder.Default.estring
-                                ~loc
-                                ("No helper for type " ^ custom_type)]]
-                | _ ->
-                    [%expr
-                      failwith
-                        [%e
-                          Ast_builder.Default.estring
-                            ~loc
-                            ("Unsupported field type: " ^ field_name)]]
-              in
-              converter)
+              value_from_ocaml
+                ~loc
+                ~what:("field " ^ field_name)
+                ld.pld_type
+                field_access)
             labels
         in
         let array_expr = Ast_builder.Default.elist ~loc field_conversions in
@@ -1339,41 +1308,11 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
               Ast_builder.Default.pexp_field ~loc [%expr record] field_lid
             in
             let converter =
-              match ld.pld_type.ptyp_desc with
-              | Ptyp_constr ({txt = Lident "float32"; _}, _)
-              | Ptyp_constr ({txt = Lident "float"; _}, _) ->
-                  [%expr Sarek.Sarek_value.VFloat32 [%e field_access]]
-              | Ptyp_constr ({txt = Lident "float64"; _}, _) ->
-                  [%expr Sarek.Sarek_value.VFloat64 [%e field_access]]
-              | Ptyp_constr ({txt = Lident "int32"; _}, _)
-              | Ptyp_constr ({txt = Lident "int"; _}, _) ->
-                  [%expr Sarek.Sarek_value.VInt32 [%e field_access]]
-              | Ptyp_constr ({txt = Lident "int64"; _}, _) ->
-                  [%expr Sarek.Sarek_value.VInt64 [%e field_access]]
-              | Ptyp_constr ({txt = Lident "bool"; _}, _) ->
-                  [%expr Sarek.Sarek_value.VBool [%e field_access]]
-              | Ptyp_constr ({txt; _}, _) ->
-                  let custom_type = String.concat "." (flatten_longident txt) in
-                  let custom_expr = custom_descriptor_expr_of_lid ~loc txt in
-                  [%expr
-                    match
-                      Sarek.Sarek_type_helpers.lookup_typed
-                        [%e custom_expr].Spoc_core.Vector.type_id
-                    with
-                    | Some (module H) -> H.to_value [%e field_access]
-                    | None ->
-                        failwith
-                          [%e
-                            Ast_builder.Default.estring
-                              ~loc
-                              ("No helper for type " ^ custom_type)]]
-              | _ ->
-                  [%expr
-                    failwith
-                      [%e
-                        Ast_builder.Default.estring
-                          ~loc
-                          ("Unsupported field type: " ^ field_name)]]
+              value_from_ocaml
+                ~loc
+                ~what:("field " ^ field_name)
+                ld.pld_type
+                field_access
             in
             Ast_builder.Default.case
               ~lhs:
@@ -1456,8 +1395,200 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
               [%e full_name_expr]
               (Sarek.Sarek_type_helpers.AnyHelpers (module H))];
       ]
+  | Ptype_variant constrs ->
+      (* Interpreter value-model helper for a variant type: convert the native
+         OCaml constructor to/from a [VVariant]. The interpreter tags a variant
+         by [Hashtbl.hash ctor mod 256] (Sarek_ir_interp_eval EVariant/EMatch/
+         SMatch), NOT by the declaration index the byte path uses; the tag is
+         emitted as a runtime [Hashtbl.hash "C" mod 256] expression so it
+         matches that convention byte-for-byte regardless of compile vs runtime.
+
+         This makes a variant field of a [@@sarek.type] record round-trip on the
+         Interpreter/Native value path (the record helper delegates the field to
+         this helper's [from_value]/[to_value]) and lets a standalone variant
+         vector element decode to a [VVariant]. It does NOT give the variant a
+         nested byte layout (that stays a Sarek_ir_layout Nested_variant
+         rejection — Rocq-coupled, out of scope), so device backends are
+         unaffected. *)
+      let cvar i = "x" ^ string_of_int i in
+      let tag_of cname =
+        [%expr Hashtbl.hash [%e Ast_builder.Default.estring ~loc cname] mod 256]
+      in
+      let payload_cts (cd : constructor_declaration) : core_type list =
+        match cd.pcd_args with
+        | Pcstr_tuple cts -> cts
+        | Pcstr_record _ ->
+            Location.raise_errorf
+              ~loc
+              "sarek: inline records in [@@sarek.type] variant constructors \
+               are not supported"
+      in
+      (* to_value: C (a, b, ..) -> VVariant (full_name, tag, [Va; Vb; ..]) *)
+      let to_value_cases =
+        List.map
+          (fun (cd : constructor_declaration) ->
+            let cname = cd.pcd_name.txt in
+            let cts = payload_cts cd in
+            let arg_pat, arg_values =
+              match cts with
+              | [] -> (None, [])
+              | [ct] ->
+                  ( Some (Ast_builder.Default.pvar ~loc (cvar 0)),
+                    [
+                      value_from_ocaml
+                        ~loc
+                        ~what:cname
+                        ct
+                        (Ast_builder.Default.evar ~loc (cvar 0));
+                    ] )
+              | cts ->
+                  let pats =
+                    List.mapi
+                      (fun i _ -> Ast_builder.Default.pvar ~loc (cvar i))
+                      cts
+                  in
+                  let vals =
+                    List.mapi
+                      (fun i ct ->
+                        value_from_ocaml
+                          ~loc
+                          ~what:cname
+                          ct
+                          (Ast_builder.Default.evar ~loc (cvar i)))
+                      cts
+                  in
+                  (Some (Ast_builder.Default.ppat_tuple ~loc pats), vals)
+            in
+            let lhs =
+              Ast_builder.Default.ppat_construct
+                ~loc
+                (Ast_builder.Default.Located.lident ~loc cname)
+                arg_pat
+            in
+            let rhs =
+              [%expr
+                Sarek.Sarek_value.VVariant
+                  ( [%e full_name_expr],
+                    [%e tag_of cname],
+                    [%e Ast_builder.Default.elist ~loc arg_values] )]
+            in
+            Ast_builder.Default.case ~lhs ~guard:None ~rhs)
+          constrs
+      in
+      let to_value_fn =
+        [%expr
+          fun v ->
+            [%e Ast_builder.Default.pexp_match ~loc [%expr v] to_value_cases]]
+      in
+      (* from_value: VVariant (_, tag, args) -> the constructor whose hashed name
+         equals [tag]; payload rebuilt positionally from [args]. Falls back to
+         the first constructor on an unknown tag (mirrors the byte-path get
+         fallback). *)
+      let build_ctor (cd : constructor_declaration) : expression =
+        let cname = cd.pcd_name.txt in
+        let cts = payload_cts cd in
+        let nth i =
+          value_to_ocaml
+            ~loc
+            ~what:(cname ^ " arg " ^ string_of_int i)
+            (List.nth cts i)
+            [%expr List.nth args [%e Ast_builder.Default.eint ~loc i]]
+        in
+        let arg =
+          match cts with
+          | [] -> None
+          | [_] -> Some (nth 0)
+          | cts ->
+              Some
+                (Ast_builder.Default.pexp_tuple
+                   ~loc
+                   (List.mapi (fun i _ -> nth i) cts))
+        in
+        Ast_builder.Default.pexp_construct
+          ~loc
+          (Ast_builder.Default.Located.lident ~loc cname)
+          arg
+      in
+      let from_value_chain =
+        let fallback =
+          match constrs with
+          | first :: _ -> build_ctor first
+          | [] -> [%expr failwith "empty variant"]
+        in
+        List.fold_right
+          (fun (cd : constructor_declaration) acc ->
+            [%expr
+              if tag = [%e tag_of cd.pcd_name.txt] then [%e build_ctor cd]
+              else [%e acc]])
+          constrs
+          fallback
+      in
+      let from_value_fn =
+        [%expr
+          fun v ->
+            match v with
+            | Sarek.Sarek_value.VVariant (_, tag, args) ->
+                ignore args ;
+                [%e from_value_chain]
+            | _ ->
+                failwith
+                  [%e
+                    Ast_builder.Default.estring
+                      ~loc
+                      ("Expected " ^ type_name ^ " VVariant")]]
+      in
+      let helper_module_name = type_name ^ "_interp_helpers" in
+      let type_lid = Ast_builder.Default.Located.lident ~loc type_name in
+      let helper_module_lid =
+        Ast_builder.Default.Located.lident ~loc helper_module_name
+      in
+      [
+        Ast_builder.Default.pstr_module
+          ~loc
+          (Ast_builder.Default.module_binding
+             ~loc
+             ~name:
+               (Ast_builder.Default.Located.mk ~loc (Some helper_module_name))
+             ~expr:
+               (Ast_builder.Default.pmod_structure
+                  ~loc
+                  [
+                    [%stri
+                      type t =
+                        [%t Ast_builder.Default.ptyp_constr ~loc type_lid []]];
+                    [%stri
+                      let type_id =
+                        [%e
+                          Ast_builder.Default.evar ~loc (type_name ^ "_custom")]
+                          .Spoc_core.Vector.type_id];
+                    [%stri let to_value = [%e to_value_fn]];
+                    [%stri let from_value = [%e from_value_fn]];
+                    (* A variant is not a named-field aggregate; the HELPERS
+                       [from_values]/[to_values]/[get_field] members exist only
+                       to satisfy the signature and are defined in terms of the
+                       single-value converters. *)
+                    [%stri let to_values v = [|to_value v|]];
+                    [%stri let from_values arr = from_value arr.(0)];
+                    [%stri
+                      let get_field _ _ =
+                        failwith
+                          [%e
+                            Ast_builder.Default.estring
+                              ~loc
+                              (type_name ^ " is a variant: no named fields")]];
+                  ]));
+        [%stri
+          let () =
+            let module H =
+              [%m
+              Ast_builder.Default.pmod_ident ~loc helper_module_lid]
+            in
+            Sarek.Sarek_type_helpers.register
+              [%e full_name_expr]
+              (Sarek.Sarek_type_helpers.AnyHelpers (module H))];
+      ]
   | _ ->
-      (* Only generate helpers for records *)
+      (* Abstract / open / extensible types have no value-model helper. *)
       []
 
 (** Generate runtime registration code for a type. The PPX emits calls to

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -119,11 +119,18 @@ let value_to_ocaml ~loc ~(what : string) (ct : core_type)
         | Sarek.Sarek_value.VFloat64 f -> f
         | Sarek.Sarek_value.VFloat32 f -> f
         | _ -> failwith [%e estr (what ^ " expected float64, got wrong type")]]
-  | Ptyp_constr ({txt = Lident ("int32" | "int"); _}, _) ->
+  | Ptyp_constr ({txt = Lident "int32"; _}, _) ->
       [%expr
         match [%e value_expr] with
         | Sarek.Sarek_value.VInt32 n -> n
         | _ -> failwith [%e estr (what ^ " expected int32, got wrong type")]]
+  | Ptyp_constr ({txt = Lident "int"; _}, _) ->
+      (* Bare [int] fields are 4-byte on the host ABI and carried through the
+         VInt32 value model; convert the int32 payload back to a native int. *)
+      [%expr
+        match [%e value_expr] with
+        | Sarek.Sarek_value.VInt32 n -> Int32.to_int n
+        | _ -> failwith [%e estr (what ^ " expected int, got wrong type")]]
   | Ptyp_constr ({txt = Lident "int64"; _}, _) ->
       [%expr
         match [%e value_expr] with
@@ -159,8 +166,11 @@ let value_from_ocaml ~loc ~(what : string) (ct : core_type)
       [%expr Sarek.Sarek_value.VFloat32 [%e ocaml_expr]]
   | Ptyp_constr ({txt = Lident "float64"; _}, _) ->
       [%expr Sarek.Sarek_value.VFloat64 [%e ocaml_expr]]
-  | Ptyp_constr ({txt = Lident ("int32" | "int"); _}, _) ->
+  | Ptyp_constr ({txt = Lident "int32"; _}, _) ->
       [%expr Sarek.Sarek_value.VInt32 [%e ocaml_expr]]
+  | Ptyp_constr ({txt = Lident "int"; _}, _) ->
+      (* Bare [int] field: wrap the native int as VInt32 (host ABI is 4-byte). *)
+      [%expr Sarek.Sarek_value.VInt32 (Int32.of_int [%e ocaml_expr])]
   | Ptyp_constr ({txt = Lident "int64"; _}, _) ->
       [%expr Sarek.Sarek_value.VInt64 [%e ocaml_expr]]
   | Ptyp_constr ({txt = Lident "bool"; _}, _) ->

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -999,3 +999,33 @@
  (alias runtest)
  (action
   (run %{dep:test_local_tuple.exe})))
+
+; deriver-variant-fields: a [@@sarek.type] record with a VARIANT-typed field as
+; a vector element, round-tripping host->device->host on the value-based
+; backends (Interpreter + Native). Fixes the L14-S2 PR #251
+; `Field 'kind' expected record` boundary bug; also covers a standalone variant
+; vector round-trip. Device backends stay out of scope (nested-variant byte
+; layout is Rocq-coupled); the erasable case already runs there via L14-S2.
+
+(executable
+ (name test_ktype_record_variant_field)
+ (modules test_ktype_record_variant_field)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  test_helpers
+  sarek_native
+  sarek_interpreter
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_ktype_record_variant_field.exe})))

--- a/sarek/tests/e2e/test_ktype_record_variant_field.ml
+++ b/sarek/tests/e2e/test_ktype_record_variant_field.ml
@@ -1,0 +1,192 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E: a [@@sarek.type] record with a VARIANT-typed field, used as a VECTOR
+ * ELEMENT (host-created, kernel-visible), round-tripping host->device->host.
+ *
+ * This is the RECORD-CONTAINS-VARIANT marshalling gap found during L14-S2
+ * (PR #251): the deriver's generated interpreter helpers treated any
+ * non-primitive record field as a [VRecord], so a variant field failed with
+ * `Field 'kind' expected record` at the host/interpreter boundary. The fix
+ * generates a value-model helper for the variant type too, and the record
+ * helper delegates the field to it, so the field decodes/encodes as a
+ * [VVariant].
+ *
+ * Scope (see briefs/deriver-variant-fields-impl.md): the interpreter is
+ * value-based (no byte layout), so the NON-erasable / runtime-selected case
+ * works here on Interpreter + Native. Device backends (CUDA/OpenCL/Vulkan)
+ * would need a nested-variant byte layout in Sarek_ir_layout, which is
+ * Rocq-coupled and out of scope; the erasable case already runs there via the
+ * L14-S2 [_erec_] synthesis. This test therefore runs on Interpreter + Native
+ * and verifies against a pure-OCaml reference.
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module Device = Spoc_core.Device
+module Transfer = Spoc_core.Transfer
+
+[@@@warning "-32"]
+
+let () = Test_helpers.Benchmarks.init ()
+
+type float32 = float
+
+(* A variant with a nullary constructor, a second nullary, and a float32
+   payload constructor - enough to exercise a tag switch and payload
+   marshalling in both directions. *)
+type color = Red | Green | Shade of float32 [@@sarek.type]
+
+(* The record under test: a variant-typed field [kind] beside a scalar. *)
+type cell = {kind : color; scale : float32} [@@sarek.type]
+
+(* Kernel over a [cell vector]: read the element (host->interp decode of a
+   VRecord whose [kind] field is a VVariant), tag-switch on the variant field,
+   and write a cell back whose [kind] is the (runtime-selected) passed-through
+   variant field (interp->host encode). *)
+let cell_kirc =
+  snd
+    [%kernel
+      fun (src : cell vector) (out : cell vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          let c = src.(tid) in
+          let s =
+            match c.kind with Red -> 10.0 | Green -> 20.0 | Shade f -> f
+          in
+          out.(tid) <- {kind = c.kind; scale = c.scale +. s}
+        end]
+
+(* Standalone variant vector (D1): read a [color vector] element (VVariant
+   decode) and write a transformed [color] back (VVariant encode). *)
+let color_kirc =
+  snd
+    [%kernel
+      fun (src : color vector) (out : color vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then
+          out.(tid) <-
+            (match src.(tid) with
+            | Red -> Green
+            | Green -> Red
+            | Shade f -> Shade (f +. 1.0))]
+
+let n = 64
+
+let mk_color i =
+  match i mod 3 with 0 -> Red | 1 -> Green | _ -> Shade (float_of_int i)
+
+(* Pure-OCaml references. *)
+let ref_cell {kind; scale} =
+  let s = match kind with Red -> 10.0 | Green -> 20.0 | Shade f -> f in
+  {kind; scale = scale +. s}
+
+let ref_color = function
+  | Red -> Green
+  | Green -> Red
+  | Shade f -> Shade (f +. 1.0)
+
+let color_eq a b =
+  match (a, b) with
+  | Red, Red | Green, Green -> true
+  | Shade x, Shade y -> abs_float (x -. y) < 1e-3
+  | _ -> false
+
+let ir_of kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "Kernel has no IR"
+
+let launch dev kirc args =
+  let threads = min 64 n in
+  let grid_x = (n + threads - 1) / threads in
+  Sarek.Execute.run_vectors
+    ~device:dev
+    ~block:(Sarek.Execute.dims1d threads)
+    ~grid:(Sarek.Execute.dims1d grid_x)
+    ~ir:(ir_of kirc)
+    ~args
+    () ;
+  Transfer.flush dev
+
+let run_cell dev =
+  let src = Vector.create_custom cell_custom n in
+  let out = Vector.create_custom cell_custom n in
+  for i = 0 to n - 1 do
+    Vector.set src i {kind = mk_color i; scale = float_of_int i}
+  done ;
+  launch
+    dev
+    cell_kirc
+    [
+      Sarek.Execute.Vec src;
+      Sarek.Execute.Vec out;
+      Sarek.Execute.Int32 (Int32.of_int n);
+    ] ;
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    let expected = ref_cell (Vector.get src i) in
+    let got = Vector.get out i in
+    if
+      (not (color_eq expected.kind got.kind))
+      || abs_float (expected.scale -. got.scale) > 1e-3
+    then ok := false
+  done ;
+  !ok
+
+let run_color dev =
+  let src = Vector.create_custom color_custom n in
+  let out = Vector.create_custom color_custom n in
+  for i = 0 to n - 1 do
+    Vector.set src i (mk_color i)
+  done ;
+  launch
+    dev
+    color_kirc
+    [
+      Sarek.Execute.Vec src;
+      Sarek.Execute.Vec out;
+      Sarek.Execute.Int32 (Int32.of_int n);
+    ] ;
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    if not (color_eq (ref_color (Vector.get src i)) (Vector.get out i)) then
+      ok := false
+  done ;
+  !ok
+
+let () =
+  let devs = Device.init ~frameworks:["Interpreter"; "Native"] () in
+  if Array.length devs = 0 then begin
+    print_endline "No Interpreter/Native device found" ;
+    exit 1
+  end ;
+  let any_failure = ref false in
+  Array.iter
+    (fun dev ->
+      Printf.printf "runtime [%s] %s:\n%!" dev.Device.framework dev.Device.name ;
+      let check label f =
+        try
+          if f dev then Printf.printf "  %s: PASSED\n%!" label
+          else begin
+            any_failure := true ;
+            Printf.printf "  %s: FAILED\n%!" label
+          end
+        with
+        | Sarek.Interp_error.Interpreter_error err ->
+            any_failure := true ;
+            Printf.printf
+              "  %s: ERROR (%s)\n%!"
+              label
+              (Sarek.Interp_error.error_to_string err)
+        | e ->
+            any_failure := true ;
+            Printf.printf "  %s: ERROR (%s)\n%!" label (Printexc.to_string e)
+      in
+      check "record-with-variant-field round-trip" run_cell ;
+      check "standalone variant vector round-trip" run_color)
+    devs ;
+  if !any_failure then exit 1
+  else print_endline "test_ktype_record_variant_field PASSED"

--- a/sarek/tests/e2e/test_ktype_record_variant_field.ml
+++ b/sarek/tests/e2e/test_ktype_record_variant_field.ml
@@ -158,9 +158,18 @@ let run_color dev =
   !ok
 
 let () =
-  let devs = Device.init ~frameworks:["Interpreter"; "Native"] () in
-  if Array.length devs = 0 then begin
-    print_endline "No Interpreter/Native device found" ;
+  let required = ["Interpreter"; "Native"] in
+  let devs = Device.init ~frameworks:required () in
+  (* Both backends are the stated contract: a Native or Interpreter regression
+     must not be silently untested because one failed to initialize. *)
+  let available =
+    Array.to_list devs |> List.map (fun d -> d.Device.framework)
+  in
+  let missing = List.filter (fun f -> not (List.mem f available)) required in
+  if missing <> [] then begin
+    Printf.eprintf
+      "Missing required backends: %s\n%!"
+      (String.concat ", " missing) ;
     exit 1
   end ;
   let any_failure = ref false in

--- a/sarek/tests/unit/ktype_variant_field/dune
+++ b/sarek/tests/unit/ktype_variant_field/dune
@@ -1,0 +1,13 @@
+; deriver-variant-fields: device-free guard for the [@@sarek.type] interpreter
+; value-model helpers with a variant-typed record field (round-trips through
+; the Sarek_type_helpers registry). Isolated in its own directory so the
+; sarek_ppx preprocessing does not collide with the metaquot test group in the
+; parent unit/ directory.
+
+(test
+ (name test_ktype_variant_field)
+ (libraries sarek spoc_core alcotest)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))

--- a/sarek/tests/unit/ktype_variant_field/test_ktype_variant_field.ml
+++ b/sarek/tests/unit/ktype_variant_field/test_ktype_variant_field.ml
@@ -1,0 +1,125 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Device-free unit guard for the [@@sarek.type] interpreter value-model
+    helpers with a VARIANT-typed record field (deriver-variant-fields).
+
+    Exercises the generated helpers through the public
+    {!Sarek.Sarek_type_helpers} registry: a variant type round-trips
+    OCaml<->VVariant, and a record with a variant field round-trips
+    OCaml<->VRecord (whose field is a VVariant). Regression guard for the L14-S2
+    PR #251 `Field 'kind' expected record` boundary bug, independent of any
+    backend. *)
+
+module V = Sarek.Sarek_value
+module H = Sarek.Sarek_type_helpers
+
+type float32 = float
+
+type color = Red | Green | Shade of float32 [@@sarek.type]
+
+type cell = {kind : color; scale : float32} [@@sarek.type]
+
+let color_helpers () =
+  match H.lookup_typed color_custom.Spoc_core.Vector.type_id with
+  | Some (module C : H.HELPERS with type t = color) ->
+      (module C : H.HELPERS with type t = color)
+  | None -> Alcotest.fail "no helper registered for color"
+
+let cell_helpers () =
+  match H.lookup_typed cell_custom.Spoc_core.Vector.type_id with
+  | Some (module C : H.HELPERS with type t = cell) ->
+      (module C : H.HELPERS with type t = cell)
+  | None -> Alcotest.fail "no helper registered for cell"
+
+let color_eq a b =
+  match (a, b) with
+  | Red, Red | Green, Green -> true
+  | Shade x, Shade y -> abs_float (x -. y) < 1e-6
+  | _ -> false
+
+(* The variant helper's [to_value] must tag with the interpreter convention
+   [Hashtbl.hash ctor mod 256] so an in-kernel match recognises a host-set
+   element. *)
+let test_color_to_value () =
+  let (module C) = color_helpers () in
+  (match C.to_value Red with
+  | V.VVariant (_, tag, []) ->
+      Alcotest.(check int) "Red tag" (Hashtbl.hash "Red" mod 256) tag
+  | _ -> Alcotest.fail "Red should be a nullary VVariant") ;
+  match C.to_value (Shade 2.5) with
+  | V.VVariant (_, tag, [V.VFloat32 f]) ->
+      Alcotest.(check int) "Shade tag" (Hashtbl.hash "Shade" mod 256) tag ;
+      Alcotest.(check (float 1e-6)) "Shade payload" 2.5 f
+  | _ -> Alcotest.fail "Shade should be a unary VVariant carrying its float"
+
+let test_color_roundtrip () =
+  let (module C) = color_helpers () in
+  List.iter
+    (fun c ->
+      let back = C.from_value (C.to_value c) in
+      Alcotest.(check bool)
+        ("color round-trip "
+        ^ match c with Red -> "Red" | Green -> "Green" | Shade _ -> "Shade")
+        true
+        (color_eq c back))
+    [Red; Green; Shade 3.5; Shade (-1.0)]
+
+let test_cell_roundtrip () =
+  let (module C) = cell_helpers () in
+  List.iter
+    (fun cell ->
+      (* to_value produces a VRecord whose [kind] field is a VVariant. *)
+      (match C.to_value cell with
+      | V.VRecord (_, [|V.VVariant _; V.VFloat32 _|]) -> ()
+      | _ ->
+          Alcotest.fail
+            "cell to_value should be a VRecord with a VVariant kind field") ;
+      let back = C.from_value (C.to_value cell) in
+      Alcotest.(check bool)
+        "cell.kind round-trip"
+        true
+        (color_eq cell.kind back.kind) ;
+      Alcotest.(check (float 1e-6))
+        "cell.scale round-trip"
+        cell.scale
+        back.scale)
+    [
+      {kind = Red; scale = 1.0};
+      {kind = Green; scale = 2.0};
+      {kind = Shade 4.5; scale = 3.0};
+    ]
+
+(* A record field holding a VVariant must be accepted by the record helper's
+   from_value (the exact site of the former "expected record" failure). *)
+let test_from_value_accepts_variant_field () =
+  let (module C) = cell_helpers () in
+  let vrec =
+    V.VRecord
+      ( "Test_ktype_variant_field.cell",
+        [|
+          V.VVariant ("color", Hashtbl.hash "Shade" mod 256, [V.VFloat32 7.0]);
+          V.VFloat32 9.0;
+        |] )
+  in
+  let cell = C.from_value vrec in
+  Alcotest.(check bool) "kind" true (color_eq cell.kind (Shade 7.0)) ;
+  Alcotest.(check (float 1e-6)) "scale" 9.0 cell.scale
+
+let () =
+  Alcotest.run
+    "ktype_variant_field"
+    [
+      ( "variant-field helpers",
+        [
+          Alcotest.test_case "color to_value tags" `Quick test_color_to_value;
+          Alcotest.test_case "color round-trip" `Quick test_color_roundtrip;
+          Alcotest.test_case "cell round-trip" `Quick test_cell_roundtrip;
+          Alcotest.test_case
+            "record from_value accepts variant field"
+            `Quick
+            test_from_value_accepts_variant_field;
+        ] );
+    ]


### PR DESCRIPTION
`[@@sarek.type]` records with variant fields failed at the Interpreter marshalling boundary (`Field 'kind' expected record` — found by the L14-S2 probes, #251).

Research verdict that scoped this: `Sarek_ir_layout.record_layout` REJECTS variant fields (`Nested_variant`) and the authority is Rocq-coupled (`PtxLayout.v` has no variant field constructor) — byte-layout support is out of scope by design. The failure is value-model-only, so:

- The deriver now emits VVariant to_value/from_value helpers for variant types (runtime tag expr `Hashtbl.hash ctor mod 256`, byte-identical to the interpreter's existing convention — verified empirically both sides).
- Record `from_values` accepts `VRecord|VVariant` keyed on the DECLARED field type (a variant where a record is declared still errors loudly).
- Two collateral interpreter bugs fixed: expression-position `EMatch` didn't bind constructor payload vars (SMatch did); standalone VVariant vector writeback was missing in both interp copies.
- Scope: full round-trip on Interpreter (seq+par) + Native incl. the runtime-selected non-erasable case; device backends unchanged (erasable via L14-S2 `_erec_*`, non-erasable keeps a clean Backend_error — never malformed code).
- Reviewer re-executed the suites (T3): 586 PASS, unit 4/4, e2e PASSED, L14-S2 controls green, ptxas 59/59.

Pipeline (full): research → spec → plan → implement → review GO → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for typed variants inside records and as value-based vector elements.
  * Enhanced interpreter/native value conversions for `@@sarek.type` variants, including full variant helper generation.
  * Improved typed variant writeback so variant elements are correctly converted and stored.

* **Bug Fixes**
  * Fixed variant payload handling in pattern matching so constructor payload variables are properly bound.
  * Improved error reporting for missing custom conversion helpers in custom conversion paths.

* **Tests**
  * Added unit tests and a new end-to-end test covering typed variant fields in vectors and record round-trips across backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->