### PR TITLE
fix(sarek/core): key the Runtime kernel cache by device and invalidate it on backend teardown (#86)

### DIFF
--- a/sarek-cuda/Cuda_api.ml
+++ b/sarek-cuda/Cuda_api.ml
@@ -277,11 +277,24 @@ module Device = struct
        recreated. *)
     Hashtbl.remove device_cache dev.id ;
     (* Notify layers above this backend BEFORE the local hooks unload modules:
-       they memoize values that close over the handles those hooks release. *)
-    Spoc_framework.Cache_hooks.notify_device_destroy dev.id ;
+       they memoize values that close over the handles those hooks release.
+       [notify_device_destroy] re-raises the first failing listener, and
+       [device_cache] has already been emptied, so letting it escape here would
+       leave the device unreachable with its context still alive and its modules
+       still loaded. Capture it, finish the teardown, re-raise at the end. A
+       failure in the teardown itself (cuCtxDestroy) legitimately wins over a
+       memoization-drop failure. *)
+    let listener_exn =
+      match
+        Spoc_framework.Cache_hooks.notify_device_destroy ~backend:"CUDA" dev.id
+      with
+      | () -> None
+      | exception e -> Some e
+    in
     List.iter (fun hook -> hook dev.id) !device_destroy_hooks ;
     retire_device dev.id ;
-    check "cuCtxDestroy" (cuCtxDestroy dev.context)
+    check "cuCtxDestroy" (cuCtxDestroy dev.context) ;
+    Option.iter raise listener_exn
 end
 
 (** {1 Memory Management} *)

--- a/sarek-cuda/Cuda_api.ml
+++ b/sarek-cuda/Cuda_api.ml
@@ -276,6 +276,9 @@ module Device = struct
        can't be returned by [Kernel.compile_cached] after the context is
        recreated. *)
     Hashtbl.remove device_cache dev.id ;
+    (* Notify layers above this backend BEFORE the local hooks unload modules:
+       they memoize values that close over the handles those hooks release. *)
+    Spoc_framework.Cache_hooks.notify_device_destroy dev.id ;
     List.iter (fun hook -> hook dev.id) !device_destroy_hooks ;
     retire_device dev.id ;
     check "cuCtxDestroy" (cuCtxDestroy dev.context)

--- a/sarek-hip/Hip_api.ml
+++ b/sarek-hip/Hip_api.ml
@@ -216,10 +216,21 @@ module Device = struct
        destroy under the runtime model, so there is no hipCtxDestroy analog. *)
     Hashtbl.remove device_cache dev.id ;
     (* Notify layers above this backend BEFORE the local hooks unload modules:
-       they memoize values that close over the handles those hooks release. *)
-    Spoc_framework.Cache_hooks.notify_device_destroy dev.id ;
+       they memoize values that close over the handles those hooks release.
+       [notify_device_destroy] re-raises the first failing listener; since
+       [device_cache] has already been emptied, letting it escape here would
+       leave the device unreachable with its modules still loaded. Capture it,
+       finish the teardown, re-raise at the end (mirrors the CUDA backend). *)
+    let listener_exn =
+      match
+        Spoc_framework.Cache_hooks.notify_device_destroy ~backend:"HIP" dev.id
+      with
+      | () -> None
+      | exception e -> Some e
+    in
     List.iter (fun hook -> hook dev.id) !device_destroy_hooks ;
-    retire_device dev.id
+    retire_device dev.id ;
+    Option.iter raise listener_exn
 end
 
 (** {1 Memory Management} *)

--- a/sarek-hip/Hip_api.ml
+++ b/sarek-hip/Hip_api.ml
@@ -215,6 +215,9 @@ module Device = struct
        selected, mirroring the CUDA backend. HIP has no explicit context to
        destroy under the runtime model, so there is no hipCtxDestroy analog. *)
     Hashtbl.remove device_cache dev.id ;
+    (* Notify layers above this backend BEFORE the local hooks unload modules:
+       they memoize values that close over the handles those hooks release. *)
+    Spoc_framework.Cache_hooks.notify_device_destroy dev.id ;
     List.iter (fun hook -> hook dev.id) !device_destroy_hooks ;
     retire_device dev.id
 end

--- a/sarek/core/Device.ml
+++ b/sarek/core/Device.ml
@@ -144,8 +144,26 @@ let best () =
       let opencl = by_framework "OpenCL" in
       if Array.length opencl > 0 then Some opencl.(0) else first ()
 
-(** Reset initialization state (for testing) *)
+(** Reset initialization state (for testing).
+
+    Retires the global id space, so every cache keyed on it must be dropped in
+    the same breath. [init] restarts [global_id] at 0 over whichever frameworks
+    it is handed, so the same id routinely denotes a DIFFERENT physical device
+    after a reset: with [~frameworks:["OpenCL"]] then
+    [~frameworks:["Native"; "OpenCL"]], the single Native device shifts OpenCL
+    down one and id 1 moves from the second OpenCL device to the first. A
+    surviving entry keyed on id 1 is then served to the wrong device, silently —
+    a compiled kernel carries no device check — which is exactly the aliasing
+    class this cache was keyed by device to prevent.
+
+    Only [Sarek.Runtime]'s outer memo is affected: it keys on the global
+    [Device.t.id], while every per-backend cache keys on its own backend-local
+    device index, which a reset does not perturb. So the notification here is
+    enough, and it releases nothing — the listeners drop memoization only (see
+    {!Spoc_framework.Cache_hooks}), so unlike [Kernel.clear_cache] this cannot
+    invalidate a handle a caller still holds. *)
 let reset () =
+  Spoc_framework.Cache_hooks.notify_clear_all () ;
   devices := [||] ;
   initialized := false
 

--- a/sarek/core/Kernel.ml
+++ b/sarek/core/Kernel.ml
@@ -160,12 +160,39 @@ let launch (Kernel (module K)) ~(args : args) ~(grid : Framework_sig.dims)
     the backend handles (clReleaseKernel / cuModuleUnload / ...), and any outer
     memo — notably [Runtime.kernel_cache] — holds [Kernel.t] closures over
     exactly those handles. Leaving them in place means the next lookup hits the
-    outer memo and launches through a released handle (segfault). *)
+    outer memo and launches through a released handle (segfault).
+
+    The notification is fired on BOTH sides of the backend clear, and that is
+    load-bearing rather than belt-and-braces. The pre-notification drops what is
+    already memoized; it cannot cover a build that starts after it. An outer
+    build that misses after the first notification snapshots the {e new}
+    generation, compiles a handle that [B.Kernel.clear_cache] then releases, and
+    on re-acquire finds the generation unchanged — so it installs a value over a
+    dead handle and poisons the memo for the rest of the process, which is the
+    exact failure [Guarded_cache]'s [~invalidated_by_clear] exists to prevent.
+    The post-notification bumps the generation again, so any build spanning the
+    release is rejected. The window it closes is the whole duration of the
+    backend clear.
+
+    Both notifications are also isolated from the backend clear. [Cache_hooks]
+    re-raises the first failing listener, and a listener is only dropping
+    memoization it does not own — letting that escape before
+    [B.Kernel.clear_cache] would skip the release this function exists to
+    perform and leak every backend handle. This mirrors the discipline
+    [Cache_hooks.mli] imposes on the device-destroy path: finish the teardown,
+    then re-raise. *)
 let clear_cache (device : Device.t) : unit =
-  Cache_hooks.notify_clear_all () ;
-  match Framework_registry.find_backend device.framework with
-  | None -> ()
-  | Some (module B : Framework_sig.BACKEND) -> B.Kernel.clear_cache ()
+  let listener_exn = ref None in
+  let notify () =
+    try Cache_hooks.notify_clear_all ()
+    with e -> if Option.is_none !listener_exn then listener_exn := Some e
+  in
+  notify () ;
+  Fun.protect ~finally:notify (fun () ->
+      match Framework_registry.find_backend device.framework with
+      | None -> ()
+      | Some (module B : Framework_sig.BACKEND) -> B.Kernel.clear_cache ()) ;
+  Option.iter raise !listener_exn
 
 (** {1 Accessors} *)
 

--- a/sarek/core/Kernel.ml
+++ b/sarek/core/Kernel.ml
@@ -154,8 +154,15 @@ let launch (Kernel (module K)) ~(args : args) ~(grid : Framework_sig.dims)
 
 (** {1 Cache Management} *)
 
-(** Clear all kernel caches *)
+(** Clear all kernel caches.
+
+    The layers ABOVE this one are dropped first: [B.Kernel.clear_cache] releases
+    the backend handles (clReleaseKernel / cuModuleUnload / ...), and any outer
+    memo — notably [Runtime.kernel_cache] — holds [Kernel.t] closures over
+    exactly those handles. Leaving them in place means the next lookup hits the
+    outer memo and launches through a released handle (segfault). *)
 let clear_cache (device : Device.t) : unit =
+  Cache_hooks.notify_clear_all () ;
   match Framework_registry.find_backend device.framework with
   | None -> ()
   | Some (module B : Framework_sig.BACKEND) -> B.Kernel.clear_cache ()

--- a/sarek/core/Runtime.ml
+++ b/sarek/core/Runtime.ml
@@ -44,26 +44,66 @@ let all_devices ?framework () =
   in
   Device.init ~frameworks ()
 
-(** Kernel source cache: (device_framework, kernel_name, source_hash) ->
-    compiled. Guarded against concurrent multi-domain access by
-    [Spoc_framework.Guarded_cache] (this is the cross-backend entry point most
-    multi-domain code hits). [destroy] is a no-op: the compiled [Kernel.t]
-    handles are owned by the per-backend caches reached through
-    [Kernel.compile_cached], which release them on their own [clear_cache];
-    clearing this outer layer only drops the memoization. *)
-let kernel_cache :
-    (string * string * int, Kernel.t) Spoc_framework.Guarded_cache.t =
+(** Outer kernel memo, keyed by {!Spoc_framework.Compile_cache.make_key} so this
+    layer keys exactly like the per-backend caches underneath it. Guarded
+    against concurrent multi-domain access by [Spoc_framework.Guarded_cache]
+    (this is the cross-backend entry point most multi-domain code hits).
+
+    The key MUST include device identity. [Device.t.framework] is the backend
+    {e name}, shared by every device of that backend, so keying on it alone
+    aliases all of them — and [Kernel.compile_cached] closes the specific
+    backend kernel into the [Kernel.t] it returns, so a hit would hand device B
+    a kernel built for device A and silently produce wrong results.
+
+    [destroy] is a no-op because the backend handles are owned by the
+    per-backend caches reached through [Kernel.compile_cached] — this layer
+    holds only memoization and must never release anything. That does NOT make
+    this layer safe to leave alone during teardown: those backend caches release
+    the handles these [Kernel.t] closures capture, so the layer has to be
+    dropped whenever they are (see the [Cache_hooks] registrations below). *)
+let kernel_cache : (string, Kernel.t) Spoc_framework.Guarded_cache.t =
   Spoc_framework.Guarded_cache.create ~size:32 ~destroy:(fun _ -> ()) ()
+
+(** Clear the kernel cache *)
+let clear_cache () = Spoc_framework.Guarded_cache.clear kernel_cache
+
+let () =
+  (* Participate in backend teardown. Both directions are handle-invalidating
+     for this layer, and neither is observable from here without the hook. *)
+  Spoc_framework.Cache_hooks.on_clear_all clear_cache ;
+  Spoc_framework.Cache_hooks.on_device_destroy (fun backend_device_id ->
+      (* The hook carries a BACKEND-local device index, while this cache groups
+         by the global [Device.t.id]. Several backends can use the same index,
+         and the notification does not say which fired, so evict every global id
+         that could be it. Over-eviction here only drops memoization (the
+         backend caches own the handles), so erring wide is free; erring narrow
+         would keep serving a released handle. Reading [Device.devices] directly
+         avoids triggering enumeration from inside a teardown path. *)
+      Array.iter
+        (fun (d : Device.t) ->
+          if d.backend_id = backend_device_id then
+            Spoc_framework.Guarded_cache.evict_device kernel_cache d.id)
+        !Device.devices)
 
 (** Compile a kernel from source, with caching *)
 let compile_kernel (device : Device.t) ~(name : string) ~(source : string) :
     Kernel.t =
-  let key = (device.framework, name, Hashtbl.hash source) in
-  Spoc_framework.Guarded_cache.find_or_build kernel_cache ~key (fun () ->
-      Kernel.compile_cached device ~name ~source)
-
-(** Clear the kernel cache *)
-let clear_cache () = Spoc_framework.Guarded_cache.clear kernel_cache
+  let key =
+    Spoc_framework.Compile_cache.make_key
+    (* [id] is already globally unique across backends; the framework name is
+         folded in so the key stays self-describing (and unambiguous even if a
+         caller ever hands us a hand-built [Device.t]). [make_key] digests each
+         component, so the separator cannot be spoofed. *)
+      ~device:(Printf.sprintf "%s#%d" device.Device.framework device.Device.id)
+      ~name
+      ~source
+      ()
+  in
+  Spoc_framework.Guarded_cache.find_or_build
+    kernel_cache
+    ~key
+    ~device_id:device.Device.id
+    (fun () -> Kernel.compile_cached device ~name ~source)
 
 (** Argument builder - collects kernel arguments *)
 type arg =

