### PR TITLE
fix(ppx): helper tuple-return wrong-width (route) + reject shared-tuple arrays (audit #55)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_reserved_prefix_for.cma > "$$out" 2>&1; if grep -q "identifiers beginning with 'sarek_' are reserved" "$$out"; then echo "  PASS: reserved-prefix for-loop variable rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing unregistered record field-type rejection (aligned ABI safety)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_unregistered_field.cma > "$$out" 2>&1; if grep -qE "unknown (size|alignment) for field type" "$$out"; then echo "  PASS: unregistered field type rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing tuple-typed shared-memory array rejection..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_shared_tuple.cma > "$$out" 2>&1; if grep -q "Tuple-typed shared-memory arrays are not supported" "$$out"; then echo "  PASS: tuple shared array rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing recursive-call vector-swap rejection (tail-recursion + vector)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tailrec_vec_swap.cma > "$$out" 2>&1; if grep -q "must pass its own vector parameter" "$$out"; then echo "  PASS: recursive vector-swap rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "All negative tests checked (see KNOWN-ISSUE line above for the one non-blocking gap, if any)"

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -600,6 +600,21 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
             (* First time - lower the function *)
             let params, body = Hashtbl.find state.fun_map name in
             let ret_ty = repr body.ty in
+            (* Wrong-width class, 3rd instance: a module-level helper whose
+               RETURN type is a primitive-component tuple ([let mk x y = (x, y)])
+               must be typed through the data mapper, not the bare
+               [elttype_of_typ] placeholder that collapses [TTuple]/[TFun] to
+               [Ir.TInt32]. The body already lowers a primitive tuple literal to
+               the synthesized [_tup_*] record (see the [TETuple] case), so a
+               placeholder return type declared the helper int-returning while
+               its body returned a compound — a silent miscompile. Routing
+               through [slot_elttype_of_typ] lowers the return to that same
+               [_tup_*] record end-to-end (backends already support an aggregate
+               helper return; see the record-arg/ret helper path). Register the
+               synthesized record so its [struct] definition is emitted even if
+               no other site did. A non-primitive tuple return raises the located
+               tuple-component error rather than miscompiling. *)
+            register_tuple_type state ret_ty ;
             Hashtbl.add state.lowering_stack name () ;
             let fun_body_ir = lower_stmt state body in
             Hashtbl.remove state.lowering_stack name ;
@@ -616,7 +631,7 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
               {
                 hf_name = name;
                 hf_params;
-                hf_ret_type = elttype_of_typ ret_ty;
+                hf_ret_type = slot_elttype_of_typ ret_ty;
                 hf_body = fun_body_ir;
               }
             in
@@ -880,7 +895,17 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
         | None -> Ir.EIntrinsic (["Sarek_stdlib"; "Gpu"], "block_dim_x", [])
       in
       let v = make_var name id (TArr (elem_ty, Sarek_types.Shared)) false in
-      let elem_ir = elttype_of_typ elem_ty in
+      (* Sibling of the helper-return wrong-width fix: a shared-memory array
+         whose ELEMENT type is a primitive-component tuple must be typed through
+         the data mapper. [elttype_of_typ] would collapse the [TTuple] element to
+         [Ir.TInt32] (wrong stride / int32-collapse), so the [__shared__]/[__local]
+         declaration and every indexed access would mistype a compound slot as a
+         scalar. [slot_elttype_of_typ] lowers it to the synthesized [_tup_*]
+         record (the same element type a tuple vector param uses); register the
+         record so its [struct] definition is emitted. A non-primitive tuple
+         element raises the located tuple-component error. *)
+      register_tuple_type state elem_ty ;
+      let elem_ir = slot_elttype_of_typ elem_ty in
       (* Use EArrayCreate with Shared memspace - codegen will emit proper declaration *)
       Ir.SLet
         (v, Ir.EArrayCreate (elem_ir, size_ir, Ir.Shared), lower_stmt state body)

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -895,17 +895,36 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
         | None -> Ir.EIntrinsic (["Sarek_stdlib"; "Gpu"], "block_dim_x", [])
       in
       let v = make_var name id (TArr (elem_ty, Sarek_types.Shared)) false in
-      (* Sibling of the helper-return wrong-width fix: a shared-memory array
-         whose ELEMENT type is a primitive-component tuple must be typed through
-         the data mapper. [elttype_of_typ] would collapse the [TTuple] element to
-         [Ir.TInt32] (wrong stride / int32-collapse), so the [__shared__]/[__local]
-         declaration and every indexed access would mistype a compound slot as a
-         scalar. [slot_elttype_of_typ] lowers it to the synthesized [_tup_*]
-         record (the same element type a tuple vector param uses); register the
-         record so its [struct] definition is emitted. A non-primitive tuple
-         element raises the located tuple-component error. *)
-      register_tuple_type state elem_ty ;
-      let elem_ir = slot_elttype_of_typ elem_ty in
+      (* Sibling of the helper-return wrong-width fix, REJECTED (round 2). A
+         [let%shared] whose ELEMENT type is a tuple/function was originally typed
+         by the bare [elttype_of_typ] placeholder, which collapses [TTuple]/[TFun]
+         to [Ir.TInt32] — a silent scalar-collapse miscompile. Routing it through
+         [slot_elttype_of_typ] to the synthesized [_tup_*] record (as data slots
+         do) was attempted, but a compound in shared memory is NOT supported by
+         the whole backend fleet: the PTX backend raises "unsupported construct:
+         btype of custom type" and Native raises "Cannot create default value for
+         this type" (proven on hardware: OpenCL/Vulkan/Interpreter passed,
+         CUDA/PTX-under-ZLUDA and Native failed; the rejection is locked by
+         sarek/tests/negative/test_shared_tuple.ml). Shipping a route that
+         miscompiles on shared-capable
+         devices is worse than a clean rejection, so a tuple/function shared
+         element is a located compile error, mirroring [lower_param]'s
+         parameter-boundary rejection. (Aggregate shared arrays are a follow-up
+         needing per-backend struct-in-__shared__ support first.) *)
+      (match repr elem_ty with
+      | TTuple _ ->
+          Ppxlib.Location.raise_errorf
+            ~loc:(Sarek_ast.loc_to_ppxlib te.te_loc)
+            "Tuple-typed shared-memory arrays are not supported; declare \
+             separate scalar [let%%shared] arrays for each component (a \
+             compound in shared memory is not supported across the CUDA/PTX \
+             and Native backends)."
+      | TFun _ ->
+          Ppxlib.Location.raise_errorf
+            ~loc:(Sarek_ast.loc_to_ppxlib te.te_loc)
+            "Function-typed shared-memory arrays are not supported."
+      | _ -> ()) ;
+      let elem_ir = elttype_of_typ elem_ty in
       (* Use EArrayCreate with Shared memspace - codegen will emit proper declaration *)
       Ir.SLet
         (v, Ir.EArrayCreate (elem_ir, size_ir, Ir.Shared), lower_stmt state body)

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1020,6 +1020,40 @@
  (action
   (run %{dep:test_local_tuple.exe})))
 
