### PR TITLE
fix(sarek/codegen): fail loud on unsupported EMatch payload bindings in GLSL/WGSL (#73)

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -287,6 +287,46 @@ let f64_root_helpers name =
 
 (** {1 Expression Generation} *)
 
+(** [ematch-payload-fail-loud] (#73): a match-EXPRESSION ([EMatch]) lowers to a
+    nested ternary [(scrut.tag == C) ? body : rest] that evaluates each case
+    body in the enclosing scope and has nowhere to declare a constructor
+    payload. A case body that {e uses} a payload binder would therefore emit an
+    undefined identifier (glslang: "undefined identifier") or, worse, silently
+    read a same-named in-scope variable. Detect that shape and fail loud rather
+    than emit silent-wrong / undefined code. A statement match ([SMatch]) is
+    unaffected — it emits real destructuring declarations (see
+    {!gen_match_pattern}). *)
+let rec expr_mentions names = function
+  | EConst _ -> false
+  | EVar v -> List.mem v.var_name names
+  | EBinop (_, a, b) -> expr_mentions names a || expr_mentions names b
+  | EUnop (_, a) -> expr_mentions names a
+  | EArrayRead (arr, i) -> List.mem arr names || expr_mentions names i
+  | EArrayReadExpr (b, i) -> expr_mentions names b || expr_mentions names i
+  | ERecordField (e, _) -> expr_mentions names e
+  | EIntrinsic (_, _, args) -> List.exists (expr_mentions names) args
+  | ECast (_, e) -> expr_mentions names e
+  | ETuple es -> List.exists (expr_mentions names) es
+  | EApp (f, args) ->
+      expr_mentions names f || List.exists (expr_mentions names) args
+  | ERecord (_, fs) -> List.exists (fun (_, v) -> expr_mentions names v) fs
+  | EVariant (_, _, args) -> List.exists (expr_mentions names) args
+  | EArrayLen n -> List.mem n names
+  | EArrayCreate (_, s, _) -> expr_mentions names s
+  | EIf (c, t, e) ->
+      expr_mentions names c || expr_mentions names t || expr_mentions names e
+  | EMatch (s, cases) ->
+      expr_mentions names s
+      || List.exists (fun (_, b) -> expr_mentions names b) cases
+
+(** A match-expression case whose constructor pattern binds at least one payload
+    name that its body actually references. Wildcard binders ([_]) never occur
+    as a referenced identifier, so [Some _] and a tag-only [PConstr (_, [])]
+    stay supported. *)
+let case_binds_used_payload = function
+  | PConstr (_, names), body when names <> [] -> expr_mentions names body
+  | _ -> false
+
 let rec gen_expr buf = function
   | EConst (CInt32 n) -> Buffer.add_string buf (Int32.to_string n)
   | EConst (CInt64 n) -> Buffer.add_string buf (Int64.to_string n ^ "L")
@@ -439,6 +479,16 @@ let rec gen_expr buf = function
       Buffer.add_string buf " : " ;
       gen_expr buf else_ ;
       Buffer.add_char buf ')'
+  | EMatch (_, cases) when List.exists case_binds_used_payload cases ->
+      (* Fail loud: the ternary lowering below discards payload binders. See
+         {!case_binds_used_payload}. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "match-expression payload binding"
+           "a match-expression case binds a constructor payload that its body \
+            uses, but the GLSL backend lowers match-expressions to nested \
+            ternaries with no place to bind the payload; use a match statement \
+            (a match whose case bodies are statements) instead")
   | EMatch (_, []) ->
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct "match" "empty match expression")

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -193,6 +193,45 @@ let wgsl_thread_intrinsic = function
 (** Names of scalar kernel params — accessed as [params.<name>] in WGSL. *)
 let scalar_param_names : string list ref = ref []
 
+(** [ematch-payload-fail-loud] (#73): a match-EXPRESSION ([EMatch]) lowers to
+    nested [select(else, then, cond)] calls that evaluate each case body in the
+    enclosing scope and have nowhere to declare a constructor payload. A case
+    body that {e uses} a payload binder would therefore emit an undefined
+    identifier or, worse, silently read a same-named in-scope variable. Detect
+    that shape and fail loud rather than emit silent-wrong / undefined code. A
+    statement match ([SMatch]) is unaffected — it emits real destructuring
+    declarations. *)
+let rec expr_mentions names = function
+  | EConst _ -> false
+  | EVar v -> List.mem v.var_name names
+  | EBinop (_, a, b) -> expr_mentions names a || expr_mentions names b
+  | EUnop (_, a) -> expr_mentions names a
+  | EArrayRead (arr, i) -> List.mem arr names || expr_mentions names i
+  | EArrayReadExpr (b, i) -> expr_mentions names b || expr_mentions names i
+  | ERecordField (e, _) -> expr_mentions names e
+  | EIntrinsic (_, _, args) -> List.exists (expr_mentions names) args
+  | ECast (_, e) -> expr_mentions names e
+  | ETuple es -> List.exists (expr_mentions names) es
+  | EApp (f, args) ->
+      expr_mentions names f || List.exists (expr_mentions names) args
+  | ERecord (_, fs) -> List.exists (fun (_, v) -> expr_mentions names v) fs
+  | EVariant (_, _, args) -> List.exists (expr_mentions names) args
+  | EArrayLen n -> List.mem n names
+  | EArrayCreate (_, s, _) -> expr_mentions names s
+  | EIf (c, t, e) ->
+      expr_mentions names c || expr_mentions names t || expr_mentions names e
+  | EMatch (s, cases) ->
+      expr_mentions names s
+      || List.exists (fun (_, b) -> expr_mentions names b) cases
+
+(** A match-expression case whose constructor pattern binds at least one payload
+    name that its body actually references. Wildcard binders ([_]) never occur
+    as a referenced identifier, so [Some _] and a tag-only [PConstr (_, [])]
+    stay supported. *)
+let case_binds_used_payload = function
+  | PConstr (_, names), body when names <> [] -> expr_mentions names body
+  | _ -> false
+
 let rec gen_expr buf = function
   | EConst (CInt32 n) -> Buffer.add_string buf (Int32.to_string n ^ "i")
   | EConst (CInt64 _) ->
@@ -306,6 +345,16 @@ let rec gen_expr buf = function
       Buffer.add_string buf ", " ;
       gen_expr buf cond ;
       Buffer.add_char buf ')'
+  | EMatch (_, cases) when List.exists case_binds_used_payload cases ->
+      (* Fail loud: the select() lowering below discards payload binders. See
+         {!case_binds_used_payload}. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "match-expression payload binding"
+           "a match-expression case binds a constructor payload that its body \
+            uses, but the WGSL backend lowers match-expressions to nested \
+            select() calls with no place to bind the payload; use a match \
+            statement (a match whose case bodies are statements) instead")
   | EMatch (_, []) ->
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct "match" "empty match expression")

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -56,3 +56,10 @@
  (libraries sarek_ir sarek_codegen sarek_backend_error alcotest)
  (instrumentation
   (backend bisect_ppx)))
