### PR TITLE
fix(sarek/codegen): emit valid GLSL for transpose_naive (was 'unexpected DOT', no SPIR-V) (#65)

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -1436,6 +1436,119 @@ let gen_f64_softmath_helpers ~pc_names buf =
       Buffer.add_char buf '\n' ;
       List.iter (gen_helper_func ~pc_names buf) helpers
 
+(** Counter for fresh push-constant-shadowing local names (see
+    {!rename_pc_shadowing_locals}). Reset per kernel in {!generate} /
+    {!generate_with_types} for deterministic output. *)
+let pc_shadow_counter = ref 0
+
+(** Alpha-rename kernel-body locals whose name collides with a push-constant
+    scalar macro.
+
+    Scalar params are exposed to the body as preprocessor macros
+    ([#define width pc.width]), so the macro rewrites {e every} [width] token in
+    [main] — including the declared name of a local. A helper inlined at its
+    call site (e.g. a [[@sarek.module]] function whose formal is named like a
+    kernel scalar) emits a self-binding [int width = width;], which the macro
+    turns into [int pc.width = pc.width;] — a syntax error ("unexpected DOT").
+    Helper {e functions} already dodge this via the [#undef]/[#define] guards in
+    {!gen_helper_func}, but a body-inlined local has no such guard.
+
+    This pass rewrites each colliding local binder (and its in-scope references)
+    to a fresh [sarek_pc_shadow_*] name that no macro touches; the initializer,
+    evaluated in the outer scope, still expands to the push constant, so
+    semantics are preserved and the generated declaration is valid. It is a
+    no-op unless a local genuinely shadows a scalar param, so collision-free
+    kernels (every existing golden) are byte-identical. GLSL-only: no other
+    backend uses macros for scalar params. *)
+let rename_pc_shadowing_locals ~pc_names body =
+  let module SM = Map.Make (String) in
+  let collides name = List.mem (escape_glsl_name name) pc_names in
+  let ren env name =
+    match SM.find_opt name env with Some n -> n | None -> name
+  in
+  let rec re_expr env e =
+    match e with
+    | EConst _ -> e
+    | EVar v -> EVar {v with var_name = ren env v.var_name}
+    | EBinop (op, a, b) -> EBinop (op, re_expr env a, re_expr env b)
+    | EUnop (op, a) -> EUnop (op, re_expr env a)
+    | EArrayRead (arr, i) -> EArrayRead (ren env arr, re_expr env i)
+    | EArrayReadExpr (b, i) -> EArrayReadExpr (re_expr env b, re_expr env i)
+    | ERecordField (e, f) -> ERecordField (re_expr env e, f)
+    | EIntrinsic (ns, n, args) -> EIntrinsic (ns, n, List.map (re_expr env) args)
+    | ECast (t, e) -> ECast (t, re_expr env e)
+    | ETuple es -> ETuple (List.map (re_expr env) es)
+    | EApp (f, args) -> EApp (re_expr env f, List.map (re_expr env) args)
+    | ERecord (n, fs) ->
+        ERecord (n, List.map (fun (k, v) -> (k, re_expr env v)) fs)
+    | EVariant (t, c, args) -> EVariant (t, c, List.map (re_expr env) args)
+    | EArrayLen n -> EArrayLen (ren env n)
+    | EArrayCreate (t, s, m) -> EArrayCreate (t, re_expr env s, m)
+    | EIf (c, t, e) -> EIf (re_expr env c, re_expr env t, re_expr env e)
+    | EMatch (s, cases) ->
+        EMatch (re_expr env s, List.map (fun (p, b) -> (p, re_expr env b)) cases)
+  in
+  let rec re_lvalue env lv =
+    match lv with
+    | LVar v -> LVar {v with var_name = ren env v.var_name}
+    | LArrayElem (arr, i) -> LArrayElem (ren env arr, re_expr env i)
+    | LArrayElemExpr (b, i) -> LArrayElemExpr (re_expr env b, re_expr env i)
+    | LRecordField (lv, f) -> LRecordField (re_lvalue env lv, f)
+  in
+  (* Bind a local: rename it when it collides with a scalar macro; otherwise
+     drop any same-named outer mapping (this fresh local shadows it). *)
+  let bind env (v : var) =
+    if collides v.var_name then begin
+      incr pc_shadow_counter ;
+      let nn =
+        Printf.sprintf
+          "sarek_pc_shadow_%s_%d"
+          (escape_glsl_name v.var_name)
+          !pc_shadow_counter
+      in
+      ({v with var_name = nn}, SM.add v.var_name nn env)
+    end
+    else (v, SM.remove v.var_name env)
+  in
+  (* Pattern binders introduce distinct locals; drop any same-named mappings in
+     the case body so references there are not mis-substituted. *)
+  let drop_pattern env = function
+    | PWild -> env
+    | PConstr (_, names) -> List.fold_left (fun e n -> SM.remove n e) env names
+  in
+  let rec re_stmt env s =
+    match s with
+    | SAssign (lv, e) -> SAssign (re_lvalue env lv, re_expr env e)
+    | SSeq ss -> SSeq (List.map (re_stmt env) ss)
+    | SIf (c, t, eo) ->
+        SIf (re_expr env c, re_stmt env t, Option.map (re_stmt env) eo)
+    | SWhile (c, b) -> SWhile (re_expr env c, re_stmt env b)
+    | SFor (v, lo, hi, dir, b) ->
+        let lo = re_expr env lo and hi = re_expr env hi in
+        let v', env' = bind env v in
+        SFor (v', lo, hi, dir, re_stmt env' b)
+    | SMatch (e, cases) ->
+        SMatch
+          ( re_expr env e,
+            List.map (fun (p, b) -> (p, re_stmt (drop_pattern env p) b)) cases
+          )
+    | SReturn e -> SReturn (re_expr env e)
+    | (SBarrier | SWarpBarrier | SMemFence | SEmpty) as s -> s
+    | SExpr e -> SExpr (re_expr env e)
+    | SLet (v, e, body) ->
+        let e = re_expr env e in
+        let v', env' = bind env v in
+        SLet (v', e, re_stmt env' body)
+    | SLetMut (v, e, body) ->
+        let e = re_expr env e in
+        let v', env' = bind env v in
+        SLetMut (v', e, re_stmt env' body)
+    | SPragma (ss, b) -> SPragma (ss, re_stmt env b)
+    | SBlock b -> SBlock (re_stmt env b)
+    | SNative _ as s -> s
+  in
+  re_stmt SM.empty body
+
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
 *)
@@ -1446,6 +1559,7 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"Vulkan" k in
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
+  pc_shadow_counter := 0 ;
   current_smod_name := compute_smod_name k ;
   current_copysign_name := compute_copysign_name k ;
   current_fmod_name := compute_fmod_name k ;
@@ -1512,9 +1626,10 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
   (* Generate helper functions *)
   List.iter (gen_helper_func ~pc_names buf) k.kern_funcs ;
 
-  (* Generate main function *)
+  (* Generate main function. Alpha-rename any body local that shadows a scalar
+     push-constant macro first (see rename_pc_shadowing_locals). *)
   Buffer.add_string buf "void main() {\n" ;
-  gen_stmt buf "  " k.kern_body ;
+  gen_stmt buf "  " (rename_pc_shadowing_locals ~pc_names k.kern_body) ;
   Buffer.add_string buf "}\n" ;
 
   let shader = Buffer.contents buf in
@@ -1552,6 +1667,7 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"Vulkan" k in
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
+  pc_shadow_counter := 0 ;
   current_smod_name := compute_smod_name k ;
   current_copysign_name := compute_copysign_name k ;
   current_fmod_name := compute_fmod_name k ;
@@ -1627,9 +1743,10 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   (* Generate helper functions *)
   List.iter (gen_helper_func ~pc_names buf) k.kern_funcs ;
 
-  (* Generate main function *)
+  (* Generate main function. Alpha-rename any body local that shadows a scalar
+     push-constant macro first (see rename_pc_shadowing_locals). *)
   Buffer.add_string buf "void main() {\n" ;
-  gen_stmt buf "  " k.kern_body ;
+  gen_stmt buf "  " (rename_pc_shadowing_locals ~pc_names k.kern_body) ;
   Buffer.add_string buf "}\n" ;
 
   let shader = Buffer.contents buf in

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -180,6 +180,75 @@ let collision_kernel () =
     body
     [collision_helper ()]
 
+(** transpose_naive regression (#65): a body local that SHADOWS a scalar kernel
+    param — the exact shape a [[@sarek.module]] helper produces when its formal
+    is named like a kernel scalar. The inliner binds the formal to the argument
+    ([let width = width]), so the emitted GLSL declares [int width = ...;].
+
+    GLSL exposes scalar params as preprocessor macros
+    ([#define width pc.width]), which rewrite EVERY [width] token in [main] —
+    including that declaration's name, yielding [int pc.width = pc.width;]:
+    glslangValidator rejects it with "unexpected DOT". HIP/OpenCL/Metal have no
+    such macro, so the same kernel assembled fine there (perf sweep 2026-07-24).
+    The GLSL emitter must alpha-rename the shadowing locals. *)
+let transpose_naive_kernel () =
+  let input = make_var "input" (TVec TFloat32) in
+  let output = make_var "output" (TVec TFloat32) in
+  let width = make_var "width" TInt32 in
+  let height = make_var "height" TInt32 in
+  (* Locals named EXACTLY like the scalar params — the module-inline shape. *)
+  let width_l = make_var "width" TInt32 in
+  let height_l = make_var "height" TInt32 in
+  let tid = make_var "tid" TInt32 in
+  let n = make_var "n" TInt32 in
+  let col = make_var "col" TInt32 in
+  let row = make_var "row" TInt32 in
+  let in_idx = make_var "in_idx" TInt32 in
+  let out_idx = make_var "out_idx" TInt32 in
+  let inner =
+    SLet
+      ( col,
+        EBinop (Mod, EVar tid, EVar width_l),
+        SLet
+          ( row,
+            EBinop (Div, EVar tid, EVar width_l),
+            SLet
+              ( in_idx,
+                EBinop (Add, EBinop (Mul, EVar row, EVar width_l), EVar col),
+                SLet
+                  ( out_idx,
+                    EBinop (Add, EBinop (Mul, EVar col, EVar height_l), EVar row),
+                    SAssign
+                      ( LArrayElem ("output", EVar out_idx),
+                        EArrayRead ("input", EVar in_idx) ) ) ) ) )
+  in
+  let body =
+    SBlock
+      (SLet
+         ( width_l,
+           EVar width,
+           SLet
+             ( height_l,
+               EVar height,
+               SLet
+                 ( tid,
+                   EIntrinsic ([], "global_thread_id", []),
+                   SLet
+                     ( n,
+                       EBinop (Mul, EVar width_l, EVar height_l),
+                       SIf (EBinop (Lt, EVar tid, EVar n), inner, None) ) ) ) ))
+  in
+  base_kernel
+    "transpose_naive"
+    [
+      DParam (input, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (output, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (width, None);
+      DParam (height, None);
+    ]
+    body
+    []
+
 (* ---- validator plumbing (mirrors the ptxas gate) ---- *)
 
 let tool_available cmd =
@@ -347,6 +416,57 @@ let test_wgsl_local_buffer_name_collision () =
           e
           wgsl
 
+(* transpose_naive (#65): a scalar-param-shadowing local must be alpha-renamed
+   so the push-constant macro does not mangle its declaration into `pc.width`.
+   Red-on-mutation: revert the rename pass in Sarek_ir_glsl and glslangValidator
+   fails here with "unexpected DOT". *)
+let test_glsl_transpose_naive_pc_shadow_validates () =
+  let k = transpose_naive_kernel () in
+  let glsl = Sarek_ir_glsl.generate k in
+  if not (contains glsl "sarek_pc_shadow_") then
+    Alcotest.failf
+      "expected the scalar-param-shadowing locals to be alpha-renamed \
+       (sarek_pc_shadow_*):\n\
+       %s"
+      glsl ;
+  (* The colliding raw declaration `int width = ` must NOT survive (it would be
+     macro-rewritten to `int pc.width = `). *)
+  if contains glsl "int width =" || contains glsl "int height =" then
+    Alcotest.failf
+      "a scalar-param-shadowing local declaration survived unrenamed:\n%s"
+      glsl ;
+  if not (Lazy.force glslang_available) then
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  else
+    match glslang_ok glsl with
+    | Ok () -> Printf.printf "  glslangValidator OK: transpose_naive\n%!"
+    | Error e ->
+        Alcotest.failf
+          "glslangValidator rejected transpose_naive GLSL (unexpected DOT?):\n\
+           %s\n\
+           --- shader ---\n\
+           %s"
+          e
+          glsl
+
+(* WGSL is NOT affected by the "unexpected DOT" defect: it exposes scalars as
+   `params.<name>` field access, not macros, so `let width : i32 = params.width;`
+   is valid. This case documents that WGSL still assembles (skips if naga is
+   absent, as elsewhere). *)
+let test_wgsl_transpose_naive_validates () =
+  let k = transpose_naive_kernel () in
+  let wgsl = Sarek_ir_wgsl.generate k in
+  if not (Lazy.force naga_available) then
+    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!"
+  else
+    match naga_ok wgsl with
+    | Ok () -> Printf.printf "  naga OK: transpose_naive\n%!"
+    | Error e ->
+        Alcotest.failf
+          "naga rejected transpose_naive WGSL:\n%s\n--- shader ---\n%s"
+          e
+          wgsl
+
 let () =
   Alcotest.run
     "shader_recursion_vector"
@@ -369,5 +489,13 @@ let () =
             "WGSL helper-local vs buffer-name collision (alpha-capture)"
             `Quick
             test_wgsl_local_buffer_name_collision;
+          Alcotest.test_case
+            "GLSL transpose_naive scalar-param-shadowing local (unexpected DOT)"
+            `Quick
+            test_glsl_transpose_naive_pc_shadow_validates;
+          Alcotest.test_case
+            "WGSL transpose_naive scalar-param-shadowing local"
+            `Quick
+            test_wgsl_transpose_naive_validates;
         ] );
     ]


### PR DESCRIPTION
## Root cause

The `transpose_naive` benchmark kernel calls a `[@sarek.module] do_transpose` helper whose formal parameters are named like the kernel's scalar params (`width`/`height`). The PPX module-inliner binds each formal to its argument, so the inlined body contains a self-binding local `int width = width;`.

The GLSL emitter exposes scalar kernel params as **preprocessor macros**:

```glsl
#define width  pc.width
#define height pc.height
```

A macro rewrites *every* `width` token in `main` — including the **declared name** of the inlined local — so `int width = width;` becomes `int pc.width = pc.width;`. `pc.width` is not a legal declaration identifier, so glslangValidator fails with `syntax error, unexpected DOT` and emits **no SPIR-V**.

This is GLSL-specific: only the GLSL backend uses `#define name pc.name` for scalars. CUDA/OpenCL/Metal pass scalars as real function parameters, so `int width = width;` is a legal shadowing local there — which is why the same kernel ran fine on **HIP (9.5 GB/s)** and **OpenCL (9.6 GB/s)**. Helper *functions* already avoided the macro via `#undef`/`#define` guards, but a body-inlined local had none.

## The fix

`sarek/codegen/Sarek_ir_glsl.ml`: a GLSL-only IR pre-pass `rename_pc_shadowing_locals` alpha-renames every body binder (`SLet`/`SLetMut`/`SFor`) whose name collides with a scalar push-constant to a fresh `sarek_pc_shadow_<name>_<n>`, substituting in-scope references. The initializer still expands to the push constant, so semantics are preserved and the declaration name no longer contains a dot. Wired into both `generate` and `generate_with_types`.

It is a no-op unless a local actually shadows a scalar param, so all **75 golden codegen tests are byte-identical**.

## Red-on-mutation (glslangValidator `-V -S comp`)

- **Without the fix:** `ERROR: ...:28: syntax error, unexpected DOT, expecting COMMA or SEMICOLON` — exit 2, no SPIR-V.
- **With the fix:** assembles to SPIR-V, exit 0; output contains `sarek_pc_shadow_`.

Added a `transpose_naive` regression case (GLSL + WGSL) to the shader-validation gate in `sarek/tests/unit/test_shader_recursion_vector.ml`. All 6 gate cases pass.

## WGSL

Not affected — WGSL exposes scalars as `params.<name>` field access (not macros), so the declaration is valid and assembles. Noted a latent shadowing-resolution quirk (harmless for transpose_naive); out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)