### PR TITLE
fix(sarek): guard kernel-compilation cache against concurrent multi-domain access

### DIFF
--- a/sarek-cuda/Cuda_api.ml
+++ b/sarek-cuda/Cuda_api.ml
@@ -461,35 +461,23 @@ module Kernel = struct
     | ArgFloat64 : float -> arg
     | ArgPtr : nativeint -> arg
 
-  (* Compilation cache *)
-  let cache : (string, t) Hashtbl.t = Hashtbl.create 16
-
-  (* Cache keys grouped by device id, so a device destroy/recreate cycle can
-     evict exactly its own stale module/function handles from [cache]
-     without needing to reverse the (digested, opaque) cache key. *)
-  let keys_by_device : (int, string list ref) Hashtbl.t = Hashtbl.create 16
-
-  let record_key_for_device device_id key =
-    match Hashtbl.find_opt keys_by_device device_id with
-    | Some keys -> keys := key :: !keys
-    | None -> Hashtbl.add keys_by_device device_id (ref [key])
+  (* Compilation cache. Guarded against concurrent multi-domain access by
+     [Spoc_framework.Guarded_cache]: cache lookup/insert, per-device key
+     tracking, eviction and clearing are all atomic, while the NVRTC compile
+     runs outside the lock. Keys are grouped by device id (via
+     [find_or_build ~device_id]) so a device destroy/recreate cycle can evict
+     exactly its own stale module/function handles without reversing the
+     (digested, opaque) cache key. *)
+  let cache : (string, t) Spoc_framework.Guarded_cache.t =
+    Spoc_framework.Guarded_cache.create
+      ~destroy:(fun k -> ignore (cuModuleUnload k.module_))
+      ()
 
   (* Evict every cached kernel compiled for [device_id]. Registered as a
      [device_destroy_hooks] callback below so [Device.destroy] retires
      these handles before the underlying CUDA context is destroyed. *)
   let evict_device device_id =
-    match Hashtbl.find_opt keys_by_device device_id with
-    | None -> ()
-    | Some keys ->
-        List.iter
-          (fun key ->
-            match Hashtbl.find_opt cache key with
-            | None -> ()
-            | Some k ->
-                let _ = cuModuleUnload k.module_ in
-                Hashtbl.remove cache key)
-          !keys ;
-        Hashtbl.remove keys_by_device device_id
+    Spoc_framework.Guarded_cache.evict_device cache device_id
 
   let () = device_destroy_hooks := evict_device :: !device_destroy_hooks
 
@@ -616,8 +604,8 @@ module Kernel = struct
   (* Shared memoization for compiled/loaded kernels. The cache key must
      include device ID and the kernel name - a source file may define more
      than one kernel, and a resolved kernel handle for one name must never be
-     returned for another (see Compile_cache.mli). [record_key_for_device]
-     keeps the device-destroy eviction hook working for every entry. *)
+     returned for another (see Compile_cache.mli). Passing [~device_id] keeps
+     the device-destroy eviction hook working for every entry. *)
   let with_cache device ~name ~source build =
     let key =
       Spoc_framework.Compile_cache.make_key
@@ -626,13 +614,11 @@ module Kernel = struct
         ~source
         ()
     in