--- a/sarek/core/Runtime.ml
+++ b/sarek/core/Runtime.ml
@@ -60,32 +60,67 @@ let all_devices ?framework () =
     holds only memoization and must never release anything. That does NOT make
     this layer safe to leave alone during teardown: those backend caches release
     the handles these [Kernel.t] closures capture, so the layer has to be
-    dropped whenever they are (see the [Cache_hooks] registrations below). *)
+    dropped whenever they are (see the [Cache_hooks] registrations below).
+
+    For the same reason the cache is created [~invalidated_by_clear:true]: its
+    values BORROW the backend caches' handles, so a build still in flight when a
+    clear runs closes over a handle the clear releases, and installing it
+    afterwards would poison the memo for the rest of the process. *)
 let kernel_cache : (string, Kernel.t) Spoc_framework.Guarded_cache.t =
-  Spoc_framework.Guarded_cache.create ~size:32 ~destroy:(fun _ -> ()) ()
+  Spoc_framework.Guarded_cache.create
+    ~size:32
+    ~invalidated_by_clear:true
+    ~destroy:(fun _ -> ())
+    ()
 
 (** Clear the kernel cache *)
 let clear_cache () = Spoc_framework.Guarded_cache.clear kernel_cache
+
+(** Does global device [d] belong to the backend family [backend]? Backends
+    register either under the family name ("HIP") or as a "<family>/<variant>"
+    refinement of it ("CUDA/PTX", "CUDA/C"), and a single backend API module can
+    back several of those, so both spellings must match. Mirrors
+    [Device.resolve_framework]. *)
+let device_is_of_backend ~backend (d : Device.t) =
+  String.equal d.framework backend
+  || String.starts_with ~prefix:(backend ^ "/") d.framework
 
 let () =
   (* Participate in backend teardown. Both directions are handle-invalidating
      for this layer, and neither is observable from here without the hook. *)
   Spoc_framework.Cache_hooks.on_clear_all clear_cache ;
-  Spoc_framework.Cache_hooks.on_device_destroy (fun backend_device_id ->
-      (* The hook carries a BACKEND-local device index, while this cache groups
-         by the global [Device.t.id]. Several backends can use the same index,
-         and the notification does not say which fired, so evict every global id
-         that could be it. Over-eviction here only drops memoization (the
-         backend caches own the handles), so erring wide is free; erring narrow
-         would keep serving a released handle. Reading [Device.devices] directly
-         avoids triggering enumeration from inside a teardown path. *)
+  Spoc_framework.Cache_hooks.on_device_destroy (fun ~backend index ->
+      (* The hook identifies the device by (backend family, backend-local
+         index); this cache groups by the global [Device.t.id], so translate.
+         Matching on [index] alone would be wrong, not merely wide: backend
+         indices collide across backends (OpenCL 0, Vulkan 0, HIP 0 all exist),
+         and [evict_device] does not just drop memoization — it also bumps the
+         device's eviction epoch, which ABORTS in-flight builds. Tearing down a
+         HIP device must not make a concurrent OpenCL compile raise.
+
+         Reading [Device.devices] directly avoids triggering enumeration from
+         inside a teardown path. Note the consequence: a device that is not in
+         the enumerated table (a hand-built [Device.t], or an enumeration
+         restricted by [Device.init ~frameworks]) has no global id here, so
+         nothing is evicted for it. Such a device cannot have been used through
+         this cache under its global id either, but a hand-built [Device.t]
+         carrying a colliding id could — a known residual corner, tracked with
+         the wider teardown follow-up. *)
       Array.iter
         (fun (d : Device.t) ->
-          if d.backend_id = backend_device_id then
+          if d.backend_id = index && device_is_of_backend ~backend d then
             Spoc_framework.Guarded_cache.evict_device kernel_cache d.id)
         !Device.devices)
 
-(** Compile a kernel from source, with caching *)
+(** Compile a kernel from source, with caching.
+
+    @raise Spoc_framework.Guarded_cache.Device_destroyed_during_build
+      if [device] is torn down by another domain while this compile is in
+      flight. There is no valid kernel to return in that case.
+    @raise Spoc_framework.Guarded_cache.Cache_cleared_during_build
+      if another domain runs [Kernel.clear_cache] (or [clear_cache] here) while
+      this compile is in flight: the kernel would close over handles that clear
+      released. Retrying after the clear completes succeeds. *)
 let compile_kernel (device : Device.t) ~(name : string) ~(source : string) :
     Kernel.t =
   let key =
@@ -138,7 +173,11 @@ let run_kernel (kernel : Kernel.t) ~(args : Kernel.args) ~(grid : dims)
     ~shared_mem
     ()
 
-(** High-level run function: compile (if needed) and execute *)
+(** High-level run function: compile (if needed) and execute.
+
+    @raise Spoc_framework.Guarded_cache.Device_destroyed_during_build
+    @raise Spoc_framework.Guarded_cache.Cache_cleared_during_build
+      both propagated from {!compile_kernel}; see there. *)
 let run (device : Device.t) ~(name : string) ~(source : string)
     ~(args : arg list) ~(grid : dims) ~(block : dims) ?(shared_mem = 0) () :
     unit =

--- a/sarek/core/Runtime.ml
+++ b/sarek/core/Runtime.ml
@@ -45,9 +45,15 @@ let all_devices ?framework () =
   Device.init ~frameworks ()
 
 (** Outer kernel memo, keyed by {!Spoc_framework.Compile_cache.make_key} so this
-    layer keys exactly like the per-backend caches underneath it. Guarded
-    against concurrent multi-domain access by [Spoc_framework.Guarded_cache]
-    (this is the cross-backend entry point most multi-domain code hits).
+    layer uses the same key {e shape} as the per-backend caches underneath it —
+    not the same key. Their device component is the backend-local device index;
+    this layer spans backends, so its device component must be globally unique
+    and is built from the global [Device.t.id] (see {!compile_kernel}). That
+    difference is why {!Device.reset}, which retires the global id space without
+    perturbing any backend-local one, has to drop this layer and only this one.
+    Guarded against concurrent multi-domain access by
+    [Spoc_framework.Guarded_cache] (this is the cross-backend entry point most
+    multi-domain code hits).
 
     The key MUST include device identity. [Device.t.framework] is the backend
     {e name}, shared by every device of that backend, so keying on it alone

--- a/sarek/core/test/test_kernel.ml
+++ b/sarek/core/test/test_kernel.ml
@@ -213,10 +213,68 @@ let test_create_args_unknown_framework () =
   print_endline "  create_args unknown framework error: OK"
 
 let test_clear_cache_unknown_framework () =
-  (* clear_cache should not raise for unknown framework - it's a no-op *)
+  (* clear_cache must not raise for an unknown framework. It is not a no-op:
+     the Cache_hooks notifications still fire (outer memos are cross-backend, so
+     they are dropped regardless of which backend resolves) - only the backend
+     clear is skipped. *)
   let fake_device = make_fake_device () in
   Spoc_core.Kernel.clear_cache fake_device ;
-  print_endline "  clear_cache unknown framework (no-op): OK"
+  print_endline "  clear_cache unknown framework (does not raise): OK"
+
+(** {1 Cache_hooks notification contract (#86)} *)
+
+(* Counts every clear-all notification. Registered once; the counter is reset
+   immediately before each assertion below, since Cache_hooks has no unregister
+   and earlier cases in this binary also call clear_cache. *)
+let notifications = ref 0
+
+let listener_should_raise = ref false
+
+exception Listener_boom
+
+let () =
+  Spoc_framework.Cache_hooks.on_clear_all (fun () ->
+      incr notifications ;
+      if !listener_should_raise then raise Listener_boom)
+
+(* [clear_cache] must notify on BOTH sides of the backend clear. The
+   pre-notification drops what is already memoized but cannot cover a build that
+   starts after it: such a build snapshots the new generation, compiles a handle
+   that the backend clear then releases, and would install it over a dead handle.
+   Only the post-notification rejects a build that spans the release. *)
+let test_clear_cache_notifies_on_both_sides () =
+  let fake_device = make_fake_device () in
+  notifications := 0 ;
+  Spoc_core.Kernel.clear_cache fake_device ;
+  if !notifications <> 2 then
+    failwith
+      (Printf.sprintf
+         "clear_cache fired %d clear-all notification(s), expected 2 (one \
+          before the backend clear and one after it); a build spanning the \
+          handle release is only rejected by the second"
+         !notifications) ;
+  print_endline "  clear_cache notifies before and after the backend clear: OK"
+
+(* A listener only drops memoization it does not own, so letting it escape early
+   would skip the release clear_cache exists to perform. The failure must still
+   be reported, but only once the clear has completed. *)
+let test_clear_cache_isolates_a_raising_listener () =
+  let fake_device = make_fake_device () in
+  notifications := 0 ;
+  listener_should_raise := true ;
+  let raised = ref false in
+  (try Spoc_core.Kernel.clear_cache fake_device
+   with Listener_boom -> raised := true) ;
+  listener_should_raise := false ;
+  if not !raised then
+    failwith "clear_cache swallowed a failing listener instead of re-raising" ;
+  if !notifications <> 2 then
+    failwith
+      (Printf.sprintf
+         "a raising listener cut the clear short after %d notification(s); the \
+          clear must complete before the exception is re-raised"
+         !notifications) ;
+  print_endline "  clear_cache completes then re-raises a listener failure: OK"
 
 (** {1 Framework_sig.dims Tests} *)
 
@@ -252,5 +310,7 @@ let () =
   test_compile_cached_unknown_framework () ;
   test_create_args_unknown_framework () ;
   test_clear_cache_unknown_framework () ;
+  test_clear_cache_notifies_on_both_sides () ;
+  test_clear_cache_isolates_a_raising_listener () ;
   test_dims_usage () ;
   print_endline "All Kernel module tests passed!"

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1172,17 +1172,25 @@
 ; -----------------------------------------------------------------------
 ; Runtime kernel-cache regressions (#86).
 ;
-; Two separate executables on purpose: the teardown case CRASHES (SIGSEGV)
+; Three separate executables on purpose: the teardown case CRASHES (SIGSEGV)
 ; rather than failing an assertion when the outer memo is not invalidated, so
-; it must not share a binary with anything else. Both are self-verifying (exit
-; nonzero on mismatch) and skip with a printed reason - exit 0 - when the
-; devices they need are not enumerated, so they gate in the default runtest
-; alias on every machine.
+; it must not share a binary with anything else, and the reset case drives
+; Device.init/reset twice over different framework lists, which is only
+; meaningful in a process that has not enumerated devices yet. All three are
+; self-verifying (exit nonzero on mismatch) and skip with a printed reason -
+; exit 0 - when the devices they need are not enumerated, so they gate in the
+; default runtest alias on every machine.
 ; -----------------------------------------------------------------------
 
 (executables
- (names test_runtime_cache_device_key test_runtime_cache_teardown)
- (modules test_runtime_cache_device_key test_runtime_cache_teardown)
+ (names
+  test_runtime_cache_device_key
+  test_runtime_cache_teardown
+  test_runtime_cache_reset_ids)
+ (modules
+  test_runtime_cache_device_key
+  test_runtime_cache_teardown
+  test_runtime_cache_reset_ids)
  (libraries spoc_core spoc_framework test_helpers))
 
 (rule
@@ -1194,3 +1202,8 @@
  (alias runtest)
  (action
   (run %{dep:test_runtime_cache_teardown.exe})))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_runtime_cache_reset_ids.exe})))

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1168,3 +1168,29 @@
    RUSTICL_FEATURES
    fp64
    (run %{dep:test_ktype_record_f64_arith.exe}))))
