### PR TITLE
fix(sarek/codegen): WGSL local shadowing a scalar param no longer reads the push-constant (#72)

### DIFF
--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -947,6 +947,159 @@ let gen_bindings buf params =
   Buffer.add_char buf '\n' ;
   List.map (fun (v : var) -> v.var_name) scalars
 
+(** {1 Scalar-param shadow renaming} *)
+
+(** Counter for fresh scalar-param-shadowing local names (see
+    {!rename_scalar_shadowing_locals}). Reset per kernel in {!generate} /
+    {!generate_with_types} for deterministic output. *)
+let scalar_shadow_counter = ref 0
+
+(** Alpha-rename kernel-body binders whose name collides with a scalar kernel
+    param.
+
+    Scalar params are accessed in the body as [params.<name>]; {!gen_expr}
+    decides this per-[EVar] by checking the {e global} [scalar_param_names] ref,
+    which ignores local scope. A local [let width = …] (or [let mut width = …])
+    that shadows a scalar param [width] therefore has every body reference to
+    [width] wrongly emitted as [params.width] — reading the uniform instead of
+    the local. For an immutable self-binding local ([let width = params.width])
+    this is accidentally correct; for a {e mutated} shadowing local it is a
+    silent wrong result (valid WGSL, no error): the declaration uses the bare
+    name ([var width : i32 = params.width;]) so writes hit the local, but every
+    read is redirected to the immutable uniform.
+
+    This mirrors the GLSL backend's {!Sarek_ir_glsl.rename_pc_shadowing_locals}:
+    each colliding binder (and its in-scope references) is rewritten to a fresh
+    [sarek_scalar_shadow_*] name that is not a scalar param, so [gen_expr]'s
+    [scalar_param_names] check never matches it and the bare fresh name is
+    emitted for both reads and writes. The initializer is evaluated in the outer
+    scope, so it still expands to [params.<name>], preserving semantics.
+
+    Covered binder forms: [SLet], [SLetMut], [SFor], and match pattern binders
+    (both [SMatch] and [EMatch]). Unlike GLSL there is no vector-length ([_len])
+    collision: WGSL emits vector length as the field access
+    [params.sarek_<arr>_length] ({!EArrayLen}), hardcoded with a [params.]
+    prefix independent of any local, so a local cannot alias it.
+
+    No-op unless a binder genuinely shadows a scalar param, so collision-free
+    kernels (every existing golden) are byte-identical. WGSL-only. *)
+let rename_scalar_shadowing_locals ~scalar_names body =
+  let module SM = Map.Make (String) in
+  (* A local collides if its name matches a scalar param — the exact check
+     [gen_expr] performs on [EVar] against [scalar_param_names] (raw names). *)
+  let collides name = List.mem name scalar_names in
+  let ren env name =
+    match SM.find_opt name env with Some n -> n | None -> name
+  in
+  (* Mint a fresh scalar-shadow name for a colliding binder. *)
+  let fresh_name orig =
+    incr scalar_shadow_counter ;
+    Printf.sprintf
+      "sarek_scalar_shadow_%s_%d"
+      (escape_wgsl_name orig)
+      !scalar_shadow_counter
+  in
+  (* Rebind a match pattern's binders: rename each that collides with a scalar
+     param to a fresh name (used both in the destructuring declaration emitted
+     by {!gen_match_pattern} and in case-body references, via [env]) and drop
+     any same-named outer mapping for non-colliding binders (they shadow it). *)
+  let bind_pattern env = function
+    | PWild -> (PWild, env)
+    | PConstr (cname, names) ->
+        let env, names =
+          List.fold_left_map
+            (fun env name ->
+              if collides name then
+                let nn = fresh_name name in
+                (SM.add name nn env, nn)
+              else (SM.remove name env, name))
+            env
+            names
+        in
+        (PConstr (cname, names), env)
+  in
+  let rec re_expr env e =
+    match e with
+    | EConst _ -> e
+    | EVar v -> EVar {v with var_name = ren env v.var_name}
+    | EBinop (op, a, b) -> EBinop (op, re_expr env a, re_expr env b)
+    | EUnop (op, a) -> EUnop (op, re_expr env a)
+    | EArrayRead (arr, i) -> EArrayRead (ren env arr, re_expr env i)
+    | EArrayReadExpr (b, i) -> EArrayReadExpr (re_expr env b, re_expr env i)
+    | ERecordField (e, f) -> ERecordField (re_expr env e, f)
+    | EIntrinsic (ns, n, args) -> EIntrinsic (ns, n, List.map (re_expr env) args)
+    | ECast (t, e) -> ECast (t, re_expr env e)
+    | ETuple es -> ETuple (List.map (re_expr env) es)
+    | EApp (f, args) -> EApp (re_expr env f, List.map (re_expr env) args)
+    | ERecord (n, fs) ->
+        ERecord (n, List.map (fun (k, v) -> (k, re_expr env v)) fs)
+    | EVariant (t, c, args) -> EVariant (t, c, List.map (re_expr env) args)
+    | EArrayLen n -> EArrayLen (ren env n)
+    | EArrayCreate (t, s, m) -> EArrayCreate (t, re_expr env s, m)
+    | EIf (c, t, e) -> EIf (re_expr env c, re_expr env t, re_expr env e)
+    | EMatch (s, cases) ->
+        (* Rebind pattern binders before each case body (mirrors [SMatch]): a
+           binder shadowing a scalar param is renamed and its body refs follow,
+           otherwise an outer mapping would wrongly substitute them. *)
+        EMatch
+          ( re_expr env s,
+            List.map
+              (fun (p, b) ->
+                let p, env = bind_pattern env p in
+                (p, re_expr env b))
+              cases )
+  in
+  let rec re_lvalue env lv =
+    match lv with
+    | LVar v -> LVar {v with var_name = ren env v.var_name}
+    | LArrayElem (arr, i) -> LArrayElem (ren env arr, re_expr env i)
+    | LArrayElemExpr (b, i) -> LArrayElemExpr (re_expr env b, re_expr env i)
+    | LRecordField (lv, f) -> LRecordField (re_lvalue env lv, f)
+  in
+  (* Bind a local: rename it when it collides with a scalar param; otherwise
+     drop any same-named outer mapping (this fresh local shadows it). *)
+  let bind env (v : var) =
+    if collides v.var_name then
+      let nn = fresh_name v.var_name in
+      ({v with var_name = nn}, SM.add v.var_name nn env)
+    else (v, SM.remove v.var_name env)
+  in
+  let rec re_stmt env s =
+    match s with
+    | SAssign (lv, e) -> SAssign (re_lvalue env lv, re_expr env e)
+    | SSeq ss -> SSeq (List.map (re_stmt env) ss)
+    | SIf (c, t, eo) ->
+        SIf (re_expr env c, re_stmt env t, Option.map (re_stmt env) eo)
+    | SWhile (c, b) -> SWhile (re_expr env c, re_stmt env b)
+    | SFor (v, lo, hi, dir, b) ->
+        let lo = re_expr env lo and hi = re_expr env hi in
+        let v', env' = bind env v in
+        SFor (v', lo, hi, dir, re_stmt env' b)
+    | SMatch (e, cases) ->
+        SMatch
+          ( re_expr env e,
+            List.map
+              (fun (p, b) ->
+                let p, env = bind_pattern env p in
+                (p, re_stmt env b))
+              cases )
+    | SReturn e -> SReturn (re_expr env e)
+    | (SBarrier | SWarpBarrier | SMemFence | SEmpty) as s -> s
+    | SExpr e -> SExpr (re_expr env e)
+    | SLet (v, e, body) ->
+        let e = re_expr env e in
+        let v', env' = bind env v in
+        SLet (v', e, re_stmt env' body)
+    | SLetMut (v, e, body) ->
+        let e = re_expr env e in
+        let v', env' = bind env v in
+        SLetMut (v', e, re_stmt env' body)
+    | SPragma (ss, b) -> SPragma (ss, re_stmt env b)
+    | SBlock b -> SBlock (re_stmt env b)
+    | SNative _ as s -> s
+  in
+  re_stmt SM.empty body
+
 (** {1 Main generate functions} *)
 
 let wgsl_header ~kernel_name ?(block = (256, 1, 1)) () =
@@ -984,6 +1137,7 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
      arguments — see Sarek_ir_inline_vec). *)
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"WGSL" k in
   scalar_param_names := [] ;