-    match Hashtbl.find_opt cache key with
-    | Some k -> k
-    | None ->
-        let k = build () in
-        Hashtbl.add cache key k ;
-        record_key_for_device device.Device.id key ;
-        k
+    Spoc_framework.Guarded_cache.find_or_build
+      cache
+      ~key
+      ~device_id:device.Device.id
+      build
 
   (** Cached variant of [load_from_ptx] — same cache as [compile_cached].
       Without it, every launch reloads (and re-JITs) the PTX module, which
@@ -645,14 +631,7 @@ module Kernel = struct
   let compile_cached device ~name ~source =
     with_cache device ~name ~source (fun () -> compile device ~name ~source)
 
-  let clear_cache () =
-    Hashtbl.iter
-      (fun _ k ->
-        let _ = cuModuleUnload k.module_ in
-        ())
-      cache ;
-    Hashtbl.clear cache ;
-    Hashtbl.clear keys_by_device
+  let clear_cache () = Spoc_framework.Guarded_cache.clear cache
 
   (** Existential wrapper for keeping Ctypes-allocated values alive during FFI
       calls *)

--- a/sarek-hip/Hip_api.ml
+++ b/sarek-hip/Hip_api.ml
@@ -353,28 +353,19 @@ module Kernel = struct
     | ArgFloat64 : float -> arg
     | ArgPtr : nativeint -> arg
 
-  let cache : (string, t) Hashtbl.t = Hashtbl.create 16
-
-  let keys_by_device : (int, string list ref) Hashtbl.t = Hashtbl.create 16
-
-  let record_key_for_device device_id key =
-    match Hashtbl.find_opt keys_by_device device_id with
-    | Some keys -> keys := key :: !keys
-    | None -> Hashtbl.add keys_by_device device_id (ref [key])
+  (* Compilation cache. Guarded against concurrent multi-domain access by
+     [Spoc_framework.Guarded_cache]: cache lookup/insert, per-device key
+     tracking, eviction and clearing are all atomic, while the hiprtc compile
+     runs outside the lock. Keys are grouped by device id (via
+     [find_or_build ~device_id]) so a device destroy/recreate cycle can evict
+     exactly its own stale module/function handles. *)
+  let cache : (string, t) Spoc_framework.Guarded_cache.t =
+    Spoc_framework.Guarded_cache.create
+      ~destroy:(fun k -> ignore (hipModuleUnload k.module_))
+      ()
 
   let evict_device device_id =
-    match Hashtbl.find_opt keys_by_device device_id with
-    | None -> ()
-    | Some keys ->
-        List.iter
-          (fun key ->
-            match Hashtbl.find_opt cache key with
-            | None -> ()
-            | Some k ->
-                let _ = hipModuleUnload k.module_ in
-                Hashtbl.remove cache key)
-          !keys ;
-        Hashtbl.remove keys_by_device device_id
+    Spoc_framework.Guarded_cache.evict_device cache device_id
 
   let () = device_destroy_hooks := evict_device :: !device_destroy_hooks
 
@@ -447,25 +438,16 @@ module Kernel = struct
         ~source
         ()
     in
-    match Hashtbl.find_opt cache key with
-    | Some k -> k
-    | None ->
-        let k = build () in
-        Hashtbl.add cache key k ;
-        record_key_for_device device.Device.id key ;
-        k
+    Spoc_framework.Guarded_cache.find_or_build
+      cache
+      ~key
+      ~device_id:device.Device.id
+      build
 
   let compile_cached device ~name ~source =
     with_cache device ~name ~source (fun () -> compile device ~name ~source)
 
-  let clear_cache () =
-    Hashtbl.iter
-      (fun _ k ->
-        let _ = hipModuleUnload k.module_ in
-        ())
-      cache ;
-    Hashtbl.clear cache ;
-    Hashtbl.clear keys_by_device
+  let clear_cache () = Spoc_framework.Guarded_cache.clear cache
 
   type ctype_ref = CTypeRef : 'a typ * 'a ptr -> ctype_ref
 

--- a/sarek-metal/Metal_plugin_base.ml
+++ b/sarek-metal/Metal_plugin_base.ml
@@ -221,8 +221,16 @@ module Metal : Framework_sig.PLUGIN_BASE = struct
        see Spoc_framework.Kernel_args. *)
     type args = arg Spoc_framework.Kernel_args.t
 
-    (* Cache: key -> compiled kernel *)
-    let cache : (string, t) Hashtbl.t = Hashtbl.create 16
+    (* Cache: key -> compiled kernel. Guarded against concurrent multi-domain
+       access by [Spoc_framework.Guarded_cache]: lookup/insert and clearing are
+       atomic critical sections, while the Metal library/pipeline compile runs
+       outside the lock. *)
+    let cache : (string, t) Spoc_framework.Guarded_cache.t =
+      Spoc_framework.Guarded_cache.create
+        ~destroy:(fun k ->
+          Metal_api.Library.release k.library ;
+          Metal_api.ComputePipeline.release k.pipeline)
+        ()
 
     let compile device ~name ~source =
       let library = Metal_api.Library.create_from_source device source in
@@ -244,20 +252,10 @@ module Metal : Framework_sig.PLUGIN_BASE = struct
           ~source
           ()
       in
-      match Hashtbl.find_opt cache key with
-      | Some k -> k
-      | None ->
-          let k = compile device ~name ~source in
-          Hashtbl.add cache key k ;
-          k
+      Spoc_framework.Guarded_cache.find_or_build cache ~key (fun () ->
+          compile device ~name ~source)
 
-    let clear_cache () =
-      Hashtbl.iter
-        (fun _ k ->
-          Metal_api.Library.release k.library ;
-          Metal_api.ComputePipeline.release k.pipeline)
-        cache ;
-      Hashtbl.clear cache
+    let clear_cache () = Spoc_framework.Guarded_cache.clear cache
 
     let load_from_ptx ~name:_ ~ptx:_ =
       Metal_error.raise_error (Metal_error.feature_not_supported "PTX kernels")

--- a/sarek-opencl/Opencl_plugin_base.ml
+++ b/sarek-opencl/Opencl_plugin_base.ml
@@ -214,8 +214,15 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
        see Spoc_framework.Kernel_args. *)
     type args = arg Spoc_framework.Kernel_args.t
 
