### PR TITLE
feat(spoc): Tier 1c — user-facing SoA vectors (Soa_vector + run_soa)

### DIFF
--- a/benchmarks/bench_soa_emitter.ml
+++ b/benchmarks/bench_soa_emitter.ml
@@ -27,7 +27,7 @@
 module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 module Transfer = Spoc_core.Transfer
-module Soa = Spoc_core.Soa
+module Soa_vector = Spoc_core.Soa_vector
 open Sarek_codegen
 
 type ('a, 'b) vector = ('a, 'b) Vector.t
@@ -84,8 +84,6 @@ let fields =
       ("f7", TFloat32);
     ]
 
-let plan = Soa.plan ~name:"wide" fields
-
 let is_ptx (dev : Device.t) = dev.Device.framework = "CUDA/PTX"
 
 (* Median wall time (ms) of [launch] over [iters], after [warmup] launches. *)
@@ -104,12 +102,14 @@ let run dev n =
   let block = Sarek.Execute.dims1d threads in
   let grid = Sarek.Execute.dims1d ((n + threads - 1) / threads) in
   let ir = ir_of kernel in
-  (* AoS source. *)
-  let pts = Vector.create_custom wide_custom n in
+  (* Storage via the real user-facing SoA API (Tier 1c). The SoA vector owns
+     the AoS host buffer (used for the AoS leg) + the N per-leaf buffers. *)
+  let sv = Soa_vector.create wide_custom ~fields n in
+  let pts = Soa_vector.aos_vector sv in
   for i = 0 to n - 1 do
     let v = float_of_int i in
-    Vector.set
-      pts
+    Soa_vector.set
+      sv
       i
       {f0 = v; f1 = v; f2 = v; f3 = v; f4 = v; f5 = v; f6 = v; f7 = v}
   done ;
@@ -128,20 +128,23 @@ let run dev n =
           () ;
         Transfer.flush dev)
   in
-  (* SoA emitter: 8 per-leaf buffers (only f0 read), driven through the emitted
-     N-pointer ABI. *)
-  let leaves = Array.init 8 (fun _ -> Vector.create Vector.float32 n) in
-  Soa.scatter
-    plan
-    ~aos:(Vector.to_ctypes_ptr pts)
-    ~length:n
-    ~leaves:(Array.map Vector.to_ctypes_ptr leaves) ;
+  (* SoA emitter: the SoA vector's 8 per-leaf buffers (only f0 read), driven
+     through the emitted N-pointer ABI. Scatter + leaf transfer are hoisted out
+     of the timed loop (amortised, exactly as the AoS leg's packed transfer is),
+     so the measurement isolates the kernel's coalescing win. The end-to-end
+     Soa_launch.run_soa path is covered in tests/e2e/test_soa_emitter_equiv. *)
+  Soa_vector.scatter sv ;
+  let leaf_args =
+    Array.to_list
+      (Array.map
+         (fun (Soa_vector.Leaf v) -> Sarek.Execute.Vec v)
+         (Soa_vector.leaves sv))
+  in
   let out_s = Vector.create Vector.float32 n in
   let ptx = Sarek_ir_ptx.generate ~soa_params:["pts"] ir in
   let len = Sarek.Execute.Int32 (Int32.of_int n) in
   let soa_args =
-    Array.to_list (Array.map (fun v -> Sarek.Execute.Vec v) leaves)
-    @ [len; Sarek.Execute.Vec out_s; len; Sarek.Execute.Int n]
+    leaf_args @ [len; Sarek.Execute.Vec out_s; len; Sarek.Execute.Int n]
   in
   let t_soa =
     time (fun () ->

--- a/sarek-cuda/Cuda_c_plugin.ml
+++ b/sarek-cuda/Cuda_c_plugin.ml
@@ -33,7 +33,8 @@ module Backend : Framework_sig.BACKEND = struct
      node. That error is allowed to PROPAGATE so callers surface the name rather
      than the opaque "generate_source returned None" — catching it here and
      returning [None] hid it identically to the Vulkan swallow (PR #259). *)
-  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+      string option =
     Some (Sarek_ir_cuda.generate_with_types ~types:ir.kern_types ir)
 
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =

--- a/sarek-cuda/Cuda_c_plugin.ml
+++ b/sarek-cuda/Cuda_c_plugin.ml
@@ -33,7 +33,7 @@ module Backend : Framework_sig.BACKEND = struct
      node. That error is allowed to PROPAGATE so callers surface the name rather
      than the opaque "generate_source returned None" — catching it here and
      returning [None] hid it identically to the Vulkan swallow (PR #259). *)
-  let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
     Some (Sarek_ir_cuda.generate_with_types ~types:ir.kern_types ir)
 
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =

--- a/sarek-cuda/Cuda_ptx_plugin.ml
+++ b/sarek-cuda/Cuda_ptx_plugin.ml
@@ -34,8 +34,9 @@ module Backend : Framework_sig.BACKEND = struct
      IR node) is allowed to PROPAGATE so callers surface it, rather than being
      converted to [None] and re-raised by Execute as the opaque
      "generate_source returned None" with the detail lost (PR #259). *)
-  let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
-    Some (Sarek_ir_ptx.generate_with_types ~types:ir.kern_types ir)
+  let generate_source ?block:_ ?(soa_params = []) (ir : Sarek_ir_types.kernel) :
+      string option =
+    Some (Sarek_ir_ptx.generate_with_types ~types:ir.kern_types ~soa_params ir)
 
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =
     Cuda_error.raise_error

--- a/sarek-metal/Metal_plugin.ml
+++ b/sarek-metal/Metal_plugin.ml
@@ -180,7 +180,7 @@ module Backend : Framework_sig.BACKEND = struct
       None" (PR #259 review); a blanket [try ... with _ -> None] previously
       swallowed it. Codegen never legitimately declines a kernel by returning
       [None]. *)
-  let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
     let source = Sarek_ir_metal.generate_with_types ~types:ir.kern_types ir in
     Spoc_core.Log.debug Kernel ("Metal source:\n" ^ source) ;
     Some source

--- a/sarek-metal/Metal_plugin.ml
+++ b/sarek-metal/Metal_plugin.ml
@@ -180,7 +180,8 @@ module Backend : Framework_sig.BACKEND = struct
       None" (PR #259 review); a blanket [try ... with _ -> None] previously
       swallowed it. Codegen never legitimately declines a kernel by returning
       [None]. *)
-  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+      string option =
     let source = Sarek_ir_metal.generate_with_types ~types:ir.kern_types ir in
     Spoc_core.Log.debug Kernel ("Metal source:\n" ^ source) ;
     Some source

--- a/sarek-opencl/Opencl_plugin.ml
+++ b/sarek-opencl/Opencl_plugin.ml
@@ -187,7 +187,8 @@ module Backend : Framework_sig.BACKEND = struct
       returned None" (PR #259 review); a blanket [try ... with _ -> None]
       previously swallowed it. Codegen never legitimately declines a kernel by
       returning [None]. *)
-  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+      string option =
     let source = Sarek_ir_opencl.generate_with_types ~types:ir.kern_types ir in
     (* Add FP64 pragma if kernel uses double precision *)
     let source =

--- a/sarek-opencl/Opencl_plugin.ml
+++ b/sarek-opencl/Opencl_plugin.ml
@@ -187,7 +187,7 @@ module Backend : Framework_sig.BACKEND = struct
       returned None" (PR #259 review); a blanket [try ... with _ -> None]
       previously swallowed it. Codegen never legitimately declines a kernel by
       returning [None]. *)