+
+(test
+ (name test_shader_ematch_payload)
+ (modules test_shader_ematch_payload)
+ (libraries sarek_ir sarek_codegen sarek_backend_error alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek/tests/codegen_golden/test_shader_ematch_payload.ml
+++ b/sarek/tests/codegen_golden/test_shader_ematch_payload.ml
@@ -1,0 +1,211 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * IR-level unit test for the match-EXPRESSION payload fail-loud guard
+ * (task [ematch-payload-fail-loud]; #73).
+ *
+ * A match-EXPRESSION ([EMatch]) lowers to a nested ternary (GLSL) / [select()]
+ * (WGSL) that evaluates each case body in the enclosing scope and has nowhere
+ * to declare a constructor payload. A case body that USES a payload binder
+ * therefore emitted an undefined identifier (glslang: "undefined identifier")
+ * or silently read a same-named in-scope variable. Both shader backends now
+ * fail loud with a located [Unsupported_construct] instead.
+ *
+ * Guarantees pinned here:
+ *
+ * 1. NEGATIVE (red-on-mutation) — a match-expression case that binds a
+ *    constructor payload AND uses it in the body raises
+ *    [Backend_error (Codegen {error = Unsupported_construct
+ *    {construct = "match-expression payload binding"; _}})] on both GLSL and
+ *    WGSL. Without the guard, generation succeeds and emits invalid /
+ *    silent-wrong code, so this test goes red if the guard is removed.
+ *
+ * 2. POSITIVE — a tag-only case ([OptSome] with no binder), a wildcard-payload
+ *    case ([OptSome _], binder never referenced), and a [PWild] catch-all still
+ *    generate successfully and emit the tag-dispatch lowering ([.tag ==] for
+ *    GLSL, [select(...)] for WGSL). These forms are NOT affected by the guard.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Glsl = Sarek_codegen.Sarek_ir_glsl
+module Wgsl = Sarek_codegen.Sarek_ir_wgsl
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var ?(mut = false) name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = mut}
+
+let opt_constrs = [("OptNone", []); ("OptSome", [TFloat32])]
+
+let opt_type = TVariant ("Opt", opt_constrs)
+
+(* A kernel whose body assigns a match-EXPRESSION result to out.[idx]:
+     out.[idx] <- (match opt.[idx] with <cases>)
+   The [cases] are supplied by each test so the same skeleton exercises the
+   payload-using (negative) and tag-only / wildcard (positive) shapes. *)
+let kernel_with_cases cases =
+  let opt = make_var "opt" (TVec opt_type) in
+  let out = make_var "out" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar idx),
+            EMatch (EArrayRead ("opt", EVar idx), cases) ) )
+  in
+  {
+    kern_name = "ematch_probe";
+    kern_params =
+      [
+        DParam (opt, Some {arr_elttype = opt_type; arr_memspace = Global});
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [("Opt", opt_constrs)];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let y = make_var "y" TFloat32
+
+(* Payload BINDER USED in the body — the unsupported shape. *)
+let payload_used_cases =
+  [
+    (PConstr ("OptSome", ["y"]), EBinop (Add, EVar y, EConst (CFloat32 1.0)));
+    (PConstr ("OptNone", []), EConst (CFloat32 0.0));
+  ]
+
+(* Tag-only: no binder at all. *)
+let tag_only_cases =
+  [
+    (PConstr ("OptSome", []), EConst (CFloat32 1.0));
+    (PConstr ("OptNone", []), EConst (CFloat32 0.0));
+  ]
+
+(* Wildcard payload [OptSome _]: binds the throwaway name ["_"] which never
+   appears as a referenced identifier, so it stays supported. *)
+let wildcard_payload_cases =
+  [
+    (PConstr ("OptSome", ["_"]), EConst (CFloat32 1.0));
+    (PConstr ("OptNone", []), EConst (CFloat32 0.0));
+  ]
+
+(* PWild catch-all arm. *)
+let pwild_cases =
+  [
+    (PConstr ("OptSome", []), EConst (CFloat32 1.0));
+    (PWild, EConst (CFloat32 0.0));
+  ]
+
+let gen_glsl k = Glsl.generate_with_types ~types:[] k
+
+let gen_wgsl k = Wgsl.generate_with_types ~types:[] k
+
+(* --- 1. Negative: payload-using match-expression fails loud --- *)
+
+let check_fails_loud ~backend_label ~expected_backend generate () =
+  match generate (kernel_with_cases payload_used_cases) with
+  | (_ : string) ->
+      Alcotest.failf
+        "%s: expected Unsupported_construct for a payload-using match \
+         expression, but generation succeeded (silent-wrong / undefined code)"
+        backend_label
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Codegen
+           {backend; error = Backend_error.Unsupported_construct {construct; _}})
+    ->
+      Alcotest.(check string)
+        (backend_label ^ ": backend tag")
+        expected_backend
+        backend ;
+      Alcotest.(check string)
+        (backend_label ^ ": names the construct")
+        "match-expression payload binding"
+        construct
+
+(* --- 2. Positive: tag-only / wildcard / PWild still generate --- *)
+
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+let check_glsl_supported ~label cases () =
+  let glsl = gen_glsl (kernel_with_cases cases) in
+  Alcotest.(check bool)
+    (label ^ ": GLSL emits the .tag dispatch")
+    true
+    (string_contains ~haystack:glsl ~needle:".tag == OptSome")
+
+let check_wgsl_supported ~label cases () =
+  let wgsl = gen_wgsl (kernel_with_cases cases) in
+  Alcotest.(check bool)
+    (label ^ ": WGSL emits a select() dispatch")
+    true
+    (string_contains ~haystack:wgsl ~needle:"select(")
+
+let () =
+  let open Alcotest in
+  run
+    "shader EMatch payload fail-loud"
+    [
+      ( "fail-loud-negative",
+        [
+          test_case
+            "GLSL raises Unsupported_construct"
+            `Quick
+            (check_fails_loud
+               ~backend_label:"GLSL"
+               ~expected_backend:"Vulkan"
+               gen_glsl);
+          test_case
+            "WGSL raises Unsupported_construct"
+            `Quick
+            (check_fails_loud
+               ~backend_label:"WGSL"
+               ~expected_backend:"WebGPU"
+               gen_wgsl);
+        ] );
+      ( "supported-positive",
+        [
+          test_case
+            "GLSL tag-only"
+            `Quick
+            (check_glsl_supported ~label:"tag-only" tag_only_cases);
+          test_case
+            "GLSL wildcard payload"
+            `Quick
+            (check_glsl_supported
+               ~label:"wildcard-payload"
+               wildcard_payload_cases);
+          test_case
+            "GLSL PWild"
+            `Quick
+            (check_glsl_supported ~label:"pwild" pwild_cases);
+          test_case
+            "WGSL tag-only"
+            `Quick
+            (check_wgsl_supported ~label:"tag-only" tag_only_cases);
+          test_case
+            "WGSL wildcard payload"
+            `Quick
+            (check_wgsl_supported
+               ~label:"wildcard-payload"
+               wildcard_payload_cases);
+          test_case
+            "WGSL PWild"
+            `Quick
+            (check_wgsl_supported ~label:"pwild" pwild_cases);
+        ] );
+    ]

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -66,7 +66,7 @@
 
 (test
  (name test_shader_recursion_vector)
- (libraries sarek.codegen alcotest unix))
+ (libraries sarek.codegen sarek_backend_error alcotest unix))
 
 ; Software f64 transcendentals for PTX: IR-level accuracy vs the OCaml stdlib
 ; (pure scalar evaluation of the helper bodies — CPU-only, no device needed)

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -28,6 +28,7 @@
 
 open Sarek_ir_types
 open Sarek_codegen
