### PR TITLE
fix(sarek/codegen): emit cvt.f64.f32 for exact f32->f64 widening + sweep the ptxas gate over all intrinsics (#87)

### DIFF
--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -419,6 +419,123 @@ let intr_no_f64 intr =
     (intr ^ ": no native f64 " ^ intr
    ^ " in PTX; compute in float32 or on the CPU")
 
+(** {1 Intrinsic name tables}
+
+    The name set OWNED by each per-category intrinsic emitter below. These are
+    the dispatch table consulted by {!emit_intrinsic_native} — not
+    documentation: a name absent from every list is [unsupported], and a name
+    present in two lists is an internal error (the emitters must partition the
+    intrinsic surface, see {!intrinsic_emitter_table}). They also give the ptxas
+    sweep gate a drift-proof enumeration of the whole PTX intrinsic surface
+    (sarek/tests/unit/test_ptx_intrinsic_sweep.ml): an intrinsic added here
+    without an assembling kernel recipe fails that test. *)
+
+let index_intrinsic_names =
+  [
+    "thread_id_x";
+    "thread_idx_x";
+    "thread_id_y";
+    "thread_idx_y";
+    "thread_id_z";
+    "thread_idx_z";
+    "block_id_x";
+    "block_idx_x";
+    "block_id_y";
+    "block_idx_y";
+    "block_id_z";
+    "block_idx_z";
+    "block_dim_x";
+    "block_dim_y";
+    "block_dim_z";
+    "grid_dim_x";
+    "grid_dim_y";
+    "grid_dim_z";
+    "global_thread_id";
+    "global_idx";
+    "global_idx_x";
+    "global_idx_y";
+    "global_size";
+    "block_barrier";
+  ]
+
+let transcendental_intrinsic_names =
+  [
+    "sin";
+    "cos";
+    "tan";
+    "sqrt";
+    "exp";
+    "log";
+    "log10";
+    "pow";
+    "sinh";
+    "cosh";
+    "tanh";
+    "asin";
+    "acos";
+    "atan";
+    "atan2";
+    "expm1";
+    "log1p";
+    "rsqrt";
+  ]
+
+let float_ops_intrinsic_names =
+  [
+    "fabs";
+    "abs_float";
+    "copysign";
+    "fmod";
+    "hypot";
+    "fma";
+    "min";
+    "max";
+    "floor";
+    "ceil";
+  ]
+
+let bitcast_intrinsic_names = ["f64_bits"; "bits_f64"]
+
+let convert_intrinsic_names =
+  [
+    "float";
+    "float_of_int";
+    "float64";
+    "float64_of_int";
+    "int_of_float";
+    "int_of_float64";
+    "of_int";
+    "to_int";
+  ]
+
+let atomic_intrinsic_names =
+  [
+    "atomic_add_int32";
+    "atomic_add_global_int32";
+    "atomic_sub_int32";
+    "atomic_min_int32";
+    "atomic_max_int32";
+    "atomic_and_int32";
+    "atomic_or_int32";
+    "atomic_xor_int32";
+    "atomic_exch_int32";
+    "atomic_exch_int64";
+    "atomic_add_int64";
+    "atomic_add_float32";
+    "atomic_add_float64";
+    "atomic_cas_int32";
+    "atomic_cas_int64";
+    "atomic_inc_int32";
+    "atomic_inc_global_int32";
+    "atomic_dec_int32";
+  ]
+
+(** Every intrinsic name the PTX backend lowers natively, in dispatch order. *)
+let intrinsic_names =
+  index_intrinsic_names @ transcendental_intrinsic_names
+  @ float_ops_intrinsic_names @ bitcast_intrinsic_names
+  @ convert_intrinsic_names @ atomic_intrinsic_names
+
 (** {1 Expression emitter}
 
     Returns the PTX register name holding the result. Emits instructions into
@@ -1195,7 +1312,13 @@ and emit_cast buf alloc r_src dst_ty : string =
       else
         let r = new_f64 alloc in
         let cvt =
-          if is_f32 r_src then "cvt.rn.f64.f32"
+          (* f32 -> f64 is EXACT (every f32 value is representable in f64) and
+             PTX forbids a rounding modifier on an exact widening: ptxas
+             rejects [cvt.rn.f64.f32] with "Illegal rounding modifier for
+             instruction 'cvt'". The int -> f64 conversions below and the
+             narrowing f64 -> f32 in the TFloat32 arm above ARE inexact, so
+             they keep (and require) the [.rn] modifier. *)
+          if is_f32 r_src then "cvt.f64.f32"
           else if is_u64 r_src then "cvt.rn.f64.s64"
           else "cvt.rn.f64.s32"
         in
@@ -1806,7 +1929,8 @@ and emit_intrinsic_transcendental buf alloc env name args : string option =
       (* f32 path: no native PTX instruction and no accurate ex2/lg2
          composition (and for expm1/log1p an exp/log composition would lose
          the near-zero precision they exist for). Widen to f64
-         (cvt.rn.f64.f32), run the softmath f64 helper, round the result back
+         (cvt.f64.f32 — exact, hence no rounding modifier), run the softmath f64
+         helper, round the result back
          (cvt.rn.f32.f64) — precision trivially exceeds f32 ulp. PERF: the
          f64 helper runs at the fp64 rate (1/16 of fp32 on most consumer
          GPUs); acceptable for these rare functions — a native-f32
@@ -2210,23 +2334,51 @@ and emit_intrinsic_atomic buf alloc env name args : string option =
            args)
   | _ -> None
 
-(* PTX-assembly intrinsic emitter. Dispatches [name] across the cohesive
-   per-category emitters above; each returns [None] for a name it does not
-   own (the name sets are disjoint), so the first [Some] wins and an
-   unrecognised name falls through to [unsupported]. *)
+(* Which emitter owns which names. Ownership is by NAME, not by "first emitter
+   that returns [Some]": a name claimed by two emitters would otherwise be
+   silently won by whichever comes first in the list (no warning, no test
+   failure, wrong lowering) — the single [match] this dispatcher replaced would
+   at least have warned about a redundant arm. Here the overlap is an explicit
+   internal error, and test_ptx_intrinsic_sweep.ml asserts the six name sets are
+   pairwise disjoint up front. A thunk because the closures reference the
+   emitters defined in this same [let rec] chain. *)
+and intrinsic_emitter_table () =
+  [
+    ( index_intrinsic_names,
+      fun buf alloc _env _path name _args -> emit_intrinsic_index buf alloc name
+    );
+    ( transcendental_intrinsic_names,
+      fun buf alloc env _path name args ->
+        emit_intrinsic_transcendental buf alloc env name args );
+    ( float_ops_intrinsic_names,
+      fun buf alloc env _path name args ->
+        emit_intrinsic_float_ops buf alloc env name args );
+    ( bitcast_intrinsic_names,
+      fun buf alloc env _path name args ->
+        emit_intrinsic_bitcast buf alloc env name args );
+    ( convert_intrinsic_names,
+      fun buf alloc env path name args ->
+        emit_intrinsic_convert buf alloc env path name args );
+    ( atomic_intrinsic_names,
+      fun buf alloc env _path name args ->
+        emit_intrinsic_atomic buf alloc env name args );
+  ]
+
+(* PTX-assembly intrinsic emitter. Looks [name] up in {!intrinsic_emitter_table}
+   and runs its owning per-category emitter; an unowned (or declined) name is
+   [unsupported]. *)
 and emit_intrinsic_native buf alloc (env : env) path name args : string =
-  let candidates =
-    [
-      (fun () -> emit_intrinsic_index buf alloc name);
-      (fun () -> emit_intrinsic_transcendental buf alloc env name args);
-      (fun () -> emit_intrinsic_float_ops buf alloc env name args);
-      (fun () -> emit_intrinsic_bitcast buf alloc env name args);
-      (fun () -> emit_intrinsic_convert buf alloc env path name args);
-      (fun () -> emit_intrinsic_atomic buf alloc env name args);
-    ]
-  in
-  let rec first = function
-    | [] -> unsupported ("intrinsic: " ^ name)
-    | f :: rest -> ( match f () with Some r -> r | None -> first rest)
-  in
-  first candidates
+  match
+    List.filter
+      (fun (names, _) -> List.mem name names)
+      (intrinsic_emitter_table ())
+  with
+  | [(_, emitter)] -> (
+      match emitter buf alloc env path name args with
+      | Some r -> r
+      | None -> unsupported ("intrinsic: " ^ name))
+  | [] -> unsupported ("intrinsic: " ^ name)
+  | _ :: _ :: _ ->
+      fail
+        ("PTX codegen: internal error: intrinsic " ^ name
+       ^ " is claimed by more than one emitter")

--- a/sarek/codegen/Sarek_ir_ptx_expr.mli
+++ b/sarek/codegen/Sarek_ir_ptx_expr.mli
@@ -60,3 +60,27 @@ val emit_cast : Buffer.t -> reg_alloc -> string -> elttype -> string
     {!Sarek_ir_ptx_types.Ptx_codegen_error} for unknown intrinsic names. *)
 val emit_intrinsic :
   Buffer.t -> reg_alloc -> env -> string list -> string -> expr list -> string
+
+(** {1 Intrinsic name tables}
+
+    The intrinsic names each per-category emitter owns. This is the dispatch
+    table {!emit_intrinsic} consults, so it cannot drift from what the backend
+    actually lowers: a name absent from every list raises
+    {!Sarek_ir_ptx_types.Ptx_codegen_error}, and a name in two lists is an
+    internal error. Exposed so the ptxas sweep gate can assemble one kernel per
+    intrinsic name and so a new intrinsic is covered automatically. *)
+
+val index_intrinsic_names : string list
+
+val transcendental_intrinsic_names : string list
+
+val float_ops_intrinsic_names : string list
+
+val bitcast_intrinsic_names : string list
+
+val convert_intrinsic_names : string list
+
+val atomic_intrinsic_names : string list
+
+(** All of the above concatenated, in dispatch order. *)
+val intrinsic_names : string list

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -60,6 +60,14 @@
  (name test_ptx_snapshot)
  (libraries sarek.codegen alcotest unix str))
 
