### PR TITLE
refactor(sarek): unify 5 backend gen_intrinsic into one dispatcher (closes #48)

### DIFF
--- a/sarek-metal/test/test_sarek_ir_metal.ml
+++ b/sarek-metal/test/test_sarek_ir_metal.ml
@@ -146,7 +146,12 @@ let test_atomics () =
   let buf = Buffer.create 128 in
   let addr = make_var "counter" TInt32 in
   let value = EConst (CInt32 1l) in
-  Sarek_ir_metal.gen_intrinsic buf [] "atomic_add" [EVar addr; value] ;
+  Sarek_ir_metal.Dispatch.gen_intrinsic
+    Sarek_ir_metal.metal_backend
+    buf
+    []
+    "atomic_add"
+    [EVar addr; value] ;
   let result = Buffer.contents buf in
   Alcotest.(check bool)
     "atomic_add generates atomic_fetch_add_explicit"

--- a/sarek-vulkan/test/test_sarek_ir_glsl.ml
+++ b/sarek-vulkan/test/test_sarek_ir_glsl.ml
@@ -162,7 +162,12 @@ let test_atomics () =
   let buf = Buffer.create 128 in
   let addr = make_var "counter" TInt32 in
   let value = EConst (CInt32 1l) in
-  Sarek_ir_glsl.gen_intrinsic buf [] "atomic_add" [EVar addr; value] ;
+  Sarek_ir_glsl.Dispatch.gen_intrinsic
+    Sarek_ir_glsl.glsl_backend
+    buf
+    []
+    "atomic_add"
+    [EVar addr; value] ;
   let result = Buffer.contents buf in
   Alcotest.(check bool)
     "atomic_add generates atomicAdd"

--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -24,6 +24,13 @@ module Codegen_error = Sarek_backend_error.Backend_error.Make (struct
   let name = "CUDA"
 end)
 
+module Dispatch = Sarek_ir_intrinsic_dispatch
+
+(** Raise a located invalid-argument-count error (atomic-arity helper for the
+    shared {!Dispatch.emit_atomic}). *)
+let bad_arity n e g =
+  Codegen_error.raise_error (Codegen_error.invalid_arg_count n e g)
+
 (** Current framework string for SNative code generation. Always [None] in
     normal use; SNative branches check this ref and error if None. *)
 let current_framework : string option ref = ref None
@@ -121,7 +128,8 @@ let rec gen_expr buf = function
       gen_expr buf e ;
       Buffer.add_char buf '.' ;
       Buffer.add_string buf field
-  | EIntrinsic (path, name, args) -> gen_intrinsic buf path name args
+  | EIntrinsic (path, name, args) ->
+      Dispatch.gen_intrinsic cuda_backend buf path name args
   | ECast (ty, e) ->
       Buffer.add_char buf '(' ;
       Buffer.add_string buf (cuda_type_of_elttype ty) ;
@@ -232,226 +240,87 @@ and gen_binop = function
 
 and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
 
-and gen_intrinsic buf path name args =
-  (* Check for thread intrinsics first *)
-  let full_name =
-    match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
-  in
-  (* For path-qualified intrinsics, query the pure registry first.
-     This handles Float32.sin -> sinf on CUDA, sin on others, etc. *)
-  let pure_registry_hit =
-    match path with
-    | [] -> None
-    | _ -> (
-        let framework = Option.value ~default:"CUDA" !current_framework in
-        match
-          Sarek_pure_registry.fun_device_template ~module_path:path name
-        with
-        | Some f -> Some (f ~framework)
-        | None -> None)
-  in
-  match pure_registry_hit with
-  | Some device_name ->
-      Buffer.add_string buf device_name ;
-      Buffer.add_char buf '(' ;
-      List.iteri
-        (fun i e ->
-          if i > 0 then Buffer.add_string buf ", " ;
-          gen_expr buf e)
-        args ;
-      Buffer.add_char buf ')'
-  | None -> (
-      if
-        (* Try thread intrinsics *)
-        List.mem
-          name
-          [
-            "thread_id_x";
-            "thread_idx_x";
-            "thread_id_y";
-            "thread_idx_y";
-            "thread_id_z";
-            "thread_idx_z";
-            "block_id_x";
-            "block_idx_x";
-            "block_id_y";
-            "block_idx_y";
-            "block_id_z";
-            "block_idx_z";
-            "block_dim_x";
-            "block_dim_y";
-            "block_dim_z";
-            "grid_dim_x";
-            "grid_dim_y";
-            "grid_dim_z";
-            "global_thread_id";
-            "global_idx";
-            "global_idx_x";
-            "global_idx_y";
-            "global_idx_z";
-            "global_size";
-          ]
-      then Buffer.add_string buf (cuda_thread_intrinsic name)
-      else
-        (* Standard math intrinsics *)
+and cuda_backend =
+  {
+    Dispatch.framework =
+      (fun () -> Option.value ~default:"CUDA" !current_framework);
+    gen_expr;
+    thread_intrinsic = cuda_thread_intrinsic;
+    pre_hook = (fun _ ~full_name:_ _ _ _ -> false);
+    post_hook =
+      (fun buf path name args ->
+        Dispatch.emit_registry_template ~gen_expr buf path name args);
+    on_unknown =
+      (fun full ->
+        Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));
+    arm =
+      (fun name ->
         match name with
         | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
         | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
-        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "atan2" | "pow" | "fma" | "min" | "max" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        (* Barrier synchronization *)
-        | "block_barrier" -> Buffer.add_string buf "__syncthreads()"
+        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" | "atan2"
+        | "pow" | "fma" | "min" | "max" ->
+            Some (fun buf args -> Dispatch.emit_call ~gen_expr buf name args)
+        | "block_barrier" ->
+            Some (fun buf _ -> Buffer.add_string buf "__syncthreads()")
         | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-            Buffer.add_string buf "atomicAdd(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | [arr; idx; value] ->
-                (* Array element atomic: atomicAdd(&arr[idx], value) *)
-                Buffer.add_char buf '&' ;
-                gen_expr buf arr ;
-                Buffer.add_char buf '[' ;
-                gen_expr buf idx ;
-                Buffer.add_string buf "], " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_add"
-                     3
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicAdd"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_add"
+                  ~expected:3
+                  ~allow_array:true
+                  args)
         | "atomic_sub" ->
-            Buffer.add_string buf "atomicSub(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_sub"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicSub"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_sub"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
         | "atomic_min" ->
-            Buffer.add_string buf "atomicMin(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_min"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicMin"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_min"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
         | "atomic_max" ->
-            Buffer.add_string buf "atomicMax(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_max"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | _ -> (
-            (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
-            match Sarek_registry.fun_device_template ~module_path:path name with
-            | Some template ->
-                (* Generate argument strings *)
-                let arg_strs =
-                  List.map
-                    (fun e ->
-                      let b = Buffer.create 64 in
-                      gen_expr b e ;
-                      Buffer.contents b)
-                    args
-                in
-                (* Count %s placeholders in template *)
-                let count_placeholders s =
-                  let rec count i acc =
-                    if i >= String.length s - 1 then acc
-                    else if s.[i] = '%' && s.[i + 1] = 's' then
-                      count (i + 2) (acc + 1)
-                    else count (i + 1) acc
-                  in
-                  count 0 0
-                in
-                let num_placeholders = count_placeholders template in
-                let result =
-                  if num_placeholders = 0 then
-                    (* Plain function/cast like "(float)" -> call as function *)
-                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                  else if num_placeholders = 1 && List.length arg_strs = 1 then
-                    match arg_strs with
-                    | [arg] ->
-                        Printf.sprintf
-                          (Scanf.format_from_string template "%s")
-                          arg
-                    | _ ->
-                        (* This should never happen due to length check above *)
-                        Codegen_error.raise_error
-                          (Codegen_error.type_error
-                             "intrinsic template"
-                             "1 placeholder, 1 argument"
-                             "unexpected list state")
-                  else if num_placeholders = 2 && List.length arg_strs = 2 then
-                    Printf.sprintf
-                      (Scanf.format_from_string template "%s%s")
-                      (List.nth arg_strs 0)
-                      (List.nth arg_strs 1)
-                  else if num_placeholders = 3 && List.length arg_strs = 3 then
-                    Printf.sprintf
-                      (Scanf.format_from_string template "%s%s%s")
-                      (List.nth arg_strs 0)
-                      (List.nth arg_strs 1)
-                      (List.nth arg_strs 2)
-                  else
-                    (* Fallback: treat as function call *)
-                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                in
-                Buffer.add_string buf result
-            | None ->
-                (* Unknown intrinsic - emit as function call *)
-                Buffer.add_string buf full_name ;
-                Buffer.add_char buf '(' ;
-                List.iteri
-                  (fun i e ->
-                    if i > 0 then Buffer.add_string buf ", " ;
-                    gen_expr buf e)
-                  args ;
-                Buffer.add_char buf ')'))
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicMax"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_max"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
+        | _ -> None);
+  }
 
 (** {1 L-value Generation} *)
 

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -25,6 +25,13 @@ module Codegen_error = Sarek_backend_error.Backend_error.Make (struct
   let name = "Vulkan"
 end)
 
