### PR TITLE
fix(tests): treat CPU-OpenCL as a known-issue device for math-intrinsics/sin flakes (#74)

### DIFF
--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -515,7 +515,8 @@
 (executable
  (name test_cpu_opencl_known_issue)
  (modules test_cpu_opencl_known_issue)
- (libraries spoc_core spoc.framework test_helpers)
+ ; unix: the F2 expiry-NOTE rows capture stdout to assert on a side effect
+ (libraries spoc_core spoc.framework test_helpers unix)
  (preprocess no_preprocessing))
 
 ; Fixture test for the OTHER half of the #74 / F1 contract: the classifier

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -358,6 +358,11 @@
 (rule
  (alias runtest)
  (action
+  (run %{dep:test_float_check_shape.exe})))
+
+(rule
+ (alias runtest)
+ (action
   (run %{dep:test_domain_pool_stress.exe})))
 
 ; compile-only alias: the assertion IS successful compilation (PPX
@@ -510,6 +515,21 @@
 (executable
  (name test_cpu_opencl_known_issue)
  (modules test_cpu_opencl_known_issue)
+ (libraries spoc_core spoc.framework test_helpers)
+ (preprocess no_preprocessing))
+
+; Fixture test for the OTHER half of the #74 / F1 contract: the classifier
+; truth table above assumes a correct float_check_shape, and this pins the
+; computation that produces it (Test_helpers.compute_float_check_shape, which
+; both test_float32_sin_pure and test_math_intrinsics delegate to). Without it a
+; miscomputed first_bad_index / bad_count / non_finite would feed the classifier
+; garbage and reopen the masking hole with no test failing. Array-in /
+; record-out: no device, no backend.
+; Run with: dune exec sarek/tests/e2e/test_float_check_shape.exe
+
+(executable
+ (name test_float_check_shape)
+ (modules test_float_check_shape)
  (libraries spoc_core spoc.framework test_helpers)
  (preprocess no_preprocessing))
 

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -353,6 +353,11 @@
 (rule
  (alias runtest)
  (action
+  (run %{dep:test_cpu_opencl_known_issue.exe})))
+
+(rule
+ (alias runtest)
+ (action
   (run %{dep:test_domain_pool_stress.exe})))
 
 ; compile-only alias: the assertion IS successful compilation (PPX
@@ -493,6 +498,19 @@
  (name test_float32_sin_pure)
  (modules test_float32_sin_pure)
  (libraries sarek sarek_ir spoc_core test_helpers unix)
+ (preprocess no_preprocessing))
+
+; Strictness guard for the CPU-OpenCL float32-math KNOWN-ISSUE classifier used
+; by test_float32_sin_pure and test_math_intrinsics (flake #74). Device-free:
+; fabricates Device.t records and checks the classifier truth table, so a
+; future widening of the predicate (e.g. back to CL_DEVICE_NAME sniffing, which
+; would swallow a real GPU regression) fails here.
+; Run with: dune exec sarek/tests/e2e/test_cpu_opencl_known_issue.exe
+
+(executable
+ (name test_cpu_opencl_known_issue)
+ (modules test_cpu_opencl_known_issue)
+ (libraries spoc_core spoc.framework test_helpers)
  (preprocess no_preprocessing))
 
 ; Regression test for the DomainPool oversubscription race (dropped block

--- a/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
+++ b/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
@@ -16,6 +16,14 @@
  * fabricated so the truth table is checked on every machine, with or without
  * a CPU-OpenCL ICD installed.
  *
+ * Device identity is NOT sufficient (audit finding #74 / F1): the failure SHAPE
+ * is a second, independent gate. On the known-issue device the classifier must
+ * still `Fail when the result is wrong from element 0 (an intrinsic-mapping or
+ * operand regression), wrong from element 1 (a kernel that never executed,
+ * leaving the 0.0 pre-fill), non-finite, or wrong in EVERY element. Only the
+ * documented signature - first bad index at or beyond the 4-wide SSE lane
+ * boundary, finite, and partial - is excused.
+ *
  * Run with: dune exec sarek/tests/e2e/test_cpu_opencl_known_issue.exe
  ******************************************************************************)
 
@@ -89,15 +97,31 @@ let verdict_name = function
   | `Known_issue _ -> "Known_issue"
   | `Fail -> "Fail"
 
-(* A wrong result (within_tol:false) on each device. *)
+let shape ?(total = 256) ?(non_finite = false) ~first_bad ~bad_count () :
+    Test_helpers.float_check_shape =
+  {first_bad_index = first_bad; bad_count; total; non_finite}
+
+(* The real flake signature: first bad element at the 4-wide SSE lane boundary,
+   finite values, only part of the buffer damaged. *)
+let flake_shape = shape ~first_bad:(Some 4) ~bad_count:60 ()
+
+(* A clean result. *)
+let clean_shape = shape ~first_bad:None ~bad_count:0 ()
+
+(* A wrong result carrying the real flake shape, on each device. *)
 let classify dev =
   verdict_name
-    (Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol:false ())
+    (Test_helpers.classify_cpu_opencl_math_result ~dev ~shape:flake_shape ())
 
 (* A correct result must always be `Pass, even on the known-issue device. *)
 let classify_ok dev =
   verdict_name
-    (Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol:true ())
+    (Test_helpers.classify_cpu_opencl_math_result ~dev ~shape:clean_shape ())
+
+(* Shape discrimination, always on the known-issue device: only the shape
+   varies, so any `Fail here is attributable to the shape gate alone. *)
+let classify_shape s dev =
+  verdict_name (Test_helpers.classify_cpu_opencl_math_result ~dev ~shape:s ())
 
 let () =
   print_endline "=== CPU-OpenCL KNOWN-ISSUE classifier truth table ===" ;
@@ -127,7 +151,8 @@ let () =
     false
     (Test_helpers.is_cpu_opencl_device vulkan_gpu) ;
 
-  print_endline "classify_cpu_opencl_math_result, wrong result:" ;
+  print_endline
+    "classify_cpu_opencl_math_result, wrong result with the flake shape:" ;
   check "CPU-OpenCL -> Known_issue" "Known_issue" (classify ci_cpu_opencl) ;
   check
     "GPU-OpenCL named like a CPU -> Fail"
@@ -137,6 +162,57 @@ let () =
   check "Native -> Fail" "Fail" (classify native_cpu) ;
   check "Interpreter -> Fail" "Fail" (classify interpreter) ;
   check "Vulkan -> Fail" "Fail" (classify vulkan_gpu) ;
+
+  (* Failure-SHAPE gate (#74 / F1). Device is held constant at the known-issue
+     device, so every `Fail below is the shape gate doing its job. *)
+  print_endline
+    "classify_cpu_opencl_math_result, shape gate on the CPU-OpenCL device:" ;
+  check
+    "first bad index 0 (intrinsic-mapping / operand regression) -> Fail"
+    "Fail"
+    (classify_shape (shape ~first_bad:(Some 0) ~bad_count:256 ()) ci_cpu_opencl) ;
+  check
+    "first bad index 0, partial -> Fail"
+    "Fail"
+    (classify_shape (shape ~first_bad:(Some 0) ~bad_count:60 ()) ci_cpu_opencl) ;
+  check
+    "first bad index 1 (kernel never executed, 0.0 pre-fill) -> Fail"
+    "Fail"
+    (classify_shape (shape ~first_bad:(Some 1) ~bad_count:255 ()) ci_cpu_opencl) ;
+  check
+    "first bad index 3 (still inside the scalar prologue) -> Fail"
+    "Fail"
+    (classify_shape (shape ~first_bad:(Some 3) ~bad_count:60 ()) ci_cpu_opencl) ;
+  check
+    "non-finite (NaN/inf) result -> Fail"
+    "Fail"
+    (classify_shape
+       (shape ~first_bad:(Some 4) ~bad_count:60 ~non_finite:true ())
+       ci_cpu_opencl) ;
+  check
+    "all elements wrong (total failure) -> Fail"
+    "Fail"
+    (classify_shape (shape ~first_bad:(Some 4) ~bad_count:256 ()) ci_cpu_opencl) ;
+  check
+    "first bad index >= 4, finite, partial (the flake) -> Known_issue"
+    "Known_issue"
+    (classify_shape (shape ~first_bad:(Some 4) ~bad_count:60 ()) ci_cpu_opencl) ;
+  check
+    "first bad index 128, finite, partial -> Known_issue"
+    "Known_issue"
+    (classify_shape
+       (shape ~first_bad:(Some 128) ~bad_count:128 ())
+       ci_cpu_opencl) ;
+  check
+    "bad_count > 0 but no first_bad_index (inconsistent shape) -> Fail"
+    "Fail"
+    (classify_shape (shape ~first_bad:None ~bad_count:60 ()) ci_cpu_opencl) ;
+  (* The flake shape on a non-known-issue device is still a hard failure: both
+     gates are required, neither alone suffices. *)
+  check
+    "flake shape on the discrete GPU -> Fail"
+    "Fail"
+    (classify_shape (shape ~first_bad:(Some 4) ~bad_count:60 ()) dgpu_opencl) ;
 
   print_endline "classify_cpu_opencl_math_result, correct result:" ;
   check "CPU-OpenCL -> Pass" "Pass" (classify_ok ci_cpu_opencl) ;

--- a/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
+++ b/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
@@ -1,0 +1,149 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Truth-table test for the CPU-OpenCL float32-math KNOWN-ISSUE classifier
+ * (Test_helpers.is_cpu_opencl_device / classify_cpu_opencl_math_result).
+ *
+ * This is the strictness guard for the #74 flake fix: the classifier must
+ * annotate a wrong float32 math result ONLY on an OpenCL device whose
+ * CL_DEVICE_TYPE is CPU, and must still `Fail on every other device -
+ * including a GPU-OpenCL device whose CL_DEVICE_NAME is a CPU model string
+ * (which is exactly what rusticl reports for an APU: "AMD Ryzen 9 7950X
+ * 16-Core Processor (radeonsi, raphael_mendocino, ...)"). Device records are
+ * fabricated so the truth table is checked on every machine, with or without
+ * a CPU-OpenCL ICD installed.
+ *
+ * Run with: dune exec sarek/tests/e2e/test_cpu_opencl_known_issue.exe
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+
+let caps ~is_cpu : Spoc_framework.Framework_sig.capabilities =
+  {
+    max_threads_per_block = 256;
+    max_block_dims = (256, 256, 64);
+    max_grid_dims = (65535, 65535, 65535);
+    shared_mem_per_block = 32768;
+    total_global_mem = 1073741824L;
+    compute_capability = (0, 0);
+    supports_fp64 = true;
+    supports_atomics = true;
+    warp_size = 32;
+    max_registers_per_block = 0;
+    clock_rate_khz = 1000000;
+    multiprocessor_count = 8;
+    is_cpu;
+  }
+
+let device ~name ~framework ~is_cpu : Device.t =
+  {id = 0; backend_id = 0; name; framework; capabilities = caps ~is_cpu}
+
+(* The CI runner's device: Intel oneAPI CPU OpenCL runtime, CL_DEVICE_TYPE=CPU,
+   and a name that contains none of the rusticl/radeonsi tokens. *)
+let ci_cpu_opencl =
+  device
+    ~name:"AMD EPYC 9V45 96-Core Processor"
+    ~framework:"OpenCL"
+    ~is_cpu:true
+
+(* The campaign workstation's iGPU under rusticl: CL_DEVICE_TYPE=GPU, but named
+   after the CPU socket. A name heuristic would misclassify this one. *)
+let igpu_named_like_a_cpu =
+  device
+    ~name:
+      "AMD Ryzen 9 7950X 16-Core Processor (radeonsi, raphael_mendocino, ACO)"
+    ~framework:"OpenCL"
+    ~is_cpu:false
+
+let dgpu_opencl =
+  device
+    ~name:"AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO)"
+    ~framework:"OpenCL"
+    ~is_cpu:false
+
+let native_cpu = device ~name:"CPU Native" ~framework:"Native" ~is_cpu:true
+
+let interpreter =
+  device ~name:"CPU Interpreter" ~framework:"Interpreter" ~is_cpu:true
+
+let vulkan_gpu =
+  device
+    ~name:"AMD Radeon RX 7900 XTX (RADV NAVI31)"
+    ~framework:"Vulkan"
+    ~is_cpu:false
+
+let failures = ref 0
+
+let check name expected actual =
+  if expected = actual then Printf.printf "  OK   %s\n" name
+  else begin
+    Printf.printf "  FAIL %s\n" name ;
+    incr failures
+  end
+
+let verdict_name = function
+  | `Pass -> "Pass"
+  | `Known_issue _ -> "Known_issue"
+  | `Fail -> "Fail"
+
+(* A wrong result (within_tol:false) on each device. *)
+let classify dev =
+  verdict_name
+    (Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol:false ())
+
+(* A correct result must always be `Pass, even on the known-issue device. *)
+let classify_ok dev =
+  verdict_name
+    (Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol:true ())
+
+let () =
+  print_endline "=== CPU-OpenCL KNOWN-ISSUE classifier truth table ===" ;
+  print_endline "is_cpu_opencl_device:" ;
+  check
+    "CI CPU-OpenCL device (AMD EPYC 9V45) is CPU-OpenCL"
+    true
+    (Test_helpers.is_cpu_opencl_device ci_cpu_opencl) ;
+  check
+    "GPU-OpenCL device named after a CPU is NOT CPU-OpenCL"
+    false
+    (Test_helpers.is_cpu_opencl_device igpu_named_like_a_cpu) ;
+  check
+    "discrete GPU-OpenCL device is NOT CPU-OpenCL"
+    false
+    (Test_helpers.is_cpu_opencl_device dgpu_opencl) ;
+  check
+    "Native CPU device is NOT CPU-OpenCL"
+    false
+    (Test_helpers.is_cpu_opencl_device native_cpu) ;
+  check
+    "Interpreter device is NOT CPU-OpenCL"
+    false
+    (Test_helpers.is_cpu_opencl_device interpreter) ;
+  check
+    "Vulkan GPU device is NOT CPU-OpenCL"
+    false
+    (Test_helpers.is_cpu_opencl_device vulkan_gpu) ;
+
+  print_endline "classify_cpu_opencl_math_result, wrong result:" ;
+  check "CPU-OpenCL -> Known_issue" "Known_issue" (classify ci_cpu_opencl) ;
+  check
+    "GPU-OpenCL named like a CPU -> Fail"
+    "Fail"
+    (classify igpu_named_like_a_cpu) ;
+  check "discrete GPU-OpenCL -> Fail" "Fail" (classify dgpu_opencl) ;
+  check "Native -> Fail" "Fail" (classify native_cpu) ;
+  check "Interpreter -> Fail" "Fail" (classify interpreter) ;
+  check "Vulkan -> Fail" "Fail" (classify vulkan_gpu) ;
+
+  print_endline "classify_cpu_opencl_math_result, correct result:" ;
+  check "CPU-OpenCL -> Pass" "Pass" (classify_ok ci_cpu_opencl) ;
+  check "Native -> Pass" "Pass" (classify_ok native_cpu) ;
+
+  if !failures = 0 then print_endline "\nAll classifier checks PASSED"
+  else begin
+    Printf.printf "\n%d classifier check(s) FAILED\n" !failures ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
+++ b/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
@@ -123,6 +123,44 @@ let classify_ok dev =
 let classify_shape s dev =
   verdict_name (Test_helpers.classify_cpu_opencl_math_result ~dev ~shape:s ())
 
+(* Run [f] with stdout redirected to a temp file and return what it printed.
+   Needed to assert on the F2 expiry NOTE, which is a side effect on the `Pass
+   path rather than part of the verdict. *)
+let capture_stdout f =
+  let tmp = Filename.temp_file "cpu_opencl_known_issue" ".out" in
+  let fd =
+    Unix.openfile tmp [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600
+  in
+  let saved = Unix.dup Unix.stdout in
+  flush stdout ;
+  Unix.dup2 fd Unix.stdout ;
+  let restore () =
+    flush stdout ;
+    Unix.dup2 saved Unix.stdout ;
+    Unix.close fd ;
+    Unix.close saved
+  in
+  (try f ()
+   with e ->
+     restore () ;
+     Sys.remove tmp ;
+     raise e) ;
+  restore () ;
+  let ic = open_in_bin tmp in
+  let out = really_input_string ic (in_channel_length ic) in
+  close_in ic ;
+  Sys.remove tmp ;
+  out
+
+let note_printed ~dev ~shape =
+  let out =
+    capture_stdout (fun () ->
+        ignore (Test_helpers.classify_cpu_opencl_math_result ~dev ~shape ()))
+  in
+  Test_helpers.string_contains
+    ~needle:"re-evaluate the CPU-OpenCL suppression"
+    out
+
 let () =
   print_endline "=== CPU-OpenCL KNOWN-ISSUE classifier truth table ===" ;
   print_endline "is_cpu_opencl_device:" ;
@@ -207,6 +245,24 @@ let () =
     "bad_count > 0 but no first_bad_index (inconsistent shape) -> Fail"
     "Fail"
     (classify_shape (shape ~first_bad:None ~bad_count:60 ()) ci_cpu_opencl) ;
+  (* Ordering guard: non_finite must be tested BEFORE the bad_count = 0 -> Pass
+     branch. This shape is unreachable today, because a non-finite value always
+     lands in bad_count too - but only as an incidental property of
+     compute_float_check_shape (drop its Float.is_nan guard and this is exactly
+     the shape a NaN buffer produces). Pins the structural guarantee instead of
+     relying on that implication holding forever. *)
+  check
+    "non_finite with bad_count 0 (unreachable today) -> Fail, not Pass"
+    "Fail"
+    (classify_shape
+       (shape ~first_bad:None ~bad_count:0 ~non_finite:true ())
+       ci_cpu_opencl) ;
+  check
+    "non_finite with bad_count 0 on a GPU device -> Fail"
+    "Fail"
+    (classify_shape
+       (shape ~first_bad:None ~bad_count:0 ~non_finite:true ())
+       dgpu_opencl) ;
   (* The flake shape on a non-known-issue device is still a hard failure: both
      gates are required, neither alone suffices. *)
   check
@@ -217,6 +273,36 @@ let () =
   print_endline "classify_cpu_opencl_math_result, correct result:" ;
   check "CPU-OpenCL -> Pass" "Pass" (classify_ok ci_cpu_opencl) ;
   check "Native -> Pass" "Pass" (classify_ok native_cpu) ;
+  check
+    "not-verified shape (--no-verify) -> Pass"
+    "Pass"
+    (classify_shape Test_helpers.float_check_not_verified ci_cpu_opencl) ;
+
+  (* F2 expiry signal. The NOTE is what lets the suppression die once the CI ICD
+     is fixed, so its presence AND its absence are both part of the contract. *)
+  print_endline "expiry NOTE on the `Pass path:" ;
+  check
+    "correct result on the known-issue device -> NOTE printed"
+    true
+    (note_printed ~dev:ci_cpu_opencl ~shape:clean_shape) ;
+  check
+    "correct result on a GPU device -> no NOTE"
+    false
+    (note_printed ~dev:dgpu_opencl ~shape:clean_shape) ;
+  check
+    "correct result on Native -> no NOTE"
+    false
+    (note_printed ~dev:native_cpu ~shape:clean_shape) ;
+  check
+    "--no-verify on the known-issue device -> no NOTE (nothing was compared)"
+    false
+    (note_printed
+       ~dev:ci_cpu_opencl
+       ~shape:Test_helpers.float_check_not_verified) ;
+  check
+    "flake shape on the known-issue device -> no NOTE (not a correct result)"
+    false
+    (note_printed ~dev:ci_cpu_opencl ~shape:flake_shape) ;
 
   if !failures = 0 then print_endline "\nAll classifier checks PASSED"
   else begin

--- a/sarek/tests/e2e/test_float32_sin_pure.ml
+++ b/sarek/tests/e2e/test_float32_sin_pure.ml
@@ -65,14 +65,17 @@ let make_float32_sin_ir () : kernel =
 
 let n = 256
 
+(** The i-th input value: [n] samples spanning [0, 2*pi]. Shared by the filler
+    and the verifier so they cannot drift apart. *)
+let input_at i = Float.pi *. 2.0 *. (float_of_int i /. float_of_int n)
+
 let run_kernel_on_device (dev : Device.t) =
   let ir = make_float32_sin_ir () in
   let a_vec = Vector.create Vector.float32 n in
   let b_vec = Vector.create Vector.float32 n in
   (* Fill input with values in [0, 2*pi] *)
   for i = 0 to n - 1 do
-    let x = Float.pi *. 2.0 *. (float_of_int i /. float_of_int n) in
-    Vector.set a_vec i x ;
+    Vector.set a_vec i (input_at i) ;
     Vector.set b_vec i 0.0
   done ;
   let block = Execute.dims1d 256 in
@@ -95,37 +98,22 @@ let run_kernel_on_device (dev : Device.t) =
     output at its 0.0 pre-fill) can never be excused. See
     [Test_helpers.classify_cpu_opencl_math_result] (#74 / F1). *)
 let verify_result result : Test_helpers.float_check_shape =
-  let errors = ref 0 in
-  let first_bad = ref None in
-  let non_finite = ref false in
-  for i = 0 to n - 1 do
-    let x = Float.pi *. 2.0 *. (float_of_int i /. float_of_int n) in
-    let expected = sin x in
-    let got = result.(i) in
-    if not (Float.is_finite got) then non_finite := true ;
-    let diff = abs_float (got -. expected) in
-    (* Allow 1e-4 absolute tolerance for GPU float32 sin variation. The
-       is_nan guard matters: a NaN result makes every comparison false, so
-       without it a NaN buffer would silently pass. *)
-    if Float.is_nan diff || diff > 1e-4 then begin
-      if !first_bad = None then first_bad := Some i ;
-      if !errors < 5 then
-        Printf.printf
-          "  Mismatch at %d: x=%.4f expected=%.6f got=%.6f diff=%.2e\n"
-          i
-          x
-          expected
-          got
-          diff ;
-      incr errors
-    end
-  done ;
-  {
-    Test_helpers.first_bad_index = !first_bad;
-    bad_count = !errors;
-    total = n;
-    non_finite = !non_finite;
-  }
+  (* Allow 1e-4 absolute tolerance for GPU float32 sin variation. The shape
+     computation itself lives in Test_helpers (single source of truth, fixture
+     tested by test_float_check_shape.ml). *)
+  Test_helpers.compute_float_check_shape
+    ~total:n
+    ~tolerance:1e-4
+    ~expected:(fun i -> sin (input_at i))
+    ~got:(fun i -> result.(i))
+    ~report:(fun ~index ~expected ~got ~diff ->
+      Printf.printf
+        "  Mismatch at %d: x=%.4f expected=%.6f got=%.6f diff=%.2e\n"
+        index
+        (input_at index)
+        expected
+        got
+        diff)
 
 let () =
   let cfg = Test_helpers.parse_args "test_float32_sin_pure" in

--- a/sarek/tests/e2e/test_float32_sin_pure.ml
+++ b/sarek/tests/e2e/test_float32_sin_pure.ml
@@ -123,14 +123,30 @@ let () =
   Printf.printf "Running Float32.sin pure-registry kernel (n=%d)...\n%!" n ;
   try
     let result = run_kernel_on_device dev in
-    if verify_result result then begin
-      Printf.printf
-        "PASSED: Float32.sin pure-registry e2e on %s\n%!"
-        dev.Device.framework
-    end
-    else begin
-      Printf.printf "FAILED: numerical mismatch\n%!" ;
-      exit 1
+    let verdict =
+      Test_helpers.classify_cpu_opencl_math_result
+        ~dev
+        ~within_tol:(verify_result result)
+        ()
+    in
+    begin match verdict with
+    | `Pass ->
+        Printf.printf
+          "PASSED: Float32.sin pure-registry e2e on %s\n%!"
+          dev.Device.framework
+    | `Known_issue label ->
+        (* CPU-OpenCL only; see
+             Test_helpers.classify_cpu_opencl_math_result. *)
+        Printf.printf
+          "KNOWN-ISSUE on %s (%s): %s\n%!"
+          dev.Device.name
+          dev.Device.framework
+          label ;
+        Printf.printf
+          "SKIPPED: Float32.sin on a known-bad CPU-OpenCL device\n%!"
+    | `Fail ->
+        Printf.printf "FAILED: numerical mismatch\n%!" ;
+        exit 1
     end
   with
   | Spoc_framework.Backend_error.Backend_error err ->

--- a/sarek/tests/e2e/test_float32_sin_pure.ml
+++ b/sarek/tests/e2e/test_float32_sin_pure.ml
@@ -89,26 +89,43 @@ let run_kernel_on_device (dev : Device.t) =
   let result = Vector.to_array b_vec in
   result
 
-let verify_result result =
+(** Verify the result and return its failure SHAPE, not just a boolean: the
+    CPU-OpenCL KNOWN-ISSUE classifier gates on where and how widely the result
+    is wrong, so that a total failure (e.g. a kernel that never ran, leaving the
+    output at its 0.0 pre-fill) can never be excused. See
+    [Test_helpers.classify_cpu_opencl_math_result] (#74 / F1). *)
+let verify_result result : Test_helpers.float_check_shape =
   let errors = ref 0 in
+  let first_bad = ref None in
+  let non_finite = ref false in
   for i = 0 to n - 1 do
     let x = Float.pi *. 2.0 *. (float_of_int i /. float_of_int n) in
     let expected = sin x in
-    let diff = abs_float (result.(i) -. expected) in
-    (* Allow 1e-4 absolute tolerance for GPU float32 sin variation *)
-    if diff > 1e-4 then begin
+    let got = result.(i) in
+    if not (Float.is_finite got) then non_finite := true ;
+    let diff = abs_float (got -. expected) in
+    (* Allow 1e-4 absolute tolerance for GPU float32 sin variation. The
+       is_nan guard matters: a NaN result makes every comparison false, so
+       without it a NaN buffer would silently pass. *)
+    if Float.is_nan diff || diff > 1e-4 then begin
+      if !first_bad = None then first_bad := Some i ;
       if !errors < 5 then
         Printf.printf
           "  Mismatch at %d: x=%.4f expected=%.6f got=%.6f diff=%.2e\n"
           i
           x
           expected
-          result.(i)
+          got
           diff ;
       incr errors
     end
   done ;
-  !errors = 0
+  {
+    Test_helpers.first_bad_index = !first_bad;
+    bad_count = !errors;
+    total = n;
+    non_finite = !non_finite;
+  }
 
 let () =
   let cfg = Test_helpers.parse_args "test_float32_sin_pure" in
@@ -126,7 +143,7 @@ let () =
     let verdict =
       Test_helpers.classify_cpu_opencl_math_result
         ~dev
-        ~within_tol:(verify_result result)
+        ~shape:(verify_result result)
         ()
     in
     begin match verdict with
@@ -135,13 +152,21 @@ let () =
           "PASSED: Float32.sin pure-registry e2e on %s\n%!"
           dev.Device.framework
     | `Known_issue label ->
-        (* CPU-OpenCL only; see
+        (* CPU-OpenCL only, and only for the flake's failure shape; see
              Test_helpers.classify_cpu_opencl_math_result. *)
         Printf.printf
           "KNOWN-ISSUE on %s (%s): %s\n%!"
           dev.Device.name
           dev.Device.framework
           label ;
+        Test_helpers.github_warning
+          ~title:"KNOWN-ISSUE (task #74)"
+          (Printf.sprintf
+             "test_float32_sin_pure: float32 sin numeric check SUPPRESSED on \
+              %s (%s) — %s"
+             dev.Device.name
+             dev.Device.framework
+             label) ;
         Printf.printf
           "SKIPPED: Float32.sin on a known-bad CPU-OpenCL device\n%!"
     | `Fail ->

--- a/sarek/tests/e2e/test_float_check_shape.ml
+++ b/sarek/tests/e2e/test_float_check_shape.ml
@@ -1,0 +1,250 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Fixture test for Test_helpers.compute_float_check_shape - the shape
+ * computation that feeds the CPU-OpenCL KNOWN-ISSUE classifier (#74 / F1).
+ *
+ * test_cpu_opencl_known_issue.ml covers the CLASSIFIER: given a shape, does it
+ * reach the right verdict. Nothing covered the other half: does the verifier
+ * compute the right SHAPE in the first place. If first_bad_index, bad_count or
+ * non_finite were miscomputed, the classifier would be fed garbage and the
+ * masking hole would reopen silently, with no test failing - e.g. a
+ * first_bad_index that reported the last mismatch instead of the first would
+ * let an all-wrong buffer look like the lane-boundary flake and be excused.
+ *
+ * compute_float_check_shape is the single source of truth: both
+ * test_float32_sin_pure.verify_result and
+ * test_math_intrinsics.verify_float_arrays delegate to it, contributing only
+ * their tolerance, their reference values and their print format. So testing it
+ * once covers both verifiers' shape logic.
+ *
+ * Array-in / record-out: no device, no backend, runs everywhere.
+ *
+ * Run with: dune exec sarek/tests/e2e/test_float_check_shape.exe
+ ******************************************************************************)
+
+let failures = ref 0
+
+let check name expected actual =
+  if expected = actual then Printf.printf "  OK   %s\n" name
+  else begin
+    Printf.printf "  FAIL %s: expected %s, got %s\n" name expected actual ;
+    incr failures
+  end
+
+let show (s : Test_helpers.float_check_shape) =
+  Printf.sprintf
+    "{first_bad_index=%s; bad_count=%d; total=%d; non_finite=%b}"
+    (match s.first_bad_index with None -> "None" | Some i -> string_of_int i)
+    s.bad_count
+    s.total
+    s.non_finite
+
+let expect ~first_bad ~bad_count ~total ~non_finite =
+  show {first_bad_index = first_bad; bad_count; total; non_finite}
+
+let tolerance = 1e-4
+
+(* Reference values: an arbitrary but non-degenerate signal, so a mismatch is
+   never masked by expected = got = 0. *)
+let total = 16
+
+let reference = Array.init total (fun i -> sin (float_of_int i *. 0.37) +. 1.5)
+
+(** Run the shape computation over [got] vs [reference]. Also counts the
+    [report] callbacks, to pin the "print at most [max_reported_mismatches]"
+    contract that keeps a totally-wrong buffer from flooding a CI log. *)
+let shape_of ?(tolerance = tolerance) got =
+  let reported = ref 0 in
+  let s =
+    Test_helpers.compute_float_check_shape
+      ~total
+      ~tolerance
+      ~expected:(fun i -> reference.(i))
+      ~got:(fun i -> got.(i))
+      ~report:(fun ~index:_ ~expected:_ ~got:_ ~diff:_ -> incr reported)
+  in
+  (s, !reported)
+
+let case ?tolerance name ~mutate ~want =
+  let got = Array.copy reference in
+  mutate got ;
+  let s, _ = shape_of ?tolerance got in
+  check name want (show s)
+
+let () =
+  print_endline "=== compute_float_check_shape fixture table ===" ;
+
+  case
+    "all elements correct -> bad_count 0, no first_bad_index, finite"
+    ~mutate:(fun _ -> ())
+    ~want:(expect ~first_bad:None ~bad_count:0 ~total ~non_finite:false) ;
+
+  case
+    "single wrong element at index 0"
+    ~mutate:(fun a -> a.(0) <- a.(0) +. 1.0)
+    ~want:(expect ~first_bad:(Some 0) ~bad_count:1 ~total ~non_finite:false) ;
+
+  case
+    "single wrong element at index 4"
+    ~mutate:(fun a -> a.(4) <- a.(4) +. 1.0)
+    ~want:(expect ~first_bad:(Some 4) ~bad_count:1 ~total ~non_finite:false) ;
+
+  (* The real CPU-OpenCL flake shape: scalar prologue intact, vectorised body
+     damaged from the 4-wide lane boundary onward. *)
+  case
+    "wrong from index 4 onward (partial, the flake shape)"
+    ~mutate:(fun a ->
+      for i = 4 to total - 1 do
+        a.(i) <- a.(i) +. 1.0
+      done)
+    ~want:
+      (expect
+         ~first_bad:(Some 4)
+         ~bad_count:(total - 4)
+         ~total
+         ~non_finite:false) ;
+
+  (* first_bad_index must be the FIRST mismatch, not the last: this is what
+     distinguishes a dead kernel from the flake. *)
+  case
+    "wrong at indices 1 and 9 -> first_bad_index is 1, not 9"
+    ~mutate:(fun a ->
+      a.(1) <- a.(1) +. 1.0 ;
+      a.(9) <- a.(9) +. 1.0)
+    ~want:(expect ~first_bad:(Some 1) ~bad_count:2 ~total ~non_finite:false) ;
+
+  case
+    "all elements wrong -> bad_count = total"
+    ~mutate:(fun a -> Array.iteri (fun i v -> a.(i) <- v +. 1.0) a)
+    ~want:(expect ~first_bad:(Some 0) ~bad_count:total ~total ~non_finite:false) ;
+
+  (* A zeroed buffer is what a kernel that never executed leaves behind. *)
+  case
+    "all-zeros buffer (kernel never executed) -> bad_count = total"
+    ~mutate:(fun a -> Array.fill a 0 total 0.0)
+    ~want:(expect ~first_bad:(Some 0) ~bad_count:total ~total ~non_finite:false) ;
+
+  (* NaN: every comparison against NaN is false, so `diff > tolerance` alone
+     silently ACCEPTS a NaN. The is_nan guard must both count it as wrong AND
+     raise non_finite. *)
+  case
+    "NaN in the result -> counted wrong AND non_finite"
+    ~mutate:(fun a -> a.(6) <- Float.nan)
+    ~want:(expect ~first_bad:(Some 6) ~bad_count:1 ~total ~non_finite:true) ;
+
+  case
+    "all-NaN result -> bad_count = total AND non_finite"
+    ~mutate:(fun a -> Array.fill a 0 total Float.nan)
+    ~want:(expect ~first_bad:(Some 0) ~bad_count:total ~total ~non_finite:true) ;
+
+  case
+    "+inf in the result -> counted wrong AND non_finite"
+    ~mutate:(fun a -> a.(7) <- Float.infinity)
+    ~want:(expect ~first_bad:(Some 7) ~bad_count:1 ~total ~non_finite:true) ;
+
+  case
+    "-inf in the result -> counted wrong AND non_finite"
+    ~mutate:(fun a -> a.(7) <- Float.neg_infinity)
+    ~want:(expect ~first_bad:(Some 7) ~bad_count:1 ~total ~non_finite:true) ;
+
+  (* Tolerance boundary, approached from a real signal value (magnitude ~1.5).
+     Note this cannot pin the boundary EXACTLY: at that magnitude
+     [v +. tolerance -. v] does not recover [tolerance] bit-for-bit, so the
+     exact-boundary case below uses exact arithmetic instead. *)
+  case
+    "diff just inside tolerance -> counted correct"
+    ~mutate:(fun a -> a.(3) <- a.(3) +. (tolerance *. 0.99))
+    ~want:(expect ~first_bad:None ~bad_count:0 ~total ~non_finite:false) ;
+
+  case
+    "diff just outside tolerance -> counted wrong"
+    ~mutate:(fun a -> a.(3) <- a.(3) +. (tolerance *. 1.01))
+    ~want:(expect ~first_bad:(Some 3) ~bad_count:1 ~total ~non_finite:false) ;
+
+  case
+    "negative-direction diff just outside tolerance -> counted wrong"
+    ~mutate:(fun a -> a.(3) <- a.(3) -. (tolerance *. 1.01))
+    ~want:(expect ~first_bad:(Some 3) ~bad_count:1 ~total ~non_finite:false) ;
+
+  (* Exact boundary. The predicate is [diff > tolerance], so a diff of exactly
+     the tolerance is CORRECT and the very next representable float above it is
+     WRONG. Compared against 0.0 so the subtraction is exact and the diff really
+     is the intended value, bit-for-bit. *)
+  print_endline "exact tolerance boundary (expected = 0.0):" ;
+  let boundary name got want =
+    let s =
+      Test_helpers.compute_float_check_shape
+        ~total:1
+        ~tolerance
+        ~expected:(fun _ -> 0.0)
+        ~got:(fun _ -> got)
+        ~report:(fun ~index:_ ~expected:_ ~got:_ ~diff:_ -> ())
+    in
+    check name want (show s)
+  in
+  boundary
+    "diff exactly = tolerance -> correct (predicate is diff > tol)"
+    tolerance
+    (expect ~first_bad:None ~bad_count:0 ~total:1 ~non_finite:false) ;
+  boundary
+    "diff one ulp above tolerance -> wrong"
+    (Float.succ tolerance)
+    (expect ~first_bad:(Some 0) ~bad_count:1 ~total:1 ~non_finite:false) ;
+  boundary
+    "diff one ulp below tolerance -> correct"
+    (Float.pred tolerance)
+    (expect ~first_bad:None ~bad_count:0 ~total:1 ~non_finite:false) ;
+  boundary
+    "negative diff exactly = tolerance -> correct (absolute value)"
+    (-.tolerance)
+    (expect ~first_bad:None ~bad_count:0 ~total:1 ~non_finite:false) ;
+  boundary
+    "negative diff one ulp above tolerance -> wrong (absolute value)"
+    (-.Float.succ tolerance)
+    (expect ~first_bad:(Some 0) ~bad_count:1 ~total:1 ~non_finite:false) ;
+
+  (* The tolerance is honoured as given, not hard-coded. *)
+  case
+    "a wider tolerance accepts what the default rejects"
+    ~tolerance:1.0
+    ~mutate:(fun a -> a.(3) <- a.(3) +. 0.5)
+    ~want:(expect ~first_bad:None ~bad_count:0 ~total ~non_finite:false) ;
+
+  (* Mismatch reporting is capped, so a totally-wrong buffer cannot flood CI. *)
+  print_endline "report callback cap:" ;
+  let all_wrong = Array.map (fun v -> v +. 1.0) reference in
+  let s, reported = shape_of all_wrong in
+  check
+    "all 16 wrong -> bad_count 16 but only max_reported_mismatches reported"
+    (Printf.sprintf "16/%d" Test_helpers.max_reported_mismatches)
+    (Printf.sprintf "%d/%d" s.bad_count reported) ;
+  let s1, reported1 = shape_of (Array.copy reference) in
+  check
+    "no mismatches -> nothing reported"
+    "0/0"
+    (Printf.sprintf "%d/%d" s1.bad_count reported1) ;
+
+  (* An empty comparison must not be mistaken for a failure. *)
+  print_endline "degenerate input:" ;
+  let empty =
+    Test_helpers.compute_float_check_shape
+      ~total:0
+      ~tolerance
+      ~expected:(fun _ -> 0.0)
+      ~got:(fun _ -> 0.0)
+      ~report:(fun ~index:_ ~expected:_ ~got:_ ~diff:_ -> ())
+  in
+  check
+    "total 0 -> clean shape"
+    (expect ~first_bad:None ~bad_count:0 ~total:0 ~non_finite:false)
+    (show empty) ;
+
+  if !failures = 0 then print_endline "\nAll float_check_shape checks PASSED"
+  else begin
+    Printf.printf "\n%d float_check_shape check(s) FAILED\n" !failures ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -471,11 +471,20 @@ let cpu_opencl_math_lane_width = 4
       an emitter is wrong from element 0, and a kernel that never executed is
       wrong from element 1 (element 0 accidentally matches for sin, since sin 0
       = 0 = the pre-fill); both must FAIL;
-    - [not non_finite] — a NaN/inf result is never this flake;
+    - [not non_finite] — a NaN/inf result is never this flake. Tested FIRST, so
+      a non-finite result [`Fail]s even if the shape claims nothing was out of
+      tolerance (see the note in the body);
     - [bad_count < total] — a partially wrong buffer. An all-elements-wrong
       result (dead kernel, dead queue, wrong buffer bound) must always FAIL.
 
     Everything else [`Fail]s, on every device.
+
+    Known residual: a partial, all-finite wrongness starting at index >= 4 on a
+    CPU-OpenCL device is excused — e.g. a dropped final work-group leaving the
+    0.0 pre-fill in the buffer tail. That is the deliberate trade that
+    suppresses the flake. It is still covered on Native, Interpreter and every
+    GPU device; it is NOT covered on CI's only OpenCL device, which is why
+    adding a conformant CPU ICD (pocl) to the CI image is tracked separately.
 
     Suppression review: this KNOWN-ISSUE exists only until the CI OpenCL ICD is
     fixed or replaced (task #74). Re-evaluate by 2027-01-01, or earlier if the
@@ -484,11 +493,25 @@ let cpu_opencl_math_lane_width = 4
     already be dead weight masking future regressions. *)
 let classify_cpu_opencl_math_result ~dev ~(shape : float_check_shape)
     ?(label = cpu_opencl_float32_math_label) () =
-  if shape.bad_count = 0 then begin
+  (* A non-finite value FAILs first, ahead of the clean-result branch. Today
+     [non_finite] implies [bad_count >= 1] (a non-finite on either side makes
+     [diff] inf or NaN, and [compute_float_check_shape] counts both), so this
+     ordering is not what makes the current code correct — it is what keeps it
+     correct. That implication is an incidental property of the verifier, not an
+     enforced invariant: with the [Float.is_nan] guard removed the shape becomes
+     [{first_bad_index = None; bad_count = 0; non_finite = true}], and a
+     [bad_count = 0 -> `Pass] test placed first would hand back `Pass on a NaN
+     buffer. Checked structurally here so no future edit to the verifier can
+     reintroduce that. Pinned by test_cpu_opencl_known_issue. *)
+  if shape.non_finite then `Fail
+  else if shape.bad_count = 0 then begin
     (* F2: the suppression must be able to expire. Announce every correct
        result from a device we would otherwise excuse, so a fixed ICD is
-       visible in the log instead of silently keeping the annotation alive. *)
-    if is_cpu_opencl_device dev then
+       visible in the log instead of silently keeping the annotation alive.
+       Gated on [total > 0]: under --no-verify nothing was compared (see
+       [float_check_not_verified]), and claiming a CORRECT result there would be
+       a misleading expiry signal. *)
+    if is_cpu_opencl_device dev && shape.total > 0 then
       Printf.printf
         "NOTE: known-issue device produced a CORRECT result — re-evaluate the \
          CPU-OpenCL suppression (task #74)\n\
@@ -496,7 +519,7 @@ let classify_cpu_opencl_math_result ~dev ~(shape : float_check_shape)
     `Pass
   end
   else if
-    is_cpu_opencl_device dev && (not shape.non_finite)
+    is_cpu_opencl_device dev
     && shape.bad_count < shape.total
     &&
     match shape.first_bad_index with

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -278,9 +278,11 @@ let string_contains ~needle haystack =
 
     We key on the OpenCL device name: rusticl reports its Gallium driver as
     ["radeonsi"] in CL_DEVICE_NAME on the campaign hardware (observed: "AMD
-    Radeon RX 7900 XTX (radeonsi, navi31, ...)" and the raphael CPU device), and
-    the ICD/platform identifies itself as ["rusticl"]. We match either token,
-    case-insensitively.
+    Radeon RX 7900 XTX (radeonsi, navi31, ...)" and the CPU-socket-named
+    "raphael_mendocino" device, which despite its name is the integrated GPU and
+    reports CL_DEVICE_TYPE=GPU — verified with clinfo during the #74
+    investigation), and the ICD/platform identifies itself as ["rusticl"]. We
+    match either token, case-insensitively.
 
     Why the device name and NOT the [RUSTICL_FEATURES] env var: the run-rules
     export [RUSTICL_FEATURES=fp64] for the WHOLE test process, so the variable
@@ -369,6 +371,39 @@ let cpu_opencl_float32_math_label =
   "CPU-OpenCL float32 transcendentals (sin/cos/exp/sqrt) are miscompiled by \
    the CI CPU OpenCL runtime on an unrecognised host CPU"
 
+(** Shape of one verified float32 array comparison — what went wrong and where,
+    not merely whether anything did.
+
+    [classify_cpu_opencl_math_result] needs this because a device-identity-only
+    gate is unsound (audit finding #74 / F1): on a CPU-OpenCL device it would
+    turn ANY wrongness of ANY extent into a non-blocking KNOWN-ISSUE, including
+    an all-zeros buffer — exactly what a kernel that never ran leaves behind,
+    since both tests pre-fill their output vector with 0.0.
+
+    - [first_bad_index]: index of the first element outside tolerance, [None] if
+      none.
+    - [bad_count]: how many elements are outside tolerance.
+    - [total]: how many elements were compared.
+    - [non_finite]: a NaN or infinity was seen in the produced or expected
+      values. NaN comparisons are false-y, so a verifier must flag them
+      explicitly rather than let [diff > tol] silently accept them. *)
+type float_check_shape = {
+  first_bad_index : int option;
+  bad_count : int;
+  total : int;
+  non_finite : bool;
+}
+
+(** The shape of a comparison that was not performed (e.g. [--no-verify]):
+    treated exactly like a clean result. *)
+let float_check_not_verified =
+  {first_bad_index = None; bad_count = 0; total = 0; non_finite = false}
+
+(** Vector lane width of the miscompiled CPU-OpenCL math library (SSE, 4 x
+    float32). The observed flake never damages the scalar prologue, so a genuine
+    wrong result at an index below this bound is NEVER the known issue. *)
+let cpu_opencl_math_lane_width = 4
+
 (** Classify one float32 math-intrinsic result, tolerating the documented
     CPU-OpenCL KNOWN-ISSUE.
 
@@ -383,13 +418,54 @@ let cpu_opencl_float32_math_label =
     its parent, on a plain re-run, and on Native / Interpreter / GPU devices, so
     it is a device-runtime defect and not a Sarek codegen regression.
 
-    Strictness is preserved everywhere else: only [is_cpu_opencl_device] devices
-    are eligible for the annotation, so Native, Interpreter, Vulkan, Metal, CUDA
-    and every GPU-OpenCL device still [`Fail] on wrong math. *)
-let classify_cpu_opencl_math_result ~dev ~within_tol
+    Device identity alone is NOT sufficient to annotate (audit finding #74 / F1,
+    and the same discipline [classify_fp64_result] applies for #52 / F5): the
+    failure must also match the flake's SHAPE. [`Known_issue] iff ALL of
+
+    - [is_cpu_opencl_device dev] — the ICD really reports CL_DEVICE_TYPE=CPU;
+    - [first_bad_index >= cpu_opencl_math_lane_width] (= 4) — the scalar
+      prologue is intact. A wrong intrinsic-name mapping or a swapped operand in
+      an emitter is wrong from element 0, and a kernel that never executed is
+      wrong from element 1 (element 0 accidentally matches for sin, since sin 0
+      = 0 = the pre-fill); both must FAIL;
+    - [not non_finite] — a NaN/inf result is never this flake;
+    - [bad_count < total] — a partially wrong buffer. An all-elements-wrong
+      result (dead kernel, dead queue, wrong buffer bound) must always FAIL.
+
+    Everything else [`Fail]s, on every device.
+
+    Suppression review: this KNOWN-ISSUE exists only until the CI OpenCL ICD is
+    fixed or replaced (task #74). Re-evaluate by 2027-01-01, or earlier if the
+    [`Pass]-on-known-issue-device note below starts appearing in CI logs — that
+    note means the device produced a CORRECT result and the suppression may
+    already be dead weight masking future regressions. *)
+let classify_cpu_opencl_math_result ~dev ~(shape : float_check_shape)
     ?(label = cpu_opencl_float32_math_label) () =
-  if within_tol then `Pass
-  else if is_cpu_opencl_device dev then `Known_issue label
+  if shape.bad_count = 0 then begin
+    (* F2: the suppression must be able to expire. Announce every correct
+       result from a device we would otherwise excuse, so a fixed ICD is
+       visible in the log instead of silently keeping the annotation alive. *)
+    if is_cpu_opencl_device dev then
+      Printf.printf
+        "NOTE: known-issue device produced a CORRECT result — re-evaluate the \
+         CPU-OpenCL suppression (task #74)\n\
+         %!" ;
+    `Pass
+  end
+  else if
+    is_cpu_opencl_device dev && (not shape.non_finite)
+    && shape.bad_count < shape.total
+    &&
+    match shape.first_bad_index with
+    | Some i -> i >= cpu_opencl_math_lane_width
+    | None -> false
+  then `Known_issue label
   else `Fail
+
+(** Emit a GitHub Actions warning annotation, so a KNOWN-ISSUE suppression is
+    visible on the checks page and not only to whoever opens the raw log (audit
+    finding #74 / F3). Outside Actions this is just a line of stdout. *)
+let github_warning ~title msg =
+  Printf.printf "::warning title=%s::%s\n%!" title msg
 
 module Benchmarks = Benchmarks

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -343,4 +343,53 @@ let classify_fp64_result ~framework ~device ~within_tol ~transcendental
   then `Known_issue label
   else `Fail
 
+(* ========================================================================== *)
+(* CPU-OpenCL float32 math-intrinsic classification                           *)
+(* ========================================================================== *)
+
+(** [true] iff [dev] is an OpenCL device whose CL_DEVICE_TYPE is CPU.
+
+    Unlike [is_rusticl_device], this predicate does NOT sniff the device name:
+    it uses the real OpenCL device-type query. [capabilities.is_cpu] is filled
+    from [CL_DEVICE_TYPE & CL_DEVICE_TYPE_CPU] in [sarek-opencl/Opencl_api.ml],
+    so the predicate holds for ANY CPU-OpenCL ICD (Intel oneAPI CPU runtime,
+    pocl, rusticl-on-llvmpipe, ...) and never for a real GPU, whatever its
+    CL_DEVICE_NAME string happens to say. That matters here: the CI runner's
+    device reports itself as "AMD EPYC 9V45 96-Core Processor", which matches
+    none of the rusticl/radeonsi name tokens, while the two OpenCL devices on
+    the campaign workstation are named after the CPU socket ("AMD Ryzen 9 7950X
+    16-Core Processor (radeonsi, raphael_mendocino)") yet are
+    CL_DEVICE_TYPE=GPU. Name matching would get both cases backwards; the
+    device-type query gets both right. *)
+let is_cpu_opencl_device (dev : Device.t) =
+  Device.is_opencl dev && Device.is_cpu dev
+
+(** KNOWN-ISSUE label for the CPU-OpenCL float32 transcendental flake. *)
+let cpu_opencl_float32_math_label =
+  "CPU-OpenCL float32 transcendentals (sin/cos/exp/sqrt) are miscompiled by \
+   the CI CPU OpenCL runtime on an unrecognised host CPU"
+
+(** Classify one float32 math-intrinsic result, tolerating the documented
+    CPU-OpenCL KNOWN-ISSUE.
+
+    Evidence (PR #282, run 30134740526): the GitHub runner's CPU-OpenCL device
+    ("AMD EPYC 9V45 96-Core Processor", Intel oneAPI CPU runtime, which logs
+    "SYCL CPU RT Warning: Unknown host CPU") intermittently returns wrong values
+    from Float32 sin/cos/exp/sqrt kernels — zeros, neighbouring input elements,
+    or garbage magnitudes (got 3041634.0 for an expected -2.34). Both failures
+    start at element 4, an SSE 4-wide lane boundary: the scalar prologue is
+    correct and the vectorised body is not, i.e. the runtime mis-JITs its vector
+    math library when it cannot identify the host CPU. The same commit passed on
+    its parent, on a plain re-run, and on Native / Interpreter / GPU devices, so
+    it is a device-runtime defect and not a Sarek codegen regression.
+
+    Strictness is preserved everywhere else: only [is_cpu_opencl_device] devices
+    are eligible for the annotation, so Native, Interpreter, Vulkan, Metal, CUDA
+    and every GPU-OpenCL device still [`Fail] on wrong math. *)
+let classify_cpu_opencl_math_result ~dev ~within_tol
+    ?(label = cpu_opencl_float32_math_label) () =
+  if within_tol then `Pass
+  else if is_cpu_opencl_device dev then `Known_issue label
+  else `Fail
+
 module Benchmarks = Benchmarks

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -399,6 +399,49 @@ type float_check_shape = {
 let float_check_not_verified =
   {first_bad_index = None; bad_count = 0; total = 0; non_finite = false}
 
+(** How many individual mismatches a verifier prints before going quiet. *)
+let max_reported_mismatches = 5
+
+(** Single source of truth for computing a [float_check_shape]: compare [total]
+    elements of [got] against [expected] at absolute tolerance [tolerance],
+    calling [report] for the first [max_reported_mismatches] mismatches.
+
+    Factored out of the two E2E verifiers (test_float32_sin_pure.verify_result
+    and test_math_intrinsics.verify_float_arrays) so the shape that gates the
+    CPU-OpenCL KNOWN-ISSUE is computed in exactly ONE place, and so it can be
+    fixture-tested device-free (test_float_check_shape.ml). If this miscomputed
+    [first_bad_index], [bad_count] or [non_finite] the classifier would silently
+    be fed garbage and the #74 / F1 masking hole would reopen with no test
+    failing. [expected] and [got] are index functions so callers can compare an
+    array against an array or against a computed reference without materialising
+    one.
+
+    The [Float.is_nan diff] guard is load-bearing: every comparison against a
+    NaN is false, so [diff > tolerance] alone silently ACCEPTS a NaN buffer.
+    Non-finite values on either side also raise [non_finite], which the
+    classifier treats as never-excusable. *)
+let compute_float_check_shape ~total ~tolerance ~expected ~got ~report =
+  let errors = ref 0 in
+  let first_bad = ref None in
+  let non_finite = ref false in
+  for i = 0 to total - 1 do
+    let e = expected i and g = got i in
+    if not (Float.is_finite g && Float.is_finite e) then non_finite := true ;
+    let diff = Float.abs (g -. e) in
+    if Float.is_nan diff || diff > tolerance then begin
+      if !first_bad = None then first_bad := Some i ;
+      if !errors < max_reported_mismatches then
+        report ~index:i ~expected:e ~got:g ~diff ;
+      incr errors
+    end
+  done ;
+  {
+    first_bad_index = !first_bad;
+    bad_count = !errors;
+    total;
+    non_finite = !non_finite;
+  }
+
 (** Vector lane width of the miscompiled CPU-OpenCL math library (SSE, 4 x
     float32). The observed flake never damages the scalar prologue, so a genuine
     wrong result at an index below this bound is NEVER the known issue. *)

--- a/sarek/tests/e2e/test_math_intrinsics.ml
+++ b/sarek/tests/e2e/test_math_intrinsics.ml
@@ -169,13 +169,24 @@ let () =
 
         try
           let time, result = run_complex_math dev in
-          let ok =
+          let within_tol =
             (not cfg.verify)
             || verify_float_arrays "runtime" result !expected_complex 0.01
           in
-          let status = if ok then "OK" else "FAIL" in
+          let verdict =
+            Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol ()
+          in
+          let status =
+            match verdict with
+            | `Pass -> "OK"
+            | `Known_issue _ -> "KNOWN-ISSUE"
+            | `Fail -> "FAIL"
+          in
 