+module Backend_error = Sarek_backend_error.Backend_error
 
 let make_var name ty =
   {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
@@ -400,10 +401,10 @@ let ematch_shadow_kernel () =
     reads, and the reads see the never-updated uniform — a silent wrong result
     (valid WGSL, no error).
 
-    The local's initializer is a constant (NOT [params.width]), so [params.width]
-    appears in the emitted shader {e only} through the buggy body reads: with the
-    scalar-shadow rename pass it must not appear at all, and the local must carry
-    a fresh [sarek_scalar_shadow_*] name. *)
+    The local's initializer is a constant (NOT [params.width]), so
+    [params.width] appears in the emitted shader {e only} through the buggy body
+    reads: with the scalar-shadow rename pass it must not appear at all, and the
+    local must carry a fresh [sarek_scalar_shadow_*] name. *)
 let wgsl_scalar_shadow_mut_kernel () =
   let out = make_var "out" (TVec TFloat32) in
   let width = make_var "width" TInt32 in
@@ -426,8 +427,7 @@ let wgsl_scalar_shadow_mut_kernel () =
                   (LVar width_l, EBinop (Add, EVar width_l, EConst (CInt32 1l)));
                 (* read the local — the bug emits params.width here *)
                 SAssign
-                  ( LArrayElem ("out", EVar tid),
-                    ECast (TFloat32, EVar width_l) );
+                  (LArrayElem ("out", EVar tid), ECast (TFloat32, EVar width_l));
               ] ) )
   in
   base_kernel