+
+; -----------------------------------------------------------------------
+; Runtime kernel-cache regressions (#86).
+;
+; Two separate executables on purpose: the teardown case CRASHES (SIGSEGV)
+; rather than failing an assertion when the outer memo is not invalidated, so
+; it must not share a binary with anything else. Both are self-verifying (exit
+; nonzero on mismatch) and skip with a printed reason - exit 0 - when the
+; devices they need are not enumerated, so they gate in the default runtest
+; alias on every machine.
+; -----------------------------------------------------------------------
+
+(executables
+ (names test_runtime_cache_device_key test_runtime_cache_teardown)
+ (modules test_runtime_cache_device_key test_runtime_cache_teardown)
+ (libraries spoc_core test_helpers))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_runtime_cache_device_key.exe})))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_runtime_cache_teardown.exe})))

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1183,7 +1183,7 @@
 (executables
  (names test_runtime_cache_device_key test_runtime_cache_teardown)
  (modules test_runtime_cache_device_key test_runtime_cache_teardown)
- (libraries spoc_core test_helpers))
+ (libraries spoc_core spoc_framework test_helpers))
 
 (rule
  (alias runtest)

--- a/sarek/tests/e2e/test_runtime_cache_device_key.ml
+++ b/sarek/tests/e2e/test_runtime_cache_device_key.ml
@@ -13,11 +13,18 @@
  * A. No exception is raised: the launch targets the wrong device and the caller
  * silently reads back whatever was (not) written.
  *
- * Two checks, both of which fail without a device-keyed cache:
- *   1. structural - the kernel handed back for device 1 is bound to device 1;
- *   2. end-to-end  - a kernel that writes 7.0 into a buffer produces 7.0 on the
- *      second device, both cold (control) and after another device of the same
- *      backend has already compiled the same source (mutation).
+ * Checks:
+ *   1.  structural - the kernel handed back for device 1 is bound to device 1;
+ *   1b. scoping    - a device-destroy notification from ANOTHER backend, with a
+ *       colliding backend-local index, must not evict this backend's entry
+ *       (eviction now aborts in-flight builds, so over-eviction is no longer
+ *       free), while the owning backend's notification must;
+ *   2.  end-to-end - a kernel that writes 7.0 into a buffer produces 7.0 on the
+ *       second device, both cold (control) and after another device of the same
+ *       backend has already compiled the same source (mutation).
+ *
+ * 1 and 2 fail without a device-keyed cache; 1b fails without backend-scoped
+ * teardown notifications.
  *
  * Requires >= 2 devices of ONE backend. The probe kernel is written in OpenCL C,
  * so the gate is the OpenCL backend specifically; the test skips (exit 0) with a
@@ -123,6 +130,46 @@ let () =
       d1.id
       (Kernel.device k1).Device.id
   else Printf.printf "OK: per-device kernels kept distinct\n%!" ;
+
+  (* 1b. A device-destroy notification must be scoped to the backend that fired
+     it. Backend-local indices collide across backends (OpenCL 0, Vulkan 0,
+     HIP 0 all exist here), and Guarded_cache.evict_device does not merely drop
+     memoization — it bumps the device's eviction epoch, which ABORTS in-flight
+     builds. So a listener matching on the index alone makes tearing down a HIP
+     device raise Device_destroyed_during_build inside a concurrent, perfectly
+     healthy OpenCL compile. Checked deterministically by cache identity:
+     an unrelated backend's teardown must leave the entry cached (same physical
+     Kernel.t), the real backend's must evict it. *)
+  let k0_again = Runtime.compile_kernel d0 ~name:kernel_name ~source in
+  if not (k0_again == k0) then
+    failf
+      "device %d's entry was evicted with no teardown at all (cache is not \
+       hitting)"
+      d0.id ;
+  Spoc_framework.Cache_hooks.notify_device_destroy ~backend:"HIP" d0.backend_id ;
+  let after_foreign = Runtime.compile_kernel d0 ~name:kernel_name ~source in
+  if not (after_foreign == k0) then
+    failf
+      "a HIP device-%d teardown evicted the OpenCL device-%d entry (hook \
+       matches on the backend-local index alone)"
+      d0.backend_id
+      d0.id
+  else
+    Printf.printf
+      "OK: a foreign backend's device-%d teardown left the OpenCL entry \
+       untouched\n\
+       %!"
+      d0.backend_id ;
+  Spoc_framework.Cache_hooks.notify_device_destroy
+    ~backend:d0.framework
+    d0.backend_id ;
+  let after_own = Runtime.compile_kernel d0 ~name:kernel_name ~source in
+  if after_own == k0 then
+    failf
+      "the OpenCL device-%d teardown did NOT evict its own entry (listener is \
+       a no-op)"
+      d0.backend_id
+  else Printf.printf "OK: the owning backend's teardown did evict the entry\n%!" ;
 
   (* 2a. Control: cold cache, only the second device is ever touched. *)
   Runtime.clear_cache () ;

--- a/sarek/tests/e2e/test_runtime_cache_device_key.ml
+++ b/sarek/tests/e2e/test_runtime_cache_device_key.ml
@@ -1,0 +1,148 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression: Runtime's outer kernel memo must be keyed by DEVICE identity.
+ *
+ * [Device.t.framework] is the BACKEND NAME, shared by every device of that
+ * backend, so a key built from (framework, name, source) aliases all of them.
+ * [Kernel.compile_cached] closes the specific backend kernel into the [Kernel.t]
+ * it returns, so a hit on that key hands device B a kernel compiled for device
+ * A. No exception is raised: the launch targets the wrong device and the caller
+ * silently reads back whatever was (not) written.
+ *
+ * Two checks, both of which fail without a device-keyed cache:
+ *   1. structural - the kernel handed back for device 1 is bound to device 1;
+ *   2. end-to-end  - a kernel that writes 7.0 into a buffer produces 7.0 on the
+ *      second device, both cold (control) and after another device of the same
+ *      backend has already compiled the same source (mutation).
+ *
+ * Requires >= 2 devices of ONE backend. The probe kernel is written in OpenCL C,
+ * so the gate is the OpenCL backend specifically; the test skips (exit 0) with a
+ * printed reason when fewer than two OpenCL devices are enumerated. A CUDA/HIP
+ * variant only needs the corresponding source spelling added here.
+ ******************************************************************************)
+
+open Spoc_core
+
+let source =
+  "__kernel void cache_key_probe(__global float* a) { a[get_global_id(0)] = \
+   7.0f; }"
+
+let kernel_name = "cache_key_probe"
+
+let n = 16
+
+let failures = ref 0
+
+let failf fmt =
+  Printf.ksprintf
+    (fun s ->
+      incr failures ;
+      Printf.printf "FAIL: %s\n%!" s)
+    fmt
+
+(* Launch the probe on [d] and read the buffer back. Returns every element, so a
+   partial write is visible rather than being masked by checking only [0]. *)
+let run_and_read (d : Device.t) =
+  let buf = Runtime.alloc_float32 d n in
+  let host = Bigarray.Array1.create Bigarray.float32 Bigarray.c_layout n in
+  Bigarray.Array1.fill host 0.0 ;
+  Memory.host_to_device ~src:host ~dst:buf ;
+  Runtime.run
+    d
+    ~name:kernel_name
+    ~source
+    ~args:[Runtime.ArgBuffer buf]
+    ~grid:(Runtime.dims1d n)
+    ~block:(Runtime.dims1d 1)
+    () ;
+  Device.synchronize d ;
+  Memory.device_to_host ~src:buf ~dst:host ;
+  host
+
+let check_all_sevens label (host : (float, _, _) Bigarray.Array1.t) =
+  let bad = ref 0 in
+  for i = 0 to n - 1 do
+    if host.{i} <> 7.0 then incr bad
+  done ;
+  if !bad > 0 then
+    failf
+      "%s: %d/%d elements were not written by the kernel (got %g %g %g %g ...) \
+       - the launch went to the wrong device"
+      label
+      !bad
+      n
+      host.{0}
+      host.{1}
+      host.{2}
+      host.{3}
+  else Printf.printf "OK: %s -> all %d elements = 7\n%!" label n
+
+let () =
+  Test_helpers.Benchmarks.init_backends () ;
+  let devs = Device.init () in
+  let opencl =
+    Array.of_list
+      (List.filter
+         (fun (d : Device.t) -> d.framework = "OpenCL")
+         (Array.to_list devs))
+  in
+  if Array.length opencl < 2 then begin
+    Printf.printf
+      "SKIP: needs >= 2 devices of one backend to detect cross-device cache \
+       aliasing; found %d OpenCL device(s) (the probe kernel is OpenCL C)\n\
+       %!"
+      (Array.length opencl) ;
+    exit 0
+  end ;
+  let d0 = opencl.(0) and d1 = opencl.(1) in
+  Printf.printf
+    "using OpenCL devices [%d] %s and [%d] %s (same framework %S)\n%!"
+    d0.id
+    d0.name
+    d1.id
+    d1.name
+    d0.framework ;
+
+  (* 1. Structural: compile for d0 first, then d1. Without a device-keyed cache
+     the second call is a cache hit and returns d0's kernel. *)
+  let k0 = Runtime.compile_kernel d0 ~name:kernel_name ~source in
+  let k1 = Runtime.compile_kernel d1 ~name:kernel_name ~source in
+  if (Kernel.device k0).Device.id <> d0.id then
+    failf
+      "requested device %d, got a kernel bound to device %d"
+      d0.id
+      (Kernel.device k0).Device.id ;
+  if (Kernel.device k1).Device.id <> d1.id then
+    failf
+      "requested device %d, got a kernel bound to device %d (outer cache key \
+       omits device identity)"
+      d1.id
+      (Kernel.device k1).Device.id
+  else Printf.printf "OK: per-device kernels kept distinct\n%!" ;
+
+  (* 2a. Control: cold cache, only the second device is ever touched. *)
+  Runtime.clear_cache () ;
+  check_all_sevens
+    (Printf.sprintf "control (cold cache, device %d only)" d1.id)
+    (run_and_read d1) ;
+
+  (* 2b. Mutation: same run, but another device of the same backend compiles the
+     same source first. Identical device, identical kernel - only the cache
+     state differs, so any difference from 2a is the aliasing bug. *)
+  Runtime.clear_cache () ;
+  ignore (run_and_read d0) ;
+  check_all_sevens
+    (Printf.sprintf
+       "after device %d warmed the cache with the same source"
+       d0.id)
+    (run_and_read d1) ;
+
+  if !failures > 0 then begin
+    Printf.printf "%d check(s) failed\n%!" !failures ;
+    exit 1
+  end ;
+  print_endline "test_runtime_cache_device_key: PASSED"

--- a/sarek/tests/e2e/test_runtime_cache_reset_ids.ml
+++ b/sarek/tests/e2e/test_runtime_cache_reset_ids.ml
@@ -1,0 +1,165 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression: Runtime's outer kernel memo must not survive [Device.reset].
+ *
+ * Keying that memo by device id fixes cross-device aliasing only while a given
+ * id keeps denoting a given device. It does not: [Device.init] restarts
+ * [global_id] at 0 over whichever frameworks it is handed, so a reset followed
+ * by an init with a different framework list reassigns the ids. A framework
+ * enumerated BEFORE OpenCL shifts every OpenCL device down by its own device
+ * count, and an id that named one OpenCL device now names another.
+ *
+ * The memo key is "<framework>#<id>", so the framework component does not save
+ * this case - both spellings are "OpenCL". A surviving entry is served to a
+ * physically different GPU with no exception raised: the launch targets the
+ * device the cached kernel was built for and the buffer the caller passed is
+ * simply never written. That is the same silent-wrong-results class the
+ * device-keying fix exists to close, reached through [Device.reset] instead of
+ * through two live devices.
+ *
+ * Only this outer layer is exposed: every per-backend cache keys on its own
+ * backend-local device index (e.g. Opencl_plugin_base keys on
+ * [device.Opencl_api.Device.id]), which a reset does not perturb. So the fix is
+ * a single [Cache_hooks.notify_clear_all] in [Device.reset], and this test goes
+ * red when that call is removed.
+ *
+ * Requires >= 2 OpenCL devices plus at least one other backend that enumerates
+ * fewer devices than OpenCL does before it, so that some id actually changes
+ * meaning. Skips with a printed reason (exit 0) otherwise - and, importantly,
+ * skips only after checking that no id changed meaning, so it cannot pass by
+ * silently failing to set up the hazard.
+ ******************************************************************************)
+
+open Spoc_core
+
+let source =
+  "__kernel void reset_probe(__global float* a) { a[get_global_id(0)] = 7.0f; }"
+
+let kernel_name = "reset_probe"
+
+let n = 16
+
+(* Launch the probe on [d] and return how many elements it failed to write. A
+   kernel served from a stale entry runs on the device it was built for, so the
+   buffer here stays at its initial 0. *)
+let run_and_count_unwritten (d : Device.t) =
+  let buf = Runtime.alloc_float32 d n in
+  let host = Bigarray.Array1.create Bigarray.float32 Bigarray.c_layout n in
+  Bigarray.Array1.fill host 0.0 ;
+  Memory.host_to_device ~src:host ~dst:buf ;
+  Runtime.run
+    d
+    ~name:kernel_name
+    ~source
+    ~args:[Runtime.ArgBuffer buf]
+    ~grid:(Runtime.dims1d n)
+    ~block:(Runtime.dims1d 1)
+    () ;
+  Device.synchronize d ;
+  Memory.device_to_host ~src:buf ~dst:host ;
+  let bad = ref 0 in
+  for i = 0 to n - 1 do
+    if host.{i} <> 7.0 then incr bad
+  done ;
+  !bad
+
+let snapshot () =
+  Array.map (fun (d : Device.t) -> (d.id, d.framework, d.name)) !Device.devices
+
+let () =
+  Test_helpers.Benchmarks.init_backends () ;
+
+  (* Init A: OpenCL alone, so its devices occupy ids 0..k-1. *)
+  ignore (Device.init ~frameworks:["OpenCL"] ()) ;
+  let before = snapshot () in
+  let opencl_count = Array.length before in
+  if opencl_count < 2 then begin
+    Printf.printf
+      "SKIP: needs >= 2 OpenCL devices for a reset to be able to move an id \
+       between two of them; found %d (the probe kernel is OpenCL C)\n\
+       %!"
+      opencl_count ;
+    exit 0
+  end ;
+
+  (* Warm the outer memo for every OpenCL id under init A's numbering. *)
+  Array.iter
+    (fun (d : Device.t) ->
+      let bad = run_and_count_unwritten d in
+      if bad > 0 then begin
+        Printf.printf
+          "FAIL: baseline run on init-A id %d (%s) left %d/%d elements \
+           unwritten; the test cannot distinguish a stale hit from a broken \
+           device\n\
+           %!"
+          d.id
+          d.name
+          bad
+          n ;
+        exit 1
+      end)
+    !Device.devices ;
+  Printf.printf
+    "init A: warmed the memo for %d OpenCL device(s)\n%!"
+    opencl_count ;
+
+  (* Init B: put another backend in front so the OpenCL ids shift. *)
+  Device.reset () ;
+  ignore (Device.init ~frameworks:["Native"; "OpenCL"] ()) ;
+  let after = snapshot () in
+
+  (* Find an id that changed meaning: same id, same framework, different
+     physical device. That is the collision the memo key cannot see. *)
+  let collision =
+    Array.to_list after
+    |> List.find_opt (fun (id, fw, name) ->
+        fw = "OpenCL"
+        && Array.exists
+             (fun (id', fw', name') -> id' = id && fw' = fw && name' <> name)
+             before)
+  in
+  match collision with
+  | None ->
+      Printf.printf
+        "SKIP: no OpenCL id changed meaning across the reset on this machine, \
+         so the hazard is not reachable here (init A ids: %s / init B ids: %s)\n\
+         %!"
+        (String.concat
+           " "
+           (List.map
+              (fun (id, _, _) -> string_of_int id)
+              (Array.to_list before)))
+        (String.concat
+           " "
+           (List.map
+              (fun (id, fw, _) -> Printf.sprintf "%d:%s" id fw)
+              (Array.to_list after))) ;
+      exit 0
+  | Some (id, _, name) ->
+      Printf.printf
+        "id %d denoted a different OpenCL device before the reset; it now \
+         denotes %s\n\
+         %!"
+        id
+        name ;
+      let d =
+        Option.get
+          (Array.find_opt (fun (dev : Device.t) -> dev.id = id) !Device.devices)
+      in
+      let bad = run_and_count_unwritten d in
+      if bad > 0 then begin
+        Printf.printf
+          "FAIL: %d/%d elements were not written - the outer memo served id \
+           %d's pre-reset entry, which is bound to a different physical device\n\
+           %!"
+          bad
+          n
+          id ;
+        exit 1
+      end ;
+      Printf.printf "OK: all %d elements = 7 after the reset\n%!" n ;
+      print_endline "test_runtime_cache_reset_ids: PASSED"

--- a/sarek/tests/e2e/test_runtime_cache_teardown.ml
+++ b/sarek/tests/e2e/test_runtime_cache_teardown.ml
@@ -1,0 +1,97 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression: Runtime's outer kernel memo must be invalidated by backend
+ * teardown.
+ *
+ * [Kernel.clear_cache device] reaches the backend's own guarded cache, whose
+ * [destroy] RELEASES the handles ([clReleaseKernel] / [clReleaseProgram],
+ * [cuModuleUnload], ...). [Runtime.kernel_cache] sits above it and holds
+ * [Kernel.t] closures over exactly those handles. If it is not dropped too, the
+ * next [Runtime.run] hits the outer memo and launches through a released
+ * driver object.
+ *
+ * Without the fix this test does not fail an assertion - it SIGSEGVs (observed
+ * rc=139). That is why it is its own executable: the crash is reported by dune
+ * as a nonzero exit of this one test instead of taking a shared test binary
+ * (and every other case in it) down.
+ *
+ * Requires the OpenCL backend (the probe kernel is OpenCL C) and at least one
+ * OpenCL device; skips with a printed reason otherwise. Native/Interpreter are
+ * deliberately not accepted: they hold no releasable driver handle, so the test
+ * would pass vacuously.
+ ******************************************************************************)
+
+open Spoc_core
+
+let source =
+  "__kernel void teardown_probe(__global float* a) { a[get_global_id(0)] = \
+   7.0f; }"
+
+let kernel_name = "teardown_probe"
+
+let n = 16
+
+let run_and_read (d : Device.t) label =
+  Printf.printf "  [%s] launching\n%!" label ;
+  let buf = Runtime.alloc_float32 d n in
+  let host = Bigarray.Array1.create Bigarray.float32 Bigarray.c_layout n in
+  Bigarray.Array1.fill host 0.0 ;
+  Memory.host_to_device ~src:host ~dst:buf ;
+  Runtime.run
+    d
+    ~name:kernel_name
+    ~source
+    ~args:[Runtime.ArgBuffer buf]
+    ~grid:(Runtime.dims1d n)
+    ~block:(Runtime.dims1d 1)
+    () ;
+  Device.synchronize d ;
+  Memory.device_to_host ~src:buf ~dst:host ;
+  Printf.printf "  [%s] readback[0] = %g\n%!" label host.{0} ;
+  host.{0}
+
+let () =
+  Test_helpers.Benchmarks.init_backends () ;
+  let devs = Device.init () in
+  match Array.find_opt (fun (d : Device.t) -> d.framework = "OpenCL") devs with
+  | None ->
+      Printf.printf
+        "SKIP: needs an OpenCL device (the probe kernel is OpenCL C and the \
+         hazard is a released driver handle, which CPU backends do not have)\n\
+         %!" ;
+      exit 0
+  | Some d ->
+      Printf.printf "using OpenCL device [%d] %s\n%!" d.id d.name ;
+      let before = run_and_read d "before clear_cache" in
+      if before <> 7.0 then begin
+        Printf.printf "FAIL: baseline launch produced %g, expected 7\n%!" before ;
+        exit 1
+      end ;
+      (* Releases the backend handles the outer memo closed over. *)
+      Printf.printf "calling Kernel.clear_cache\n%!" ;
+      Kernel.clear_cache d ;
+      Printf.printf "clear_cache returned\n%!" ;
+      (* Must recompile, not serve the stale closure. SIGSEGV here before the
+         fix. *)
+      let after = run_and_read d "after clear_cache" in
+      if after <> 7.0 then begin
+        Printf.printf
+          "FAIL: post-clear launch produced %g, expected 7\n%!"
+          after ;
+        exit 1
+      end ;
+      (* And a second clear/run cycle, to confirm the invalidation is not a
+         one-shot. *)
+      Kernel.clear_cache d ;
+      let again = run_and_read d "after a second clear_cache" in
+      if again <> 7.0 then begin
+        Printf.printf
+          "FAIL: second post-clear launch produced %g, expected 7\n%!"
+          again ;
+        exit 1
+      end ;
+      print_endline "test_runtime_cache_teardown: PASSED"

--- a/spoc/framework/Cache_hooks.ml
+++ b/spoc/framework/Cache_hooks.ml
@@ -1,0 +1,45 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Cache_hooks - cross-layer cache-teardown notifications.
+ *
+ * See Cache_hooks.mli for the rationale. The registries are plain lists behind
+ * a Mutex; notification snapshots the list under the lock and runs the
+ * callbacks outside it, so a callback may itself register or touch a cache.
+ ******************************************************************************)
+
+let mutex = Mutex.create ()
+
+let device_destroy_hooks : (int -> unit) list ref = ref []
+
+let clear_all_hooks : (unit -> unit) list ref = ref []
+
+let on_device_destroy f =
+  Mutex.protect mutex (fun () ->
+      device_destroy_hooks := f :: !device_destroy_hooks)
+
+let on_clear_all f =
+  Mutex.protect mutex (fun () -> clear_all_hooks := f :: !clear_all_hooks)
+
+(* Every hook runs even if an earlier one raises: hooks are independent cache
+   layers, and skipping the rest would leave some of them holding handles the
+   caller is about to release. The first exception is re-raised once all hooks
+   have run, so a failure is still reported rather than swallowed. *)
+let run_all hooks =
+  let first_exn = ref None in
+  List.iter
+    (fun h ->
+      try h () with e -> if Option.is_none !first_exn then first_exn := Some e)
+    hooks ;
+  match !first_exn with None -> () | Some e -> raise e
+
+let notify_device_destroy device_id =
+  let hooks = Mutex.protect mutex (fun () -> !device_destroy_hooks) in
+  run_all (List.map (fun h () -> h device_id) hooks)
+
+let notify_clear_all () =
+  let hooks = Mutex.protect mutex (fun () -> !clear_all_hooks) in
+  run_all hooks

