### PR TITLE
refactor(sarek/codegen): share C-family gen_param/gen_lvalue into Sarek_ir_codegen (#77, factorization #58.3+4)

### DIFF
--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -324,23 +324,7 @@ and cuda_backend =
 
 (** {1 L-value Generation} *)
 
-let rec gen_lvalue buf = function
-  | LVar v -> Buffer.add_string buf v.var_name
-  | LArrayElem (arr, idx) ->
-      Buffer.add_string buf arr ;
-      Buffer.add_char buf '[' ;
-      gen_expr buf idx ;
-      Buffer.add_char buf ']'
-  | LArrayElemExpr (base, idx) ->
-      Buffer.add_char buf '(' ;
-      gen_expr buf base ;
-      Buffer.add_string buf ")[" ;
-      gen_expr buf idx ;
-      Buffer.add_char buf ']'
-  | LRecordField (lv, field) ->
-      gen_lvalue buf lv ;
-      Buffer.add_char buf '.' ;
-      Buffer.add_string buf field
+let gen_lvalue buf lv = Sarek_ir_codegen.gen_lvalue ~gen_expr buf lv
 
 (** {1 Statement Generation} *)
 
@@ -566,31 +550,22 @@ and gen_array_decl buf v elem_ty size mem =
 
 (** {1 Declaration Generation} *)
 
-(** Check if a type is a vector (requires length parameter) *)
-let is_vec_type = function TVec _ -> true | _ -> false
-
-let gen_param buf = function
-  | DParam (v, None) ->
+(* CUDA's array parameter uses [cuda_param_type] (which already carries the
+   [__restrict__] spelling and pointer syntax) and, unlike OpenCL/Metal, emits
+   no address-space qualifier, so it supplies its own [gen_array_param] rather
+   than the shared {!Sarek_ir_codegen.gen_global_array_param}. *)
+let gen_param buf decl =
+  Sarek_ir_codegen.gen_param
+    ~param_type:cuda_param_type
+    ~gen_array_param:(fun buf (v : var) _arr ->
       Buffer.add_string buf (cuda_param_type v.var_type) ;
       Buffer.add_char buf ' ' ;
-      Buffer.add_string buf v.var_name ;
-      (* Add length parameter for vectors *)
-      if is_vec_type v.var_type then begin
-        Buffer.add_string buf ", int sarek_" ;
-        Buffer.add_string buf v.var_name ;
-        Buffer.add_string buf "_length"
-      end
-  | DParam (v, Some _arr) ->
-      (* Array with explicit info - always needs length *)
-      Buffer.add_string buf (cuda_param_type v.var_type) ;
-      Buffer.add_string buf " " ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf ", int sarek_" ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf "_length"
-  | DLocal _ | DShared _ ->
+      Buffer.add_string buf v.var_name)
+    ~invalid:(fun () ->
       Codegen_error.raise_error
-        (Codegen_error.invalid_memory_space "gen_param" "DLocal or DShared")
+        (Codegen_error.invalid_memory_space "gen_param" "DLocal or DShared"))
+    buf
+    decl
 
 let gen_local buf indent = function
   | DLocal (v, None) ->
@@ -717,20 +692,9 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
   List.iter (gen_variant_def buf) k.kern_variants ;
 
   (* Record type definitions *)
-  List.iter
-    (fun (name, fields) ->
-      Buffer.add_string buf "typedef struct {\n" ;
-      List.iter
-        (fun (fname, ftype) ->
-          Buffer.add_string buf "  " ;
-          Buffer.add_string buf (cuda_type_of_elttype ftype) ;
-          Buffer.add_char buf ' ' ;
-          Buffer.add_string buf fname ;
-          Buffer.add_string buf ";\n")
-        fields ;
-      Buffer.add_string buf "} " ;
-      Buffer.add_string buf (mangle_name name) ;
-      Buffer.add_string buf ";\n\n")
+  Sarek_ir_codegen.gen_record_typedefs
+    ~type_of_elttype:cuda_type_of_elttype
+    buf
     types ;
 
   (* Generate helper functions before kernel *)

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -406,23 +406,7 @@ and metal_backend =
 
 (** {1 L-value Generation} *)
 