@@ -678,8 +678,7 @@ let test_wgsl_scalar_shadow_mut_local () =
   if contains wgsl "params.width" then
     Alcotest.failf
       "a body reference to the mutated shadowing local was emitted as \
-       `params.width` (reads the uniform, not the local — silent wrong \
-       result):\n\
+       `params.width` (reads the uniform, not the local — silent wrong result):\n\
        %s"
       wgsl ;
   (* The declaration and the mutation must both use the renamed local. *)
@@ -767,32 +766,37 @@ let test_glsl_vec_len_shadow_validates () =
           k
 
 (* #71 gap #2 (silent wrong-var read). Semantic assertion, not a validator gate
-   (EMatch expression binders emit no declaration — see kernel docstring). The
-   OptSome arm binds `width` shadowing the outer renamed local; with the EMatch
-   arm made consistent with SMatch, the pattern binder gets its OWN fresh name
-   (sarek_pc_shadow_width_2), distinct from the outer local
-   (sarek_pc_shadow_width_1). Red-on-mutation: revert the EMatch arm to reuse
-   the outer env and both ternary branches collapse to _1 — the OptSome arm
-   silently reads the outer local (no _2 is ever minted), failing this check. *)
+   (EMatch expression binders emit no declaration — see kernel docstring).
+
+   [ematch-payload-fail-loud] (#73) superseded the earlier shadow-rename
+   assertion here: an [EMatch] arm that binds AND reads its payload binder is no
+   longer lowered to a wrong-variable ternary read — the GLSL backend now fails
+   loud with a located [Unsupported_construct "match-expression payload
+   binding"] before any code is emitted. This is the correct terminal behavior
+   for that pre-existing limitation (no destructuring declaration exists for
+   expression-position matches), so the guarantee under test is now the raise
+   itself. Red-on-mutation: remove the backend guard and generation succeeds
+   again, emitting silent-wrong / undefined GLSL, and this check fails. *)
 let test_glsl_ematch_pattern_shadow_rebinds () =
-  let k =
+  match
     Sarek_ir_glsl.generate_with_types ~types:[] (ematch_shadow_kernel ())
-  in
-  if not (contains k "sarek_pc_shadow_width_1") then
-    Alcotest.failf
-      "expected the outer scalar-shadowing local to be renamed \
-       (sarek_pc_shadow_width_1):\n\
-       %s"
-      k ;
-  if not (contains k "sarek_pc_shadow_width_2") then
-    Alcotest.failf
-      "EMatch pattern binder was not rebound: the OptSome arm reuses the outer \
-       local (sarek_pc_shadow_width_1) instead of its own binder \
-       (sarek_pc_shadow_width_2) — silent wrong-variable read:\n\
-       %s"
-      k ;
-  Printf.printf
-    "  semantic OK: ematch_shadow (pattern binder rebound to _2)\n%!"
+  with
+  | (_ : string) ->
+      Alcotest.failf
+        "expected a located Unsupported_construct for the payload-using EMatch \
+         arm, but GLSL generation succeeded (silent-wrong / undefined code)"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Codegen
+           {backend; error = Backend_error.Unsupported_construct {construct; _}})
+    ->
+      Alcotest.(check string) "backend tag" "Vulkan" backend ;
+      Alcotest.(check string)
+        "names the construct"
+        "match-expression payload binding"
+        construct ;
+      Printf.printf
+        "  fail-loud OK: ematch_shadow (payload binding rejected)\n%!"
 
 let () =
   Alcotest.run