+; helper-tuple-return: a module-level helper whose RETURN type is a
+; primitive-component tuple ([let mk x y = (x, y)]). Locks the third
+; "wrong-width" instance — the helper return type must lower to the synthesized
+; [_tup_*] record (not the [elttype_of_typ] int placeholder), verified in the
+; emitted CUDA/OpenCL/GLSL (Axis 1) and behaviourally on every device (Axis 2).
+; CPU-safe and self-verifying, so it gates in the default runtest alias.
+
+(executable
+ (name test_helper_tuple_ret)
+ (modules test_helper_tuple_ret)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  sarek.codegen
+  spoc_core
+  test_helpers
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_helper_tuple_ret.exe})))
+
 ; deriver-variant-fields: a [@@sarek.type] record with a VARIANT-typed field as
 ; a vector element, round-tripping host->device->host on the value-based
 ; backends (Interpreter + Native). Fixes the L14-S2 PR #251

--- a/sarek/tests/e2e/test_helper_tuple_ret.ml
+++ b/sarek/tests/e2e/test_helper_tuple_ret.ml
@@ -1,0 +1,230 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test for a module-level HELPER FUNCTION whose RETURN type is a
+ * primitive-component tuple ([let mk x y = (x, y)]).
+ *
+ * This is the third "wrong-width" instance of the class the L13 local-tuple /
+ * vector-of-tuple work already closed for data slots. A module-level helper's
+ * return type was typed by the bare [elttype_of_typ] placeholder in
+ * [Sarek_lower_ir.lower_expr] (the [TEApp]/fun_map branch), which maps
+ * [TTuple]/[TFun] to [Ir.TInt32]. The helper body, however, lowers a primitive
+ * tuple literal to the synthesized positional record ([_tup_*], fields
+ * [_0.._n]), so the emitted helper was declared int-returning while its body
+ * returned a compound value:
+ *
+ *     __device__ int mk(float x, float y) {
+ *       return (struct _tup_float32_float32){ ... };   // int-vs-compound
+ *     }
+ *
+ * — a silent miscompile with no diagnostic. The fix routes the helper return
+ * type through [slot_elttype_of_typ] (the same data mapper vector/local slots
+ * use) so a primitive-tuple return lowers to the synthesized [_tup_*] record
+ * end-to-end, matching the body.
+ *
+ * Axis 1 (codegen): the emitted CUDA/OpenCL/GLSL declares the helper with the
+ *   synthesized struct return type and defines that struct — never [int mk].
+ * Axis 2 (behaviour): results match a pure-OCaml reference on every available
+ *   device (CUDA/PTX under ZLUDA, OpenCL, Vulkan, Metal, Native, Interpreter).
+ ******************************************************************************)
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Benchmarks = Test_helpers.Benchmarks
+
+type float32 = float
+
+(* A: all-float32 tuple return. dst[i] = a + b with (a, b) = mk src[i] (src[i]+1)
+   = (src[i], src[i]+1), so dst[i] = 2*src[i] + 1. *)
+let k_ff =
+  snd
+    [%kernel
+      let mk (x : float32) (y : float32) : float32 * float32 = (x, y) in
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let open Std in
+        let tid = global_thread_id in
+        if tid < n then begin
+          let p = mk src.(tid) (src.(tid) +. 1.0) in
+          match p with a, b -> dst.(tid) <- a +. b
+        end]
+
+(* B: mixed (float32 * int32) tuple return; int component consumed via float.
+   dst[i] = a + float_of_int b with (a, b) = mk src[i] tid = (src[i], tid). *)
+let k_fi =
+  snd
+    [%kernel
+      let mkm (x : float32) (i : int32) : float32 * int32 = (x, i) in
+      fun (src : float32 vector) (dst : float32 vector) (n : int32) ->
+        let open Std in
+        let tid = global_thread_id in
+        if tid < n then begin
+          let p = mkm src.(tid) tid in
+          match p with a, b -> dst.(tid) <- a +. float b
+        end]
+
+(* ---- OCaml references (must mirror the kernels exactly) ------------------ *)
+
+let ref_src i = float_of_int i -. 8.0
+
+let ref_ff i = ref_src i +. (ref_src i +. 1.0)
+
+let ref_fi i = ref_src i +. float_of_int i
+
+(* ---- Axis 1: emitted-source structural check ----------------------------- *)
+
+let ir_of name kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith ("no IR for " ^ name)
+
+let contains hay needle =
+  let nh = String.length needle and h = String.length hay in
+  let rec go i =
+    if i + nh > h then false
+    else if String.sub hay i nh = needle then true
+    else go (i + 1)
+  in
+  nh = 0 || go 0
+
+let codegen_ok = ref true
+
+(* The helper must be declared with the synthesized struct return type, and the
+   struct must be defined. It must never be declared int-returning (the old
+   placeholder collapse) while its body returns a compound. *)
+let check_codegen name kirc ~struct_name ~helper =
+  let ir = ir_of name kirc in
+  let types = ir.Sarek_ir_types.kern_types in
+  let backends =
+    [
+      ("CUDA", Sarek_codegen.Sarek_ir_cuda.generate_with_types ~types ir);
+      ("OpenCL", Sarek_codegen.Sarek_ir_opencl.generate_with_types ~types ir);
+      ("GLSL", Sarek_codegen.Sarek_ir_glsl.generate_with_types ~types ir);
+    ]
+  in
+  List.iter
+    (fun (bk, src) ->
+      let has_struct = contains src struct_name in
+      (* The int-vs-compound miscompile: helper declared "int <helper>(" . *)
+      let mistyped = contains src ("int " ^ helper ^ "(") in
+      if (not has_struct) || mistyped then begin
+        codegen_ok := false ;
+        Printf.printf
+          "  codegen[%s/%s]: FAIL (struct present=%b, int-returning helper=%b)\n\
+           %s\n\
+           %!"
+          name
+          bk
+          has_struct
+          mistyped
+          src
+      end
+      else Printf.printf "  codegen[%s/%s]: OK\n%!" name bk)
+    backends
+
+(* ---- Axis 2: behavioural equivalence on every device --------------------- *)
+
+let must_pass fw =
+  match fw with
+  | "CUDA" | "OpenCL" | "Vulkan" | "Metal" | "Native" | "Interpreter" -> true
+  | _ -> false
+
+let any_failure = ref false
+
+let pass_count = ref 0
+
+let run_kernel_on name kirc reff dev n =
+  let ir = ir_of name kirc in
+  let src = Vector.create Vector.float32 n in
+  let dst = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set src i (ref_src i) ;
+    Vector.set dst i (-999.0)
+  done ;
+  let threads = min 64 n in
+  let grid_x = (n + threads - 1) / threads in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~block:(Execute.dims1d threads)
+    ~grid:(Execute.dims1d grid_x)
+    ~args:[Execute.Vec src; Execute.Vec dst; Execute.Int32 (Int32.of_int n)]
+    () ;
+  Transfer.flush dev ;
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    let got = Vector.get dst i and exp = reff i in
+    if abs_float (got -. exp) > 1e-3 then begin
+      ok := false ;
+      if i < 5 then
+        Printf.printf
+          "\n    %s mismatch at %d: got %.3f expected %.3f%!"
+          name
+          i
+          got
+          exp
+    end
+  done ;
+  !ok
+
+let kernels = [("ff", k_ff, ref_ff); ("fi", k_fi, ref_fi)]
+
+let () =
+  print_endline "=== helper-tuple-return E2E ===" ;
+  (* Axis 1 — codegen structural check (no device needed). *)
+  print_endline "-- emitted-source structural check --" ;
+  check_codegen "ff" k_ff ~struct_name:"_tup_float32_float32" ~helper:"mk" ;
+  check_codegen "fi" k_fi ~struct_name:"_tup_float32_int32" ~helper:"mkm" ;
+  if not !codegen_ok then any_failure := true ;
+
+  (* Axis 2 — behaviour on every available device. *)
+  Benchmarks.init () ;
+  let devs =
+    Device.init
+      ~frameworks:["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"; "Metal"]
+      ()
+  in
+  if Array.length devs = 0 then
+    print_endline "No runtime devices — codegen axis only"
+  else begin
+    let n = 64 in
+    Array.iter
+      (fun dev ->
+        let fw = dev.Device.framework in
+        List.iter
+          (fun (name, kirc, reff) ->
+            Printf.printf "runtime [%s/%s]: %!" fw name ;
+            try
+              if run_kernel_on name kirc reff dev n then begin
+                incr pass_count ;
+                print_endline "PASSED"
+              end
+              else if must_pass fw then begin
+                any_failure := true ;
+                print_endline "FAILED"
+              end
+              else print_endline "skip (non-required)"
+            with e ->
+              let msg =
+                match e with
+                | Sarek_backend_error.Backend_error.Backend_error err ->
+                    Sarek_backend_error.Backend_error.to_string err
+                | e -> Printexc.to_string e
+              in
+              if must_pass fw then begin
+                any_failure := true ;
+                Printf.printf "FAIL (%s)\n%!" msg
+              end
+              else Printf.printf "skip (%s)\n%!" msg)
+          kernels)
+      devs
+  end ;
+  Printf.printf
+    "\n=== helper-tuple-return: %d runtime checks passed ===\n"
+    !pass_count ;
+  if !any_failure then exit 1

