### PR TITLE
test(e2e): annotate real64 OpenCL native-f64 rows with the cited rusticl known issue

### DIFF
--- a/sarek/tests/e2e/test_real64.ml
+++ b/sarek/tests/e2e/test_real64.ml
@@ -139,6 +139,45 @@ let tol_for ~(substrate : Real64.substrate) ~framework ~op =
       | "Vulkan", ("mul" | "div") -> f32_tol
       | _ -> base)
 
+(* KNOWN ISSUE - rusticl / Mesa fp64 (RUSTICL_FEATURES=fp64) is non-conformant:
+   fp64 +, -, * are computed at full double precision, but fp64 [sqrt] and
+   division are computed at only ~single precision. Measured directly with a
+   hand-written OpenCL C repro (briefs/opencl-f64-while-loop-impl.md, harness
+   clprobe.c) on both rusticl devices (navi31 GPU + raphael CPU):
+
+       max rel err:  sqrt = 1.82e-08   1.0/v = 1.64e-08   v*v - v = 3.97e-16
+
+   Vulkan/RADV on the same GPU is exact, so this is a rusticl driver limitation,
+   not a Sarek codegen artefact. Full evidence: PR #266 (test_float64_kernel_arith
+   carries the same annotation for its final sqrt).
+
+   Reachability here: WITHOUT the flag, OpenCL reports fp64=false and real64
+   selects the exact df64 fallback substrate - the default baseline never hits
+   this branch and is unaffected. WITH RUSTICL_FEATURES=fp64 the Native_f64
+   substrate is selected and only div/sqrt carry the ~1e-8 error; +, -, * stay
+   exact. We therefore annotate an OpenCL Native_f64 div/sqrt result whose
+   relative error is within the transcendental envelope below as a KNOWN-ISSUE
+   rather than a bare FAIL. A *real* regression still FAILs: add/sub/mul beyond
+   the f64 tolerance, a non-finite (NaN/inf) result - [rel_error]/[check] already
+   maps NaN to infinity so it can never fit the envelope - or the wrong substrate
+   being selected (Fallback_df64 is exact and is never annotated). *)
+let opencl_fp64_transcendental_envelope = 1e-5
+
+(* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
+   div/sqrt KNOWN-ISSUE (OpenCL + Native_f64 only, error inside the envelope), or
+   a genuine FAIL. *)
+let op_status ~(substrate : Real64.substrate) ~framework ~op ~err ~tol =
+  if err <= tol then `Pass
+  else
+    match substrate with
+    | Real64.Native_f64
+      when framework = "OpenCL"
+           && (op = "div" || op = "sqrt")
+           && Float.is_finite err
+           && err <= opencl_fp64_transcendental_envelope ->
+        `Known_issue
+    | _ -> `Fail
+
 (* ========== One pass on one device with one substrate ========== *)
 
 let failures = ref 0
@@ -211,14 +250,17 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
     (fun op ->
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
-      let ok = err <= tol in
-      if not ok then incr failures ;
+      let status = op_status ~substrate ~framework ~op ~err ~tol in
+      (match status with `Fail -> incr failures | `Pass | `Known_issue -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
         err
         tol
-        (if ok then "PASS" else "FAIL"))
+        (match status with
+        | `Pass -> "PASS"
+        | `Known_issue -> "KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+        | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 
 (* ========== Main ========== *)

--- a/sarek/tests/e2e/test_real64_single_source.ml
+++ b/sarek/tests/e2e/test_real64_single_source.ml
@@ -101,6 +101,45 @@ let tol_for ~(substrate : Real64.substrate) ~framework ~op =
       | "Vulkan", ("mul" | "div") -> f32_tol
       | _ -> base)
 