--- a/spoc/framework/Cache_hooks.ml
+++ b/spoc/framework/Cache_hooks.ml
@@ -13,7 +13,7 @@
 
 let mutex = Mutex.create ()
 
-let device_destroy_hooks : (int -> unit) list ref = ref []
+let device_destroy_hooks : (backend:string -> int -> unit) list ref = ref []
 
 let clear_all_hooks : (unit -> unit) list ref = ref []
 
@@ -36,9 +36,9 @@ let run_all hooks =
     hooks ;
   match !first_exn with None -> () | Some e -> raise e
 
-let notify_device_destroy device_id =
+let notify_device_destroy ~backend device_id =
   let hooks = Mutex.protect mutex (fun () -> !device_destroy_hooks) in
-  run_all (List.map (fun h () -> h device_id) hooks)
+  run_all (List.map (fun h () -> h ~backend device_id) hooks)
 
 let notify_clear_all () =
   let hooks = Mutex.protect mutex (fun () -> !clear_all_hooks) in

--- a/spoc/framework/Cache_hooks.mli
+++ b/spoc/framework/Cache_hooks.mli
@@ -23,19 +23,36 @@
     release backend resources, since they do not own any. Registration and
     notification are safe from any domain: the registry is mutex-guarded and
     callbacks run outside the lock. If a callback raises, the remaining
-    callbacks still run and the first exception is re-raised afterwards. *)
+    callbacks still run and the first exception is re-raised afterwards.
 
-(** [on_device_destroy f] registers [f] to be called with a {e backend-local}
-    device id whenever that device is being torn down. Note the id is the
-    backend's own device index, not a global [Device.id]: a listener that keys
-    by a different id space must widen (never narrow) its invalidation
-    accordingly. *)
-val on_device_destroy : (int -> unit) -> unit
+    {2 Notifying from a teardown path}
 
-(** [notify_device_destroy backend_device_id] runs every callback registered
-    with {!on_device_destroy}. Called by a backend from its device-destroy path,
-    before it releases anything. *)
-val notify_device_destroy : int -> unit
+    Because the first callback failure is re-raised, [notify_*] can throw out of
+    the middle of a device-destroy sequence, where escaping early would skip the
+    release of the very resources the teardown exists to free. A backend calling
+    these from [Device.destroy] must therefore
+    {b complete its teardown first and re-raise afterwards} — capture the
+    exception, unload modules, retire streams, destroy the context, then let it
+    out. The CUDA and HIP backends do exactly this; copy that shape in any new
+    backend. *)
+
+(** [on_device_destroy f] registers [f], called as [f ~backend index] whenever a
+    device is being torn down.
+
+    [backend] is the backend {e family} name as used by [Device.init] /
+    [Device.resolve_framework] (["CUDA"], ["HIP"], ...); a device's
+    [Device.t.framework] either equals it or is a ["<family>/<variant>"]
+    refinement of it (["CUDA/PTX"]), and a listener must treat both as matching.
+    [index] is the backend's own device index, {e not} a global [Device.id]: the
+    pair ([backend], [index]) is what identifies the device across id spaces.
+    Matching on [index] alone aliases unrelated backends' devices. *)
+val on_device_destroy : (backend:string -> int -> unit) -> unit
+
+(** [notify_device_destroy ~backend index] runs every callback registered with
+    {!on_device_destroy}. Called by a backend from its device-destroy path,
+    before it releases anything — see "Notifying from a teardown path" above for
+    the obligation that comes with the re-raise. *)
+val notify_device_destroy : backend:string -> int -> unit
 
 (** [on_clear_all f] registers [f] to be called whenever a backend's whole
     kernel cache is cleared. *)

--- a/spoc/framework/Cache_hooks.mli
+++ b/spoc/framework/Cache_hooks.mli
@@ -25,6 +25,29 @@
     callbacks run outside the lock. If a callback raises, the remaining
     callbacks still run and the first exception is re-raised afterwards.
 
+    {2 What actually notifies today — this back-channel is not yet universal}
+
+    Registering a listener does {b not} mean every handle release will reach it.
+    The current coverage is exactly:
+
+    - {!notify_clear_all} is fired by [Sarek.Kernel.clear_cache] (on both sides
+      of the backend clear) and by [Sarek.Device.reset]. Those are the only
+      notifying entry points. A caller that resolves a backend through
+      [Framework_registry.find_backend] and calls [B.Kernel.clear_cache ()]
+      {e directly} releases the handles without notifying anything, and an outer
+      memo will then serve a released handle — the same failure this module
+      exists to prevent, through a sibling entry point. Go through
+      [Sarek.Kernel.clear_cache].
+    - {!notify_device_destroy} is fired by the CUDA and HIP backends only.
+      Vulkan has a device-destroy path ([Vulkan_api_device.destroy]) and does
+      {e not} fire it; its kernel cache also passes no [~device_id] to
+      {!Guarded_cache.find_or_build}, so per-device eviction is not expressible
+      there at either layer. OpenCL and Metal expose no device-destroy entry
+      point at all, so there is nothing for them to notify from.
+
+    Treat this list as the contract, not as an implementation detail: a listener
+    that assumes total coverage is wrong today.
+
     {2 Notifying from a teardown path}
 
     Because the first callback failure is re-raised, [notify_*] can throw out of

--- a/spoc/framework/Cache_hooks.mli
+++ b/spoc/framework/Cache_hooks.mli
@@ -1,0 +1,46 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Cross-layer cache-teardown notifications.
+
+    Compiled kernels are memoized at {e two} levels: each backend keeps its own
+    {!Guarded_cache} of resolved backend handles, and [Sarek.Runtime] keeps an
+    outer memo of [Kernel.t] closures {e over} those handles. Only the backend
+    layer owns the handles, so only it releases them — but a release performed
+    there invalidates every outer layer that closed over the handle, and the
+    outer layers sit in libraries the backend cannot reference (they are loaded
+    the other way round). This module is the missing back-channel: a layer above
+    the backends registers an invalidation callback here, and the backends fire
+    it when they are about to release handles.
+
+    Without it, an outer memo keeps serving [Kernel.t] values whose backend
+    handle has already been [clReleaseKernel]d / [cuModuleUnload]ed, and the
+    next launch dereferences freed driver memory.
+
+    Callbacks registered here must only {e drop memoization} — they must not
+    release backend resources, since they do not own any. Registration and
+    notification are safe from any domain: the registry is mutex-guarded and
+    callbacks run outside the lock. If a callback raises, the remaining
+    callbacks still run and the first exception is re-raised afterwards. *)
+
+(** [on_device_destroy f] registers [f] to be called with a {e backend-local}
+    device id whenever that device is being torn down. Note the id is the
+    backend's own device index, not a global [Device.id]: a listener that keys
+    by a different id space must widen (never narrow) its invalidation
+    accordingly. *)
+val on_device_destroy : (int -> unit) -> unit
+
+(** [notify_device_destroy backend_device_id] runs every callback registered
+    with {!on_device_destroy}. Called by a backend from its device-destroy path,
+    before it releases anything. *)
+val notify_device_destroy : int -> unit
+
+(** [on_clear_all f] registers [f] to be called whenever a backend's whole
+    kernel cache is cleared. *)
+val on_clear_all : (unit -> unit) -> unit
+
+(** [notify_clear_all ()] runs every callback registered with {!on_clear_all}.
+    Called before a backend clears its own cache. *)
+val notify_clear_all : unit -> unit

