### PR TITLE
refactor(sarek/codegen): share GLSL+WGSL shadow-rename pre-pass (#76, factorization #58.1)

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -1486,11 +1486,6 @@ let gen_f64_softmath_helpers ~pc_names buf =
       Buffer.add_char buf '\n' ;
       List.iter (gen_helper_func ~pc_names buf) helpers
 
-(** Counter for fresh push-constant-shadowing local names (see
-    {!rename_pc_shadowing_locals}). Reset per kernel in {!generate} /
-    {!generate_with_types} for deterministic output. *)
-let pc_shadow_counter = ref 0
-
 (** Alpha-rename kernel-body binders whose name collides with a push-constant
     macro.
 
@@ -1504,137 +1499,24 @@ let pc_shadow_counter = ref 0
     Helper {e functions} already dodge this via the [#undef]/[#define] guards in
     {!gen_helper_func}, but a body-inlined binder has no such guard.
 
-    Covered binder forms: [SLet], [SLetMut], [SFor], and match pattern binders
-    (both [SMatch] and [EMatch]). Both scalar-param macros ([pc_names]) and
-    vector-length macros ([len_names]) are treated as collisions.
-
-    Each colliding binder (and its in-scope references) is rewritten to a fresh
-    [sarek_pc_shadow_*] name that no macro touches; for [SLet]/[SLetMut]/[SFor]
-    the initializer, evaluated in the outer scope, still expands to the push
-    constant, so semantics are preserved and the declaration is valid. It is a
-    no-op unless a binder genuinely shadows a macro, so collision-free kernels
-    (every existing golden) are byte-identical. GLSL-only: no other backend uses
-    macros for params. *)
+    Both scalar-param macros ([pc_names]) and vector-length macros ([len_names])
+    are treated as collisions; a colliding binder is rewritten to a fresh
+    [sarek_pc_shadow_*] name that no macro touches, so semantics are preserved
+    and the declaration is valid. Delegates the shared traversal to
+    {!Sarek_ir_codegen.rename_shadowing_locals}, supplying only the GLSL
+    collision set (escaped-name membership in [pc_names]/[len_names]) and
+    fresh-name scheme. GLSL-only: no other backend uses macros for params. *)
 let rename_pc_shadowing_locals ~pc_names ~len_names body =
-  let module SM = Map.Make (String) in
-  (* A local collides if its escaped name matches a scalar-param macro
-     ([#define name pc.name]) or a vector-length macro ([#define vec_len
-     pc.vec_len]); either would rewrite the declared identifier to [pc....]. *)
-  let collides name =
-    let n = escape_glsl_name name in
-    List.mem n pc_names || List.mem n len_names
-  in
-  let ren env name =
-    match SM.find_opt name env with Some n -> n | None -> name
-  in
-  (* Mint a fresh push-constant-shadow name for a colliding binder. *)
-  let fresh_name orig =
-    incr pc_shadow_counter ;
-    Printf.sprintf
-      "sarek_pc_shadow_%s_%d"
-      (escape_glsl_name orig)
-      !pc_shadow_counter
-  in
-  (* Rebind a match pattern's binders: rename each that collides with a macro
-     to a fresh name — used both in the destructuring declaration emitted by
-     {!gen_match_pattern} and in case-body references (via [env]) — and drop
-     any same-named outer mapping for non-colliding binders (they shadow it). *)
-  let bind_pattern env = function
-    | PWild -> (PWild, env)
-    | PConstr (cname, names) ->
-        let env, names =
-          List.fold_left_map
-            (fun env name ->
-              if collides name then
-                let nn = fresh_name name in
-                (SM.add name nn env, nn)
-              else (SM.remove name env, name))
-            env
-            names
-        in
-        (PConstr (cname, names), env)
-  in
-  let rec re_expr env e =
-    match e with
-    | EConst _ -> e
-    | EVar v -> EVar {v with var_name = ren env v.var_name}
-    | EBinop (op, a, b) -> EBinop (op, re_expr env a, re_expr env b)
-    | EUnop (op, a) -> EUnop (op, re_expr env a)
-    | EArrayRead (arr, i) -> EArrayRead (ren env arr, re_expr env i)
-    | EArrayReadExpr (b, i) -> EArrayReadExpr (re_expr env b, re_expr env i)
-    | ERecordField (e, f) -> ERecordField (re_expr env e, f)
-    | EIntrinsic (ns, n, args) -> EIntrinsic (ns, n, List.map (re_expr env) args)
-    | ECast (t, e) -> ECast (t, re_expr env e)
-    | ETuple es -> ETuple (List.map (re_expr env) es)
-    | EApp (f, args) -> EApp (re_expr env f, List.map (re_expr env) args)
-    | ERecord (n, fs) ->
-        ERecord (n, List.map (fun (k, v) -> (k, re_expr env v)) fs)
-    | EVariant (t, c, args) -> EVariant (t, c, List.map (re_expr env) args)
-    | EArrayLen n -> EArrayLen (ren env n)
-    | EArrayCreate (t, s, m) -> EArrayCreate (t, re_expr env s, m)
-    | EIf (c, t, e) -> EIf (re_expr env c, re_expr env t, re_expr env e)
-    | EMatch (s, cases) ->
-        (* Rebind pattern binders before each case body (mirrors [SMatch]): a
-           binder shadowing a scalar/_len macro is renamed and its body refs
-           follow, otherwise an outer mapping would wrongly substitute them. *)
-        EMatch
-          ( re_expr env s,
-            List.map
-              (fun (p, b) ->
-                let p, env = bind_pattern env p in
-                (p, re_expr env b))
-              cases )
-  in
-  let rec re_lvalue env lv =
-    match lv with
-    | LVar v -> LVar {v with var_name = ren env v.var_name}
-    | LArrayElem (arr, i) -> LArrayElem (ren env arr, re_expr env i)
-    | LArrayElemExpr (b, i) -> LArrayElemExpr (re_expr env b, re_expr env i)
-    | LRecordField (lv, f) -> LRecordField (re_lvalue env lv, f)
-  in
-  (* Bind a local: rename it when it collides with a scalar macro; otherwise
-     drop any same-named outer mapping (this fresh local shadows it). *)
-  let bind env (v : var) =
-    if collides v.var_name then
-      let nn = fresh_name v.var_name in
-      ({v with var_name = nn}, SM.add v.var_name nn env)
-    else (v, SM.remove v.var_name env)
-  in
-  let rec re_stmt env s =
-    match s with
-    | SAssign (lv, e) -> SAssign (re_lvalue env lv, re_expr env e)
-    | SSeq ss -> SSeq (List.map (re_stmt env) ss)
-    | SIf (c, t, eo) ->
-        SIf (re_expr env c, re_stmt env t, Option.map (re_stmt env) eo)
-    | SWhile (c, b) -> SWhile (re_expr env c, re_stmt env b)
-    | SFor (v, lo, hi, dir, b) ->
-        let lo = re_expr env lo and hi = re_expr env hi in
-        let v', env' = bind env v in
-        SFor (v', lo, hi, dir, re_stmt env' b)
-    | SMatch (e, cases) ->
-        SMatch
-          ( re_expr env e,
-            List.map
-              (fun (p, b) ->
-                let p, env = bind_pattern env p in
-                (p, re_stmt env b))
-              cases )
-    | SReturn e -> SReturn (re_expr env e)
-    | (SBarrier | SWarpBarrier | SMemFence | SEmpty) as s -> s
-    | SExpr e -> SExpr (re_expr env e)
-    | SLet (v, e, body) ->
-        let e = re_expr env e in
-        let v', env' = bind env v in
-        SLet (v', e, re_stmt env' body)
-    | SLetMut (v, e, body) ->
-        let e = re_expr env e in
-        let v', env' = bind env v in
-        SLetMut (v', e, re_stmt env' body)
-    | SPragma (ss, b) -> SPragma (ss, re_stmt env b)
-    | SBlock b -> SBlock (re_stmt env b)
-    | SNative _ as s -> s
-  in
-  re_stmt SM.empty body
+  Sarek_ir_codegen.rename_shadowing_locals
+    ~collides:(fun name ->
+      (* A local collides if its escaped name matches a scalar-param macro
+         ([#define name pc.name]) or a vector-length macro ([#define vec_len
+         pc.vec_len]); either would rewrite the declared identifier to [pc....]. *)
+      let n = escape_glsl_name name in
+      List.mem n pc_names || List.mem n len_names)
+    ~fresh_name:(fun orig n ->
+      Printf.sprintf "sarek_pc_shadow_%s_%d" (escape_glsl_name orig) n)
+    body
 
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
@@ -1646,7 +1528,6 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"Vulkan" k in
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
-  pc_shadow_counter := 0 ;
   current_smod_name := compute_smod_name k ;
   current_copysign_name := compute_copysign_name k ;
   current_fmod_name := compute_fmod_name k ;
@@ -1770,7 +1651,6 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"Vulkan" k in
   (* Clear per-kernel state *)
   Hashtbl.clear helper_vec_param_indices ;
-  pc_shadow_counter := 0 ;
   current_smod_name := compute_smod_name k ;
   current_copysign_name := compute_copysign_name k ;
   current_fmod_name := compute_fmod_name k ;

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -998,11 +998,6 @@ let gen_bindings buf params =
 
 (** {1 Scalar-param shadow renaming} *)
 
-(** Counter for fresh scalar-param-shadowing local names (see
-    {!rename_scalar_shadowing_locals}). Reset per kernel in {!generate} /
-    {!generate_with_types} for deterministic output. *)
-let scalar_shadow_counter = ref 0
-
 (** Alpha-rename kernel-body binders whose name collides with a scalar kernel
     param.
 
@@ -1017,137 +1012,27 @@ let scalar_shadow_counter = ref 0
     name ([var width : i32 = params.width;]) so writes hit the local, but every
     read is redirected to the immutable uniform.
 
-    This mirrors the GLSL backend's {!Sarek_ir_glsl.rename_pc_shadowing_locals}:
-    each colliding binder (and its in-scope references) is rewritten to a fresh
-    [sarek_scalar_shadow_*] name that is not a scalar param, so [gen_expr]'s
-    [scalar_param_names] check never matches it and the bare fresh name is
-    emitted for both reads and writes. The initializer is evaluated in the outer
-    scope, so it still expands to [params.<name>], preserving semantics.
-
-    Covered binder forms: [SLet], [SLetMut], [SFor], and match pattern binders
-    (both [SMatch] and [EMatch]). Unlike GLSL there is no vector-length ([_len])
-    collision: WGSL emits vector length as the field access
-    [params.sarek_<arr>_length] ({!EArrayLen}), hardcoded with a [params.]
-    prefix independent of any local, so a local cannot alias it.
-
-    No-op unless a binder genuinely shadows a scalar param, so collision-free
-    kernels (every existing golden) are byte-identical. WGSL-only. *)
+    This mirrors the GLSL backend's {!Sarek_ir_glsl.rename_pc_shadowing_locals};
+    both delegate the shared traversal to
+    {!Sarek_ir_codegen.rename_shadowing_locals}. Each colliding binder (and its
+    in-scope references) is rewritten to a fresh [sarek_scalar_shadow_*] name
+    that is not a scalar param, so [gen_expr]'s [scalar_param_names] check never
+    matches it. The initializer is evaluated in the outer scope, so it still
+    expands to [params.<name>], preserving semantics. Unlike GLSL there is no
+    vector-length ([_len]) collision: WGSL emits vector length as the field
+    access [params.sarek_<arr>_length] ({!EArrayLen}), hardcoded with a
+    [params.] prefix independent of any local, so a local cannot alias it — the
+    collision set is scalar params only. WGSL-only. *)
 let rename_scalar_shadowing_locals ~scalar_names body =