-    (* Cache: key -> compiled kernel *)
-    let cache : (string, t) Hashtbl.t = Hashtbl.create 16
+    (* Cache: key -> compiled kernel. Guarded against concurrent multi-domain
+       access by [Spoc_framework.Guarded_cache]: lookup/insert and clearing are
+       atomic critical sections, while clBuildProgram runs outside the lock. *)
+    let cache : (string, t) Spoc_framework.Guarded_cache.t =
+      Spoc_framework.Guarded_cache.create
+        ~destroy:(fun k ->
+          Opencl_api.Kernel.release k.kernel ;
+          Opencl_api.Program.release k.program)
+        ()
 
     let compile device ~name ~source =
       let state = get_state device.Opencl_api.Device.id in
@@ -238,20 +245,10 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
           ~source
           ()
       in
-      match Hashtbl.find_opt cache key with
-      | Some k -> k
-      | None ->
-          let k = compile device ~name ~source in
-          Hashtbl.add cache key k ;
-          k
+      Spoc_framework.Guarded_cache.find_or_build cache ~key (fun () ->
+          compile device ~name ~source)
 
-    let clear_cache () =
-      Hashtbl.iter
-        (fun _ k ->
-          Opencl_api.Kernel.release k.kernel ;
-          Opencl_api.Program.release k.program)
-        cache ;
-      Hashtbl.clear cache
+    let clear_cache () = Spoc_framework.Guarded_cache.clear cache
 
     let load_from_ptx ~name:_ ~ptx:_ =
       Opencl_error.raise_error

--- a/sarek-vulkan/Vulkan_api_kernel.ml
+++ b/sarek-vulkan/Vulkan_api_kernel.ml
@@ -113,8 +113,23 @@ let validate_buffer_indices ~expected_count
               (List.map (fun (idx, _) -> string_of_int idx) entries)))
     else Ok ()
 
-(* Compilation cache *)
-let cache : (string, t) Hashtbl.t = Hashtbl.create 16
+(* Compilation cache (compiled compute pipelines). Guarded against concurrent
+   multi-domain access by [Spoc_framework.Guarded_cache]: lookup/insert and
+   clearing are atomic critical sections, while GLSL->SPIR-V compilation and
+   pipeline creation run outside the lock. The on-disk SPIR-V cache
+   ([Framework_cache]) is a separate layer. *)
+let cache : (string, t) Spoc_framework.Guarded_cache.t =
+  Spoc_framework.Guarded_cache.create
+    ~destroy:(fun k ->
+      vkDestroyPipeline k.device.Device.device k.pipeline null ;
+      vkDestroyPipelineLayout k.device.Device.device k.pipeline_layout null ;
+      vkDestroyDescriptorPool k.device.Device.device k.descriptor_pool null ;
+      vkDestroyDescriptorSetLayout
+        k.device.Device.device
+        k.descriptor_set_layout
+        null ;
+      vkDestroyShaderModule k.device.Device.device k.shader_module null)
+    ()
 
 (** Create shader module from SPIR-V *)
 let create_shader_module device spirv =
@@ -393,26 +408,10 @@ let compile_cached device ~name ~source =
       ~source
       ()
   in
-  match Hashtbl.find_opt cache key with
-  | Some k -> k
-  | None ->
-      let k = compile device ~name ~source in
-      Hashtbl.add cache key k ;
-      k
+  Spoc_framework.Guarded_cache.find_or_build cache ~key (fun () ->
+      compile device ~name ~source)
 
-let clear_cache () =
-  Hashtbl.iter
-    (fun _ k ->
-      vkDestroyPipeline k.device.Device.device k.pipeline null ;
-      vkDestroyPipelineLayout k.device.Device.device k.pipeline_layout null ;
-      vkDestroyDescriptorPool k.device.Device.device k.descriptor_pool null ;
-      vkDestroyDescriptorSetLayout
-        k.device.Device.device
-        k.descriptor_set_layout
-        null ;
-      vkDestroyShaderModule k.device.Device.device k.shader_module null)
-    cache ;
-  Hashtbl.clear cache
+let clear_cache () = Spoc_framework.Guarded_cache.clear cache
 
 let create_args () =
   {

--- a/sarek/core/Runtime.ml
+++ b/sarek/core/Runtime.ml
@@ -45,23 +45,25 @@ let all_devices ?framework () =
   Device.init ~frameworks ()
 
 (** Kernel source cache: (device_framework, kernel_name, source_hash) ->
-    compiled *)
-let kernel_cache : (string * string * int, Kernel.t) Hashtbl.t =
-  Hashtbl.create 32
+    compiled. Guarded against concurrent multi-domain access by
+    [Spoc_framework.Guarded_cache] (this is the cross-backend entry point most
+    multi-domain code hits). [destroy] is a no-op: the compiled [Kernel.t]
+    handles are owned by the per-backend caches reached through
+    [Kernel.compile_cached], which release them on their own [clear_cache];
+    clearing this outer layer only drops the memoization. *)
+let kernel_cache :
+    (string * string * int, Kernel.t) Spoc_framework.Guarded_cache.t =
+  Spoc_framework.Guarded_cache.create ~size:32 ~destroy:(fun _ -> ()) ()
 
 (** Compile a kernel from source, with caching *)
 let compile_kernel (device : Device.t) ~(name : string) ~(source : string) :
     Kernel.t =
   let key = (device.framework, name, Hashtbl.hash source) in