+; ptxas sweep over the WHOLE PTX intrinsic surface: one kernel per intrinsic
+; name, enumerated from Sarek_ir_ptx_expr's own dispatch tables so a new
+; intrinsic is assembled automatically. Skips cleanly without ptxas.
+
+(test
+ (name test_ptx_intrinsic_sweep)
+ (libraries sarek.codegen alcotest unix str))
+
 ; Shader-validation gate for recursion + vector-parameter helpers.
 ; GLSL assembled with glslangValidator; WGSL validated with naga if present,
 ; else skipped cleanly (mirrors the ptxas gate above). CPU-only, no device.

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -66,6 +66,9 @@
 
 (test
  (name test_ptx_intrinsic_sweep)
+ ; The emitter source is a dep: one test scans its intrinsic match arms and
+ ; requires them to agree with the exported name tables.
+ (deps ../../codegen/Sarek_ir_ptx_expr.ml)
  (libraries sarek.codegen alcotest unix str))
 
 ; Shader-validation gate for recursion + vector-parameter helpers.

--- a/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
+++ b/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
@@ -16,8 +16,10 @@
     ({!Sarek_ir_ptx_expr.intrinsic_names}) rather than a hand-picked list: it
     builds and assembles at least one kernel per intrinsic NAME, and an
     intrinsic added to the emitter with no kernel recipe here FAILS the recipe