--- a/spoc/framework/Guarded_cache.ml
+++ b/spoc/framework/Guarded_cache.ml
@@ -6,25 +6,51 @@
 (******************************************************************************
  * Guarded_cache - concurrency-safe kernel-compilation cache.
  *
- * See Guarded_cache.mli for the rationale. One Mutex guards both the main
- * key -> value table and the device-id -> keys index. The expensive JIT
- * compile runs outside the lock (check under lock -> miss -> release lock ->
- * build -> re-acquire -> double-check -> insert), so multiple domains never
- * serialize on compilation, only on the (cheap) table operations.
+ * See Guarded_cache.mli for the rationale. One Mutex guards the main
+ * key -> value table, the device-id -> keys index and the per-device eviction
+ * epochs. The expensive JIT compile runs outside the lock (check under lock ->
+ * miss -> release lock -> build -> re-acquire -> double-check -> insert), so
+ * multiple domains never serialize on compilation, only on the (cheap) table
+ * operations. Every critical section here uses Mutex.protect: both are
+ * straight-line, and an exception escaping a raw lock/unlock pair (a Hashtbl
+ * resize under Out_of_memory, Stack_overflow) would leave the mutex held and
+ * deadlock every later cache operation on every domain.
+ *
+ * This module guards the TABLE, not the VALUES it hands out - see the
+ * "Value lifetime" section of the .mli for the caller's obligation.
  ******************************************************************************)
 
 type ('k, 'v) t = {
   mutex : Mutex.t;
   table : ('k, 'v) Hashtbl.t;
   keys_by_device : (int, 'k list ref) Hashtbl.t;
+  (* Per-device eviction epoch, bumped by [evict_device]. A device teardown
+     landing inside [find_or_build]'s unlocked build window is invisible to
+     [evict_device] (the entry is not in [table] yet), so the epoch is read at
+     miss time and re-checked on re-acquire: a change means the value was built
+     for a device that no longer exists and must not be installed. *)
+  epochs : (int, int) Hashtbl.t;
   destroy : 'v -> unit;
 }
+
+exception Device_destroyed_during_build of int
+
+let () =
+  Printexc.register_printer (function
+    | Device_destroyed_during_build id ->
+        Some
+          (Printf.sprintf
+             "Guarded_cache: device %d was destroyed while its kernel was \
+              being compiled"
+             id)
+    | _ -> None)
 
 let create ?(size = 16) ~destroy () =
   {
     mutex = Mutex.create ();
     table = Hashtbl.create size;
     keys_by_device = Hashtbl.create 16;
+    epochs = Hashtbl.create 16;
     destroy;
   }
 
@@ -34,37 +60,85 @@ let record_key_for_device t device_id key =
   | Some keys -> keys := key :: !keys
   | None -> Hashtbl.add t.keys_by_device device_id (ref [key])
 
+(* Caller must hold [t.mutex]. *)
+let epoch_of t device_id =
+  Option.value ~default:0 (Hashtbl.find_opt t.epochs device_id)
+
+(* Destroy every victim even if some of them raise. The victims have already
+   been unlinked from the table, so abandoning the tail on the first failure
+   leaks it outright — the caller has no handle left to retry with. The first
+   exception is re-raised once every victim has been attempted, so a failing
+   release is still reported. *)
+let destroy_all t victims =
+  let first_exn = ref None in
+  List.iter
+    (fun v ->
+      try t.destroy v
+      with e -> if Option.is_none !first_exn then first_exn := Some e)
+    victims ;
+  match !first_exn with None -> () | Some e -> raise e
+
+(* Destroy a value we are about to discard, on a path where a failing release
+   must not become the caller's result. Used for the lost-race loser: a valid
+   [winner] exists and turning its return into an intermittent,
+   multi-domain-only compile failure would be strictly worse than dropping the
+   release error. *)
+let destroy_discarded t v = try t.destroy v with _ -> ()
+
 let find_or_build t ~key ?device_id build =
-  (* Fast path: hit under the lock. *)
-  Mutex.lock t.mutex ;
-  match Hashtbl.find_opt t.table key with
-  | Some v ->
-      Mutex.unlock t.mutex ;
-      v
-  | None -> (
-      (* Miss: release the lock so the JIT compile does not serialize other
-         domains, then re-acquire to install the result. *)
-      Mutex.unlock t.mutex ;
+  (* Fast path: hit under the lock. On a miss, snapshot the target device's
+     eviction epoch so the post-build re-check can detect a teardown that
+     happened while the lock was released. *)
+  let hit_or_epoch =
+    Mutex.protect t.mutex (fun () ->
+        match Hashtbl.find_opt t.table key with
+        | Some v -> Either.Left v
+        | None ->
+            Either.Right (Option.map (fun id -> (id, epoch_of t id)) device_id))
+  in
+  match hit_or_epoch with
+  | Either.Left v -> v
+  | Either.Right at_miss -> (
+      (* Miss: the JIT compile runs with the lock released so it does not
+         serialize other domains. *)
       let built = build () in
-      Mutex.lock t.mutex ;
-      match Hashtbl.find_opt t.table key with
-      | Some winner ->
-          (* Lost a concurrent compile of the same key: keep the value already
-             installed and discard ours. Destroy the loser outside the lock so
-             no backend resource leaks. *)
-          Mutex.unlock t.mutex ;
-          t.destroy built ;
+      let outcome =
+        Mutex.protect t.mutex (fun () ->
+            match Hashtbl.find_opt t.table key with
+            | Some winner -> `Lost winner
+            | None -> (
+                match at_miss with
+                | Some (id, epoch) when epoch_of t id <> epoch ->
+                    (* [id] was destroyed (or fully evicted) during the build:
+                       installing now would record the value against a dead
+                       device id, so nothing would ever unload it and a later
+                       lookup — possibly after the id is recreated — would be
+                       served a value from the old context. *)
+                    `Stale id
+                | _ ->
+                    Hashtbl.replace t.table key built ;
+                    Option.iter
+                      (fun id -> record_key_for_device t id key)
+                      device_id ;
+                    `Installed))
+      in
+      (* [destroy] always runs outside the lock. *)
+      match outcome with
+      | `Installed -> built
+      | `Lost winner ->
+          destroy_discarded t built ;
           winner
-      | None ->
-          Hashtbl.replace t.table key built ;
-          Option.iter (fun id -> record_key_for_device t id key) device_id ;
-          Mutex.unlock t.mutex ;
-          built)
+      | `Stale id ->
+          destroy_discarded t built ;
+          raise (Device_destroyed_during_build id))
 
 let evict_device t device_id =
-  (* Snapshot + unlink under the lock; destroy released outside it. *)
+  (* Snapshot + unlink under the lock; destroy released outside it. The epoch
+     bump happens under the same lock, so a build that is in flight for this
+     device observes it on re-acquire and discards its result. *)
   let victims =
     Mutex.protect t.mutex (fun () ->
+        Hashtbl.replace t.epochs device_id (epoch_of t device_id + 1) ;
         match Hashtbl.find_opt t.keys_by_device device_id with
         | None -> []
         | Some keys ->
@@ -81,9 +155,13 @@ let evict_device t device_id =
             Hashtbl.remove t.keys_by_device device_id ;
             vs)
   in
-  List.iter t.destroy victims
+  destroy_all t victims
 
 let clear t =
+  (* [epochs] is deliberately NOT reset: the counters are the only record that
+     an in-flight build's device was retired, and clearing them could lose a
+     bump. [clear] itself does not invalidate an in-flight build — the device is
+     still alive, so the value being built is still valid and may be installed. *)
   let victims =
     Mutex.protect t.mutex (fun () ->
         let vs = Hashtbl.fold (fun _ v acc -> v :: acc) t.table [] in
@@ -91,6 +169,6 @@ let clear t =
         Hashtbl.clear t.keys_by_device ;
         vs)
   in
-  List.iter t.destroy victims
+  destroy_all t victims
 
 let length t = Mutex.protect t.mutex (fun () -> Hashtbl.length t.table)

--- a/spoc/framework/Guarded_cache.ml
+++ b/spoc/framework/Guarded_cache.ml
@@ -30,10 +30,29 @@ type ('k, 'v) t = {
      miss time and re-checked on re-acquire: a change means the value was built
      for a device that no longer exists and must not be installed. *)
   epochs : (int, int) Hashtbl.t;
+  (* Cache-wide generation, bumped by [clear]. Same window as [epochs], but for
+     the whole cache rather than one device. Only consulted when
+     [invalidated_by_clear] is set - see below. *)
+  mutable generation : int;
+  (* Does [clear] invalidate a build that is already in flight?
+     - OWNING caches (every backend's): NO. [clear] releases the handles this
+       cache owns; it does not touch the DEVICE, so a value built during the
+       window is still perfectly valid and installing it is correct.
+     - BORROWING caches (Runtime's outer memo, whose values are closures over
+       another cache's handles): YES. For them [clear] is the announcement that
+       the borrowed handles are about to be released, so a value built during
+       the window closes over a handle that is dead by the time it is installed,
+       and it would then be served for the rest of the process - surviving the
+       very teardown the clear was performing.
+     The distinction is per-cache, not global, which is why it is a create-time
+     flag rather than a blanket rule. *)
+  invalidated_by_clear : bool;
   destroy : 'v -> unit;
 }
 
 exception Device_destroyed_during_build of int
+
+exception Cache_cleared_during_build
 
 let () =
   Printexc.register_printer (function
@@ -43,14 +62,20 @@ let () =
              "Guarded_cache: device %d was destroyed while its kernel was \
               being compiled"
              id)
+    | Cache_cleared_during_build ->
+        Some
+          "Guarded_cache: the cache was cleared while this kernel was being \
+           compiled, and its value borrows handles that the clear released"
     | _ -> None)
 
-let create ?(size = 16) ~destroy () =
+let create ?(size = 16) ?(invalidated_by_clear = false) ~destroy () =
   {
     mutex = Mutex.create ();
     table = Hashtbl.create size;
     keys_by_device = Hashtbl.create 16;
     epochs = Hashtbl.create 16;
+    generation = 0;
+    invalidated_by_clear;
     destroy;
   }
 
@@ -87,18 +112,20 @@ let destroy_discarded t v = try t.destroy v with _ -> ()
 
 let find_or_build t ~key ?device_id build =
   (* Fast path: hit under the lock. On a miss, snapshot the target device's
-     eviction epoch so the post-build re-check can detect a teardown that
-     happened while the lock was released. *)
+     eviction epoch and the cache generation so the post-build re-check can
+     detect a teardown that happened while the lock was released. *)
   let hit_or_epoch =
     Mutex.protect t.mutex (fun () ->
         match Hashtbl.find_opt t.table key with
         | Some v -> Either.Left v
         | None ->
-            Either.Right (Option.map (fun id -> (id, epoch_of t id)) device_id))
+            Either.Right
+              ( Option.map (fun id -> (id, epoch_of t id)) device_id,
+                t.generation ))
   in
   match hit_or_epoch with
   | Either.Left v -> v
-  | Either.Right at_miss -> (
+  | Either.Right (at_miss, generation_at_miss) -> (
       (* Miss: the JIT compile runs with the lock released so it does not
          serialize other domains. *)
       let built = build () in
@@ -115,6 +142,16 @@ let find_or_build t ~key ?device_id build =
                        lookup — possibly after the id is recreated — would be
                        served a value from the old context. *)
                     `Stale id
+                | _
+                  when t.invalidated_by_clear
+                       && t.generation <> generation_at_miss ->
+                    (* Borrowing cache, cleared during the build: the handles
+                       this value closes over were released by that clear, and
+                       the clear has already passed over this table without
+                       seeing the entry. Installing now would poison the cache
+                       permanently — the value survives the very teardown that
+                       was in progress. *)
+                    `Cleared
                 | _ ->
                     Hashtbl.replace t.table key built ;
                     Option.iter
@@ -130,7 +167,10 @@ let find_or_build t ~key ?device_id build =
           winner
       | `Stale id ->
           destroy_discarded t built ;
-          raise (Device_destroyed_during_build id))
+          raise (Device_destroyed_during_build id)
+      | `Cleared ->
+          destroy_discarded t built ;
+          raise Cache_cleared_during_build)
 
 let evict_device t device_id =
   (* Snapshot + unlink under the lock; destroy released outside it. The epoch
@@ -158,12 +198,18 @@ let evict_device t device_id =
   destroy_all t victims
 
 let clear t =
-  (* [epochs] is deliberately NOT reset: the counters are the only record that
-     an in-flight build's device was retired, and clearing them could lose a
-     bump. [clear] itself does not invalidate an in-flight build — the device is
-     still alive, so the value being built is still valid and may be installed. *)
+  (* [epochs] and [generation] are deliberately NOT reset: they are the only
+     record that an in-flight build has been invalidated, and resetting them
+     would lose the bump.
+
+     Whether the generation bump actually invalidates an in-flight build depends
+     on [invalidated_by_clear] (see the type declaration): for an OWNING cache
+     the device is still alive and the value being built is still valid, so it
+     is installed; for a BORROWING cache the clear is releasing the very handles
+     that value closes over, so it must not be. *)
   let victims =
     Mutex.protect t.mutex (fun () ->
+        t.generation <- t.generation + 1 ;
         let vs = Hashtbl.fold (fun _ v acc -> v :: acc) t.table [] in
         Hashtbl.clear t.table ;
         Hashtbl.clear t.keys_by_device ;

--- a/spoc/framework/Guarded_cache.mli
+++ b/spoc/framework/Guarded_cache.mli
@@ -75,10 +75,18 @@ exception Cache_cleared_during_build
     [destroy] is allowed to raise (some backends' release calls go through an
     error check that does). One failing [destroy] never prevents the remaining
     victims of a {!clear} / {!evict_device} from being released: every victim is
-    attempted and the first exception is re-raised afterwards. On the
-    lost-a-race path in {!find_or_build}, a failing [destroy] of the discarded
-    loser is dropped rather than raised, so it cannot turn a successfully
-    resolved value into an intermittent compile failure.
+    attempted and the first exception is re-raised afterwards.
+
+    On every path in {!find_or_build} that discards a value it has just built —
+    losing the race, {!Device_destroyed_during_build},
+    {!Cache_cleared_during_build} — a failing [destroy] of that discarded value
+    is dropped rather than raised. On the lost-race path this keeps a release
+    error from turning a successfully resolved [winner] into an intermittent,
+    multi-domain-only compile failure; on the other two it keeps the exception
+    the caller sees the one that describes {e why} no value could be returned,
+    rather than a secondary release error from the cleanup. In all three cases
+    the release error is not reported at all, which is a deliberate trade
+    against masking the primary outcome.
 
     [size] is the initial table size (default 16).
 

--- a/spoc/framework/Guarded_cache.mli
+++ b/spoc/framework/Guarded_cache.mli
@@ -19,17 +19,61 @@
     The value type ['v] (resolved module/function handles, compiled pipelines,
     SPIR-V-backed objects, ...) and the key type ['k] differ per backend, so the
     cache is parametric in both. A per-cache [destroy] callback releases the
-    backend resource held by an evicted or cleared value. *)
+    backend resource held by an evicted or cleared value.
+
+    {2 Value lifetime is the caller's obligation}
+
+    What this module makes concurrency-safe is the {b table}, not the
+    {b values}. A value returned by {!find_or_build} escapes the lock, and
+    {!clear} / {!evict_device} run [destroy] outside the lock by design (so
+    [destroy] may re-enter the cache). Nothing here refcounts a value or defers
+    its release, so this interleaving is {e not} prevented:
+
+    - domain A resolves a kernel from the cache and enters [Kernel.launch];
+    - domain B calls [clear_cache], which unlinks that same value and runs
+      [destroy] on it ([clReleaseKernel] / [cuModuleUnload] /
+      [vkDestroyPipeline]);
+    - domain A's launch dereferences a released driver object.
+
+    The contract is therefore:
+    {b a cached value must not be released while any domain may still be using
+       it.} Callers must not call {!clear} or {!evict_device} concurrently with
+    work that is using values obtained from the same cache — quiesce (or
+    externally serialize) the users of the cache first. Backend teardown paths
+    satisfy this by running device destroy / cache clear as a program-wide
+    quiescent operation.
+
+    Adding refcounting or deferred destroy here would remove the obligation;
+    that is a deliberate, tracked follow-up rather than part of the current
+    contract. Note that the concurrency tests only assert that nothing raises,
+    which by construction cannot detect a violation of this obligation. *)
 
 (** A guarded cache from keys ['k] to compiled values ['v]. *)
 type ('k, 'v) t
+
+(** Raised by {!find_or_build} when the [device_id] it was building for was
+    retired by {!evict_device} while the (unlocked) build was in flight. The
+    freshly built value is [destroy]ed rather than installed: the device it was
+    compiled against is gone, so no valid value can be returned. Callers that
+    tear devices down concurrently with compilation must handle this (retry
+    against a live device, or propagate). *)
+exception Device_destroyed_during_build of int
 
 (** [create ~destroy ()] builds an empty cache. [destroy] is applied to every
     value removed by {!clear} or {!evict_device} (and to the loser of a rare
     concurrent double-compile in {!find_or_build}); it should release the
     backend resource the value owns (e.g. [cuModuleUnload]). [destroy] is always
-    invoked {e outside} the cache lock, so it must not itself call back into
-    this cache. [size] is the initial table size (default 16). *)
+    invoked {e outside} the cache lock, so it may re-enter this cache.
+
+    [destroy] is allowed to raise (some backends' release calls go through an
+    error check that does). One failing [destroy] never prevents the remaining
+    victims of a {!clear} / {!evict_device} from being released: every victim is
+    attempted and the first exception is re-raised afterwards. On the
+    lost-a-race path in {!find_or_build}, a failing [destroy] of the discarded
+    loser is dropped rather than raised, so it cannot turn a successfully
+    resolved value into an intermittent compile failure.
+
+    [size] is the initial table size (default 16). *)
 val create : ?size:int -> destroy:('v -> unit) -> unit -> ('k, 'v) t
 
 (** [find_or_build t ~key ?device_id build] returns the cached value for [key],
@@ -49,15 +93,26 @@ val create : ?size:int -> destroy:('v -> unit) -> unit -> ('k, 'v) t
     {!evict_device} can later retire exactly the entries compiled for it (used
     by backends whose device-destroy hook must unload modules before the
     underlying context is torn down). Omit it for caches with no per-device
-    eviction. *)
+    eviction.
+
+    Supplying [device_id] also makes the build window {e eviction-aware}: the
+    device's eviction epoch is read under the lock at miss time and re-checked
+    on re-acquire. If {!evict_device} ran for that device in between, the built
+    value is [destroy]ed instead of installed and
+    {!Device_destroyed_during_build} is raised — an entry that is not yet in the
+    table cannot be seen by {!evict_device}, so without this check the value
+    would be installed against a dead device id (never unloaded, and served to
+    later lookups, including after the id is recreated). *)
 val find_or_build : ('k, 'v) t -> key:'k -> ?device_id:int -> (unit -> 'v) -> 'v
 
 (** [evict_device t device_id] removes and {!destroy}s every value recorded for
     [device_id] via {!find_or_build}'s [~device_id]. Safe to call from a
     device-destroy hook: it acquires the lock only to snapshot and unlink the
     affected entries, then releases it before running [destroy], so it never
-    re-enters the cache while holding the lock. A no-op for an unknown
-    [device_id]. *)
+    re-enters the cache while holding the lock. Also bumps [device_id]'s
+    eviction epoch, so a {!find_or_build} currently building for it discards its
+    result (see {!find_or_build}); this is why the call is {e not} a no-op for a
+    [device_id] with no cached entries. *)
 val evict_device : ('k, 'v) t -> int -> unit
 
 (** [clear t] removes and {!destroy}s every cached value and forgets all

--- a/spoc/framework/Guarded_cache.mli
+++ b/spoc/framework/Guarded_cache.mli
@@ -59,6 +59,13 @@ type ('k, 'v) t
     against a live device, or propagate). *)
 exception Device_destroyed_during_build of int
 