-  let generate_source ?block:_ (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
     let source = Sarek_ir_opencl.generate_with_types ~types:ir.kern_types ir in
     (* Add FP64 pragma if kernel uses double precision *)
     let source =

--- a/sarek-vulkan/Vulkan_plugin.ml
+++ b/sarek-vulkan/Vulkan_plugin.ml
@@ -187,7 +187,8 @@ module Backend : Framework_sig.BACKEND = struct
       it, and Execute then raised the opaque "generate_source returned None"
       with the name lost (PR #259 review). This function therefore always
       returns [Some _] on success. *)
-  let generate_source ?block ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+      string option =
     let block_tuple =
       match block with
       | Some b -> Some (b.Framework_sig.x, b.Framework_sig.y, b.Framework_sig.z)

--- a/sarek-vulkan/Vulkan_plugin.ml
+++ b/sarek-vulkan/Vulkan_plugin.ml
@@ -187,7 +187,7 @@ module Backend : Framework_sig.BACKEND = struct
       it, and Execute then raised the opaque "generate_source returned None"
       with the name lost (PR #259 review). This function therefore always
       returns [Some _] on success. *)
-  let generate_source ?block (ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block ?soa_params:_ (ir : Sarek_ir_types.kernel) : string option =
     let block_tuple =
       match block with
       | Some b -> Some (b.Framework_sig.x, b.Framework_sig.y, b.Framework_sig.z)

--- a/sarek/codegen/Sarek_ir_ptx_kernel.ml
+++ b/sarek/codegen/Sarek_ir_ptx_kernel.ml
@@ -70,10 +70,11 @@ let soa_leaves_of_param param_name (elt : elttype) : (string * elttype) list =
 
     [~soa_params] lists vector parameters to lower as Structure-of-Arrays: each
     such custom (record) vector expands to one [.param .u64] base pointer per
-    scalar leaf (named [param_<name>_soa_<field>]) followed by the shared
-    [.param .u32 param_sarek_<name>_length], instead of the single AoS
-    [(ptr, length)] pair. The N leaf base registers are recorded in
-    [alloc.arr_soa] for the element load/store paths. Parameters absent from
+    scalar leaf (named [param_sarek_soa_<name>_<field>], in the reserved
+    [sarek_] namespace so it can never alias a user parameter's generated name)
+    followed by the shared [.param .u32 param_sarek_<name>_length], instead of
+    the single AoS [(ptr, length)] pair. The N leaf base registers are recorded
+    in [alloc.arr_soa] for the element load/store paths. Parameters absent from
     [~soa_params] are unchanged (packed AoS). *)
 let emit_params buf alloc (env : env) ~(soa_params : string list)
     (params : decl list) : string =
@@ -117,7 +118,7 @@ let emit_params buf alloc (env : env) ~(soa_params : string list)
                     Buffer.add_string
                       param_decls
                       (Printf.sprintf
-                         "    .param .u64 param_%s_soa_%s"
+                         "    .param .u64 param_sarek_soa_%s_%s"
                          v.var_name
                          field))
                   leaves ;
@@ -130,7 +131,7 @@ let emit_params buf alloc (env : env) ~(soa_params : string list)
                       let r = new_u64 alloc in
                       emit
                         buf
-                        "ld.param.u64 %s, [param_%s_soa_%s];"
+                        "ld.param.u64 %s, [param_sarek_soa_%s_%s];"
                         r
                         v.var_name
                         field ;

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -1,0 +1,73 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* See Soa_vector.mli for the design rationale. *)
+
+type packed_leaf = Leaf : ('e, 'f) Vector.t -> packed_leaf
+
+type 'a t = {
+  aos : ('a, unit) Vector.t;
+  plan : Soa.plan;
+  leaves : packed_leaf array;
+  length : int;
+}
+
+(* A leaf host buffer is a bit-preserving byte transport sized to the leaf's
+   scalar width; Soa.scatter/gather copy raw 4/8-byte words, so an int32/int64
+   scalar vector of the right width is a correct container for any leaf type
+   (f32/f64/i32/i64). *)
+let leaf_vector_of_size length size : packed_leaf =
+  match size with
+  | 4 -> Leaf (Vector.create Vector.int32 length)
+  | 8 -> Leaf (Vector.create Vector.int64 length)
+  | _ ->
+      invalid_arg
+        (Printf.sprintf
+           "Soa_vector: unsupported leaf byte size %d (expected 4 or 8)"
+           size)
+
+let create (custom : 'a Vector.custom_type)
+    ~(fields : (string * Sarek_ir_types.elttype) list) (length : int) : 'a t =
+  let plan = Soa.plan ~name:custom.Vector.name fields in
+  let aos = Vector.create_custom custom length in
+  let leaves =
+    Array.of_list
+      (List.map
+         (fun (l : Soa.leaf) -> leaf_vector_of_size length l.Soa.size)
+         plan.Soa.leaves)
+  in
+  {aos; plan; leaves; length}
+
+let aos_vector t = t.aos
+
+let plan t = t.plan
+
+let leaves t = t.leaves
+
+let num_leaves t = Array.length t.leaves
+
+let length t = t.length
+
+let set t i v = Vector.set t.aos i v
+
+let get t i = Vector.get t.aos i
+
+let leaf_ptrs t = Array.map (fun (Leaf v) -> Vector.to_ctypes_ptr v) t.leaves
+
+let scatter t =
+  (* Make the AoS host copy authoritative before transposing out of it. *)
+  Vector.ensure_cpu_sync t.aos ;
+  Soa.scatter
+    t.plan
+    ~aos:(Vector.to_ctypes_ptr t.aos)
+    ~length:t.length
+    ~leaves:(leaf_ptrs t)
+
+let gather t =
+  Soa.gather
+    t.plan
+    ~leaves:(leaf_ptrs t)
+    ~length:t.length
+    ~aos:(Vector.to_ctypes_ptr t.aos)

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -20,7 +20,7 @@
  *
  * The device-side consumption (lowering [pts.(i).x] to N base pointers +
  * coalesced scalar loads) is the #260 PTX emitter; the launch that binds these
- * N leaf buffers as that ABI is {!Sarek.Execute.run_soa}, which is CUDA/PTX
+ * N leaf buffers as that ABI is {!Sarek.Soa_launch.run_soa}, which is CUDA/PTX
  * only. This module is pure host storage + transpose and is backend-agnostic.
  *
  * This is deliberately layered above {!Vector} + {!Soa} rather than being a new

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -41,9 +41,19 @@ type 'a t
 
 (** [create custom ~fields length] builds a SoA custom vector of [length]
     elements. [custom] is the PPX-generated custom type (the AoS source of
-    truth); [fields] is the record's field layout [(name, scalar type)] in
-    declaration order (the [custom_type] does not carry it, so it must be
-    supplied). Raises {!Soa.Unsupported} if [fields] is not a flat record. *)
+    truth); [fields] is the record's field layout [(name, scalar type)].
+
+    {b Precondition — [fields] MUST match the record's declaration order and
+       types exactly.} The [custom_type] carries no layout, so this cannot be
+    checked: [fields] is the sole description of how the packed AoS element is
+    split into leaves. If it disagrees with the actual record layout (wrong
+    order, wrong widths, missing/extra field), {!scatter}/{!gather} transpose
+    against the wrong byte offsets and the vector carries
+    {e silently transposed / corrupted} data with no error. Pass exactly the
+    fields the [[@@sarek.type]] record declares, in order — the same list the
+    kernel IR's [TRecord] uses.
+
+    Raises {!Soa.Unsupported} if [fields] is not a flat record. *)
 val create :
   'a Vector.custom_type ->
   fields:(string * Sarek_ir_types.elttype) list ->

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -1,0 +1,84 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * User-facing Structure-of-Arrays (SoA) custom-vector storage — Tier 1c host
+ * half.
+ *
+ * Opt-in SoA storage for a custom (flat-record) vector. Bundles:
+ *   - an ordinary AoS custom {!Vector.t} as the host source of truth (so the
+ *     full existing Vector host API — get/set/PPX accessors — works unchanged);
+ *   - a {!Soa.plan} (the leaf enumeration reused from Tier 1a);
+ *   - N per-leaf host buffers, each a width-matched scalar {!Vector.t} used as a
+ *     bit-preserving byte transport (4-byte leaf -> int32 vector, 8-byte leaf ->
+ *     int64 vector; the logical leaf type is irrelevant because
+ *     {!Soa.scatter}/{!Soa.gather} copy raw words). Each leaf is therefore an
+ *     ordinary scalar vector reusing the existing scalar transfer/allocation
+ *     path — no new backend or codegen support needed on the host side.
+ *
+ * The device-side consumption (lowering [pts.(i).x] to N base pointers +
+ * coalesced scalar loads) is the #260 PTX emitter; the launch that binds these
+ * N leaf buffers as that ABI is {!Sarek.Execute.run_soa}, which is CUDA/PTX
+ * only. This module is pure host storage + transpose and is backend-agnostic.
+ *
+ * This is deliberately layered above {!Vector} + {!Soa} rather than being a new
+ * constructor on the core [host_storage] GADT: the PPX [custom_type] carries no
+ * record layout (so the field list must be supplied here), and a fully
+ * transparent [Vector.create ~layout:SoA] + generic [Execute.run] auto-dispatch
+ * would additionally require threading SoA param names through every backend and
+ * generalising the 1-buffer-per-device table — deferred (see
+ * docs/optimization/tier1b-emitter-soa-handoff.md and the impl brief).
+ ******************************************************************************)
+
+(** A per-leaf host buffer, type-erased: a width-matched scalar vector used as a
+    bit-preserving byte transport for one SoA leaf. *)
+type packed_leaf = Leaf : ('e, 'f) Vector.t -> packed_leaf
+
+(** A SoA custom vector of element type ['a]. *)
+type 'a t
+
+(** [create custom ~fields length] builds a SoA custom vector of [length]
+    elements. [custom] is the PPX-generated custom type (the AoS source of
+    truth); [fields] is the record's field layout [(name, scalar type)] in
+    declaration order (the [custom_type] does not carry it, so it must be
+    supplied). Raises {!Soa.Unsupported} if [fields] is not a flat record. *)
+val create :
+  'a Vector.custom_type ->
+  fields:(string * Sarek_ir_types.elttype) list ->
+  int ->
+  'a t
+
+(** The AoS host vector (source of truth). Use it for the non-PTX host fallback
+    (drive it through the ordinary {!Sarek.Execute.run_vectors} AoS path). *)
+val aos_vector : 'a t -> ('a, unit) Vector.t
+
+(** The SoA storage plan (leaf enumeration + AoS stride). *)
+val plan : 'a t -> Soa.plan
+
+(** The N per-leaf host buffers, in {!Soa.plan} leaf (record declaration) order.
+*)
+val leaves : 'a t -> packed_leaf array
+
+(** Number of scalar leaves (= number of base pointers a kernel launch binds).
+*)
+val num_leaves : 'a t -> int
+
+(** Number of elements. *)
+val length : 'a t -> int
+
+(** [set t i v] / [get t i] delegate to the AoS host vector (the source of
+    truth). *)
+val set : 'a t -> int -> 'a -> unit
+
+val get : 'a t -> int -> 'a
+
+(** [scatter t] transposes the AoS host buffer into the N per-leaf host buffers
+    (call before transferring the leaves to a device). Ensures the AoS host copy
+    is current first. *)
+val scatter : 'a t -> unit
+
+(** [gather t] transposes the N per-leaf host buffers back into the AoS host
+    buffer (call after reading leaves back from a device that wrote them). *)
+val gather : 'a t -> unit

--- a/sarek/core/dune
+++ b/sarek/core/dune
@@ -23,6 +23,7 @@
   Vector_transfer
   Vector
   Soa
+  Soa_vector
   Gpu_memory
   Transfer
   Profiling

--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -82,6 +82,19 @@ let rs_args_of_reg (a : Execute.vector_arg) (dev : Device.t) :
 
 (** Execute a kernel with SoA-lowered custom-vector arguments.
 
+    {b Host coherence contract.} The AoS host buffer of each SoA vector is the
+    source of truth. [run_soa] calls {!Spoc_core.Soa_vector.scatter} internally
+    (AoS host -> per-leaf host -> device) immediately before launch, so there is
+    no user-visible window between scatter and launch and host [set]s made
+    before the call are always reflected on the device. For a kernel that only
+    {e reads} SoA leaves nothing more is needed. For a kernel that {e writes} an
+    SoA leaf, the device-side leaf buffers become authoritative; to observe the
+    result through the AoS vector the caller must round-trip explicitly:
+    transfer each leaf back to the host (e.g. {!Spoc_core.Transfer.to_cpu} on
+    every {!Spoc_core.Soa_vector.leaves} entry — [run_soa] marks them stale so
+    this triggers a D2H copy) and then call {!Spoc_core.Soa_vector.gather}
+    (per-leaf host -> AoS host). [run_soa] never gathers automatically.
+
     @param device Target device (must be a CUDA/PTX backend)
     @param ir Sarek IR kernel definition
     @param args Kernel arguments (SoA vectors + regular args) in param order

--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -1,0 +1,180 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Structure-of-Arrays (SoA) kernel launch — Tier 1c.
+ *
+ * Launches a Sarek kernel with one or more custom (flat-record) vector
+ * arguments lowered as Structure-of-Arrays: each such argument binds N per-leaf
+ * base pointers + one shared length (the #260 PTX emitter ABI) instead of a
+ * single packed AoS (pointer, length) pair.
+ *
+ * SoA lowering is CUDA/PTX-only (the #260 emitter path). {!run_soa} raises a
+ * located error on any non-PTX backend rather than binding the SoA N-pointer
+ * ABI to an AoS kernel signature (which would read wrong data), so it can never
+ * produce incorrect results. For a non-PTX device, drive the AoS host vector
+ * ({!Spoc_core.Soa_vector.aos_vector}) through {!Execute.run_vectors} instead.
+ *
+ * This lives in a separate module (not Execute.ml) because Execute.ml is copied
+ * verbatim into the ctypes-free jsoo smoke target, whose Spoc_core shim has no
+ * Soa/Soa_vector. Keeping the SoA launch here confines the Soa_vector
+ * dependency to the native library.
+ ******************************************************************************)
+
+open Spoc_framework
+open Spoc_framework_registry
+open Spoc_core
+open Execute_error
+
+(** An argument to {!run_soa}: either a regular {!Execute.vector_arg}, or a SoA
+    custom vector (lowered in place to its N leaf base pointers + shared
+    length). *)
+type soa_arg =
+  | SA_Soa : 'a Soa_vector.t -> soa_arg
+  | SA_Reg of Execute.vector_arg
+
+(** Names of the kernel's [DParam]s, in declaration order. *)
+let kernel_param_names (ir : Sarek_ir_types.kernel) : string list =
+  List.filter_map
+    (function
+      | Sarek_ir_types.DParam (v, _) -> Some v.Sarek_ir_types.var_name
+      | _ -> None)
+    ir.Sarek_ir_types.kern_params
+
+(** [run_source_arg]s for one regular vector: (buffer, length). *)
+let rs_args_of_reg_vector (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
+    Framework_sig.run_source_arg list =
+  let (module B : Vector.DEVICE_BUFFER) = Execute.get_device_buffer v dev in
+  let len = Vector.length v in
+  [
+    Framework_sig.RSA_Buffer {binder = B.bind_to_kargs; length = len};
+    Framework_sig.RSA_Vector_Length (Int32.of_int len);
+  ]
+
+(** [run_source_arg]s for a SoA vector: N leaf base pointers (leaf order)
+    followed by one shared [RSA_Vector_Length]. *)
+let rs_args_of_soa_vector (sv : 'a Soa_vector.t) (dev : Device.t) :
+    Framework_sig.run_source_arg list =
+  let len = Soa_vector.length sv in
+  let leaf_args =
+    Array.to_list
+      (Array.map
+         (fun (Soa_vector.Leaf v) ->
+           let (module B : Vector.DEVICE_BUFFER) =
+             Execute.get_device_buffer v dev
+           in
+           Framework_sig.RSA_Buffer {binder = B.bind_to_kargs; length = len})
+         (Soa_vector.leaves sv))
+  in
+  leaf_args @ [Framework_sig.RSA_Vector_Length (Int32.of_int len)]
+
+let rs_args_of_reg (a : Execute.vector_arg) (dev : Device.t) :
+    Framework_sig.run_source_arg list =
+  match a with
+  | Execute.Vec v -> rs_args_of_reg_vector v dev
+  | Execute.Int n -> [Framework_sig.RSA_Int32 (Int32.of_int n)]
+  | Execute.Int32 n -> [Framework_sig.RSA_Int32 n]
+  | Execute.Int64 n -> [Framework_sig.RSA_Int64 n]
+  | Execute.Float32 f -> [Framework_sig.RSA_Float32 f]
+  | Execute.Float64 f -> [Framework_sig.RSA_Float64 f]
+
+(** Execute a kernel with SoA-lowered custom-vector arguments.
+
+    @param device Target device (must be a CUDA/PTX backend)
+    @param ir Sarek IR kernel definition
+    @param args Kernel arguments (SoA vectors + regular args) in param order
+    @param block Thread block dimensions
+    @param grid Grid dimensions
+    @param shared_mem Optional shared memory size in bytes (default: 0)
+    @raise Execute_error on a non-PTX device or a codegen/launch failure *)
+let run_soa ~(device : Device.t) ~(ir : Sarek_ir_types.kernel)
+    ~(args : soa_arg list) ~(block : Framework_sig.dims)
+    ~(grid : Framework_sig.dims) ?(shared_mem : int = 0) () : unit =
+  match Framework_registry.find_backend device.framework with
+  | None ->
+      raise_error
+        (Backend_error
+           {
+             backend = device.framework;
+             message = "Backend not found in registry";
+           })
+  | Some (module B : Framework_sig.BACKEND) ->
+      (* Gate: SoA lowering is PTX-only. Never emit the SoA N-pointer ABI for a
+         backend that generates AoS code. *)
+      if not (List.mem Framework_sig.PTX B.supported_source_langs) then
+        raise_error
+          (Unsupported_argument
+             {
+               arg_type = "SoA custom vector";
+               context =
+                 device.framework
+                 ^ " backend: SoA lowering requires a CUDA/PTX device (drive \
+                    the AoS host vector through run_vectors for other \
+                    backends)";
+             }) ;
+      (* SoA parameter names = kernel param name at each SA_Soa position. *)
+      let param_names = kernel_param_names ir in
+      let soa_params =
+        List.filteri
+          (fun i _ ->
+            match List.nth_opt args i with
+            | Some (SA_Soa _) -> true
+            | _ -> false)
+          param_names
+      in
+      (* Generate SoA-lowered source through the backend (keeps Execute
+         codegen-free; only the CUDA/PTX backend honours ~soa_params). *)
+      let source =
+        match B.generate_source ~block ~soa_params ir with
+        | Some s -> s
+        | None ->
+            raise_error
+              (Compilation_failed
+                 {
+                   kernel = ir.Sarek_ir_types.kern_name;
+                   reason = device.framework ^ ": generate_source returned None";
+                 })
+      in
+      (* Host->device: scatter each SoA vector into its leaves and transfer
+         every leaf; transfer regular vectors. *)
+      List.iter
+        (function
+          | SA_Soa sv ->
+              Soa_vector.scatter sv ;
+              Array.iter
+                (fun (Soa_vector.Leaf v) -> Transfer.to_device v device)
+                (Soa_vector.leaves sv)
+          | SA_Reg (Execute.Vec v) -> Transfer.to_device v device
+          | SA_Reg _ -> ())
+        args ;
+      (* Build the run_source args in parameter order. *)
+      let rs_args =
+        List.concat_map
+          (function
+            | SA_Soa sv -> rs_args_of_soa_vector sv device
+            | SA_Reg a -> rs_args_of_reg a device)
+          args
+      in
+      let dev = B.Device.get device.backend_id in
+      B.Device.set_current dev ;
+      B.run_source
+        ~source
+        ~lang:Framework_sig.PTX
+        ~kernel_name:ir.Sarek_ir_types.kern_name
+        ~block
+        ~grid
+        ~shared_mem
+        rs_args ;
+      (* Mark device-authoritative vectors stale on CPU (regular outputs and any
+         SoA leaves the kernel may have written). *)
+      List.iter
+        (function
+          | SA_Reg a -> Execute.mark_vectors_stale [a] device
+          | SA_Soa sv ->
+              Array.iter
+                (fun (Soa_vector.Leaf v) ->
+                  Execute.mark_vectors_stale [Execute.Vec v] device)
+                (Soa_vector.leaves sv))
+        args

--- a/sarek/execute/dune
+++ b/sarek/execute/dune
@@ -15,7 +15,7 @@
   sarek_ir
   sarek_registry
   sarek_interp)
- (modules Execute Execute_error)
+ (modules Execute Execute_error Soa_launch)
  (preprocess no_preprocessing)
  (instrumentation
   (backend bisect_ppx)))

--- a/sarek/framework/test/dummy_backend.ml
+++ b/sarek/framework/test/dummy_backend.ml
@@ -25,7 +25,7 @@ module Dummy_backend : BACKEND = struct
 
   let supported_source_langs = []
 
-  let generate_source ?block:_ _ir = None
+  let generate_source ?block:_ ?soa_params:_ _ir = None
 
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args = ()
 

--- a/sarek/plugins/interpreter/Interpreter_plugin.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin.ml
@@ -73,7 +73,8 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.Custom
 
   (** Generate source - not used for Interpreter (returns None) *)
-  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) :
+      string option =
     None
 
   (** Execute directly by interpreting the IR. Interpreter always interprets,

--- a/sarek/plugins/interpreter/Interpreter_plugin.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin.ml
@@ -73,7 +73,7 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.Custom
 
   (** Generate source - not used for Interpreter (returns None) *)
-  let generate_source ?block:_ (_ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) : string option =
     None
 
   (** Execute directly by interpreting the IR. Interpreter always interprets,

--- a/sarek/plugins/native/Native_plugin.ml
+++ b/sarek/plugins/native/Native_plugin.ml
@@ -154,7 +154,7 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.Direct
 
   (** Generate source - not used for Direct backend *)
-  let generate_source ?block:_ (_ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) : string option =
     None
 
   (** Convert exec_arg to native_arg for typed native function *)

--- a/sarek/plugins/native/Native_plugin.ml
+++ b/sarek/plugins/native/Native_plugin.ml
@@ -154,7 +154,8 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.Direct
 
   (** Generate source - not used for Direct backend *)
-  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) :
+      string option =
     None
 
   (** Convert exec_arg to native_arg for typed native function *)

--- a/sarek/plugins/webgpu/Webgpu_plugin.ml
+++ b/sarek/plugins/webgpu/Webgpu_plugin.ml
@@ -160,7 +160,7 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.JIT
 
   (** Generate source - WGSL codegen not yet wired; returns None *)
-  let generate_source ?block:_ (_ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) : string option =
     None
 
   (** Direct execution not applicable to JIT backend *)

--- a/sarek/plugins/webgpu/Webgpu_plugin.ml
+++ b/sarek/plugins/webgpu/Webgpu_plugin.ml
@@ -160,7 +160,8 @@ module Backend : Framework_sig.BACKEND = struct
   let execution_model = Framework_sig.JIT
 
   (** Generate source - WGSL codegen not yet wired; returns None *)
-  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) : string option =
+  let generate_source ?block:_ ?soa_params:_ (_ir : Sarek_ir_types.kernel) :
+      string option =
     None
 
   (** Direct execution not applicable to JIT backend *)

--- a/sarek/sarek/Soa_launch.ml
+++ b/sarek/sarek/Soa_launch.ml
@@ -1,0 +1,6 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+(** Forwarding alias: Sarek.Soa_launch → Sarek_execute.Soa_launch *)
+include Sarek_execute.Soa_launch

--- a/sarek/sarek/dune
+++ b/sarek/sarek/dune
@@ -37,6 +37,7 @@
   Interp_error
   Sarek_type_helpers
   Execute
-  Execute_error)
+  Execute_error
+  Soa_launch)
  (instrumentation
   (backend bisect_ppx)))

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -44,7 +44,10 @@ type float32 = float
 
 type float64 = float
 