-    test. Assembly self-skips (with a printed reason) when [ptxas] is absent,
-    mirroring the existing gate, so the suite stays green off-CUDA machines. *)
+    test. Kernel GENERATION always runs; only the [ptxas] assembly step
+    self-skips (with a printed reason saying what is still checked) when the
+    tool is absent, so the suite stays green — and still meaningful — off-CUDA
+    machines. *)
 
 open Sarek_ir_types
 open Sarek_codegen
@@ -332,6 +334,129 @@ let test_name_sets_disjoint () =
                (String.concat "; " ds)))
     named_sets
 
+(* ---- registry vs. emitter arms ------------------------------------------- *)
+
+(* The name tables and the emitters' [match] arms are two sources for one fact,
+   hundreds of lines apart: a name declared in a table but with no arm, or an
+   arm added without its table entry, is drift. The unregistered direction is
+   fail-loud at runtime (the name reaches no emitter and becomes [unsupported])
+   but nothing FAILS A TEST — the arm is simply absent from dispatch, from
+   [intrinsic_names] and from this sweep, all at once. Until the categories
+   become single name -> handler registries (which would make this structural),
+   scan the emitter source and require the two to agree exactly. *)
+
+let emitter_source_path () =
+  List.find_opt
+    Sys.file_exists
+    ((match Sys.getenv_opt "SAREK_PTX_EXPR_SRC" with
+       | Some p -> [p]
+       | None -> [])
+    @ [
+        (* cwd is the test's build dir under dune runtest; the file is a
+           declared dep of this test in sarek/tests/unit/dune. *)
+        Filename.concat
+          ".."
+          (Filename.concat ".." "codegen/Sarek_ir_ptx_expr.ml");
+        "sarek/codegen/Sarek_ir_ptx_expr.ml";
+      ])
+
+let read_lines path =
+  let ic = open_in path in
+  let rec go acc =
+    match input_line ic with
+    | l -> go (l :: acc)
+    | exception End_of_file ->
+        close_in ic ;
+        List.rev acc
+  in
+  go []
+
+(* The quoted names of a top-level [match] arm: everything before the [->], so
+   string arguments in the arm's BODY (e.g. ~f32_op:(Some "sqrt.rn.f32")) are
+   not mistaken for patterns. *)
+let pattern_names line =
+  let head =
+    match Str.bounded_split_delim (Str.regexp_string "->") line 2 with
+    | h :: _ -> h
+    | [] -> line
+  in
+  let re = Str.regexp "\"\\([a-z0-9_]+\\)\"" in
+  let rec go i acc =
+    match Str.search_forward re head i with
+    | exception Not_found -> List.rev acc
+    | _ -> go (Str.match_end ()) (Str.matched_group 1 head :: acc)
+  in
+  go 0 []
+
+(** [category, arm names] scraped from the emitter source, in file order. *)
+let arms_by_category lines =
+  let categories =
+    ["index"; "transcendental"; "float_ops"; "bitcast"; "convert"; "atomic"]
+  in
+  let acc = Hashtbl.create 8 in
+  let current = ref None in
+  List.iter
+    (fun line ->
+      (match
+         List.find_opt
+           (fun c -> starts_with ("and emit_intrinsic_" ^ c ^ " ") line)
+           categories
+       with
+      | Some c -> current := Some c
+      | None -> if starts_with "and " line then current := None) ;
+      match !current with
+      | None -> ()
+      | Some c ->
+          let t = String.trim line in
+          if starts_with "| \"" t then
+            let previous = Option.value (Hashtbl.find_opt acc c) ~default:[] in
+            Hashtbl.replace acc c (previous @ pattern_names t))
+    lines ;
+  List.map
+    (fun c -> (c, Option.value (Hashtbl.find_opt acc c) ~default:[]))
+    categories
+
+(** The exported name tables and the emitters' own [match] arms must agree, name
+    for name, in both directions. *)
+let test_arms_match_registry () =
+  match emitter_source_path () with
+  | None ->
+      Alcotest.fail
+        "cannot locate Sarek_ir_ptx_expr.ml to scan its intrinsic match arms \
+         (declare it as a dep of this test, or set SAREK_PTX_EXPR_SRC)"
+  | Some path ->
+      let scraped = arms_by_category (read_lines path) in
+      let registered = named_sets in
+      List.iter
+        (fun (cat, arms) ->
+          let declared =
+            Option.value (List.assoc_opt cat registered) ~default:[]
+          in
+          let arms = List.sort_uniq compare arms in
+          let declared = List.sort_uniq compare declared in
+          let missing = List.filter (fun n -> not (List.mem n declared)) arms in
+          let extra = List.filter (fun n -> not (List.mem n arms)) declared in
+          if missing <> [] then
+            Alcotest.fail
+              (Printf.sprintf
+                 "emit_intrinsic_%s has match arm(s) [%s] that are NOT in \
+                  %s_intrinsic_names — the arm is unreachable: dispatch is by \
+                  name, so the intrinsic is [unsupported] and absent from the \
+                  sweep"
+                 cat
+                 (String.concat "; " missing)
+                 cat) ;
+          if extra <> [] then
+            Alcotest.fail
+              (Printf.sprintf
+                 "%s_intrinsic_names declares [%s] with no matching arm in \
+                  emit_intrinsic_%s — dispatch would route the name to an \
+                  emitter that declines it"
+                 cat
+                 (String.concat "; " extra)
+                 cat))
+        scraped
+
 (** Every dispatched intrinsic name has an assembling kernel recipe above. This
     is the anti-drift check: add an intrinsic to the emitter and this fails
     until the sweep covers it. *)
@@ -357,53 +482,94 @@ let all_cases () =
       | Some cs -> List.map (fun (label, k) -> (n, label, k)) cs)
     Sarek_ir_ptx_expr.intrinsic_names
 