+module Dispatch = Sarek_ir_intrinsic_dispatch
+
+(** Raise a located invalid-argument-count error (atomic-arity helper for the
+    shared {!Dispatch.emit_atomic}). *)
+let bad_arity n e g =
+  Codegen_error.raise_error (Codegen_error.invalid_arg_count n e g)
+
 (** Current kernel's variant definitions (set during generate) *)
 let current_variants : (string * (string * elttype list) list) list ref = ref []
 
@@ -358,7 +365,8 @@ let rec gen_expr buf = function
       gen_expr buf e ;
       Buffer.add_char buf '.' ;
       Buffer.add_string buf field
-  | EIntrinsic (path, name, args) -> gen_intrinsic buf path name args
+  | EIntrinsic (path, name, args) ->
+      Dispatch.gen_intrinsic glsl_backend buf path name args
   | ECast (ty, e) ->
       Buffer.add_string buf (glsl_type_of_elttype ty) ;
       Buffer.add_char buf '(' ;
@@ -608,271 +616,120 @@ and gen_f64_transcendental buf name args =
             (Codegen_error.unknown_intrinsic
                (Printf.sprintf "%s (wrong arity for f64 transcendental)" name)))
 
-and gen_intrinsic buf path name args =
-  let full_name =
-    match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
-  in
-  (* A [Float64] path component marks the double-precision route; the plain
-     [Float32]/[Math.Float32] and unqualified (core-primitive, f32-typed)
-     spellings stay single-precision. This mirrors how the pure registry keys
-     the same intrinsics by their [Float64] vs [Float32] module path. *)
-  let is_f64 = List.mem "Float64" path in
-  if is_f64 && f64_root_helpers name <> None then
-    (* GLSL core has no double overload for the transcendental builtins; route
-       [Float64] sin/cos/exp/log/log10/pow/…/exp2/log2/cbrt/expm1/log1p through
-       the software helper family instead of emitting an invalid [sin(<double>)].
-       f32 spellings and native-f64 builtins (sqrt/floor/fma/hypot/…) fall
-       through to the existing logic unchanged. *)
-    gen_f64_transcendental buf name args
-  else if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"; "log10"] then
-    gen_glsl_polyfill buf ~is_f64 name args
-  else if name = "copysign" then (
-    (* GLSL has no [copysign] builtin under any name, and [abs(x)*sign(y)] is
-       wrong for [y=0] (GLSL [sign(0)=0]) and the [x=0]/NaN sign-transfer edge
-       cases. Lower to the bit-level [sarek_copysign] helper emitted in the
-       preamble by [gen_copysign_helper], ahead of both the pure registry
-       (which would emit the raw un-suffixed [copysign(...)] for
-       [Float32.copysign]) and the unqualified match arms (where
-       [Float64.copysign] would fall through to the raw-name fallback and emit
-       the swizzle-parsed [Float64.copysign(...)] that glslang rejects).
-       Routing through a function (not inlining the bit twiddling) evaluates
-       each argument exactly once — the same single-eval guarantee as the
-       [sarek_smod] helper. *)
-    Buffer.add_string buf !current_copysign_name ;
-    Buffer.add_char buf '(' ;
-    List.iteri
-      (fun i e ->
-        if i > 0 then Buffer.add_string buf ", " ;
-        gen_expr buf e)
-      args ;
-    Buffer.add_char buf ')')
-  else if name = "fmod" then (
-    (* GLSL's [mod(x,y)] is floor-based ([x - y*floor(x/y)], sign of the
-       divisor), NOT the truncated C [fmod] ([x - y*trunc(x/y)], sign of the
-       dividend) that Float32.fmod/Float64.fmod contract for; GLSL has no
-       [fmod] builtin under any name. Lower to the [sarek_fmod] helper emitted
-       in the preamble by [gen_fmod_helper], ahead of both the pure registry
-       (which would emit the raw un-suffixed [fmod(...)] glslang rejects) and
-       the unqualified match arms. Routing through a function (not inlining
-       [x - y*trunc(x/y)]) evaluates each argument exactly once — the same
-       single-eval guarantee as [sarek_copysign]/[sarek_smod]. *)
-    Buffer.add_string buf !current_fmod_name ;
-    Buffer.add_char buf '(' ;
-    List.iteri
-      (fun i e ->
-        if i > 0 then Buffer.add_string buf ", " ;
-        gen_expr buf e)
-      args ;
-    Buffer.add_char buf ')')
-  else
-    (* For path-qualified intrinsics, query the pure registry first.
-     Float32.sin -> sin on GLSL (GLSL uses un-suffixed names). *)
-    let pure_registry_hit =
-      match path with
-      | [] -> None
-      | _ -> (
-          match
-            Sarek_pure_registry.fun_device_template ~module_path:path name
-          with
-          | Some f -> Some (f ~framework:"GLSL")
-          | None -> None)
-    in
-    match pure_registry_hit with
-    | Some device_name ->
-        Buffer.add_string buf device_name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | None -> (
-        if
-          (* Try thread intrinsics *)
-          List.mem
-            name
-            [
-              "thread_id_x";
-              "thread_idx_x";
-              "thread_id_y";
-              "thread_idx_y";
-              "thread_id_z";
-              "thread_idx_z";
-              "block_id_x";
-              "block_idx_x";
-              "block_id_y";
-              "block_idx_y";
-              "block_id_z";
-              "block_idx_z";
-              "block_dim_x";
-              "block_dim_y";
-              "block_dim_z";
-              "grid_dim_x";
-              "grid_dim_y";
-              "grid_dim_z";
-              "global_thread_id";
-              "global_idx";
-              "global_idx_x";
-              "global_idx_y";
-              "global_idx_z";
-              "global_size";
-            ]
-        then Buffer.add_string buf (glsl_thread_intrinsic name)
-        else
-          (* Standard math intrinsics - GLSL versions *)
-          match name with
-          | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-          | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
-          | "round" | "trunc" | "abs" ->
-              Buffer.add_string buf name ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')'
-          | "fabs" | "abs_float" ->
-              (* GLSL has no [fabs]; its abs() has an fp64 overload under
-                 GL_ARB_gpu_shader_fp64 (enabled on the f64 path). [abs_float]
-                 (Float64.abs_float) reaches here rather than via the pure
-                 registry — it is absent from [float64_list] because that list's
-                 generic template would emit the raw name on CUDA/OpenCL, which
-                 need [fabs]. See spoc/ir/Sarek_pure_registry.ml. *)
-              Buffer.add_string buf "abs" ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')'
-          | "rsqrt" ->
-              Buffer.add_string buf "inversesqrt" ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')'
-          | "atan2" | "pow" | "min" | "max" ->
-              Buffer.add_string buf name ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')'
-          | "fma" ->
-              Buffer.add_string buf "fma" ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')'
-          | "f64_bits" | "bits_f64" ->
-              (* IEEE-754 double <-> int64 reinterpret casts used by the
-                 software f64 transcendentals ({!Sarek_ir_softmath}) to pick
-                 apart the exponent/mantissa fields. GLSL spells them
-                 [doubleBitsToInt64] / [int64BitsToDouble], both from
-                 [GL_ARB_gpu_shader_int64] (emitted by [glsl_header] when a
-                 needed helper uses int64). *)
-              let fn =
-                if name = "f64_bits" then "doubleBitsToInt64"
-                else "int64BitsToDouble"
-              in
-              Buffer.add_string buf fn ;
-              Buffer.add_char buf '(' ;
-              (match args with
-              | [e] -> gen_expr buf e
-              | _ ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count name 1 (List.length args))) ;
-              Buffer.add_char buf ')'
-          (* Barrier synchronization *)
-          | "block_barrier" -> Buffer.add_string buf "barrier()"
-          (* Atomic operations - GLSL uses atomicAdd etc. *)
-          | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-              Buffer.add_string buf "atomicAdd(" ;
-              (match args with
-              | [addr; value] ->
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | [arr; idx; value] ->
-                  gen_expr buf arr ;
-                  Buffer.add_char buf '[' ;
-                  gen_expr buf idx ;
-                  Buffer.add_string buf "], " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_add"
-                       2
-                       (List.length args))) ;
-              Buffer.add_char buf ')'
-          | "atomic_min" ->
-              Buffer.add_string buf "atomicMin(" ;
-              (match args with
-              | [addr; value] ->
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_min"
-                       2
-                       (List.length args))) ;
-              Buffer.add_char buf ')'
-          | "atomic_max" ->
-              Buffer.add_string buf "atomicMax(" ;
-              (match args with
-              | [addr; value] ->
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_max"
-                       2
-                       (List.length args))) ;
-              Buffer.add_char buf ')'
-          | "float" ->
-              Buffer.add_string buf "float(" ;
-              (match args with [e] -> gen_expr buf e | _ -> ()) ;
-              Buffer.add_char buf ')'
-          | "int_of_float" ->
-              Buffer.add_string buf "int(" ;
-              (match args with [e] -> gen_expr buf e | _ -> ()) ;
-              Buffer.add_char buf ')'
-          | _ ->
-              (* No GLSL lowering for this intrinsic. Unlike CUDA/OpenCL/Metal,
-                 GLSL does NOT fall back to [Sarek_registry] (the FFI registry):
-                 its device closures only branch CUDA-vs-OpenCL and have no GLSL
-                 arm, so consulting it would splice OpenCL C — [get_global_id],
-                 [barrier(CLK_LOCAL_MEM_FENCE)], [(float)] casts — into GLSL,
-                 which glslang rejects just as cryptically as the old behaviour
-                 of emitting the raw OCaml path [full_name(...)] ("vector
-                 swizzle too long"). Raise a located error naming the intrinsic
-                 and backend instead — strictly better than emitting garbage.
-
-                 To give a future intrinsic a real GLSL lowering, extend one of
-                 (a) [Sarek_pure_registry.glsl_override_name] for a plain rename,
-                 (b) [gen_glsl_polyfill] above for a multi-token expression, or
-                 (c) an explicit match arm here. The pure registry is already
-                 GLSL-parameterised (it receives [~framework:"GLSL"]), so no
-                 registry-type change is needed and existing registrations are
-                 untouched. *)
-              Codegen_error.raise_error
-                (Codegen_error.unknown_intrinsic full_name))
+and glsl_backend =
+  {
+    Dispatch.framework = (fun () -> "GLSL");
+    gen_expr;
+    thread_intrinsic = glsl_thread_intrinsic;
+    pre_hook =
+      (fun buf ~full_name:_ path name args ->
+        let is_f64 = List.mem "Float64" path in
+        if is_f64 && f64_root_helpers name <> None then (
+          gen_f64_transcendental buf name args ;
+          true)
+        else if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"; "log10"] then (
+          gen_glsl_polyfill buf ~is_f64 name args ;
+          true)
+        else if name = "copysign" then (
+          Dispatch.emit_call ~gen_expr buf !current_copysign_name args ;
+          true)
+        else if name = "fmod" then (
+          Dispatch.emit_call ~gen_expr buf !current_fmod_name args ;
+          true)
+        else false);
+    post_hook = (fun _ _ _ _ -> false);
+    on_unknown =
+      (fun full ->
+        Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));
+    arm =
+      (fun name ->
+        match name with
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+        | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
+        | "round" | "trunc" | "abs" | "atan2" | "pow" | "min" | "max" | "fma" ->
+            Some (fun buf args -> Dispatch.emit_call ~gen_expr buf name args)
+        | "fabs" | "abs_float" ->
+            Some (fun buf args -> Dispatch.emit_call ~gen_expr buf "abs" args)
+        | "rsqrt" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_call ~gen_expr buf "inversesqrt" args)
+        | "f64_bits" | "bits_f64" ->
+            Some
+              (fun buf args ->
+                let fn =
+                  if name = "f64_bits" then "doubleBitsToInt64"
+                  else "int64BitsToDouble"
+                in
+                Buffer.add_string buf fn ;
+                Buffer.add_char buf '(' ;
+                (match args with
+                | [e] -> gen_expr buf e
+                | _ ->
+                    Codegen_error.raise_error
+                      (Codegen_error.invalid_arg_count
+                         name
+                         1
+                         (List.length args))) ;
+                Buffer.add_char buf ')')
+        | "block_barrier" ->
+            Some (fun buf _ -> Buffer.add_string buf "barrier()")
+        | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicAdd"
+                  ~prefix:""
+                  ~suffix:")"
+                  ~opname:"atomic_add"
+                  ~expected:2
+                  ~allow_array:true
+                  args)
+        | "atomic_min" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicMin"
+                  ~prefix:""
+                  ~suffix:")"
+                  ~opname:"atomic_min"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
+        | "atomic_max" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicMax"
+                  ~prefix:""
+                  ~suffix:")"
+                  ~opname:"atomic_max"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
+        | "float" ->
+            Some
+              (fun buf args ->
+                Buffer.add_string buf "float(" ;
+                (match args with [e] -> gen_expr buf e | _ -> ()) ;
+                Buffer.add_char buf ')')
+        | "int_of_float" ->
+            Some
+              (fun buf args ->
+                Buffer.add_string buf "int(" ;
+                (match args with [e] -> gen_expr buf e | _ -> ()) ;
+                Buffer.add_char buf ')')
+        | _ -> None);
+  }
 
 (** {1 L-value Generation} *)
 

