### PR TITLE
fix(glsl,wgsl): inline vector-param helpers + validator gate over shader snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_reserved_prefix_for.cma > "$$out" 2>&1; if grep -q "identifiers beginning with 'sarek_' are reserved" "$$out"; then echo "  PASS: reserved-prefix for-loop variable rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing unregistered record field-type rejection (aligned ABI safety)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_unregistered_field.cma > "$$out" 2>&1; if grep -qE "unknown (size|alignment) for field type" "$$out"; then echo "  PASS: unregistered field type rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing recursive-call vector-swap rejection (tail-recursion + vector)..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tailrec_vec_swap.cma > "$$out" 2>&1; if grep -q "must pass its own vector parameter" "$$out"; then echo "  PASS: recursive vector-swap rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "All negative tests checked (see KNOWN-ISSUE line above for the one non-blocking gap, if any)"
 
 

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -1226,6 +1226,9 @@ let gen_copysign_helper buf (k : kernel) =
 *)
 let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
     =
+  (* Inline vector-parameter helpers (buffers cannot be passed as GLSL function
+     arguments — see Sarek_ir_inline_vec). *)
+  let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"Vulkan" k in
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
   current_smod_name := compute_smod_name k ;
@@ -1317,6 +1320,9 @@ let gen_variant_def buf v =
 *)
 let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
     ~(types : (string * (string * elttype) list) list) (k : kernel) : string =
+  (* Inline vector-parameter helpers (buffers cannot be passed as GLSL function
+     arguments — see Sarek_ir_inline_vec). *)
+  let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"Vulkan" k in
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
   current_smod_name := compute_smod_name k ;

--- a/sarek/codegen/Sarek_ir_inline_vec.ml
+++ b/sarek/codegen/Sarek_ir_inline_vec.ml
@@ -73,6 +73,13 @@ let fresh_temp_name ctx =
   ctx.temp_counter <- ctx.temp_counter + 1 ;
   Printf.sprintf "_sarek_inl_%d" ctx.temp_counter
 
+(** Fresh name for a helper local that must be alpha-renamed to avoid capturing
+    a substituted-in buffer reference. [sarek_]-prefixed (a reserved,
+    collision-proof namespace on every backend). *)
+let fresh_local_name ctx =
+  ctx.temp_counter <- ctx.temp_counter + 1 ;
+  Printf.sprintf "sarek_inl_local_%d" ctx.temp_counter
+
 (** Is [e] a call to a vector-parameter helper? Returns its name + args. *)
 let as_vec_call ctx = function
   | EApp (EVar f, args) when Hashtbl.mem ctx.vec_helpers f.var_name ->
@@ -83,69 +90,127 @@ let as_vec_call ctx = function
 (* Vector-parameter name substitution                                  *)
 (* ------------------------------------------------------------------ *)
 
-(** [subst] maps a helper's vector-parameter name to the call site's buffer
-    name. Applied throughout the spliced body so every buffer access
-    ([EArrayRead], [EArrayLen], [LArrayElem], and any bare [EVar] of the
-    parameter) reads the caller's global buffer directly. *)
+(** [subst] maps a name to its replacement (identity if absent). Two uses:
+    - vector-parameter substitution: maps a helper's vector-parameter name to
+      the call site's buffer name, so every buffer access ([EArrayRead],
+      [EArrayLen], [LArrayElem], and any bare [EVar]) reads the caller's global
+      buffer directly. Here [~rename_binders:false] — the vector parameter has
+      no binder in the body, and a shadowing local of the same name must NOT be
+      touched.
+    - alpha-renaming: maps a helper local that would collide with a
+      substituted-in buffer name to a fresh name. Here [~rename_binders:true] so
+      the binder occurrences ([SLet]/[SLetMut]/[SFor] variables and match
+      pattern bindings) are rewritten too, not only the uses. *)
 let sub subst name =
   match List.assoc_opt name subst with Some n -> n | None -> name
 
-let rec subst_expr subst e =
+let sub_pattern ~rename_binders subst = function
+  | PConstr (cname, bindings) when rename_binders ->
+      PConstr (cname, List.map (sub subst) bindings)
+  | p -> p
+
+let rec subst_expr ~rename_binders subst e =
+  let se = subst_expr ~rename_binders subst in
   match e with
   | EConst _ -> e
   | EVar v -> EVar {v with var_name = sub subst v.var_name}
-  | EBinop (op, a, b) -> EBinop (op, subst_expr subst a, subst_expr subst b)
-  | EUnop (op, a) -> EUnop (op, subst_expr subst a)
-  | EArrayRead (name, idx) -> EArrayRead (sub subst name, subst_expr subst idx)
-  | EArrayReadExpr (base, idx) ->
-      EArrayReadExpr (subst_expr subst base, subst_expr subst idx)
-  | ERecordField (a, f) -> ERecordField (subst_expr subst a, f)
-  | EIntrinsic (path, name, args) ->
-      EIntrinsic (path, name, List.map (subst_expr subst) args)
-  | ECast (ty, a) -> ECast (ty, subst_expr subst a)
-  | ETuple es -> ETuple (List.map (subst_expr subst) es)
-  | EApp (fn, args) ->
-      EApp (subst_expr subst fn, List.map (subst_expr subst) args)
+  | EBinop (op, a, b) -> EBinop (op, se a, se b)
+  | EUnop (op, a) -> EUnop (op, se a)
+  | EArrayRead (name, idx) -> EArrayRead (sub subst name, se idx)
+  | EArrayReadExpr (base, idx) -> EArrayReadExpr (se base, se idx)
+  | ERecordField (a, f) -> ERecordField (se a, f)
+  | EIntrinsic (path, name, args) -> EIntrinsic (path, name, List.map se args)
+  | ECast (ty, a) -> ECast (ty, se a)
+  | ETuple es -> ETuple (List.map se es)
+  | EApp (fn, args) -> EApp (se fn, List.map se args)
   | ERecord (name, fields) ->
-      ERecord (name, List.map (fun (f, x) -> (f, subst_expr subst x)) fields)
-  | EVariant (t, c, args) -> EVariant (t, c, List.map (subst_expr subst) args)
+      ERecord (name, List.map (fun (f, x) -> (f, se x)) fields)
+  | EVariant (t, c, args) -> EVariant (t, c, List.map se args)
   | EArrayLen name -> EArrayLen (sub subst name)
-  | EArrayCreate (ty, sz, ms) -> EArrayCreate (ty, subst_expr subst sz, ms)
-  | EIf (c, t, e2) ->
-      EIf (subst_expr subst c, subst_expr subst t, subst_expr subst e2)
+  | EArrayCreate (ty, sz, ms) -> EArrayCreate (ty, se sz, ms)
+  | EIf (c, t, e2) -> EIf (se c, se t, se e2)
   | EMatch (s, cases) ->
       EMatch
-        ( subst_expr subst s,
-          List.map (fun (p, b) -> (p, subst_expr subst b)) cases )
+        ( se s,
+          List.map
+            (fun (p, b) -> (sub_pattern ~rename_binders subst p, se b))
+            cases )
 
-and subst_lvalue subst = function
+and subst_lvalue ~rename_binders subst lv =
+  let se = subst_expr ~rename_binders subst in
+  match lv with
   | LVar v -> LVar {v with var_name = sub subst v.var_name}
-  | LArrayElem (name, idx) -> LArrayElem (sub subst name, subst_expr subst idx)
-  | LArrayElemExpr (base, idx) ->
-      LArrayElemExpr (subst_expr subst base, subst_expr subst idx)
-  | LRecordField (lv, f) -> LRecordField (subst_lvalue subst lv, f)
+  | LArrayElem (name, idx) -> LArrayElem (sub subst name, se idx)
+  | LArrayElemExpr (base, idx) -> LArrayElemExpr (se base, se idx)
+  | LRecordField (lv, f) ->
+      LRecordField (subst_lvalue ~rename_binders subst lv, f)
 
