### PR TITLE
fix(sarek/ppx): reject reserved/sarek_-prefixed superstep binding names (#56)

### DIFF
--- a/sarek/ppx/Sarek_typer.ml
+++ b/sarek/ppx/Sarek_typer.ml
@@ -848,6 +848,16 @@ let rec infer (env : t) (expr : expr) : (texpr * t) result =
             loc,
           env' )
   | ESuperstep (name, divergent, step_body, cont) ->
+      (* The superstep name is a user-written binder: guard it against the
+         reserved-name policy exactly as other binders (see [MFun]) — a
+         reserved C/CUDA/OpenCL keyword or the generated [sarek_] prefix. Latent
+         today (the name is never emitted as an identifier), but this closes the
+         collision class should a future emission path use it. *)
+      let* () =
+        if Sarek_reserved.is_reserved name then
+          Error [Reserved_keyword (name, loc)]
+        else check_reserved_prefix name loc
+      in
       (* Type the superstep body - should be unit *)
       let* tstep_body, env = infer env step_body in
       let* () = unify_or_error tstep_body.ty t_unit step_body.expr_loc in

--- a/sarek/tests/unit/test_typer.ml
+++ b/sarek/tests/unit/test_typer.ml
@@ -693,6 +693,59 @@ let test_seq () =
   let expr = mk_expr (ESeq (int_expr 1, float_expr 2.0)) in
   check_infer_ok "1; 2.0 has type of last expr" env expr t_float32
 
+(* A superstep binding name is a user-written binder and must obey the same
+   reserved-name policy as any other binder: a reserved C/CUDA/OpenCL keyword
+   ([Reserved_keyword]) or the generated [sarek_] prefix ([Reserved_prefix]) is
+   rejected at the point the superstep is elaborated. Guards the collision class
+   even though the name is not emitted as an identifier today. See #56. *)
+let superstep_expr name =
+  mk_expr (ESuperstep (name, false, unit_expr, int32_expr 0l))
+
+let check_infer_error_is msg env expr pred =
+  reset_tvar_counter () ;
+  reset_var_id_counter () ;
+  match infer env expr with
+  | Ok (te, _) ->
+      Alcotest.failf
+        "%s: expected error but got type %s"
+        msg
+        (typ_to_string te.ty)
+  | Error errors ->
+      if List.exists pred errors then ()
+      else
+        Alcotest.failf
+          "%s: wrong error(s): %s"
+          msg
+          (String.concat ", " (List.map Sarek_error.error_to_string errors))
+
+let test_superstep_reserved_prefix_rejected () =
+  let env = with_stdlib empty in
+  check_infer_error_is
+    "sarek_-prefixed superstep name rejected"
+    env
+    (superstep_expr "sarek_step")
+    (function
+    | Sarek_error.Reserved_prefix _ -> true
+    | _ -> false)
+
+let test_superstep_reserved_keyword_rejected () =
+  let env = with_stdlib empty in
+  check_infer_error_is
+    "reserved-keyword superstep name rejected"
+    env
+    (superstep_expr "for")
+    (function
+    | Sarek_error.Reserved_keyword _ -> true
+    | _ -> false)
+
+let test_superstep_ordinary_name_accepted () =
+  let env = with_stdlib empty in
+  check_infer_ok
+    "ordinary superstep name accepted"
+    env
+    (superstep_expr "phase1")
+    t_int32
+
 (* Test suite *)
 let () =
   Alcotest.run
@@ -804,5 +857,20 @@ let () =
             "f32 behaviour unchanged"
             `Quick
             test_float_literal_f32_unchanged;
+        ] );
+      ( "superstep reserved names",
+        [
+          Alcotest.test_case
+            "sarek_ prefix rejected"
+            `Quick
+            test_superstep_reserved_prefix_rejected;
+          Alcotest.test_case
+            "reserved keyword rejected"
+            `Quick
+            test_superstep_reserved_keyword_rejected;
+          Alcotest.test_case
+            "ordinary name accepted"
+            `Quick
+            test_superstep_ordinary_name_accepted;
         ] );
     ]


### PR DESCRIPTION
## What

The BSP superstep name in `ESuperstep (name, divergent, step_body, cont)` was the one user-written binder introduction site in the typer that escaped the `Sarek_reserved` policy. Every other binder (kernel params, local `let`/`let mut`, module `let`, `[@@sarek.type]` names) is validated against reserved C/CUDA/OpenCL keywords and the generated `sarek_` prefix — but the superstep name flowed through `infer` unchecked.

## The guard

Added at the head of the `ESuperstep` branch of `Sarek_typer.infer`, mirroring the existing `MFun` module-function binder check **exactly** — same two predicates, same located-error shape, no new error type:

```ocaml
if Sarek_reserved.is_reserved name then Error [Reserved_keyword (name, loc)]
else check_reserved_prefix name loc   (* -> Reserved_prefix on `sarek_` *)
```

`Reserved_keyword` / `Reserved_prefix` are reused with the `loc` (`= expr.expr_loc`) already in scope.

## Latent until now

The superstep name is never emitted as an identifier into generated device code, so no real kernel is affected today. This is behaviour-preserving — superstep names in real kernels are ordinary identifiers, so only a colliding name (a reserved keyword or a `sarek_`-prefixed name), previously silently accepted, now errors. Closes the user/generated collision class at its root should a future emission path use the name.

## Test + red-on-mutation

New `test_typer.ml` group "superstep reserved names": a `sarek_`-prefixed name and a reserved keyword (`for`) are rejected with the **specific** located error constructor; an ordinary name (`phase1`) is accepted. Proven red-on-mutation:

- Guard removed → both rejection cases FAIL (`expected error but got type int32`), accepted case still passes.
- Guard present → 44/44 `test_typer` green.

## Gates

- `dune build` clean; `@fmt` clean on touched files.
- Green: test_typer, test_reserved, test_sarek_reserved (ppx), test_quote, test_convergence, test_lower, test_lower_ir, test_tailrec*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Superstep names are now validated during type checking.
  * Names using the reserved `sarek_` prefix or reserved C, CUDA, and OpenCL keywords are rejected with clear errors.
  * Ordinary superstep names continue to be accepted.

* **Tests**
  * Added coverage for reserved-prefix, reserved-keyword, and valid superstep names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->