--- a/sarek/codegen/Sarek_ir_intrinsic_dispatch.ml
+++ b/sarek/codegen/Sarek_ir_intrinsic_dispatch.ml
@@ -1,0 +1,199 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Shared, table-driven [EIntrinsic] dispatcher for the source backends
+    (GLSL/Vulkan, WGSL/WebGPU, Metal, CUDA, OpenCL).
+
+    Before this module each backend hand-rolled a near-identical [gen_intrinsic]
+    (~200-265 lines apiece): the same 25-entry thread-intrinsic list, the same
+    "emit [callee(arg0, arg1, ...)]" argument loop, the same atomic add/min/max
+    arg-count arms copy-pasted three times per backend, the same pure-registry
+    query skeleton, and the same FFI-registry template expansion. Unifying them
+    (audit #49) also closes audit #48: the unknown-intrinsic fall-through no
+    longer emits a raw [full_name(args)] string (which the pipeline returned
+    [Ok], yielding invalid device code) - it now raises the same located
+    [unknown_intrinsic] error on every backend, exactly as GLSL already did
+    after #259.
+
+    PTX is intentionally NOT a client: it lowers intrinsics natively through
+    [Sarek_ir_ptx_expr.emit_intrinsic_native] and is owned by a separate task.
+*)
+
+type 'e spec = {
+  framework : unit -> string;
+      (** Framework tag passed to [Sarek_pure_registry.fun_device_template]. A
+          thunk because most backends read a mutable [current_framework] ref set
+          per kernel. GLSL always yields the constant ["GLSL"]. *)
+  gen_expr : Buffer.t -> 'e -> unit;
+      (** The backend's (recursive) expression generator, for call arguments. *)
+  thread_intrinsic : string -> string;
+      (** Maps a thread-intrinsic name to its backend spelling. Only invoked for
+          names in {!thread_intrinsic_names}. *)
+  arm : string -> (Buffer.t -> 'e list -> unit) option;
+      (** Backend-specific math / atomic / cast lowering. [None] means "not
+          handled here" - the dispatcher then tries [post_hook] and finally
+          raises via [on_unknown]. *)
+  pre_hook :
+    Buffer.t -> full_name:string -> string list -> string -> 'e list -> bool;
+      (** Arms tried BEFORE the pure registry. Returns [true] iff it emitted. *)
+  post_hook : Buffer.t -> string list -> string -> 'e list -> bool;
+      (** Arms tried AFTER [arm], before raising. Returns [true] iff it emitted
+          (the FFI-registry template path for Metal/CUDA/OpenCL). *)
+  on_unknown : string -> unit;
+      (** Raise the backend's located [unknown_intrinsic] error. Never returns.
+      *)
+}
+
+(** The thread/grid position intrinsics, identical across all five backends. *)
+let thread_intrinsic_names =
+  [
+    "thread_id_x";
+    "thread_idx_x";
+    "thread_id_y";
+    "thread_idx_y";
+    "thread_id_z";
+    "thread_idx_z";
+    "block_id_x";
+    "block_idx_x";
+    "block_id_y";
+    "block_idx_y";
+    "block_id_z";
+    "block_idx_z";
+    "block_dim_x";
+    "block_dim_y";
+    "block_dim_z";
+    "grid_dim_x";
+    "grid_dim_y";
+    "grid_dim_z";
+    "global_thread_id";
+    "global_idx";
+    "global_idx_x";
+    "global_idx_y";
+    "global_idx_z";
+    "global_size";
+  ]
+
+(** The dotted OCaml source name of an intrinsic ([Float64.log10], [sin], ...).
+*)
+let full_name path name =
+  match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
+
+(** Emit [arg0, arg1, ...] (comma-space separated) using the backend generator.
+*)
+let emit_args ~gen_expr buf args =
+  List.iteri
+    (fun i e ->
+      if i > 0 then Buffer.add_string buf ", " ;
+      gen_expr buf e)
+    args
+
+(** Emit a plain call [callee(arg0, arg1, ...)]. *)
+let emit_call ~gen_expr buf callee args =
+  Buffer.add_string buf callee ;
+  Buffer.add_char buf '(' ;
+  emit_args ~gen_expr buf args ;
+  Buffer.add_char buf ')'
+
+(** Emit a binary atomic, factoring the add/min/max arg-count arms that were
+    copy-pasted three times inside every backend's [gen_intrinsic]. Output is
+    [callee(<prefix>addr, value)<suffix>] for the two-argument form, or
+    [callee(<prefix>arr[idx], value)<suffix>] for the optional three-argument
+    array form. *)
+let emit_atomic ~gen_expr ~invalid_arg_count buf ~callee ~prefix ~suffix ~opname
+    ~expected ~allow_array args =
+  Buffer.add_string buf callee ;
+  Buffer.add_char buf '(' ;
+  (match args with
+  | [addr; value] ->
+      Buffer.add_string buf prefix ;
+      gen_expr buf addr ;
+      Buffer.add_string buf ", " ;
+      gen_expr buf value
+  | [arr; idx; value] when allow_array ->
+      Buffer.add_string buf prefix ;
+      gen_expr buf arr ;
+      Buffer.add_char buf '[' ;
+      gen_expr buf idx ;
+      Buffer.add_string buf "], " ;
+      gen_expr buf value
+  | _ -> invalid_arg_count opname expected (List.length args)) ;
+  Buffer.add_string buf suffix
+
+(* Count [%s] placeholders in an FFI-registry device template. *)
+let count_placeholders s =
+  let rec count i acc =
+    if i >= String.length s - 1 then acc
+    else if s.[i] = '%' && s.[i + 1] = 's' then count (i + 2) (acc + 1)
+    else count (i + 1) acc
+  in
+  count 0 0
+
+(** Expand a Metal/CUDA/OpenCL FFI-registry ([Sarek_registry]) device template
+    for [path.name]. Returns [false] when the registry has no template (caller
+    then raises the unknown-intrinsic error); [true] once emitted. *)
+let emit_registry_template ~gen_expr buf path name args =
+  match Sarek_registry.fun_device_template ~module_path:path name with
+  | None -> false
+  | Some template ->
+      let arg_strs =
+        List.map
+          (fun e ->
+            let b = Buffer.create 64 in
+            gen_expr b e ;
+            Buffer.contents b)
+          args
+      in
+      let num_placeholders = count_placeholders template in
+      let result =
+        if num_placeholders = 0 then
+          template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+        else
+          match (num_placeholders, arg_strs) with
+          | 1, [arg1] ->
+              Printf.sprintf (Scanf.format_from_string template "%s") arg1
+          | 2, [arg1; arg2] ->
+              Printf.sprintf
+                (Scanf.format_from_string template "%s%s")
+                arg1
+                arg2
+          | 3, [arg1; arg2; arg3] ->
+              Printf.sprintf
+                (Scanf.format_from_string template "%s%s%s")
+                arg1
+                arg2
+                arg3
+          | _ -> template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+      in
+      Buffer.add_string buf result ;
+      true
+
+(** The shared dispatch pipeline every backend routes through. Order matches the
+    former hand-rolled bodies: pre_hook, pure registry (path-qualified), shared
+    thread list, arm, post_hook, else raise via on_unknown (audit #48). *)
+let gen_intrinsic (spec : 'e spec) buf path name (args : 'e list) =
+  let full = full_name path name in
+  if spec.pre_hook buf ~full_name:full path name args then ()
+  else
+    let pure_registry_hit =
+      match path with
+      | [] -> None
+      | _ -> (
+          match
+            Sarek_pure_registry.fun_device_template ~module_path:path name
+          with
+          | Some f -> Some (f ~framework:(spec.framework ()))
+          | None -> None)
+    in
+    match pure_registry_hit with
+    | Some device_name -> emit_call ~gen_expr:spec.gen_expr buf device_name args
+    | None -> (
+        if List.mem name thread_intrinsic_names then
+          Buffer.add_string buf (spec.thread_intrinsic name)
+        else
+          match spec.arm name with
+          | Some emit -> emit buf args
+          | None ->
+              if spec.post_hook buf path name args then ()
+              else spec.on_unknown full)

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -24,6 +24,13 @@ module Codegen_error = Sarek_backend_error.Backend_error.Make (struct
   let name = "Metal"
 end)
 
+module Dispatch = Sarek_ir_intrinsic_dispatch
+
+(** Raise a located invalid-argument-count error (atomic-arity helper for the
+    shared {!Dispatch.emit_atomic}). *)
+let bad_arity n e g =
+  Codegen_error.raise_error (Codegen_error.invalid_arg_count n e g)
+
 (** Current framework string for SNative code generation. Always [None] in
     normal use; SNative branches check this ref and error if None. *)
 let current_framework : string option ref = ref None
@@ -141,7 +148,8 @@ let rec gen_expr buf = function
       gen_expr buf e ;
       Buffer.add_char buf '.' ;
       Buffer.add_string buf field
-  | EIntrinsic (path, name, args) -> gen_intrinsic buf path name args
+  | EIntrinsic (path, name, args) ->
+      Dispatch.gen_intrinsic metal_backend buf path name args
   | ECast (ty, e) ->
       Buffer.add_char buf '(' ;
       Buffer.add_string buf (metal_type_of_elttype ty) ;
@@ -291,253 +299,110 @@ and gen_metal_polyfill buf name args =
         (Codegen_error.unknown_intrinsic
            (Printf.sprintf "%s (wrong arity for Metal polyfill)" name))
 
-and gen_intrinsic buf path name args =
-  let full_name =
-    match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
-  in
-  if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"] then
-    gen_metal_polyfill buf name args
-  else
-    (* For path-qualified intrinsics, query the pure registry first.
-     Float32.sin -> sin on Metal (Metal uses un-suffixed names). *)
-    let pure_registry_hit =
-      match path with
-      | [] -> None
-      | _ -> (
-          let framework = Option.value ~default:"Metal" !current_framework in
-          match
-            Sarek_pure_registry.fun_device_template ~module_path:path name
-          with
-          | Some f -> Some (f ~framework)
-          | None -> None)
-    in
-    match pure_registry_hit with
-    | Some device_name ->
-        Buffer.add_string buf device_name ;
-        Buffer.add_char buf '(' ;
-        List.iteri
-          (fun i e ->
-            if i > 0 then Buffer.add_string buf ", " ;
-            gen_expr buf e)
-          args ;
-        Buffer.add_char buf ')'
-    | None -> (
-        if
-          (* Try thread intrinsics - support both idx and id naming *)
-          List.mem
-            name
-            [
-              "thread_id_x";
-              "thread_idx_x";
-              "thread_id_y";
-              "thread_idx_y";
-              "thread_id_z";
-              "thread_idx_z";
-              "block_id_x";
-              "block_idx_x";
-              "block_id_y";
-              "block_idx_y";
-              "block_id_z";
-              "block_idx_z";
-              "block_dim_x";
-              "block_dim_y";
-              "block_dim_z";
-              "grid_dim_x";
-              "grid_dim_y";
-              "grid_dim_z";
-              "global_thread_id";
-              "global_idx";
-              "global_idx_x";
-              "global_idx_y";
-              "global_idx_z";
-              "global_size";
-            ]
-        then Buffer.add_string buf (metal_thread_intrinsic name)
-        else
-          (* Standard math intrinsics - Metal uses same names *)
-          match name with
-          | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
-          | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt"
-          | "rsqrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
-              Buffer.add_string buf name ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')'
-          | "atan2" | "pow" | "fma" | "min" | "max" ->
-              Buffer.add_string buf name ;
-              Buffer.add_char buf '(' ;
-              List.iteri
-                (fun i e ->
-                  if i > 0 then Buffer.add_string buf ", " ;
-                  gen_expr buf e)
-                args ;
-              Buffer.add_char buf ')'
-          (* Barrier synchronization *)
-          | "block_barrier" ->
-              Buffer.add_string
-                buf
-                "threadgroup_barrier(mem_flags::mem_threadgroup)"
-          | "atomic_add" | "atomic_add_int32" ->
-              Buffer.add_string buf "atomic_fetch_add_explicit(" ;
-              (match args with
-              | [addr; value] ->
-                  (* Cast pointer to threadgroup atomic type *)
-                  Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | [arr; idx; value] ->
-                  (* Array element atomic with threadgroup cast *)
-                  Buffer.add_string buf "(volatile threadgroup atomic_int*)&" ;
-                  gen_expr buf arr ;
-                  Buffer.add_char buf '[' ;
-                  gen_expr buf idx ;
-                  Buffer.add_string buf "], " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_add"
-                       2
-                       (List.length args))) ;
-              Buffer.add_string buf ", memory_order_relaxed)"
-          | "atomic_add_global_int32" ->
-              Buffer.add_string buf "atomic_fetch_add_explicit(" ;
-              (match args with
-              | [addr; value] ->
-                  (* Cast pointer to device atomic type *)
-                  Buffer.add_string buf "(volatile device atomic_int*)&" ;
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | [arr; idx; value] ->
-                  (* Array element atomic with device cast *)
-                  Buffer.add_string buf "(volatile device atomic_int*)&" ;
-                  gen_expr buf arr ;
-                  Buffer.add_char buf '[' ;
-                  gen_expr buf idx ;
-                  Buffer.add_string buf "], " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_add_global"
-                       2
-                       (List.length args))) ;
-              (* Use relaxed memory order *)
-              Buffer.add_string buf ", memory_order_relaxed)"
-          | "atomic_sub" ->
-              Buffer.add_string buf "atomic_sub(" ;
-              (match args with
-              | [addr; value] ->
-                  Buffer.add_char buf '&' ;
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_sub"
-                       2
-                       (List.length args))) ;
-              Buffer.add_char buf ')'
-          | "atomic_min" ->
-              Buffer.add_string buf "atomic_min(" ;
-              (match args with
-              | [addr; value] ->
-                  Buffer.add_char buf '&' ;
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_min"
-                       2
-                       (List.length args))) ;
-              Buffer.add_char buf ')'
-          | "atomic_max" ->
-              Buffer.add_string buf "atomic_max(" ;
-              (match args with
-              | [addr; value] ->
-                  Buffer.add_char buf '&' ;
-                  gen_expr buf addr ;
-                  Buffer.add_string buf ", " ;
-                  gen_expr buf value
-              | args ->
-                  Codegen_error.raise_error
-                    (Codegen_error.invalid_arg_count
-                       "atomic_max"
-                       2
-                       (List.length args))) ;
-              Buffer.add_char buf ')'
-          | _ -> (
-              (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
-              match
-                Sarek_registry.fun_device_template ~module_path:path name
-              with
-              | Some template ->
-                  (* Generate argument strings *)
-                  let arg_strs =
-                    List.map
-                      (fun e ->
-                        let b = Buffer.create 64 in
-                        gen_expr b e ;
-                        Buffer.contents b)
-                      args
-                  in
-                  (* Count %s placeholders in template *)
-                  let count_placeholders s =
-                    let rec count i acc =
-                      if i >= String.length s - 1 then acc
-                      else if s.[i] = '%' && s.[i + 1] = 's' then
-                        count (i + 2) (acc + 1)
-                      else count (i + 1) acc
-                    in
-                    count 0 0
-                  in
-                  let num_placeholders = count_placeholders template in
-                  let result =
-                    if num_placeholders = 0 then
-                      (* Plain function/cast like "(float)" -> call as function *)
-                      template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                    else if num_placeholders = 1 && List.length arg_strs = 1
-                    then
-                      Printf.sprintf
-                        (Scanf.format_from_string template "%s")
-                        (List.hd arg_strs)
-                    else if num_placeholders = 2 && List.length arg_strs = 2
-                    then
-                      Printf.sprintf
-                        (Scanf.format_from_string template "%s%s")
-                        (List.nth arg_strs 0)
-                        (List.nth arg_strs 1)
-                    else if num_placeholders = 3 && List.length arg_strs = 3
-                    then
-                      Printf.sprintf
-                        (Scanf.format_from_string template "%s%s%s")
-                        (List.nth arg_strs 0)
-                        (List.nth arg_strs 1)
-                        (List.nth arg_strs 2)
-                    else
-                      (* Fallback: treat as function call *)
-                      template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                  in
-                  Buffer.add_string buf result
-              | None ->
-                  (* Unknown intrinsic - emit as function call *)
-                  Buffer.add_string buf full_name ;
-                  Buffer.add_char buf '(' ;
-                  List.iteri
-                    (fun i e ->
-                      if i > 0 then Buffer.add_string buf ", " ;
-                      gen_expr buf e)
-                    args ;
-                  Buffer.add_char buf ')'))
+and metal_backend =
+  {
+    Dispatch.framework =
+      (fun () -> Option.value ~default:"Metal" !current_framework);
+    gen_expr;
+    thread_intrinsic = metal_thread_intrinsic;
+    pre_hook =
+      (fun buf ~full_name:_ _path name args ->
+        if List.mem name ["cbrt"; "hypot"; "expm1"; "log1p"] then (
+          gen_metal_polyfill buf name args ;
+          true)
+        else false);
+    post_hook =
+      (fun buf path name args ->
+        Dispatch.emit_registry_template ~gen_expr buf path name args);
+    on_unknown =
+      (fun full ->
+        Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));
+    arm =
+      (fun name ->
+        match name with
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
+        | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
+        | "floor" | "ceil" | "round" | "trunc" | "fabs" | "atan2" | "pow"
+        | "fma" | "min" | "max" ->
+            Some (fun buf args -> Dispatch.emit_call ~gen_expr buf name args)
+        | "block_barrier" ->
+            Some
+              (fun buf _ ->
+                Buffer.add_string
+                  buf
+                  "threadgroup_barrier(mem_flags::mem_threadgroup)")
+        | "atomic_add" | "atomic_add_int32" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_fetch_add_explicit"
+                  ~prefix:"(volatile threadgroup atomic_int*)&"
+                  ~suffix:", memory_order_relaxed)"
+                  ~opname:"atomic_add"
+                  ~expected:2
+                  ~allow_array:true
+                  args)
+        | "atomic_add_global_int32" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_fetch_add_explicit"
+                  ~prefix:"(volatile device atomic_int*)&"
+                  ~suffix:", memory_order_relaxed)"
+                  ~opname:"atomic_add_global"
+                  ~expected:2
+                  ~allow_array:true
+                  args)
+        | "atomic_sub" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_sub"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_sub"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
+        | "atomic_min" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_min"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_min"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
+        | "atomic_max" ->
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_max"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_max"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
+        | _ -> None);
+  }
 
 (** {1 L-value Generation} *)
 

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -24,6 +24,13 @@ module Codegen_error = Sarek_backend_error.Backend_error.Make (struct
   let name = "OpenCL"
 end)
 