-let rec gen_lvalue buf = function
-  | LVar v -> Buffer.add_string buf v.var_name
-  | LArrayElem (arr, idx) ->
-      Buffer.add_string buf arr ;
-      Buffer.add_char buf '[' ;
-      gen_expr buf idx ;
-      Buffer.add_char buf ']'
-  | LArrayElemExpr (base, idx) ->
-      Buffer.add_char buf '(' ;
-      gen_expr buf base ;
-      Buffer.add_string buf ")[" ;
-      gen_expr buf idx ;
-      Buffer.add_char buf ']'
-  | LRecordField (lv, field) ->
-      gen_lvalue buf lv ;
-      Buffer.add_char buf '.' ;
-      Buffer.add_string buf field
+let gen_lvalue buf lv = Sarek_ir_codegen.gen_lvalue ~gen_expr buf lv
 
 (** {1 Statement Generation} *)
 
@@ -638,8 +622,9 @@ let rec gen_stmt buf indent = function
 
 (** {1 Declaration Generation} *)
 
-(** Check if a type is a vector (requires length parameter) *)
-let is_vec_type = function TVec _ -> true | _ -> false
+(** Check if a type is a vector (requires length parameter). Still used by the
+    Metal-specific {!gen_param_metal} below (buffer-index variant). *)
+let is_vec_type = Sarek_ir_codegen.is_vec_type
 
 (** Generate parameter with Metal buffer attributes, returns next buffer index
 *)
@@ -690,30 +675,18 @@ let gen_param_metal buf atomic_vars idx = function
            "gen_param_metal"
            "expected DParam")
 
-let gen_param buf = function
-  | DParam (v, None) ->
-      Buffer.add_string buf (metal_param_type v.var_type) ;
-      Buffer.add_char buf ' ' ;
-      Buffer.add_string buf v.var_name ;
-      (* Add length parameter for vectors *)
-      if is_vec_type v.var_type then begin
-        Buffer.add_string buf ", int sarek_" ;
-        Buffer.add_string buf v.var_name ;
-        Buffer.add_string buf "_length"
-      end
-  | DParam (v, Some arr) ->
-      (* Array with explicit info - always needs length *)
-      Buffer.add_string buf (metal_memspace arr.arr_memspace) ;
-      Buffer.add_char buf ' ' ;
-      Buffer.add_string buf (metal_type_of_elttype arr.arr_elttype) ;
-      Buffer.add_string buf "* restrict " ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf ", int sarek_" ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf "_length"
-  | DLocal _ | DShared _ ->
+let gen_param buf decl =
+  Sarek_ir_codegen.gen_param
+    ~param_type:metal_param_type
+    ~gen_array_param:
+      (Sarek_ir_codegen.gen_global_array_param
+         ~memspace:metal_memspace
+         ~type_of_elttype:metal_type_of_elttype)
+    ~invalid:(fun () ->
       Codegen_error.raise_error
-        (Codegen_error.unsupported_construct "gen_param" "expected DParam")
+        (Codegen_error.unsupported_construct "gen_param" "expected DParam"))
+    buf
+    decl
 
 (** Collect variable names used in atomic operations *)
 let rec collect_atomic_vars_expr = function
@@ -979,20 +952,9 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
   List.iter (gen_variant_def buf) k.kern_variants ;
 
   (* Record type definitions *)
-  List.iter
-    (fun (name, fields) ->
-      Buffer.add_string buf "typedef struct {\n" ;
-      List.iter
-        (fun (fname, ftype) ->
-          Buffer.add_string buf "  " ;
-          Buffer.add_string buf (metal_type_of_elttype ftype) ;
-          Buffer.add_char buf ' ' ;
-          Buffer.add_string buf fname ;
-          Buffer.add_string buf ";\n")
-        fields ;
-      Buffer.add_string buf "} " ;
-      Buffer.add_string buf (mangle_name name) ;
-      Buffer.add_string buf ";\n\n")
+  Sarek_ir_codegen.gen_record_typedefs
+    ~type_of_elttype:metal_type_of_elttype
+    buf
     types ;
 
   (* Generate helper functions before kernel *)

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -344,23 +344,7 @@ and opencl_backend =
 
 (** {1 L-value Generation} *)
 
-let rec gen_lvalue buf = function
-  | LVar v -> Buffer.add_string buf v.var_name
-  | LArrayElem (arr, idx) ->
-      Buffer.add_string buf arr ;
-      Buffer.add_char buf '[' ;
-      gen_expr buf idx ;
-      Buffer.add_char buf ']'
-  | LArrayElemExpr (base, idx) ->
-      Buffer.add_char buf '(' ;
-      gen_expr buf base ;
-      Buffer.add_string buf ")[" ;
-      gen_expr buf idx ;
-      Buffer.add_char buf ']'
-  | LRecordField (lv, field) ->
-      gen_lvalue buf lv ;
-      Buffer.add_char buf '.' ;
-      Buffer.add_string buf field
+let gen_lvalue buf lv = Sarek_ir_codegen.gen_lvalue ~gen_expr buf lv
 
 (** {1 Statement Generation} *)
 