@@ -837,7 +841,7 @@ let () =
             `Quick
             test_glsl_vec_len_shadow_validates;
           Alcotest.test_case
-            "GLSL EMatch pattern binder rebinds (silent wrong-var read)"
+            "GLSL EMatch payload binding fails loud (#73)"
             `Quick
             test_glsl_ematch_pattern_shadow_rebinds;
         ] );


### PR DESCRIPTION
## Reachability finding (Step 0): CONFIRMED — live bug
A match-EXPRESSION whose case binds a constructor payload and **uses** it in the body is constructible in the Sarek DSL and reaches GLSL/WGSL codegen:
- One match node in the frontend (`EMatch`/`TEMatch`); the statement-vs-expression split happens only at lowering (`lower_stmt` → `SMatch` vs `lower_expr` → `EMatch`). A match in value position lowers to `Ir.EMatch`.
- The typer binds payload vars (`infer_pattern` on `PConstr(name, Some (PVar y))` adds `y` to the env and types the body in it) and `lower_pattern` preserves the binder names.
- Empirically exercised by `sarek/tests/e2e/test_static_tag_erasure.ml:60`: `let sq = match s with Circle r -> r *. r | Square x -> x in ...`. At baseline the Vulkan/GLSL path emitted invalid GLSL that glslangValidator rejected ("SPIR-V is not generated for failed compile").