+module Dispatch = Sarek_ir_intrinsic_dispatch
+
+(** Raise a located invalid-argument-count error (atomic-arity helper for the
+    shared {!Dispatch.emit_atomic}). *)
+let bad_arity n e g =
+  Codegen_error.raise_error (Codegen_error.invalid_arg_count n e g)
+
 (** {1 Constants} *)
 
 (** Buffer size for small temporary string buffers *)
@@ -137,7 +144,8 @@ let rec gen_expr buf = function
       gen_expr buf e ;
       Buffer.add_char buf '.' ;
       Buffer.add_string buf field
-  | EIntrinsic (path, name, args) -> gen_intrinsic buf path name args
+  | EIntrinsic (path, name, args) ->
+      Dispatch.gen_intrinsic opencl_backend buf path name args
   | ECast (ty, e) ->
       Buffer.add_char buf '(' ;
       Buffer.add_string buf (opencl_type_of_elttype ty) ;
@@ -250,219 +258,89 @@ and gen_binop = function
 
 and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
 
-and gen_intrinsic buf path name args =
-  let full_name =
-    match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
-  in
-  (* For path-qualified intrinsics, query the pure registry first.
-     Float32.sin -> sin on OpenCL; Float64.sin -> sin on OpenCL. *)
-  let pure_registry_hit =
-    match path with
-    | [] -> None
-    | _ -> (
-        let framework = Option.value ~default:"OpenCL" !current_framework in
-        match
-          Sarek_pure_registry.fun_device_template ~module_path:path name
-        with
-        | Some f -> Some (f ~framework)
-        | None -> None)
-  in
-  match pure_registry_hit with
-  | Some device_name ->
-      Buffer.add_string buf device_name ;
-      Buffer.add_char buf '(' ;
-      List.iteri
-        (fun i e ->
-          if i > 0 then Buffer.add_string buf ", " ;
-          gen_expr buf e)
-        args ;
-      Buffer.add_char buf ')'
-  | None -> (
-      if
-        (* Try thread intrinsics - support both idx and id naming *)
-        List.mem
-          name
-          [
-            "thread_id_x";
-            "thread_idx_x";
-            "thread_id_y";
-            "thread_idx_y";
-            "thread_id_z";
-            "thread_idx_z";
-            "block_id_x";
-            "block_idx_x";
-            "block_id_y";
-            "block_idx_y";
-            "block_id_z";
-            "block_idx_z";
-            "block_dim_x";
-            "block_dim_y";
-            "block_dim_z";
-            "grid_dim_x";
-            "grid_dim_y";
-            "grid_dim_z";
-            "global_thread_id";
-            "global_idx";
-            "global_idx_x";
-            "global_idx_y";
-            "global_idx_z";
-            "global_size";
-          ]
-      then Buffer.add_string buf (opencl_thread_intrinsic name)
-      else
-        (* Standard math intrinsics - OpenCL uses same names *)
+and opencl_backend =
+  {
+    Dispatch.framework =
+      (fun () -> Option.value ~default:"OpenCL" !current_framework);
+    gen_expr;
+    thread_intrinsic = opencl_thread_intrinsic;
+    pre_hook = (fun _ ~full_name:_ _ _ _ -> false);
+    post_hook =
+      (fun buf path name args ->
+        Dispatch.emit_registry_template ~gen_expr buf path name args);
+    on_unknown =
+      (fun full ->
+        Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));
+    arm =
+      (fun name ->
         match name with
         | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
         | "tanh" | "exp" | "exp2" | "log" | "log2" | "log10" | "sqrt" | "rsqrt"
-        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "atan2" | "pow" | "fma" | "min" | "max" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        (* Barrier synchronization *)
+        | "cbrt" | "floor" | "ceil" | "round" | "trunc" | "fabs" | "atan2"
+        | "pow" | "fma" | "min" | "max" ->
+            Some (fun buf args -> Dispatch.emit_call ~gen_expr buf name args)
         | "block_barrier" ->
-            Buffer.add_string buf "barrier(CLK_LOCAL_MEM_FENCE)"
+            Some
+              (fun buf _ ->
+                Buffer.add_string buf "barrier(CLK_LOCAL_MEM_FENCE)")
         | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-            Buffer.add_string buf "atomic_add(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | [arr; idx; value] ->
-                (* Array element atomic: atomic_add(&arr[idx], value) *)
-                Buffer.add_char buf '&' ;
-                gen_expr buf arr ;
-                Buffer.add_char buf '[' ;
-                gen_expr buf idx ;
-                Buffer.add_string buf "], " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_add"
-                     3
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_add"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_add"
+                  ~expected:3
+                  ~allow_array:true
+                  args)
         | "atomic_sub" ->
-            Buffer.add_string buf "atomic_sub(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_sub"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_sub"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_sub"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
         | "atomic_min" ->
-            Buffer.add_string buf "atomic_min(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_min"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_min"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_min"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
         | "atomic_max" ->
-            Buffer.add_string buf "atomic_max(" ;
-            (match args with
-            | [addr; value] ->
-                Buffer.add_char buf '&' ;
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | _ ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_max"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
-        | _ -> (
-            (* Try registry lookup for intrinsics like float, int_of_float, etc. *)
-            match Sarek_registry.fun_device_template ~module_path:path name with
-            | Some template ->
-                (* Generate argument strings *)
-                let arg_strs =
-                  List.map
-                    (fun e ->
-                      let b = Buffer.create 64 in
-                      gen_expr b e ;
-                      Buffer.contents b)
-                    args
-                in
-                (* Count %s placeholders in template *)
-                let count_placeholders s =
-                  let rec count i acc =
-                    if i >= String.length s - 1 then acc
-                    else if s.[i] = '%' && s.[i + 1] = 's' then
-                      count (i + 2) (acc + 1)
-                    else count (i + 1) acc
-                  in
-                  count 0 0
-                in
-                let num_placeholders = count_placeholders template in
-                let result =
-                  if num_placeholders = 0 then
-                    (* Plain function/cast like "(float)" -> call as function *)
-                    template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                  else
-                    match (num_placeholders, arg_strs) with
-                    | 1, [arg1] ->
-                        Printf.sprintf
-                          (Scanf.format_from_string template "%s")
-                          arg1
-                    | 2, [arg1; arg2] ->
-                        Printf.sprintf
-                          (Scanf.format_from_string template "%s%s")
-                          arg1
-                          arg2
-                    | 3, [arg1; arg2; arg3] ->
-                        Printf.sprintf
-                          (Scanf.format_from_string template "%s%s%s")
-                          arg1
-                          arg2
-                          arg3
-                    | _ ->
-                        (* Fallback: treat as function call *)
-                        template ^ "(" ^ String.concat ", " arg_strs ^ ")"
-                in
-                Buffer.add_string buf result
-            | None ->
-                (* Unknown intrinsic - emit as function call *)
-                Buffer.add_string buf full_name ;
-                Buffer.add_char buf '(' ;
-                List.iteri
-                  (fun i e ->
-                    if i > 0 then Buffer.add_string buf ", " ;
-                    gen_expr buf e)
-                  args ;
-                Buffer.add_char buf ')'))
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomic_max"
+                  ~prefix:"&"
+                  ~suffix:")"
+                  ~opname:"atomic_max"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
+        | _ -> None);
+  }
 
 (** {1 L-value Generation} *)
 

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -25,6 +25,13 @@ module Codegen_error = Sarek_backend_error.Backend_error.Make (struct
   let name = "WebGPU"
 end)
 