@@ -569,33 +553,18 @@ and gen_array_decl buf indent v elem_ty size mem body =
 
 (** {1 Declaration Generation} *)
 
-(** Check if a type is a vector (requires length parameter) *)
-let is_vec_type = function TVec _ -> true | _ -> false
-
-let gen_param buf = function
-  | DParam (v, None) ->
-      Buffer.add_string buf (opencl_param_type v.var_type) ;
-      Buffer.add_char buf ' ' ;
-      Buffer.add_string buf v.var_name ;
-      (* Add length parameter for vectors *)
-      if is_vec_type v.var_type then begin
-        Buffer.add_string buf ", int sarek_" ;
-        Buffer.add_string buf v.var_name ;
-        Buffer.add_string buf "_length"
-      end
-  | DParam (v, Some arr) ->
-      (* Array with explicit info - always needs length *)
-      Buffer.add_string buf (opencl_memspace arr.arr_memspace) ;
-      Buffer.add_char buf ' ' ;
-      Buffer.add_string buf (opencl_type_of_elttype arr.arr_elttype) ;
-      Buffer.add_string buf "* restrict " ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf ", int sarek_" ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf "_length"
-  | DLocal _ | DShared _ ->
+let gen_param buf decl =
+  Sarek_ir_codegen.gen_param
+    ~param_type:opencl_param_type
+    ~gen_array_param:
+      (Sarek_ir_codegen.gen_global_array_param
+         ~memspace:opencl_memspace
+         ~type_of_elttype:opencl_type_of_elttype)
+    ~invalid:(fun () ->
       Codegen_error.raise_error
-        (Codegen_error.invalid_memory_space "gen_param" "DLocal or DShared")
+        (Codegen_error.invalid_memory_space "gen_param" "DLocal or DShared"))
+    buf
+    decl
 
 let gen_local buf indent = function
   | DLocal (v, None) ->
@@ -707,20 +676,9 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
   List.iter (gen_variant_def buf) k.kern_variants ;
 
   (* Record type definitions *)
-  List.iter
-    (fun (name, fields) ->
-      Buffer.add_string buf "typedef struct {\n" ;
-      List.iter
-        (fun (fname, ftype) ->
-          Buffer.add_string buf "  " ;
-          Buffer.add_string buf (opencl_type_of_elttype ftype) ;
-          Buffer.add_char buf ' ' ;
-          Buffer.add_string buf fname ;
-          Buffer.add_string buf ";\n")
-        fields ;
-      Buffer.add_string buf "} " ;
-      Buffer.add_string buf (mangle_name name) ;
-      Buffer.add_string buf ";\n\n")
+  Sarek_ir_codegen.gen_record_typedefs
+    ~type_of_elttype:opencl_type_of_elttype
+    buf
     types ;
 
   (* Generate helper functions before kernel *)

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -232,6 +232,100 @@ let gen_variant_def ~type_of_elttype ~constructor_prefix buf (name, constrs) =
       Buffer.add_string buf "  return r;\n}\n\n")
     constrs
 
