### PR TITLE
fix(sarek/codegen): extend GLSL push-constant shadow rename to pattern binders + vector _len (#71)

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -1441,30 +1441,68 @@ let gen_f64_softmath_helpers ~pc_names buf =
     {!generate_with_types} for deterministic output. *)
 let pc_shadow_counter = ref 0
 
-(** Alpha-rename kernel-body locals whose name collides with a push-constant
-    scalar macro.
+(** Alpha-rename kernel-body binders whose name collides with a push-constant
+    macro.
 
     Scalar params are exposed to the body as preprocessor macros
-    ([#define width pc.width]), so the macro rewrites {e every} [width] token in
+    ([#define width pc.width]), and each vector param exposes a length macro
+    ([#define v_len pc.v_len]); a macro rewrites {e every} matching token in
     [main] — including the declared name of a local. A helper inlined at its
     call site (e.g. a [[@sarek.module]] function whose formal is named like a
     kernel scalar) emits a self-binding [int width = width;], which the macro
     turns into [int pc.width = pc.width;] — a syntax error ("unexpected DOT").
     Helper {e functions} already dodge this via the [#undef]/[#define] guards in
-    {!gen_helper_func}, but a body-inlined local has no such guard.
+    {!gen_helper_func}, but a body-inlined binder has no such guard.
 
-    This pass rewrites each colliding local binder (and its in-scope references)
-    to a fresh [sarek_pc_shadow_*] name that no macro touches; the initializer,
-    evaluated in the outer scope, still expands to the push constant, so
-    semantics are preserved and the generated declaration is valid. It is a
-    no-op unless a local genuinely shadows a scalar param, so collision-free
-    kernels (every existing golden) are byte-identical. GLSL-only: no other
-    backend uses macros for scalar params. *)
-let rename_pc_shadowing_locals ~pc_names body =
+    Covered binder forms: [SLet], [SLetMut], [SFor], and match pattern binders
+    (both [SMatch] and [EMatch]). Both scalar-param macros ([pc_names]) and
+    vector-length macros ([len_names]) are treated as collisions.
+
+    Each colliding binder (and its in-scope references) is rewritten to a fresh
+    [sarek_pc_shadow_*] name that no macro touches; for [SLet]/[SLetMut]/[SFor]
+    the initializer, evaluated in the outer scope, still expands to the push
+    constant, so semantics are preserved and the declaration is valid. It is a
+    no-op unless a binder genuinely shadows a macro, so collision-free kernels
+    (every existing golden) are byte-identical. GLSL-only: no other backend uses
+    macros for params. *)
+let rename_pc_shadowing_locals ~pc_names ~len_names body =
   let module SM = Map.Make (String) in
-  let collides name = List.mem (escape_glsl_name name) pc_names in
+  (* A local collides if its escaped name matches a scalar-param macro
+     ([#define name pc.name]) or a vector-length macro ([#define vec_len
+     pc.vec_len]); either would rewrite the declared identifier to [pc....]. *)
+  let collides name =
+    let n = escape_glsl_name name in
+    List.mem n pc_names || List.mem n len_names
+  in
   let ren env name =
     match SM.find_opt name env with Some n -> n | None -> name
+  in
+  (* Mint a fresh push-constant-shadow name for a colliding binder. *)
+  let fresh_name orig =
+    incr pc_shadow_counter ;
+    Printf.sprintf
+      "sarek_pc_shadow_%s_%d"
+      (escape_glsl_name orig)
+      !pc_shadow_counter
+  in
+  (* Rebind a match pattern's binders: rename each that collides with a macro
+     to a fresh name — used both in the destructuring declaration emitted by
+     {!gen_match_pattern} and in case-body references (via [env]) — and drop
+     any same-named outer mapping for non-colliding binders (they shadow it). *)
+  let bind_pattern env = function
+    | PWild -> (PWild, env)
+    | PConstr (cname, names) ->
+        let env, names =
+          List.fold_left_map
+            (fun env name ->
+              if collides name then
+                let nn = fresh_name name in
+                (SM.add name nn env, nn)
+              else (SM.remove name env, name))
+            env
+            names
+        in
+        (PConstr (cname, names), env)
   in
   let rec re_expr env e =
     match e with
@@ -1486,7 +1524,16 @@ let rename_pc_shadowing_locals ~pc_names body =
     | EArrayCreate (t, s, m) -> EArrayCreate (t, re_expr env s, m)
     | EIf (c, t, e) -> EIf (re_expr env c, re_expr env t, re_expr env e)
     | EMatch (s, cases) ->
-        EMatch (re_expr env s, List.map (fun (p, b) -> (p, re_expr env b)) cases)
+        (* Rebind pattern binders before each case body (mirrors [SMatch]): a
+           binder shadowing a scalar/_len macro is renamed and its body refs
+           follow, otherwise an outer mapping would wrongly substitute them. *)
+        EMatch
+          ( re_expr env s,
+            List.map
+              (fun (p, b) ->
+                let p, env = bind_pattern env p in
+                (p, re_expr env b))
+              cases )
   in
   let rec re_lvalue env lv =
     match lv with
@@ -1498,23 +1545,10 @@ let rename_pc_shadowing_locals ~pc_names body =
   (* Bind a local: rename it when it collides with a scalar macro; otherwise
      drop any same-named outer mapping (this fresh local shadows it). *)
   let bind env (v : var) =
-    if collides v.var_name then begin
-      incr pc_shadow_counter ;
-      let nn =
-        Printf.sprintf
-          "sarek_pc_shadow_%s_%d"
-          (escape_glsl_name v.var_name)
-          !pc_shadow_counter
-      in
+    if collides v.var_name then
+      let nn = fresh_name v.var_name in
       ({v with var_name = nn}, SM.add v.var_name nn env)
-    end
     else (v, SM.remove v.var_name env)
-  in
-  (* Pattern binders introduce distinct locals; drop any same-named mappings in
-     the case body so references there are not mis-substituted. *)
-  let drop_pattern env = function
-    | PWild -> env
-    | PConstr (_, names) -> List.fold_left (fun e n -> SM.remove n e) env names
   in
   let rec re_stmt env s =
     match s with
@@ -1530,8 +1564,11 @@ let rename_pc_shadowing_locals ~pc_names body =
     | SMatch (e, cases) ->
         SMatch
           ( re_expr env e,
-            List.map (fun (p, b) -> (p, re_stmt (drop_pattern env p) b)) cases
-          )
+            List.map
+              (fun (p, b) ->
+                let p, env = bind_pattern env p in
+                (p, re_stmt env b))
+              cases )
     | SReturn e -> SReturn (re_expr env e)
     | (SBarrier | SWarpBarrier | SMemFence | SEmpty) as s -> s
     | SExpr e -> SExpr (re_expr env e)
@@ -1601,6 +1638,19 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
         | _ -> None)
       k.kern_params
   in
+  (* Vector params emit a length macro [#define <vec>_len pc.<vec>_len]; a local
+     named [<vec>_len] collides with it (see rename_pc_shadowing_locals). *)
+  let len_names =
+    List.filter_map
+      (fun decl ->
+        match decl with
+        | DParam (v, _) -> (
+            match v.var_type with
+            | TVec _ -> Some (escape_glsl_name v.var_name ^ "_len")
+            | _ -> None)
+        | _ -> None)
+      k.kern_params
+  in
 
   (* Generate shared declarations at module scope (GLSL requirement) *)
   let shared_decls = collect_shared_decls k.kern_body in
@@ -1629,7 +1679,10 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
   (* Generate main function. Alpha-rename any body local that shadows a scalar
      push-constant macro first (see rename_pc_shadowing_locals). *)
   Buffer.add_string buf "void main() {\n" ;
-  gen_stmt buf "  " (rename_pc_shadowing_locals ~pc_names k.kern_body) ;
+  gen_stmt
+    buf
+    "  "
+    (rename_pc_shadowing_locals ~pc_names ~len_names k.kern_body) ;
   Buffer.add_string buf "}\n" ;
 
   let shader = Buffer.contents buf in
@@ -1718,6 +1771,19 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
         | _ -> None)
       k.kern_params
   in
+  (* Vector params emit a length macro [#define <vec>_len pc.<vec>_len]; a local
+     named [<vec>_len] collides with it (see rename_pc_shadowing_locals). *)
+  let len_names =
+    List.filter_map
+      (fun decl ->
+        match decl with
+        | DParam (v, _) -> (
+            match v.var_type with
+            | TVec _ -> Some (escape_glsl_name v.var_name ^ "_len")
+            | _ -> None)
+        | _ -> None)
+      k.kern_params
+  in
 
   (* Generate shared declarations at module scope (GLSL requirement) *)
   let shared_decls = collect_shared_decls k.kern_body in
@@ -1746,7 +1812,10 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   (* Generate main function. Alpha-rename any body local that shadows a scalar
      push-constant macro first (see rename_pc_shadowing_locals). *)
   Buffer.add_string buf "void main() {\n" ;
-  gen_stmt buf "  " (rename_pc_shadowing_locals ~pc_names k.kern_body) ;
+  gen_stmt
+    buf
+    "  "
+    (rename_pc_shadowing_locals ~pc_names ~len_names k.kern_body) ;
   Buffer.add_string buf "}\n" ;
 
   let shader = Buffer.contents buf in

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -249,6 +249,147 @@ let transpose_naive_kernel () =
     body
     []
 
+(** Match-pattern-binder shadow (#71, same class as #65): a [match] whose
+    variant destructuring binds a name equal to a scalar push-constant param
+    ([width]). [gen_match_pattern] emits the binding as a real declaration
+    [float width = scrut.OptSome_v;]; the scalar macro [#define width pc.width]
+    rewrites it to [float pc.width = pc.width;] → glslangValidator "unexpected
+    DOT". The pre-pass must alpha-rename the pattern binder (and its body refs)
+    to [sarek_pc_shadow_*], consistently with the SLet path. *)
+let match_pc_shadow_kernel () =
+  let opt_constrs = [("OptNone", []); ("OptSome", [TFloat32])] in
+  let opt_type = TVariant ("Opt", opt_constrs) in
+  let data = make_var "data" (TVec opt_type) in
+  let out = make_var "out" (TVec TFloat32) in
+  (* scalar param named EXACTLY like the pattern binder below *)
+  let width = make_var "width" TFloat32 in
+  let tid = make_var "tid" TInt32 in
+  let scrut = make_var "scrut" opt_type in
+  (* the [OptSome] payload binder — same name as the scalar param *)
+  let width_bind = make_var "width" TFloat32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( scrut,
+            EArrayRead ("data", EVar tid),
+            SMatch
+              ( EVar scrut,
+                [
+                  ( PConstr ("OptSome", ["width"]),
+                    SAssign (LArrayElem ("out", EVar tid), EVar width_bind) );
+                  ( PConstr ("OptNone", []),
+                    SAssign (LArrayElem ("out", EVar tid), EConst (CFloat32 0.0))
+                  );
+                ] ) ) )
+  in
+  let k =
+    base_kernel
+      "match_pc_shadow"
+      [
+        DParam (data, None);
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (width, None);
+      ]
+      body
+      []
+  in
+  {k with kern_variants = [("Opt", opt_constrs)]}
+
+(** Vector-length-macro shadow (#71, Minor): each vector param [v] emits a
+    length macro [#define v_len pc.v_len]. A local named [<vec>_len] collides
+    with it: [int data_len = ...;] → [int pc.data_len = ...;] → "unexpected
+    DOT". [pc_names] excludes vectors, so the pre-pass must additionally treat
+    the [_len] macro names as collisions. *)
+let vec_len_shadow_kernel () =
+  let data = make_var "data" (TVec TFloat32) in
+  let out = make_var "out" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  (* local named EXACTLY like the [data] vector's length macro *)
+  let data_len_l = make_var "data_len" TInt32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( data_len_l,
+            EConst (CInt32 0l),
+            SAssign
+              ( LArrayElem ("out", EVar tid),
+                EArrayRead ("data", EVar (make_var "data_len" TInt32)) ) ) )
+  in
+  base_kernel
+    "vec_len_shadow"
+    [
+      DParam (data, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    body
+    []
+
+(** EMatch env-drop asymmetry (#71 gap #2, silent-bug once gap #1 lands). An
+    outer local [width] shadows the scalar param and is alpha-renamed to
+    [sarek_pc_shadow_width_1]. An expression-position [match] then binds [width]
+    again in its [OptSome] arm and reads it, while the fallback arm reads the
+    OUTER [width].
+
+    [EMatch] emits a ternary and NO binder declaration, so unlike [SMatch] the
+    fix's manifestation is a {e substitution} bug, not a syntax error: if the
+    [EMatch] arm does not rebind the pattern binder (as [SMatch] does), the
+    outer [width -> sarek_pc_shadow_width_1] mapping leaks into the [OptSome]
+    arm and its [width] reference is silently substituted with the outer local's
+    name — a wrong-variable read. With the fix the pattern binder gets its own
+    fresh name ([sarek_pc_shadow_width_2]).
+
+    This is a semantic assertion, not a glslangValidator case: an [EMatch] arm
+    that references its payload binder is a separate pre-existing backend
+    limitation (no destructuring declaration is emitted for expression-position
+    matches), so the shader is not expected to assemble regardless. *)
+let ematch_shadow_kernel () =
+  let opt_constrs = [("OptNone", []); ("OptSome", [TFloat32])] in
+  let opt_type = TVariant ("Opt", opt_constrs) in
+  let data = make_var "data" (TVec opt_type) in
+  let out = make_var "out" (TVec TFloat32) in
+  let width = make_var "width" TFloat32 in
+  let tid = make_var "tid" TInt32 in
+  let scrut = make_var "scrut" opt_type in
+  (* outer local named like the scalar param -> renamed to _1 *)
+  let width_outer = make_var "width" TFloat32 in
+  (* inner OptSome payload binder, same name -> must get its own _2 *)
+  let width_bind = make_var "width" TFloat32 in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( width_outer,
+            EConst (CFloat32 5.0),
+            SLet
+              ( scrut,
+                EArrayRead ("data", EVar tid),
+                SAssign
+                  ( LArrayElem ("out", EVar tid),
+                    EMatch
+                      ( EVar scrut,
+                        [
+                          (PConstr ("OptSome", ["width"]), EVar width_bind);
+                          (PConstr ("OptNone", []), EVar width_outer);
+                        ] ) ) ) ) )
+  in
+  let k =
+    base_kernel
+      "ematch_shadow"
+      [
+        DParam (data, None);
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (width, None);
+      ]
+      body
+      []
+  in
+  {k with kern_variants = [("Opt", opt_constrs)]}
+
 (* ---- validator plumbing (mirrors the ptxas gate) ---- *)
 
 let tool_available cmd =
@@ -467,6 +608,99 @@ let test_wgsl_transpose_naive_validates () =
           e
           wgsl
 
+(* #71 gap #1: a match variant binder named like a scalar param must be
+   alpha-renamed (gen_match_pattern emits it as a real declaration). Red-on-
+   mutation: revert the pattern-binder rename and glslangValidator fails with
+   "unexpected DOT" on `float pc.width = ...`. *)
+let test_glsl_match_pattern_pc_shadow_validates () =
+  let k =
+    Sarek_ir_glsl.generate_with_types ~types:[] (match_pc_shadow_kernel ())
+  in
+  if not (contains k "sarek_pc_shadow_") then
+    Alcotest.failf
+      "expected the match pattern binder to be alpha-renamed \
+       (sarek_pc_shadow_*):\n\
+       %s"
+      k ;
+  (* The raw destructuring declaration `float width = ` must NOT survive (it
+     would be macro-rewritten to `float pc.width = `). *)
+  if contains k "float width =" then
+    Alcotest.failf
+      "a scalar-param-shadowing match binder declaration survived unrenamed:\n\
+       %s"
+      k ;
+  if not (Lazy.force glslang_available) then
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  else
+    match glslang_ok k with
+    | Ok () -> Printf.printf "  glslangValidator OK: match_pc_shadow\n%!"
+    | Error e ->
+        Alcotest.failf
+          "glslangValidator rejected match_pc_shadow GLSL (unexpected DOT?):\n\
+           %s\n\
+           --- shader ---\n\
+           %s"
+          e
+          k
+
+(* #71 gap #3: a local named like a vector-length macro (`data_len`) must be
+   alpha-renamed. Red-on-mutation: drop the `_len` names from the pre-pass
+   collision set and glslangValidator fails with "unexpected DOT" on
+   `int pc.data_len = ...`. *)
+let test_glsl_vec_len_shadow_validates () =
+  let k = Sarek_ir_glsl.generate (vec_len_shadow_kernel ()) in
+  if not (contains k "sarek_pc_shadow_") then
+    Alcotest.failf
+      "expected the vector-_len-shadowing local to be alpha-renamed \
+       (sarek_pc_shadow_*):\n\
+       %s"
+      k ;
+  if contains k "int data_len =" then
+    Alcotest.failf
+      "a vector-_len-shadowing local declaration survived unrenamed:\n%s"
+      k ;
+  if not (Lazy.force glslang_available) then
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  else
+    match glslang_ok k with
+    | Ok () -> Printf.printf "  glslangValidator OK: vec_len_shadow\n%!"
+    | Error e ->
+        Alcotest.failf
+          "glslangValidator rejected vec_len_shadow GLSL (unexpected DOT?):\n\
+           %s\n\
+           --- shader ---\n\
+           %s"
+          e
+          k
+
+(* #71 gap #2 (silent wrong-var read). Semantic assertion, not a validator gate
+   (EMatch expression binders emit no declaration — see kernel docstring). The
+   OptSome arm binds `width` shadowing the outer renamed local; with the EMatch
+   arm made consistent with SMatch, the pattern binder gets its OWN fresh name
+   (sarek_pc_shadow_width_2), distinct from the outer local
+   (sarek_pc_shadow_width_1). Red-on-mutation: revert the EMatch arm to reuse
+   the outer env and both ternary branches collapse to _1 — the OptSome arm
+   silently reads the outer local (no _2 is ever minted), failing this check. *)
+let test_glsl_ematch_pattern_shadow_rebinds () =
+  let k =
+    Sarek_ir_glsl.generate_with_types ~types:[] (ematch_shadow_kernel ())
+  in
+  if not (contains k "sarek_pc_shadow_width_1") then
+    Alcotest.failf
+      "expected the outer scalar-shadowing local to be renamed \
+       (sarek_pc_shadow_width_1):\n\
+       %s"
+      k ;
+  if not (contains k "sarek_pc_shadow_width_2") then
+    Alcotest.failf
+      "EMatch pattern binder was not rebound: the OptSome arm reuses the outer \
+       local (sarek_pc_shadow_width_1) instead of its own binder \
+       (sarek_pc_shadow_width_2) — silent wrong-variable read:\n\
+       %s"
+      k ;
+  Printf.printf
+    "  semantic OK: ematch_shadow (pattern binder rebound to _2)\n%!"
+
 let () =
   Alcotest.run
     "shader_recursion_vector"
@@ -497,5 +731,17 @@ let () =
             "WGSL transpose_naive scalar-param-shadowing local"
             `Quick
             test_wgsl_transpose_naive_validates;
+          Alcotest.test_case
+            "GLSL match pattern binder shadows scalar param (unexpected DOT)"
+            `Quick
+            test_glsl_match_pattern_pc_shadow_validates;
+          Alcotest.test_case
+            "GLSL local shadows vector _len macro (unexpected DOT)"
+            `Quick
+            test_glsl_vec_len_shadow_validates;
+          Alcotest.test_case
+            "GLSL EMatch pattern binder rebinds (silent wrong-var read)"
+            `Quick
+            test_glsl_ematch_pattern_shadow_rebinds;
         ] );
     ]


### PR DESCRIPTION
Extends #65's GLSL push-constant-macro shadow-rename pre-pass (`rename_pc_shadowing_locals`) to the binder forms #65 did not yet cover. Same "unexpected DOT" class; all three gaps were **pre-existing** same-class gaps to #65 (reviewer-identified on PR #281).

## Gaps closed

**Gap #1 — match pattern binders (Important).** `gen_match_pattern` emits each variant destructuring binding as a real declaration (`float width = scrut.OptSome_v;`), so a binder named like a scalar param became `float pc.width = ...` under `#define width pc.width` → "unexpected DOT". The pre-pass now alpha-renames colliding `PConstr` binders (new `bind_pattern` helper) in both the emitted declaration and case-body references, consistent with the `SLet` path.

**Gap #2 — EMatch env-drop asymmetry (silent bug once #1 lands).** `re_expr`'s `EMatch` arm renamed case bodies with the outer env, never rebinding pattern binders like `SMatch`. Once #1 lands, an outer local shadowing a scalar leaks into an `EMatch` arm that rebinds the same name → the arm's reference is silently substituted with the outer local's name (both ternary branches collapse to `sarek_pc_shadow_width_1`). `EMatch` now uses `bind_pattern` per case, **consistent with SMatch**.

**Gap #3 — vector `_len` macros (Minor).** Each vector param emits `#define <vec>_len pc.<vec>_len`, but `pc_names` excluded vectors so `collides` missed a local named `<vec>_len`. Both callers now compute `len_names` and the collision set checks it.

**Docstring.** Corrected `rename_pc_shadowing_locals`'s over-claiming docstring to name the covered binder forms (SLet/SLetMut/SFor/pattern-binders/vector-_len) and both macro classes.

## Red-on-mutation (shader-validation gate)

- **match binder** (test 6): revert the `SMatch` rename → `float width = scrut.OptSome_v;` survives under the macro (unexpected DOT).
- **vector `_len`** (test 7): drop `len_names` from `collides` → `int data_len = 0;` survives under `#define data_len pc.data_len`.
- **EMatch silent read** (test 8, semantic assertion — EMatch expression binders emit no declaration): revert the EMatch arm → ternary becomes `((scrut.tag == OptSome) ? sarek_pc_shadow_width_1 : sarek_pc_shadow_width_1)`, both branches reading the outer local; no `sarek_pc_shadow_width_2` minted.

## Gates
- `dune build` clean; `@fmt` clean on touched files.
- Golden codegen 75/75 (byte-identical — pre-pass is a no-op without a real collision).
- Shader gate 9/9 incl. 3 new cases (glslangValidator validated).
- Full `sarek/tests/unit` runtest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated GLSL when local variables or pattern bindings share names with push-constant or vector-length macros.
  * Corrected variable rebinding in expression and statement pattern matches to preserve expected shader behavior.
  * Prevented invalid GLSL and incorrect variable reads in affected shader scenarios.

* **Tests**
  * Added regression coverage for macro-name collisions, vector-length names, and match-pattern rebinding.
  * Added validation using GLSL compilation checks when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->