+module Dispatch = Sarek_ir_intrinsic_dispatch
+
+(** Raise a located invalid-argument-count error (atomic-arity helper for the
+    shared {!Dispatch.emit_atomic}). *)
+let bad_arity n e g =
+  Codegen_error.raise_error (Codegen_error.invalid_arg_count n e g)
+
 (** Current kernel's variant definitions (set during generate) *)
 let current_variants : (string * (string * elttype list) list) list ref = ref []
 
@@ -241,7 +248,8 @@ let rec gen_expr buf = function
       gen_expr buf e ;
       Buffer.add_char buf '.' ;
       Buffer.add_string buf field
-  | EIntrinsic (path, name, args) -> gen_intrinsic buf path name args
+  | EIntrinsic (path, name, args) ->
+      Dispatch.gen_intrinsic wgsl_backend buf path name args
   | ECast (ty, e) ->
       Buffer.add_string buf (wgsl_type_of_elttype ty) ;
       Buffer.add_char buf '(' ;
@@ -370,199 +378,106 @@ and gen_binop = function
 
 and gen_unop = function Neg -> "-" | Not -> "!" | BitNot -> "~"
 
-and gen_intrinsic buf path name args =
-  let full_name =
-    match path with [] -> name | _ -> String.concat "." path ^ "." ^ name
-  in
-  let framework = Option.value ~default:"WGSL" !current_framework in
-  if name = "fmod" then
-    (* WGSL has no [fmod] builtin (the pure registry, queried below, would emit
-       an invalid [fmod(...)] call). The bare [%] operator was WRONG for two
-       cases (both raised in review): an infinite divisor gives
-       [x - inf*trunc(0)] = NaN where C wants [x], and large [|x/y|] loses
-       quotient precision. Lower instead to the [sarek_fmod] preamble helper
-       ([gen_fmod_helper]), whose bounded exact reduction is C-conformant for
-       finite operands and the infinite-divisor case. f64 is unsupported in
-       WGSL, so only the f32 [Float32.fmod] spelling ever reaches here. *)
-    match args with
-    | [x; y] ->
-        Buffer.add_string buf "sarek_fmod(" ;
-        gen_expr buf x ;
-        Buffer.add_string buf ", " ;
-        gen_expr buf y ;
-        Buffer.add_char buf ')'
-    | _ ->
-        Codegen_error.raise_error
-          (Codegen_error.invalid_arg_count "fmod" 2 (List.length args))
-  else
-    let pure_registry_hit =
-      match path with
-      | [] -> None
-      | _ -> (
-          match
-            Sarek_pure_registry.fun_device_template ~module_path:path name
-          with
-          | Some f -> Some (f ~framework)
-          | None -> None)
-    in
-    match pure_registry_hit with
-  | Some device_name ->
-      Buffer.add_string buf device_name ;
-      Buffer.add_char buf '(' ;
-      List.iteri
-        (fun i e ->
-          if i > 0 then Buffer.add_string buf ", " ;
-          gen_expr buf e)
-        args ;
-      Buffer.add_char buf ')'
-  | None -> (
-      if
-        List.mem
-          name
-          [
-            "thread_id_x";
-            "thread_idx_x";
-            "thread_id_y";
-            "thread_idx_y";
-            "thread_id_z";
-            "thread_idx_z";
-            "block_id_x";
-            "block_idx_x";
-            "block_id_y";
-            "block_idx_y";
-            "block_id_z";
-            "block_idx_z";
-            "block_dim_x";
-            "block_dim_y";
-            "block_dim_z";
-            "grid_dim_x";
-            "grid_dim_y";
-            "grid_dim_z";
-            "global_thread_id";
-            "global_idx";
-            "global_idx_x";
-            "global_idx_y";
-            "global_idx_z";
-            "global_size";
-          ]
-      then Buffer.add_string buf (wgsl_thread_intrinsic name)
-      else
+and wgsl_backend =
+  {
+    Dispatch.framework =
+      (fun () -> Option.value ~default:"WGSL" !current_framework);
+    gen_expr;
+    thread_intrinsic = wgsl_thread_intrinsic;
+    pre_hook =
+      (fun buf ~full_name:_ _path name args ->
+        if name = "fmod" then
+          match args with
+          | [x; y] ->
+              Buffer.add_string buf "sarek_fmod(" ;
+              gen_expr buf x ;
+              Buffer.add_string buf ", " ;
+              gen_expr buf y ;
+              Buffer.add_char buf ')' ;
+              true
+          | _ ->
+              Codegen_error.raise_error
+                (Codegen_error.invalid_arg_count "fmod" 2 (List.length args))
+        else false);
+    post_hook = (fun _ _ _ _ -> false);
+    on_unknown =
+      (fun full ->
+        Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));
+    arm =
+      (fun name ->
         match name with
         | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh" | "cosh"
         | "tanh" | "exp" | "exp2" | "log" | "log2" | "sqrt" | "floor" | "ceil"
-        | "round" | "trunc" | "abs" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
+        | "round" | "trunc" | "abs" | "atan2" | "pow" | "min" | "max" | "fma" ->
+            Some (fun buf args -> Dispatch.emit_call ~gen_expr buf name args)
         | "fabs" ->
-            Buffer.add_string buf "abs" ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
+            Some (fun buf args -> Dispatch.emit_call ~gen_expr buf "abs" args)
         | "rsqrt" ->
-            Buffer.add_string buf "(1.0f / sqrt(" ;
-            (match args with
-            | [e] -> gen_expr buf e
-            | _ ->
-                List.iteri
-                  (fun i e ->
-                    if i > 0 then Buffer.add_string buf ", " ;
-                    gen_expr buf e)
-                  args) ;
-            Buffer.add_string buf "))"
-        | "atan2" | "pow" | "min" | "max" ->
-            Buffer.add_string buf name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "fma" ->
-            Buffer.add_string buf "fma" ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')'
-        | "block_barrier" -> Buffer.add_string buf "workgroupBarrier()"
+            Some
+              (fun buf args ->
+                Buffer.add_string buf "(1.0f / sqrt(" ;
+                (match args with
+                | [e] -> gen_expr buf e
+                | _ -> Dispatch.emit_args ~gen_expr buf args) ;
+                Buffer.add_string buf "))")
+        | "block_barrier" ->
+            Some (fun buf _ -> Buffer.add_string buf "workgroupBarrier()")
         | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
-            Buffer.add_string buf "atomicAdd(" ;
-            (match args with
-            | [addr; value] ->
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | [arr; idx; value] ->
-                gen_expr buf arr ;
-                Buffer.add_char buf '[' ;
-                gen_expr buf idx ;
-                Buffer.add_string buf "], " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_add"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicAdd"
+                  ~prefix:""
+                  ~suffix:")"
+                  ~opname:"atomic_add"
+                  ~expected:2
+                  ~allow_array:true
+                  args)
         | "atomic_min" ->
-            Buffer.add_string buf "atomicMin(" ;
-            (match args with
-            | [addr; value] ->
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_min"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicMin"
+                  ~prefix:""
+                  ~suffix:")"
+                  ~opname:"atomic_min"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
         | "atomic_max" ->
-            Buffer.add_string buf "atomicMax(" ;
-            (match args with
-            | [addr; value] ->
-                gen_expr buf addr ;
-                Buffer.add_string buf ", " ;
-                gen_expr buf value
-            | args ->
-                Codegen_error.raise_error
-                  (Codegen_error.invalid_arg_count
-                     "atomic_max"
-                     2
-                     (List.length args))) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Dispatch.emit_atomic
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~callee:"atomicMax"
+                  ~prefix:""
+                  ~suffix:")"
+                  ~opname:"atomic_max"
+                  ~expected:2
+                  ~allow_array:false
+                  args)
         | "float" ->
-            Buffer.add_string buf "f32(" ;
-            (match args with [e] -> gen_expr buf e | _ -> ()) ;
-            Buffer.add_char buf ')'
+            Some
+              (fun buf args ->
+                Buffer.add_string buf "f32(" ;
+                (match args with [e] -> gen_expr buf e | _ -> ()) ;
+                Buffer.add_char buf ')')
         | "int_of_float" ->
-            Buffer.add_string buf "i32(" ;
-            (match args with [e] -> gen_expr buf e | _ -> ()) ;
-            Buffer.add_char buf ')'
-        | _ ->
-            Buffer.add_string buf full_name ;
-            Buffer.add_char buf '(' ;
-            List.iteri
-              (fun i e ->
-                if i > 0 then Buffer.add_string buf ", " ;
-                gen_expr buf e)
-              args ;
-            Buffer.add_char buf ')')
+            Some
+              (fun buf args ->
+                Buffer.add_string buf "i32(" ;
+                (match args with [e] -> gen_expr buf e | _ -> ()) ;
+                Buffer.add_char buf ')')
+        | _ -> None);
+  }
 
 (** {1 L-value Generation} *)
 