-  let module SM = Map.Make (String) in
-  (* A local collides if its name matches a scalar param — the exact check
-     [gen_expr] performs on [EVar] against [scalar_param_names] (raw names). *)
-  let collides name = List.mem name scalar_names in
-  let ren env name =
-    match SM.find_opt name env with Some n -> n | None -> name
-  in
-  (* Mint a fresh scalar-shadow name for a colliding binder. *)
-  let fresh_name orig =
-    incr scalar_shadow_counter ;
-    Printf.sprintf
-      "sarek_scalar_shadow_%s_%d"
-      (escape_wgsl_name orig)
-      !scalar_shadow_counter
-  in
-  (* Rebind a match pattern's binders: rename each that collides with a scalar
-     param to a fresh name (used both in the destructuring declaration emitted
-     by {!gen_match_pattern} and in case-body references, via [env]) and drop
-     any same-named outer mapping for non-colliding binders (they shadow it). *)
-  let bind_pattern env = function
-    | PWild -> (PWild, env)
-    | PConstr (cname, names) ->
-        let env, names =
-          List.fold_left_map
-            (fun env name ->
-              if collides name then
-                let nn = fresh_name name in
-                (SM.add name nn env, nn)
-              else (SM.remove name env, name))
-            env
-            names
-        in
-        (PConstr (cname, names), env)
-  in
-  let rec re_expr env e =
-    match e with
-    | EConst _ -> e
-    | EVar v -> EVar {v with var_name = ren env v.var_name}
-    | EBinop (op, a, b) -> EBinop (op, re_expr env a, re_expr env b)
-    | EUnop (op, a) -> EUnop (op, re_expr env a)
-    | EArrayRead (arr, i) -> EArrayRead (ren env arr, re_expr env i)
-    | EArrayReadExpr (b, i) -> EArrayReadExpr (re_expr env b, re_expr env i)
-    | ERecordField (e, f) -> ERecordField (re_expr env e, f)
-    | EIntrinsic (ns, n, args) -> EIntrinsic (ns, n, List.map (re_expr env) args)
-    | ECast (t, e) -> ECast (t, re_expr env e)
-    | ETuple es -> ETuple (List.map (re_expr env) es)
-    | EApp (f, args) -> EApp (re_expr env f, List.map (re_expr env) args)
-    | ERecord (n, fs) ->
-        ERecord (n, List.map (fun (k, v) -> (k, re_expr env v)) fs)
-    | EVariant (t, c, args) -> EVariant (t, c, List.map (re_expr env) args)
-    | EArrayLen n -> EArrayLen (ren env n)
-    | EArrayCreate (t, s, m) -> EArrayCreate (t, re_expr env s, m)
-    | EIf (c, t, e) -> EIf (re_expr env c, re_expr env t, re_expr env e)
-    | EMatch (s, cases) ->
-        (* Rebind pattern binders before each case body (mirrors [SMatch]): a
-           binder shadowing a scalar param is renamed and its body refs follow,
-           otherwise an outer mapping would wrongly substitute them. *)
-        EMatch
-          ( re_expr env s,
-            List.map
-              (fun (p, b) ->
-                let p, env = bind_pattern env p in
-                (p, re_expr env b))
-              cases )
-  in
-  let rec re_lvalue env lv =
-    match lv with
-    | LVar v -> LVar {v with var_name = ren env v.var_name}
-    | LArrayElem (arr, i) -> LArrayElem (ren env arr, re_expr env i)
-    | LArrayElemExpr (b, i) -> LArrayElemExpr (re_expr env b, re_expr env i)
-    | LRecordField (lv, f) -> LRecordField (re_lvalue env lv, f)
-  in
-  (* Bind a local: rename it when it collides with a scalar param; otherwise
-     drop any same-named outer mapping (this fresh local shadows it). *)
-  let bind env (v : var) =
-    if collides v.var_name then
-      let nn = fresh_name v.var_name in
-      ({v with var_name = nn}, SM.add v.var_name nn env)
-    else (v, SM.remove v.var_name env)
-  in
-  let rec re_stmt env s =
-    match s with
-    | SAssign (lv, e) -> SAssign (re_lvalue env lv, re_expr env e)
-    | SSeq ss -> SSeq (List.map (re_stmt env) ss)
-    | SIf (c, t, eo) ->
-        SIf (re_expr env c, re_stmt env t, Option.map (re_stmt env) eo)
-    | SWhile (c, b) -> SWhile (re_expr env c, re_stmt env b)
-    | SFor (v, lo, hi, dir, b) ->
-        let lo = re_expr env lo and hi = re_expr env hi in
-        let v', env' = bind env v in
-        SFor (v', lo, hi, dir, re_stmt env' b)
-    | SMatch (e, cases) ->
-        SMatch
-          ( re_expr env e,
-            List.map
-              (fun (p, b) ->
-                let p, env = bind_pattern env p in
-                (p, re_stmt env b))
-              cases )
-    | SReturn e -> SReturn (re_expr env e)
-    | (SBarrier | SWarpBarrier | SMemFence | SEmpty) as s -> s
-    | SExpr e -> SExpr (re_expr env e)
-    | SLet (v, e, body) ->
-        let e = re_expr env e in
-        let v', env' = bind env v in
-        SLet (v', e, re_stmt env' body)
-    | SLetMut (v, e, body) ->
-        let e = re_expr env e in
-        let v', env' = bind env v in
-        SLetMut (v', e, re_stmt env' body)
-    | SPragma (ss, b) -> SPragma (ss, re_stmt env b)
-    | SBlock b -> SBlock (re_stmt env b)
-    | SNative _ as s -> s
-  in
-  re_stmt SM.empty body
+  Sarek_ir_codegen.rename_shadowing_locals
+    ~collides:(fun name ->
+      (* A local collides if its name matches a scalar param — the exact check
+         [gen_expr] performs on [EVar] against [scalar_param_names] (raw
+         names). *)
+      List.mem name scalar_names)
+    ~fresh_name:(fun orig n ->
+      Printf.sprintf "sarek_scalar_shadow_%s_%d" (escape_wgsl_name orig) n)
+    body
 
 (** {1 Main generate functions} *)
 