-  match Hashtbl.find_opt kernel_cache key with
-  | Some k -> k
-  | None ->
-      let k = Kernel.compile_cached device ~name ~source in
-      Hashtbl.replace kernel_cache key k ;
-      k
+  Spoc_framework.Guarded_cache.find_or_build kernel_cache ~key (fun () ->
+      Kernel.compile_cached device ~name ~source)
 
 (** Clear the kernel cache *)
-let clear_cache () = Hashtbl.clear kernel_cache
+let clear_cache () = Spoc_framework.Guarded_cache.clear kernel_cache
 
 (** Argument builder - collects kernel arguments *)
 type arg =

--- a/spoc/framework/Guarded_cache.ml
+++ b/spoc/framework/Guarded_cache.ml
@@ -1,0 +1,96 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Guarded_cache - concurrency-safe kernel-compilation cache.
+ *
+ * See Guarded_cache.mli for the rationale. One Mutex guards both the main
+ * key -> value table and the device-id -> keys index. The expensive JIT
+ * compile runs outside the lock (check under lock -> miss -> release lock ->
+ * build -> re-acquire -> double-check -> insert), so multiple domains never
+ * serialize on compilation, only on the (cheap) table operations.
+ ******************************************************************************)
+
+type ('k, 'v) t = {
+  mutex : Mutex.t;
+  table : ('k, 'v) Hashtbl.t;
+  keys_by_device : (int, 'k list ref) Hashtbl.t;
+  destroy : 'v -> unit;
+}
+
+let create ?(size = 16) ~destroy () =
+  {
+    mutex = Mutex.create ();
+    table = Hashtbl.create size;
+    keys_by_device = Hashtbl.create 16;
+    destroy;
+  }
+
+(* Caller must hold [t.mutex]. *)
+let record_key_for_device t device_id key =
+  match Hashtbl.find_opt t.keys_by_device device_id with
+  | Some keys -> keys := key :: !keys
+  | None -> Hashtbl.add t.keys_by_device device_id (ref [key])
+
+let find_or_build t ~key ?device_id build =
+  (* Fast path: hit under the lock. *)
+  Mutex.lock t.mutex ;
+  match Hashtbl.find_opt t.table key with
+  | Some v ->
+      Mutex.unlock t.mutex ;
+      v
+  | None -> (
+      (* Miss: release the lock so the JIT compile does not serialize other
+         domains, then re-acquire to install the result. *)
+      Mutex.unlock t.mutex ;
+      let built = build () in
+      Mutex.lock t.mutex ;
+      match Hashtbl.find_opt t.table key with
+      | Some winner ->
+          (* Lost a concurrent compile of the same key: keep the value already
+             installed and discard ours. Destroy the loser outside the lock so
+             no backend resource leaks. *)
+          Mutex.unlock t.mutex ;
+          t.destroy built ;
+          winner
+      | None ->
+          Hashtbl.replace t.table key built ;
+          Option.iter (fun id -> record_key_for_device t id key) device_id ;
+          Mutex.unlock t.mutex ;
+          built)
+
+let evict_device t device_id =
+  (* Snapshot + unlink under the lock; destroy released outside it. *)
+  let victims =
+    Mutex.protect t.mutex (fun () ->
+        match Hashtbl.find_opt t.keys_by_device device_id with
+        | None -> []
+        | Some keys ->
+            let vs =
+              List.filter_map
+                (fun key ->
+                  match Hashtbl.find_opt t.table key with
+                  | None -> None
+                  | Some v ->
+                      Hashtbl.remove t.table key ;
+                      Some v)
+                !keys
+            in
+            Hashtbl.remove t.keys_by_device device_id ;
+            vs)
+  in
+  List.iter t.destroy victims
+
+let clear t =
+  let victims =
+    Mutex.protect t.mutex (fun () ->
+        let vs = Hashtbl.fold (fun _ v acc -> v :: acc) t.table [] in
+        Hashtbl.clear t.table ;
+        Hashtbl.clear t.keys_by_device ;
+        vs)
+  in
+  List.iter t.destroy victims
+
+let length t = Mutex.protect t.mutex (fun () -> Hashtbl.length t.table)

--- a/spoc/framework/Guarded_cache.mli
+++ b/spoc/framework/Guarded_cache.mli
@@ -1,0 +1,70 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Concurrency-safe kernel-compilation cache, shared by every GPU backend.
+
+    Each backend memoizes compiled kernels in a [(string, t) Hashtbl.t] keyed by
+    a {!Compile_cache.make_key} string. Under OCaml 5 multi-domain execution
+    (now a supported use case) an unsynchronized [Hashtbl] is a data race: two
+    domains inserting concurrently can corrupt the table's internal buckets
+    during a resize, or a lookup can observe a half-linked bucket and raise.
+    This module wraps the table behind a single {!Mutex.t} so cache lookup,
+    insertion, per-device key tracking, eviction, and clearing are all atomic
+    critical sections, while the expensive JIT compile
+    ([nvrtc]/[hiprtc]/[clBuildProgram]/ shader compilation) runs {e outside} the
+    lock.
+
+    The value type ['v] (resolved module/function handles, compiled pipelines,
+    SPIR-V-backed objects, ...) and the key type ['k] differ per backend, so the
+    cache is parametric in both. A per-cache [destroy] callback releases the
+    backend resource held by an evicted or cleared value. *)
+
+(** A guarded cache from keys ['k] to compiled values ['v]. *)
+type ('k, 'v) t
+
+(** [create ~destroy ()] builds an empty cache. [destroy] is applied to every
+    value removed by {!clear} or {!evict_device} (and to the loser of a rare
+    concurrent double-compile in {!find_or_build}); it should release the
+    backend resource the value owns (e.g. [cuModuleUnload]). [destroy] is always
+    invoked {e outside} the cache lock, so it must not itself call back into
+    this cache. [size] is the initial table size (default 16). *)
+val create : ?size:int -> destroy:('v -> unit) -> unit -> ('k, 'v) t
+
+(** [find_or_build t ~key ?device_id build] returns the cached value for [key],
+    compiling it with [build] on a miss.
+
+    Lock discipline: the cache is checked under the lock; on a hit the value is
+    returned immediately. On a miss the lock is {e released} before [build] runs
+    (JIT compilation must never hold the cache lock), then re-acquired to
+    insert. A double-check on re-acquire handles the case where another domain
+    compiled the same key while the lock was released: the value already present
+    wins and is returned, and the just-built loser is passed to the cache's
+    [destroy] (outside the lock) so no backend resource leaks. This means, under
+    a race, the same key may be compiled more than once, but at most one value
+    is ever retained and every caller observes that single value.
+
+    If [device_id] is supplied, [key] is recorded against that device so
+    {!evict_device} can later retire exactly the entries compiled for it (used
+    by backends whose device-destroy hook must unload modules before the
+    underlying context is torn down). Omit it for caches with no per-device
+    eviction. *)
+val find_or_build : ('k, 'v) t -> key:'k -> ?device_id:int -> (unit -> 'v) -> 'v
+
+(** [evict_device t device_id] removes and {!destroy}s every value recorded for
+    [device_id] via {!find_or_build}'s [~device_id]. Safe to call from a
+    device-destroy hook: it acquires the lock only to snapshot and unlink the
+    affected entries, then releases it before running [destroy], so it never
+    re-enters the cache while holding the lock. A no-op for an unknown
+    [device_id]. *)
+val evict_device : ('k, 'v) t -> int -> unit
+
+(** [clear t] removes and {!destroy}s every cached value and forgets all
+    per-device key tracking. Values are snapshotted under the lock and destroyed
+    after it is released. *)
+val clear : ('k, 'v) t -> unit
+
+(** [length t] is the number of entries currently cached (under the lock).
+    Intended for tests and diagnostics. *)
+val length : ('k, 'v) t -> int

--- a/spoc/framework/dune
+++ b/spoc/framework/dune
@@ -7,7 +7,8 @@
   Typed_value
   Backend_error
   Kernel_args
-  Compile_cache)
+  Compile_cache
+  Guarded_cache)
  (libraries sarek_ir sarek_backend_error)
  (preprocess no_preprocessing)
  (instrumentation

--- a/spoc/framework/test/dune
+++ b/spoc/framework/test/dune
@@ -5,5 +5,6 @@
   test_device_type
   test_backend_error
   test_kernel_args
-  test_compile_cache)
+  test_compile_cache
+  test_guarded_cache)
  (libraries spoc_framework alcotest str))