+(** Raised by {!find_or_build} on a cache created with
+    [~invalidated_by_clear:true] when {!clear} ran while the (unlocked) build
+    was in flight. The value borrows handles that the clear released, so it is
+    [destroy]ed rather than installed. Callers may retry: a fresh build after
+    the clear has completed will borrow live handles again. *)
+exception Cache_cleared_during_build
+
 (** [create ~destroy ()] builds an empty cache. [destroy] is applied to every
     value removed by {!clear} or {!evict_device} (and to the loser of a rare
     concurrent double-compile in {!find_or_build}); it should release the
@@ -73,8 +80,37 @@ exception Device_destroyed_during_build of int
     loser is dropped rather than raised, so it cannot turn a successfully
     resolved value into an intermittent compile failure.
 
-    [size] is the initial table size (default 16). *)
-val create : ?size:int -> destroy:('v -> unit) -> unit -> ('k, 'v) t
+    [size] is the initial table size (default 16).
+
+    [invalidated_by_clear] (default [false]) declares whether the cached values
+    {b own} the resources they refer to or merely {b borrow} them from a cache
+    underneath, and it changes what {!clear} means for a build that is already
+    in flight:
+
+    - [false] — {b owning} cache (every backend's kernel cache). [clear]
+      releases the handles this cache owns; it says nothing about the device, so
+      a value built while the clear was running is still valid and is installed
+      normally.
+    - [true] — {b borrowing} cache (a memo layered on top of another cache, e.g.
+      [Sarek.Runtime]'s outer memo of [Kernel.t] closures over backend handles).
+      For such a cache, [clear] is the signal that the borrowed handles are
+      about to be released. A build that started before the clear and finishes
+      after it closes over a handle that is dead by the time it would be
+      installed — and, because the clear has already walked the table without
+      seeing the not-yet-inserted entry, that dead value would then be served
+      for the rest of the process, outliving the teardown that was in progress.
+      With the flag set, such a build is [destroy]ed and
+      {!Cache_cleared_during_build} is raised instead.
+
+    Set it iff the values borrow. Setting it on an owning cache turns benign
+    concurrent clears into spurious build failures; leaving it off on a
+    borrowing cache is a use-after-free. *)
+val create :
+  ?size:int ->
+  ?invalidated_by_clear:bool ->
+  destroy:('v -> unit) ->
+  unit ->
+  ('k, 'v) t
 
 (** [find_or_build t ~key ?device_id build] returns the cached value for [key],
     compiling it with [build] on a miss.
@@ -102,7 +138,12 @@ val create : ?size:int -> destroy:('v -> unit) -> unit -> ('k, 'v) t
     {!Device_destroyed_during_build} is raised — an entry that is not yet in the
     table cannot be seen by {!evict_device}, so without this check the value
     would be installed against a dead device id (never unloaded, and served to
-    later lookups, including after the id is recreated). *)
+    later lookups, including after the id is recreated).
+
+    On a cache created with [~invalidated_by_clear:true] the cache-wide
+    generation is snapshotted and re-checked the same way, raising
+    {!Cache_cleared_during_build}. This check does not need [device_id]: a clear
+    invalidates every in-flight build on such a cache, not just one device's. *)
 val find_or_build : ('k, 'v) t -> key:'k -> ?device_id:int -> (unit -> 'v) -> 'v
 
 (** [evict_device t device_id] removes and {!destroy}s every value recorded for
@@ -117,7 +158,9 @@ val evict_device : ('k, 'v) t -> int -> unit
 
 (** [clear t] removes and {!destroy}s every cached value and forgets all
     per-device key tracking. Values are snapshotted under the lock and destroyed
-    after it is released. *)
+    after it is released. Also bumps the cache-wide generation, which aborts
+    in-flight builds iff the cache was created with [~invalidated_by_clear:true]
+    (see {!create}). *)
 val clear : ('k, 'v) t -> unit
 
 (** [length t] is the number of entries currently cached (under the lock).

--- a/spoc/framework/dune
+++ b/spoc/framework/dune
@@ -8,7 +8,8 @@
   Backend_error
   Kernel_args
   Compile_cache
-  Guarded_cache)
+  Guarded_cache
+  Cache_hooks)
  (libraries sarek_ir sarek_backend_error)
  (preprocess no_preprocessing)
  (instrumentation

--- a/spoc/framework/test/dune
+++ b/spoc/framework/test/dune
@@ -6,5 +6,6 @@
   test_backend_error
   test_kernel_args
   test_compile_cache
-  test_guarded_cache)
+  test_guarded_cache
+  test_cache_hooks)
  (libraries spoc_framework alcotest str))

