### PR TITLE
test(e2e): document rusticl fp64 sqrt/div precision as a cited known issue

### DIFF
--- a/sarek/tests/e2e/test_float64_kernel_arith.ml
+++ b/sarek/tests/e2e/test_float64_kernel_arith.ml
@@ -147,6 +147,61 @@ let verify ~exact got_iters got_mag =
 let is_native (dev : Device.t) =
   dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
 
+(* KNOWN ISSUE — rusticl / Mesa fp64 (RUSTICL_FEATURES=fp64) is non-conformant:
+   fp64 +, -, * are computed at full double precision, but fp64 [sqrt] and
+   division are computed at only ~single precision. Measured directly with a
+   hand-written OpenCL C repro (attached in briefs/opencl-f64-while-loop-impl.md,
+   harness clprobe.c) on both rusticl devices (navi31 GPU + raphael CPU):
+
+       max rel err:  sqrt = 1.82e-08   1.0/v = 1.64e-08   v*v - v = 3.97e-16
+
+   The .cl repro also proves this is NOT a Sarek codegen artefact: the exact
+   emitted source (bare integer literals for the f64 constants, e.g. `4`, `2`)
+   and a variant with explicit double literals (`4.0`, `2.0`) produce
+   byte-identical output — C's int->double promotion is correct, and both match
+   Sarek's result exactly. Vulkan/RADV on the same GPU is exact, so this is a
+   rusticl driver limitation, not a bug in Sarek.
+
+   Effect on this kernel: the escape-loop condition uses only +, -, * and <=,
+   so iteration counts are EXACT on OpenCL; only the final sqrt(x^2 + y^2)
+   carries the ~1e-8 error. We therefore annotate the OpenCL result as a known
+   issue rather than a bare FAIL. A *real* regression still reports FAIL: wrong
+   iteration counts, or a magnitude error beyond the fp64-transcendental
+   envelope below, is NOT covered by this annotation. *)
+let opencl_fp64_transcendental_envelope = 1e-5
+
+(* Reporting-only detail: iteration mismatches (loop math, expected exact) and
+   the worst relative magnitude error (the sqrt-bearing output). *)
+let detailed_stats got_iters got_mag =
+  let iter_bad = ref 0 in
+  let max_rel = ref 0.0 in
+  for i = 0 to n - 1 do
+    let ref_iter, ref_mag = ocaml_reference (cx_of i) (cy_of i) in
+    if Int32.compare got_iters.(i) ref_iter <> 0 then incr iter_bad ;
+    let denom = Stdlib.abs_float ref_mag in
+    let ad = Stdlib.abs_float (got_mag.(i) -. ref_mag) in
+    let rel = if denom > 0.0 then ad /. denom else ad in
+    if rel > !max_rel then max_rel := rel
+  done ;
+  (!iter_bad, !max_rel)
+
+(* Status for a non-native device: PASS, the documented rusticl fp64 KNOWN-ISSUE,
+   or a genuine FAIL. *)
+let device_status (dev : Device.t) ~bad got_iters got_mag =
+  if bad = 0 then "PASS"
+  else
+    let iter_bad, max_rel = detailed_stats got_iters got_mag in
+    if
+      dev.Device.framework = "OpenCL"
+      && iter_bad = 0
+      && max_rel <= opencl_fp64_transcendental_envelope
+    then
+      Printf.sprintf
+        "KNOWN-ISSUE (rusticl fp64 sqrt/div ~single-precision; iters exact, \
+         mag max_rel=%.2g; see brief)"
+        max_rel
+    else "FAIL"
+
 let () =
   let _, kirc = f64_mandelbrot_kernel in
   let ir =
@@ -174,11 +229,15 @@ let () =
         try
           let got_iters, got_mag = run_on_device dev ir in
           let bad = verify ~exact:native got_iters got_mag in
+          let status =
+            if native then if bad = 0 then "PASS" else "FAIL"
+            else device_status dev ~bad got_iters got_mag
+          in
           Printf.printf
             "  %-10s %-24s %s (%d/%d ok)\n%!"
             dev.Device.framework
             dev.Device.name
-            (if bad = 0 then "PASS" else "FAIL")
+            status
             (n - bad)
             n ;
           if native then begin

--- a/sarek/tests/e2e/test_float64_kernel_arith.ml
+++ b/sarek/tests/e2e/test_float64_kernel_arith.ml
@@ -130,7 +130,10 @@ let verify ~exact got_iters got_mag =
     let ref_iter, ref_mag = ocaml_reference (cx_of i) (cy_of i) in
     let di = abs (Int32.to_int got_iters.(i) - Int32.to_int ref_iter) in
     let dm = Stdlib.abs_float (got_mag.(i) -. ref_mag) in
-    if di > iter_tol || dm > mag_tol then begin
+    (* A non-finite device magnitude must count as a mismatch: [dm > mag_tol]
+       is false for NaN, which would otherwise slip through both this check
+       and the KNOWN-ISSUE envelope. *)
+    if di > iter_tol || dm > mag_tol || not (Float.is_finite dm) then begin
       if !bad < 5 then
         Printf.printf
           "    mismatch @%d: iter got=%ld ref=%ld | mag got=%.15g ref=%.15g\n%!"
@@ -181,6 +184,9 @@ let detailed_stats got_iters got_mag =
     let denom = Stdlib.abs_float ref_mag in
     let ad = Stdlib.abs_float (got_mag.(i) -. ref_mag) in
     let rel = if denom > 0.0 then ad /. denom else ad in
+    (* [rel > !max_rel] is false for NaN — treat any non-finite deviation as
+       infinitely bad so it can never fit the KNOWN-ISSUE envelope. *)
+    let rel = if Float.is_finite rel then rel else Float.infinity in
     if rel > !max_rel then max_rel := rel
   done ;
   (!iter_bad, !max_rel)


### PR DESCRIPTION
Diagnosis of the 'f64 while-loop returns wrong values on OpenCL' report (3/64): NOT a Sarek codegen bug.

**Per-op probe evidence (T3):** on rusticl with `RUSTICL_FEATURES=fp64`, fp64 `+ − ×` are exact (rel ~4e-16) but `sqrt` and `/` only reach ~single precision (1.8e-08, 1.6e-08). The Mandelbrot loop's escape condition uses only exact ops — iteration counts match everywhere; only the final `sqrt(x²+y²)` drifts (worst 1.9e-06 after chaotic accumulation). Codegen cleared: a hand-written .cl with the exact emitted source and an explicit-double-literal variant produce byte-identical results; Vulkan/RADV on the same GPU is exact. Independently corroborated by test_real64's df64 fallback (Newton on exact ops) passing at 1e-15 while its native-f64 OpenCL path fails.

Fix: a cited KNOWN-ISSUE annotation with a TIGHT signature — only `framework=OpenCL && iter_bad=0 && max_rel ≤ 1e-5` reports known-issue; wrong iterations or larger drift still FAIL. No silent workaround; repro harnesses preserved.

Follow-up tracked: test_real64/* need the same annotation under the fp64 flag.

Pipeline (fast, diagnosis-first): implement → review GO → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved floating-point arithmetic test reporting for OpenCL devices.
  * Recognizes a known precision limitation in supported environments and labels it as a known issue instead of an outright failure when results remain within acceptable bounds.
  * Preserves failure reporting for unexpected iteration counts or errors beyond the accepted tolerance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->