-type point3d = {x : float32; y : float32; z : float32} [@@sarek.type]
+(* Fields mutable so the round-trip kernel can write a leaf in place
+   (pts.(i).y <- ...); the read legs are unaffected. *)
+type point3d = {mutable x : float32; mutable y : float32; mutable z : float32}
+[@@sarek.type]
 
 type dpair = {u : float64; v : float64} [@@sarek.type]
 
@@ -65,6 +68,15 @@ let dpair_kernel =
       fun (pv : dpair vector) (out : float64 vector) (n : int32) ->
         let tid = thread_idx_x + (block_idx_x * block_dim_x) in
         if tid < n then out.(tid) <- pv.(tid).u +. pv.(tid).v]
+
+(* Write case: scales the y leaf in place. Exercises the SoA field STORE path
+   (D2H leaf readback + gather round-trip on the host side). *)
+let p3_scale_y_kernel =
+  snd
+    [%kernel
+      fun (pts : point3d vector) (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then pts.(tid).y <- pts.(tid).y *. 2.0]
 
 let ir_of kirc =
   match kirc.Sarek.Kirc_types.body_ir with
@@ -358,6 +370,87 @@ let check_gate dev =
         true
   end
 
+(* Round-trip: a kernel WRITES the y leaf on the device; then we transfer each
+   leaf back (D2H) and gather into the AoS vector, and check the AoS y values.
+   Exercises the leaf-writeback + Soa_vector.gather path (no other shipped test
+   writes an SoA leaf). CUDA/PTX only. *)
+let check_roundtrip dev n =
+  if not (is_ptx dev) then true
+  else begin
+    Printf.printf
+      "SoA-roundtrip [%s] %s: %!"
+      dev.Device.framework
+      dev.Device.name ;
+    try
+      let threads = min 128 n in
+      let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+      let sv =
+        Soa_vector.create
+          point3d_custom
+          ~fields:
+            Sarek_ir_types.[("x", TFloat32); ("y", TFloat32); ("z", TFloat32)]
+          n
+      in
+      let orig i =
+        {
+          x = float_of_int i;
+          y = (float_of_int i *. 0.5) +. 1.0;
+          z = float_of_int (n - i);
+        }
+      in
+      for i = 0 to n - 1 do
+        Soa_vector.set sv i (orig i)
+      done ;
+      let ir = ir_of p3_scale_y_kernel in
+      Soa_launch.run_soa
+        ~device:dev
+        ~ir
+        ~args:[Soa_launch.SA_Soa sv; Soa_launch.SA_Reg (Sarek.Execute.Int n)]
+        ~block
+        ~grid
+        () ;
+      (* Device wrote the y leaf; round-trip explicitly per the run_soa
+         contract: D2H every leaf, then gather back into the AoS vector. *)
+      Array.iter
+        (fun (Soa_vector.Leaf v) -> Transfer.to_cpu ~force:true v)
+        (Soa_vector.leaves sv) ;
+      Soa_vector.gather sv ;
+      let ok = ref true in
+      for i = 0 to n - 1 do
+        let got = Soa_vector.get sv i in
+        let o = orig i in
+        (* y doubled; x and z untouched. *)
+        if
+          abs_float (got.y -. (o.y *. 2.0)) > 1e-3
+          || abs_float (got.x -. o.x) > 1e-3
+          || abs_float (got.z -. o.z) > 1e-3
+        then begin
+          ok := false ;
+          if i < 5 then
+            Printf.printf
+              "\n\
+              \  roundtrip mismatch @%d: got {x=%f;y=%f;z=%f} expected \
+               {x=%f;y=%f;z=%f}%!"
+              i
+              got.x
+              got.y
+              got.z
+              o.x
+              (o.y *. 2.0)
+              o.z
+        end
+      done ;
+      if !ok then (
+        Printf.printf "PASSED\n%!" ;
+        true)
+      else (
+        Printf.printf "FAILED\n%!" ;
+        false)
+    with e ->
+      Printf.printf "FAIL (%s)\n%!" (Printexc.to_string e) ;
+      false
+  end
+
 let () =
   Benchmarks.init () ;
   let n = 1024 in
@@ -382,6 +475,8 @@ let () =
          exercised elsewhere.) *)
       if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