+(* KNOWN ISSUE - rusticl / Mesa fp64 (RUSTICL_FEATURES=fp64) is non-conformant:
+   fp64 +, -, * are computed at full double precision, but fp64 [sqrt] and
+   division are computed at only ~single precision. Measured directly with a
+   hand-written OpenCL C repro (briefs/opencl-f64-while-loop-impl.md, harness
+   clprobe.c) on both rusticl devices (navi31 GPU + raphael CPU):
+
+       max rel err:  sqrt = 1.82e-08   1.0/v = 1.64e-08   v*v - v = 3.97e-16
+
+   Vulkan/RADV on the same GPU is exact, so this is a rusticl driver limitation,
+   not a Sarek codegen artefact. Full evidence: PR #266 (test_float64_kernel_arith
+   carries the same annotation for its final sqrt).
+
+   Reachability here: WITHOUT the flag, OpenCL reports fp64=false and real64
+   selects the exact df64 fallback substrate - the default baseline never hits
+   this branch and is unaffected. WITH RUSTICL_FEATURES=fp64 the Native_f64
+   substrate is selected and only div/sqrt carry the ~1e-8 error; +, -, * stay
+   exact. We therefore annotate an OpenCL Native_f64 div/sqrt result whose
+   relative error is within the transcendental envelope below as a KNOWN-ISSUE
+   rather than a bare FAIL. A *real* regression still FAILs: add/sub/mul beyond
+   the f64 tolerance, a non-finite (NaN/inf) result - [rel_error]/[check] already
+   maps NaN to infinity so it can never fit the envelope - or the wrong substrate
+   being selected (Fallback_df64 is exact and is never annotated). *)
+let opencl_fp64_transcendental_envelope = 1e-5
+
+(* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
+   div/sqrt KNOWN-ISSUE (OpenCL + Native_f64 only, error inside the envelope), or
+   a genuine FAIL. *)
+let op_status ~(substrate : Real64.substrate) ~framework ~op ~err ~tol =
+  if err <= tol then `Pass
+  else
+    match substrate with
+    | Real64.Native_f64
+      when framework = "OpenCL"
+           && (op = "div" || op = "sqrt")
+           && Float.is_finite err
+           && err <= opencl_fp64_transcendental_envelope ->
+        `Known_issue
+    | _ -> `Fail
+
 (* ========== One pass on one device with one substrate ===================== *)
 
 let failures = ref 0
@@ -167,14 +206,17 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
     (fun op ->
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
-      let ok = err <= tol in
-      if not ok then incr failures ;
+      let status = op_status ~substrate ~framework ~op ~err ~tol in
+      (match status with `Fail -> incr failures | `Pass | `Known_issue -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
         err
         tol
-        (if ok then "PASS" else "FAIL"))
+        (match status with
+        | `Pass -> "PASS"
+        | `Known_issue -> "KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+        | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 
 (* ========== Main ========== *)


### PR DESCRIPTION
Follow-up from #266: under `RUSTICL_FEATURES=fp64`, both real64 e2e tests failed their OpenCL native-f64 rows (div 4.1e-08, sqrt 2.6e-08 — the documented rusticl fp64 sqrt/div ~single-precision driver bug) while being green in the default no-flag baseline (df64 fallback, exact).

Same tight-signature pattern as #266: `Known_issue` ONLY when OpenCL ∧ Native_f64 substrate ∧ op ∈ {div,sqrt} ∧ finite ∧ ≤1e-5; add/sub/mul beyond f64 tolerance, non-finite, other frameworks/substrates still FAIL. Default baseline byte-identical (the branch is unreachable without the flag).

Note: the transient `test_static_tag_erasure` Vulkan segfault reported during development was verified NOT reproducible on main (6/6 clean runs) — RADV flakiness under concurrent multi-process GPU load, tracked informally.

Pipeline (express): implement → review GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated fp64 validation reporting to recognize documented OpenCL rusticl/Mesa discrepancies for division and square-root operations.
  * Known discrepancies are now clearly labeled and do not cause test runs to fail, while other out-of-tolerance results continue to be reported as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->