@@ -1186,7 +1071,6 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
      arguments — see Sarek_ir_inline_vec). *)
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"WGSL" k in
   scalar_param_names := [] ;
-  scalar_shadow_counter := 0 ;
   current_variants := k.kern_variants ;
   let buf = Buffer.create 1024 in
   let scalars = gen_bindings buf k.kern_params in
@@ -1219,7 +1103,6 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
      arguments — see Sarek_ir_inline_vec). *)
   let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"WGSL" k in
   scalar_param_names := [] ;
-  scalar_shadow_counter := 0 ;
   current_variants := k.kern_variants ;
   let buf = Buffer.create 1024 in
   List.iter (gen_record_def buf) types ;

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -14,6 +14,147 @@
     "Module_point") *)
 let mangle_name name = String.map (fun c -> if c = '.' then '_' else c) name
 
+(** Alpha-rename kernel-body binders whose name collides with a backend-reserved
+    identifier, so a colliding local no longer aliases a param/macro.
+
+    Backends expose scalar params to the body through a mechanism that keys on
+    the {e name} (a GLSL [#define] macro, or WGSL's [gen_expr] check against the
+    global [scalar_param_names]); a local binder sharing that name is silently
+    captured — the GLSL macro rewrites the declared identifier to [pc....] (a
+    syntax error), and WGSL redirects every read to the uniform. This pass
+    rewrites each colliding binder (and its in-scope references) to a fresh name
+    that the exposing mechanism never touches. Initializers, evaluated in the
+    outer scope, still expand to the param, so semantics are preserved.
+
+    Covered binder forms: [SLet], [SLetMut], [SFor], and match pattern binders
+    (both [SMatch] and [EMatch]). It is a no-op unless a binder genuinely
+    shadows — collision-free kernels are byte-identical.
+
+    Backend-specific inputs, and only these, are parameters:
+    - [collides name]: whether [name] (as written in the IR, before any escape)
+      is a reserved identifier for this backend. GLSL escapes then checks its
+      scalar-macro and vector-[_len]-macro sets; WGSL checks the raw
+      scalar-param set (it has no [_len] macro).
+    - [fresh_name orig n]: mint the [n]-th shadow name for original binder
+      [orig] ([n] is 1-based, incremented once per colliding binder). GLSL uses
+      [sarek_pc_shadow_<esc>_<n>], WGSL uses [sarek_scalar_shadow_<esc>_<n>].
+
+    The per-call counter starts at 0 and is threaded internally, so each
+    invocation (one per kernel) numbers shadows from 1 — matching the backends'
+    former reset-then-generate discipline exactly. *)
+let rename_shadowing_locals ~collides ~fresh_name body =
+  let open Sarek_ir_types in
+  let module SM = Map.Make (String) in
+  let counter = ref 0 in
+  let mint orig =
+    incr counter ;
+    fresh_name orig !counter
+  in
+  let ren env name =
+    match SM.find_opt name env with Some n -> n | None -> name
+  in
+  (* Rebind a match pattern's binders: rename each that collides with a reserved
+     identifier to a fresh name — used both in the destructuring declaration
+     emitted by [gen_match_pattern] and in case-body references (via [env]) — and
+     drop any same-named outer mapping for non-colliding binders (they shadow
+     it). *)
+  let bind_pattern env = function
+    | PWild -> (PWild, env)
+    | PConstr (cname, names) ->
+        let env, names =
+          List.fold_left_map
+            (fun env name ->
+              if collides name then
+                let nn = mint name in
+                (SM.add name nn env, nn)
+              else (SM.remove name env, name))
+            env
+            names
+        in
+        (PConstr (cname, names), env)
+  in
+  let rec re_expr env e =
+    match e with
+    | EConst _ -> e
+    | EVar v -> EVar {v with var_name = ren env v.var_name}
+    | EBinop (op, a, b) -> EBinop (op, re_expr env a, re_expr env b)
+    | EUnop (op, a) -> EUnop (op, re_expr env a)
+    | EArrayRead (arr, i) -> EArrayRead (ren env arr, re_expr env i)
+    | EArrayReadExpr (b, i) -> EArrayReadExpr (re_expr env b, re_expr env i)
+    | ERecordField (e, f) -> ERecordField (re_expr env e, f)
+    | EIntrinsic (ns, n, args) -> EIntrinsic (ns, n, List.map (re_expr env) args)
+    | ECast (t, e) -> ECast (t, re_expr env e)
+    | ETuple es -> ETuple (List.map (re_expr env) es)
+    | EApp (f, args) -> EApp (re_expr env f, List.map (re_expr env) args)
+    | ERecord (n, fs) ->
+        ERecord (n, List.map (fun (k, v) -> (k, re_expr env v)) fs)
+    | EVariant (t, c, args) -> EVariant (t, c, List.map (re_expr env) args)
+    | EArrayLen n -> EArrayLen (ren env n)
+    | EArrayCreate (t, s, m) -> EArrayCreate (t, re_expr env s, m)
+    | EIf (c, t, e) -> EIf (re_expr env c, re_expr env t, re_expr env e)
+    | EMatch (s, cases) ->
+        (* Rebind pattern binders before each case body (mirrors [SMatch]): a
+           binder shadowing a reserved identifier is renamed and its body refs
+           follow, otherwise an outer mapping would wrongly substitute them. *)
+        EMatch
+          ( re_expr env s,
+            List.map
+              (fun (p, b) ->
+                let p, env = bind_pattern env p in
+                (p, re_expr env b))
+              cases )
+  in
+  let rec re_lvalue env lv =
+    match lv with
+    | LVar v -> LVar {v with var_name = ren env v.var_name}
+    | LArrayElem (arr, i) -> LArrayElem (ren env arr, re_expr env i)
+    | LArrayElemExpr (b, i) -> LArrayElemExpr (re_expr env b, re_expr env i)
+    | LRecordField (lv, f) -> LRecordField (re_lvalue env lv, f)
+  in
+  (* Bind a local: rename it when it collides with a reserved identifier;
+     otherwise drop any same-named outer mapping (this fresh local shadows it). *)
+  let bind env (v : var) =
+    if collides v.var_name then
+      let nn = mint v.var_name in
+      ({v with var_name = nn}, SM.add v.var_name nn env)
+    else (v, SM.remove v.var_name env)
+  in
+  let rec re_stmt env s =
+    match s with
+    | SAssign (lv, e) -> SAssign (re_lvalue env lv, re_expr env e)
+    | SSeq ss -> SSeq (List.map (re_stmt env) ss)
+    | SIf (c, t, eo) ->
+        SIf (re_expr env c, re_stmt env t, Option.map (re_stmt env) eo)
+    | SWhile (c, b) -> SWhile (re_expr env c, re_stmt env b)
+    | SFor (v, lo, hi, dir, b) ->
+        let lo = re_expr env lo and hi = re_expr env hi in
+        let v', env' = bind env v in
+        SFor (v', lo, hi, dir, re_stmt env' b)
+    | SMatch (e, cases) ->
+        SMatch
+          ( re_expr env e,
+            List.map
+              (fun (p, b) ->
+                let p, env = bind_pattern env p in
+                (p, re_stmt env b))
+              cases )
+    | SReturn e -> SReturn (re_expr env e)
+    | (SBarrier | SWarpBarrier | SMemFence | SEmpty) as s -> s
+    | SExpr e -> SExpr (re_expr env e)
+    | SLet (v, e, body) ->
+        let e = re_expr env e in
+        let v', env' = bind env v in
+        SLet (v', e, re_stmt env' body)
+    | SLetMut (v, e, body) ->
+        let e = re_expr env e in
+        let v', env' = bind env v in
+        SLetMut (v', e, re_stmt env' body)
+    | SPragma (ss, b) -> SPragma (ss, re_stmt env b)
+    | SBlock b -> SBlock (re_stmt env b)
+    | SNative _ as s -> s
+  in
+  re_stmt SM.empty body
+
 (** Emit a C/MSL tagged-union variant type (enum + typedef struct + union +
     inline constructors). [type_of_elttype] and [constructor_prefix] are the
     only backend-specific inputs. *)

--- a/spoc/ir/Sarek_ir_codegen.mli
+++ b/spoc/ir/Sarek_ir_codegen.mli
@@ -11,6 +11,27 @@
     "Module.point" -> "Module_point"). Replaces '.' with '_'. *)
 val mangle_name : string -> string
 