-      if not (check_gate dev) then ok := false)
+      if not (check_gate dev) then ok := false ;
+      (* Leaf-write round-trip (D2H + gather) on CUDA/PTX. *)
+      if is_ptx dev && not (check_roundtrip dev n) then ok := false)
     devs ;
   if not !ok then exit 1

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -33,6 +33,8 @@ module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 module Transfer = Spoc_core.Transfer
 module Soa = Spoc_core.Soa
+module Soa_vector = Spoc_core.Soa_vector
+module Soa_launch = Sarek.Soa_launch
 module Benchmarks = Test_helpers.Benchmarks
 open Sarek_codegen
 
@@ -102,6 +104,27 @@ let run_soa dev ir ~leaves ~out ~n ~block ~grid =
     args ;
   Transfer.flush dev
 
+(* Tier 1c: the SAME kernel driven through the real user-facing API —
+   Soa_vector storage + Soa_launch.run_soa. Unlike run_soa above (which pokes
+   the emitter directly), this exercises the whole host path: SoA storage
+   allocation, host AoS->leaf scatter, per-leaf H2D transfer, N-base-pointer
+   launch expansion, and the CUDA/PTX gate. [sv] is the SoA input vector (kernel
+   param 0), [out] the scalar output, [n] the length. *)
+let run_soa_via_api dev ir ~sv ~out ~n ~block ~grid =
+  Soa_launch.run_soa
+    ~device:dev
+    ~ir
+    ~args:
+      [
+        Soa_launch.SA_Soa sv;
+        Soa_launch.SA_Reg (Sarek.Execute.Vec out);
+        Soa_launch.SA_Reg (Sarek.Execute.Int n);
+      ]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev
+
 (* ---- point3d (f32) ---- *)
 
 let run_p3 dev n =