+  scalar_shadow_counter := 0 ;
   current_variants := k.kern_variants ;
   let buf = Buffer.create 1024 in
   let scalars = gen_bindings buf k.kern_params in
@@ -993,7 +1147,12 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
   gen_fmod_helper buf k ;
   List.iter (gen_helper_func buf) k.kern_funcs ;
   Buffer.add_string buf (wgsl_header ~kernel_name:k.kern_name ?block ()) ;
-  gen_stmt buf "  " k.kern_body ;
+  (* Alpha-rename any body local that shadows a scalar param first (see
+     rename_scalar_shadowing_locals). *)
+  gen_stmt
+    buf
+    "  "
+    (rename_scalar_shadowing_locals ~scalar_names:scalars k.kern_body) ;
   Buffer.add_string buf "}\n" ;
   let shader = Buffer.contents buf in
   log (Printf.sprintf "[WGSL] Generated shader:\n%s" shader) ;
@@ -1011,6 +1170,7 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
      arguments — see Sarek_ir_inline_vec). *)
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"WGSL" k in
   scalar_param_names := [] ;
+  scalar_shadow_counter := 0 ;
   current_variants := k.kern_variants ;
   let buf = Buffer.create 1024 in
   List.iter (gen_record_def buf) types ;
@@ -1022,7 +1182,12 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   gen_fmod_helper buf k ;
   List.iter (gen_helper_func buf) k.kern_funcs ;
   Buffer.add_string buf (wgsl_header ~kernel_name:k.kern_name ?block ()) ;