+(** {1 C-family shared helpers}
+
+    Emitters shared by the C-family backends (CUDA, OpenCL, Metal), whose
+    generated syntax for l-values, kernel parameters, and record typedefs is
+    identical up to a handful of backend-specific spellings threaded in as
+    callbacks. GLSL/WGSL and PTX diverge too much to share these. *)
+
+(** Whether a parameter type carries an implicit trailing [sarek_<name>_length]
+    argument. Only vectors do. Shared verbatim by the C-family backends. *)
+let is_vec_type (t : Sarek_ir_types.elttype) =
+  match t with TVec _ -> true | _ -> false
+
+(** Emit an l-value (assignment target / read path). Identical across the
+    C-family backends; [gen_expr] (used for array-index subexpressions) is the
+    only backend-specific input. *)
+let gen_lvalue ~gen_expr buf lv =
+  let open Sarek_ir_types in
+  let rec go = function
+    | LVar v -> Buffer.add_string buf v.var_name
+    | LArrayElem (arr, idx) ->
+        Buffer.add_string buf arr ;
+        Buffer.add_char buf '[' ;
+        gen_expr buf idx ;
+        Buffer.add_char buf ']'
+    | LArrayElemExpr (base, idx) ->
+        Buffer.add_char buf '(' ;
+        gen_expr buf base ;
+        Buffer.add_string buf ")[" ;
+        gen_expr buf idx ;
+        Buffer.add_char buf ']'
+    | LRecordField (lv, field) ->
+        go lv ;
+        Buffer.add_char buf '.' ;
+        Buffer.add_string buf field
+  in
+  go lv
+
+(** Emit the array-parameter head [<memspace> <elttype>* restrict <name>] — the
+    shape shared by the OpenCL and Metal backends. CUDA spells [restrict]
+    differently and emits no memspace qualifier, so it supplies its own
+    [gen_array_param] to {!gen_param} instead of using this. *)
+let gen_global_array_param ~memspace ~type_of_elttype buf
+    (v : Sarek_ir_types.var) (arr : Sarek_ir_types.array_info) =
+  Buffer.add_string buf (memspace arr.arr_memspace) ;
+  Buffer.add_char buf ' ' ;
+  Buffer.add_string buf (type_of_elttype arr.arr_elttype) ;
+  Buffer.add_string buf "* restrict " ;
+  Buffer.add_string buf v.var_name
+
+(** Emit a kernel parameter declaration. The vector length-suffix and the
+    overall match structure are shared; the backend-specific inputs are:
+    - [param_type]: scalar/pointer type spelling for the no-array-info case;
+    - [gen_array_param]: emit the array-parameter head when [array_info] is
+      present (see {!gen_global_array_param} for the OpenCL/Metal spelling);
+    - [invalid]: reject a [DLocal]/[DShared] declaration by raising the
+      backend's located error (never returns). *)
+let gen_param ~param_type ~gen_array_param ~invalid buf decl =
+  let open Sarek_ir_types in
+  let emit_length name =
+    Buffer.add_string buf ", int sarek_" ;
+    Buffer.add_string buf name ;
+    Buffer.add_string buf "_length"
+  in
+  match decl with
+  | DParam (v, None) ->
+      Buffer.add_string buf (param_type v.var_type) ;
+      Buffer.add_char buf ' ' ;
+      Buffer.add_string buf v.var_name ;
+      if is_vec_type v.var_type then emit_length v.var_name
+  | DParam (v, Some arr) ->
+      gen_array_param buf v arr ;
+      emit_length v.var_name
+  | DLocal _ | DShared _ -> invalid ()
+
+(** Emit C-family record type declarations: one [typedef struct { ... } name;]
+    per record, one field per line. Shared by CUDA/OpenCL/Metal; only
+    [type_of_elttype] differs. *)
+let gen_record_typedefs ~type_of_elttype buf types =
+  List.iter
+    (fun (name, fields) ->
+      Buffer.add_string buf "typedef struct {\n" ;
+      List.iter
+        (fun (fname, ftype) ->
+          Buffer.add_string buf "  " ;
+          Buffer.add_string buf (type_of_elttype ftype) ;
+          Buffer.add_char buf ' ' ;
+          Buffer.add_string buf fname ;
+          Buffer.add_string buf ";\n")
+        fields ;
+      Buffer.add_string buf "} " ;
+      Buffer.add_string buf (mangle_name name) ;
+      Buffer.add_string buf ";\n\n")
+    types
+
 (** Emit a GLSL variant type. GLSL lacks enum/typedef/union, so tags are
     const-int declarations, the type is a bare struct with flat payload fields,
     and constructors have no qualifier prefix. *)

--- a/spoc/ir/Sarek_ir_codegen.mli
+++ b/spoc/ir/Sarek_ir_codegen.mli
@@ -49,6 +49,65 @@ val gen_variant_def :
   string * (string * Sarek_ir_types.elttype list) list ->
   unit
 
+(** {1 C-family shared helpers}
+
+    Shared by the C-family backends (CUDA, OpenCL, Metal). GLSL/WGSL and PTX
+    diverge too much to use these. *)
+
+(** [is_vec_type t] is [true] iff [t] is a vector type, i.e. carries an implicit
+    trailing [sarek_<name>_length] kernel argument. *)
+val is_vec_type : Sarek_ir_types.elttype -> bool
+
+(** Emit an l-value (assignment target / read path): [LVar], [LArrayElem],
+    [LArrayElemExpr], [LRecordField]. Identical across the C-family backends;
+    [gen_expr] renders array-index subexpressions. *)
+val gen_lvalue :
+  gen_expr:(Buffer.t -> Sarek_ir_types.expr -> unit) ->
+  Buffer.t ->
+  Sarek_ir_types.lvalue ->
+  unit
+
+(** Emit the array kernel-parameter head
+    [<memspace> <elttype>* restrict <name>], the spelling shared by the OpenCL
+    and Metal backends. [memspace] maps the array's memory space to its
+    qualifier and [type_of_elttype] its element type. CUDA differs (no memspace,
+    [__restrict__]) and does not use this. Intended as the [gen_array_param]
+    argument to {!gen_param}. *)
+val gen_global_array_param :
+  memspace:(Sarek_ir_types.memspace -> string) ->
+  type_of_elttype:(Sarek_ir_types.elttype -> string) ->
+  Buffer.t ->
+  Sarek_ir_types.var ->
+  Sarek_ir_types.array_info ->
+  unit
+
+(** Emit a kernel parameter declaration. Shared skeleton: the scalar case emits
+    [<param_type> <name>] plus a [, int sarek_<name>_length] suffix for vectors;
+    the array-info case emits [gen_array_param] followed by that same length
+    suffix.
+
+    [param_type] spells the scalar/pointer type; [gen_array_param] emits the
+    array-parameter head (see {!gen_global_array_param}); [invalid] rejects a
+    [DLocal]/[DShared] declaration by raising the backend's located error (it
+    never returns). *)
+val gen_param :
+  param_type:(Sarek_ir_types.elttype -> string) ->
+  gen_array_param:
+    (Buffer.t -> Sarek_ir_types.var -> Sarek_ir_types.array_info -> unit) ->
+  invalid:(unit -> unit) ->
+  Buffer.t ->
+  Sarek_ir_types.decl ->
+  unit
+
+(** Emit C-family record type declarations: one [typedef struct { ... } name;]
+    per record, one field per line. Only [type_of_elttype] differs per backend.
+*)
+val gen_record_typedefs :
+  type_of_elttype:(Sarek_ir_types.elttype -> string) ->
+  Buffer.t ->
+  (string * (string * Sarek_ir_types.elttype) list) list ->
+  unit
+
 (** Emit a GLSL variant type. GLSL has no [enum], [typedef], or [union], so tags
     are [const int] declarations, the type is a bare [struct], payloads are flat
     fields, and constructor functions have no qualifier prefix.


### PR DESCRIPTION
## Summary
Behaviour-preserving refactor mutualising duplicated **C-family** (CUDA / OpenCL / Metal) codegen helpers into the shared `spoc/ir/Sarek_ir_codegen.ml{,i}`. Implements factorization opportunities **#3 + #4** from the #58 review (PR #286). GLSL/WGSL and PTX are **out of scope** (they diverge too much per #58's own caveat).

## Extracted (one documented copy in `Sarek_ir_codegen`)
- **`gen_lvalue` (#4)** — was byte-identical in all three backends; `~gen_expr` (array-index subexpressions) is the only backend input.
- **`is_vec_type`** — was 3× identical.
- **`gen_param` (#3)** — shared match skeleton + scalar (`DParam(_,None)`) branch via `~param_type` + the vector length suffix.
- **`gen_global_array_param`** — the OpenCL≡Metal array-parameter head (`<memspace> <elttype>* restrict <name>`).
- **`gen_record_typedefs`** — the `typedef struct {...} name;` loop, 3× identical modulo the element-type mapper.

## Left per-backend (genuine divergence — not forced into the shared helper)
- **CUDA array-parameter spelling** uses `cuda_param_type` (carrying `__restrict__`) with no address-space qualifier and ignores `array_info`, unlike OpenCL/Metal → passed as a small per-backend `~gen_array_param` closure.
- **`DLocal`/`DShared` rejection (`~invalid`)** — CUDA/OpenCL raise `invalid_memory_space`, Metal raises `unsupported_construct`, and `Codegen_error` is a per-backend module.
- **Metal `gen_param_metal`** (buffer-index `[[buffer(n)]]` variant) is Metal-only with no CUDA/OpenCL analogue → untouched; Metal keeps a one-line `is_vec_type` alias for it.
- `gen_expr`, `gen_stmt`, thread-intrinsics, atomic dispatch — untouched.

## Byte-identical goldens (the oracle)
- `dune build @sarek/tests/codegen_golden/runtest` → **75 tests pass, no snapshot promoted** (CUDA/OpenCL/Metal byte-identical, before and after).
- `dune build @sarek/tests/unit/runtest` → 10 pass.
- Pre-existing unrelated failure `test_static_tag_erasure` (live-GPU Vulkan/OpenCL match-expression payload binding — GLSL, OOS) is **identical on the stashed baseline**, not caused by this change.
- `dune build` clean; `@fmt` clean on touched files.

## Net LOC
Backends −116 combined (cuda −36, metal −38, opencl −42); shared `.ml` +94 (single documented copy) → **implementation net −22 LOC**; plus a new documented `.mli` interface (+59) → overall +37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)