@@ -156,11 +179,37 @@ let run_p3 dev n =
       Some out
     end
   in
+  (* SoA via the real user-facing API (Soa_vector + Soa_launch.run_soa). *)
+  let out_api =
+    if not (is_ptx dev) then None
+    else begin
+      let sv =
+        Soa_vector.create
+          point3d_custom
+          ~fields:
+            Sarek_ir_types.[("x", TFloat32); ("y", TFloat32); ("z", TFloat32)]
+          n
+      in
+      for i = 0 to n - 1 do
+        Soa_vector.set
+          sv
+          i
+          {
+            x = float_of_int i;
+            y = (float_of_int i *. 0.5) +. 1.0;
+            z = float_of_int (n - i);
+          }
+      done ;
+      let out = Vector.create Vector.float32 n in
+      run_soa_via_api dev ir ~sv ~out ~n ~block ~grid ;
+      Some out
+    end
+  in
   let reference i =
     let p = Vector.get src i in
     p.x +. p.y +. p.z
   in
-  (out_aos, out_soa, reference)
+  (out_aos, out_soa, out_api, reference)
 
 (* ---- dpair (f64) ---- *)
 
@@ -202,11 +251,31 @@ let run_dpair dev n =
       Some out
     end
   in
+  let out_api =
+    if not (is_ptx dev) then None
+    else begin
+      let sv =
+        Soa_vector.create
+          dpair_custom
+          ~fields:Sarek_ir_types.[("u", TFloat64); ("v", TFloat64)]
+          n
+      in
+      for i = 0 to n - 1 do
+        Soa_vector.set
+          sv
+          i
+          {u = float_of_int i *. 1.5; v = float_of_int (n - i) -. 0.25}
+      done ;
+      let out = Vector.create Vector.float64 n in
+      run_soa_via_api dev ir ~sv ~out ~n ~block ~grid ;
+      Some out
+    end
+  in
   let reference i =
     let p = Vector.get src i in
     p.u +. p.v
   in