-          if not ok then all_ok := false ;
+          (match verdict with
+          | `Pass -> ()
+          | `Known_issue label -> Printf.printf "  KNOWN-ISSUE: %s\n" label
+          | `Fail -> all_ok := false) ;
 
           Printf.printf
             "%-35s %10.4f %10s\n"
@@ -215,16 +226,33 @@ let () =
     try
       let time, result = run_complex_math dev in
       Printf.printf "  Time: %.4f ms\n%!" time ;
-      let ok =
+      let within_tol =
         (not cfg.verify)
         || verify_float_arrays "runtime" result !expected_complex 0.01
       in
-      Printf.printf "  Status: %s\n%!" (if ok then "PASSED" else "FAILED") ;
+      let verdict =
+        Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol ()
+      in
+      Printf.printf
+        "  Status: %s\n%!"
+        (match verdict with
+        | `Pass -> "PASSED"
+        | `Known_issue _ -> "KNOWN-ISSUE"
+        | `Fail -> "FAILED") ;
 
-      if ok then print_endline "\nMath intrinsics tests PASSED"
-      else begin
-        print_endline "\nMath intrinsics tests FAILED" ;
-        exit 1
+      begin match verdict with
+      | `Pass -> print_endline "\nMath intrinsics tests PASSED"
+      | `Known_issue label ->
+          (* CPU-OpenCL only; see
+               Test_helpers.classify_cpu_opencl_math_result. *)
+          Printf.printf "  KNOWN-ISSUE: %s\n%!" label ;
+          Printf.printf
+            "Math intrinsics tests SKIPPED on known-bad CPU-OpenCL device %s\n\
+             %!"
+            dev.Device.name
+      | `Fail ->
+          print_endline "\nMath intrinsics tests FAILED" ;
+          exit 1
       end
     with
     | Spoc_framework.Backend_error.Backend_error _ ->

--- a/sarek/tests/e2e/test_math_intrinsics.ml
+++ b/sarek/tests/e2e/test_math_intrinsics.ml
@@ -113,24 +113,44 @@ let run_complex_math (dev : Device.t) =
 
 (* ========== Verification ========== *)
 
-let verify_float_arrays name result expected tolerance =
+(** Compare [result] against [expected] and return the failure SHAPE (first bad
+    index, how many, out of how many, non-finite seen) rather than a bare
+    boolean. The CPU-OpenCL KNOWN-ISSUE classifier gates on that shape so a
+    total failure — e.g. a kernel that never ran, leaving the output at its 0.0
+    pre-fill — can never be excused as "known". See
+    [Test_helpers.classify_cpu_opencl_math_result] (#74 / F1). *)
+let verify_float_arrays name result expected tolerance :
+    Test_helpers.float_check_shape =
   let n = Array.length expected in
   let errors = ref 0 in
+  let first_bad = ref None in
+  let non_finite = ref false in
   for i = 0 to n - 1 do
-    let diff = abs_float (result.(i) -. expected.(i)) in
-    if diff > tolerance then begin
+    let got = result.(i) in
+    if not (Float.is_finite got && Float.is_finite expected.(i)) then
+      non_finite := true ;
+    let diff = abs_float (got -. expected.(i)) in
+    (* The is_nan guard matters: a NaN result makes every comparison false, so
+       without it a NaN buffer would silently pass. *)
+    if Float.is_nan diff || diff > tolerance then begin
+      if !first_bad = None then first_bad := Some i ;
       if !errors < 5 then
         Printf.printf
           "  %s mismatch at %d: expected %.6f, got %.6f (diff=%.6f)\n"
           name
           i
           expected.(i)
-          result.(i)
+          got
           diff ;
       incr errors
     end
   done ;
-  !errors = 0
+  {
+    Test_helpers.first_bad_index = !first_bad;
+    bad_count = !errors;
+    total = n;
+    non_finite = !non_finite;
+  }
 
 let () =
   let c = Test_helpers.parse_args "test_math_intrinsics" in
@@ -169,12 +189,12 @@ let () =
 
         try
           let time, result = run_complex_math dev in
-          let within_tol =
-            (not cfg.verify)
-            || verify_float_arrays "runtime" result !expected_complex 0.01
+          let shape =
+            if not cfg.verify then Test_helpers.float_check_not_verified
+            else verify_float_arrays "runtime" result !expected_complex 0.01
           in
           let verdict =
-            Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol ()
+            Test_helpers.classify_cpu_opencl_math_result ~dev ~shape ()
           in
           let status =
             match verdict with
@@ -185,7 +205,16 @@ let () =
 
           (match verdict with
           | `Pass -> ()