-(** Generate and assemble one kernel per case, reporting per-name pass/fail so a
-    failure names the culprit intrinsic. The whole sweep (114 kernels) costs
-    ~1.3s of ptxas, so it stays on the default [runtest] alias. *)
+(* Opcode forms known to be invalid PTX, checked on the generated text so a
+   CPU-only run catches this class too — without a CUDA toolkit the assembler
+   cannot say so, and this gate exists precisely because such a form shipped.
+   Keep it to forms proven illegal against ptxas, one line per form. *)
+let illegal_opcodes =
+  [
+    ( "cvt.rn.f64.f32",
+      "a rounding modifier on the EXACT f32->f64 widening (ptxas: Illegal \
+       rounding modifier for instruction 'cvt'); emit cvt.f64.f32" );
+  ]
+
+let contains haystack needle =
+  match Str.search_forward (Str.regexp_string needle) haystack 0 with
+  | _ -> true
+  | exception Not_found -> false
+
+(** Generate — and, where [ptxas] exists, assemble — one kernel per case,
+    reporting per-name pass/fail so a failure names the culprit intrinsic. The
+    whole sweep (114 kernels) costs ~1.3s of ptxas, so it stays on the default
+    [runtest] alias.
+
+    GENERATION ALWAYS RUNS, including on CPU-only machines: it is what proves
+    every registered name is actually claimed by an emitter, that the emitter
+    does not decline it, and that the recipe's arguments are accepted. Only the
+    [ptxas] assembly step — the extra layer that catches invalid opcodes such as
+    the [cvt.rn.f64.f32] this gate was built for — is skipped when the tool is
+    absent. *)
 let sweep () =
-  if not (Lazy.force ptxas_available) then
-    Printf.printf "  SKIP: ptxas not on PATH (CPU-only environment)\n%!"
-  else begin
-    let cases = all_cases () in
-    let failures = ref [] in
-    let ok = ref 0 in
-    List.iter
-      (fun (name, label, k) ->
-        match
-          try Ok (Sarek_ir_ptx.generate k)
-          with e -> Error ("codegen raised " ^ Printexc.to_string e)
-        with
-        | Error e ->
-            failures := (name, label, e) :: !failures ;
-            Printf.printf "  FAIL %-28s %s\n%!" label e
-        | Ok ptx -> (
+  let have_ptxas = Lazy.force ptxas_available in
+  if not have_ptxas then
+    Printf.printf
+      "  NOTE: ptxas not on PATH — assembly is skipped, but every intrinsic \
+       kernel is still enumerated and GENERATED (an unclaimed name, a \
+       declining emitter or any codegen exception still fails this test)\n\
+       %!" ;
+  let cases = all_cases () in
+  let failures = ref [] in
+  let generated = ref 0 in
+  let assembled = ref 0 in
+  List.iter
+    (fun (name, label, k) ->
+      match
+        try Ok (Sarek_ir_ptx.generate k)
+        with e -> Error ("codegen raised " ^ Printexc.to_string e)
+      with
+      | Error e ->
+          failures := (name, label, e) :: !failures ;
+          Printf.printf "  FAIL %-28s %s\n%!" label e
+      | Ok ptx -> (
+          incr generated ;
+          List.iter
+            (fun (op, why) ->
+              if contains ptx op then begin
+                let e = Printf.sprintf "emits illegal %s — %s" op why in
+                failures := (name, label, e) :: !failures ;
+                Printf.printf "  FAIL %-28s %s\n%!" label e
+              end)
+            illegal_opcodes ;
+          if not have_ptxas then Printf.printf "  gen  %s\n%!" label
+          else
             match assemble_ok ptx with
             | Ok () ->
-                incr ok ;
+                incr assembled ;
                 Printf.printf "  ok   %s\n%!" label
             | Error err ->
                 failures := (name, label, String.trim err) :: !failures ;
                 Printf.printf "  FAIL %-28s %s\n%!" label (String.trim err)))
-      cases ;
-    Printf.printf
-      "  ptxas sweep: %d/%d cases assembled\n%!"
-      !ok
-      (List.length cases) ;
-    match List.rev !failures with
-    | [] -> ()
-    | fs ->
-        let names = List.sort_uniq compare (List.map (fun (n, _, _) -> n) fs) in
-        Alcotest.fail
-          (Printf.sprintf
-             "ptxas rejected %d kernel(s) — broken intrinsic(s): %s\n%s"
-             (List.length fs)
-             (String.concat ", " names)
-             (String.concat
-                "\n"
-                (List.map
-                   (fun (_, label, e) -> Printf.sprintf "  %s: %s" label e)
-                   fs)))
-  end
+    cases ;
+  Printf.printf
+    "  intrinsic sweep: %d/%d kernels generated, %d assembled%s\n%!"
+    !generated
+    (List.length cases)
+    !assembled
+    (if have_ptxas then "" else " (ptxas absent)") ;
+  match List.rev !failures with
+  | [] -> ()
+  | fs ->
+      let names = List.sort_uniq compare (List.map (fun (n, _, _) -> n) fs) in
+      Alcotest.fail
+        (Printf.sprintf
+           "%d intrinsic kernel(s) rejected — broken intrinsic(s): %s\n%s"
+           (List.length fs)
+           (String.concat ", " names)
+           (String.concat
+              "\n"
+              (List.map
+                 (fun (_, label, e) -> Printf.sprintf "  %s: %s" label e)
+                 fs)))
 
 let () =
   Alcotest.run
@@ -416,6 +582,10 @@ let () =
             `Quick
             test_name_sets_disjoint;
           Alcotest.test_case
+            "emitter match arms and the exported name tables agree"
+            `Quick
+            test_arms_match_registry;
+          Alcotest.test_case
             "every dispatched intrinsic has a sweep kernel"
             `Quick
             test_every_name_has_a_recipe;
@@ -423,7 +593,8 @@ let () =
       ( "ptxas",
         [
           Alcotest.test_case
-            "assembles a kernel per intrinsic name (skips if ptxas absent)"
+            "generates (always) and assembles (if ptxas) a kernel per \
+             intrinsic name"
             `Quick
             sweep;
         ] );