-  gen_stmt buf "  " k.kern_body ;
+  (* Alpha-rename any body local that shadows a scalar param first (see
+     rename_scalar_shadowing_locals). *)
+  gen_stmt
+    buf
+    "  "
+    (rename_scalar_shadowing_locals ~scalar_names:scalars k.kern_body) ;
   Buffer.add_string buf "}\n" ;
   let shader = Buffer.contents buf in
   log (Printf.sprintf "[WGSL] Generated shader:\n%s" shader) ;

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -390,6 +390,55 @@ let ematch_shadow_kernel () =
   in
   {k with kern_variants = [("Opt", opt_constrs)]}
 
+(** WGSL scalar-param-shadowing MUTATED local (#72). WGSL accesses scalar params
+    as [params.<name>] field reads, decided per-[EVar] by the global
+    [scalar_param_names] ref, which ignores local scope. A local [let mut width]
+    that shadows a scalar param [width] therefore has every body {e read} of
+    [width] emitted as [params.width] (the immutable uniform), while the
+    declaration and the assignment {e target} use the bare name (writing the
+    local). For a mutated local the two diverge: the writes hit a local nobody
+    reads, and the reads see the never-updated uniform — a silent wrong result
+    (valid WGSL, no error).
+
+    The local's initializer is a constant (NOT [params.width]), so [params.width]
+    appears in the emitted shader {e only} through the buggy body reads: with the
+    scalar-shadow rename pass it must not appear at all, and the local must carry
+    a fresh [sarek_scalar_shadow_*] name. *)
+let wgsl_scalar_shadow_mut_kernel () =
+  let out = make_var "out" (TVec TFloat32) in
+  let width = make_var "width" TInt32 in
+  let tid = make_var "tid" TInt32 in
+  (* mutable local named EXACTLY like the scalar param *)
+  let width_l = {(make_var "width" TInt32) with var_mutable = true} in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SLetMut
+          ( width_l,
+            (* init from a constant, NOT from the param — so any params.width in
+               the output can only come from the buggy body reads below *)
+            EConst (CInt32 1l),
+            SSeq
+              [
+                (* mutate the local: width := width + 1 *)
+                SAssign
+                  (LVar width_l, EBinop (Add, EVar width_l, EConst (CInt32 1l)));
+                (* read the local — the bug emits params.width here *)
+                SAssign
+                  ( LArrayElem ("out", EVar tid),
+                    ECast (TFloat32, EVar width_l) );
+              ] ) )
+  in
+  base_kernel
+    "wgsl_scalar_shadow_mut"
+    [
+      DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (width, None);
+    ]
+    body
+    []
+
 (* ---- validator plumbing (mirrors the ptxas gate) ---- *)
 
 let tool_available cmd =
@@ -608,6 +657,50 @@ let test_wgsl_transpose_naive_validates () =
           e
           wgsl
 