-  (out_aos, out_soa, reference)
+  (out_aos, out_soa, out_api, reference)
 
 let check name dev n runner =
   Printf.printf
@@ -215,8 +284,26 @@ let check name dev n runner =
     dev.Device.framework
     dev.Device.name ;
   try
-    let out_aos, out_soa, reference = runner dev n in
+    let out_aos, out_soa, out_api, reference = runner dev n in
     let ok = ref true in
+    let check_leg label o a r i =
+      match o with
+      | None -> ()
+      | Some o ->
+          let s = Vector.get o i in
+          if abs_float (s -. r) > 1e-3 || abs_float (s -. a) > 1e-4 then begin
+            ok := false ;
+            if i < 5 then
+              Printf.printf
+                "\n  %s mismatch @%d: %s=%f aos=%f ref=%f%!"
+                label
+                i
+                label
+                s
+                a
+                r
+          end
+    in
     for i = 0 to n - 1 do
       let r = reference i in
       let a = Vector.get out_aos i in
@@ -225,20 +312,10 @@ let check name dev n runner =
         if i < 5 then
           Printf.printf "\n  AoS mismatch @%d: aos=%f ref=%f%!" i a r
       end ;
-      match out_soa with
-      | None -> ()
-      | Some o ->
-          let s = Vector.get o i in
-          if abs_float (s -. r) > 1e-3 || abs_float (s -. a) > 1e-4 then begin
-            ok := false ;
-            if i < 5 then
-              Printf.printf
-                "\n  SoA mismatch @%d: soa=%f aos=%f ref=%f%!"
-                i
-                s
-                a
-                r
-          end
+      (* Direct-emitter SoA leg. *)
+      check_leg "SoA" out_soa a r i ;
+      (* Real user-facing API leg (Soa_vector + Soa_launch.run_soa). *)
+      check_leg "SoA-API" out_api a r i
     done ;
     let soa_note =
       match out_soa with None -> " (SoA skipped: non-PTX)" | Some _ -> ""