--- a/spoc/framework/test/test_guarded_cache.ml
+++ b/spoc/framework/test/test_guarded_cache.ml
@@ -1,0 +1,245 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Guarded_cache Tests - concurrent multi-domain (OCaml 5 Domain) safety.
+ *
+ * These are backend-agnostic: they exercise the shared guarded cache directly
+ * with plain int values, so no GPU / driver is required and the same
+ * regression guard covers every backend that uses Spoc_framework.Guarded_cache
+ * (CUDA, HIP, OpenCL, Metal, Vulkan) plus the core Runtime cache.
+ *
+ * Why the primary test is a GREEN stress test rather than a deterministic
+ * red-on-race: concurrent writes to a *raw* stdlib Hashtbl from several Domains
+ * are undefined behaviour - the observed failure ranges from a caught
+ * exception (bucket half-linked during a resize) to a hard segfault that would
+ * take down the whole test binary non-deterministically. There is no reliable,
+ * catchable, deterministic "red" to assert on. Instead we hammer the *guarded*
+ * cache hard enough to hit the concurrent-insert / double-compile / evict paths
+ * and assert its invariants hold. A runnable red demonstration against a raw
+ * Hashtbl is provided but gated behind SAREK_GUARDED_CACHE_RED=1 so the default
+ * suite stays safe (see [red_demo_unguarded]).
+ ******************************************************************************)
+
+module GC = Spoc_framework.Guarded_cache
+
+let num_domains = 8
+
+let iterations_per_domain = 4000
+
+let shared_key_count = 16
+
+(* A tiny variable delay inside [build] widens the miss window so concurrent
+   compiles of the same key actually race (exercising the loser-destroy path),
+   rather than the fast domain always winning uncontended. *)
+let jitter () =
+  for _ = 0 to Random.int 40 do
+    Domain.cpu_relax ()
+  done
+
+(* Every built value is a globally unique int; every destroyed value is
+   recorded. Invariant under any interleaving: builds - destroys = table size,
+   i.e. every value ever built is either retained in the table or destroyed as
+   a race loser - never leaked, never double-counted. *)
+let test_stress_shared_and_distinct_keys () =
+  let builds = Atomic.make 0 in
+  let destroys = Atomic.make 0 in
+  let cache =
+    GC.create
+      ~destroy:(fun (_ : int) -> ignore (Atomic.fetch_and_add destroys 1))
+      ()
+  in
+  let build () =
+    jitter () ;
+    Atomic.fetch_and_add builds 1
+  in
+  (* Each domain repeatedly resolves shared keys (contended) and its own
+     domain-private keys (uncontended inserts), checking that a shared key
+     always hands back one stable value. *)
+  let worker d () =
+    let last_for_shared = Array.make shared_key_count (-1) in
+    for i = 0 to iterations_per_domain - 1 do
+      let use_shared = i land 1 = 0 in
+      if use_shared then begin
+        (* [i] is even in this branch, so [i mod shared_key_count] would only
+           ever hit even indices; divide first so all shared keys are used. *)
+        let k = i / 2 mod shared_key_count in
+        let key = Printf.sprintf "shared_%d" k in
+        let v = GC.find_or_build cache ~key ~device_id:0 build in
+        if last_for_shared.(k) >= 0 && last_for_shared.(k) <> v then
+          Alcotest.failf
+            "shared key %s resolved to two different values (%d then %d)"
+            key
+            last_for_shared.(k)
+            v ;
+        last_for_shared.(k) <- v
+      end
+      else begin
+        let key = Printf.sprintf "d%d_k%d" d i in
+        let _ = GC.find_or_build cache ~key ~device_id:(1 + d) build in
+        ()
+      end
+    done
+  in
+  let domains = List.init num_domains (fun d -> Domain.spawn (worker d)) in
+  List.iter Domain.join domains ;
+  let total_built = Atomic.get builds in
+  let total_destroyed = Atomic.get destroys in
+  let retained = GC.length cache in
+  (* Distinct keys inserted = shared keys + one private key per (odd) iteration
+     per domain. *)
+  let private_per_domain =
+    (* count of odd i in [0, iterations_per_domain) *)
+    iterations_per_domain / 2
+  in
+  let expected_distinct =
+    shared_key_count + (num_domains * private_per_domain)
+  in
+  Alcotest.(check int)
+    "retained entries = number of distinct keys"
+    expected_distinct
+    retained ;
+  Alcotest.(check int)
+    "every built value is either retained or destroyed (no leak, no \
+     double-count)"
+    retained
+    (total_built - total_destroyed) ;
+  Alcotest.(check bool)
+    "at least one build per distinct key happened"
+    true
+    (total_built >= expected_distinct)
+
+(* Concurrent clear vs. find_or_build: no exception, and afterwards the cache is
+   internally consistent (length matches a fresh recount). *)
+let test_concurrent_clear () =
+  let cache = GC.create ~destroy:(fun (_ : int) -> ()) () in
+  let counter = Atomic.make 0 in
+  let build () = Atomic.fetch_and_add counter 1 in
+  let writer () =
+    for i = 0 to iterations_per_domain - 1 do
+      let key = Printf.sprintf "k%d" (i mod 32) in
+      let _ = GC.find_or_build cache ~key build in
+      ()
+    done
+  in
+  let clearer () =
+    for _ = 0 to 200 do
+      GC.clear cache ;
+      Domain.cpu_relax ()
+    done
+  in
+  let ds =
+    Domain.spawn clearer :: List.init num_domains (fun _ -> Domain.spawn writer)
+  in
+  List.iter Domain.join ds ;
+  (* A final clear leaves it empty; the key assertion is that nothing above
+     raised or corrupted the table. *)
+  GC.clear cache ;
+  Alcotest.(check int) "cache empty after final clear" 0 (GC.length cache)
+
+(* Concurrent evict_device: each domain owns a device id and evicts it while
+   others keep inserting. Must not raise; destroy count must never exceed the
+   number of builds. *)
+let test_concurrent_evict_device () =
+  let builds = Atomic.make 0 in
+  let destroys = Atomic.make 0 in
+  let cache =
+    GC.create
+      ~destroy:(fun (_ : int) -> ignore (Atomic.fetch_and_add destroys 1))
+      ()
+  in
+  let build () = Atomic.fetch_and_add builds 1 in
+  let worker d () =
+    for i = 0 to iterations_per_domain - 1 do
+      let key = Printf.sprintf "d%d_k%d" d (i mod 64) in
+      let _ = GC.find_or_build cache ~key ~device_id:d build in
+      if i mod 500 = 0 then GC.evict_device cache d
+    done
+  in
+  let ds = List.init num_domains (fun d -> Domain.spawn (worker d)) in
+  List.iter Domain.join ds ;
+  Alcotest.(check bool)
+    "destroys never exceed builds"
+    true
+    (Atomic.get destroys <= Atomic.get builds) ;
+  Alcotest.(check bool)
+    "retained + destroyed = built (conservation)"
+    true
+    (GC.length cache + Atomic.get destroys = Atomic.get builds)
+
+(* Runnable red demonstration, OFF by default (would be UB/segfault-prone in
+   the suite). With SAREK_GUARDED_CACHE_RED=1 it hammers a *raw* unguarded
+   Hashtbl from several domains and reports the corruption/exception - the very
+   failure Guarded_cache prevents. *)
+let red_demo_unguarded () =
+  match Sys.getenv_opt "SAREK_GUARDED_CACHE_RED" with
+  | Some "1" ->
+      (* Each domain inserts its OWN disjoint block of keys, so with correct
+         synchronization the final length is exactly [num_domains * m]. A raw
+         Hashtbl started small forces many resizes; concurrent resizes drop
+         entries (silent corruption) - reliably observed as a large length
+         shortfall - and can also raise or segfault (all are manifestations of
+         the same data race). *)
+      let m = 200_000 in
+      let raw : (int, int) Hashtbl.t = Hashtbl.create 4 in
+      let failed = Atomic.make false in
+      let worker d () =
+        try
+          for i = 0 to m - 1 do
+            let key = (d * m) + i in
+            Hashtbl.replace raw key i ;
+            ignore (Hashtbl.find_opt raw key)
+          done
+        with e ->
+          Atomic.set failed true ;
+          Printf.eprintf
+            "[red-demo] raw Hashtbl raised under contention: %s\n%!"
+            (Printexc.to_string e)
+      in
+      let ds = List.init num_domains (fun d -> Domain.spawn (worker d)) in
+      List.iter Domain.join ds ;
+      let expected = num_domains * m in
+      let got = Hashtbl.length raw in
+      Printf.eprintf
+        "[red-demo] raw unguarded Hashtbl: expected %d distinct entries, \
+         retained %d (lost %d), raised=%b -> CORRUPTION %s\n\
+         %!"
+        expected
+        got
+        (expected - got)
+        (Atomic.get failed)
+        (if got <> expected || Atomic.get failed then "OBSERVED (RED)"
+         else "not observed this run (race is non-deterministic)")
+  | _ ->
+      Printf.printf
+        "  red demo skipped (set SAREK_GUARDED_CACHE_RED=1 to run the \
+         raw-Hashtbl race)\n\
+         %!"
+
+let () =
+  Random.self_init () ;
+  Alcotest.run
+    "Guarded_cache"
+    [
+      ( "concurrency",
+        [
+          Alcotest.test_case
+            "stress: shared + distinct keys, N domains"
+            `Slow
+            test_stress_shared_and_distinct_keys;
+          Alcotest.test_case
+            "concurrent clear vs find_or_build"
+            `Slow
+            test_concurrent_clear;
+          Alcotest.test_case
+            "concurrent evict_device"
+            `Slow
+            test_concurrent_evict_device;
+          Alcotest.test_case
+            "red demo (unguarded, opt-in)"
+            `Quick
+            red_demo_unguarded;
+        ] );
+    ]


