### PR TITLE
test(e2e): exercise f64 custom-record vectors on OpenCL

### DIFF
--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -92,7 +92,8 @@
   test_bounded_recursion
   test_inline_pragma
   test_nested_types
-  test_ktype_mixed_align)
+  test_ktype_mixed_align
+  test_ktype_record_f64_arith)
  (modules
   test_vector_add
   test_module_const
@@ -130,9 +131,11 @@
   test_module_poly
   test_bounded_recursion
   test_inline_pragma
-  test_nested_types)
+  test_nested_types
+  test_ktype_record_f64_arith)
  (libraries
   sarek
+  spoc.ir
   sarek.stdlib
   sarek.float64
   sarek_geometry
@@ -1029,3 +1032,19 @@
  (alias runtest)
  (action
   (run %{dep:test_ktype_record_variant_field.exe})))
+
+; ktype-record-f64-arith: a [@@sarek.type] record with float64 fields used as a
+; vector, with float64 ARITHMETIC on the fields. CPU-safe and self-verifying
+; (exits nonzero on a verified-device mismatch), so it gates in the default
+; runtest alias. RUSTICL_FEATURES=fp64 is set so the rusticl OpenCL ICD
+; advertises cl_khr_fp64 and the OpenCL leg is actually exercised (rather than
+; skipped); devices that still lack fp64 are skipped, never failed. Harmless on
+; non-rusticl ICDs, which ignore the variable.
+
+(rule
+ (alias runtest)
+ (action
+  (setenv
+   RUSTICL_FEATURES
+   fp64
+   (run %{dep:test_ktype_record_f64_arith.exe}))))