@@ -252,6 +329,34 @@ let check name dev n runner =
   with e ->
     Printf.printf "FAIL (%s)\n%!" (Printexc.to_string e) ;
     false
+
+(* Item 3 gate: run_soa on a non-PTX device MUST raise a located error rather
+   than binding the SoA N-pointer ABI to an AoS kernel signature (which would
+   read wrong data). This is the "never wrong data" guarantee, checked
+   concretely on whatever non-PTX backends are present. *)
+let check_gate dev =
+  if is_ptx dev then true
+  else begin
+    Printf.printf "SoA-gate [%s] %s: %!" dev.Device.framework dev.Device.name ;
+    let ir = ir_of p3_kernel in
+    let sv =
+      Soa_vector.create
+        point3d_custom
+        ~fields:
+          Sarek_ir_types.[("x", TFloat32); ("y", TFloat32); ("z", TFloat32)]
+        16
+    in
+    let out = Vector.create Vector.float32 16 in
+    match
+      run_soa_via_api dev ir ~sv ~out ~n:16 ~block:(dims 16) ~grid:(dims 1)
+    with
+    | () | (exception Not_found) ->
+        Printf.printf "FAILED (run_soa did not reject a non-PTX device)\n%!" ;
+        false
+    | exception Sarek.Execute_error.Execution_error _ ->
+        Printf.printf "rejected (located error) OK\n%!" ;
+        true
+  end
 
 let () =
   Benchmarks.init () ;
@@ -275,6 +380,8 @@ let () =
          only. (Some non-PTX backends — e.g. OpenCL/radeonsi — have an unrelated
          f64 custom-vector gap that is out of scope for this emitter test and is
          exercised elsewhere.) *)
-      if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false)
+      if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false ;
+      (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
+      if not (check_gate dev) then ok := false)
     devs ;
   if not !ok then exit 1

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -2302,9 +2302,9 @@ let test_ptxas_assembles () =
 let test_soa_field_read_markers () =
   let k = soa_field_sum_kernel () in
   let soa = Sarek_ir_ptx.generate ~soa_params:["pts"] k in
-  assert_contains soa ".param .u64 param_pts_soa_x" ;
-  assert_contains soa ".param .u64 param_pts_soa_y" ;
-  assert_contains soa ".param .u64 param_pts_soa_z" ;
+  assert_contains soa ".param .u64 param_sarek_soa_pts_x" ;
+  assert_contains soa ".param .u64 param_sarek_soa_pts_y" ;
+  assert_contains soa ".param .u64 param_sarek_soa_pts_z" ;
   assert_contains soa ".param .u32 param_sarek_pts_length" ;
   if count_substr soa "ld.global.f32" < 3 then
     Alcotest.fail (Printf.sprintf "expected >=3 coalesced leaf loads:\n%s" soa) ;
@@ -2325,7 +2325,7 @@ let test_soa_field_read_markers () =
   assert_contains aos "mul.wide.u32" ;
   assert_absent
     aos
-    "param_pts_soa_x"
+    "param_sarek_soa_pts_x"
     ~why:"AoS compilation must not emit SoA per-leaf pointers"
 
 (** Whole-element copy between two SoA vectors: per-leaf coalesced loads from
@@ -2357,8 +2357,8 @@ let test_soa_whole_copy_markers () =
       []
   in
   let soa = Sarek_ir_ptx.generate ~soa_params:["src"; "dst"] k in
-  assert_contains soa ".param .u64 param_src_soa_x" ;
-  assert_contains soa ".param .u64 param_dst_soa_z" ;
+  assert_contains soa ".param .u64 param_sarek_soa_src_x" ;
+  assert_contains soa ".param .u64 param_sarek_soa_dst_z" ;
   if count_substr soa "ld.global.f32" < 3 then
     Alcotest.fail (Printf.sprintf "expected >=3 leaf loads:\n%s" soa) ;
   if count_substr soa "st.global.f32" < 3 then
@@ -2442,8 +2442,8 @@ let test_soa_mixed_width_markers () =
       []
   in
   let soa = Sarek_ir_ptx.generate ~soa_params:["v"] k in
-  assert_contains soa ".param .u64 param_v_soa_i" ;
-  assert_contains soa ".param .u64 param_v_soa_d" ;
+  assert_contains soa ".param .u64 param_sarek_soa_v_i" ;
+  assert_contains soa ".param .u64 param_sarek_soa_v_d" ;
   assert_contains soa "ld.global.s32" ;
   assert_contains soa "ld.global.f64" ;
   assert_absent
@@ -2455,8 +2455,8 @@ let test_soa_mixed_width_markers () =
     load, each from its own base (the remaining two leaf widths). *)
 let test_soa_int64_markers () =
   let soa = Sarek_ir_ptx.generate ~soa_params:["v"] (soa_long_kernel ()) in