+(** Alpha-rename kernel-body binders whose name collides with a backend-reserved
+    identifier, rewriting each colliding binder (and its in-scope references) to
+    a fresh name so it no longer aliases a scalar param exposed by name. Covers
+    [SLet], [SLetMut], [SFor], and [SMatch]/[EMatch] pattern binders; a no-op
+    for collision-free kernels.
+
+    [collides name] reports whether [name] (as written in the IR) is reserved
+    for this backend. [fresh_name orig n] mints the [n]-th shadow name for
+    original binder [orig] ([n] is 1-based, incremented once per colliding
+    binder). The counter is internal and starts at 0 on every call, so a single
+    per-kernel invocation numbers shadows from 1.
+
+    Shared by the GLSL (push-constant / vector-[_len] macros,
+    [sarek_pc_shadow_*]) and WGSL (scalar-param field access,
+    [sarek_scalar_shadow_*]) backends. *)
+val rename_shadowing_locals :
+  collides:(string -> bool) ->
+  fresh_name:(string -> int -> string) ->
+  Sarek_ir_types.stmt ->
+  Sarek_ir_types.stmt
+
 (** Emit a C/MSL tagged-union variant type: an [enum] of constructor tags, a
     [typedef struct] with a [tag] field and a [union] of payloads, and one
     inline constructor function per case.


### PR DESCRIPTION
## What & why

The GLSL `rename_pc_shadowing_locals` and WGSL `rename_scalar_shadowing_locals`
IR pre-passes were **~93% byte-identical** — the entire
`ren`/`bind_pattern`/`re_expr`/`re_lvalue`/`bind`/`re_stmt` traversal (81 lines)
was duplicated verbatim. This is factorization opportunity **#1** from the #58
review of PR #286: the differences reduce to a `~collides` predicate and a
`~fresh_name` closure.

## The shared module

New `Sarek_ir_codegen.rename_shadowing_locals` in `spoc/ir/Sarek_ir_codegen.ml`
(+ `.mli`) — the established callback-idiom home (already factors variant
emission via `~type_of_elttype`):

```
rename_shadowing_locals :
  collides:(string -> bool) ->
  fresh_name:(string -> int -> string) ->
  Sarek_ir_types.stmt -> Sarek_ir_types.stmt
```

A per-call counter starts at 0 on each invocation and is threaded internally to
`fresh_name orig n` (n 1-based). This reproduces the backends' former
reset-then-generate discipline **exactly**: each backend called rename once per
kernel, immediately after resetting its module-level counter to 0. The
module-level counters (`pc_shadow_counter`, `scalar_shadow_counter`) and their
four `:= 0` resets are removed.

## The two call sites

- **GLSL** `rename_pc_shadowing_locals` →
  `~collides:(fun n -> let e = escape_glsl_name n in mem e pc_names || mem e len_names)`
  and `~fresh_name:(fun orig n -> "sarek_pc_shadow_<esc>_<n>")`.
- **WGSL** `rename_scalar_shadowing_locals` →
  `~collides:(fun n -> mem n scalar_names)` (raw name, no `_len` macro — WGSL
  uses `params.sarek_<arr>_length` field access) and
  `~fresh_name:(fun orig n -> "sarek_scalar_shadow_<esc>_<n>")`.

### Subtle difference parameterized
GLSL **escapes** the name before the membership check and collides against
**two** sets (scalar-param macros + vector `_len` macros); WGSL checks the
**raw** name against scalar params **only**. Both are fully encapsulated in the
`~collides` closure, so no escaping/collision logic leaks into the shared pass.

## Behaviour preservation (goldens are the oracle)

- **Baseline green before:** `dune test sarek/tests/codegen_golden` = 75 OK;
  `dune test sarek/tests/unit` (incl. `test_shader_recursion_vector`) = 10 OK.
- **Byte-identical after (both backends):** same 75 golden + 10 shader tests OK,
  **no test modified**. Covers `test_codegen_golden` (all backends),
  `test_glsl_name_collision`, `test_shader_ematch_payload`,
  `test_shader_recursion_vector`.
- `dune build` clean; `@fmt` clean on all touched files.

## Net LOC

`+199 / -274` = **-75**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GLSL and WGSL code generation when local variable names conflict with reserved kernel parameter or macro names.
  * Ensured renamed variables and their references remain correctly scoped, including variables introduced in pattern matching.
  * Improved consistency of generated names across kernels and backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->