--- a/sarek/tests/e2e/test_ktype_record_f64_arith.ml
+++ b/sarek/tests/e2e/test_ktype_record_f64_arith.ml
@@ -1,0 +1,165 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test: a custom [@@sarek.type] record with float64 fields, used as a
+ * VECTOR, with real float64 ARITHMETIC on the fields inside the kernel.
+ *
+ * This closes the coverage gap left open by test_ktype_mixed_align, which only
+ * COPIES the float64 field verbatim ("Float64 arithmetic is out of scope for
+ * the ABI test") and by test_soa_emitter_equiv, whose f64 record leg runs on
+ * PTX only. The custom-vector float64 path was never exercised on OpenCL with
+ * arithmetic before this test.
+ *
+ * Diagnosis (2026-07-24, RX 7900 XTX + Ryzen 7950X, rusticl ICD): the OpenCL
+ * source generator DOES emit `#pragma OPENCL EXTENSION cl_khr_fp64 : enable`
+ * for records whose fields are float64 (Sarek_ir_analysis.kernel_uses_float64
+ * recurses through TRecord fields, and the record is always present in
+ * ir.kern_types). The layout (L8 aligned aggregate ABI) and the kernel-arg
+ * marshalling are also correct: the round-trip below matches the OCaml binary64
+ * reference bit-closely on every fp64-capable device. The historical "OpenCL
+ * errors on f64 custom vectors" symptom is a DEVICE-CAPABILITY gate: the
+ * rusticl ICD only advertises cl_khr_fp64 when RUSTICL_FEATURES=fp64 is set, so
+ * without it the program build legitimately fails with
+ *   "error: use of type 'double' requires cl_khr_fp64 support".
+ * The runtest rule for this test sets RUSTICL_FEATURES=fp64 so the OpenCL leg
+ * is actually exercised here; devices that still do not report fp64 are skipped
+ * (never failed), exactly like test_ktype_mixed_align.
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module Device = Spoc_core.Device
+module Transfer = Spoc_core.Transfer
+
+[@@@warning "-32"]
+
+let () =
+  Sarek_native.Native_plugin.init () ;
+  Sarek_interpreter.Interpreter_plugin.init () ;
+  Sarek_cuda.Cuda_plugin.init () ;
+  Sarek_opencl.Opencl_plugin.init ()
+
+type float64 = float
+
+(* All-float64 record (natural alignment 8, stride 24). *)
+type vec3 = {x : float64; y : float64; z : float64} [@@sarek.type]
+
+(* Float64 arithmetic on every field: multiply, add, subtract, all in double
+   precision. If the pragma were missing the program would not build; if the
+   layout or marshalling were wrong the field values would come back wrong. *)
+let scale_kirc =
+  snd
+    [%kernel
+      fun (src : vec3 vector) (dst : vec3 vector) (n : int32) ->
+        let tid = thread_idx_x in
+        if tid < n then
+          let p = src.(tid) in
+          let next : vec3 =
+            {x = (p.x *. 2.0) +. p.z; y = (p.y -. 0.5) *. p.x; z = p.z +. 1.25}
+          in
+          dst.(tid) <- next]
+
+(* OCaml binary64 reference: identical arithmetic to the kernel body. *)
+let ref_x x _y z = (x *. 2.0) +. z
+
+let ref_y x y _z = (y -. 0.5) *. x
+
+let ref_z _x _y z = z +. 1.25
+
+let is_cpu (dev : Device.t) =
+  dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
+
+let () =
+  print_endline "=== ktype record {f64;f64;f64} float64 arithmetic ===" ;
+  let devs =
+    Device.init ~frameworks:["Interpreter"; "Native"; "CUDA"; "OpenCL"] ()
+  in
+  if Array.length devs = 0 then begin
+    print_endline "No runtime devices found - IR generation test passed" ;
+    exit 0
+  end ;
+  let ir =
+    match scale_kirc.Sarek.Kirc_types.body_ir with
+    | Some ir -> ir
+    | None -> failwith "Kernel has no IR"
+  in
+  (* Guard: the kernel must actually lower to a float64 kernel (the pragma
+     decision keys on exactly this predicate). *)
+  if not (Sarek_ir_analysis.kernel_uses_float64 ir) then begin
+    print_endline
+      "FAILED - kernel_uses_float64 = false (float64 record field not detected)" ;
+    exit 1
+  end ;
+  let any_failure = ref false in
+  Array.iter
+    (fun (dev : Device.t) ->
+      Printf.printf "runtime [%s] %s: %!" dev.Device.framework dev.Device.name ;
+      if (not (is_cpu dev)) && not (Device.allows_fp64 dev) then
+        print_endline "SKIP (no device fp64 support)"
+      else
+        try
+          let n = 64 in
+          let src = Vector.create_custom vec3_custom n in
+          let dst = Vector.create_custom vec3_custom n in
+          for i = 0 to n - 1 do
+            Vector.set
+              src
+              i
+              {
+                x = float_of_int i +. 0.25;
+                y = float_of_int (n - i) -. 0.5;
+                z = (float_of_int i *. 0.5) +. 0.125;
+              } ;
+            Vector.set dst i {x = 0.0; y = 0.0; z = 0.0}
+          done ;
+          let threads = min 64 n in
+          let grid_x = (n + threads - 1) / threads in
+          Sarek.Execute.run_vectors
+            ~device:dev
+            ~block:(Sarek.Execute.dims1d threads)
+            ~grid:(Sarek.Execute.dims1d grid_x)
+            ~ir
+            ~args:
+              [
+                Sarek.Execute.Vec src;
+                Sarek.Execute.Vec dst;
+                Sarek.Execute.Int32 (Int32.of_int n);
+              ]
+            () ;
+          Transfer.flush dev ;
+          let ok = ref true in
+          for i = 0 to n - 1 do
+            let s = Vector.get src i in
+            let d = Vector.get dst i in
+            if
+              abs_float (d.x -. ref_x s.x s.y s.z) > 1e-9
+              || abs_float (d.y -. ref_y s.x s.y s.z) > 1e-9
+              || abs_float (d.z -. ref_z s.x s.y s.z) > 1e-9
+            then begin
+              ok := false ;
+              if i < 5 then
+                Printf.printf
+                  "\n\
+                  \  mismatch @%d: got {%.6f,%.6f,%.6f} expected \
+                   {%.6f,%.6f,%.6f}%!"
+                  i
+                  d.x
+                  d.y
+                  d.z
+                  (ref_x s.x s.y s.z)
+                  (ref_y s.x s.y s.z)
+                  (ref_z s.x s.y s.z)
+            end
+          done ;
+          if !ok then print_endline "PASSED"
+          else begin
+            any_failure := true ;
+            print_endline "FAILED"
+          end
+        with e ->
+          any_failure := true ;
+          Printf.printf "FAIL (%s)\n%!" (Printexc.to_string e))
+    devs ;
+  if !any_failure then exit 1


### PR DESCRIPTION
Diagnosis of the 'f64 custom vectors error on OpenCL' gap (found by #260's e2e): NOT a codegen bug. All three hypothesized causes were probed and hold — the fp64 pragma is emitted and recurses through record fields; the L8 aligned layout round-trips at 1e-9 (no host/device divergence — the Rocq-coupled STOP was not needed); marshalling is correct. Root cause: the rusticl ICD only advertises `cl_khr_fp64` with `RUSTICL_FEATURES=fp64` — a device-capability gate. ZLUDA exposes fp64 unconditionally, hence 'works on CUDA, errors on OpenCL'.

What ships: an e2e (`vec3 = {x;y;z:float64}` record vector with real f64 arithmetic vs OCaml reference — a path never exercised on OpenCL before) wired into runtest under `setenv RUSTICL_FEATURES fp64`; devices without fp64 SKIP cleanly. The opaque-error half of the gap was fixed by #263's printer (verified post-rebase: the OpenCL build log renders through Printexc).

Also flagged (tracked separately): plain f64 while-loop kernels return wrong values on OpenCL/rusticl even with fp64 (3/64) — control-flow issue, unrelated to custom vectors.

Pipeline (fast): implement (diagnosis-first) → review GO → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)