-  assert_contains soa ".param .u64 param_v_soa_p" ;
-  assert_contains soa ".param .u64 param_v_soa_q" ;
+  assert_contains soa ".param .u64 param_sarek_soa_v_p" ;
+  assert_contains soa ".param .u64 param_sarek_soa_v_q" ;
   assert_contains soa "ld.global.s64" ;
   assert_contains soa "ld.global.s32" ;
   assert_absent
@@ -2500,6 +2500,62 @@ let test_soa_nested_record_rejected () =
   match Sarek_ir_ptx.generate ~soa_params:["v"] k with
   | _ -> Alcotest.fail "SoA on a nested-record vector should be rejected"
   | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
+(** PRECONDITION regression (Tier 1c namespace fix): a SoA vector [x] with field
+    [y] alongside a distinct scalar param literally named [x_soa_y] must compile
+    to two DISTINCT PTX operands. The generated SoA leaf now lives in the
+    reserved [sarek_] namespace ([param_sarek_soa_x_y]), so it cannot alias the
+    user param's generated name ([param_x_soa_y]). Before the fix both mangled
+    to [param_x_soa_y] — silently-wrong PTX. (A user param cannot itself be
+    [sarek_]-prefixed — #258 reserves that — so the collision is one-directional
+    and fully closed by prefixing the generated side.) *)
+let test_soa_param_name_collision_safe () =
+  let xy_ty = TRecord ("xy", [("y", TFloat32); ("z", TFloat32)]) in
+  let x = make_var "x" (TVec xy_ty) in
+  (* User scalar param whose name collides with the OLD SoA mangle
+     [param_<vec>_soa_<field>] for vector [x], field [y]. *)
+  let x_soa_y = make_var "x_soa_y" TFloat32 in
+  let out = make_var "out" (TVec TFloat32) in
+  let n = make_var "n" TInt32 in
+  let tid = make_var "tid" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SIf
+          ( EBinop (Lt, EVar tid, EVar n),
+            SAssign
+              ( LArrayElem ("out", EVar tid),
+                EBinop
+                  ( Add,
+                    ERecordField (EArrayRead ("x", EVar tid), "y"),
+                    EVar x_soa_y ) ),
+            None ) )
+  in
+  let k =
+    base_kernel
+      "collision"
+      [
+        DParam (x, Some {arr_elttype = xy_ty; arr_memspace = Global});
+        DParam (x_soa_y, None);
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (n, None);
+      ]
+      body
+      []
+  in
+  let soa = Sarek_ir_ptx.generate ~soa_params:["x"] k in
+  (* Generated SoA leaf sits in the reserved namespace. *)
+  assert_contains soa ".param .u64 param_sarek_soa_x_y" ;
+  (* User scalar keeps its own (non-reserved) generated name. *)
+  assert_contains soa ".param .f32 param_x_soa_y" ;
+  (* And the generated leaf must NOT have taken the user's name. *)
+  assert_absent
+    soa
+    ".param .u64 param_x_soa_y"
+    ~why:
+      "the generated SoA leaf must not alias the user scalar param's name — it \
+       is prefixed into the reserved sarek_ namespace"
 
 let () =
   Alcotest.run
@@ -2744,5 +2800,9 @@ let () =
             "SoA on a nested-record vector is rejected"
             `Quick
             test_soa_nested_record_rejected;
+          Alcotest.test_case
+            "SoA leaf name cannot alias a user param named <vec>_soa_<field>"
+            `Quick
+            test_soa_param_name_collision_safe;
         ] );
     ]

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -306,8 +306,19 @@ module type BACKEND = sig
       Direct/Custom backends.
       @param block
         Optional block dimensions (required for Vulkan/GLSL which embeds
-        workgroup size in shader) *)
-  val generate_source : ?block:dims -> Sarek_ir_types.kernel -> string option
+        workgroup size in shader)
+      @param soa_params
+        Names of custom (record) vector parameters to lower as
+        Structure-of-Arrays: each expands to N per-leaf base pointers + one
+        shared length instead of a single packed AoS pointer (the #260 PTX
+        emitter ABI). Honoured only by the CUDA/PTX backend; every other backend
+        ignores it and emits its ordinary AoS code. Defaults to [[]] (all AoS),
+        so existing callers are byte-identical. *)
+  val generate_source :
+    ?block:dims ->
+    ?soa_params:string list ->
+    Sarek_ir_types.kernel ->
+    string option
 
   (** Execute a kernel directly (for Direct/Custom backends). JIT backends
       should raise an error if this is called. The backend chooses which


### PR DESCRIPTION
The user-facing half of the SoA work (#260 shipped the emitter). Honest STOP on the handoff's fully-transparent form — two blockers it didn't surface: `custom_type` carries no record layout (a one-arg `~layout:SoA` can't derive a plan) and the runtime libs deliberately exclude codegen (`~soa_params` must flow through `Framework_sig.BACKEND.generate_source`). What ships is the reusable substrate the transparent form will build on:

- **Namespace precondition FIRST** (the #260 handoff's mandate): generated SoA params renamed into the reserved namespace (`param_sarek_soa_<vec>_<field>`), with a collision regression test (user scalar literally named `x_soa_y` coexists). ptxas 60/60.
- **`Spoc_core.Soa_vector`**: AoS host vector as source-of-truth + Tier 1a `Soa.plan`/scatter/gather + N per-leaf transports. **`Sarek.Soa_launch.run_soa`**: per-leaf H2D, N base pointers + shared length in record-declaration order (ABI verified against the emitter to 3 fields).
- **Per-device located gate**: non-PTX devices reject at launch (ran live on all 6) — never wrong data; AoS fallback stays available.
- **Round-trip e2e**: leaf-writing kernel → D2H leaves → gather → AoS assertions, PASS both CUDA devices (first coverage of that path). Docs: host-coherence contract at run_soa; `~fields` order precondition with its silent-transposition consequence named.
- **Bench through the real API (ZLUDA, 8-field record)**: 1.43× → **4.08×** at N=2²⁴ (169.7 → 691.6 GB/s).

Deferred with documented prerequisites: `Custom_storage_soa` GADT + transparent `Execute.run` dispatch (~25 match sites + 1→N device-buffer table).

Pipeline (full): research → spec → plan → implement → review GO (8-implementor blast radius verified; positive path independently T3-verified) → round-2 (round-trip e2e + contracts) → QA GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-facing Structure-of-Arrays (SoA) vector API with element access, scatter, and gather operations.
  * Added SoA kernel launching support for CUDA/PTX, including automatic data transfer and writeback handling.
  * Added public SoA launch functionality through the main Sarek interface.
* **Bug Fixes**
  * Improved generated parameter naming to prevent conflicts with user-defined kernel parameters.
* **Compatibility**
  * Updated backend interfaces to accept SoA configuration while preserving existing behavior on non-CUDA/PTX backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->