### PR TITLE
fix(plugins): let located codegen errors reach the user

### DIFF
--- a/sarek-cuda/Cuda_c_plugin.ml
+++ b/sarek-cuda/Cuda_c_plugin.ml
@@ -27,9 +27,14 @@ module Backend : Framework_sig.BACKEND = struct
 
   let execution_model = Framework_sig.JIT
 
+  (* Codegen never legitimately declines a kernel by returning [None]: it either
+     produces source or raises a located
+     [Backend_error (Codegen {backend = "CUDA/C"; _})] naming the offending IR
+     node. That error is allowed to PROPAGATE so callers surface the name rather
+     than the opaque "generate_source returned None" — catching it here and
+     returning [None] hid it identically to the Vulkan swallow (PR #259). *)
   let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
-    try Some (Sarek_ir_cuda.generate_with_types ~types:ir.kern_types ir)
-    with Sarek_backend_error.Backend_error.Backend_error _ -> None
+    Some (Sarek_ir_cuda.generate_with_types ~types:ir.kern_types ir)
 
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =
     Cuda_error.raise_error

--- a/sarek-cuda/Cuda_ptx_plugin.ml
+++ b/sarek-cuda/Cuda_ptx_plugin.ml
@@ -12,8 +12,8 @@
  *
  * Records, variants and tuples are supported (SROA registers + field-wise
  * global access; see spoc/ir/Sarek_ir_layout.ml). Remaining unsupported IR
- * nodes (e.g. bounded recursion, f64 transcendentals) cause generate_source
- * to return None.
+ * nodes (e.g. bounded recursion, f64 transcendentals) raise a located
+ * [Ptx_codegen_error] from generate_source (propagated, not swallowed).
  ******************************************************************************)
 
 open Spoc_framework
@@ -30,10 +30,12 @@ module Backend : Framework_sig.BACKEND = struct
 
   let execution_model = Framework_sig.JIT
 
+  (* A located [Ptx_codegen_error] (its string message carries the unsupported
+     IR node) is allowed to PROPAGATE so callers surface it, rather than being
+     converted to [None] and re-raised by Execute as the opaque
+     "generate_source returned None" with the detail lost (PR #259). *)
   let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
-    match Sarek_ir_ptx.generate_with_types ~types:ir.kern_types ir with
-    | s -> Some s
-    | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> None
+    Some (Sarek_ir_ptx.generate_with_types ~types:ir.kern_types ir)
 
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =
     Cuda_error.raise_error

--- a/sarek-metal/Metal_plugin.ml
+++ b/sarek-metal/Metal_plugin.ml
@@ -172,13 +172,18 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.JIT
 
   (** Generate Metal Shading Language source from Sarek IR.
-      @param block Ignored - Metal specifies work-group size at launch *)
+      @param block Ignored - Metal specifies work-group size at launch
+
+      A located [Backend_error (Codegen {backend = "Metal"; _})] from codegen is
+      deliberately allowed to PROPAGATE so callers surface the offending IR node
+      (e.g. an intrinsic name) rather than the opaque "generate_source returned
+      None" (PR #259 review); a blanket [try ... with _ -> None] previously
+      swallowed it. Codegen never legitimately declines a kernel by returning
+      [None]. *)
   let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
-    try
-      let source = Sarek_ir_metal.generate_with_types ~types:ir.kern_types ir in
-      Spoc_core.Log.debug Kernel ("Metal source:\n" ^ source) ;
-      Some source
-    with _ -> None
+    let source = Sarek_ir_metal.generate_with_types ~types:ir.kern_types ir in
+    Spoc_core.Log.debug Kernel ("Metal source:\n" ^ source) ;
+    Some source
 
   (** Execute directly - not supported for JIT backend *)
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =

--- a/sarek-opencl/Opencl_plugin.ml
+++ b/sarek-opencl/Opencl_plugin.ml
@@ -179,21 +179,24 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.JIT
 
   (** Generate OpenCL source from Sarek IR.
-      @param block Ignored - OpenCL specifies work-group size at launch *)
+      @param block Ignored - OpenCL specifies work-group size at launch
+
+      A located [Backend_error (Codegen {backend = "OpenCL"; _})] from codegen
+      is deliberately allowed to PROPAGATE so callers surface the offending IR
+      node (e.g. an intrinsic name) rather than the opaque "generate_source
+      returned None" (PR #259 review); a blanket [try ... with _ -> None]
+      previously swallowed it. Codegen never legitimately declines a kernel by
+      returning [None]. *)
   let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
-    try
-      let source =
-        Sarek_ir_opencl.generate_with_types ~types:ir.kern_types ir
-      in
-      (* Add FP64 pragma if kernel uses double precision *)
-      let source =
-        if Sarek_ir_analysis.kernel_uses_float64 ir then
-          "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\n" ^ source
-        else source
-      in
-      Spoc_core.Log.debug Kernel ("OpenCL source:\n" ^ source) ;
-      Some source
-    with _ -> None
+    let source = Sarek_ir_opencl.generate_with_types ~types:ir.kern_types ir in
+    (* Add FP64 pragma if kernel uses double precision *)
+    let source =
+      if Sarek_ir_analysis.kernel_uses_float64 ir then
+        "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\n" ^ source
+      else source
+    in
+    Spoc_core.Log.debug Kernel ("OpenCL source:\n" ^ source) ;
+    Some source
 
   (** Execute directly - not supported for JIT backend *)
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =

--- a/sarek-vulkan/Vulkan_plugin.ml
+++ b/sarek-vulkan/Vulkan_plugin.ml
@@ -177,21 +177,28 @@ module Backend : Framework_sig.BACKEND = struct
 
   (** Generate GLSL source from Sarek IR.
       @param block Workgroup dimensions - required for correct GLSL local_size
-  *)
+
+      Codegen never legitimately declines a kernel by returning [None]:
+      {!Sarek_ir_glsl.generate_with_types} either produces source or raises a
+      located [Backend_error (Codegen {backend = "Vulkan"; _})] naming the
+      offending IR node (e.g. an intrinsic with no GLSL lowering). That
+      exception is deliberately allowed to PROPAGATE so callers surface the
+      intrinsic name — a blanket [try ... with _ -> None] previously swallowed
+      it, and Execute then raised the opaque "generate_source returned None"
+      with the name lost (PR #259 review). This function therefore always
+      returns [Some _] on success. *)
   let generate_source ?block (ir : Sarek_ir_types.kernel) : string option =
     let block_tuple =
       match block with
       | Some b -> Some (b.Framework_sig.x, b.Framework_sig.y, b.Framework_sig.z)
       | None -> None
     in
-    try
-      Some
-        (Sarek_ir_glsl.generate_with_types
-           ?block:block_tuple
-           ~log:(fun s -> Spoc_core.Log.debugf Spoc_core.Log.Device "%s" s)
-           ~types:ir.kern_types
-           ir)
-    with _ -> None
+    Some
+      (Sarek_ir_glsl.generate_with_types
+         ?block:block_tuple
+         ~log:(fun s -> Spoc_core.Log.debugf Spoc_core.Log.Device "%s" s)
+         ~types:ir.kern_types
+         ir)
 
   (** Execute directly - not supported for JIT backend *)
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =

--- a/sarek-vulkan/test/dune
+++ b/sarek-vulkan/test/dune
@@ -19,3 +19,7 @@
 (test
  (name test_vulkan_buffer_index_validation)
  (libraries sarek_vulkan spoc_framework alcotest str))
+
+(test
+ (name test_vulkan_error_observability)
+ (libraries sarek_vulkan sarek_ir sarek_backend_error alcotest))

--- a/sarek-vulkan/test/test_vulkan_error_observability.ml
+++ b/sarek-vulkan/test/test_vulkan_error_observability.ml
@@ -1,0 +1,173 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression test for the Vulkan error-observability finding (PR #259 review).
+ *
+ * Before the fix, [Vulkan_plugin.Backend.generate_source] wrapped codegen in
+ * [try Some (...) with _ -> None], swallowing the located
+ * [Backend_error (Codegen {backend = "Vulkan"; Unknown_intrinsic {name}})]
+ * into a bare [None]. Execute.ml then raised the generic
+ * "generate_source returned None (kernel may use unsupported IR nodes)" and the
+ * offending intrinsic NAME was lost.
+ *
+ * Two guarantees are pinned here:
+ *
+ * 1. [Backend.generate_source] on a kernel that uses an intrinsic with no GLSL
+ *    lowering must PROPAGATE the located [Backend_error], not return [None].
+ *    The error's rendered message must name the intrinsic.
+ *
+ * 2. [Printexc.to_string] on a raw [Backend_error] must render the full
+ *    human-readable message (via the registered printer), not the opaque
+ *    [Backend_error(_)] constructor — so any generic stringify path
+ *    (e.g. Sarek_transpile's [Internal_error (Printexc.to_string exn)]) keeps
+ *    the intrinsic name.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend = Sarek_vulkan.Vulkan_plugin.Backend
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* Minimal kernel: c.[0] <- <intr>(a.[0], a.[0]) with a float32 in/out pair. *)
+let kernel_calling ~name ~arity =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let arg = EArrayRead ("a", EConst (CInt32 0l)) in
+  let args = List.init arity (fun _ -> arg) in
+  {
+    kern_name = "observability_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body =
+      SAssign (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic ([], name, args));
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(* Dependency-light substring check (mirror of the codegen_golden helper). *)
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+(* --- 1. generate_source propagates the located error (never swallows) --- *)
+
+let test_generate_source_propagates () =
+  let ir = kernel_calling ~name:"warp_shuffle" ~arity:2 in
+  match Backend.generate_source ir with
+  | Some (_ : string) ->
+      Alcotest.fail
+        "expected Backend_error for unsupported intrinsic, but generate_source \
+         returned Some _"
+  | None ->
+      Alcotest.fail
+        "generate_source returned None — the located Backend_error was \
+         swallowed (observability regression)"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Codegen
+           {backend; error = Backend_error.Unknown_intrinsic {name}}) ->
+      Alcotest.(check string) "backend is Vulkan" "Vulkan" backend ;
+      Alcotest.(check string) "error names the intrinsic" "warp_shuffle" name
+
+(* --- 2. the rendered message (to_string) names the intrinsic --- *)
+
+let test_message_contains_name () =
+  let ir = kernel_calling ~name:"warp_shuffle" ~arity:2 in
+  match Backend.generate_source ir with
+  | _ -> Alcotest.fail "expected Backend_error, generation did not raise"
+  | exception Backend_error.Backend_error err ->
+      let msg = Backend_error.to_string err in
+      Alcotest.(check bool)
+        (Printf.sprintf "to_string message %S contains 'warp_shuffle'" msg)
+        true
+        (string_contains ~haystack:msg ~needle:"warp_shuffle")
+
+(* --- 3. Printexc printer renders the message, not the opaque ctor --- *)
+
+let test_printexc_printer () =
+  let err =
+    Backend_error.Codegen
+      {
+        backend = "Vulkan";
+        error = Backend_error.Unknown_intrinsic {name = "warp_shuffle"};
+      }
+  in
+  let rendered = Printexc.to_string (Backend_error.Backend_error err) in
+  Alcotest.(check bool)
+    (Printf.sprintf "Printexc.to_string %S names the intrinsic" rendered)
+    true
+    (string_contains ~haystack:rendered ~needle:"warp_shuffle") ;
+  Alcotest.(check bool)
+    "Printexc.to_string is not the opaque constructor"
+    false
+    (string_contains ~haystack:rendered ~needle:"Backend_error(_)")
+
+(* --- 4. a well-formed kernel still compiles (no behavior change) --- *)
+
+let test_supported_kernel_ok () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let ir =
+    {
+      kern_name = "identity_probe";
+      kern_params =
+        [
+          DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+          DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_locals = [];
+      kern_body =
+        SAssign
+          ( LArrayElem ("c", EConst (CInt32 0l)),
+            EArrayRead ("a", EConst (CInt32 0l)) );
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  match Backend.generate_source ir with
+  | Some (_ : string) -> ()
+  | None -> Alcotest.fail "supported kernel unexpectedly returned None"
+
+let () =
+  let open Alcotest in
+  run
+    "Vulkan error observability"
+    [
+      ( "generate_source",
+        [
+          test_case
+            "propagates located error (no swallow)"
+            `Quick
+            test_generate_source_propagates;
+          test_case "message names intrinsic" `Quick test_message_contains_name;
+          test_case
+            "supported kernel still compiles"
+            `Quick
+            test_supported_kernel_ok;
+        ] );
+      ( "printexc-printer",
+        [
+          test_case
+            "renders message not opaque ctor"
+            `Quick
+            test_printexc_printer;
+        ] );
+    ]

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -453,9 +453,14 @@ and gen_glsl_polyfill buf ~is_f64 name args =
       gen_expr buf x ;
       Buffer.add_string buf "))"
   | _ ->
+      (* [gen_glsl_polyfill] is only ever entered for a KNOWN polyfill name
+         (guarded by the [List.mem name [...]] test in {!gen_intrinsic}), so a
+         fall-through here is always an arity mismatch — not an unknown
+         intrinsic. Report it as such: every polyfill above is unary except
+         [hypot], which is binary. *)
+      let expected = if name = "hypot" then 2 else 1 in
       Codegen_error.raise_error
-        (Codegen_error.unknown_intrinsic
-           (Printf.sprintf "%s (wrong arity for GLSL polyfill)" name))
+        (Codegen_error.invalid_arg_count name expected (List.length args))
 
 and gen_intrinsic buf path name args =
   let full_name =

--- a/spoc/framework_error/Backend_error.ml
+++ b/spoc/framework_error/Backend_error.ml
@@ -267,6 +267,17 @@ let to_string = function
       | Feature_not_supported {feature; backend = _} ->
           Printf.sprintf "%s Feature not supported: %s" prefix feature)
 
+(** Render [Backend_error] through {!to_string} anywhere an exception is
+    stringified via [Printexc.to_string] — notably generic funnels that catch an
+    arbitrary [exn] and re-wrap it (e.g. Sarek_transpile's
+    [Internal_error (Printexc.to_string exn)]). Without this printer such paths
+    emit the opaque [Backend_error(_)] constructor and lose the located message
+    (backend + intrinsic name). *)
+let () =
+  Printexc.register_printer (function
+    | Backend_error err -> Some (to_string err)
+    | _ -> None)
+
 (** Raise backend error as exception *)
 let raise_error err = raise (Backend_error err)
 


### PR DESCRIPTION
Completes #259's user-facing benefit: `Vulkan_plugin.generate_source`'s `try Some(...) with _ -> None` swallowed the located `Unknown_intrinsic` error — users got the generic "generate_source returned None" with the intrinsic name lost.

- Uniform audit of all 5 plugins: Vulkan/OpenCL/Metal shared the swallow-everything shape (narrowed: errors propagate; None never returned); CUDA-C/PTX converted their located errors to None (same defect, milder — extended for uniformity).
- None-contract verified exhaustively before narrowing: no call site uses None for backend-fallback control flow (Execute raises, Kirc_kernel raises, best_backend never calls generate_source).
- `Printexc.register_printer` for Backend_error (module-init, always linked) so generic stringify paths render the real message.
- GLSL polyfill arity errors now use `invalid_arg_count` (hypot=2, others=1) instead of a string-encoded unknown_intrinsic.
- Deterministic device-free test at the generate_source boundary: red 3/4 on main (swallow + opaque printer) → green 4/4.

Follow-up noted: Metal's polyfill arity has the identical LOW (out of scope here).

Pipeline (fast): implement → review GO (reviewer executed the test) → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)