## The fix (both shader backends)
Both backends lowered `EMatch` to a nested ternary (GLSL) / `select()` (WGSL) that **discards** the payload binder — so a case body using it emitted an undefined identifier or silently read a same-named in-scope variable.

- `sarek/codegen/Sarek_ir_glsl.ml`: `expr_mentions` + `case_binds_used_payload` helpers, guard as the first `EMatch` arm raising `Codegen_error.unsupported_construct "match-expression payload binding" …` (backend "Vulkan").
- `sarek/codegen/Sarek_ir_wgsl.ml`: same helpers + guard (backend "WebGPU").

Detection is conservative: a `PConstr` case binding ≥1 name that its body references raises. Tag-only `PConstr(_, [])`, `Some _` (binder `"_"`, never referenced), and `PWild` stay fully supported. **`SMatch` (statement match, which emits real destructuring declarations) is unchanged.**

This converts silent-wrong / undefined output into a clear, located error.

## Red-on-mutation
New golden test `sarek/tests/codegen_golden/test_shader_ematch_payload.ml` (negative: GLSL+WGSL raise; positive: tag-only / wildcard-payload / PWild still generate). The pre-existing `test_glsl_ematch_pattern_shadow_rebinds` (which tested a cosmetic shadow-rename on this now-rejected construct — its own docstring admitted "the shader is not expected to assemble regardless") is updated to assert the fail-loud raise. Disabling the guard makes both go red.

## Other backends
CUDA / OpenCL / Metal have the **identical** `EMatch` payload discard — same latent bug, flagged but out of scope for this task (shader backends only).

## Gates
- `dune build`: clean. `ocamlformat --check`: clean on all touched files.
- Golden codegen 75/75 byte-identical; GLSL + WGSL validation sweeps green. Unit + new_runtime green.
- e2e is pre-existing flaky on this hardware (GPU driver teardown segfault, baseline also fails); this change strictly improves its GLSL path (clean SKIP + clear message vs previously-rejected garbage GLSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)