### PR DESCRIPTION
## Problem

OCaml 5 multi-domain (Domain) execution is now a supported use case. Every backend's kernel-compilation cache was a plain stdlib `Hashtbl` accessed with **no synchronization** — `find_opt`-then-`add` on miss, plus `record_key_for_device` / `evict_device` / `clear_cache`. Concurrent inserts from multiple domains are a data race: they can corrupt the table during a resize (silently dropping entries) or raise on a half-linked bucket. Only `pending_lock` was previously guarded.

## Fix — shared guarded-cache helper

New **`Spoc_framework.Guarded_cache`**: one `Mutex`-guarded, parametric (`'k`,`'v`) cache used by **all** sites, mutualizing the logic (relates to backend factorization #58). Chosen over per-backend replication because a single correct implementation is easier to audit and reuse. Value/key types differ per backend, so a per-cache `~destroy` callback releases the backend resource. `Compile_cache.make_key` (key *shape*) is unchanged and still builds the keys.

### Sites wired to it
| Backend | Cache sites |
|---|---|
| `sarek-cuda/Cuda_api.ml` (Kernel) | cache + keys_by_device + `evict_device` (device-destroy hook) + `with_cache` + `clear_cache` |
| `sarek-hip/Hip_api.ml` (Kernel) | same shape |
| `sarek-opencl/Opencl_plugin_base.ml` | cache + `compile_cached` + `clear_cache` |
| `sarek-metal/Metal_plugin_base.ml` | cache + `compile_cached` + `clear_cache` |
| `sarek-vulkan/Vulkan_api_kernel.ml` | in-memory pipeline cache + `clear_cache` (on-disk SPIR-V `Framework_cache` layer untouched) |
| `sarek/core/Runtime.ml` | cross-backend `compile_kernel` memoization (the entry point most multi-domain code hits) |

**Native / Interpreter**: no JIT compile cache — their tables are startup registration maps (`register_kernel`, no compile-on-miss). Left as-is.

## Lock discipline

Lookup+insert, record-key, evict, and clear are each **one atomic critical section**. The expensive JIT compile (nvrtc/hiprtc/clBuildProgram/shader) runs **outside** the lock: check under lock → miss → release lock → build → re-acquire → double-check → insert. On a lost race the already-installed value wins and the just-built loser is passed to `~destroy` (outside the lock) — no GPU resource leaks, at most one value per key retained, every caller sees that single value.

## Deadlock analysis of `evict_device`

`evict_device` runs from `device_destroy_hooks`. It only snapshots + unlinks affected entries **under** the lock, then releases the lock **before** running `~destroy` (`cuModuleUnload`/`hipModuleUnload`), so it never re-enters the cache while holding the lock, and no path invokes a device-destroy hook while the cache lock is held. Runtime's `find_or_build` releases its lock before `build()` acquires the backend cache lock, so the two nested guarded caches never hold both locks at once — no lock-ordering cycle.

## Test

`spoc/framework/test/test_guarded_cache.ml` — backend-agnostic (no GPU), covers every backend at the helper level.
- **GREEN** stress tests: 8 domains hammering shared + distinct keys, concurrent `clear`, concurrent `evict_device`; assert conservation (`built = retained + destroyed`, no leak/double-count) and single-value-per-key. Stable across repeated runs.
- **RED** demonstration gated behind `SAREK_GUARDED_CACHE_RED=1` (a deterministic in-suite red is unsafe — raw concurrent `Hashtbl` access is UB and can segfault). It shows a raw unguarded Hashtbl silently losing **~1M of 1.6M** concurrently-inserted distinct entries.

## Gates

- `dune build` clean; `dune build @fmt` clean on touched files
- framework + core test suites pass
- **HIP étape-A hardware gate on the RX 7900 XTX: PASSED** (vector_add + all gemm cases, on GPU and CPU HIP devices) — no regression/deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a concurrency-safe compilation cache shared across GPU backends.
  * Improved cache handling for device-specific eviction and resource cleanup.
  * Added cache size monitoring and complete cache clearing support.

* **Bug Fixes**
  * Prevented duplicate concurrent compilations and resource leaks.
  * Improved cleanup of compiled GPU resources when entries are evicted or cleared.

* **Tests**
  * Added stress tests covering concurrent compilation, clearing, and device eviction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->