@@ -809,9 +724,9 @@ let gen_helper_func buf (hf : helper_func) =
 
 (** Emit the [sarek_fmod] C-fmod helper (f32; WGSL has no f64) when the kernel
     uses [fmod]. Replaces the earlier bare [%] lowering, which shared C-fmod's
-    two divergences (both raised in review): the single-pass
-    [x - y*trunc(x/y)] loses quotient precision for large [|x/y|], and an
-    infinite divisor yields NaN where C defines [fmod(x, ±inf) = x].
+    two divergences (both raised in review): the single-pass [x - y*trunc(x/y)]
+    loses quotient precision for large [|x/y|], and an infinite divisor yields
+    NaN where C defines [fmod(x, ±inf) = x].
 
     The body is a bounded exact reduction by power-of-two scaling (identical in
     shape to the GLSL [sarek_fmod] helper): scale [d = |y|] up by [×2] to the
@@ -842,10 +757,10 @@ let gen_fmod_helper buf (k : kernel) =
       \  if (ax < ay) { return x; }\n\
       \  var r = ax; var d = ay;\n\
       \  loop { if (!(d <= 0.5 * r)) { break; } d = d * 2.0; }\n\
-      \  loop { if (r >= d) { r = r - d; } if (d == ay) { break; } d = d * 0.5; \
-       }\n\
-      \  return bitcast<f32>((bitcast<u32>(r) & 0x7fffffffu) | (bitcast<u32>(x) \
-       & 0x80000000u));\n\
+      \  loop { if (r >= d) { r = r - d; } if (d == ay) { break; } d = d * \
+       0.5; }\n\
+      \  return bitcast<f32>((bitcast<u32>(r) & 0x7fffffffu) | \
+       (bitcast<u32>(x) & 0x80000000u));\n\
        }\n\n"
 
 (** {1 Record and Variant Type Generation} *)