+(* #72: a MUTATED local shadowing a scalar param must be alpha-renamed so its
+   body reads resolve to the local, not the immutable `params.<name>` uniform.
+   Codegen-golden (naga absent): asserts the emitted WGSL tokens directly, no
+   runtime execution. Were naga present this kernel would also be a semantic
+   positive control (writes-then-reads the local). Red-on-mutation: revert the
+   rename pass in Sarek_ir_wgsl and the body reads emit `params.width` (the
+   silent wrong result) while `sarek_scalar_shadow_` never appears. *)
+let test_wgsl_scalar_shadow_mut_local () =
+  let wgsl = Sarek_ir_wgsl.generate (wgsl_scalar_shadow_mut_kernel ()) in
+  (* The mutated shadowing local must be alpha-renamed. *)
+  if not (contains wgsl "sarek_scalar_shadow_width_1") then
+    Alcotest.failf
+      "expected the mutated scalar-param-shadowing local to be alpha-renamed \
+       (sarek_scalar_shadow_width_1):\n\
+       %s"
+      wgsl ;
+  (* The local's init is a constant, so `params.width` can appear ONLY through
+     the buggy body reads of the shadowed local. With the fix it must not. *)
+  if contains wgsl "params.width" then
+    Alcotest.failf
+      "a body reference to the mutated shadowing local was emitted as \
+       `params.width` (reads the uniform, not the local — silent wrong \
+       result):\n\
+       %s"
+      wgsl ;
+  (* The declaration and the mutation must both use the renamed local. *)
+  if not (contains wgsl "var sarek_scalar_shadow_width_1 : i32 = 1i") then
+    Alcotest.failf
+      "expected the mutable local declaration to use the renamed name:\n%s"
+      wgsl ;
+  if not (Lazy.force naga_available) then
+    Printf.printf
+      "  codegen-golden OK: wgsl_scalar_shadow_mut (naga absent — WGSL \
+       assertion is on emitted text, not runtime)\n\
+       %!"
+  else
+    match naga_ok wgsl with
+    | Ok () -> Printf.printf "  naga OK: wgsl_scalar_shadow_mut\n%!"
+    | Error e ->
+        Alcotest.failf
+          "naga rejected wgsl_scalar_shadow_mut WGSL:\n%s\n--- shader ---\n%s"
+          e
+          wgsl
+
 (* #71 gap #1: a match variant binder named like a scalar param must be
    alpha-renamed (gen_match_pattern emits it as a real declaration). Red-on-
    mutation: revert the pattern-binder rename and glslangValidator fails with
@@ -731,6 +824,10 @@ let () =
             "WGSL transpose_naive scalar-param-shadowing local"
             `Quick
             test_wgsl_transpose_naive_validates;
+          Alcotest.test_case
+            "WGSL mutated local shadows scalar param (silent wrong result)"
+            `Quick
+            test_wgsl_scalar_shadow_mut_local;
           Alcotest.test_case
             "GLSL match pattern binder shadows scalar param (unexpected DOT)"
             `Quick


### PR DESCRIPTION
## Root cause

`gen_expr` decides per-`EVar` whether a name is a scalar kernel param by checking the **global** `scalar_param_names` ref (`Sarek_ir_wgsl.ml` ~line 194), which ignores local scope. A body local `let width` / `let mut width` that **shadows** a scalar param `width` therefore has every body reference emitted as `params.width` (the uniform), while `gen_var_decl` and `gen_lvalue LVar` use the bare name (the local).

- Immutable self-binding local (`let width = params.width`): accidentally correct — both sides read the same value.
- **Mutated** shadowing local: **silent wrong result** (valid WGSL, no error) — writes hit a local nobody reads, reads see the never-updated uniform.

## Fix

Mirror the GLSL backend's `rename_pc_shadowing_locals` with a WGSL-specific `rename_scalar_shadowing_locals` IR pre-pass. Any `SLet`/`SLetMut`/`SFor` binder, plus match pattern binders (`SMatch` and `EMatch`), whose name collides with a scalar param is alpha-renamed to a fresh `sarek_scalar_shadow_<name>_<n>`. The initializer is evaluated in the outer scope so it still expands to `params.<name>`; body reads/writes follow the fresh name; `gen_expr`'s `scalar_param_names` check never matches the renamed local, so the bare fresh name is emitted for both reads and writes. Wired into `generate` and `generate_with_types` with a per-kernel counter reset for deterministic output.

**Why the pre-pass (over scope-threading):** stays consistent with GLSL and reuses the proven, reviewed #65/#71 design. No-op unless a binder genuinely shadows a scalar param, so every existing golden is byte-identical.

**Vector `_len` is N/A for WGSL:** GLSL's `_len` collision is macro-specific (`#define <vec>_len pc.<vec>_len`); WGSL emits vector length as the field access `params.sarek_<arr>_length` (`EArrayLen`), hardcoded with a `params.` prefix independent of any local, so a local cannot alias it. Verified in code, skipped.

## Regression test (codegen-golden, red-on-mutation — naga absent)

`sarek/tests/unit/test_shader_recursion_vector.ml`: a kernel with a **mutated** local shadowing a scalar param (init from a constant, so `params.width` can only appear via the buggy body reads). Asserts the emitted WGSL contains the renamed local `sarek_scalar_shadow_width_1` and does **not** contain `params.width`. Red-on-mutation confirmed: reverting the pre-pass wiring emits `width = (params.width + 1i)` / `out[tid] = f32(params.width)` and the test fails. naga is absent on this machine, so the assertion is on emitted WGSL text, not runtime; were naga present the kernel would also be a semantic positive control.

## Gates

- `dune build` clean; `ocamlformat --check` clean on both touched files.
- Golden codegen tests 75/75 pass, WGSL sweep byte-identical.
- Full `sarek/tests/unit` runtest green (incl. 10/10 shader_recursion_vector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed WGSL generation when local variables reuse scalar parameter names.
  - Preserved correct variable references across scoped bindings, pattern matches, and loops.
  - Prevented local mutations from being incorrectly redirected to immutable kernel parameters.

- **Tests**
  - Added regression coverage for mutable locals shadowing scalar parameters.
  - Added validation of generated WGSL output, including optional shader validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->