-let rec subst_stmt subst s =
+(** Rewrite a binder's variable, renaming it only when [~rename_binders]. *)
+let sub_binder ~rename_binders subst (v : var) =
+  if rename_binders then {v with var_name = sub subst v.var_name} else v
+
+let rec subst_stmt ~rename_binders subst s =
+  let se = subst_expr ~rename_binders subst in
+  let ss = subst_stmt ~rename_binders subst in
+  let sb v = sub_binder ~rename_binders subst v in
   match s with
-  | SAssign (lv, e) -> SAssign (subst_lvalue subst lv, subst_expr subst e)
-  | SSeq ss -> SSeq (List.map (subst_stmt subst) ss)
-  | SIf (c, t, e) ->
-      SIf
-        (subst_expr subst c, subst_stmt subst t, Option.map (subst_stmt subst) e)
-  | SWhile (c, b) -> SWhile (subst_expr subst c, subst_stmt subst b)
-  | SFor (v, lo, hi, dir, b) ->
-      SFor (v, subst_expr subst lo, subst_expr subst hi, dir, subst_stmt subst b)
+  | SAssign (lv, e) -> SAssign (subst_lvalue ~rename_binders subst lv, se e)
+  | SSeq stmts -> SSeq (List.map ss stmts)
+  | SIf (c, t, e) -> SIf (se c, ss t, Option.map ss e)
+  | SWhile (c, b) -> SWhile (se c, ss b)
+  | SFor (v, lo, hi, dir, b) -> SFor (sb v, se lo, se hi, dir, ss b)
   | SMatch (e, cases) ->
       SMatch
-        ( subst_expr subst e,
-          List.map (fun (p, b) -> (p, subst_stmt subst b)) cases )
-  | SReturn e -> SReturn (subst_expr subst e)
+        ( se e,
+          List.map
+            (fun (p, b) -> (sub_pattern ~rename_binders subst p, ss b))
+            cases )
+  | SReturn e -> SReturn (se e)
   | (SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _) as s -> s
-  | SExpr e -> SExpr (subst_expr subst e)
-  | SLet (v, e, b) -> SLet (v, subst_expr subst e, subst_stmt subst b)
-  | SLetMut (v, e, b) -> SLetMut (v, subst_expr subst e, subst_stmt subst b)
-  | SPragma (h, b) -> SPragma (h, subst_stmt subst b)
-  | SBlock b -> SBlock (subst_stmt subst b)
+  | SExpr e -> SExpr (se e)
+  | SLet (v, e, b) -> SLet (sb v, se e, ss b)
+  | SLetMut (v, e, b) -> SLetMut (sb v, se e, ss b)
+  | SPragma (h, b) -> SPragma (h, ss b)
+  | SBlock b -> SBlock (ss b)
+
+(* ------------------------------------------------------------------ *)
+(* Binder collection (for alpha-renaming)                              *)
+(* ------------------------------------------------------------------ *)
+
+(** All local binder names introduced anywhere in [s]: [SLet]/[SLetMut]/[SFor]
+    variables and match-pattern bindings. Used to detect names that would
+    capture a substituted-in buffer reference. *)
+let collect_binders s =
+  let acc = ref [] in
+  let add n = acc := n :: !acc in
+  let pat = function
+    | PConstr (_, bindings) -> List.iter add bindings
+    | PWild -> ()
+  in
+  let rec go = function
+    | SLet (v, _, b) | SLetMut (v, _, b) ->
+        add v.var_name ;
+        go b
+    | SFor (v, _, _, _, b) ->
+        add v.var_name ;
+        go b
+    | SSeq stmts -> List.iter go stmts
+    | SIf (_, t, e) ->
+        go t ;
+        Option.iter go e
+    | SWhile (_, b) | SPragma (_, b) | SBlock b -> go b
+    | SMatch (_, cases) ->
+        List.iter
+          (fun (p, b) ->
+            pat p ;
+            go b)
+          cases
+    | SAssign _ | SReturn _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence
+    | SEmpty | SNative _ ->
+        ()
+  in
+  go s ;
+  !acc
 
 (* ------------------------------------------------------------------ *)
 (* Return rewriting (tail-position only)                               *)
@@ -283,8 +348,29 @@ let rec splice_call ctx sink (fname : string) (args : expr list) : stmt =
       args
       ([], [])
   in
+  (* Alpha-capture avoidance. A helper local (or scalar-parameter) whose name
+     collides with a name involved in the buffer substitution — either the
+     buffer we substitute IN (a value) or the vector parameter we substitute
+     AWAY (a key) — would, once spliced into the caller's block, shadow the
+     global buffer and make substituted [buf[i]] accesses read the local
+     instead. Rename every such colliding binder to a fresh [sarek_]-prefixed
+     name (binder AND uses) BEFORE the buffer substitution runs. *)
+  let dangerous = List.map fst subst @ List.map snd subst in
+  let scalar_param_names = List.map (fun (p, _) -> p.var_name) scalar_binds in
+  let rename =
+    List.sort_uniq compare (collect_binders hf.hf_body @ scalar_param_names)
+    |> List.filter_map (fun name ->
+        if List.mem name dangerous then Some (name, fresh_local_name ctx)
+        else None)
+  in
+  let body = subst_stmt ~rename_binders:true rename hf.hf_body in
+  let scalar_binds =
+    List.map
+      (fun (p, arg) -> ({p with var_name = sub rename p.var_name}, arg))
+      scalar_binds
+  in
   (* Substitute buffer names, then route returns to the sink. *)
-  let body = subst_stmt subst hf.hf_body in
+  let body = subst_stmt ~rename_binders:false subst body in
   let body = rewrite_returns ctx sink body in
   (* Bind scalar parameters as lets wrapping the body. *)
   let bound =

--- a/sarek/codegen/Sarek_ir_inline_vec.ml
+++ b/sarek/codegen/Sarek_ir_inline_vec.ml
@@ -1,0 +1,466 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek IR - Vector-parameter helper inlining (GLSL / WGSL)
+ *
+ * On GLSL and WGSL a storage buffer cannot be passed as a function argument, so
+ * a helper function taking a [TVec] parameter cannot be emitted as a real
+ * device function: the earlier code stripped the vector parameter from the
+ * signature and left the body referencing an identifier that no longer existed
+ * (GLSL), while the WGSL call site still forwarded the stripped buffer argument
+ * (arity mismatch). Both produced invalid shaders that no pass validated.
+ *
+ * This pass inlines every helper that takes a vector parameter at its call
+ * sites, then drops those helpers from the kernel. It is the IR-level analogue
+ * of the PTX EApp inliner (Sarek_ir_ptx_expr: bind params, splice the body,
+ * recursion guard). PTX can inline directly inside its expression emitter
+ * because that emitter is register/statement-based and returns a binding; the
+ * GLSL/WGSL emitters are purely textual (gen_expr cannot emit statements
+ * mid-expression), so the faithful analogue is an IR-to-IR splice performed
+ * before textual generation. Only GLSL and WGSL use this pass — CUDA, OpenCL,
+ * Metal pass buffers as real pointer parameters, and PTX inlines in its own
+ * emitter.
+ *
+ * Scope / limitations (rejected with a located [Unsupported_construct]):
+ * - a vector argument must be a plain vector variable (a global buffer or an
+ *   enclosing vector parameter); an arbitrary expression cannot alias a buffer;
+ * - the helper body's [return]s must be in tail position (the shape the
+ *   tail-recursion elimination pass produces); a mid-body early return cannot
+ *   be spliced into straight-line code and is refused;
+ * - a residual self / mutually-recursive call to a vector-parameter helper is
+ *   refused (depth-bounded non-tail recursion on these backends is out of
+ *   scope; tail recursion is already a loop by the time it reaches codegen);
+ * - a vector-parameter helper returning an aggregate (record/variant) is
+ *   refused (no default initializer synthesised for the result temporary).
+ ******************************************************************************)
+
+open Sarek_ir_types
+
+(** Does [hf] take at least one vector parameter? Only such helpers are inlined;
+    scalar-only helpers stay real device functions on both backends. *)
+let has_vec_param (hf : helper_func) =
+  List.exists
+    (fun (v : var) -> match v.var_type with TVec _ -> true | _ -> false)
+    hf.hf_params
+
+(** Where the result of an inlined call must go. *)
+type sink =
+  | Assign of lvalue  (** store the returned value into [lvalue] *)
+  | Return  (** [return] the value from the enclosing function *)
+  | Discard  (** unit-typed call kept only for its side effects *)
+
+(** Inliner state: the vector-parameter helpers keyed by name, the backend name
+    for error messages, and the stack of helpers currently being inlined (the
+    recursion guard). *)
+type ctx = {
+  vec_helpers : (string, helper_func) Hashtbl.t;
+  backend : string;
+  mutable stack : string list;
+  mutable temp_counter : int;
+}
+
+let fail ctx construct reason =
+  Sarek_backend_error.Backend_error.raise_error
+    (Sarek_backend_error.Backend_error.unsupported_construct
+       ~backend:ctx.backend
+       construct
+       reason)
+
+let fresh_temp_name ctx =
+  ctx.temp_counter <- ctx.temp_counter + 1 ;
+  Printf.sprintf "_sarek_inl_%d" ctx.temp_counter
+
+(** Is [e] a call to a vector-parameter helper? Returns its name + args. *)
+let as_vec_call ctx = function
+  | EApp (EVar f, args) when Hashtbl.mem ctx.vec_helpers f.var_name ->
+      Some (f.var_name, args)
+  | _ -> None
+
+(* ------------------------------------------------------------------ *)
+(* Vector-parameter name substitution                                  *)
+(* ------------------------------------------------------------------ *)
+
+(** [subst] maps a helper's vector-parameter name to the call site's buffer
+    name. Applied throughout the spliced body so every buffer access
+    ([EArrayRead], [EArrayLen], [LArrayElem], and any bare [EVar] of the
+    parameter) reads the caller's global buffer directly. *)
+let sub subst name =
+  match List.assoc_opt name subst with Some n -> n | None -> name
+
+let rec subst_expr subst e =
+  match e with
+  | EConst _ -> e
+  | EVar v -> EVar {v with var_name = sub subst v.var_name}
+  | EBinop (op, a, b) -> EBinop (op, subst_expr subst a, subst_expr subst b)
+  | EUnop (op, a) -> EUnop (op, subst_expr subst a)
+  | EArrayRead (name, idx) -> EArrayRead (sub subst name, subst_expr subst idx)
+  | EArrayReadExpr (base, idx) ->
+      EArrayReadExpr (subst_expr subst base, subst_expr subst idx)
+  | ERecordField (a, f) -> ERecordField (subst_expr subst a, f)
+  | EIntrinsic (path, name, args) ->
+      EIntrinsic (path, name, List.map (subst_expr subst) args)
+  | ECast (ty, a) -> ECast (ty, subst_expr subst a)
+  | ETuple es -> ETuple (List.map (subst_expr subst) es)
+  | EApp (fn, args) ->
+      EApp (subst_expr subst fn, List.map (subst_expr subst) args)
+  | ERecord (name, fields) ->
+      ERecord (name, List.map (fun (f, x) -> (f, subst_expr subst x)) fields)
+  | EVariant (t, c, args) -> EVariant (t, c, List.map (subst_expr subst) args)
+  | EArrayLen name -> EArrayLen (sub subst name)
+  | EArrayCreate (ty, sz, ms) -> EArrayCreate (ty, subst_expr subst sz, ms)
+  | EIf (c, t, e2) ->
+      EIf (subst_expr subst c, subst_expr subst t, subst_expr subst e2)
+  | EMatch (s, cases) ->
+      EMatch
+        ( subst_expr subst s,
+          List.map (fun (p, b) -> (p, subst_expr subst b)) cases )
+
+and subst_lvalue subst = function
+  | LVar v -> LVar {v with var_name = sub subst v.var_name}
+  | LArrayElem (name, idx) -> LArrayElem (sub subst name, subst_expr subst idx)
+  | LArrayElemExpr (base, idx) ->
+      LArrayElemExpr (subst_expr subst base, subst_expr subst idx)
+  | LRecordField (lv, f) -> LRecordField (subst_lvalue subst lv, f)
+
+let rec subst_stmt subst s =
+  match s with
+  | SAssign (lv, e) -> SAssign (subst_lvalue subst lv, subst_expr subst e)
+  | SSeq ss -> SSeq (List.map (subst_stmt subst) ss)
+  | SIf (c, t, e) ->
+      SIf
+        (subst_expr subst c, subst_stmt subst t, Option.map (subst_stmt subst) e)
+  | SWhile (c, b) -> SWhile (subst_expr subst c, subst_stmt subst b)
+  | SFor (v, lo, hi, dir, b) ->
+      SFor (v, subst_expr subst lo, subst_expr subst hi, dir, subst_stmt subst b)
+  | SMatch (e, cases) ->
+      SMatch
+        ( subst_expr subst e,
+          List.map (fun (p, b) -> (p, subst_stmt subst b)) cases )
+  | SReturn e -> SReturn (subst_expr subst e)
+  | (SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _) as s -> s
+  | SExpr e -> SExpr (subst_expr subst e)
+  | SLet (v, e, b) -> SLet (v, subst_expr subst e, subst_stmt subst b)
+  | SLetMut (v, e, b) -> SLetMut (v, subst_expr subst e, subst_stmt subst b)
+  | SPragma (h, b) -> SPragma (h, subst_stmt subst b)
+  | SBlock b -> SBlock (subst_stmt subst b)
+
+(* ------------------------------------------------------------------ *)
+(* Return rewriting (tail-position only)                               *)
+(* ------------------------------------------------------------------ *)
+
+(** Replace each (tail-position) [SReturn e] in the spliced helper body with the
+    action dictated by [sink]. A [return] found in a non-tail position (e.g. the
+    middle of a sequence) is refused — it would fall through into the code after
+    the splice, changing semantics. *)
+let rec rewrite_returns ctx sink s =
+  let recurse = rewrite_returns ctx sink in
+  match s with
+  | SReturn e -> (
+      match sink with
+      | Assign lv -> SAssign (lv, e)
+      | Return -> SReturn e
+      | Discard -> ( match e with EConst CUnit -> SEmpty | _ -> SExpr e))
+  | SSeq [] -> SSeq []
+  | SSeq ss ->
+      let rev = List.rev ss in
+      let last = List.hd rev in
+      let init = List.rev (List.tl rev) in
+      List.iter (assert_no_return ctx) init ;
+      SSeq (init @ [recurse last])
+  | SIf (c, t, e) -> SIf (c, recurse t, Option.map recurse e)
+  | SMatch (e, cases) ->
+      SMatch (e, List.map (fun (p, b) -> (p, recurse b)) cases)
+  | SLet (v, e, b) -> SLet (v, e, recurse b)
+  | SLetMut (v, e, b) -> SLetMut (v, e, recurse b)
+  | SPragma (h, b) -> SPragma (h, recurse b)
+  | SBlock b -> SBlock (recurse b)
+  | SWhile _ | SFor _ ->
+      (* A tail-position loop cannot carry the function's return value. *)
+      assert_no_return ctx s ;
+      s
+  | ( SAssign _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence | SEmpty
+    | SNative _ ) as s ->
+      s
+
+(** Verify [s] contains no [SReturn] anywhere (used for non-tail sub-statements
+    of an inlined body). *)
+and assert_no_return ctx s =
+  let rec chk = function
+    | SReturn _ ->
+        fail
+          ctx
+          "recursion+vector helper"
+          "helper has an early (non-tail) return that cannot be inlined on \
+           this backend; rewrite it so every return is in tail position"
+    | SSeq ss -> List.iter chk ss
+    | SIf (_, t, e) ->
+        chk t ;
+        Option.iter chk e
+    | SWhile (_, b) | SFor (_, _, _, _, b) | SBlock b | SPragma (_, b) -> chk b
+    | SMatch (_, cases) -> List.iter (fun (_, b) -> chk b) cases
+    | SLet (_, _, b) | SLetMut (_, _, b) -> chk b
+    | SAssign _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence | SEmpty
+    | SNative _ ->
+        ()
+  in
+  chk s
+
+(* ------------------------------------------------------------------ *)
+(* Default initializer for a result temporary                          *)
+(* ------------------------------------------------------------------ *)
+
+let default_expr ctx = function
+  | TInt32 -> EConst (CInt32 0l)
+  | TInt64 -> EConst (CInt64 0L)
+  | TFloat32 -> EConst (CFloat32 0.0)
+  | TFloat64 -> EConst (CFloat64 0.0)
+  | TBool -> EConst (CBool false)
+  | TUnit -> EConst CUnit
+  | (TRecord _ | TVariant _ | TArray _ | TVec _) as t ->
+      fail
+        ctx
+        "recursion+vector helper"
+        (Printf.sprintf
+           "cannot inline a vector-parameter helper returning %s (no default \
+            initializer for the result temporary)"
+           (match t with
+           | TRecord (n, _) -> "record " ^ n
+           | TVariant (n, _) -> "variant " ^ n
+           | TArray _ -> "an array"
+           | _ -> "a vector"))
+
+(* ------------------------------------------------------------------ *)
+(* Core: splice one call                                               *)
+(* ------------------------------------------------------------------ *)
+
+(** Build the statement that computes [f args] and routes the result to [sink].
+    Scalar parameters are bound with [SLet]; vector parameters are substituted
+    by name; the whole body is wrapped in an [SBlock] so its locals never leak
+    into (or collide across) call sites. The spliced body is itself run through
+    [inline_stmt] so a vector helper that calls another vector helper is fully
+    resolved. *)
+let rec splice_call ctx sink (fname : string) (args : expr list) : stmt =
+  if List.mem fname ctx.stack then
+    fail
+      ctx
+      "recursion+vector helper"
+      (Printf.sprintf
+         "helper '%s' is (mutually) recursive through a vector parameter; \
+          depth-bounded non-tail recursion is not supported on this backend"
+         fname) ;
+  let hf = Hashtbl.find ctx.vec_helpers fname in
+  if List.length args <> List.length hf.hf_params then
+    fail
+      ctx
+      "recursion+vector helper"
+      (Printf.sprintf
+         "helper '%s' called with %d arguments, expects %d"
+         fname
+         (List.length args)
+         (List.length hf.hf_params)) ;
+  (* Partition parameters into vector substitutions and scalar bindings. *)
+  let subst, scalar_binds =
+    List.fold_right2
+      (fun (p : var) arg (subst, binds) ->
+        match p.var_type with
+        | TVec _ -> (
+            match arg with
+            | EVar buf -> ((p.var_name, buf.var_name) :: subst, binds)
+            | _ ->
+                fail
+                  ctx
+                  "recursion+vector helper"
+                  (Printf.sprintf
+                     "vector argument to helper '%s' (parameter '%s') must be \
+                      a vector variable, not an arbitrary expression"
+                     fname
+                     p.var_name))
+        | _ -> (subst, (p, arg) :: binds))
+      hf.hf_params
+      args
+      ([], [])
+  in
+  (* Substitute buffer names, then route returns to the sink. *)
+  let body = subst_stmt subst hf.hf_body in
+  let body = rewrite_returns ctx sink body in
+  (* Bind scalar parameters as lets wrapping the body. *)
+  let bound =
+    List.fold_right (fun (p, arg) acc -> SLet (p, arg, acc)) scalar_binds body
+  in
+  (* Recursively inline nested vector-helper calls inside this body. *)
+  ctx.stack <- fname :: ctx.stack ;
+  let bound = inline_stmt ctx bound in
+  ctx.stack <- List.tl ctx.stack ;
+  SBlock bound
+
+(* ------------------------------------------------------------------ *)
+(* Statement / expression rewriting driving the splice                 *)
+(* ------------------------------------------------------------------ *)
+
+(** Lift every vector-helper call nested inside expression [e] into a preceding
+    result temporary, so it can be spliced as a statement. Returns the list of
+    (temp var, helper name, args) hoisted (in evaluation order) and the
+    rewritten expression referring to the temporaries. Direct-position calls
+    (handled by [inline_stmt]) are not reached here. *)
+and hoist_expr ctx e =
+  let hoisted = ref [] in
+  let rec go e =
+    match as_vec_call ctx e with
+    | Some (fname, args) ->
+        let args = List.map go args in
+        let hf = Hashtbl.find ctx.vec_helpers fname in
+        let tmp =
+          {
+            var_name = fresh_temp_name ctx;
+            var_id = 0;
+            var_type = hf.hf_ret_type;
+            var_mutable = true;
+          }
+        in
+        hoisted := (tmp, fname, args) :: !hoisted ;
+        EVar tmp
+    | None -> (
+        match e with
+        | EConst _ | EVar _ | EArrayLen _ -> e
+        | EBinop (op, a, b) -> EBinop (op, go a, go b)
+        | EUnop (op, a) -> EUnop (op, go a)
+        | EArrayRead (n, i) -> EArrayRead (n, go i)
+        | EArrayReadExpr (b, i) -> EArrayReadExpr (go b, go i)
+        | ERecordField (a, f) -> ERecordField (go a, f)
+        | EIntrinsic (p, n, args) -> EIntrinsic (p, n, List.map go args)
+        | ECast (ty, a) -> ECast (ty, go a)
+        | ETuple es -> ETuple (List.map go es)
+        | EApp (fn, args) -> EApp (fn, List.map go args)
+        | ERecord (n, fs) -> ERecord (n, List.map (fun (f, x) -> (f, go x)) fs)
+        | EVariant (t, c, args) -> EVariant (t, c, List.map go args)
+        | EArrayCreate (ty, sz, ms) -> EArrayCreate (ty, go sz, ms)
+        | EIf (c, t, e2) -> EIf (go c, go t, go e2)
+        | EMatch (s, cases) ->
+            EMatch (go s, List.map (fun (p, b) -> (p, go b)) cases))
+  in
+  let e' = go e in
+  (List.rev !hoisted, e')
+
+(** Wrap [core] (a statement using the hoisted temporaries) with a mutable
+    result temporary and an inlined splice for each hoisted call, in order. *)
+and with_hoisted ctx hoisted core =
+  List.fold_right
+    (fun (tmp, fname, args) acc ->
+      SLetMut
+        ( tmp,
+          default_expr ctx tmp.var_type,
+          SSeq [splice_call ctx (Assign (LVar tmp)) fname args; acc] ))
+    hoisted
+    core
+
+(** Rewrite one statement, inlining vector-helper calls. Direct-position calls
+    (the whole RHS of an assignment / let / return / expression statement) are
+    spliced without a temporary; calls nested inside other expressions are
+    hoisted first. *)
+and inline_stmt ctx s : stmt =
+  match s with
+  (* Direct-position calls: splice straight into the sink. *)
+  | SAssign (lv, e) when as_vec_call ctx e <> None ->
+      let fname, args = Option.get (as_vec_call ctx e) in
+      splice_call ctx (Assign lv) fname args
+  | SReturn e when as_vec_call ctx e <> None ->
+      let fname, args = Option.get (as_vec_call ctx e) in
+      splice_call ctx Return fname args
+  | SExpr e when as_vec_call ctx e <> None ->
+      let fname, args = Option.get (as_vec_call ctx e) in
+      splice_call ctx Discard fname args
+  | SLet (v, e, body) when as_vec_call ctx e <> None ->
+      let fname, args = Option.get (as_vec_call ctx e) in
+      SLetMut
+        ( v,
+          default_expr ctx v.var_type,
+          SSeq
+            [splice_call ctx (Assign (LVar v)) fname args; inline_stmt ctx body]
+        )
+  | SLetMut (v, e, body) when as_vec_call ctx e <> None ->
+      let fname, args = Option.get (as_vec_call ctx e) in
+      SLetMut
+        ( v,
+          default_expr ctx v.var_type,
+          SSeq
+            [splice_call ctx (Assign (LVar v)) fname args; inline_stmt ctx body]
+        )
+  (* Otherwise: hoist nested calls out of the statement's expressions, then
+     recurse structurally. *)
+  | SAssign (lv, e) ->
+      let h, e' = hoist_expr ctx e in
+      with_hoisted ctx h (SAssign (lv, e'))
+  | SReturn e ->
+      let h, e' = hoist_expr ctx e in
+      with_hoisted ctx h (SReturn e')
+  | SExpr e ->
+      let h, e' = hoist_expr ctx e in
+      with_hoisted ctx h (SExpr e')
+  | SLet (v, e, body) ->
+      let h, e' = hoist_expr ctx e in
+      with_hoisted ctx h (SLet (v, e', inline_stmt ctx body))
+  | SLetMut (v, e, body) ->
+      let h, e' = hoist_expr ctx e in
+      with_hoisted ctx h (SLetMut (v, e', inline_stmt ctx body))
+  | SIf (c, t, e) ->
+      let h, c' = hoist_expr ctx c in
+      with_hoisted
+        ctx
+        h
+        (SIf (c', inline_stmt ctx t, Option.map (inline_stmt ctx) e))
+  | SWhile (c, b) ->
+      let h, c' = hoist_expr ctx c in
+      (* A hoisted call in the condition is evaluated once before the loop; a
+         call in the loop condition proper is uncommon and would need
+         re-evaluation each iteration — refuse rather than change semantics. *)
+      if h <> [] then
+        fail
+          ctx
+          "recursion+vector helper"
+          "a vector-helper call in a while-condition cannot be inlined safely" ;
+      SWhile (c', inline_stmt ctx b)
+  | SFor (v, lo, hi, dir, b) ->
+      let h1, lo' = hoist_expr ctx lo in
+      let h2, hi' = hoist_expr ctx hi in
+      with_hoisted ctx (h1 @ h2) (SFor (v, lo', hi', dir, inline_stmt ctx b))
+  | SMatch (e, cases) ->
+      let h, e' = hoist_expr ctx e in
+      with_hoisted
+        ctx
+        h
+        (SMatch (e', List.map (fun (p, b) -> (p, inline_stmt ctx b)) cases))
+  | SSeq ss -> SSeq (List.map (inline_stmt ctx) ss)
+  | SBlock b -> SBlock (inline_stmt ctx b)
+  | SPragma (hints, b) -> SPragma (hints, inline_stmt ctx b)
+  | (SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _) as s -> s
+
+(* ------------------------------------------------------------------ *)
+(* Entry point                                                         *)
+(* ------------------------------------------------------------------ *)
+
+(** Inline all vector-parameter helpers into the kernel body and into the
+    remaining (scalar-only) helper bodies, then drop the inlined helpers. A
+    no-op when the kernel has no vector-parameter helper. *)
+let inline_vec_helpers ~backend (k : kernel) : kernel =
+  let vec_helpers = Hashtbl.create 8 in
+  List.iter
+    (fun hf ->
+      if has_vec_param hf then Hashtbl.replace vec_helpers hf.hf_name hf)
+    k.kern_funcs ;
+  if Hashtbl.length vec_helpers = 0 then k
+  else begin
+    let ctx = {vec_helpers; backend; stack = []; temp_counter = 0} in
+    let kern_body = inline_stmt ctx k.kern_body in
+    (* Keep only scalar-only helpers; inline vector-helper calls inside them. *)
+    let kern_funcs =
+      List.filter_map
+        (fun hf ->
+          if has_vec_param hf then None
+          else Some {hf with hf_body = inline_stmt ctx hf.hf_body})
+        k.kern_funcs
+    in
+    {k with kern_body; kern_funcs}
+  end

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -1004,6 +1004,9 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
       (Codegen_error.unsupported_construct
          "f64 parameter"
          "WGSL: f64 unsupported — WebGPU has no float64 type") ;
+  (* Inline vector-parameter helpers (buffers cannot be passed as WGSL function
+     arguments — see Sarek_ir_inline_vec). *)
+  let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"WGSL" k in
   scalar_param_names := [] ;
   current_variants := k.kern_variants ;
   let buf = Buffer.create 1024 in
@@ -1027,6 +1030,9 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
       (Codegen_error.unsupported_construct
          "f64 parameter"
          "WGSL: f64 unsupported — WebGPU has no float64 type") ;
+  (* Inline vector-parameter helpers (buffers cannot be passed as WGSL function
+     arguments — see Sarek_ir_inline_vec). *)
+  let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"WGSL" k in
   scalar_param_names := [] ;
   current_variants := k.kern_variants ;
   let buf = Buffer.create 1024 in

--- a/sarek/codegen/dune
+++ b/sarek/codegen/dune
@@ -12,6 +12,7 @@
   Sarek_ir_cuda
   Sarek_ir_opencl
   Sarek_ir_metal
+  Sarek_ir_inline_vec
   Sarek_ir_glsl
   Sarek_ir_wgsl
   Sarek_wgsl_abi

--- a/sarek/ppx/Sarek_tailrec_elim.ml
+++ b/sarek/ppx/Sarek_tailrec_elim.ml
@@ -30,11 +30,18 @@ let fresh_transform_id () = Atomic.fetch_and_add transform_var_counter 1
     - Recursive call: update loop vars (continue stays true) *)
 let eliminate_tail_recursion (fname : string) (params : tparam list)
     (body : texpr) (loc : Sarek_ast.loc) : texpr =
-  (* Create loop variable IDs for each parameter - use __name to avoid C redeclaration *)
+  (* Create loop variable IDs for each parameter - use __name to avoid C
+     redeclaration. Vector ([TVec]) parameters are EXCLUDED: on GPU backends a
+     vector/buffer cannot be reassigned (GLSL/WGSL cannot even take one as a
+     function argument), so it stays a plain parameter reference — never a
+     mutable loop variable — and a recursive call must pass it unchanged (see
+     the self-call transform below, which rejects a different vector). *)
   let loop_vars =
-    List.map
+    List.filter_map
       (fun p ->
-        (p.tparam_name, p.tparam_id, fresh_transform_id (), p.tparam_type))
+        if p.tparam_is_vec then None
+        else
+          Some (p.tparam_name, p.tparam_id, fresh_transform_id (), p.tparam_type))
       params
   in
 
@@ -201,24 +208,69 @@ let eliminate_tail_recursion (fname : string) (params : tparam list)
              __a := _tmp_0;
              __b := _tmp_1;
         *)
-        (* Create temporary variables for each argument *)
+        (* Pair each parameter with its argument. A vector parameter must be
+           passed back unchanged (it has no loop variable to update); passing a
+           DIFFERENT vector is meaningless on GLSL/WGSL — where the call is
+           inlined and the buffer name substituted — so reject it with a located
+           error. Only non-vector parameters become loop-variable updates. *)
+        let pairs =
+          if List.length params <> List.length args then
+            Sarek_error.raise_error
+              (Sarek_error.Invalid_kernel
+                 ( Printf.sprintf
+                     "recursive call to '%s' has %d arguments but the function \
+                      takes %d parameters"
+                     fname
+                     (List.length args)
+                     (List.length params),
+                   expr.te_loc ))
+          else List.combine params args
+        in
+        let scalar_pairs =
+          List.filter
+            (fun (p, arg) ->
+              if p.tparam_is_vec then begin
+                (match arg.te with
+                | TEVar (n, id) when n = p.tparam_name && id = p.tparam_id -> ()
+                | _ ->
+                    Sarek_error.raise_error
+                      (Sarek_error.Invalid_kernel
+                         ( Printf.sprintf
+                             "recursive call to '%s' must pass its own vector \
+                              parameter '%s' unchanged; passing a different \
+                              vector is not supported (a vector/buffer cannot \
+                              be reassigned on GPU backends)"
+                             fname
+                             p.tparam_name,
+                           arg.te_loc ))) ;
+                false
+              end
+              else true)
+            pairs
+        in
+        (* Create temporary variables for each non-vector argument *)
         let temps =
           List.mapi
-            (fun i arg ->
+            (fun i (_p, arg) ->
               let tmp_id = fresh_transform_id () in
               let tmp_name = "_tmp_" ^ string_of_int i in
               (tmp_name, tmp_id, arg))
-            args
+            scalar_pairs
         in
         (* Create assignments from temps to loop vars *)
         let assigns =
           List.map2
-            (fun (name, _orig_id, loop_id, _ty) (tmp_name, tmp_id, arg) ->
+            (fun (p, _arg) (tmp_name, tmp_id, arg) ->
+              let _, _, loop_id, _ =
+                List.find
+                  (fun (n, oid, _, _) -> n = p.tparam_name && oid = p.tparam_id)
+                  loop_vars
+              in
               let tmp_ref =
                 {te = TEVar (tmp_name, tmp_id); ty = arg.ty; te_loc = loc}
               in
-              mk_loop_assign name loop_id tmp_ref)
-            loop_vars
+              mk_loop_assign p.tparam_name loop_id tmp_ref)
+            scalar_pairs
             temps
         in
         (* Wrap assigns in let bindings for temps *)

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -32,7 +32,7 @@
 (test
  (name test_codegen_golden)
  (modules test_codegen_golden)
- (libraries codegen_golden_backends sarek_ir alcotest)
+ (libraries codegen_golden_backends sarek_ir alcotest unix)
  (instrumentation
   (backend bisect_ppx)))
 

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -1761,6 +1761,162 @@ let metal_only_tests () =
           check_golden "metal" kernel_name actual))
     (metal_only_kernels ())
 
+(** {1 Shader-validation sweep}
+
+    The golden strings above pin byte-exact codegen output but never checked
+    that the emitted shader is VALID. This sweep runs every GLSL golden through
+    [glslangValidator] and every WGSL golden through [naga] (validating that the
+    whole committed corpus assembles, not just the recursion+vector regression
+    in the unit gate). Both skip cleanly when the tool is absent (mirrors the
+    ptxas gate in test_ptx_snapshot.ml). *)
+
+let tool_available cmd =
+  match Unix.system (Printf.sprintf "command -v %s >/dev/null 2>&1" cmd) with
+  | Unix.WEXITED 0 -> true
+  | _ -> false
+
+let glslang_available = lazy (tool_available "glslangValidator")
+
+let naga_available = lazy (tool_available "naga")
+
+let read_file f =
+  try
+    let ic = open_in f in
+    let n = in_channel_length ic in
+    let s = really_input_string ic n in
+    close_in ic ;
+    s
+  with _ -> ""
+
+(** Assemble GLSL compute source with glslangValidator (same invocation as the
+    production Vulkan path: [-V -S comp], entry [main], no --target-env). *)
+let glslang_ok glsl =
+  let base = Filename.temp_file "sarek_golden_glsl_" "" in
+  let src = base ^ ".comp" in
+  let spv = base ^ ".spv" in
+  let err = base ^ ".err" in
+  let oc = open_out src in
+  output_string oc glsl ;
+  close_out oc ;
+  let cmd =
+    Printf.sprintf
+      "glslangValidator -V -S comp -o %s %s >%s 2>&1"
+      (Filename.quote spv)
+      (Filename.quote src)
+      (Filename.quote err)
+  in
+  let rc = Unix.system cmd in
+  let out = read_file err in
+  List.iter (fun f -> try Sys.remove f with _ -> ()) [src; spv; err; base] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+let naga_ok wgsl =
+  let base = Filename.temp_file "sarek_golden_wgsl_" "" in
+  let src = base ^ ".wgsl" in
+  let err = base ^ ".err" in
+  let oc = open_out src in
+  output_string oc wgsl ;
+  close_out oc ;
+  let cmd =
+    Printf.sprintf
+      "naga --validate all %s >%s 2>&1"
+      (Filename.quote src)
+      (Filename.quote err)
+  in
+  let rc = Unix.system cmd in
+  let out = read_file err in
+  List.iter (fun f -> try Sys.remove f with _ -> ()) [src; err; base] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+(** Per-case exclusions from the validation sweep, each with a cited reason. A
+    golden here is still byte-exact-checked above; it is only skipped by the
+    validator (e.g. it exercises an intentionally partial construct). Keyed by
+    (backend, kernel_name). Empty unless a genuine, documented gap is found. *)
+let validation_exclusions : ((string * string) * string) list =
+  [
+    (* PRE-EXISTING float64-transcendental GLSL codegen gap (NOT related to the
+       vector-helper work): GLSL core has no double-precision overload for the
+       transcendental builtins, so the float64 log10 path emits [log(<double>)]
+       and the float64 cbrt path emits [pow(<double>, ...)], both of which
+       glslangValidator rejects ("no matching overloaded function"). These
+       goldens pin the current (float-builtin) lowering and are still
+       byte-exact-checked above; validating them is out of scope for this task
+       and would require a genuine double-precision transcendental lowering
+       (software polyfill) on the Vulkan backend. *)
+    ( ("glsl", "float64_log10_path"),
+      "GLSL core has no double overload for log(); pre-existing f64 \
+       transcendental codegen gap, out of scope" );
+    ( ("glsl", "float64_cbrt_path"),
+      "GLSL core has no double overload for pow(); pre-existing f64 \
+       transcendental codegen gap, out of scope" );
+  ]
+
+let excluded backend name = List.assoc_opt (backend, name) validation_exclusions
+
+(** GLSL corpus = cross-backend kernels + GLSL-only kernels. *)
+let glsl_validation_tests () =
+  List.map
+    (fun (kernel_name, k) ->
+      Alcotest.test_case
+        (Printf.sprintf "glsl-validate/%s" kernel_name)
+        `Quick
+        (fun () ->
+          match excluded "glsl" kernel_name with
+          | Some reason ->
+              Printf.printf
+                "  SKIP (excluded): glsl/%s — %s\n%!"
+                kernel_name
+                reason
+          | None -> (
+              Gen_glsl.reset_state () ;
+              let glsl = Gen_glsl.generate_with_types ~types:k.kern_types k in
+              if not (Lazy.force glslang_available) then
+                Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+              else
+                match glslang_ok glsl with
+                | Ok () ->
+                    Printf.printf "  glslangValidator OK: %s\n%!" kernel_name
+                | Error e ->
+                    Alcotest.failf
+                      "glslangValidator rejected golden glsl/%s:\n\
+                       %s\n\
+                       --- shader ---\n\
+                       %s"
+                      kernel_name
+                      e
+                      glsl)))
+    (test_kernels () @ glsl_only_kernels ())
+
+(** WGSL corpus = cross-backend kernels + WGSL-only kernels. *)
+let wgsl_validation_tests () =
+  List.map
+    (fun (kernel_name, k) ->
+      Alcotest.test_case
+        (Printf.sprintf "wgsl-validate/%s" kernel_name)
+        `Quick
+        (fun () ->
+          match excluded "wgsl" kernel_name with
+          | Some reason ->
+              Printf.printf
+                "  SKIP (excluded): wgsl/%s — %s\n%!"
+                kernel_name
+                reason
+          | None -> (
+              Gen_wgsl.reset_state () ;
+              let wgsl = Gen_wgsl.generate_with_types ~types:k.kern_types k in
+              if not (Lazy.force naga_available) then
+                Printf.printf "  SKIP: naga not on PATH\n%!"
+              else
+                match naga_ok wgsl with
+                | Ok () -> Printf.printf "  naga OK: %s\n%!" kernel_name
+                | Error e ->
+                    Alcotest.failf
+                      "naga rejected golden wgsl/%s:\n%s\n--- shader ---\n%s"
+                      kernel_name
+                      e
+                      wgsl)))
+    (test_kernels () @ wgsl_only_kernels ())
+
 let () =
   Alcotest.run
     "codegen_golden"
@@ -1769,4 +1925,6 @@ let () =
         ("wgsl_only", wgsl_only_tests ());
         ("glsl_only", glsl_only_tests ());
         ("metal_only", metal_only_tests ());
+        ("glsl_validation_sweep", glsl_validation_tests ());
+        ("wgsl_validation_sweep", wgsl_validation_tests ());
       ])

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -553,6 +553,23 @@
  (action
   (run %{dep:test_vulkan_float64.exe})))
 
+; Recursion + vector-parameter helper on Vulkan: builds a loop-form
+; vector-reduction helper (the shape tail-recursion elimination produces) and
+; runs it end-to-end, exercising the vector-helper inlining pass through GLSL
+; and glslangValidator to a real device. Device-filtered to Vulkan; skips
+; cleanly if none present.
+
+(executable
+ (name test_vulkan_recursion_vector)
+ (modules test_vulkan_recursion_vector)
+ (optional)
+ (libraries sarek_ir sarek_execute sarek_vulkan spoc_core))
+
+(rule
+ (alias e2e-gpu)
+ (action
+  (run %{dep:test_vulkan_recursion_vector.exe})))
+
 ; PR-5a proof: FFI-free stdlib metadata population
 ; Asserts that sarek_stdlib_meta populates Sarek_ppx_registry without
 ; any Ctypes or Spoc_core dependency (sarek_frontend + sarek_stdlib_meta only).

--- a/sarek/tests/e2e/test_vulkan_recursion_vector.ml
+++ b/sarek/tests/e2e/test_vulkan_recursion_vector.ml
@@ -1,0 +1,217 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E regression test: recursion + vector-parameter helper on Vulkan.
+ *
+ * A helper that takes a vector ([TVec]) parameter cannot be emitted as a real
+ * GLSL/WGSL function (a storage buffer is not a valid function argument). Before
+ * the vector-helper inlining pass (Sarek_ir_inline_vec) the pipeline returned
+ * [Ok] while emitting an invalid shader — the helper referenced a stripped
+ * parameter that no longer existed. This test builds a Sarek IR kernel with a
+ * loop-form vector-reduction helper (exactly the shape the tail-recursion
+ * elimination pass produces from a tail-recursive reduction) directly and runs
+ * it on a real Vulkan device, checking the result against a host reference.
+ *
+ *   out[tid] = sum_range(data, tid + 1)      where
+ *   sum_range(arr, n) = arr[0] + arr[1] + ... + arr[n-1]
+ *
+ * With data[i] = 1.0 the reference is out[tid] = tid + 1 (exact in f32 for the
+ * small n used here).
+ *
+ * Device-filtered to Vulkan only; skips cleanly (prints [SKIP], exits 0) if no
+ * Vulkan device is available.
+ *
+ * Run with: dune exec sarek/tests/e2e/test_vulkan_recursion_vector.exe
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Execute = Sarek_execute.Execute
+
+let () = Sarek_vulkan.Vulkan_plugin.init ()
+
+let n = 256
+
+(** Loop-form vector-reduction helper: [sum_range(arr, len)] returns the sum of
+    [arr.(0 .. len-1)]. This is the shape the tail-recursion elimination pass
+    emits from a tail-recursive accumulator reduction — a bounded [while] loop
+    over the vector parameter, with the accumulator returned. The [arr]
+    parameter is a [TVec], which is what the inlining pass must resolve. *)
+let sum_range_helper () =
+  let arr =
+    {
+      var_name = "arr";
+      var_id = 10;
+      var_type = TVec TFloat32;
+      var_mutable = false;
+    }
+  in
+  let len =
+    {var_name = "len"; var_id = 11; var_type = TInt32; var_mutable = false}
+  in
+  let i =
+    {var_name = "__i"; var_id = 12; var_type = TInt32; var_mutable = true}
+  in
+  let acc =
+    {var_name = "_result"; var_id = 13; var_type = TFloat32; var_mutable = true}
+  in
+  let body =
+    SLetMut
+      ( i,
+        EConst (CInt32 0l),
+        SLetMut
+          ( acc,
+            EConst (CFloat32 0.0),
+            SSeq
+              [
+                SWhile
+                  ( EBinop (Lt, EVar i, EVar len),
+                    SSeq
+                      [
+                        SAssign
+                          ( LVar acc,
+                            EBinop (Add, EVar acc, EArrayRead ("arr", EVar i))
+                          );
+                        SAssign
+                          (LVar i, EBinop (Add, EVar i, EConst (CInt32 1l)));
+                      ] );
+                SReturn (EVar acc);
+              ] ) )
+  in
+  {
+    hf_name = "sum_range";
+    hf_params = [arr; len];
+    hf_ret_type = TFloat32;
+    hf_body = body;
+  }
+
+(** out[tid] = sum_range(data, tid + 1). *)
+let make_ir () : kernel =
+  let data =
+    {
+      var_name = "data";
+      var_id = 0;
+      var_type = TVec TFloat32;
+      var_mutable = false;
+    }
+  in
+  let out =
+    {
+      var_name = "out";
+      var_id = 1;
+      var_type = TVec TFloat32;
+      var_mutable = false;
+    }
+  in
+  let tid =
+    {var_name = "tid"; var_id = 2; var_type = TInt32; var_mutable = false}
+  in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SIf
+          ( EBinop (Lt, EVar tid, EConst (CInt32 (Int32.of_int n))),
+            SAssign
+              ( LArrayElem ("out", EVar tid),
+                EApp
+                  ( EVar
+                      {
+                        var_name = "sum_range";
+                        var_id = 3;
+                        var_type = TFloat32;
+                        var_mutable = false;
+                      },
+                    [EVar data; EBinop (Add, EVar tid, EConst (CInt32 1l))] ) ),
+            None ) )
+  in
+  {
+    kern_name = "recursion_vector_vulkan";
+    kern_params =
+      [
+        DParam (data, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [sum_range_helper ()];
+    kern_native_fn = None;
+  }
+
+let find_vulkan_device () =
+  let vulkan_devices = Device.by_framework "Vulkan" in
+  if Array.length vulkan_devices > 0 then Some vulkan_devices.(0) else None
+
+let run_test (dev : Device.t) =
+  let ir = make_ir () in
+  let data = Vector.create Vector.float32 n in
+  let out = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set data i 1.0 ;
+    Vector.set out i 0.0
+  done ;
+  let block = Execute.dims1d 256 in
+  let grid = Execute.dims1d ((n + 255) / 256) in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Execute.Vec data; Execute.Vec out]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  Vector.to_array out
+
+(* Host reference: with data.(i) = 1.0, out.(tid) = tid + 1. *)
+let verify result =
+  let errors = ref 0 in
+  for i = 0 to n - 1 do
+    let expected = float_of_int (i + 1) in
+    if abs_float (result.(i) -. expected) > 1e-3 then begin
+      if !errors < 5 then
+        Printf.printf
+          "  Mismatch at %d: expected %.1f, got %.6f\n"
+          i
+          expected
+          result.(i) ;
+      incr errors
+    end
+  done ;
+  !errors = 0
+
+let () =
+  match find_vulkan_device () with
+  | None ->
+      Printf.printf
+        "[SKIP] No Vulkan device available - skipping recursion+vector Vulkan \
+         e2e test\n\
+         %!"
+  | Some dev -> (
+      Printf.printf
+        "Running recursion+vector kernel on Vulkan device: %s\n%!"
+        dev.Device.name ;
+      match run_test dev with
+      | result ->
+          if verify result then
+            Printf.printf
+              "[PASS] Vulkan recursion+vector kernel: %d elements match host \
+               reference\n\
+               %!"
+              n
+          else begin
+            Printf.printf
+              "[FAIL] Vulkan recursion+vector kernel produced wrong results\n%!" ;
+            exit 1
+          end
+      | exception e ->
+          Printf.printf
+            "[FAIL] Vulkan recursion+vector kernel raised: %s\n%!"
+            (Printexc.to_string e) ;
+          exit 1)

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -38,6 +38,17 @@
   (= %{profile} "negative")))
 
 (library
+ (name neg_test_tailrec_vec_swap)
+ (modules test_tailrec_vec_swap)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+(library
  (name neg_test_convention_kernel_fail)
  (modules test_convention_kernel_fail)
  (libraries sarek sarek.stdlib sarek.ppx.lib sarek_geometry)

--- a/sarek/tests/negative/test_tailrec_vec_swap.ml
+++ b/sarek/tests/negative/test_tailrec_vec_swap.ml
@@ -1,0 +1,35 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile:
+   - A tail-recursive helper takes two vector parameters [a] and [b] and, in the
+     recursive call, SWAPS them ([sum_two b a ...]). A vector/buffer cannot be
+     reassigned on GPU backends (GLSL/WGSL inline the helper and substitute the
+     buffer name), so passing a DIFFERENT vector than the one received is
+     rejected by the tail-recursion elimination pass with a located error.
+
+   Expected error: "must pass its own vector parameter 'a' unchanged". *)
+
+module Std = Sarek_stdlib.Std
+open Sarek
+
+let () =
+  let bad_kernel =
+    [%kernel
+      let open Std in
+      let rec sum_two (a : int32 vector) (b : int32 vector) (i : int32)
+          (n : int32) (acc : int32) : int32 =
+        if i >= n then acc else sum_two b a (i + 1l) n (acc + a.(i))
+      in
+      fun (out : int32 vector)
+          (x : int32 vector)
+          (y : int32 vector)
+          (n : int32)
+        ->
+        let idx = global_idx_x in
+        out.(idx) <- sum_two x y 0l n 0l]
+  in
+  ignore bad_kernel ;
+  print_endline "This should not print - test should have failed to compile"

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -97,5 +97,3 @@
 (test
  (name test_soa)
  (libraries spoc_core spoc.ir ctypes alcotest))
-
-

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -60,6 +60,14 @@
  (name test_ptx_snapshot)
  (libraries sarek.codegen alcotest unix str))
 
+; Shader-validation gate for recursion + vector-parameter helpers.
+; GLSL assembled with glslangValidator; WGSL validated with naga if present,
+; else skipped cleanly (mirrors the ptxas gate above). CPU-only, no device.
+
+(test
+ (name test_shader_recursion_vector)
+ (libraries sarek.codegen alcotest unix))
+
 ; Software f64 transcendentals for PTX: IR-level accuracy vs the OCaml stdlib
 ; (pure scalar evaluation of the helper bodies — CPU-only, no device needed)
 
@@ -89,3 +97,5 @@
 (test
  (name test_soa)
  (libraries spoc_core spoc.ir ctypes alcotest))
+
+

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -1,0 +1,244 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Shader-validation gate for recursion + vector-parameter helpers on the GLSL
+    and WGSL backends.
+
+    Before this gate existed the pipeline returned [Ok] while emitting an
+    invalid shader for any helper taking a vector parameter: the helper was
+    emitted as a real GLSL/WGSL function with the vector parameter stripped from
+    its signature, so the body referenced an identifier that no longer existed
+    (GLSL), and the WGSL call site still forwarded the stripped argument (arity
+    mismatch). Nothing assembled the generated source, so the breakage was
+    silent.
+
+    This module builds a post-tail-recursion vector-reduction kernel (the shape
+    the PPX tail-recursion pass produces: a bounded [while] loop over a vector
+    parameter inside a helper) and, when a validator is on PATH:
+
+    - GLSL: assembles with [glslangValidator] (present since the copysign work);
+    - WGSL: validates with [naga] if available, otherwise skips cleanly with a
+      message (mirrors the ptxas gate in test_ptx_snapshot.ml).
+
+    Substring markers additionally pin that the vector-parameter helper was
+    inlined away (no residual function definition, the global buffer is read
+    directly). *)
+
+open Sarek_ir_types
+open Sarek_codegen
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let base_kernel name params body funcs =
+  {
+    kern_name = name;
+    kern_params = params;
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = funcs;
+    kern_native_fn = None;
+  }
+
+(** A vector-reduction helper in the exact shape the tail-recursion elimination
+    pass emits: the recursion is already a bounded [while] loop over the vector
+    parameter [arr], accumulating into a mutable local and returning it. The
+    helper keeps its [TVec] parameter, which is what breaks the GLSL/WGSL
+    backends unless it is inlined at the call site. *)
+let sum_range_helper () =
+  let arr = make_var "arr" (TVec TFloat32) in
+  let n = make_var "n" TInt32 in
+  (* Internal loop state uses names distinct from the parameters, exactly like
+     the tail-recursion elimination pass (which prefixes loop vars). *)
+  let i = {(make_var "__i" TInt32) with var_mutable = true} in
+  let acc = {(make_var "_result" TFloat32) with var_mutable = true} in
+  let body =
+    SLetMut
+      ( i,
+        EConst (CInt32 0l),
+        SLetMut
+          ( acc,
+            EConst (CFloat32 0.0),
+            SSeq
+              [
+                SWhile
+                  ( EBinop (Lt, EVar i, EVar n),
+                    SSeq
+                      [
+                        SAssign
+                          ( LVar acc,
+                            EBinop (Add, EVar acc, EArrayRead ("arr", EVar i))
+                          );
+                        SAssign
+                          (LVar i, EBinop (Add, EVar i, EConst (CInt32 1l)));
+                      ] );
+                SReturn (EVar acc);
+              ] ) )
+  in
+  {
+    hf_name = "sum_range";
+    hf_params = [arr; n];
+    hf_ret_type = TFloat32;
+    hf_body = body;
+  }
+
+(** Kernel: out[tid] = sum_range(data, tid + 1) — a prefix-sum-ish reduction
+    that calls the vector-parameter helper once per thread. *)
+let recursion_vector_kernel () =
+  let data = make_var "data" (TVec TFloat32) in
+  let out = make_var "out" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let helper = sum_range_helper () in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar tid),
+            EApp
+              ( EVar (make_var "sum_range" TFloat32),
+                [EVar data; EBinop (Add, EVar tid, EConst (CInt32 1l))] ) ) )
+  in
+  base_kernel
+    "recursion_vector"
+    [
+      DParam (data, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    body
+    [helper]
+
+(* ---- validator plumbing (mirrors the ptxas gate) ---- *)
+
+let tool_available cmd =
+  match Unix.system (Printf.sprintf "command -v %s >/dev/null 2>&1" cmd) with
+  | Unix.WEXITED 0 -> true
+  | _ -> false
+
+let glslang_available = lazy (tool_available "glslangValidator")
+
+let naga_available = lazy (tool_available "naga")
+
+let read_file f =
+  try
+    let ic = open_in f in
+    let n = in_channel_length ic in
+    let s = really_input_string ic n in
+    close_in ic ;
+    s
+  with _ -> ""
+
+(** Assemble GLSL compute source with glslangValidator (same invocation as
+    Vulkan_api_base: [-V -S comp], entry point [main], no --target-env). Returns
+    [Ok ()] on a clean assemble, [Error stderr] otherwise. *)
+let glslang_ok glsl =
+  let base = Filename.temp_file "sarek_glsl_" "" in
+  let src = base ^ ".comp" in
+  let spv = base ^ ".spv" in
+  let err = base ^ ".err" in
+  let oc = open_out src in
+  output_string oc glsl ;
+  close_out oc ;
+  let cmd =
+    Printf.sprintf
+      "glslangValidator -V -S comp -o %s %s >%s 2>&1"
+      (Filename.quote spv)
+      (Filename.quote src)
+      (Filename.quote err)
+  in
+  let rc = Unix.system cmd in
+  let out = read_file err in
+  List.iter (fun f -> try Sys.remove f with _ -> ()) [src; spv; err; base] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+(** Validate WGSL with naga (front-end + validation). naga infers the input
+    language from the [.wgsl] extension. *)
+let naga_ok wgsl =
+  let base = Filename.temp_file "sarek_wgsl_" "" in
+  let src = base ^ ".wgsl" in
+  let err = base ^ ".err" in
+  let oc = open_out src in
+  output_string oc wgsl ;
+  close_out oc ;
+  let cmd =
+    Printf.sprintf
+      "naga --validate all %s >%s 2>&1"
+      (Filename.quote src)
+      (Filename.quote err)
+  in
+  let rc = Unix.system cmd in
+  let out = read_file err in
+  List.iter (fun f -> try Sys.remove f with _ -> ()) [src; err; base] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+let contains s sub =
+  let sl = String.length sub in
+  let found = ref false in
+  for i = 0 to String.length s - sl do
+    if String.sub s i sl = sub then found := true
+  done ;
+  !found
+
+(* ---- tests ---- *)
+
+let test_glsl_recursion_vector_validates () =
+  let k = recursion_vector_kernel () in
+  let glsl = Sarek_ir_glsl.generate k in
+  (* The vector-parameter helper must be inlined away: no `float sum_range(`
+     definition, and the global buffer `data` must be read directly in main. *)
+  if contains glsl "sum_range(" then
+    Alcotest.failf
+      "vector-parameter helper must be inlined, found a residual call/def:\n%s"
+      glsl ;
+  if not (Lazy.force glslang_available) then
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  else
+    match glslang_ok glsl with
+    | Ok () -> Printf.printf "  glslangValidator OK: recursion_vector\n%!"
+    | Error e ->
+        Alcotest.failf
+          "glslangValidator rejected recursion_vector GLSL:\n\
+           %s\n\
+           --- shader ---\n\
+           %s"
+          e
+          glsl
+
+let test_wgsl_recursion_vector_validates () =
+  let k = recursion_vector_kernel () in
+  let wgsl = Sarek_ir_wgsl.generate k in
+  if contains wgsl "sum_range(" then
+    Alcotest.failf
+      "vector-parameter helper must be inlined, found a residual call/def:\n%s"
+      wgsl ;
+  if not (Lazy.force naga_available) then
+    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!"
+  else
+    match naga_ok wgsl with
+    | Ok () -> Printf.printf "  naga OK: recursion_vector\n%!"
+    | Error e ->
+        Alcotest.failf
+          "naga rejected recursion_vector WGSL:\n%s\n--- shader ---\n%s"
+          e
+          wgsl
+
+let () =
+  Alcotest.run
+    "shader_recursion_vector"
+    [
+      ( "validation-gate",
+        [
+          Alcotest.test_case
+            "GLSL recursion+vector validates"
+            `Quick
+            test_glsl_recursion_vector_validates;
+          Alcotest.test_case
+            "WGSL recursion+vector validates"
+            `Quick
+            test_wgsl_recursion_vector_validates;
+        ] );
+    ]

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -112,6 +112,74 @@ let recursion_vector_kernel () =
     body
     [helper]
 
+(** A vector-parameter helper whose own LOCAL accumulator is named [data] — the
+    same name as the kernel's buffer the call passes for the vector parameter.
+    Without alpha-renaming, substituting the vector parameter [arr] -> [data]
+    makes the spliced body read the local scalar [data] as an array ([data[i]])
+    and shadows the global buffer: invalid GLSL. The inliner must rename the
+    colliding local to a fresh [sarek_]-prefixed name. *)
+let collision_helper () =
+  let arr = make_var "arr" (TVec TFloat32) in
+  let n = make_var "n" TInt32 in
+  let i = {(make_var "__i" TInt32) with var_mutable = true} in
+  (* local named EXACTLY like the kernel buffer parameter below *)
+  let data_local = {(make_var "data" TFloat32) with var_mutable = true} in
+  let body =
+    SLetMut
+      ( i,
+        EConst (CInt32 0l),
+        SLetMut
+          ( data_local,
+            EConst (CFloat32 0.0),
+            SSeq
+              [
+                SWhile
+                  ( EBinop (Lt, EVar i, EVar n),
+                    SSeq
+                      [
+                        SAssign
+                          ( LVar data_local,
+                            EBinop
+                              (Add, EVar data_local, EArrayRead ("arr", EVar i))
+                          );
+                        SAssign
+                          (LVar i, EBinop (Add, EVar i, EConst (CInt32 1l)));
+                      ] );
+                SReturn (EVar data_local);
+              ] ) )
+  in
+  {
+    hf_name = "sum_range";
+    hf_params = [arr; n];
+    hf_ret_type = TFloat32;
+    hf_body = body;
+  }
+
+(** Same call shape, but the buffer parameter is literally named [data] and the
+    helper's local accumulator is also [data]. *)
+let collision_kernel () =
+  let data = make_var "data" (TVec TFloat32) in
+  let out = make_var "out" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar tid),
+            EApp
+              ( EVar (make_var "sum_range" TFloat32),
+                [EVar data; EBinop (Add, EVar tid, EConst (CInt32 1l))] ) ) )
+  in
+  base_kernel
+    "collision_vector"
+    [
+      DParam (data, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    body
+    [collision_helper ()]
+
 (* ---- validator plumbing (mirrors the ptxas gate) ---- *)
 
 let tool_available cmd =
@@ -226,6 +294,59 @@ let test_wgsl_recursion_vector_validates () =
           e
           wgsl
 
+(* Alpha-capture regression: a helper local named like the kernel buffer. The
+   fixed inliner renames the local to a fresh sarek_-prefixed name; the buffer
+   read survives; glslangValidator accepts. Before the fix this GLSL was invalid
+   (a scalar `data` indexed as `data[i]`, shadowing the global buffer). *)
+let test_glsl_local_buffer_name_collision () =
+  let k = collision_kernel () in
+  let glsl = Sarek_ir_glsl.generate k in
+  if contains glsl "sum_range(" then
+    Alcotest.failf "helper must be inlined, found residual call/def:\n%s" glsl ;
+  (* The colliding local must have been renamed. *)
+  if not (contains glsl "sarek_inl_local_") then
+    Alcotest.failf
+      "expected the colliding local to be alpha-renamed (sarek_inl_local_*):\n\
+       %s"
+      glsl ;
+  if not (Lazy.force glslang_available) then
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  else
+    match glslang_ok glsl with
+    | Ok () -> Printf.printf "  glslangValidator OK: collision_vector\n%!"
+    | Error e ->
+        Alcotest.failf
+          "glslangValidator rejected collision_vector GLSL (alpha-capture?):\n\
+           %s\n\
+           --- shader ---\n\
+           %s"
+          e
+          glsl
+
+let test_wgsl_local_buffer_name_collision () =
+  let k = collision_kernel () in
+  let wgsl = Sarek_ir_wgsl.generate k in
+  if contains wgsl "sum_range(" then
+    Alcotest.failf "helper must be inlined, found residual call/def:\n%s" wgsl ;
+  if not (contains wgsl "sarek_inl_local_") then
+    Alcotest.failf
+      "expected the colliding local to be alpha-renamed (sarek_inl_local_*):\n\
+       %s"
+      wgsl ;
+  if not (Lazy.force naga_available) then
+    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!"
+  else
+    match naga_ok wgsl with
+    | Ok () -> Printf.printf "  naga OK: collision_vector\n%!"
+    | Error e ->
+        Alcotest.failf
+          "naga rejected collision_vector WGSL (alpha-capture?):\n\
+           %s\n\
+           --- shader ---\n\
+           %s"
+          e
+          wgsl
+
 let () =
   Alcotest.run
     "shader_recursion_vector"
@@ -240,5 +361,13 @@ let () =
             "WGSL recursion+vector validates"
             `Quick
             test_wgsl_recursion_vector_validates;
+          Alcotest.test_case
+            "GLSL helper-local vs buffer-name collision (alpha-capture)"
+            `Quick
+            test_glsl_local_buffer_name_collision;
+          Alcotest.test_case
+            "WGSL helper-local vs buffer-name collision (alpha-capture)"
+            `Quick
+            test_wgsl_local_buffer_name_collision;
         ] );
     ]


### PR DESCRIPTION
Vector-parameter helpers produced INVALID shaders on GLSL/WGSL while the pipeline returned Ok (maintainer-diagnosed; red captured: stripped signature still referencing the vector param — glslang exit 2, WGSL arity mismatch).

Maintainer's 4-point plan, implemented:
1. **Inline vector-param helpers** on GLSL+WGSL via a new shared IR→IR pass (`Sarek_ir_inline_vec`): per-call-site buffer substitution, scalar args bound once (effectful-arg safe), fixpoint on nested helper calls, recursion guard (located error), typed sink hoisting for expression-position calls. Alpha-capture closed in review round 2 (`rename_binders` mechanism + red→green collision test: helper local named like the caller's buffer).
2. **Tailrec**: no loop vars for TVec params; a recursive call passing a different vector is rejected with a located error — universal across backends (verified safe: no prior legal usage anywhere in-tree).
3. **WGSL call-site filtering**: resolved by inlining (no vector args survive to call sites).
4. **Validator gate — the real hole**: glslangValidator/naga sweep over the ENTIRE golden shader corpus (skip-if-absent, ptxas-gate pattern). GLSL: 16/18 validated; the 2 exclusions (cited) immediately surfaced a pre-existing bug — f64 transcendentals emit invalid GLSL silently (tracked separately). WGSL: 6 skip-clean (naga absent on this host).

Vulkan runtime [PASS] on RX 7900 XTX (256 elements vs OCaml reference). PTX/CUDA/OpenCL/Metal generation paths untouched (no double-inlining); scalar tail-recursion e2e unchanged.

Pipeline (fast, maintainer-validated spec): implement → review GO → round-2 (alpha-capture + corpus sweep) → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GLSL and WGSL shader generation for recursive helpers that use vector parameters.
  * Added safer handling of variable-name conflicts during shader generation.
  * Added Vulkan coverage for recursive vector-parameter kernels.

* **Bug Fixes**
  * Prevented unsupported vector-parameter reassignment during tail recursion and provided clearer compilation errors.

* **Tests**
  * Added automated GLSL and WGSL validation checks, plus regression coverage for recursive vector helpers and invalid parameter swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->