### PR TITLE
refactor(tests): factor rusticl fp64 KNOWN-ISSUE classifier + tighten ICD gating (audit #52)

### DIFF
--- a/sarek-cuda/Cuda_plugin.ml
+++ b/sarek-cuda/Cuda_plugin.ml
@@ -20,6 +20,3 @@ let find_intrinsic = Cuda_shared.Cuda_intrinsics.find
 
 (** Generate CUDA source with custom types. *)
 let generate_with_types = Sarek_ir_cuda.generate_with_types
-
-(** Generate CUDA source for a kernel. *)
-let generate_source = Sarek_ir_cuda.generate

--- a/sarek-opencl/Opencl_plugin.ml
+++ b/sarek-opencl/Opencl_plugin.ml
@@ -300,8 +300,5 @@ let find_intrinsic = Opencl_intrinsics.find
 (** Generate OpenCL source with custom types *)
 let generate_with_types = Sarek_ir_opencl.generate_with_types
 
-(** Generate OpenCL source for a kernel *)
-let generate_source = Sarek_ir_opencl.generate
-
 (** Generate OpenCL source with FP64 extension if needed *)
 let generate_with_fp64 = Sarek_ir_opencl.generate_with_fp64

--- a/sarek-vulkan/Vulkan_plugin.ml
+++ b/sarek-vulkan/Vulkan_plugin.ml
@@ -344,9 +344,6 @@ let find_intrinsic = Vulkan_intrinsics.find
 (** Generate GLSL source with custom types *)
 let generate_with_types = Sarek_ir_glsl.generate_with_types
 
-(** Generate GLSL source for a kernel *)
-let generate_source = Sarek_ir_glsl.generate
-
 (** Check if glslangValidator is available *)
 let glslang_available = Vulkan_api.glslang_available
 

--- a/sarek/tests/e2e/test_float64_kernel_arith.ml
+++ b/sarek/tests/e2e/test_float64_kernel_arith.ml
@@ -150,28 +150,17 @@ let verify ~exact got_iters got_mag =
 let is_native (dev : Device.t) =
   dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
 
-(* KNOWN ISSUE — rusticl / Mesa fp64 (RUSTICL_FEATURES=fp64) is non-conformant:
-   fp64 +, -, * are computed at full double precision, but fp64 [sqrt] and
-   division are computed at only ~single precision. Measured directly with a
-   hand-written OpenCL C repro (attached in briefs/opencl-f64-while-loop-impl.md,
-   harness clprobe.c) on both rusticl devices (navi31 GPU + raphael CPU):
-
-       max rel err:  sqrt = 1.82e-08   1.0/v = 1.64e-08   v*v - v = 3.97e-16
-
-   The .cl repro also proves this is NOT a Sarek codegen artefact: the exact
-   emitted source (bare integer literals for the f64 constants, e.g. `4`, `2`)
-   and a variant with explicit double literals (`4.0`, `2.0`) produce
-   byte-identical output — C's int->double promotion is correct, and both match
-   Sarek's result exactly. Vulkan/RADV on the same GPU is exact, so this is a
-   rusticl driver limitation, not a bug in Sarek.
+(* KNOWN ISSUE — rusticl / Mesa fp64 (RUSTICL_FEATURES=fp64) computes fp64 sqrt
+   and division at only ~single precision while +, -, * stay exact; the
+   classifier, the transcendental envelope and the rusticl-identity gate now
+   live in [Test_helpers] (audit #52 / F4, F5). See
+   [Test_helpers.classify_fp64_result] for the full evidence and rationale.
 
    Effect on this kernel: the escape-loop condition uses only +, -, * and <=,
-   so iteration counts are EXACT on OpenCL; only the final sqrt(x^2 + y^2)
-   carries the ~1e-8 error. We therefore annotate the OpenCL result as a known
-   issue rather than a bare FAIL. A *real* regression still reports FAIL: wrong
-   iteration counts, or a magnitude error beyond the fp64-transcendental
-   envelope below, is NOT covered by this annotation. *)
-let opencl_fp64_transcendental_envelope = 1e-5
+   so iteration counts are EXACT on OpenCL ([exact_ok = iter_bad = 0]); only the
+   final sqrt(x^2 + y^2) carries the ~1e-8 error, so it is [transcendental].
+   A *real* regression still reports FAIL: wrong iteration counts, or a
+   magnitude error beyond the envelope, is NOT covered by this annotation. *)
 
 (* Reporting-only detail: iteration mismatches (loop math, expected exact) and
    the worst relative magnitude error (the sqrt-bearing output). *)
@@ -194,19 +183,28 @@ let detailed_stats got_iters got_mag =
 (* Status for a non-native device: PASS, the documented rusticl fp64 KNOWN-ISSUE,
    or a genuine FAIL. *)
 let device_status (dev : Device.t) ~bad got_iters got_mag =
-  if bad = 0 then "PASS"
-  else
-    let iter_bad, max_rel = detailed_stats got_iters got_mag in
-    if
-      dev.Device.framework = "OpenCL"
-      && iter_bad = 0
-      && max_rel <= opencl_fp64_transcendental_envelope
-    then
-      Printf.sprintf
-        "KNOWN-ISSUE (rusticl fp64 sqrt/div ~single-precision; iters exact, \
-         mag max_rel=%.2g; see brief)"
-        max_rel
-    else "FAIL"
+  let iter_bad, max_rel = detailed_stats got_iters got_mag in
+  let label =
+    Printf.sprintf
+      "KNOWN-ISSUE (rusticl fp64 sqrt/div ~single-precision; iters exact, mag \
+       max_rel=%.2g; see brief)"
+      max_rel
+  in
+  match
+    Test_helpers.classify_fp64_result
+      ~framework:dev.Device.framework
+      ~device:dev.Device.name
+      ~within_tol:(bad = 0)
+      ~transcendental:true
+      ~exact_ok:(iter_bad = 0)
+      ~max_rel
+      ~non_finite:(not (Float.is_finite max_rel))
+      ~label
+      ()
+  with
+  | `Pass -> "PASS"
+  | `Known_issue s -> s
+  | `Fail -> "FAIL"
 
 let () =
   let _, kirc = f64_mandelbrot_kernel in

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -252,4 +252,95 @@ let time_it f =
   let t1 = Unix.gettimeofday () in
   (result, (t1 -. t0) *. 1000.0)
 
+(* ========================================================================== *)
+(* fp64 result classification (shared by the float64 / real64 E2E tests)      *)
+(* ========================================================================== *)
+
+(** [true] iff [haystack] contains [needle] as a substring. *)
+let string_contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  if nl = 0 then true
+  else begin
+    let rec go i =
+      i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1))
+    in
+    go 0
+  end
+
+(** [true] iff [(framework, device)] identifies a rusticl (Mesa) OpenCL device.
+
+    The rusticl fp64 KNOWN-ISSUE (div/sqrt at ~single precision, see
+    [classify_fp64_result]) is a limitation of exactly this one ICD, so the
+    annotation must be gated on rusticl IDENTITY rather than on the generic
+    ["OpenCL"] framework tag. Otherwise a conformant NON-rusticl ICD that
+    regressed its fp64 div/sqrt into the tolerance envelope would be silently
+    masked as "known" instead of FAILing (audit finding #52 / F5).
+
+    We key on the OpenCL device name: rusticl reports its Gallium driver as
+    ["radeonsi"] in CL_DEVICE_NAME on the campaign hardware (observed: "AMD
+    Radeon RX 7900 XTX (radeonsi, navi31, ...)" and the raphael CPU device), and
+    the ICD/platform identifies itself as ["rusticl"]. We match either token,
+    case-insensitively.
+
+    Why the device name and NOT the [RUSTICL_FEATURES] env var: the run-rules
+    export [RUSTICL_FEATURES=fp64] for the WHOLE test process, so the variable
+    is present for every device in the run and cannot discriminate a
+    co-installed non-rusticl ICD from rusticl within the same process. The
+    device name is per-device and can. Name sniffing is admittedly driver-string
+    dependent; if a future rusticl build changes CL_DEVICE_NAME this predicate
+    must be revisited (a bare non-rusticl over-tolerance simply FAILs, which is
+    the safe direction). *)
+let is_rusticl_device ~framework ~device =
+  framework = "OpenCL"
+  &&
+  let d = String.lowercase_ascii device in
+  string_contains ~needle:"rusticl" d || string_contains ~needle:"radeonsi" d
+
+(** Default relative-error envelope for the rusticl fp64 div/sqrt KNOWN-ISSUE.
+
+    rusticl / Mesa fp64 (with RUSTICL_FEATURES=fp64) computes fp64 division and
+    sqrt at only ~single precision while +, -, * stay exact. Measured directly
+    with a hand-written OpenCL C repro (briefs/opencl-f64-while-loop-impl.md,
+    harness clprobe.c) on both rusticl devices: sqrt/div rel err ~1.8e-8, mul
+    ~4e-16. Vulkan/RADV on the same GPU is exact, so this is a driver
+    limitation, not a Sarek codegen artefact (evidence: PR #266). *)
+let opencl_fp64_transcendental_envelope = 1e-5
+
+(** Classify one fp64 result as [`Pass], the documented rusticl fp64 div/sqrt
+    KNOWN-ISSUE, or a genuine [`Fail]. Single source of truth for the fp64 E2E
+    tests (audit finding #52 / F4), replacing the constant + classifier + label
+    previously copy-pasted across test_real64, test_real64_single_source,
+    test_float64_kernel_arith and test_ktype_record_f64_arith.
+
+    - [framework], [device]: the running device's framework tag and name; used
+      only to decide rusticl identity via [is_rusticl_device] (F5 gating).
+    - [within_tol]: the result met its normal tolerance -> [`Pass] outright.
+    - [transcendental]: this result depends on fp64 div/sqrt (the ops rusticl
+      computes at ~single precision). Only such results are eligible for the
+      KNOWN-ISSUE annotation. A result that uses only +,-,* is never eligible
+      and, over tolerance, always [`Fail]s.
+    - [exact_ok]: the companion parts that MUST stay exact (e.g. escape-loop
+      iteration counts, or add/sub/mul in the same pass) are exact. A violation
+      here is a real regression -> [`Fail].
+    - [max_rel]: worst relative error of the transcendental part.
+    - [non_finite]: a non-finite (NaN/inf) result was observed. This forces
+      [`Fail] independently of [max_rel] (a NaN must never fit the envelope).
+    - [envelope]: KNOWN-ISSUE ceiling (default
+      [opencl_fp64_transcendental_envelope] = 1e-5).
+    - [label]: the KNOWN-ISSUE text surfaced (and printed) when annotated.
+
+    A result is annotated [`Known_issue] iff it is over tolerance AND on a
+    rusticl device AND transcendental AND its exact companions are exact AND the
+    error is finite AND within [envelope]; everything else [`Fail]s. *)
+let classify_fp64_result ~framework ~device ~within_tol ~transcendental
+    ~exact_ok ~max_rel ~non_finite
+    ?(envelope = opencl_fp64_transcendental_envelope) ~label () =
+  if within_tol then `Pass
+  else if
+    is_rusticl_device ~framework ~device
+    && transcendental && exact_ok && (not non_finite) && Float.is_finite max_rel
+    && max_rel <= envelope
+  then `Known_issue label
+  else `Fail
+
 module Benchmarks = Benchmarks

--- a/sarek/tests/e2e/test_ktype_record_f64_arith.ml
+++ b/sarek/tests/e2e/test_ktype_record_f64_arith.ml
@@ -153,10 +153,28 @@ let () =
                   (ref_z s.x s.y s.z)
             end
           done ;
-          if !ok then print_endline "PASSED"
-          else begin
-            any_failure := true ;
-            print_endline "FAILED"
+          (* Route through the shared fp64 classifier (audit #52 / F4). This
+             kernel does only +, -, * on fp64 (no div/sqrt), so it never touches
+             the rusticl transcendental KNOWN-ISSUE: [transcendental=false]
+             keeps it a strict PASS/FAIL, exactly the pre-refactor behaviour. *)
+          (* [`Known_issue] is unreachable here (transcendental:false). *)
+          begin match
+            Test_helpers.classify_fp64_result
+              ~framework:dev.Device.framework
+              ~device:dev.Device.name
+              ~within_tol:!ok
+              ~transcendental:false
+              ~exact_ok:true
+              ~max_rel:0.0
+              ~non_finite:false
+              ~label:""
+              ()
+          with
+          | `Pass -> print_endline "PASSED"
+          | `Known_issue s -> print_endline s
+          | `Fail ->
+              any_failure := true ;
+              print_endline "FAILED"
           end
         with e ->
           any_failure := true ;

--- a/sarek/tests/e2e/test_real64.ml
+++ b/sarek/tests/e2e/test_real64.ml
@@ -139,44 +139,28 @@ let tol_for ~(substrate : Real64.substrate) ~framework ~op =
       | "Vulkan", ("mul" | "div") -> f32_tol
       | _ -> base)
 
-(* KNOWN ISSUE - rusticl / Mesa fp64 (RUSTICL_FEATURES=fp64) is non-conformant:
-   fp64 +, -, * are computed at full double precision, but fp64 [sqrt] and
-   division are computed at only ~single precision. Measured directly with a
-   hand-written OpenCL C repro (briefs/opencl-f64-while-loop-impl.md, harness
-   clprobe.c) on both rusticl devices (navi31 GPU + raphael CPU):
-
-       max rel err:  sqrt = 1.82e-08   1.0/v = 1.64e-08   v*v - v = 3.97e-16
-
-   Vulkan/RADV on the same GPU is exact, so this is a rusticl driver limitation,
-   not a Sarek codegen artefact. Full evidence: PR #266 (test_float64_kernel_arith
-   carries the same annotation for its final sqrt).
-
-   Reachability here: WITHOUT the flag, OpenCL reports fp64=false and real64
-   selects the exact df64 fallback substrate - the default baseline never hits
-   this branch and is unaffected. WITH RUSTICL_FEATURES=fp64 the Native_f64
-   substrate is selected and only div/sqrt carry the ~1e-8 error; +, -, * stay
-   exact. We therefore annotate an OpenCL Native_f64 div/sqrt result whose
-   relative error is within the transcendental envelope below as a KNOWN-ISSUE
-   rather than a bare FAIL. A *real* regression still FAILs: add/sub/mul beyond
-   the f64 tolerance, a non-finite (NaN/inf) result - [rel_error]/[check] already
-   maps NaN to infinity so it can never fit the envelope - or the wrong substrate
-   being selected (Fallback_df64 is exact and is never annotated). *)
-let opencl_fp64_transcendental_envelope = 1e-5
-
 (* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
-   div/sqrt KNOWN-ISSUE (OpenCL + Native_f64 only, error inside the envelope), or
-   a genuine FAIL. *)
-let op_status ~(substrate : Real64.substrate) ~framework ~op ~err ~tol =
-  if err <= tol then `Pass
-  else
-    match substrate with
-    | Real64.Native_f64
-      when framework = "OpenCL"
-           && (op = "div" || op = "sqrt")
-           && Float.is_finite err
-           && err <= opencl_fp64_transcendental_envelope ->
-        `Known_issue
-    | _ -> `Fail
+   div/sqrt KNOWN-ISSUE, or a genuine FAIL. The classifier, the transcendental
+   envelope and the rusticl-identity gate all live in [Test_helpers] now (audit
+   #52 / F4, F5); see [Test_helpers.classify_fp64_result] for the full rationale.
+
+   Only the Native_f64 substrate can hit the rusticl div/sqrt error: WITHOUT
+   RUSTICL_FEATURES=fp64 OpenCL reports fp64=false and real64 selects the exact
+   df64 fallback (never annotated); WITH it, Native_f64 is selected and only
+   div/sqrt carry the ~1e-8 error while +, -, * stay exact. [transcendental] is
+   therefore [Native_f64 && (div|sqrt)]. A non-finite result forces FAIL. *)
+let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol =
+  Test_helpers.classify_fp64_result
+    ~framework
+    ~device
+    ~within_tol:(err <= tol)
+    ~transcendental:
+      (substrate = Real64.Native_f64 && (op = "div" || op = "sqrt"))
+    ~exact_ok:true
+    ~max_rel:err
+    ~non_finite:(not (Float.is_finite err))
+    ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+    ()
 
 (* ========== One pass on one device with one substrate ========== *)
 
@@ -223,6 +207,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
     () ;
   Transfer.flush dev ;
   let framework = dev.Device.framework in
+  let device = dev.Device.name in
   let worst = Hashtbl.create 8 in
   let check op got expected =
     let err =
@@ -250,8 +235,10 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
     (fun op ->
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
-      let status = op_status ~substrate ~framework ~op ~err ~tol in
-      (match status with `Fail -> incr failures | `Pass | `Known_issue -> ()) ;
+      let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
+      (match status with
+      | `Fail -> incr failures
+      | `Pass | `Known_issue _ -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
@@ -259,7 +246,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
         tol
         (match status with
         | `Pass -> "PASS"
-        | `Known_issue -> "KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+        | `Known_issue s -> s
         | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 

--- a/sarek/tests/e2e/test_real64_single_source.ml
+++ b/sarek/tests/e2e/test_real64_single_source.ml
@@ -101,44 +101,28 @@ let tol_for ~(substrate : Real64.substrate) ~framework ~op =
       | "Vulkan", ("mul" | "div") -> f32_tol
       | _ -> base)
 
-(* KNOWN ISSUE - rusticl / Mesa fp64 (RUSTICL_FEATURES=fp64) is non-conformant:
-   fp64 +, -, * are computed at full double precision, but fp64 [sqrt] and
-   division are computed at only ~single precision. Measured directly with a
-   hand-written OpenCL C repro (briefs/opencl-f64-while-loop-impl.md, harness
-   clprobe.c) on both rusticl devices (navi31 GPU + raphael CPU):
-
-       max rel err:  sqrt = 1.82e-08   1.0/v = 1.64e-08   v*v - v = 3.97e-16
-
-   Vulkan/RADV on the same GPU is exact, so this is a rusticl driver limitation,
-   not a Sarek codegen artefact. Full evidence: PR #266 (test_float64_kernel_arith
-   carries the same annotation for its final sqrt).
-
-   Reachability here: WITHOUT the flag, OpenCL reports fp64=false and real64
-   selects the exact df64 fallback substrate - the default baseline never hits
-   this branch and is unaffected. WITH RUSTICL_FEATURES=fp64 the Native_f64
-   substrate is selected and only div/sqrt carry the ~1e-8 error; +, -, * stay
-   exact. We therefore annotate an OpenCL Native_f64 div/sqrt result whose
-   relative error is within the transcendental envelope below as a KNOWN-ISSUE
-   rather than a bare FAIL. A *real* regression still FAILs: add/sub/mul beyond
-   the f64 tolerance, a non-finite (NaN/inf) result - [rel_error]/[check] already
-   maps NaN to infinity so it can never fit the envelope - or the wrong substrate
-   being selected (Fallback_df64 is exact and is never annotated). *)
-let opencl_fp64_transcendental_envelope = 1e-5
-
 (* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
-   div/sqrt KNOWN-ISSUE (OpenCL + Native_f64 only, error inside the envelope), or
-   a genuine FAIL. *)
-let op_status ~(substrate : Real64.substrate) ~framework ~op ~err ~tol =
-  if err <= tol then `Pass
-  else
-    match substrate with
-    | Real64.Native_f64
-      when framework = "OpenCL"
-           && (op = "div" || op = "sqrt")
-           && Float.is_finite err
-           && err <= opencl_fp64_transcendental_envelope ->
-        `Known_issue
-    | _ -> `Fail
+   div/sqrt KNOWN-ISSUE, or a genuine FAIL. The classifier, the transcendental
+   envelope and the rusticl-identity gate all live in [Test_helpers] now (audit
+   #52 / F4, F5); see [Test_helpers.classify_fp64_result] for the full rationale.
+
+   Only the Native_f64 substrate can hit the rusticl div/sqrt error: WITHOUT
+   RUSTICL_FEATURES=fp64 OpenCL reports fp64=false and real64 selects the exact
+   df64 fallback (never annotated); WITH it, Native_f64 is selected and only
+   div/sqrt carry the ~1e-8 error while +, -, * stay exact. [transcendental] is
+   therefore [Native_f64 && (div|sqrt)]. A non-finite result forces FAIL. *)
+let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol =
+  Test_helpers.classify_fp64_result
+    ~framework
+    ~device
+    ~within_tol:(err <= tol)
+    ~transcendental:
+      (substrate = Real64.Native_f64 && (op = "div" || op = "sqrt"))
+    ~exact_ok:true
+    ~max_rel:err
+    ~non_finite:(not (Float.is_finite err))
+    ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+    ()
 
 (* ========== One pass on one device with one substrate ===================== *)
 
@@ -181,6 +165,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
     () ;
   Transfer.flush dev ;
   let framework = dev.Device.framework in
+  let device = dev.Device.name in
   let worst = Hashtbl.create 8 in
   let check op got expected =
     let err =
@@ -206,8 +191,10 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
     (fun op ->
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
-      let status = op_status ~substrate ~framework ~op ~err ~tol in
-      (match status with `Fail -> incr failures | `Pass | `Known_issue -> ()) ;
+      let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
+      (match status with
+      | `Fail -> incr failures
+      | `Pass | `Known_issue _ -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
@@ -215,7 +202,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
         tol
         (match status with
         | `Pass -> "PASS"
-        | `Known_issue -> "KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+        | `Known_issue s -> s
         | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 


### PR DESCRIPTION
Audit findings F4/F5/F6. Factors the copy-pasted rusticl fp64 sqrt/div KNOWN-ISSUE classifier (envelope 1e-5 + logic + label) into one `Test_helpers.classify_fp64_result` (```Pass | `Known_issue | `Fail```), routes all 4 fp64 e2e tests through it. **Tightens ICD gating (F5)**: keys the known-issue on rusticl IDENTITY (device name contains radeonsi/rusticl) not the generic OpenCL framework tag — a conformant non-rusticl ICD regressing into the envelope now FAILs instead of being masked (rationale: env var is process-global, can't discriminate per-device; device name can). Non-finite hardening preserved. Removes 3 dead `generate_source` module aliases (F6, grep-confirmed zero callers).

Before/after both env modes identical (rusticl→KNOWN-ISSUE with RUSTICL_FEATURES=fp64, df64-fallback all-PASS without); gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed code-generation support for CUDA, OpenCL, and Vulkan integrations, replacing the previous source-generation entry points.

* **Tests**
  * Centralized fp64 result classification across end-to-end tests.
  * Improved reporting for passing, failing, and recognized platform-specific known issues.
  * Added device-aware handling for fp64 numerical tolerance and non-finite results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->