--- a/sarek/codegen/dune
+++ b/sarek/codegen/dune
@@ -9,6 +9,7 @@
  (public_name sarek.codegen)
  (libraries sarek_ir sarek_registry sarek_backend_error)
  (modules
+  Sarek_ir_intrinsic_dispatch
   Sarek_ir_cuda
   Sarek_ir_opencl
   Sarek_ir_metal

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -49,3 +49,10 @@
  (libraries sarek_ir sarek_codegen sarek_backend_error alcotest)
  (instrumentation
   (backend bisect_ppx)))
+
+(test
+ (name test_intrinsic_fallback_all)
+ (modules test_intrinsic_fallback_all)
+ (libraries sarek_ir sarek_codegen sarek_backend_error alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek/tests/codegen_golden/test_intrinsic_fallback_all.ml
+++ b/sarek/tests/codegen_golden/test_intrinsic_fallback_all.ml
@@ -1,0 +1,99 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * IR-level unit test for the unified intrinsic-dispatch fall-through on the
+ * four non-GLSL source backends (WGSL/WebGPU, Metal, CUDA, OpenCL).
+ *
+ * This pins the audit #48 fix delivered by the #49 unification: an intrinsic
+ * with no backend lowering (and no FFI-registry template) must now RAISE a
+ * located [Backend_error (Codegen {backend; Unknown_intrinsic {name}})] on
+ * EVERY backend, exactly as GLSL already did after #259. Before #49 these four
+ * backends silently emitted the raw OCaml path [warp_shuffle(...)] — a call to
+ * a non-existent device function — and the pipeline returned [Ok], yielding
+ * invalid device code that only failed (cryptically) at the driver.
+ *
+ * GLSL's own fall-through is already covered by [test_glsl_intrinsic_fallback].
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend_error = Sarek_backend_error.Backend_error
+module Wgsl = Sarek_codegen.Sarek_ir_wgsl
+module Metal = Sarek_codegen.Sarek_ir_metal
+module Cuda = Sarek_codegen.Sarek_ir_cuda
+module Opencl = Sarek_codegen.Sarek_ir_opencl
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* A minimal kernel: c.[0] <- <intr>(a.[0], a.[0]) with a float32 in/out pair.
+   The indices are bare literals so the body never introduces another intrinsic
+   that could mask the one under test. *)
+let kernel_calling ~path ~name ~arity =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let arg = EArrayRead ("a", EConst (CInt32 0l)) in
+  let args = List.init arity (fun _ -> arg) in
+  {
+    kern_name = "fallback_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body =
+      SAssign
+        (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic (path, name, args));
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(* Each backend's IR-to-source entry point, uniformly [kernel -> string]. *)
+let backends =
+  [
+    ("WGSL", "WebGPU", fun k -> Wgsl.generate_with_types ~types:[] k);
+    ("Metal", "Metal", fun k -> Metal.generate_with_types ~types:[] k);
+    ("CUDA", "CUDA", fun k -> Cuda.generate_with_types ~types:[] k);
+    ("OpenCL", "OpenCL", fun k -> Opencl.generate_with_types ~types:[] k);
+  ]
+
+(* An intrinsic with no lowering on any backend and no FFI-registry template. *)
+let unknown_name = "warp_shuffle"
+
+let test_backend_raises (label, expected_backend, generate) () =
+  let k = kernel_calling ~path:[] ~name:unknown_name ~arity:2 in
+  match generate k with
+  | (_ : string) ->
+      Alcotest.failf
+        "%s: expected Unknown_intrinsic for %S but generation succeeded"
+        label
+        unknown_name
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Codegen
+           {backend; error = Backend_error.Unknown_intrinsic {name = got}}) ->
+      Alcotest.(check string)
+        (label ^ ": backend name")
+        expected_backend
+        backend ;
+      Alcotest.(check string)
+        (label ^ ": error names the intrinsic")
+        unknown_name
+        got
+
+let () =
+  let open Alcotest in
+  run
+    "intrinsic fallback (all backends)"
+    [
+      ( "unknown-intrinsic-raises",
+        List.map
+          (fun ((label, _, _) as spec) ->
+            test_case label `Quick (test_backend_raises spec))
+          backends );
+    ]


### PR DESCRIPTION
## What

Replaces the five near-identical hand-rolled `gen_intrinsic` bodies (GLSL / WGSL / Metal / CUDA / OpenCL, ~200–265 lines apiece, ~1100 duplicated) with a single table-driven dispatcher, `sarek/codegen/Sarek_ir_intrinsic_dispatch.ml` (199 lines).

Each backend now supplies one `'e spec` record (framework thunk, `gen_expr`, thread-intrinsic map, pre/post hooks, an `arm` lowering table, and an `on_unknown` raiser) and routes its `EIntrinsic` arm through `Dispatch.gen_intrinsic <backend>_backend`. Shared helpers factor the 25-entry thread-intrinsic list, the `callee(args)` loop, the atomic add/min/max arg-count arms (copy-pasted 3× per backend), and the FFI-registry `%s`-template expansion.

**Net line delta: −300** (827 insertions, 1127 deletions across 11 files) — the 199-line dispatcher + 99-line negative test are more than paid for by the deleted duplication.

## Closes #48 (silent-invalid-shader hole)

Before this change, the unknown-intrinsic fall-through emitted a raw `full_name(args)` string on WGSL / Metal / CUDA / OpenCL — invalid device code that the pipeline returned `Ok` for. The shared dispatcher's final arm now calls `spec.on_unknown`, and every backend's `on_unknown` raises the located `unknown_intrinsic` error (exactly as GLSL already did after #259). Byte-identity for all KNOWN intrinsics is preserved: the 75-test golden suite stays green with zero diffs.

New negative test `sarek/tests/codegen_golden/test_intrinsic_fallback_all.ml` proves the four previously-broken backends (WGSL/Metal/CUDA/OpenCL) raise on an unhandled intrinsic; GLSL's raise remains covered by its own `test_glsl_intrinsic_fallback`.

## Scope reconciliation with current main

- **PTX is deliberately out of scope.** `Sarek_ir_ptx_expr.ml` / `Sarek_ir_ptx_kernel.ml` use a different emission model (native PTX assembly via `emit_intrinsic_native`), not the C-like `name(args)` string emission the five other backends share. Folding it into the string dispatcher would be a mismatch; it is untouched.
- **HIP rides the CUDA path automatically.** `sarek-hip/Hip_plugin.ml` calls `Sarek_codegen.Sarek_ir_cuda.generate_with_types`, so the native ROCm/HIP backend (#274) inherits the unified CUDA `gen_intrinsic` with no HIP-specific intrinsic code — verified no separate HIP `gen_intrinsic` exists.

Rebased cleanly onto current `main` (through the #272 fp64-classifier, #274 HIP, #275 Guarded_cache work); no conflicts, as main touched none of the five codegen files after this artifact's base.

## Gates

- `dune build` clean
- `@fmt` clean on all touched files (pre-existing drift in Device.ml / Sarek_float32.ml / test_ir_layout.ml left untouched)
- 75/75 golden codegen tests pass, zero diffs
- ptxas gate assembles (ptxas on PATH)
- `test_intrinsic_fallback_all` passes: unknown intrinsic raises on all four unified backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)