--- a/spoc/framework/test/test_cache_hooks.ml
+++ b/spoc/framework/test/test_cache_hooks.ml
@@ -1,0 +1,72 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Cache_hooks tests - the cross-layer teardown back-channel.
+ *
+ * The load-bearing property is that a device-destroy notification carries the
+ * BACKEND FAMILY as well as the backend-local index. Backend indices collide
+ * across backends (OpenCL 0, Vulkan 0, HIP 0 all exist on the same machine), so
+ * a listener matching on the index alone invalidates unrelated backends'
+ * entries - which stopped being harmless once eviction gained the power to
+ * abort in-flight builds.
+ ******************************************************************************)
+
+module CH = Spoc_framework.Cache_hooks
+
+let test_device_destroy_carries_backend_and_index () =
+  let seen = ref [] in
+  CH.on_device_destroy (fun ~backend index -> seen := (backend, index) :: !seen) ;
+  CH.notify_device_destroy ~backend:"HIP" 0 ;
+  CH.notify_device_destroy ~backend:"CUDA" 3 ;
+  Alcotest.(check (list (pair string int)))
+    "listener receives (backend family, backend-local index)"
+    [("HIP", 0); ("CUDA", 3)]
+    (List.rev !seen)
+
+let test_all_listeners_run_and_first_failure_is_reported () =
+  let ran = ref [] in
+  CH.on_clear_all (fun () -> ran := "c" :: !ran) ;
+  CH.on_clear_all (fun () ->
+      ran := "b" :: !ran ;
+      failwith "listener b failed") ;
+  CH.on_clear_all (fun () -> ran := "a" :: !ran) ;
+  let raised =
+    try
+      CH.notify_clear_all () ;
+      false
+    with Failure _ -> true
+  in
+  Alcotest.(check bool) "the failing listener is reported" true raised ;
+  (* Order across registrations is unspecified; what matters is that a failure
+     in one did not skip the others - every layer must be dropped. *)
+  Alcotest.(check int)
+    "every listener ran despite the failure"
+    3
+    (List.length !ran) ;
+  List.iter
+    (fun tag ->
+      Alcotest.(check bool)
+        (Printf.sprintf "listener %s ran" tag)
+        true
+        (List.mem tag !ran))
+    ["a"; "b"; "c"]
+
+let () =
+  Alcotest.run
+    "Cache_hooks"
+    [
+      ( "notification",
+        [
+          Alcotest.test_case
+            "device destroy carries backend family + index"
+            `Quick
+            test_device_destroy_carries_backend_and_index;
+          Alcotest.test_case
+            "a failing listener does not skip the others"
+            `Quick
+            test_all_listeners_run_and_first_failure_is_reported;
+        ] );
+    ]

--- a/spoc/framework/test/test_guarded_cache.ml
+++ b/spoc/framework/test/test_guarded_cache.ml
@@ -154,7 +154,11 @@ let test_concurrent_evict_device () =
   let worker d () =
     for i = 0 to iterations_per_domain - 1 do
       let key = Printf.sprintf "d%d_k%d" d (i mod 64) in
-      let _ = GC.find_or_build cache ~key ~device_id:d build in
+      (* A build whose device is evicted mid-flight is reported rather than
+         installed (the value is destroyed, so conservation below still holds).
+         Expected here: this test evicts concurrently with building on purpose. *)
+      (try ignore (GC.find_or_build cache ~key ~device_id:d build)
+       with GC.Device_destroyed_during_build _ -> ()) ;
       if i mod 500 = 0 then GC.evict_device cache d
     done
   in
@@ -168,6 +172,152 @@ let test_concurrent_evict_device () =
     "retained + destroyed = built (conservation)"
     true
     (GC.length cache + Atomic.get destroys = Atomic.get builds)