--- a/sarek/tests/e2e/test_helper_tuple_ret.ml
+++ b/sarek/tests/e2e/test_helper_tuple_ret.ml
@@ -94,9 +94,21 @@ let contains hay needle =
 
 let codegen_ok = ref true
 
-(* The helper must be declared with the synthesized struct return type, and the
-   struct must be defined. It must never be declared int-returning (the old
-   placeholder collapse) while its body returns a compound. *)
+(* Pin the EXACT wrong-width signature the fix targets. Three direct assertions
+   on the emitted source, one per backend:
+
+   (a) The helper is DECLARED returning the synthesized [_tup_*] record — the
+       emitted source contains ["<struct_name> <helper>("] (the struct-return
+       form all three C-family backends emit: [cuda/opencl/glsl_type_of_elttype]
+       maps the tuple's [TRecord] to the mangled [_tup_*] name, then a space,
+       then the helper name and its parameter list).
+   (b) It is NOT declared int-returning — the emitted source must NOT contain
+       ["int <helper>("], the old [elttype_of_typ] placeholder collapse
+       ([TTuple] -> [Ir.TInt32]) that produced the int-vs-compound miscompile.
+   (c) The [_tup_*] struct DEFINITION is emitted (not merely the name in a
+       literal/usage). CUDA and OpenCL emit a C typedef (["} <struct_name>;"]);
+       GLSL emits a tagged struct (["struct <struct_name> {"]). Either form
+       counts as a definition. *)
 let check_codegen name kirc ~struct_name ~helper =
   let ir = ir_of name kirc in
   let types = ir.Sarek_ir_types.kern_types in