-          | `Known_issue label -> Printf.printf "  KNOWN-ISSUE: %s\n" label
+          | `Known_issue label ->
+              Printf.printf "  KNOWN-ISSUE: %s\n" label ;
+              Test_helpers.github_warning
+                ~title:"KNOWN-ISSUE (task #74)"
+                (Printf.sprintf
+                   "test_math_intrinsics: float32 math-intrinsic numeric check \
+                    SUPPRESSED on %s (%s) — %s"
+                   name
+                   framework
+                   label)
           | `Fail -> all_ok := false) ;
 
           Printf.printf
@@ -226,12 +255,12 @@ let () =
     try
       let time, result = run_complex_math dev in
       Printf.printf "  Time: %.4f ms\n%!" time ;
-      let within_tol =
-        (not cfg.verify)
-        || verify_float_arrays "runtime" result !expected_complex 0.01
+      let shape =
+        if not cfg.verify then Test_helpers.float_check_not_verified
+        else verify_float_arrays "runtime" result !expected_complex 0.01
       in
       let verdict =
-        Test_helpers.classify_cpu_opencl_math_result ~dev ~within_tol ()
+        Test_helpers.classify_cpu_opencl_math_result ~dev ~shape ()
       in
       Printf.printf
         "  Status: %s\n%!"
@@ -243,9 +272,17 @@ let () =
       begin match verdict with
       | `Pass -> print_endline "\nMath intrinsics tests PASSED"
       | `Known_issue label ->
-          (* CPU-OpenCL only; see
+          (* CPU-OpenCL only, and only for the flake's failure shape; see
                Test_helpers.classify_cpu_opencl_math_result. *)
           Printf.printf "  KNOWN-ISSUE: %s\n%!" label ;
+          Test_helpers.github_warning
+            ~title:"KNOWN-ISSUE (task #74)"
+            (Printf.sprintf
+               "test_math_intrinsics: float32 math-intrinsic numeric check \
+                SUPPRESSED on %s (%s) — %s"
+               dev.Device.name
+               dev.Device.framework
+               label) ;
           Printf.printf
             "Math intrinsics tests SKIPPED on known-bad CPU-OpenCL device %s\n\
              %!"

--- a/sarek/tests/e2e/test_math_intrinsics.ml
+++ b/sarek/tests/e2e/test_math_intrinsics.ml
@@ -121,36 +121,21 @@ let run_complex_math (dev : Device.t) =
     [Test_helpers.classify_cpu_opencl_math_result] (#74 / F1). *)
 let verify_float_arrays name result expected tolerance :
     Test_helpers.float_check_shape =
-  let n = Array.length expected in
-  let errors = ref 0 in
-  let first_bad = ref None in
-  let non_finite = ref false in
-  for i = 0 to n - 1 do
-    let got = result.(i) in
-    if not (Float.is_finite got && Float.is_finite expected.(i)) then
-      non_finite := true ;
-    let diff = abs_float (got -. expected.(i)) in
-    (* The is_nan guard matters: a NaN result makes every comparison false, so
-       without it a NaN buffer would silently pass. *)
-    if Float.is_nan diff || diff > tolerance then begin
-      if !first_bad = None then first_bad := Some i ;
-      if !errors < 5 then
-        Printf.printf
-          "  %s mismatch at %d: expected %.6f, got %.6f (diff=%.6f)\n"
-          name
-          i
-          expected.(i)
-          got
-          diff ;
-      incr errors
-    end
-  done ;
-  {
-    Test_helpers.first_bad_index = !first_bad;
-    bad_count = !errors;
-    total = n;
-    non_finite = !non_finite;
-  }
+  (* The shape computation itself lives in Test_helpers (single source of truth,
+     fixture tested by test_float_check_shape.ml). *)
+  Test_helpers.compute_float_check_shape
+    ~total:(Array.length expected)
+    ~tolerance
+    ~expected:(fun i -> expected.(i))
+    ~got:(fun i -> result.(i))
+    ~report:(fun ~index ~expected ~got ~diff ->
+      Printf.printf
+        "  %s mismatch at %d: expected %.6f, got %.6f (diff=%.6f)\n"
+        name
+        index
+        expected
+        got
+        diff)
 
 let () =
   let c = Test_helpers.parse_args "test_math_intrinsics" in


### PR DESCRIPTION
## The flake

`test_float32_sin_pure` and `test_math_intrinsics` intermittently fail on the GitHub runner's CPU-OpenCL device and block unrelated PRs. Observed on PR #282, run 30134740526, device `AMD EPYC 9V45 96-Core Processor (OpenCL)`:

```
Mismatch at 4: x=0.0982 expected=0.098017 got=0.000000
Mismatch at 5: expected=0.122411 got=0.024544
FAILED: numerical mismatch