+
+(* Deterministic regression test for the insert-after-evict window.
+
+   Domain A misses on key K for device 7 and releases the lock to run the (slow)
+   build. While the build is in flight, device 7 is destroyed, which runs
+   [evict_device 7]. A's entry is not in the table yet, so eviction finds
+   nothing; before the eviction-epoch check, A then re-acquired the lock and
+   INSERTED a value built against a now-dead device, recorded against a dead
+   device id: never unloaded (leak), and served to every later lookup - possibly
+   after the id was recreated, i.e. a launch on a module from a destroyed
+   context. The conservation assertion in [test_concurrent_evict_device] is
+   satisfied by that interleaving, which is why the suite was green.
+
+   Deterministic because the two domains hand off through atomics rather than
+   racing: the eviction is guaranteed to land inside the build window. *)
+let test_evict_device_during_build () =
+  let destroyed = Atomic.make 0 in
+  let cache =
+    GC.create
+      ~destroy:(fun (_ : string) -> ignore (Atomic.fetch_and_add destroyed 1))
+      ()
+  in
+  let build_started = Atomic.make false in
+  let evict_done = Atomic.make false in
+  let builder () =
+    try
+      `Returned
+        (GC.find_or_build cache ~key:"K" ~device_id:7 (fun () ->
+             Atomic.set build_started true ;
+             while not (Atomic.get evict_done) do
+               Domain.cpu_relax ()
+             done ;
+             "module-for-device-7"))
+    with GC.Device_destroyed_during_build id -> `Rejected id
+  in
+  let d = Domain.spawn builder in
+  while not (Atomic.get build_started) do
+    Domain.cpu_relax ()
+  done ;
+  (* Device 7 is destroyed here: its context is gone, its modules must all be
+     unloaded and none may be installed afterwards. *)
+  GC.evict_device cache 7 ;
+  Atomic.set evict_done true ;
+  (match Domain.join d with
+  | `Rejected id ->
+      Alcotest.(check int) "rejection names the destroyed device" 7 id
+  | `Returned v ->
+      Alcotest.failf
+        "find_or_build installed and returned %S for a device destroyed during \
+         the build"
+        v) ;
+  Alcotest.(check int)
+    "the value built for the destroyed device was destroyed, not leaked"
+    1
+    (Atomic.get destroyed) ;
+  Alcotest.(check int)
+    "nothing was installed for the destroyed device"
+    0
+    (GC.length cache) ;
+  (* And the key is genuinely free again: a later lookup rebuilds rather than
+     being served the value compiled against the destroyed device. *)
+  let later =
+    GC.find_or_build cache ~key:"K" ~device_id:7 (fun () -> "freshly-rebuilt")
+  in
+  Alcotest.(check string) "later lookup rebuilds" "freshly-rebuilt" later
+
+(* [clear] must NOT reject an in-flight build: unlike a device teardown it does
+   not invalidate the device, so the value being built is still valid and
+   installing it is correct. Guards against over-applying the epoch check. *)
+let test_clear_during_build_still_installs () =
+  let cache = GC.create ~destroy:(fun (_ : string) -> ()) () in
+  let build_started = Atomic.make false in
+  let clear_done = Atomic.make false in
+  let d =
+    Domain.spawn (fun () ->
+        GC.find_or_build cache ~key:"K" ~device_id:3 (fun () ->
+            Atomic.set build_started true ;
+            while not (Atomic.get clear_done) do
+              Domain.cpu_relax ()
+            done ;
+            "v"))
+  in
+  while not (Atomic.get build_started) do
+    Domain.cpu_relax ()
+  done ;
+  GC.clear cache ;
+  Atomic.set clear_done true ;
+  Alcotest.(check string)
+    "build result installed after a clear"
+    "v"
+    (Domain.join d) ;
+  Alcotest.(check int) "and it is cached" 1 (GC.length cache)
+
+(* A raising [destroy] must not strand the other victims: they are already
+   unlinked from the table, so a bail-out on the first failure leaks them
+   outright. Every victim is attempted; the failure is still reported. *)
+let test_raising_destroy_does_not_strand_victims () =
+  let destroyed = Atomic.make 0 in
+  let cache =
+    GC.create
+      ~destroy:(fun v ->
+        ignore (Atomic.fetch_and_add destroyed 1) ;
+        if v = "boom" then failwith "release failed")
+      ()
+  in
+  List.iter
+    (fun (k, v) ->
+      ignore (GC.find_or_build cache ~key:k ~device_id:1 (fun () -> v)))
+    [("a", "ok1"); ("b", "boom"); ("c", "ok2"); ("d", "ok3")] ;
+  let raised =
+    try
+      GC.clear cache ;
+      false
+    with Failure _ -> true
+  in
+  Alcotest.(check bool) "the failing release is reported" true raised ;
+  Alcotest.(check int) "every victim was attempted" 4 (Atomic.get destroyed) ;
+  Alcotest.(check int) "the table is empty" 0 (GC.length cache)
+
+(* A raising [destroy] on the lost-race path must not destroy the winner: a
+   valid value exists and the caller asked for a value, not for the release
+   error of the copy we threw away. *)
+let test_raising_destroy_on_lost_race_returns_winner () =
+  let cache =
+    GC.create ~destroy:(fun (_ : string) -> failwith "release failed") ()
+  in
+  let build_started = Atomic.make false in
+  let winner_installed = Atomic.make false in
+  let loser =
+    Domain.spawn (fun () ->
+        GC.find_or_build cache ~key:"K" (fun () ->
+            Atomic.set build_started true ;
+            while not (Atomic.get winner_installed) do
+              Domain.cpu_relax ()
+            done ;
+            "loser"))
+  in
+  while not (Atomic.get build_started) do
+    Domain.cpu_relax ()
+  done ;
+  ignore (GC.find_or_build cache ~key:"K" (fun () -> "winner")) ;
+  Atomic.set winner_installed true ;
+  Alcotest.(check string)
+    "loser observes the winner, not the release error"
+    "winner"
+    (Domain.join loser)
 
 (* Runnable red demonstration, OFF by default (would be UB/segfault-prone in
    the suite). With SAREK_GUARDED_CACHE_RED=1 it hammers a *raw* unguarded
@@ -237,6 +387,22 @@ let () =
             "concurrent evict_device"
             `Slow
             test_concurrent_evict_device;
+          Alcotest.test_case
+            "evict_device during an in-flight build (deterministic)"
+            `Quick
+            test_evict_device_during_build;
+          Alcotest.test_case
+            "clear during an in-flight build still installs"
+            `Quick
+            test_clear_during_build_still_installs;
+          Alcotest.test_case
+            "a raising destroy does not strand the other victims"
+            `Quick
+            test_raising_destroy_does_not_strand_victims;
+          Alcotest.test_case
+            "a raising destroy on a lost race still returns the winner"
+            `Quick
+            test_raising_destroy_on_lost_race_returns_winner;
           Alcotest.test_case
             "red demo (unguarded, opt-in)"
             `Quick

--- a/spoc/framework/test/test_guarded_cache.ml
+++ b/spoc/framework/test/test_guarded_cache.ml
@@ -291,10 +291,14 @@ let test_clear_during_build_rejected_when_borrowing () =
   Alcotest.(check int) "nothing survived the clear" 0 (GC.length cache) ;
   (* The decisive check: a LATER lookup must rebuild against live handles, not
      be served the closure over the handle the clear released. *)
-  let mutable_seen_released = ref true in
+  (* Seeded [false] on purpose: the failure under test is the later lookup being
+     served the poisoned entry, in which case this closure never runs at all.
+     Seeding it with the asserted value would make the check pass in exactly
+     that case, i.e. assert nothing. *)
+  let rebuilt_after_release = ref false in
   let later =
     GC.find_or_build cache ~key:"K" ~device_id:0 (fun () ->
-        mutable_seen_released := Atomic.get released ;
+        rebuilt_after_release := Atomic.get released ;
         "closure-over-handle-2")
   in
   Alcotest.(check string)
@@ -302,9 +306,10 @@ let test_clear_during_build_rejected_when_borrowing () =
     "closure-over-handle-2"
     later ;
   Alcotest.(check bool)
-    "and it rebuilt after the release, i.e. against fresh handles"
+    "the build closure actually ran, after the release, i.e. against fresh \
+     handles"
     true
-    !mutable_seen_released
+    !rebuilt_after_release
 
 (* The mirror image: on an OWNING cache (the default), [clear] must NOT reject
    an in-flight build. It releases the handles this cache owns; it does not

--- a/spoc/framework/test/test_guarded_cache.ml
+++ b/spoc/framework/test/test_guarded_cache.ml
@@ -238,9 +238,80 @@ let test_evict_device_during_build () =
   in
   Alcotest.(check string) "later lookup rebuilds" "freshly-rebuilt" later
 
-(* [clear] must NOT reject an in-flight build: unlike a device teardown it does
-   not invalidate the device, so the value being built is still valid and
-   installing it is correct. Guards against over-applying the epoch check. *)
+(* On a BORROWING cache ([~invalidated_by_clear:true]), [clear] must reject an
+   in-flight build.
+
+   The interleaving, which the per-device epoch alone does not cover because no
+   device is destroyed: (1) domain A misses on key K and releases the lock; its
+   build finishes - for a real borrowing cache that means the inner cache handed
+   back a value closing over handle H - but is not installed yet. (2) Domain B
+   clears: the clear walks the table, does not see A's entry, and (in the real
+   system) the layer underneath then releases H. (3) A re-acquires, finds the
+   key absent, and installs. The cache now serves a value over a released handle
+   PERMANENTLY, having survived the very teardown that was in progress.
+
+   Modelled here with a handle whose release is observable, so the assertion is
+   on the poisoning itself ("a later lookup is served a released handle") rather
+   than on a crash. Deterministic: the two domains hand off through atomics. *)
+let test_clear_during_build_rejected_when_borrowing () =
+  (* Stand-in for a backend handle owned by the layer underneath. *)
+  let released = Atomic.make false in
+  let cache =
+    GC.create ~invalidated_by_clear:true ~destroy:(fun (_ : string) -> ()) ()
+  in
+  let build_started = Atomic.make false in
+  let clear_done = Atomic.make false in
+  let builder () =
+    match
+      GC.find_or_build cache ~key:"K" ~device_id:0 (fun () ->
+          Atomic.set build_started true ;
+          while not (Atomic.get clear_done) do
+            Domain.cpu_relax ()
+          done ;
+          "closure-over-handle-1")
+    with
+    | v -> `Returned v
+    | exception GC.Cache_cleared_during_build -> `Rejected
+  in
+  let d = Domain.spawn builder in
+  while not (Atomic.get build_started) do
+    Domain.cpu_relax ()
+  done ;
+  (* The teardown: drop the memo, then the layer underneath releases the handle
+     every cached closure was built over. *)
+  GC.clear cache ;
+  Atomic.set released true ;
+  Atomic.set clear_done true ;
+  (match Domain.join d with
+  | `Rejected -> ()
+  | `Returned v ->
+      Alcotest.failf
+        "a build that finished across a clear was installed and returned %S"
+        v) ;
+  Alcotest.(check int) "nothing survived the clear" 0 (GC.length cache) ;
+  (* The decisive check: a LATER lookup must rebuild against live handles, not
+     be served the closure over the handle the clear released. *)
+  let mutable_seen_released = ref true in
+  let later =
+    GC.find_or_build cache ~key:"K" ~device_id:0 (fun () ->
+        mutable_seen_released := Atomic.get released ;
+        "closure-over-handle-2")
+  in
+  Alcotest.(check string)
+    "a later lookup rebuilds instead of being served the poisoned value"
+    "closure-over-handle-2"
+    later ;
+  Alcotest.(check bool)
+    "and it rebuilt after the release, i.e. against fresh handles"
+    true
+    !mutable_seen_released
+
+(* The mirror image: on an OWNING cache (the default), [clear] must NOT reject
+   an in-flight build. It releases the handles this cache owns; it does not
+   touch the device, so the value being built is still valid and installing it
+   is correct. Guards against applying the generation check globally - the
+   distinction is per-cache, and getting it backwards turns benign concurrent
+   clears into spurious compile failures for every backend. *)
 let test_clear_during_build_still_installs () =
   let cache = GC.create ~destroy:(fun (_ : string) -> ()) () in
   let build_started = Atomic.make false in
@@ -392,7 +463,11 @@ let () =
             `Quick
             test_evict_device_during_build;
           Alcotest.test_case
-            "clear during an in-flight build still installs"
+            "clear during an in-flight build is rejected on a borrowing cache"
+            `Quick
+            test_clear_during_build_rejected_when_borrowing;
+          Alcotest.test_case
+            "clear during an in-flight build still installs on an owning cache"
             `Quick
             test_clear_during_build_still_installs;
           Alcotest.test_case


### PR DESCRIPTION
Fixes six findings in the kernel-compilation cache layers (#86). Every High/Medium below was reproduced by execution on this machine (two OpenCL devices are enumerated — dGPU id 0, iGPU id 1 — which is what makes F1/F2 reproducible), and each fix has a red-on-mutation regression test.

## F1 — High, silent wrong results: the Runtime cache key omitted device identity

`Runtime.compile_kernel` keyed its memo on `(device.framework, name, Hashtbl.hash source)`. `Device.t.framework` is the **backend name** (`Device.ml`: `framework = B.name`), so every device of one backend collided on it, while `Kernel.compile_cached` closes the *specific* backend kernel into the `Kernel.t` it returns — an outer cache hit handed device B a kernel built for device A, with no exception raised. Each backend's own cache already keyed correctly via `Compile_cache.make_key ~device:…`; this outer layer threw that away.

Reproduced: `compile_kernel` for device 1 after device 0 returned a kernel bound to device 0; end-to-end, a kernel writing `7.0` read back `7 7 7 7` on a solo device-1 run and `0 0 0 0` when device 0 warmed the cache first, on the identical device. Fixed at `sarek/core/Runtime.ml:88-106` by building the key with `Compile_cache.make_key` and the device folded in, which also retires the 30-bit `Hashtbl.hash source` (a second, lower-probability wrong-kernel channel) in favour of the MD5-digest convention every other key in the tree uses. Red→green evidence: `test_runtime_cache_device_key` reports `requested device 1, got a kernel bound to device 0` and `16/16 elements were not written` when the device component is removed; all three checks pass with it.

## F2 — High, use-after-free through the public API: the outer memo was never invalidated by teardown

The comment on the cache claimed `destroy` could be a no-op because "clearing this outer layer only drops the memoization". That was backwards. `Kernel.clear_cache device` → `B.Kernel.clear_cache ()` → `Guarded_cache.clear` → `destroy` → `Opencl_api.Kernel.release` / `cuModuleUnload`, while `Runtime.kernel_cache` still held `Kernel.t` values closing over the released handles and served them to the next `Runtime.run`. Same hazard via `device_destroy_hooks` → `Kernel.evict_device`.

Reproduced: `run` → 7; `Kernel.clear_cache d` → OK; `run` again → **SIGSEGV rc=139**.

Fixed by making the outer layer participate in teardown. The backends sit *below* `Runtime` and cannot reference it, so this needs a back-channel: new `spoc/framework/Cache_hooks.{ml,mli}` carries `on_clear_all` / `on_device_destroy` listeners. `Runtime.ml:70-86` registers `clear` and an `evict_device` mapper; `Kernel.ml:157-166` fires `notify_clear_all` **before** the backend releases anything; `Cuda_api.ml:270-277` and `Hip_api.ml:213-220` fire `notify_device_destroy` before their local hooks unload modules. The false comment is replaced with one that states the actual invariant. The device-destroy notification carries a *backend-local* index while the Runtime cache groups by global `Device.id`, so the listener widens rather than narrows — over-eviction of a pure memo is free, under-eviction serves a released handle. Red→green: removing the `notify_clear_all` call makes `test_runtime_cache_teardown` exit 139; with it, exit 0 over two clear/run cycles.

## F3 — Medium: a build survived eviction of the device it was built for

`Guarded_cache.find_or_build` released the lock for the build, so a device destroy landing between the miss and the re-acquire evicted nothing (the entry was not in the table yet); the builder then inserted and recorded the value against a now-dead device id — never unloaded (leak), and served to later lookups, including after the id was recreated (a launch on a module from a destroyed context). `test_concurrent_evict_device`'s conservation assertion is *satisfied* by that interleaving, which is why the suite was green.

Fixed with a per-device eviction epoch, read under the lock at miss time and re-checked on re-acquire; on a change the freshly built value is `destroy`ed instead of installed and `Device_destroyed_during_build` is raised (returning it would be the same use-after-free class as F2 — no valid value exists for a device that is gone). The reviewer's deterministic probe is promoted into `test_guarded_cache.ml`, plus a companion asserting that `clear` — which does *not* invalidate the device — still installs an in-flight build, so the epoch check is not over-applied.

## F4 — Medium: values escape the lock with no ownership — chose (a), documented

`find_or_build` returns `v` after unlocking, and `clear`/`evict_device` run `destroy` outside the lock, so domain B's `clear_cache` can `clReleaseKernel` / `cuModuleUnload` a handle domain A is mid-`Kernel.launch` with. The `.mli` presented the module as making "the cache" concurrency-safe; it makes the **table** safe, not the **values**, and `test_concurrent_clear` only asserts that nothing raised, so it cannot detect the difference.

Chose **(a): document the caller obligation precisely, no behaviour change.** Reasoning: (b) is not clean here. Refcounting would have to reach every `find_or_build` caller across five backends plus `Runtime` (each would need an explicit release around `launch`, and `Kernel.t` currently exposes no such scope), and deferred destroy needs a quiescence signal the library does not have — a device teardown must release *now*, before `cuCtxDestroy`, so "defer until no reader" can only be implemented as a wait, which would let a stuck reader block teardown. That is a design change deserving its own review, not a passenger on a keying fix. Meanwhile the obligation is in fact satisfied by every in-tree caller (teardown is a program-wide quiescent operation), so (a) states the truth rather than papering over a live bug. The `.mli` now spells out the exact bad interleaving, states the obligation, notes that the tests cannot detect a violation of it, and names refcounting/deferred destroy as a tracked follow-up instead of an implied guarantee.

## F5 — Low: raw lock/unlock in `find_or_build`

An exception between `Mutex.lock` and `Mutex.unlock` (a `Hashtbl.replace` resize under `Out_of_memory`, or `Stack_overflow`) would leave the mutex held forever and deadlock every later cache operation on every domain. Both critical sections are straight-line, so both now use `Mutex.protect`, matching the rest of the module.

## F6 — Low: a raising `destroy` stranded the other victims

OpenCL/Metal `destroy` callbacks *can* raise (`Opencl_api.release` goes through `check`; CUDA/HIP wrap in `ignore` and cannot). `List.iter t.destroy victims` abandoned every remaining victim on the first raise — and they are already unlinked from the table, so that leaked them outright, a behaviour regression from the pre-#275 `clear_cache`, which released inline *before* clearing so a raise left entries still cached and reclaimable. Each `destroy` is now isolated and the first exception re-raised once every victim has been attempted, so the failure is still reported without being fatal to the rest. Separately, on the lost-race path a failing `destroy` of the discarded loser no longer propagates in place of the perfectly good `winner`, removing an intermittent, multi-domain-only compile failure. Both have regression tests that go red when the isolation is removed.

## Does F1 invalidate the benchmark sweep?

**No, and not narrowly — the sweep never reaches the buggy code path.** `docs/benchmarks/hip-vs-opencl-vulkan-2026-07-24.md` runs `bench_*`, which goes `Execute.run_vectors` → `B.run_source` → `B.Kernel.compile_cached`, i.e. straight into the **per-backend** cache whose key already included the device id. `Runtime.compile_kernel` — the F1 site — has no in-tree caller outside tests.

Verified rather than assumed, by re-running the `Verified ✗` rows after the fix:

| benchmark | size | backend | dev 0 (dGPU) | dev 1 (iGPU) |
|---|--:|---|:--:|:--:|
| vector_add | 1 M | HIP | verified ✓ | verified ✓ |
| vector_add | 100 M | HIP | verified ✗ | verified ✗ |
| vector_add | 1 M | OpenCL | verified ✓ | verified ✓ |
| vector_add | 100 M | OpenCL | verified ✗ | verified ✗ |
| nbody | 1024 | HIP | verified ✓ | verified ✓ |
| nbody | 4096 | HIP | verified ✗ | verified ✗ |

The ✗ persists after the fix, is **size-dependent** (✓ at the small size, ✗ at the large one), is identical across backends, and appears on **both** devices — including device 0, which is enumerated and compiled first and therefore could never have aliased. That is exactly the float32-vs-float64 epsilon signature footnote 2 describes. F1 would instead have produced an unwritten buffer at *every* size and only on the *second* device. The `HIP wins 13/21` verdict and the whole dGPU comparison stand; no doc change needed.

## Gates

- `@spoc/framework/test/runtest` — green (Guarded_cache: 8/8, including the 4 new cases).
- `@sarek/tests/unit/runtest` — green.
- `@sarek/tests/codegen_golden/runtest` — green, goldens byte-identical (this is a caching/keying change; no generated code moves).
- New e2e tests `test_runtime_cache_device_key` and `test_runtime_cache_teardown` — both exit 0, both wired into the default `runtest` alias, both skip with a printed reason (exit 0) when the devices they need are not enumerated.
- `@sarek/tests/e2e/runtest` — one failing rule, `test_static_tag_erasure`, **pre-existing**: it fails identically on the unmodified base (exit 1, intermittently 139) on the Vulkan/RADV dGPU leg. Unrelated to this change.
- `@fmt` — clean on every touched file. Pre-existing drift left alone in `sarek/core/Device.ml`, `sarek/interp/Sarek_float32.ml`, `sarek/tests/unit/test_ir_layout.ml`, and also `sarek/codegen/Sarek_ir_{glsl,softmath,ptx_expr}.ml` and `sarek-cuda/test/test_ptx_stride_spike.ml`.
- A whole-repo `dune build` still fails pre-existing on `sarek/transpile/test/test_transpile_proof.bc` (bytecode link, `caml_unix_sigwait` missing in this switch); the aliases above were built individually.

## Deliberately deferred

- **F4 (b)** — refcounting / deferred destroy in `Guarded_cache`, per the reasoning above. The obligation is now documented instead of silently assumed.
- **Vulkan device teardown** — `Vulkan_api_device.destroy` calls `vkDestroyDevice` with no eviction hook at all, so `Vulkan_api_kernel.cache` keeps pipelines from a destroyed device. That is a pre-existing gap in the *backend* layer, wider than #86, and adding only the outer notification would have hidden it behind a half-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