@@ -109,19 +121,28 @@ let check_codegen name kirc ~struct_name ~helper =
   in
   List.iter
     (fun (bk, src) ->
-      let has_struct = contains src struct_name in
-      (* The int-vs-compound miscompile: helper declared "int <helper>(" . *)
+      (* (a) helper declared returning the synthesized struct type. *)
+      let struct_ret = contains src (struct_name ^ " " ^ helper ^ "(") in
+      (* (b) the int-vs-compound miscompile: helper declared "int <helper>(". *)
       let mistyped = contains src ("int " ^ helper ^ "(") in
-      if (not has_struct) || mistyped then begin
+      (* (c) the struct definition itself (typedef for CUDA/OpenCL, tagged
+         struct for GLSL) — not just the mangled name in a literal. *)
+      let struct_def =
+        contains src ("} " ^ struct_name ^ ";")
+        || contains src ("struct " ^ struct_name ^ " {")
+      in
+      if (not struct_ret) || mistyped || not struct_def then begin
         codegen_ok := false ;
         Printf.printf
-          "  codegen[%s/%s]: FAIL (struct present=%b, int-returning helper=%b)\n\
+          "  codegen[%s/%s]: FAIL (struct-returning helper=%b, int-returning \
+           helper=%b, struct defined=%b)\n\
            %s\n\
            %!"
           name
           bk
-          has_struct
+          struct_ret
           mistyped
+          struct_def
           src
       end
       else Printf.printf "  codegen[%s/%s]: OK\n%!" name bk)

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -15,6 +15,7 @@
 ; - test_convention_kernel_fail2: "Cannot unify types"
 ; - test_inline_node_exhaustion: "Inlining produced N nodes (limit: 10000)"
 ; - test_tuple_param: "Tuple-typed kernel parameters are not supported"