--- a/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
+++ b/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
@@ -1,0 +1,430 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** ptxas gate over the WHOLE PTX intrinsic surface.
+
+    The hand-picked ptxas gate in test_ptx_snapshot.ml assembles five kernels;
+    the intrinsic surface is 80 names. That gap let an invalid opcode ship: the
+    f32→f64 widening of [Float32.{asin,acos,atan,atan2,expm1,log1p}] emitted
+    [cvt.rn.f64.f32], which PTX forbids on an exact widening — the kernels
+    generated fine, passed a substring snapshot test that asserted the invalid
+    opcode, and died at [cuModuleLoadData].
+
+    So this gate is driven by the emitter's own dispatch tables
+    ({!Sarek_ir_ptx_expr.intrinsic_names}) rather than a hand-picked list: it
+    builds and assembles at least one kernel per intrinsic NAME, and an
+    intrinsic added to the emitter with no kernel recipe here FAILS the recipe
+    test. Assembly self-skips (with a printed reason) when [ptxas] is absent,
+    mirroring the existing gate, so the suite stays green off-CUDA machines. *)
+
+open Sarek_ir_types
+open Sarek_codegen
+
+(* ---- ptxas plumbing (mirrors test_ptx_snapshot.ml's gate) ---------------- *)
+
+let ptxas_available =
+  lazy
+    (match Unix.system "command -v ptxas >/dev/null 2>&1" with
+    | Unix.WEXITED 0 -> true
+    | _ -> false)
+
+let assemble_ok ptx =
+  let base = Filename.temp_file "sarek_sweep_" "" in
+  let src = base ^ ".ptx" in
+  let obj = base ^ ".cubin" in
+  let oc = open_out src in
+  output_string oc ptx ;
+  close_out oc ;
+  (* ptxas assumes a low default SM and rejects any PTX whose [.target] is
+     higher, so pass the module's own target explicitly. *)
+  let gpu_name =
+    let target_re = Str.regexp "\\.target[ \t]+\\(sm_[0-9]+\\)" in
+    try
+      ignore (Str.search_forward target_re ptx 0) ;
+      Str.matched_group 1 ptx
+    with Not_found -> "sm_86"
+  in
+  let cmd =
+    Printf.sprintf
+      "ptxas --compile-only --gpu-name %s -o %s %s 2>%s.err"
+      (Filename.quote gpu_name)
+      (Filename.quote obj)
+      (Filename.quote src)
+      (Filename.quote base)
+  in
+  let rc = Unix.system cmd in
+  let err =
+    try
+      let ic = open_in (base ^ ".err") in
+      let n = in_channel_length ic in
+      let s = really_input_string ic n in
+      close_in ic ;
+      s
+    with _ -> ""
+  in
+  List.iter
+    (fun f -> try Sys.remove f with _ -> ())
+    [src; obj; base; base ^ ".err"] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error err
+
+(* ---- kernel fixtures ----------------------------------------------------- *)
+
+let mk name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let param n ty =
+  DParam (mk n (TVec ty), Some {arr_elttype = ty; arr_memspace = Global})
+
+(* One in and one out array per scalar width: every recipe below writes its
+   result to the out array of the matching width. *)
+let params =
+  [
+    param "of32" TFloat32;
+    param "of64" TFloat64;
+    param "oi32" TInt32;
+    param "oi64" TInt64;
+    param "af32" TFloat32;
+    param "af64" TFloat64;
+    param "ai32" TInt32;
+    param "ai64" TInt64;
+  ]
+
+let tid = mk "tid" TInt32
+
+let rd a = EArrayRead (a, EVar tid)
+
+let arr a ty = EVar (mk a (TVec ty))
+
+let kernel label out e =
+  {
+    kern_name = "k_" ^ label;
+    kern_params = params;
+    kern_locals = [];
+    kern_body =
+      SLet
+        ( tid,
+          EIntrinsic ([], "global_thread_id", []),
+          SAssign (LArrayElem (out, EVar tid), e) );
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let f32_path = ["Sarek_stdlib"; "Float32"]
+
+let f64_path = ["Sarek_stdlib"; "Float64"]
+
+let stdlib_path = ["Sarek_stdlib"]
+
+(* Arity of every math intrinsic (transcendentals + elementary float ops). An
+   entry is REQUIRED: a name added to the emitter's tables with no arity here
+   has no recipe and fails [test_every_name_has_a_recipe]. *)
+let math_arity =
+  [
+    (* transcendentals *)
+    ("sin", 1);
+    ("cos", 1);
+    ("tan", 1);
+    ("sqrt", 1);
+    ("exp", 1);
+    ("log", 1);
+    ("log10", 1);
+    ("pow", 2);
+    ("sinh", 1);
+    ("cosh", 1);
+    ("tanh", 1);
+    ("asin", 1);
+    ("acos", 1);
+    ("atan", 1);
+    ("atan2", 2);
+    ("expm1", 1);
+    ("log1p", 1);
+    ("rsqrt", 1);
+    (* elementary float ops *)
+    ("fabs", 1);
+    ("abs_float", 1);
+    ("copysign", 2);
+    ("fmod", 2);
+    ("hypot", 2);
+    ("fma", 3);
+    ("min", 2);
+    ("max", 2);
+    ("floor", 1);
+    ("ceil", 1);
+  ]
+
+(* Conversions are per-name (source and destination widths differ), and
+   "of_int"/"to_int" exist in both the Float32 and the Float64 module. Each
+   entry is (label, module path, argument array, out array). *)
+let convert_recipes =
+  [
+    ("float", [("float", stdlib_path, "ai32", "of32")]);
+    ("float_of_int", [("float_of_int", stdlib_path, "ai32", "of32")]);
+    ("float64", [("float64", stdlib_path, "ai32", "of64")]);
+    ("float64_of_int", [("float64_of_int", stdlib_path, "ai32", "of64")]);
+    ("int_of_float", [("int_of_float", stdlib_path, "af32", "oi32")]);
+    ("int_of_float64", [("int_of_float64", stdlib_path, "af64", "oi32")]);
+    ( "of_int",
+      [
+        ("of_int_f32", f32_path, "ai32", "of32");
+        ("of_int_f64", f64_path, "ai32", "of64");
+      ] );
+    ( "to_int",
+      [
+        ("to_int_f32", f32_path, "af32", "oi32");
+        ("to_int_f64", f64_path, "af64", "oi32");
+      ] );
+  ]
+
+(* Atomics: (argument shape, element type). The array operand comes first, then
+   the index, then the value(s) — [atomic_inc/dec] take no value. *)
+type atomic_shape = Rmw | Cas | Incdec
+
+let starts_with p s =
+  String.length s >= String.length p && String.sub s 0 (String.length p) = p
+
+let ends_with suf s =
+  let ls = String.length s and lf = String.length suf in
+  ls >= lf && String.sub s (ls - lf) lf = suf
+
+let atomic_recipe name =
+  let ty, a, out =
+    if ends_with "int32" name then (TInt32, "ai32", "oi32")
+    else if ends_with "int64" name then (TInt64, "ai64", "oi64")
+    else if ends_with "float32" name then (TFloat32, "af32", "of32")
+    else (TFloat64, "af64", "of64")
+  in
+  let shape =
+    if starts_with "atomic_cas" name then Cas
+    else if starts_with "atomic_inc" name || starts_with "atomic_dec" name then
+      Incdec
+    else Rmw
+  in
+  let args =
+    match shape with
+    | Rmw -> [arr a ty; EVar tid; rd a]
+    | Cas -> [arr a ty; EVar tid; rd a; rd a]
+    | Incdec -> [arr a ty; EVar tid]
+  in
+  [(name, kernel name out (EIntrinsic (stdlib_path, name, args)))]
+
+(** [cases_for name] is every (label, kernel) pair exercising intrinsic [name],
+    or [None] when the name has no recipe (a drift alarm, not a skip). *)
+let cases_for name =
+  if List.mem name Sarek_ir_ptx_expr.index_intrinsic_names then
+    Some [(name, kernel name "oi32" (EIntrinsic ([], name, [])))]
+  else if List.mem name Sarek_ir_ptx_expr.bitcast_intrinsic_names then
+    match name with
+    | "f64_bits" ->
+        Some
+          [
+            ( "f64_bits",
+              kernel
+                "f64_bits"
+                "oi64"
+                (EIntrinsic (f64_path, name, [rd "af64"])) );
+          ]
+    | "bits_f64" ->
+        Some
+          [
+            ( "bits_f64",
+              kernel
+                "bits_f64"
+                "of64"
+                (EIntrinsic (f64_path, name, [rd "ai64"])) );
+          ]
+    | _ -> None
+  else if List.mem name Sarek_ir_ptx_expr.convert_intrinsic_names then
+    match List.assoc_opt name convert_recipes with
+    | None -> None
+    | Some rs ->
+        Some
+          (List.map
+             (fun (label, path, a, out) ->
+               (label, kernel label out (EIntrinsic (path, name, [rd a]))))
+             rs)
+  else if List.mem name Sarek_ir_ptx_expr.atomic_intrinsic_names then
+    Some (atomic_recipe name)
+  else if
+    List.mem name Sarek_ir_ptx_expr.transcendental_intrinsic_names
+    || List.mem name Sarek_ir_ptx_expr.float_ops_intrinsic_names
+  then
+    match List.assoc_opt name math_arity with
+    | None -> None
+    | Some n ->
+        (* Both widths: the f32 path (where the widen-to-f64 transcendentals
+           live) and the f64 path (native f64 ops or softmath helpers). *)
+        let width (label, path, a, out) =
+          ( label,
+            kernel
+              label
+              out
+              (EIntrinsic (path, name, List.init n (fun _ -> rd a))) )
+        in
+        let widths =
+          [
+            (name ^ "_f32", f32_path, "af32", "of32");
+            (name ^ "_f64", f64_path, "af64", "of64");
+          ]
+          (* min/max are also the integer min/max intrinsics. *)
+          @
+          if name = "min" || name = "max" then
+            [
+              (name ^ "_i32", stdlib_path, "ai32", "oi32");
+              (name ^ "_i64", stdlib_path, "ai64", "oi64");
+            ]
+          else []
+        in
+        Some (List.map width widths)
+  else None
+
+(* ---- tests --------------------------------------------------------------- *)
+
+let named_sets =
+  [
+    ("index", Sarek_ir_ptx_expr.index_intrinsic_names);
+    ("transcendental", Sarek_ir_ptx_expr.transcendental_intrinsic_names);
+    ("float_ops", Sarek_ir_ptx_expr.float_ops_intrinsic_names);
+    ("bitcast", Sarek_ir_ptx_expr.bitcast_intrinsic_names);
+    ("convert", Sarek_ir_ptx_expr.convert_intrinsic_names);
+    ("atomic", Sarek_ir_ptx_expr.atomic_intrinsic_names);
+  ]
+
+(** The six emitter name sets must PARTITION the intrinsic surface. Dispatch
+    picks an emitter by name, so a name claimed twice is ambiguous: before the
+    dispatch table it was silently won by whichever emitter came first in the
+    candidate list (no warning, no failure, wrong lowering). *)
+let test_name_sets_disjoint () =
+  let rec pairs = function
+    | [] -> []
+    | x :: rest -> List.map (fun y -> (x, y)) rest @ pairs rest
+  in
+  List.iter
+    (fun ((na, a), (nb, b)) ->
+      let common = List.filter (fun n -> List.mem n b) a in
+      if common <> [] then
+        Alcotest.fail
+          (Printf.sprintf
+             "intrinsic name(s) [%s] are claimed by both the %s and the %s \
+              emitter — dispatch would be ambiguous"
+             (String.concat "; " common)
+             na
+             nb))
+    (pairs named_sets) ;
+  (* No name may repeat inside one set either. *)
+  List.iter
+    (fun (n, names) ->
+      let sorted = List.sort compare names in
+      let rec dups = function
+        | a :: (b :: _ as rest) -> if a = b then a :: dups rest else dups rest
+        | _ -> []
+      in
+      match dups sorted with
+      | [] -> ()
+      | ds ->
+          Alcotest.fail
+            (Printf.sprintf
+               "%s emitter lists [%s] more than once"
+               n
+               (String.concat "; " ds)))
+    named_sets
+
+(** Every dispatched intrinsic name has an assembling kernel recipe above. This
+    is the anti-drift check: add an intrinsic to the emitter and this fails
+    until the sweep covers it. *)
+let test_every_name_has_a_recipe () =
+  let missing =
+    List.filter
+      (fun n -> match cases_for n with None | Some [] -> true | _ -> false)
+      Sarek_ir_ptx_expr.intrinsic_names
+  in
+  if missing <> [] then
+    Alcotest.fail
+      (Printf.sprintf
+         "no ptxas-sweep kernel recipe for intrinsic(s) [%s] — add one to \
+          test_ptx_intrinsic_sweep.ml so the new intrinsic is assembled"
+         (String.concat "; " missing))
+
+(* All (intrinsic name, label, kernel) triples, in dispatch order. *)
+let all_cases () =
+  List.concat_map
+    (fun n ->
+      match cases_for n with
+      | None -> []
+      | Some cs -> List.map (fun (label, k) -> (n, label, k)) cs)
+    Sarek_ir_ptx_expr.intrinsic_names
+
+(** Generate and assemble one kernel per case, reporting per-name pass/fail so a
+    failure names the culprit intrinsic. The whole sweep (114 kernels) costs
+    ~1.3s of ptxas, so it stays on the default [runtest] alias. *)
+let sweep () =
+  if not (Lazy.force ptxas_available) then
+    Printf.printf "  SKIP: ptxas not on PATH (CPU-only environment)\n%!"
+  else begin
+    let cases = all_cases () in
+    let failures = ref [] in
+    let ok = ref 0 in
+    List.iter
+      (fun (name, label, k) ->
+        match
+          try Ok (Sarek_ir_ptx.generate k)
+          with e -> Error ("codegen raised " ^ Printexc.to_string e)
+        with
+        | Error e ->
+            failures := (name, label, e) :: !failures ;
+            Printf.printf "  FAIL %-28s %s\n%!" label e
+        | Ok ptx -> (
+            match assemble_ok ptx with
+            | Ok () ->
+                incr ok ;
+                Printf.printf "  ok   %s\n%!" label
+            | Error err ->
+                failures := (name, label, String.trim err) :: !failures ;
+                Printf.printf "  FAIL %-28s %s\n%!" label (String.trim err)))
+      cases ;
+    Printf.printf
+      "  ptxas sweep: %d/%d cases assembled\n%!"
+      !ok
+      (List.length cases) ;
+    match List.rev !failures with
+    | [] -> ()
+    | fs ->
+        let names = List.sort_uniq compare (List.map (fun (n, _, _) -> n) fs) in
+        Alcotest.fail
+          (Printf.sprintf
+             "ptxas rejected %d kernel(s) — broken intrinsic(s): %s\n%s"
+             (List.length fs)
+             (String.concat ", " names)
+             (String.concat
+                "\n"
+                (List.map
+                   (fun (_, label, e) -> Printf.sprintf "  %s: %s" label e)
+                   fs)))
+  end
+
+let () =
+  Alcotest.run
+    "ptx_intrinsic_sweep"
+    [
+      ( "dispatch",
+        [
+          Alcotest.test_case
+            "emitter name sets partition the intrinsic surface"
+            `Quick
+            test_name_sets_disjoint;
+          Alcotest.test_case
+            "every dispatched intrinsic has a sweep kernel"
+            `Quick
+            test_every_name_has_a_recipe;
+        ] );
+      ( "ptxas",
+        [
+          Alcotest.test_case
+            "assembles a kernel per intrinsic name (skips if ptxas absent)"
+            `Quick
+            sweep;
+        ] );
+    ]

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -1913,12 +1913,21 @@ let test_f64_exp_log_softmath () =
     Alcotest.fail "f64 log must not emit the f32 .approx instruction"
 
 (** f32 asin has no native PTX op and no accurate composition; it lowers via the
-    f64 softmath helper: widen (cvt.rn.f64.f32), inline the fdlibm-style f64
-    body (fma.rn.f64 + sqrt.rn.f64), round back (cvt.rn.f32.f64). *)
+    f64 softmath helper: widen (cvt.f64.f32 — an EXACT conversion, on which PTX
+    forbids a rounding modifier: [cvt.rn.f64.f32] is rejected by ptxas), inline
+    the fdlibm-style f64 body (fma.rn.f64 + sqrt.rn.f64), round back
+    (cvt.rn.f32.f64 — inexact, so that one requires .rn). The kernel is
+    assembled by the sweep gate in test_ptx_intrinsic_sweep.ml. *)
 let test_f32_asin_via_f64 () =
   let k = make_math_kernel TFloat32 ["Sarek_stdlib"; "Float32"] "asin" in
   let ptx = Sarek_ir_ptx.generate k in
-  assert_contains ptx "cvt.rn.f64.f32" ;
+  assert_contains ptx "cvt.f64.f32" ;
+  assert_absent
+    ptx
+    "cvt.rn.f64.f32"
+    ~why:
+      "a rounding modifier on the exact f32->f64 widening is illegal PTX \
+       (ptxas: Illegal rounding modifier for instruction 'cvt')" ;
   assert_contains ptx "fma.rn.f64" ;
   assert_contains ptx "sqrt.rn.f64" ;
   assert_contains ptx "cvt.rn.f32.f64"


### PR DESCRIPTION
## The bug (one token)

`emit_cast`'s `TFloat64` arm emitted **`cvt.rn.f64.f32`** for the f32 → f64 widening. That conversion is **exact**, and PTX forbids a rounding modifier on it, so `ptxas` rejects the whole module:

```
line 55; error   : Illegal rounding modifier for instruction 'cvt'
ptxas fatal   : Ptx assembly aborted due to errors
```

Six **public** DSL intrinsics were therefore unusable on the CUDA/PTX backend:

`Sarek_stdlib.Float32.{asin, acos, atan, atan2, expm1, log1p}`

They have no native f32 PTX op, so they reach the widen-to-f64 arm of `emit_intrinsic_transcendental`, generate PTX fine, and then die at `cuModuleLoadData`.

Fix: `cvt.f64.f32`. The narrowing sibling `cvt.rn.f32.f64` and every int → float `cvt` are **inexact**, where the modifier is *required* — confirmed against ptxas, which rejects `cvt.f64.s32` for a *missing* modifier. f32 → f64 is the only exact widening the PTX emitters produce, so it is the only affected site (all `cvt.rzi.*`, `cvt.rmi/rpi`, `cvt.u64.u32`, `cvt.s64.s32`, `cvt.u32.u64` sites re-checked).

**Provenance:** this pre-dates #279. It came in with 80317b39 ("feat(ptx): inverse trig, expm1 and log1p"), which added the six intrinsics; `emit_cast` is not in #279's diff.

## Why it hid

- `test_f32_asin_via_f64` was a **green test asserting the invalid opcode**: `assert_contains ptx "cvt.rn.f64.f32"`. It now asserts `cvt.f64.f32` and additionally asserts the `.rn` form is absent.
- The ptxas gate — whose entire purpose is catching exactly this class — covered five hand-picked kernels (`vector_add`, `int_div_rem_signed`, `int64_compare`, `fmod_intrinsic`, `binop_operand_order`) with no inverse-trig case, i.e. it was bypassed for the whole intrinsic surface. 37 of the 80 intrinsic names reached the PTX emitter in **no** test at all.

## The new gate

`sarek/tests/unit/test_ptx_intrinsic_sweep.ml` assembles **one kernel per intrinsic NAME** — 114 kernels across the 80 dispatched names, ~1.3s of ptxas, so it stays on the default `runtest` alias (no separate alias needed).

- Enumerated from the emitter's own dispatch tables, now exposed as `Sarek_ir_ptx_expr.{index,transcendental,float_ops,bitcast,convert,atomic}_intrinsic_names` — it cannot drift: a new intrinsic is either assembled automatically or fails the "every dispatched intrinsic has a sweep kernel" recipe check.
- Per-name pass/fail reporting, so a failure names the culprit intrinsic.
- Self-skips with a printed reason when `ptxas` is absent (mirrors the existing gate), so the suite stays green off-CUDA.

**Red-on-mutation** (fix reverted) names exactly the six:

```
FAIL asin_f32   ... Illegal rounding modifier for instruction 'cvt'
FAIL acos_f32   ...
FAIL atan_f32   ...
FAIL atan2_f32  ... (two illegal cvts: lines 55 and 60 — the two-arg case)
FAIL expm1_f32  ...
FAIL log1p_f32  ...
ptxas rejected 6 kernel(s) — broken intrinsic(s): acos, asin, atan, atan2, expm1, log1p
```

## Second gap: the dispatcher's unenforced invariant

`emit_intrinsic_native` tried six emitters and took the first `Some`, which is equivalent to the original single `match` **only** while no name is claimed by two emitters — and nothing checked that. Adding e.g. `"rsqrt"` to `emit_intrinsic_float_ops` (where floor/ceil/min/max live), unaware it is already in `emit_intrinsic_transcendental`, would be silently won by list order: no warning, no test failure, wrong lowering. The original `match` would at least have warned about a redundant arm.

Dispatch is now a **name → emitter table lookup** (a double claim raises an explicit internal error) plus a unit test asserting the six name sets are pairwise disjoint. The invariant did hold before this change: 80 distinct names, zero duplicates.

## Gates

- `@sarek/tests/unit/runtest` — green (includes the new sweep)
- `@sarek/tests/codegen_golden/runtest` — green; no golden file contained the old string, so **no snapshot churn**
- `@fmt` — clean on touched files (pre-existing drift in `Device.ml`, `Sarek_float32.ml`, `test_ir_layout.ml` left alone)

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected f32-to-f64 conversion in PTX output to use a valid widening instruction without an unsupported rounding modifier.
  - Improved intrinsic dispatch so duplicate intrinsic ownership is detected and reported clearly.

- **Tests**
  - Added comprehensive PTX intrinsic coverage, including assembly validation when `ptxas` is available.
  - Added checks for complete intrinsic coverage and non-overlapping dispatch categories.
  - Updated snapshots to verify the corrected conversion instruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->