runtime mismatch at 4: expected -2.342313, got 3041634.000000
Status: FAILED
Math intrinsics tests FAILED
```

Not a regression: the parent commit passed the identical CI, the PR diff was GLSL-only with byte-identical goldens, a plain `gh run rerun --failed` passed, and both tests pass deterministically on Native, Interpreter and GPU devices.

## Cause: the device runtime, not Sarek

`ci/Dockerfile` builds on `intel/oneapi-runtime`, so the only OpenCL ICD in CI is the Intel oneAPI **CPU** runtime — and the same job log carries `SYCL CPU RT Warning: Unknown host CPU`. It cannot identify the Zen 5 host and mis-JITs its vector math library. The signature confirms it: in **both** tests the first bad element is index 4, an SSE 4-wide float lane boundary — the scalar prologue is correct, the vectorised body returns zeros, neighbouring inputs, or garbage magnitudes.

## Fix

Follows the fp64/rusticl precedent from #272: classify instead of fail. `Test_helpers` gains `is_cpu_opencl_device` and `classify_cpu_opencl_math_result`; the two tests print `KNOWN-ISSUE` (with the mismatch detail still shown) and exit 0 on such a device.

The predicate uses the real OpenCL **device-type query** — `capabilities.is_cpu`, filled from `CL_DEVICE_TYPE & CL_DEVICE_TYPE_CPU` in `Opencl_api.ml` — not `CL_DEVICE_NAME` sniffing. Name matching gets both live cases backwards:

* the CI device name contains none of the `rusticl`/`radeonsi` tokens `is_rusticl_device` looks for;
* the workstation's two OpenCL devices are named after the CPU socket (`AMD Ryzen 9 7950X 16-Core Processor (radeonsi, raphael_mendocino, ...)`) yet both report `CL_DEVICE_TYPE=GPU` — a "looks like a CPU name" heuristic would mask a real GPU regression there.

`.github/workflows/ci.yml` is deliberately untouched: disabling the CPU-OpenCL device in CI would remove the only OpenCL device in the image and silently drop OpenCL coverage for both tests.

## Strictness is preserved

No tolerance widened, no coverage removed, no test skipped wholesale. Only OpenCL devices with `CL_DEVICE_TYPE=CPU` are eligible; Native, Interpreter, Vulkan, Metal, CUDA and every GPU-OpenCL device still fail on wrong math.

Positive control — perturbed the expected value by `+. 99.0` at index 4 and rebuilt:

* `--native` → `runtime mismatch at 4: expected 96.657687, got -2.342313`, `Status: FAILED`, exit 1
* default device (dGPU under OpenCL) → `Status: FAILED`

Perturbation reverted. The new device-free `test_cpu_opencl_known_issue.ml` locks the truth table in permanently (14 checks), including the exact CI device record and the CPU-named iGPU that must keep failing.

## Verification

* `dune build` (whole repo) clean
* `dune build @sarek/tests/e2e/fmt` — 0 diffs on touched files
* `dune build @sarek/tests/unit/runtest` — green
* `dune build @sarek/tests/e2e/runtest` — exit 0
* `scripts/check-test-alias-coverage.sh` — OK, all 70 e2e executables wired

**Local reproduction: no.** This workstation has no CPU-OpenCL ICD (`clinfo -l` shows only rusticl with two `CL_DEVICE_TYPE=GPU` devices), so the flake cannot be reproduced here and the change is a runtime no-op locally. That is why the CI device is covered by a fabricated-device truth-table test rather than by a live run.

## Follow-up worth considering

If the CPU-OpenCL runtime is wrong often rather than intermittently, these two tests give no OpenCL coverage in CI at all — visible in the log as `KNOWN-ISSUE` rather than silent, but installing a conformant CPU ICD (pocl) in `ci/Dockerfile` would restore a trustworthy CI OpenCL device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of documented CPU-OpenCL floating-point discrepancies so known issues are reported without failing the run.
  * Updated math intrinsic verification to provide more informative results and preserve failures for genuinely unexpected mismatches.

* **Tests**
  * Added end-to-end coverage to validate CPU-OpenCL result classification across multiple device types.
  * Wired the new known-issue guard into the default test execution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->