+; - test_shared_tuple: "Tuple-typed shared-memory arrays are not supported"
 ; - test_tuple_local_nonprim: "Tuple values support only scalar components"
 ; - test_tuple_destructure_nonprim: "Tuple values support only scalar components"
 ; - test_fun_param: "Function-typed kernel parameters are not supported"
@@ -63,6 +64,17 @@
  (name neg_test_convention_kernel_fail2)
  (modules test_convention_kernel_fail2)
  (libraries sarek sarek.stdlib sarek.ppx.lib sarek_geometry)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+(library
+ (name neg_test_shared_tuple)
+ (modules test_shared_tuple)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
  (preprocess
   (pps sarek_ppx))
  (flags

--- a/sarek/tests/negative/test_shared_tuple.ml
+++ b/sarek/tests/negative/test_shared_tuple.ml
@@ -1,0 +1,35 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile:
+   - Declares a [let%shared] array whose ELEMENT type is a primitive-component
+     tuple. Routing this through the data mapper to the synthesized [_tup_*]
+     record was attempted (the TELetShared sibling of the helper-return
+     wrong-width fix) but PROVEN to miscompile on shared-capable backends: the
+     PTX backend raises "unsupported construct: btype of custom type" and the
+     Native backend "Cannot create default value for this type" (OpenCL/Vulkan
+     happen to accept it). A compound in shared memory is therefore rejected at
+     the [let%shared] boundary, mirroring lower_param's tuple-parameter
+     rejection — a clean located compile error, not unproven codegen.
+     See briefs/helper-return-wrong-width-impl.md (round 2). *)
+
+let () =
+  let bad_kernel =
+    snd
+      [%kernel
+        fun (src : float32 vector) (dst : float32 vector) (len : int32) ->
+          let open Sarek_stdlib.Std in
+          let%shared (tile : float32 * float32) = 64l in
+          let tid = global_thread_id in
+          let lid = thread_idx_x in
+          if tid < len then begin
+            tile.(lid) <- (src.(tid), src.(tid) +. 1.0) ;
+            block_barrier () ;
+            let p = tile.(lid) in
+            match p with a, b -> dst.(tid) <- a +. b
+          end]
+  in
+  ignore bad_kernel ;
+  print_endline "This should not print - test should have failed to compile"


### PR DESCRIPTION
3rd instance of the wrong-width class (#244/#261). Two siblings, resolved differently per hardware evidence:

- **Helper RETURN type** (Sarek_lower_ir.ml): was typed via bare elttype_of_typ → a helper returning a primitive tuple emitted `int mk(...)` while the body returned a compound (silent miscompile, red repro captured). Fixed by routing through slot_elttype_of_typ → the synthesized _tup_* record end-to-end. 14 runtime checks pass (Interp/Native/OpenCL/Vulkan).
- **Shared-array element** (TELetShared): the review flagged the initial ROUTE as untested. Empirically proved-then-rejected — a shared array of a tuple **hard-fails on CUDA/PTX (ZLUDA)** (`unsupported construct: btype of custom type`) **and Native** (2 of 5 shared-capable backends), though it works on OpenCL/Vulkan/Interp. A route broken fleet-wide is worse than a clean error → reject with a located compile error (mirrors lower_param), + negative test test_shared_tuple.

Scalar let%shared unchanged (test_superstep/reduce/scan unaffected). Record-field sibling safe (scalars-only upstream).

Pipeline (fast): implement → review NO-GO (untested shared route) → prove-then-reject with per-device hardware evidence → gates green (ptxas 61, negative test rejects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect handling of module-level helper functions returning primitive-component tuples.
  * Added clear compile-time errors for unsupported tuple- and function-typed shared-memory arrays.

* **Tests**
  * Added end-to-end validation across supported backends and runtime devices for tuple-returning helpers.
  * Added negative coverage confirming tuple-typed shared-memory arrays are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->