### PR TITLE
ci: install ptxas/nvrtc/glslang/naga and assert them, so codegen gates stop self-skipping (#84/#51/#45)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,29 @@
-# Build context for ci/Dockerfile.
+# Build context for BOTH images built from this repository. Docker resolves
+# .dockerignore relative to the CONTEXT root, not to the Dockerfile, and both
+# builds use `context: .`, so this one file governs:
 #
-# The Dockerfile COPYs nothing from the repo — it only installs tooling — yet
-# the whole tree was being uploaded to the daemon as context for two jobs
-# (`build` and `check-generated-code`) on every run. On a working tree with
-# _build/ populated that is ~3.8 GB, of which ~3.6 GB is _build and ~155 MB is
-# .git. Excluding the heavy directories keeps the context to the source tree,
-# and changes to _build no longer invalidate the context hash.
+#   ci/Dockerfile   — the CI toolchain image (jobs `build`,
+#                     `check-generated-code`). COPYs nothing from the repo; it
+#                     only installs tooling, so nothing here can affect it
+#                     beyond context upload size.
+#   ./Dockerfile    — the GHCR interactive image (.github/workflows/
+#                     ghcr-image.yml). This one DOES copy the tree
+#                     (`COPY --chown=opam:opam . .`), so every pattern below
+#                     removes files from that image.
+#
+# Checked for the second image: the excluded tracked files are the 132 committed
+# Rocq build artefacts (*.vo/*.vok/*.vos/*.glob), plus .git/ and .github/.
+# `formal/dune` declares no stanzas, so dune never builds the proofs and
+# `dune build @install` does not need them — the image is unaffected today. The
+# *.o/*.a/*.so/*.exe/*.install globs are the ones to watch: they are aimed at
+# build residue, and would silently drop a tracked stub library or opam
+# .install file from that image if one were ever committed.
+#
+# Why it was added: the whole tree was being uploaded to the daemon on every
+# run. On a working tree with _build/ populated that is ~3.8 GB, of which
+# ~3.6 GB is _build and ~155 MB is .git. Excluding the heavy directories keeps
+# the context to the source tree, and changes to _build no longer invalidate
+# the context hash.
 _build/
 _opam/
 _site/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Build context for ci/Dockerfile.
+#
+# The Dockerfile COPYs nothing from the repo — it only installs tooling — yet
+# the whole tree was being uploaded to the daemon as context for two jobs
+# (`build` and `check-generated-code`) on every run. On a working tree with
+# _build/ populated that is ~3.8 GB, of which ~3.6 GB is _build and ~155 MB is
+# .git. Excluding the heavy directories keeps the context to the source tree,
+# and changes to _build no longer invalidate the context hash.
+_build/
+_opam/
+_site/
+_coverage/
+.git/
+.github/
+.opam-ci/
+node_modules/
+
+# Editor and OS noise
+*.swp
+*~
+.DS_Store
+
+# Local artefacts
+*.install
+*.cm[ioxat]
+*.cmx[as]
+*.o
+*.a
+*.so
+*.exe
+*.vo
+*.vok
+*.vos
+*.glob

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,11 @@ jobs:
   formal-proofs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Least privilege: this job only reads the checkout and runs rocq in a
+    # container. Without an explicit block it would inherit the repository
+    # default token scope (zizmor: excessive-permissions).
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,26 +143,14 @@ jobs:
               eval $(opam env --switch=${{ matrix.ocaml-compiler }}) && \
               dune runtest'
 
-      # OCL_ICD_VENDORS pins OpenCL device enumeration to pocl for this step.
-      # The image registers two CPU ICDs, and with both visible "the CPU OpenCL
-      # device" is whichever the loader happened to enumerate first — not
-      # something a test can rely on. The Intel oneAPI CPU runtime mis-JITs its
-      # vector math library on the Zen runners (task #74: it logs "Unknown host
-      # CPU", first bad element at index 4, an SSE lane boundary), which is why
-      # the float32 math checks had to be soft-failed on it. Pinning to the
-      # conformant ICD means those checks are enforced for real here; the Intel
-      # runtime stays installed and is still reachable via
-      # OCL_ICD_VENDORS=/etc/OpenCL/vendors-intel or the default
-      # /etc/OpenCL/vendors, which still lists both.
-      #
-      # The suppression itself is narrowed to match: Test_helpers.is_pocl_device
-      # excludes pocl from the known-issue carve-out, so a pocl miscomputation
-      # is a hard failure. Without that, adding a conformant ICD would have
-      # bought nothing.
+      # No OCL_ICD_VENDORS pinning: the image ships exactly one OpenCL ICD, the
+      # Intel oneAPI CPU runtime. Adding pocl as a second, conformant ICD (#79)
+      # and pinning e2e to it made things strictly worse — pocl 1.8 + LLVM 11 on
+      # jammy compiles no kernel at all, so the float32 math tests SKIPPED — and
+      # it moves to a separate experimental PR. See ci/Dockerfile.
       - name: Run fast e2e tests
         run: |
           docker run --rm \
-            -e OCL_ICD_VENDORS=/etc/OpenCL/vendors-pocl \
             -v ${{ github.workspace }}:/work \
             -w /work \
             spoc-ci:latest \
@@ -220,9 +208,6 @@ jobs:
   formal-proofs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container:
-      image: rocq/rocq-prover:9.1.1
-      options: --user root
 
     steps:
       - name: Checkout code
@@ -230,8 +215,25 @@ jobs:
         with:
           persist-credentials: false
 
+      # Deliberately `docker run` rather than a job-level `container:`.
+      #
+      # A `container:` job does NOT work here, and the failure is silent-ish:
+      # GitHub Actions discards the image ENTRYPOINT (["opam","exec","--"]) and
+      # runs every step through `docker exec sh -e -c`, so the opam switch's
+      # bin/ never reaches PATH and rocq, coqc and rocqchk all look MISSING —
+      # the real binaries live in /home/rocq/.opam/4.14.2+flambda/bin. Adding
+      # `options: --user root` to fix workspace permissions makes it worse: the
+      # switch belongs to the `rocq` user under /home/rocq, so opam refuses it.
+      #
+      # `docker run` honours the ENTRYPOINT, runs as the image's own user, and
+      # matches how every other step in this workflow invokes a container.
       - name: Rebuild and kernel-re-check the Rocq proofs
-        run: ./scripts/check-formal-proofs.sh
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -w /work \
+            rocq/rocq-prover:9.1.1 \
+            bash -lc './scripts/check-formal-proofs.sh'
 
   check-generated-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,26 @@ jobs:
       #
       # `docker run` honours the ENTRYPOINT, runs as the image's own user, and
       # matches how every other step in this workflow invokes a container.
+      # The chown is required, not tidiness. rocq/rocq-prover runs as its own
+      # `rocq` user (uid 1000); a GitHub-hosted runner owns the checkout as
+      # `runner` (uid 1001) with mode 0755. check-formal-proofs.sh rebuilds in
+      # place — it deletes the committed .vo files and regenerates CoqMakefile
+      # beside the sources — so without this the container cannot write a single
+      # file and the job dies on step 1 with EACCES.
+      #
+      # Measured, not assumed: a uid-1000 process in this image cannot create or
+      # unlink a file in a uid-1001 0755 bind mount. It is invisible when the
+      # script is run locally, because a developer's checkout is already owned by
+      # the user running it — the job passing on a workstation says nothing about
+      # this. The script now probes writability up front so a future regression
+      # of this line fails with that sentence instead of a confusing rm error.
+      #
+      # chown rather than `--user`: the ENTRYPOINT is ["opam","exec","--"] and
+      # the opam switch lives under /home/rocq, so running as any other uid (or
+      # as root, HOME=/root) loses the switch and rocq/coqc look MISSING.
       - name: Rebuild and kernel-re-check the Rocq proofs
         run: |
+          sudo chown -R 1000:1000 "$GITHUB_WORKSPACE"
           docker run --rm \
             -v ${{ github.workspace }}:/work \
             -w /work \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,19 @@ jobs:
 
       - name: Formal proofs admit gate
         run: |
-          # The formal projects claim 0 admits; fail if an Admitted/admit/Axiom
-          # sneaks into a .v file. Word-boundary regex with optional space
-          # before the terminating dot catches bulleted tactics (`- admit.`),
-          # same-line sequences (`Proof. Admitted.`) and `Axiom(`/`Axioms`.
+          # Fast LEXICAL tripwire only. It runs without a Rocq toolchain and
+          # catches an `Admitted.` in seconds, but a grep is not a proof: it
+          # cannot tell whether the sources still compile or whether the
+          # committed .vo files match them. The machine-checked guarantee is
+          # the `formal-proofs` job below, which rebuilds every .v from scratch
+          # and runs `rocq check` (#45). Keep both: this one for the fast
+          # signal, that one for the assurance.
+          #
+          # Word-boundary regex with optional space before the terminating dot
+          # catches bulleted tactics (`- admit.`), same-line sequences
+          # (`Proof. Admitted.`) and `Axiom(`/`Axioms`.
           # Note: `Parameter` remains a sanctioned escape hatch (see
-          # AGpuSemantics.v) - this gate enforces the textual invariant only;
-          # full assurance needs a proof-building CI job (tracked follow-up).
+          # AGpuSemantics.v) - this gate enforces the textual invariant only.
           set +e
           ls formal/*/theories/*.v >/dev/null 2>&1 || { echo "::error::admit gate could not find formal .v files"; exit 1; }
           matches=$(grep -rnE "(^|[^[:alnum:]_'])((Admitted|admit)[[:space:]]*\.|Axioms?([[:space:]]|\())" formal --include='*.v')
@@ -71,6 +77,21 @@ jobs:
             CACHEBUST=${{ env.CACHE_WEEK }}
           cache-from: type=gha,scope=spoc-ci-${{ hashFiles('ci/Dockerfile') }}
           cache-to: type=gha,scope=spoc-ci-${{ hashFiles('ci/Dockerfile') }},mode=max
+
+      # Fail fast, before anything is built. Every codegen gate self-skips when
+      # its tool is missing, which is correct on a developer machine and
+      # catastrophic here: the previous image carried none of ptxas, NVRTC,
+      # glslangValidator, naga or a conformant OpenCL ICD, so the gates all
+      # printed SKIP and CI reported success having validated nothing. This step
+      # is what makes a regression of ci/Dockerfile a red build instead of a
+      # silent return to green-but-vacuous. See ci/assert-toolchain.sh.
+      - name: Assert codegen toolchain is present and runnable
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -w /work \
+            spoc-ci:latest \
+            bash -lc './ci/assert-toolchain.sh'
 
       - name: Cache opam root
         uses: actions/cache@v4
@@ -122,9 +143,26 @@ jobs:
               eval $(opam env --switch=${{ matrix.ocaml-compiler }}) && \
               dune runtest'
 
+      # OCL_ICD_VENDORS pins OpenCL device enumeration to pocl for this step.
+      # The image registers two CPU ICDs, and with both visible "the CPU OpenCL
+      # device" is whichever the loader happened to enumerate first — not
+      # something a test can rely on. The Intel oneAPI CPU runtime mis-JITs its
+      # vector math library on the Zen runners (task #74: it logs "Unknown host
+      # CPU", first bad element at index 4, an SSE lane boundary), which is why
+      # the float32 math checks had to be soft-failed on it. Pinning to the
+      # conformant ICD means those checks are enforced for real here; the Intel
+      # runtime stays installed and is still reachable via
+      # OCL_ICD_VENDORS=/etc/OpenCL/vendors-intel or the default
+      # /etc/OpenCL/vendors, which still lists both.
+      #
+      # The suppression itself is narrowed to match: Test_helpers.is_pocl_device
+      # excludes pocl from the known-issue carve-out, so a pocl miscomputation
+      # is a hard failure. Without that, adding a conformant ICD would have
+      # bought nothing.
       - name: Run fast e2e tests
         run: |
           docker run --rm \
+            -e OCL_ICD_VENDORS=/etc/OpenCL/vendors-pocl \
             -v ${{ github.workspace }}:/work \
             -w /work \
             spoc-ci:latest \
@@ -164,6 +202,36 @@ jobs:
           path: _coverage/unit-report
           retention-days: 30
           if-no-files-found: ignore
+
+  # #45: make the formal-proof guarantee machine-checked instead of grepped.
+  #
+  # The admit gate in the `build` job is a grep over .v sources, and the
+  # committed .vo files were never re-verified on a branch — a lexical check
+  # standing in for a proof. This job rebuilds every .v from scratch (deleting
+  # the committed .vo first, so they cannot vouch for themselves) and runs
+  # `rocq check`, the standalone kernel re-checker.
+  #
+  # Cost, measured on Rocq 9.1.1 with all artefacts deleted: ~11 s to compile
+  # all three projects and ~39 s to kernel-re-check them, ~50 s of CPU total.
+  # The toolchain is deliberately NOT added to ci/Dockerfile — the official
+  # rocq/rocq-prover image already ships the exact version these proofs were
+  # developed against, and pinning it here costs an image pull instead of a
+  # multi-minute Rocq build baked into every CI image rebuild.
+  formal-proofs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: rocq/rocq-prover:9.1.1
+      options: --user root
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Rebuild and kernel-re-check the Rocq proofs
+        run: ./scripts/check-formal-proofs.sh
 
   check-generated-code:
     runs-on: ubuntu-latest

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -44,54 +44,49 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # ran. See ci/assert-toolchain.sh, which turns a future regression of this layer
 # back into a red build instead of a silent return to self-skipping.
 #
+# TOTAL IMAGE COST, measured by summing `docker history` layer sizes for a build
+# of this file against a build of the previous ci/Dockerfile:
+#   baseline           4483 MB
+#   with this file     4834 MB   -> +351 MB
+# broken down as: CUDA layer 304 MB, glslang layer 35.8 MB, naga 6.8 MB, gnupg
+# (needed for the NVIDIA apt keyring) 5 MB, symlink/ldconfig 0.1 MB.
+#
 #   glslang-tools       glslangValidator, the GLSL -> SPIR-V validator used by
 #                       the shader-validation sweep and by the production Vulkan
-#                       path (Sarek_vulkan.Vulkan_api_base). ~3 MB.
-#   spirv-tools         spirv-val, for cross-checking emitted SPIR-V. ~10 MB.
-#   pocl-opencl-icd     a conformant CPU OpenCL ICD. The image's only other ICD
-#                       is Intel's oneAPI CPU runtime, which mis-JITs its vector
-#                       math library on the Zen runners (it logs "Unknown host
-#                       CPU"; first bad element lands at index 4, an SSE lane
-#                       boundary) and therefore had to be classified as a
-#                       known-issue device (task #74) — leaving CI with zero
-#                       trustworthy OpenCL coverage. Both ICDs stay registered;
-#                       see the OCL_ICD_VENDORS split below. ~40 MB with LLVM
-#                       runtime deps.
-#   clinfo              used by ci/assert-toolchain.sh to prove the pocl device
-#                       actually enumerates. <1 MB.
+#                       path (Sarek_vulkan.Vulkan_api_base). 7.4 MB itself, but
+#                       35.8 MB as a layer: on jammy `glslang-tools` has a hard
+#                       `Depends: spirv-tools` (25.5 MB), so spirv-tools arrives
+#                       whether or not it is asked for. It is no longer listed
+#                       explicitly, because nothing in this repository uses
+#                       spirv-val and claiming it as a capability would be
+#                       false — but it cannot actually be removed without
+#                       losing glslangValidator.
+#
+# NOT installed, and why:
+#
+#   pocl-opencl-icd
+#                 A conformant CPU OpenCL ICD is still wanted (task #79: the
+#                 image's only ICD is Intel's oneAPI CPU runtime, classified as
+#                 a known-issue device by #74). But pocl 1.8 + LLVM 11 on jammy
+#                 cannot compile a single kernel in this image: every build
+#                 fails with `error: unknown target CPU 'generic'` against the
+#                 device string `pthread-x86_64-pc-linux-gnu-generic`. Pinning
+#                 e2e to it made test_float32_sin_pure and test_math_intrinsics
+#                 SKIP while `make e2e-fast` logged 11 errors and still exited
+#                 0 — strictly worse than the status quo. Measured in the same
+#                 image, the Intel ICD computed sin/cos/exp/sqrt correctly
+#                 (worst relative error 1.3e-07) and SPOC's own #74 expiry NOTE
+#                 fired to say so. pocl also dragged in ~243 MB of LLVM.
+#                 It moves to a separate experimental PR that installs it
+#                 WITHOUT pinning and logs whether it can compile a kernel on
+#                 the actual GitHub runner (Ice Lake / Zen 3), where LLVM 11 may
+#                 resolve a real target CPU and where #74's flake was first
+#                 seen. The inert Test_helpers.is_pocl_device carve-out stays in
+#                 the tree for that PR to use.
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    clinfo \
     glslang-tools \
-    ocl-icd-libopencl1 \
-    pocl-opencl-icd \
-    spirv-tools \
   && rm -rf /var/lib/apt/lists/*
-
-# ---------------------------------------------------------------------------
-# Deterministic OpenCL ICD selection.
-#
-# With two ICDs registered, `clCreateContextFromType`/device enumeration order
-# is up to the loader, so "the CPU OpenCL device" is not a well-defined thing
-# any more. Rather than remove one, keep /etc/OpenCL/vendors holding both (so
-# both are enumerable and comparable) and add two single-entry directories that
-# a CI step can point OCL_ICD_VENDORS at to pin exactly one ICD:
-#
-#   /etc/OpenCL/vendors-pocl   -> the conformant device, used for the float32
-#                                 math E2E tests that #74 had to soft-fail.
-#   /etc/OpenCL/vendors-intel  -> the oneAPI CPU runtime, still available.
-#
-# ci/assert-toolchain.sh checks that each directory resolves to exactly the
-# expected device, so a package rename cannot silently empty one of them.
-# ---------------------------------------------------------------------------
-RUN mkdir -p /etc/OpenCL/vendors-pocl /etc/OpenCL/vendors-intel \
-  && for icd in /etc/OpenCL/vendors/*.icd; do \
-       case "$(basename "$icd")" in \
-         pocl*) cp "$icd" /etc/OpenCL/vendors-pocl/ ;; \
-         *)     cp "$icd" /etc/OpenCL/vendors-intel/ ;; \
-       esac ; \
-     done \
-  && ls -l /etc/OpenCL/vendors /etc/OpenCL/vendors-pocl /etc/OpenCL/vendors-intel
 
 # ---------------------------------------------------------------------------
 # CUDA host-side compilers: ptxas (PTX assembler) and NVRTC (CUDA-C -> PTX).
@@ -110,15 +105,18 @@ RUN mkdir -p /etc/OpenCL/vendors-pocl /etc/OpenCL/vendors-intel \
 #     search list)".
 #
 # Granular packages only — deliberately NOT the `cuda-toolkit` metapackage
-# (multi-GB). Measured installed sizes (`ar p ... | tar -xJ`, du -sm):
-#   cuda-nvcc-12-6        148 MB  (ptxas 31 MB, nvlink 31 MB, nvcc 23 MB,
-#                                  libnvptxcompiler_static.a 60 MB)
-#   cuda-nvrtc-12-6        61 MB  (libnvrtc.so.12 + builtins)
-#   cuda-cudart-dev-12-6    7 MB  (cuda_fp16.h and friends)
-#   cuda-cccl-12-6         15 MB  (pulled in as a cudart-dev dependency)
-#   cuda-crt-12-6 + cuda-cudart-12-6  ~2 MB
+# (multi-GB). Sizes below are `dpkg-query Installed-Size` read out of the BUILT
+# image, dependencies included, not estimates from the .deb payloads:
+#   cuda-nvcc-12-6       147.6 MB  ptxas 31 MB, nvlink 31 MB, nvcc 23 MB,
+#                                  libnvptxcompiler_static.a 60 MB
+#   cuda-nvrtc-12-6       60.5 MB  libnvrtc.so.12 + builtins
+#   cuda-nvvm-12-6        56.1 MB  hard dependency of cuda-nvcc (cicc/libnvvm);
+#                                  not requested, not optional
+#   cuda-cccl-12-6        12.4 MB  dependency of cuda-cudart-dev
+#   cuda-cudart-dev-12-6   6.8 MB  cuda_fp16.h and the rest of the header tree
+#   cuda-crt / cuda-cudart / config / driver-dev   ~2.2 MB
 #   ------------------------------------------------------------------
-#   total                ~233 MB
+#   packages             285.6 MB;  layer as built: 304 MB
 #
 # cuda-nvrtc-dev-12-6 (93 MB: libnvrtc_static.a, libnvptxcompiler_static.a,
 # nvrtc.h) is deliberately NOT installed. Sarek reaches NVRTC by dlopen through
@@ -155,7 +153,9 @@ RUN ln -sfn "/usr/local/cuda-${CUDA_SERIES_DOTTED}" /usr/local/cuda \
        > /etc/ld.so.conf.d/999-cuda.conf \
   && ldconfig \
   && /usr/local/cuda/bin/ptxas --version \
-  && find /usr/local/cuda/ -name cuda_fp16.h | head -1
+  && fp16="$(find -L /usr/local/cuda -name cuda_fp16.h | head -1)" \
+  && [ -n "$fp16" ] \
+  && echo "cuda_fp16.h: $fp16"
 ENV CUDA_PATH=/usr/local/cuda
 ENV PATH=/usr/local/cuda/bin:$PATH
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -161,5 +161,7 @@ ENV PATH=/usr/local/cuda/bin:$PATH
 
 COPY --from=naga-builder /out/bin/naga /usr/local/bin/naga
 
-# Intel oneAPI already provides an OpenCL runtime; pocl is added alongside it.
+# Intel oneAPI provides the ONLY OpenCL runtime in this image. pocl was tried as
+# a second, conformant CPU ICD and removed — see the "NOT installed, and why"
+# block above; it moves to a separate experimental PR.
 ENV OPAMYES=1

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,3 +1,20 @@
+# ---------------------------------------------------------------------------
+# naga (WGSL validator) — built in a throwaway stage.
+#
+# There is no apt package and no upstream prebuilt binary for naga-cli, so the
+# only options are a Rust toolchain or Dawn's `tint` (a CMake/depot_tools build,
+# far more expensive). A builder stage keeps the ~1.5 GB Rust toolchain out of
+# the final image: only the 6.0 MB `naga` binary is copied across, and the whole
+# stage is one cached layer keyed on this Dockerfile.
+#
+# Measured: 6.0 MB binary, 21 s to build on a 16-core workstation with a warm
+# cargo registry; budget a few minutes for a cold 2-core GitHub runner.
+# ---------------------------------------------------------------------------
+# naga 30.0.0 declares rust-version = "1.87"; 1.90 is the pinned floor above it.
+FROM rust:1.90-slim-bookworm AS naga-builder
+ARG NAGA_VERSION=30.0.0
+RUN cargo install naga-cli --version "${NAGA_VERSION}" --locked --root /out
+
 FROM intel/oneapi-runtime:2024.2.1-0-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -11,6 +28,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     clang \
     curl \
     git \
+    gnupg \
     libffi-dev \
     libx11-dev \
     m4 \
@@ -18,5 +36,130 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     pkg-config \
   && rm -rf /var/lib/apt/lists/*
 
-# Intel oneAPI already provides OpenCL runtime
+# ---------------------------------------------------------------------------
+# Codegen-validation toolchain.
+#
+# Every gate below already existed and already skipped itself when its tool was
+# absent, which on this image meant ALL of them: CI was green because nothing
+# ran. See ci/assert-toolchain.sh, which turns a future regression of this layer
+# back into a red build instead of a silent return to self-skipping.
+#
+#   glslang-tools       glslangValidator, the GLSL -> SPIR-V validator used by
+#                       the shader-validation sweep and by the production Vulkan
+#                       path (Sarek_vulkan.Vulkan_api_base). ~3 MB.
+#   spirv-tools         spirv-val, for cross-checking emitted SPIR-V. ~10 MB.
+#   pocl-opencl-icd     a conformant CPU OpenCL ICD. The image's only other ICD
+#                       is Intel's oneAPI CPU runtime, which mis-JITs its vector
+#                       math library on the Zen runners (it logs "Unknown host
+#                       CPU"; first bad element lands at index 4, an SSE lane
+#                       boundary) and therefore had to be classified as a
+#                       known-issue device (task #74) — leaving CI with zero
+#                       trustworthy OpenCL coverage. Both ICDs stay registered;
+#                       see the OCL_ICD_VENDORS split below. ~40 MB with LLVM
+#                       runtime deps.
+#   clinfo              used by ci/assert-toolchain.sh to prove the pocl device
+#                       actually enumerates. <1 MB.
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    clinfo \
+    glslang-tools \
+    ocl-icd-libopencl1 \
+    pocl-opencl-icd \
+    spirv-tools \
+  && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Deterministic OpenCL ICD selection.
+#
+# With two ICDs registered, `clCreateContextFromType`/device enumeration order
+# is up to the loader, so "the CPU OpenCL device" is not a well-defined thing
+# any more. Rather than remove one, keep /etc/OpenCL/vendors holding both (so
+# both are enumerable and comparable) and add two single-entry directories that
+# a CI step can point OCL_ICD_VENDORS at to pin exactly one ICD:
+#
+#   /etc/OpenCL/vendors-pocl   -> the conformant device, used for the float32
+#                                 math E2E tests that #74 had to soft-fail.
+#   /etc/OpenCL/vendors-intel  -> the oneAPI CPU runtime, still available.
+#
+# ci/assert-toolchain.sh checks that each directory resolves to exactly the
+# expected device, so a package rename cannot silently empty one of them.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /etc/OpenCL/vendors-pocl /etc/OpenCL/vendors-intel \
+  && for icd in /etc/OpenCL/vendors/*.icd; do \
+       case "$(basename "$icd")" in \
+         pocl*) cp "$icd" /etc/OpenCL/vendors-pocl/ ;; \
+         *)     cp "$icd" /etc/OpenCL/vendors-intel/ ;; \
+       esac ; \
+     done \
+  && ls -l /etc/OpenCL/vendors /etc/OpenCL/vendors-pocl /etc/OpenCL/vendors-intel
+
+# ---------------------------------------------------------------------------
+# CUDA host-side compilers: ptxas (PTX assembler) and NVRTC (CUDA-C -> PTX).
+#
+# BOTH ARE HOST-SIDE. Neither needs an NVIDIA device, a driver, or /dev/nvidia*,
+# so this does not change device enumeration: no CUDA device appears, the CUDA
+# plugin still finds no driver, and the CUDA E2E tests keep skipping. What it
+# does buy is that the two static gates stop self-skipping:
+#   - test_ptx_snapshot.ml assembles the emitted PTX with ptxas;
+#   - test_cuda_nvrtc_gate.ml compiles the emitted CUDA-C with real NVRTC —
+#     which is the check that would have caught the f16 backend emitting
+#     `#include <cuda_fp16.h>`, a header NVRTC cannot resolve because it has no
+#     filesystem include path unless one is passed. Verified locally: prepending
+#     that include to the corpus turns all 17 cases red with "catastrophic
+#     error: could not open source file \"cuda_fp16.h\" (no directories in
+#     search list)".
+#
+# Granular packages only — deliberately NOT the `cuda-toolkit` metapackage
+# (multi-GB). Measured installed sizes (`ar p ... | tar -xJ`, du -sm):
+#   cuda-nvcc-12-6        148 MB  (ptxas 31 MB, nvlink 31 MB, nvcc 23 MB,
+#                                  libnvptxcompiler_static.a 60 MB)
+#   cuda-nvrtc-12-6        61 MB  (libnvrtc.so.12 + builtins)
+#   cuda-cudart-dev-12-6    7 MB  (cuda_fp16.h and friends)
+#   cuda-cccl-12-6         15 MB  (pulled in as a cudart-dev dependency)
+#   cuda-crt-12-6 + cuda-cudart-12-6  ~2 MB
+#   ------------------------------------------------------------------
+#   total                ~233 MB
+#
+# cuda-nvrtc-dev-12-6 (93 MB: libnvrtc_static.a, libnvptxcompiler_static.a,
+# nvrtc.h) is deliberately NOT installed. Sarek reaches NVRTC by dlopen through
+# ctypes (sarek-cuda/Cuda_nvrtc.ml), so it needs the shared object and no
+# headers at all.
+#
+# Version-pinned to the 12.6 series so an upstream CUDA bump cannot silently
+# change what the gates assemble against.
+# ---------------------------------------------------------------------------
+ARG CUDA_APT_SERIES=12-6
+ARG CUDA_SERIES_DOTTED=12.6
+RUN curl -fsSLO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
+  && dpkg -i cuda-keyring_1.1-1_all.deb \
+  && rm cuda-keyring_1.1-1_all.deb \
+  && apt-get update && apt-get install --no-install-recommends -y \
+       "cuda-nvcc-${CUDA_APT_SERIES}" \
+       "cuda-nvrtc-${CUDA_APT_SERIES}" \
+       "cuda-cudart-dev-${CUDA_APT_SERIES}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# The /usr/local/cuda -> /usr/local/cuda-<series> symlink normally comes from
+# the `cuda-toolkit` metapackage we are deliberately not installing, so create
+# it here; everything below (PATH, CUDA_PATH, ld.so.conf) is written against the
+# unversioned path so a series bump only touches CUDA_APT_SERIES.
+#
+# Setting CUDA_PATH also flips one `enabled_if` in the tree:
+# sarek/tests/new_runtime/dune gates test_runtime_comparison on CUDA_PATH being
+# non-empty, so that executable now gets BUILT in CI. It is an (executable) with
+# no run rule, so this adds a compile check and no runtime dependency on a
+# device — and NVRTC/driver are dlopen'd lazily, so it links without -lnvrtc.
+RUN ln -sfn "/usr/local/cuda-${CUDA_SERIES_DOTTED}" /usr/local/cuda \
+  && printf '%s\n%s\n' /usr/local/cuda/lib64 \
+       /usr/local/cuda/targets/x86_64-linux/lib \
+       > /etc/ld.so.conf.d/999-cuda.conf \
+  && ldconfig \
+  && /usr/local/cuda/bin/ptxas --version \
+  && find /usr/local/cuda/ -name cuda_fp16.h | head -1
+ENV CUDA_PATH=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:$PATH
+
+COPY --from=naga-builder /out/bin/naga /usr/local/bin/naga
+
+# Intel oneAPI already provides an OpenCL runtime; pocl is added alongside it.
 ENV OPAMYES=1

--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -33,6 +33,15 @@
 # ---------------------------------------------------------------------------
 set -uo pipefail
 
+# How many checks must actually run. Pinned for the same reason
+# check-formal-proofs.sh pins EXPECTED_PROJECTS: without it, deleting a section
+# — or an edit that makes one stop running — shrinks this script's scope in
+# silence and it still prints "OK: N/N checks passed" and exits 0. "N of N"
+# is tautological by construction and can never report a gap on its own.
+#
+# The Rocq section below is deliberately NOT counted; see its comment.
+EXPECTED_CHECKS=8
+
 failures=0
 checks=0
 
@@ -62,6 +71,9 @@ $out"
 # --------------------------------------------------------------------------
 section "ptxas (PTX assembler — host-side, no GPU required)"
 if ! command -v ptxas >/dev/null 2>&1; then
+  # Counted: a failure that is not in the denominator reads as "1 of 6 failed"
+  # out of a 6 that excludes it.
+  checks=$((checks + 1))
   fail "ptxas is not on PATH. The PTX assembly gate in test_ptx_snapshot.ml \
 will self-skip and CI will validate nothing. Install cuda-nvcc-12-6 (see \
 ci/Dockerfile)."
@@ -156,6 +168,7 @@ fi
 # --------------------------------------------------------------------------
 section "glslangValidator (GLSL -> SPIR-V)"
 if ! command -v glslangValidator >/dev/null 2>&1; then
+  checks=$((checks + 1))
   fail "glslangValidator is not on PATH. The GLSL shader-validation sweep will \
 self-skip. Install glslang-tools (see ci/Dockerfile)."
 else
@@ -181,6 +194,7 @@ fi
 # --------------------------------------------------------------------------
 section "naga (WGSL validation)"
 if ! command -v naga >/dev/null 2>&1; then
+  checks=$((checks + 1))
   fail "naga is not on PATH. WGSL has NO other executable validation anywhere \
 in this repository, so the wgsl_validation_sweep would silently validate \
 nothing. Built from naga-cli in the Dockerfile's builder stage."
@@ -219,14 +233,24 @@ fi
 # on the real GitHub runner. When that lands, the checks belong here.
 #
 # --------------------------------------------------------------------------
-section "Rocq / Coq proof checker"
-# #45: the formal guarantee ("0 admits, N theorems") was enforced by grep only,
-# and the committed .vo files were never re-verified on a branch. A real
-# rocqchk needs the toolchain to be here.
+section "Rocq / Coq proof checker (informational — NOT a gate)"
+# Reported, not asserted, and deliberately excluded from EXPECTED_CHECKS.
+#
+# #45's guarantee is enforced by the separate formal-proofs job, which runs
+# scripts/check-formal-proofs.sh inside the official rocq/rocq-prover image.
+# This image ships no Rocq on purpose (see the comment above the formal-proofs
+# job in .github/workflows/ci.yml), so there is nothing here to assert: a check
+# that passes whether or not the tool is present is the exact anti-pattern this
+# script exists to remove, and an earlier revision of this section was one.
+#
+# Absence is not asserted either — adding Rocq to this image would be wasteful
+# but not wrong, and failing on it would make this script a style gate.
 if command -v rocq >/dev/null 2>&1; then
-  run_check "rocq --version" rocq --version
+  echo "  NOTE: rocq present ($(rocq --version 2>&1 | head -1)); the proof job" \
+       "does not use it."
 elif command -v coqc >/dev/null 2>&1; then
-  run_check "coqc --version" coqc --version
+  echo "  NOTE: coqc present ($(coqc --version 2>&1 | head -1)); the proof job" \
+       "does not use it."
 else
   echo "  NOTE: no rocq/coqc in this image — the proof-checking job runs in the" \
        "official rocq/rocq-prover container instead, so this is expected here."
@@ -241,4 +265,13 @@ if [ "$failures" -gt 0 ]; then
   echo "ci/Dockerfile rather than relaxing this script."
   exit 1
 fi
-echo "toolchain assertion OK: $checks/$checks checks passed."
+# Reached only when every check that RAN passed — which is exactly when a
+# silently-vanished check would otherwise be invisible.
+if [ "$checks" -ne "$EXPECTED_CHECKS" ]; then
+  echo "::error::toolchain assertion ran $checks checks, expected \
+$EXPECTED_CHECKS. Every check passed, so this is not a broken tool — it is a \
+check that stopped running. Restore it, or update EXPECTED_CHECKS at the top of \
+this script if the removal was deliberate."
+  exit 1
+fi
+echo "toolchain assertion OK: $checks/$EXPECTED_CHECKS checks passed."

--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+# ---------------------------------------------------------------------------
+# Assert that the codegen-validation toolchain is present and runnable.
+#
+# WHY THIS EXISTS
+#
+# Every codegen gate in this repository self-skips when its tool is absent:
+#
+#   sarek/tests/unit/test_ptx_snapshot.ml         -> ptxas
+#   sarek/tests/codegen_golden/test_codegen_golden.ml
+#     glsl_validation_sweep                       -> glslangValidator
+#     wgsl_validation_sweep                       -> naga
+#   sarek/tests/unit/test_shader_recursion_vector.ml -> glslangValidator + naga
+#   sarek-cuda/test/test_cuda_nvrtc_gate.ml       -> libnvrtc
+#
+# That skip is correct behaviour for a developer machine, which legitimately has
+# none of these installed. It is a disaster in CI: the previous image carried
+# none of them, so every gate printed "SKIP" and reported success. CI was green
+# and had validated nothing. That is exactly how the f16 work shipped a
+# generated `#include <cuda_fp16.h>` that NVRTC cannot resolve — caught only
+# when a reviewer pasted the generated source into a real NVRTC by hand.
+#
+# The gates therefore KEEP their skip logic, and this script is the thing that
+# makes a missing tool a CI FAILURE rather than a silent pass. It must run early
+# and fail fast, before any test step: without it, one bad edit to ci/Dockerfile
+# silently returns the whole suite to green-but-vacuous with nobody noticing.
+#
+# Each check runs the tool, not merely `command -v` it: a present-but-broken
+# binary (wrong ABI, missing shared library) skips just as silently as an
+# absent one.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+failures=0
+checks=0
+
+fail() {
+  echo "::error::$*"
+  failures=$((failures + 1))
+}
+
+ok() { echo "  OK  $*"; }
+
+section() { echo; echo "== $1"; }
+
+run_check() {
+  # run_check <label> <command...>
+  local label="$1"
+  shift
+  checks=$((checks + 1))
+  local out
+  if out=$("$@" 2>&1); then
+    ok "$label — $(printf '%s' "$out" | head -1)"
+  else
+    fail "$label: '$*' failed (exit $?):
+$out"
+  fi
+}
+
+# --------------------------------------------------------------------------
+section "ptxas (PTX assembler — host-side, no GPU required)"
+if ! command -v ptxas >/dev/null 2>&1; then
+  fail "ptxas is not on PATH. The PTX assembly gate in test_ptx_snapshot.ml \
+will self-skip and CI will validate nothing. Install cuda-nvcc-12-6 (see \
+ci/Dockerfile)."
+else
+  run_check "ptxas --version" ptxas --version
+  # Positive control: assemble a minimal module. Proves ptxas can actually
+  # produce a cubin here, not just print a version banner.
+  tmpdir=$(mktemp -d)
+  cat >"$tmpdir/probe.ptx" <<'PTX'
+.version 7.0
+.target sm_75
+.address_size 64
+.visible .entry probe(.param .u64 p)
+{
+  .reg .u64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  ret;
+}
+PTX
+  checks=$((checks + 1))
+  # sm_75 rather than sm_70: CUDA 13 dropped Volta from ptxas's --gpu-name
+  # list, and sm_75 is accepted by every 12.x and 13.x toolkit, so this probe
+  # keeps working across a toolkit bump.
+  if out=$(ptxas --compile-only --gpu-name sm_75 -o "$tmpdir/probe.cubin" \
+             "$tmpdir/probe.ptx" 2>&1); then
+    ok "ptxas assembled a probe module"
+  else
+    fail "ptxas is on PATH but cannot assemble a trivial module:
+$out"
+  fi
+  rm -rf "$tmpdir"
+fi
+
+# --------------------------------------------------------------------------
+section "NVRTC (CUDA-C -> PTX — host-side, no GPU required)"
+# Sarek reaches NVRTC by dlopen (sarek-cuda/Cuda_nvrtc.ml tries libnvrtc.so,
+# .so.12, .so.11), so assert exactly that: the library resolves AND dlopen
+# succeeds AND nvrtcVersion is callable. `ls` alone would pass on a library
+# whose own dependencies are missing.
+nvrtc_probe=$(mktemp -d)
+cat >"$nvrtc_probe/probe.c" <<'C'
+#include <dlfcn.h>
+#include <stdio.h>
+int main(void) {
+  const char *cands[] = {"libnvrtc.so", "libnvrtc.so.12", "libnvrtc.so.11", 0};
+  for (int i = 0; cands[i]; i++) {
+    void *h = dlopen(cands[i], RTLD_LAZY);
+    if (!h) continue;
+    int (*ver)(int *, int *) = dlsym(h, "nvrtcVersion");
+    if (!ver) { printf("%s: no nvrtcVersion symbol\n", cands[i]); return 1; }
+    int maj = 0, min = 0;
+    if (ver(&maj, &min) != 0) { printf("nvrtcVersion failed\n"); return 1; }
+    printf("%s -> NVRTC %d.%d\n", cands[i], maj, min);
+    return 0;
+  }
+  printf("no libnvrtc could be dlopen'd: %s\n", dlerror());
+  return 1;
+}
+C
+checks=$((checks + 1))
+if ! cc -o "$nvrtc_probe/probe" "$nvrtc_probe/probe.c" -ldl 2>"$nvrtc_probe/cc.err"; then
+  fail "could not build the NVRTC dlopen probe:
+$(cat "$nvrtc_probe/cc.err")"
+elif out=$("$nvrtc_probe/probe" 2>&1); then
+  ok "NVRTC dlopen — $out"
+else
+  fail "libnvrtc is not loadable, so test_cuda_nvrtc_gate.ml will self-skip and \
+the generated CUDA-C will not be compile-checked: $out
+Install cuda-nvrtc-12-6 (see ci/Dockerfile)."
+fi
+rm -rf "$nvrtc_probe"
+
+# CUDA headers: the f16 regression was an unresolvable #include, so assert the
+# header tree the emitter may reference is actually on disk.
+checks=$((checks + 1))
+fp16=$(find "${CUDA_PATH:-/usr/local/cuda}" /usr/local/cuda -name cuda_fp16.h \
+         2>/dev/null | head -1)
+if [ -n "$fp16" ]; then
+  ok "CUDA headers present ($fp16)"
+else
+  fail "cuda_fp16.h not found under \
+${CUDA_PATH:-/usr/local/cuda}. The f16 regression this gate exists for was an \
+#include NVRTC could not resolve, so the header tree must really be on disk. \
+Install cuda-cudart-dev-12-6 (see ci/Dockerfile)."
+fi
+
+# --------------------------------------------------------------------------
+section "glslangValidator (GLSL -> SPIR-V)"
+if ! command -v glslangValidator >/dev/null 2>&1; then
+  fail "glslangValidator is not on PATH. The GLSL shader-validation sweep will \
+self-skip. Install glslang-tools (see ci/Dockerfile)."
+else
+  run_check "glslangValidator --version" glslangValidator --version
+  tmpdir=$(mktemp -d)
+  cat >"$tmpdir/probe.comp" <<'GLSL'
+#version 450
+layout(local_size_x = 1) in;
+void main() {}
+GLSL
+  checks=$((checks + 1))
+  if out=$(glslangValidator -V -S comp -o "$tmpdir/probe.spv" \
+             "$tmpdir/probe.comp" 2>&1); then
+    ok "glslangValidator compiled a probe shader"
+  else
+    fail "glslangValidator is on PATH but cannot compile a trivial compute \
+shader:
+$out"
+  fi
+  rm -rf "$tmpdir"
+fi
+
+# --------------------------------------------------------------------------
+section "naga (WGSL validation)"
+if ! command -v naga >/dev/null 2>&1; then
+  fail "naga is not on PATH. WGSL has NO other executable validation anywhere \
+in this repository, so the wgsl_validation_sweep would silently validate \
+nothing. Built from naga-cli in the Dockerfile's builder stage."
+else
+  run_check "naga --version" naga --version
+  tmpdir=$(mktemp -d)
+  cat >"$tmpdir/probe.wgsl" <<'WGSL'
+@compute @workgroup_size(1)
+fn main() {}
+WGSL
+  checks=$((checks + 1))
+  # A single positional argument with no output file makes naga run the full
+  # front-end + validator. NOTE: `--validate all` does NOT work — the flag takes
+  # a numeric ValidationFlags bitmask, and passing a keyword makes naga exit
+  # non-zero during argument parsing. That mistake is what kept the WGSL sweep
+  # from ever passing, so this probe deliberately pins the working invocation.
+  if out=$(naga "$tmpdir/probe.wgsl" 2>&1); then
+    ok "naga validated a probe shader — $out"
+  else
+    fail "naga is on PATH but cannot validate a trivial compute shader:
+$out"
+  fi
+  rm -rf "$tmpdir"
+fi
+
+# --------------------------------------------------------------------------
+section "OpenCL ICDs"
+if ! command -v clinfo >/dev/null 2>&1; then
+  fail "clinfo is not installed, so the OpenCL device inventory cannot be \
+asserted. Install clinfo (see ci/Dockerfile)."
+else
+  clinfo_out=$(clinfo 2>&1 || true)
+  echo "$clinfo_out" | grep -E '^\s*(Platform Name|Device Name|Device Type)' \
+    | sed 's/^/    /' || true
+
+  checks=$((checks + 1))
+  if echo "$clinfo_out" | grep -qi 'portable computing language\|pocl'; then
+    ok "pocl platform enumerates"
+  else
+    fail "no pocl platform in clinfo output. Task #74 had to classify the Intel \
+oneAPI CPU runtime as a known-issue device, which leaves CI with zero \
+trustworthy OpenCL coverage unless pocl is present and working. Install \
+pocl-opencl-icd (see ci/Dockerfile)."
+  fi
+
+  # The known-issue suppression in sarek/tests/e2e/test_helpers.ml identifies
+  # pocl by CL_DEVICE_NAME prefix ("pthread-" on pocl 1.x, "cpu-" from pocl 3.x
+  # on). If pocl ever renames its CPU device, that predicate stops recognising
+  # it and pocl failures would be silently EXCUSED as the Intel flake. Assert
+  # the prefix here so a rename breaks the build loudly instead.
+  checks=$((checks + 1))
+  if echo "$clinfo_out" | grep -E '^\s*Device Name' \
+       | grep -qE '(pthread-|cpu-)'; then
+    ok "pocl CPU device name matches the prefixes test_helpers.ml keys on"
+  else
+    fail "no OpenCL device name starting with 'pthread-' or 'cpu-'. \
+Test_helpers.is_pocl_device would no longer recognise the conformant device, \
+and the CPU-OpenCL known-issue suppression (#74) would wrongly excuse real \
+pocl failures. Update pocl_device_name_prefixes in \
+sarek/tests/e2e/test_helpers.ml together with this check."
+  fi
+
+  # Deterministic single-ICD selection: each directory must resolve to exactly
+  # one platform, so a CI step can pin one with OCL_ICD_VENDORS.
+  for pair in "vendors-pocl:portable computing language" "vendors-intel:intel"; do
+    dir="/etc/OpenCL/${pair%%:*}"
+    want="${pair#*:}"
+    checks=$((checks + 1))
+    if [ ! -d "$dir" ]; then
+      fail "$dir is missing; OCL_ICD_VENDORS cannot pin a single ICD."
+    elif [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+      fail "$dir is empty; a package rename probably broke the ICD split in \
+ci/Dockerfile."
+    elif OCL_ICD_VENDORS="$dir" clinfo 2>&1 | grep -qi "$want"; then
+      ok "OCL_ICD_VENDORS=$dir resolves to the expected platform ($want)"
+    else
+      fail "OCL_ICD_VENDORS=$dir did not enumerate a '$want' platform."
+    fi
+  done
+fi
+
+# --------------------------------------------------------------------------
+section "Rocq / Coq proof checker"
+# #45: the formal guarantee ("0 admits, N theorems") was enforced by grep only,
+# and the committed .vo files were never re-verified on a branch. A real
+# rocqchk needs the toolchain to be here.
+if command -v rocq >/dev/null 2>&1; then
+  run_check "rocq --version" rocq --version
+elif command -v coqc >/dev/null 2>&1; then
+  run_check "coqc --version" coqc --version
+else
+  echo "  NOTE: no rocq/coqc in this image — the proof-checking job runs in the" \
+       "official rocq/rocq-prover container instead, so this is expected here."
+fi
+
+# --------------------------------------------------------------------------
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "::error::toolchain assertion FAILED: $failures of $checks checks failed."
+  echo "A missing tool here means the corresponding codegen gate silently"
+  echo "self-skips and CI goes green without validating anything. Fix"
+  echo "ci/Dockerfile rather than relaxing this script."
+  exit 1
+fi
+echo "toolchain assertion OK: $checks/$checks checks passed."

--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -136,9 +136,14 @@ rm -rf "$nvrtc_probe"
 
 # CUDA headers: the f16 regression was an unresolvable #include, so assert the
 # header tree the emitter may reference is actually on disk.
+#
+# -L is load-bearing: /usr/local/cuda is a SYMLINK to /usr/local/cuda-<series>,
+# and GNU find does not follow a symlinked starting point unless told to (a
+# trailing slash also works, but -L says what is meant). Without it this check
+# reported the header missing on an image where it was plainly present.
 checks=$((checks + 1))
-fp16=$(find "${CUDA_PATH:-/usr/local/cuda}" /usr/local/cuda -name cuda_fp16.h \
-         2>/dev/null | head -1)
+fp16=$(find -L "${CUDA_PATH:-/usr/local/cuda}" /usr/local/cuda \
+         -name cuda_fp16.h 2>/dev/null | head -1)
 if [ -n "$fp16" ]; then
   ok "CUDA headers present ($fp16)"
 else
@@ -202,61 +207,17 @@ $out"
 fi
 
 # --------------------------------------------------------------------------
-section "OpenCL ICDs"
-if ! command -v clinfo >/dev/null 2>&1; then
-  fail "clinfo is not installed, so the OpenCL device inventory cannot be \
-asserted. Install clinfo (see ci/Dockerfile)."
-else
-  clinfo_out=$(clinfo 2>&1 || true)
-  echo "$clinfo_out" | grep -E '^\s*(Platform Name|Device Name|Device Type)' \
-    | sed 's/^/    /' || true
-
-  checks=$((checks + 1))
-  if echo "$clinfo_out" | grep -qi 'portable computing language\|pocl'; then
-    ok "pocl platform enumerates"
-  else
-    fail "no pocl platform in clinfo output. Task #74 had to classify the Intel \
-oneAPI CPU runtime as a known-issue device, which leaves CI with zero \
-trustworthy OpenCL coverage unless pocl is present and working. Install \
-pocl-opencl-icd (see ci/Dockerfile)."
-  fi
-
-  # The known-issue suppression in sarek/tests/e2e/test_helpers.ml identifies
-  # pocl by CL_DEVICE_NAME prefix ("pthread-" on pocl 1.x, "cpu-" from pocl 3.x
-  # on). If pocl ever renames its CPU device, that predicate stops recognising
-  # it and pocl failures would be silently EXCUSED as the Intel flake. Assert
-  # the prefix here so a rename breaks the build loudly instead.
-  checks=$((checks + 1))
-  if echo "$clinfo_out" | grep -E '^\s*Device Name' \
-       | grep -qE '(pthread-|cpu-)'; then
-    ok "pocl CPU device name matches the prefixes test_helpers.ml keys on"
-  else
-    fail "no OpenCL device name starting with 'pthread-' or 'cpu-'. \
-Test_helpers.is_pocl_device would no longer recognise the conformant device, \
-and the CPU-OpenCL known-issue suppression (#74) would wrongly excuse real \
-pocl failures. Update pocl_device_name_prefixes in \
-sarek/tests/e2e/test_helpers.ml together with this check."
-  fi
-
-  # Deterministic single-ICD selection: each directory must resolve to exactly
-  # one platform, so a CI step can pin one with OCL_ICD_VENDORS.
-  for pair in "vendors-pocl:portable computing language" "vendors-intel:intel"; do
-    dir="/etc/OpenCL/${pair%%:*}"
-    want="${pair#*:}"
-    checks=$((checks + 1))
-    if [ ! -d "$dir" ]; then
-      fail "$dir is missing; OCL_ICD_VENDORS cannot pin a single ICD."
-    elif [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
-      fail "$dir is empty; a package rename probably broke the ICD split in \
-ci/Dockerfile."
-    elif OCL_ICD_VENDORS="$dir" clinfo 2>&1 | grep -qi "$want"; then
-      ok "OCL_ICD_VENDORS=$dir resolves to the expected platform ($want)"
-    else
-      fail "OCL_ICD_VENDORS=$dir did not enumerate a '$want' platform."
-    fi
-  done
-fi
-
+# NOT asserted here: the OpenCL ICD inventory.
+#
+# An earlier revision installed pocl as a second, conformant CPU ICD (task #79)
+# and asserted it enumerated. Measured in this image, pocl 1.8 + LLVM 11 on
+# jammy cannot compile any kernel at all — `error: unknown target CPU 'generic'`
+# — so the assertion would have guarded a device that cannot run a test, while
+# the Intel oneAPI runtime it was meant to replace computed sin/cos/exp/sqrt
+# correctly here (worst relative error 1.3e-07). pocl moves to a separate
+# experimental PR that installs it unpinned and reports whether it can compile
+# on the real GitHub runner. When that lands, the checks belong here.
+#
 # --------------------------------------------------------------------------
 section "Rocq / Coq proof checker"
 # #45: the formal guarantee ("0 admits, N theorems") was enforced by grep only,

--- a/sarek-cuda/test/dune
+++ b/sarek-cuda/test/dune
@@ -56,6 +56,18 @@
  (instrumentation
   (backend bisect_ppx)))
 
+; NVRTC compile gate for the CUDA-C emitter. Host-side only: nvrtcCompileProgram
+; needs no CUDA device, so this runs on CPU-only CI. Skips when libnvrtc cannot
+; be dlopen'd; ci/assert-toolchain.sh is what turns a missing libnvrtc in the CI
+; image into a build failure instead of a silent skip.
+
+(test
+ (name test_cuda_nvrtc_gate)
+ (modules test_cuda_nvrtc_gate)
+ (libraries sarek_cuda sarek.codegen spoc.ir alcotest)
+ (instrumentation
+  (backend bisect_ppx)))
+
 (test
  (name test_ptx_localarr_probe)
  (modules test_ptx_localarr_probe)

--- a/sarek-cuda/test/test_cuda_nvrtc_gate.ml
+++ b/sarek-cuda/test/test_cuda_nvrtc_gate.ml
@@ -1,0 +1,261 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** NVRTC compile gate for the CUDA-C backend.
+
+    The CUDA-C emitter had no executable validation anywhere: the golden
+    snapshots in [sarek/tests/codegen_golden] pin the emitted bytes, and
+    [sarek/tests/unit/test_ptx_snapshot.ml] assembles the *PTX* backend with
+    [ptxas], but nothing ever fed the emitted CUDA *C* to a compiler. The
+    consequence is a whole class of "generated source is byte-exact and
+    completely uncompilable" bugs that only a reviewer pasting the output into a
+    real compiler would catch — the historical example being an emitted
+    [#include <cuda_fp16.h>] that NVRTC could not resolve, because NVRTC has no
+    filesystem include path unless one is passed explicitly.
+
+    This gate closes that hole with the same NVRTC entry point the runtime
+    actually uses ([Cuda_nvrtc.compile_to_ptx]), so the gate and production
+    share the include/option behaviour. Two properties matter:
+
+    - NVRTC is a {b host-side} compiler: [nvrtcCompileProgram] needs no CUDA
+      device, no driver and no [/dev/nvidia*]. This gate therefore runs on a
+      CPU-only CI machine, which is why it is worth having in CI at all.
+    - It skips cleanly when [libnvrtc] cannot be dlopen'd, because a developer
+      machine without a CUDA toolkit is a legitimate configuration. The CI-side
+      guarantee that the skip does not silently return is
+      [ci/assert-toolchain.sh], which fails the build when [libnvrtc] is missing
+      from the image. *)
+
+open Sarek_cuda
+open Sarek_ir_types
+
+let make_var ?(mut = false) name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = mut}
+
+let base_kernel name params body =
+  {
+    kern_name = name;
+    kern_params = params;
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let vec name ty = DParam (make_var name (TVec ty), None)
+
+let scalar name ty = DParam (make_var name ty, None)
+
+(** [tid] bound from [thread_idx_x], then [body tid]. *)
+let with_tid body =
+  let tid = make_var "tid" TInt32 in
+  SLet (tid, EIntrinsic ([], "thread_idx_x", []), body tid)
+
+(** {1 Corpus}
+
+    Deliberately spans the axes where an emitter can produce well-formed-looking
+    but uncompilable C: element types (i32/i64/f32/f64), intrinsic lowering
+    (native vs software helper families), shared memory, control flow and
+    locally-declared arrays. Each entry is a whole kernel module, so the
+    generated preamble (typedefs, helper functions, [#include] lines) is
+    compiled too — that preamble is where the historical f16 include bug lived,
+    and no per-expression test would have reached it. *)
+let corpus () =
+  let f32_binop op name =
+    ( name,
+      base_kernel
+        name
+        [vec "a" TFloat32; vec "b" TFloat32; vec "out" TFloat32]
+        (with_tid (fun tid ->
+             SAssign
+               ( LArrayElem ("out", EVar tid),
+                 EBinop
+                   (op, EArrayRead ("a", EVar tid), EArrayRead ("b", EVar tid))
+               ))) )
+  in
+  (* [path] is the intrinsic's module qualifier, e.g. ["Float32"]. The
+     dispatcher keys on it (see Sarek_ir_intrinsic_dispatch), so an unqualified
+     name only resolves for the framework-wide intrinsics. *)
+  let unary_intrinsic ty tyname path fn =
+    let name = Printf.sprintf "%s_%s" tyname fn in
+    ( name,
+      base_kernel
+        name
+        [vec "a" ty; vec "out" ty]
+        (with_tid (fun tid ->
+             SAssign
+               ( LArrayElem ("out", EVar tid),
+                 EIntrinsic (path, fn, [EArrayRead ("a", EVar tid)]) ))) )
+  in
+  let binary_intrinsic ty tyname path fn =
+    let name = Printf.sprintf "%s_%s" tyname fn in
+    ( name,
+      base_kernel
+        name
+        [vec "a" ty; vec "b" ty; vec "out" ty]
+        (with_tid (fun tid ->
+             SAssign
+               ( LArrayElem ("out", EVar tid),
+                 EIntrinsic
+                   ( path,
+                     fn,
+                     [EArrayRead ("a", EVar tid); EArrayRead ("b", EVar tid)] )
+               ))) )
+  in
+  [
+    f32_binop Add "f32_add";
+    f32_binop Mul "f32_mul";
+    f32_binop Div "f32_div";
+    (* Integer division/remainder: the signed-division lowering is the exact
+       shape the ptxas gate covers on the PTX side. *)
+    ( "i32_div_rem",
+      base_kernel
+        "i32_div_rem"
+        [vec "a" TInt32; vec "b" TInt32; vec "out" TInt32]
+        (with_tid (fun tid ->
+             SAssign
+               ( LArrayElem ("out", EVar tid),
+                 EBinop
+                   ( Add,
+                     EBinop
+                       ( Div,
+                         EArrayRead ("a", EVar tid),
+                         EArrayRead ("b", EVar tid) ),
+                     EBinop
+                       ( Mod,
+                         EArrayRead ("a", EVar tid),
+                         EArrayRead ("b", EVar tid) ) ) ))) );
+    ( "i64_compare",
+      base_kernel
+        "i64_compare"
+        [vec "a" TInt64; vec "out" TInt32]
+        (with_tid (fun tid ->
+             SIf
+               ( EBinop (Lt, EArrayRead ("a", EVar tid), EConst (CInt64 7L)),
+                 SAssign (LArrayElem ("out", EVar tid), EConst (CInt32 1l)),
+                 Some
+                   (SAssign (LArrayElem ("out", EVar tid), EConst (CInt32 0l)))
+               ))) );
+    (* f64 transcendentals: these are the ones that go through the software
+       helper family on shader targets, so the CUDA path emits a different
+       preamble and is worth compiling. *)
+    unary_intrinsic TFloat64 "f64" ["Float64"] "sqrt";
+    unary_intrinsic TFloat64 "f64" ["Float64"] "sin";
+    unary_intrinsic TFloat64 "f64" ["Float64"] "exp";
+    unary_intrinsic TFloat64 "f64" ["Float64"] "log";
+    unary_intrinsic TFloat32 "f32" ["Float32"] "sqrt";
+    unary_intrinsic TFloat32 "f32" ["Float32"] "rsqrt";
+    unary_intrinsic TFloat32 "f32" ["Float32"] "abs_float";
+    binary_intrinsic TFloat32 "f32" ["Float32"] "fmod";
+    binary_intrinsic TFloat32 "f32" ["Float32"] "copysign";
+    binary_intrinsic TFloat64 "f64" ["Float64"] "fmod";
+    (* Shared memory + barrier: exercises the __shared__ declaration path. *)
+    ( "shared_reduce",
+      base_kernel
+        "shared_reduce"
+        [vec "inp" TFloat32; vec "out" TFloat32]
+        (with_tid (fun tid ->
+             let sdata = make_var "sdata" (TArray (TFloat32, Shared)) in
+             SLet
+               ( sdata,
+                 EArrayCreate (TFloat32, EConst (CInt32 256l), Shared),
+                 SSeq
+                   [
+                     SAssign
+                       ( LArrayElem ("sdata", EVar tid),
+                         EArrayRead ("inp", EVar tid) );
+                     SBarrier;
+                     SAssign
+                       ( LArrayElem ("out", EVar tid),
+                         EArrayRead ("sdata", EVar tid) );
+                   ] ))) );
+    (* Mutable local + while loop: the shape tail-recursion elimination
+       produces. *)
+    ( "while_accumulate",
+      base_kernel
+        "while_accumulate"
+        [vec "data" TFloat32; vec "out" TFloat32; scalar "n" TInt32]
+        (with_tid (fun tid ->
+             let i = make_var ~mut:true "i" TInt32 in
+             let acc = make_var ~mut:true "acc" TFloat32 in
+             SLet
+               ( i,
+                 EConst (CInt32 0l),
+                 SLet
+                   ( acc,
+                     EConst (CFloat32 0.0),
+                     SSeq
+                       [
+                         SWhile
+                           ( EBinop (Lt, EVar i, EVar (make_var "n" TInt32)),
+                             SSeq
+                               [
+                                 SAssign
+                                   ( LVar acc,
+                                     EBinop
+                                       ( Add,
+                                         EVar acc,
+                                         EArrayRead ("data", EVar i) ) );
+                                 SAssign
+                                   ( LVar i,
+                                     EBinop (Add, EVar i, EConst (CInt32 1l)) );
+                               ] );
+                         SAssign (LArrayElem ("out", EVar tid), EVar acc);
+                       ] ) ))) );
+  ]
+
+(** {1 Gate} *)
+
+let nvrtc_available = lazy (Cuda_nvrtc.is_available ())
+
+(* compute_75 is the floor Sarek's own NVRTC path falls back through, and needs
+   no device to target. *)
+let arch = "compute_75"
+
+let compile_ok name cuda =
+  match Cuda_nvrtc.compile_to_ptx ~name ~arch cuda with
+  | ptx ->
+      if String.length ptx = 0 then
+        Alcotest.failf "NVRTC returned empty PTX for %s" name ;
+      (* A compiled module must contain the entry point; an empty-but-successful
+         compile would otherwise pass vacuously. *)
+      if not (String.length ptx > 0 && String.length ptx > 32) then
+        Alcotest.failf "NVRTC PTX for %s is implausibly short:\n%s" name ptx ;
+      Ok ()
+  | exception e -> Error (Printexc.to_string e)
+
+let gate_tests () =
+  List.map
+    (fun (name, k) ->
+      Alcotest.test_case (Printf.sprintf "nvrtc/%s" name) `Quick (fun () ->
+          let cuda = Sarek_ir_cuda.generate_with_types ~types:k.kern_types k in
+          (* Generation is unconditional: with no toolkit we still exercise the
+             emitter and would catch a codegen exception. Only the compile step
+             is conditional. *)
+          if String.length cuda = 0 then
+            Alcotest.failf "CUDA-C generation produced empty source for %s" name ;
+          if not (Lazy.force nvrtc_available) then
+            Printf.printf
+              "  SKIP: libnvrtc not loadable (no CUDA toolkit) — %s generated \
+               only\n\
+               %!"
+              name
+          else
+            match compile_ok name cuda with
+            | Ok () -> Printf.printf "  nvrtc OK: %s\n%!" name
+            | Error e ->
+                Alcotest.failf
+                  "NVRTC rejected generated CUDA-C for %s:\n\
+                   %s\n\
+                   --- source ---\n\
+                   %s"
+                  name
+                  e
+                  cuda))
+    (corpus ())
+
+let () = Alcotest.run "cuda_nvrtc_gate" [("nvrtc-compile-gate", gate_tests ())]

--- a/sarek-cuda/test/test_cuda_nvrtc_gate.ml
+++ b/sarek-cuda/test/test_cuda_nvrtc_gate.ml
@@ -216,15 +216,32 @@ let nvrtc_available = lazy (Cuda_nvrtc.is_available ())
    no device to target. *)
 let arch = "compute_75"
 
-let compile_ok name cuda =
+(** [true] iff [needle] occurs anywhere in [hay]. *)
+let contains hay needle =
+  let n = String.length needle and h = String.length hay in
+  n <= h
+  &&
+  let rec go i = i + n <= h && (String.sub hay i n = needle || go (i + 1)) in
+  go 0
+
+let compile_ok ~kernel_name name cuda =
   match Cuda_nvrtc.compile_to_ptx ~name ~arch cuda with
   | ptx ->
-      if String.length ptx = 0 then
-        Alcotest.failf "NVRTC returned empty PTX for %s" name ;
-      (* A compiled module must contain the entry point; an empty-but-successful
-         compile would otherwise pass vacuously. *)
-      if not (String.length ptx > 0 && String.length ptx > 32) then
-        Alcotest.failf "NVRTC PTX for %s is implausibly short:\n%s" name ptx ;
+      (* NVRTC can return successfully with PTX that contains no kernel at all —
+         e.g. if the emitter dropped the __global__ qualifier, or emitted the
+         body into a device function nobody calls. Assert the entry point is
+         really there, keyed on the kernel's own name, so a compiling-but-empty
+         module cannot pass. A length threshold cannot do this: NVRTC's PTX
+         header alone clears any plausible bound. *)
+      let entry = ".entry " ^ kernel_name in
+      if not (contains ptx entry) then
+        Alcotest.failf
+          "NVRTC compiled %s but the PTX has no '%s' — the module carries no \
+           kernel:\n\
+           %s"
+          kernel_name
+          entry
+          ptx ;
       Ok ()
   | exception e -> Error (Printexc.to_string e)
 
@@ -245,7 +262,7 @@ let gate_tests () =
                %!"
               name
           else
-            match compile_ok name cuda with
+            match compile_ok ~kernel_name:k.kern_name name cuda with
             | Ok () -> Printf.printf "  nvrtc OK: %s\n%!" name
             | Error e ->
                 Alcotest.failf

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -44,9 +44,37 @@ let current_framework : string option ref = ref None
 
 let mangle_name = Sarek_ir_codegen.mangle_name
 
-(** WGSL reserved keywords that cannot be used as identifiers *)
+(** Names that must never be emitted as a WGSL identifier.
+
+    Three groups, kept separate because they are reserved for different reasons
+    and a reader needs to know which ones are load-bearing:
+
+    - {b Predeclared names} (types, address spaces, access modes, attribute
+      names). WGSL {i does} accept these as user identifiers — they live in a
+      scope outside module scope and are shadowable — so escaping them is
+      defensive rather than mandatory: a kernel variable named [f32] parses, but
+      then [f32] can no longer be spelled as a type in the same scope and the
+      emitter would produce a shader that fails much later and much less
+      legibly.
+    - {b Keywords} (WGSL §2.3 "Keyword Summary"). Hard parse errors.
+    - {b Reserved words} (WGSL §2.4 "Reserved Words"). Also hard parse errors,
+      and this is where the previous table was materially incomplete: plausible
+      OCaml variable names such as [ref], [set], [get], [from], [shared],
+      [filter], [target] and [where] are all reserved in WGSL and were being
+      emitted verbatim, producing a shader that no WebGPU implementation
+      accepts.
+
+    The keyword and reserved-word groups are not a transcription from memory:
+    every entry below was verified to be {i actually} rejected by running [naga]
+    30.0.0 (the validator [ci/assert-toolchain.sh] pins) over a minimal compute
+    shader declaring [var <name> : i32]. The probe also established that the
+    predeclared group is {i not} rejected, which is why it is labelled defensive
+    above rather than merged into the other two. Re-run the probe when bumping
+    naga: a word moving between these groups changes nothing (both are escaped),
+    but a word being {i added} to WGSL must be added here. *)
 let wgsl_reserved_keywords =
   [
+    (* -- Predeclared names: escaped defensively, not rejected by WGSL. ----- *)
     (* Types *)
     "bool";
     "f32";
@@ -66,29 +94,6 @@ let wgsl_reserved_keywords =
     "ptr";
     "sampler";
     "texture_2d";
-    (* Storage qualifiers *)
-    "var";
-    "let";
-    "const";
-    "override";
-    (* Control flow *)
-    "if";
-    "else";
-    "for";
-    "while";
-    "loop";
-    "break";
-    "continue";
-    "return";
-    "switch";
-    "case";
-    "default";
-    "fallthrough";
-    "discard";
-    (* Functions / structure *)
-    "fn";
-    "struct";
-    "type";
     (* Address spaces *)
     "storage";
     "uniform";
@@ -107,25 +112,194 @@ let wgsl_reserved_keywords =
     "group";
     "binding";
     "workgroup_size";
-    (* Built-in values *)
-    "true";
-    "false";
     (* Entry point name — avoid shadowing *)
     "main";
     (* Params struct name we emit *)
     "Params";
     "params";
     (* Internal builtin parameter names emitted by wgsl_header; must not
-       be shadowed by user variable declarations in the kernel body. *)
+       be shadowed by user variable declarations in the kernel body.
+       Redundant since [escape_wgsl_name] reserves the whole ["sarek_"]
+       prefix, kept so the intent survives a change to that rule. *)
     "sarek_gid";
     "sarek_lid";
     "sarek_wid";
     "sarek_nwg";
+    (* -- Keywords (WGSL §2.3). Hard parse errors. ------------------------- *)
+    "alias";
+    "break";
+    "case";
+    "const";
+    "const_assert";
+    "continue";
+    "continuing";
+    "default";
+    "diagnostic";
+    "discard";
+    "else";
+    "enable";
+    "false";
+    "fn";
+    "for";
+    "if";
+    "let";
+    "loop";
+    "override";
+    "requires";
+    "return";
+    "struct";
+    "switch";
+    "true";
+    "var";
+    "while";
+    (* -- Reserved words (WGSL §2.4). Hard parse errors. ------------------- *)
+    "NULL";
+    "Self";
+    "abstract";
+    "active";
+    "alignas";
+    "alignof";
+    "as";
+    "asm";
+    "asm_fragment";
+    "async";
+    "attribute";
+    "auto";
+    "await";
+    "become";
+    "cast";
+    "catch";
+    "class";
+    "co_await";
+    "co_return";
+    "co_yield";
+    "coherent";
+    "column_major";
+    "common";
+    "compile";
+    "compile_fragment";
+    "concept";
+    "consteval";
+    "constexpr";
+    "constinit";
+    "crate";
+    "do";
+    "dynamic_cast";
+    "enum";
+    "explicit";
+    "export";
+    "extends";
+    "extern";
+    "external";
+    "fallthrough";
+    "filter";
+    "final";
+    "finally";
+    "friend";
+    "from";
+    "fxgroup";
+    "get";
+    "goto";
+    "groupshared";
+    "highp";
+    "impl";
+    "implements";
+    "import";
+    "inline";
+    "instanceof";
+    "interface";
+    "layout";
+    "lowp";
+    "macro";
+    "macro_rules";
+    "match";
+    "mediump";
+    "meta";
+    "mod";
+    "module";
+    "move";
+    "mut";
+    "mutable";
+    "namespace";
+    "new";
+    "nil";
+    "noexcept";
+    "noinline";
+    "nointerpolation";
+    "non_coherent";
+    "noncoherent";
+    "noperspective";
+    "null";
+    "nullptr";
+    "of";
+    "operator";
+    "package";
+    "packoffset";
+    "partition";
+    "pass";
+    "patch";
+    "pixelfragment";
+    "precise";
+    "precision";
+    "premerge";
+    "priv";
+    "protected";
+    "pub";
+    "public";
+    "readonly";
+    "ref";
+    "regardless";
+    "register";
+    "reinterpret_cast";
+    "require";
+    "resource";
+    "restrict";
+    "self";
+    "set";
+    "shared";
+    "sizeof";
+    "smooth";
+    "snorm";
+    "static";
+    "static_assert";
+    "static_cast";
+    "std";
+    "subroutine";
+    "super";
+    "target";
+    "template";
+    "this";
+    "thread_local";
+    "throw";
+    "trait";
+    "try";
+    "type";
+    "typedef";
+    "typeid";
+    "typename";
+    "typeof";
+    "union";
+    "unless";
+    "unorm";
+    "unsafe";
+    "unsized";
+    "use";
+    "using";
+    "varying";
+    "virtual";
+    "volatile";
+    "wgsl";
+    "where";
+    "with";
+    "writeonly";
+    "yield";
   ]
 
 (** Escape identifiers that WGSL forbids.
 
-    Two distinct rules, in order:
+    Four things make a name unusable as a WGSL identifier. All four are handled
+    by the same rewrite — prefixing with ["sarek_"] — for the injectivity reason
+    set out below.
 
     - {b Reserved prefix} (WGSL §4.4.1): an identifier must not start with a
       double underscore. The frontend's tail-recursion elimination
@@ -135,27 +309,101 @@ let wgsl_reserved_keywords =
       this emitter with a [__]-prefixed variable. C-family targets (CUDA,
       OpenCL, GLSL, Metal) accept those names, WGSL rejects them outright at
       parse time ("Identifier starts with a reserved prefix"), which made the
-      emitted shader unusable on every WebGPU implementation. Re-prefixing with
-      ["sarek"] keeps the name recognisable and moves the double underscore off
-      the front, where it is legal.
+      emitted shader unusable on every WebGPU implementation. Prefixing keeps
+      the name recognisable and moves the double underscore off the front, where
+      it is legal.
     - {b Bare underscore} (same clause): a lone ["_"] is not an identifier in
       WGSL either — it is the phony-assignment target. An OCaml wildcard or
       generated placeholder reaching the emitter as ["_"] would produce
-      [let _ : i32 = ...], which naga rejects. Rewritten the same way.
-    - {b Reserved keywords}: escaped by appending a ['v'] suffix.
+      [let _ : i32 = ...], which naga rejects.
+    - {b Reserved names}: anything in {!wgsl_reserved_keywords} — WGSL keywords
+      and reserved words, plus the predeclared and internal names this emitter
+      escapes defensively.
+    - {b The escaped namespace itself}: a source name that already starts with
+      ["sarek_"] is escaped too, so it cannot be confused with the image of one
+      that was. This is what makes the rewrite injective; see below.
 
-    Both rewrites are injective except for a source identifier that already
-    literally spells the escaped form (e.g. a user variable named [sarek__i]);
-    that is the same theoretical collision the keyword suffix has, documented
-    below with the shadowing limitation. *)
+    {2 Injectivity}
+
+    An earlier form of this function rewrote each problem separately — ["_"] to
+    ["sarek_"], a ["__"] prefix to ["sarek" ^ name], a keyword to [name ^ "v"] —
+    and was {i not} injective: ["__i"] and ["sarek__i"] both emitted
+    ["sarek__i"], ["_"] and ["sarek_"] both emitted ["sarek_"], and ["if"] and
+    ["ifv"] both emitted ["ifv"]. Two source variables colliding on one WGSL
+    name is not a cosmetic problem: the second [var] declaration shadows the
+    first in the same block, every later read silently resolves to the wrong
+    binding, and the shader still compiles. A wrong answer with no diagnostic is
+    the worst failure mode available here.
+
+    The rule below is a single unconditional one: the whole ["sarek_"] prefix is
+    reserved, and any name that is reserved, or that could be confused with an
+    escaped name, is prefixed with it.
+
+    That this is injective on source identifiers is checkable by cases rather
+    than by inspection:
+    - the escaping branch only ever emits names starting with ["sarek_"];
+    - the identity branch only ever emits names {i not} starting with
+      ["sarek_"], because such a name would have taken the escaping branch;
+    - the two images are therefore disjoint, and each branch is injective on its
+      own ([name ↦ "sarek_" ^ name] and the identity).
+
+    {2 Generator-produced names}
+
+    {!wgsl_generated_prefixes} is exempt, and the exemption is structural rather
+    than a convenience. [rename_scalar_shadowing_locals] mints
+    [sarek_scalar_shadow_*] names and puts them into the IR as ordinary
+    variables, so they reach this function again on the way out. A name in the
+    escaped namespace cannot be a fixed point of the rule above — that is what
+    reserving the prefix means — so re-escaping produced
+    [sarek_sarek_scalar_shadow_width_1], and the alternative of choosing an
+    internal name that {i is} a fixed point is self-defeating: every fixed point
+    is, by definition, reachable from the identical source identifier. Internal
+    names must therefore be minted in final form and left alone.
+
+    The cost is one contrived residual: a user identifier spelled exactly like a
+    generator-internal name (a local literally named
+    [sarek_scalar_shadow_width_1]) is no longer pushed out of the namespace and
+    can collide with the generated one. That is strictly smaller than what this
+    function replaced, which collided on [__i]/[sarek__i], [_]/[sarek_] and
+    [if]/[ifv] — three families of ordinary, plausible names.
+
+    The output is also always a legal WGSL identifier: it never starts with
+    ["__"] (an escaped name starts with ["sarek"], and an unescaped one cannot
+    start with ["__"] or it would have been escaped), it is never a bare ["_"],
+    and it is never reserved (no WGSL keyword or reserved word starts with
+    ["sarek_"]).
+
+    {2 Residual}
+
+    [abi] builds the uniform-struct length fields as
+    ["sarek_" ^ escape_wgsl_name v ^ "_length"], a second construction in the
+    same namespace that this function cannot police. A vector named ["if"] and a
+    scalar named ["sarek_if_length"] in one kernel still collide there. Closing
+    it needs a length-prefixed encoding for that namespace, which changes the
+    emitted ABI field names, so it is deliberately left for its own change
+    rather than folded into this one. *)
+let wgsl_escape_prefix = "sarek_"
+
+(** Prefixes of names this generator mints itself, in already-final form. They
+    round-trip unchanged through {!escape_wgsl_name}; see its
+    "Generator-produced names" section for why the exemption is unavoidable
+    rather than a shortcut. Anything added here must be a name a generator
+    constructs, never a name that can arrive from source. *)
+let wgsl_generated_prefixes = ["sarek_scalar_shadow_"]
+
 let escape_wgsl_name name =
-  let name =
-    if name = "_" then "sarek_"
-    else if String.length name >= 2 && String.sub name 0 2 = "__" then
-      "sarek" ^ name
-    else name
-  in
-  if List.mem name wgsl_reserved_keywords then name ^ "v" else name
+  if
+    List.exists
+      (fun p -> String.starts_with ~prefix:p name)
+      wgsl_generated_prefixes
+  then name
+  else if
+    name = "_"
+    || String.starts_with ~prefix:"__" name
+    || String.starts_with ~prefix:wgsl_escape_prefix name
+    || List.mem name wgsl_reserved_keywords
+  then wgsl_escape_prefix ^ name
+  else name
 
 (** Map Sarek IR element type to WGSL type string. Float64 (f64) is not
     supported in WebGPU — callers must check for TFloat64 before reaching this
@@ -795,7 +1043,13 @@ let gen_helper_func buf (hf : helper_func) =
       hf.hf_params
   in
   Buffer.add_string buf "fn " ;
-  Buffer.add_string buf hf.hf_name ;
+  (* Escaped, like every other identifier. A call to this helper is an
+     [EApp (EVar _, _)], and [gen_expr]'s [EVar] case escapes — so emitting the
+     definition raw does not merely risk an illegal name, it guarantees the
+     definition and its call sites disagree. A helper named [__f] was defined as
+     `fn __f(` (illegal: reserved double-underscore prefix) and called as
+     `sarek___f(` (undefined function): two errors from one omission. *)
+  Buffer.add_string buf (escape_wgsl_name hf.hf_name) ;
   Buffer.add_char buf '(' ;
   List.iteri
     (fun i (v : var) ->
@@ -831,9 +1085,11 @@ let gen_helper_func buf (hf : helper_func) =
     return [x] purely to keep the reduction loop terminating; this is the one
     residual divergence from C, unavoidable in WGSL and documented as such.
 
-    The helper name is a fixed [sarek_fmod] (WGSL codegen has no collision-safe
-    naming pass); a user helper of the same name would clash — a pre-existing
-    limitation shared with any reserved WGSL identifier. *)
+    The helper name is a fixed [sarek_fmod], emitted verbatim at both its
+    definition here and its call site in [gen_expr]. A user helper of the same
+    name no longer clashes with it: [escape_wgsl_name] reserves the whole
+    ["sarek_"] prefix, so a user [sarek_fmod] is emitted as [sarek_sarek_fmod]
+    at its definition and at every call. *)
 let gen_fmod_helper buf (k : kernel) =
   if Sarek_ir_analysis.kernel_uses_intrinsic "fmod" k then
     Buffer.add_string

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -138,6 +138,10 @@ let wgsl_reserved_keywords =
       emitted shader unusable on every WebGPU implementation. Re-prefixing with
       ["sarek"] keeps the name recognisable and moves the double underscore off
       the front, where it is legal.
+    - {b Bare underscore} (same clause): a lone ["_"] is not an identifier in
+      WGSL either — it is the phony-assignment target. An OCaml wildcard or
+      generated placeholder reaching the emitter as ["_"] would produce
+      [let _ : i32 = ...], which naga rejects. Rewritten the same way.
     - {b Reserved keywords}: escaped by appending a ['v'] suffix.
 
     Both rewrites are injective except for a source identifier that already
@@ -146,7 +150,9 @@ let wgsl_reserved_keywords =
     below with the shadowing limitation. *)
 let escape_wgsl_name name =
   let name =
-    if String.length name >= 2 && String.sub name 0 2 = "__" then "sarek" ^ name
+    if name = "_" then "sarek_"
+    else if String.length name >= 2 && String.sub name 0 2 = "__" then
+      "sarek" ^ name
     else name
   in
   if List.mem name wgsl_reserved_keywords then name ^ "v" else name

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -123,8 +123,32 @@ let wgsl_reserved_keywords =
     "sarek_nwg";
   ]
 
-(** Escape reserved WGSL keywords by adding 'v' suffix. *)
+(** Escape identifiers that WGSL forbids.
+
+    Two distinct rules, in order:
+
+    - {b Reserved prefix} (WGSL §4.4.1): an identifier must not start with a
+      double underscore. The frontend's tail-recursion elimination
+      ([Sarek_tailrec_elim]) renames every eliminated loop parameter to
+      ["__" ^ name], and the native backend emits ["__v%d"]/["__m%d"]
+      temporaries, so any kernel whose recursion is turned into a loop reached
+      this emitter with a [__]-prefixed variable. C-family targets (CUDA,
+      OpenCL, GLSL, Metal) accept those names, WGSL rejects them outright at
+      parse time ("Identifier starts with a reserved prefix"), which made the
+      emitted shader unusable on every WebGPU implementation. Re-prefixing with
+      ["sarek"] keeps the name recognisable and moves the double underscore off
+      the front, where it is legal.
+    - {b Reserved keywords}: escaped by appending a ['v'] suffix.
+
+    Both rewrites are injective except for a source identifier that already
+    literally spells the escaped form (e.g. a user variable named [sarek__i]);
+    that is the same theoretical collision the keyword suffix has, documented
+    below with the shadowing limitation. *)
 let escape_wgsl_name name =
+  let name =
+    if String.length name >= 2 && String.sub name 0 2 = "__" then "sarek" ^ name
+    else name
+  in
   if List.mem name wgsl_reserved_keywords then name ^ "v" else name
 
 (** Map Sarek IR element type to WGSL type string. Float64 (f64) is not

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -2180,6 +2180,12 @@ let glslang_ok glsl =
   List.iter (fun f -> try Sys.remove f with _ -> ()) [src; spv; err; base] ;
   match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
 
+(** Invocation note: naga-cli's [--validate] flag takes a numeric
+    ValidationFlags BITMASK, not a keyword, so the former ["--validate all"]
+    exited non-zero during argument parsing for every input ("invalid digit
+    found in string") — this sweep could not ever have passed once naga was on
+    PATH. A single positional argument with no output file makes naga run the
+    full front-end + validator and print "Validation successful". *)
 let naga_ok wgsl =
   let base = Filename.temp_file "sarek_golden_wgsl_" "" in
   let src = base ^ ".wgsl" in
@@ -2188,10 +2194,7 @@ let naga_ok wgsl =
   output_string oc wgsl ;
   close_out oc ;
   let cmd =
-    Printf.sprintf
-      "naga --validate all %s >%s 2>&1"
-      (Filename.quote src)
-      (Filename.quote err)
+    Printf.sprintf "naga %s >%s 2>&1" (Filename.quote src) (Filename.quote err)
   in
   let rc = Unix.system cmd in
   let out = read_file err in

--- a/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
+++ b/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
@@ -57,6 +57,17 @@ let ci_cpu_opencl =
     ~framework:"OpenCL"
     ~is_cpu:true
 
+(* pocl's CPU device, the conformant CPU ICD added to the CI image so the tests
+   this suppression soft-fails regain real coverage (#79). Also
+   CL_DEVICE_TYPE=CPU, so it satisfies is_cpu_opencl_device — the carve-out in
+   classify_cpu_opencl_math_result is what keeps its failures hard. Two names,
+   one per pocl naming era: "pthread-" (1.x, Ubuntu 22.04) and "cpu-" (3.x+). *)
+let pocl_cpu_pthread =
+  device ~name:"pthread-znver3" ~framework:"OpenCL" ~is_cpu:true
+
+let pocl_cpu_modern =
+  device ~name:"cpu-znver4-AMD EPYC 9V45" ~framework:"OpenCL" ~is_cpu:true
+
 (* The campaign workstation's iGPU under rusticl: CL_DEVICE_TYPE=GPU, but named
    after the CPU socket. A name heuristic would misclassify this one. *)
 let igpu_named_like_a_cpu =
@@ -270,6 +281,40 @@ let () =
     "Fail"
     (classify_shape (shape ~first_bad:(Some 4) ~bad_count:60 ()) dgpu_opencl) ;
 
+  (* pocl carve-out (#79). pocl is CL_DEVICE_TYPE=CPU on OpenCL, so it passes
+     is_cpu_opencl_device; if it were not carved out, the exact flake shape
+     would be excused on it and adding a conformant ICD to the CI image would
+     have bought no coverage. Both naming eras must Fail. *)
+  print_endline "pocl (conformant CPU ICD) is never excused:" ;
+  check
+    "flake shape on pocl (pthread- name) -> Fail"
+    "Fail"
+    (classify_shape
+       (shape ~first_bad:(Some 4) ~bad_count:60 ())
+       pocl_cpu_pthread) ;
+  check
+    "flake shape on pocl (cpu- name) -> Fail"
+    "Fail"
+    (classify_shape
+       (shape ~first_bad:(Some 4) ~bad_count:60 ())
+       pocl_cpu_modern) ;
+  check
+    "is_pocl_device on pocl (pthread-) -> true"
+    true
+    (Test_helpers.is_pocl_device pocl_cpu_pthread) ;
+  check
+    "is_pocl_device on pocl (cpu-) -> true"
+    true
+    (Test_helpers.is_pocl_device pocl_cpu_modern) ;
+  check
+    "is_pocl_device on the Intel oneAPI CPU device -> false"
+    false
+    (Test_helpers.is_pocl_device ci_cpu_opencl) ;
+  check
+    "is_pocl_device on Native -> false"
+    false
+    (Test_helpers.is_pocl_device native_cpu) ;
+
   print_endline "classify_cpu_opencl_math_result, correct result:" ;
   check "CPU-OpenCL -> Pass" "Pass" (classify_ok ci_cpu_opencl) ;
   check "Native -> Pass" "Pass" (classify_ok native_cpu) ;
@@ -293,6 +338,12 @@ let () =
     "correct result on Native -> no NOTE"
     false
     (note_printed ~dev:native_cpu ~shape:clean_shape) ;
+  (* pocl is not the device whose defect the suppression tracks, so a correct
+     result from it is not an expiry signal for the Intel flake. *)
+  check
+    "correct result on pocl -> no NOTE"
+    false
+    (note_printed ~dev:pocl_cpu_pthread ~shape:clean_shape) ;
   check
     "--no-verify on the known-issue device -> no NOTE (nothing was compared)"
     false

--- a/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
+++ b/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
@@ -57,11 +57,13 @@ let ci_cpu_opencl =
     ~framework:"OpenCL"
     ~is_cpu:true
 
-(* pocl's CPU device, the conformant CPU ICD added to the CI image so the tests
-   this suppression soft-fails regain real coverage (#79). Also
-   CL_DEVICE_TYPE=CPU, so it satisfies is_cpu_opencl_device — the carve-out in
-   classify_cpu_opencl_math_result is what keeps its failures hard. Two names,
-   one per pocl naming era: "pthread-" (1.x, Ubuntu 22.04) and "cpu-" (3.x+). *)
+(* pocl's CPU device. Not in the CI image today (see Test_helpers.is_pocl_device
+   for why the jammy build was reverted), but CL_DEVICE_TYPE=CPU, so it would
+   satisfy is_cpu_opencl_device the moment one appears — and the carve-out in
+   classify_cpu_opencl_math_result is what would keep its failures hard. Pinning
+   the behaviour now means the experimental pocl PR cannot land the coverage
+   regression silently. Two names, one per pocl naming era: "pthread-" (1.x,
+   Ubuntu 22.04) and "cpu-" (3.x+). *)
 let pocl_cpu_pthread =
   device ~name:"pthread-znver3" ~framework:"OpenCL" ~is_cpu:true
 
@@ -284,7 +286,7 @@ let () =
   (* pocl carve-out (#79). pocl is CL_DEVICE_TYPE=CPU on OpenCL, so it passes
      is_cpu_opencl_device; if it were not carved out, the exact flake shape
      would be excused on it and adding a conformant ICD to the CI image would
-     have bought no coverage. Both naming eras must Fail. *)
+     buy no coverage. Both naming eras must Fail. *)
   print_endline "pocl (conformant CPU ICD) is never excused:" ;
   check
     "flake shape on pocl (pthread- name) -> Fail"

--- a/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
+++ b/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
@@ -85,6 +85,15 @@ let dgpu_opencl =
     ~framework:"OpenCL"
     ~is_cpu:false
 
+(* A GPU whose CL_DEVICE_NAME happens to start with a pocl prefix. Contrived as
+   a product name, but it is the case that separates the two possible readings
+   of is_pocl_device: name-only (would say "pocl") versus name-AND-device-type
+   (says "not pocl", which is what the predicate's contract states). Without
+   this row, dropping the CL_DEVICE_TYPE test from is_pocl_device passes the
+   whole suite. *)
+let gpu_named_like_pocl =
+  device ~name:"cpu-znver4 compatibility GPU" ~framework:"OpenCL" ~is_cpu:false
+
 let native_cpu = device ~name:"CPU Native" ~framework:"Native" ~is_cpu:true
 
 let interpreter =
@@ -316,6 +325,14 @@ let () =
     "is_pocl_device on Native -> false"
     false
     (Test_helpers.is_pocl_device native_cpu) ;
+  check
+    "is_pocl_device on a GPU whose name starts with a pocl prefix -> false"
+    false
+    (Test_helpers.is_pocl_device gpu_named_like_pocl) ;
+  check
+    "is_pocl_device on the iGPU named like a CPU -> false"
+    false
+    (Test_helpers.is_pocl_device igpu_named_like_a_cpu) ;
 
   print_endline "classify_cpu_opencl_math_result, correct result:" ;
   check "CPU-OpenCL -> Pass" "Pass" (classify_ok ci_cpu_opencl) ;

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -372,20 +372,24 @@ let pocl_device_name_prefixes = ["pthread-"; "cpu-"]
 
 (** [true] iff [dev] is pocl's CPU device.
 
-    Needed because the CPU-OpenCL known-issue suppression below is keyed on
-    "some CPU OpenCL device", and the CI image now registers TWO CPU ICDs: the
-    Intel oneAPI CPU runtime (the defective one) and pocl (added for exactly
-    this reason — see task #79). Left unnarrowed, the suppression would excuse
-    genuine pocl wrongness too, and adding a conformant ICD would have bought no
-    real coverage at all.
+    {b Currently inert: the CI image ships no pocl.} It is kept because it is
+    the precondition for ever adding one. The CPU-OpenCL known-issue suppression
+    below is keyed on "some CPU OpenCL device", and pocl's device is also
+    CL_DEVICE_TYPE=CPU — so a second, conformant CPU ICD would be swallowed by
+    the same carve-out and buy no coverage at all (task #79). This predicate is
+    what makes pocl's failures hard.
+
+    An attempt to install pocl 1.8 on jammy was reverted: it cannot compile a
+    kernel in that image (`error: unknown target CPU 'generic'`), and pinning
+    the E2E tests to it made them SKIP. It moves to a separate experimental PR;
+    this predicate is pre-positioned for it.
 
     This does sniff the device name, which [is_cpu_opencl_device] deliberately
     avoids — but here the alternative is worse: the device-type query cannot
     distinguish two CPU ICDs, and SPOC's [Device.t] carries no platform or
-    vendor field. The failure mode is guarded rather than argued away:
-    [ci/assert-toolchain.sh] asserts that a device matching these prefixes
-    really enumerates in the CI image, so a pocl rename fails the build loudly
-    instead of quietly re-widening the suppression. *)
+    vendor field. When pocl does land, [ci/assert-toolchain.sh] must assert that
+    a device matching these prefixes really enumerates, so a pocl rename fails
+    the build loudly instead of quietly re-widening the suppression. *)
 let is_pocl_device (dev : Device.t) =
   Device.is_opencl dev
   && List.exists
@@ -492,9 +496,9 @@ let cpu_opencl_math_lane_width = 4
     failure must also match the flake's SHAPE. [`Known_issue] iff ALL of
 
     - [is_cpu_opencl_device dev] — the ICD really reports CL_DEVICE_TYPE=CPU;
-    - [not (is_pocl_device dev)] — pocl is the conformant CPU ICD added to the
-      CI image so these tests regain real coverage (#79), so it is never
-      excused: any wrongness from pocl is a hard failure whatever its shape;
+    - [not (is_pocl_device dev)] — if a conformant CPU ICD (pocl) is ever
+      present, it is never excused: any wrongness from it is a hard failure
+      whatever its shape (#79). Inert today; see [is_pocl_device];
     - [first_bad_index >= cpu_opencl_math_lane_width] (= 4) — the scalar
       prologue is intact. A wrong intrinsic-name mapping or a swapped operand in
       an emitter is wrong from element 0, and a kernel that never executed is
@@ -512,10 +516,9 @@ let cpu_opencl_math_lane_width = 4
     CPU-OpenCL device is excused — e.g. a dropped final work-group leaving the
     0.0 pre-fill in the buffer tail. That is the deliberate trade that
     suppresses the flake. It is still covered on Native, Interpreter and every
-    GPU device — and, since pocl joined the CI image, on a conformant CPU OpenCL
-    device too, which is the point of the [is_pocl_device] carve-out: the
-    residual now applies only to the Intel runtime, not to "CPU OpenCL" as a
-    class.
+    GPU device. The [is_pocl_device] carve-out narrows the residual to the Intel
+    runtime rather than to "CPU OpenCL" as a class, so a conformant CPU ICD
+    would close it as soon as one is available in CI.
 
     Suppression review: this KNOWN-ISSUE exists only until the CI OpenCL ICD is
     fixed or replaced (task #74). Re-evaluate by 2027-01-01, or earlier if the
@@ -552,10 +555,10 @@ let classify_cpu_opencl_math_result ~dev ~(shape : float_check_shape)
   end
   else if
     is_cpu_opencl_device dev
-    (* pocl is a conformant ICD and is in the CI image precisely so that the
-       tests this suppression soft-fails get real coverage from SOMETHING
-       (#79). Excusing pocl would defeat that, so it is explicitly outside the
-       suppression: a pocl miscomputation is always a hard failure. *)
+    (* A conformant ICD exists to give these tests real coverage from
+       SOMETHING (#79); excusing it would defeat that, so pocl is explicitly
+       outside the suppression and a pocl miscomputation is always a hard
+       failure. Inert while the CI image ships only the Intel runtime. *)
     && (not (is_pocl_device dev))
     && shape.bad_count < shape.total
     &&

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -391,7 +391,15 @@ let pocl_device_name_prefixes = ["pthread-"; "cpu-"]
     a device matching these prefixes really enumerates, so a pocl rename fails
     the build loudly instead of quietly re-widening the suppression. *)
 let is_pocl_device (dev : Device.t) =
-  Device.is_opencl dev
+  (* [is_cpu_opencl_device], not a bare [Device.is_opencl]: the contract above
+     is "pocl's CPU device", and pocl's device is CL_DEVICE_TYPE=CPU. The name
+     prefixes alone do not carry that — as the comment on
+     [is_cpu_opencl_device] records, an OpenCL device on this workstation is
+     named after the CPU socket while reporting CL_DEVICE_TYPE=GPU, so a
+     name-only test is exactly the classifier that gets such a device wrong.
+     The callers' outer CPU check currently masks the difference; that is a
+     property of the callers, not of this predicate. *)
+  is_cpu_opencl_device dev
   && List.exists
        (fun p -> String.starts_with ~prefix:p (String.lowercase_ascii dev.name))
        pocl_device_name_prefixes

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -366,6 +366,32 @@ let classify_fp64_result ~framework ~device ~within_tol ~transcendental
 let is_cpu_opencl_device (dev : Device.t) =
   Device.is_opencl dev && Device.is_cpu dev
 
+(** CL_DEVICE_NAME prefixes pocl uses for its CPU device: ["pthread-"] on the
+    1.x series (what Ubuntu 22.04 ships) and ["cpu-"] from 3.x on. *)
+let pocl_device_name_prefixes = ["pthread-"; "cpu-"]
+
+(** [true] iff [dev] is pocl's CPU device.
+
+    Needed because the CPU-OpenCL known-issue suppression below is keyed on
+    "some CPU OpenCL device", and the CI image now registers TWO CPU ICDs: the
+    Intel oneAPI CPU runtime (the defective one) and pocl (added for exactly
+    this reason — see task #79). Left unnarrowed, the suppression would excuse
+    genuine pocl wrongness too, and adding a conformant ICD would have bought no
+    real coverage at all.
+
+    This does sniff the device name, which [is_cpu_opencl_device] deliberately
+    avoids — but here the alternative is worse: the device-type query cannot
+    distinguish two CPU ICDs, and SPOC's [Device.t] carries no platform or
+    vendor field. The failure mode is guarded rather than argued away:
+    [ci/assert-toolchain.sh] asserts that a device matching these prefixes
+    really enumerates in the CI image, so a pocl rename fails the build loudly
+    instead of quietly re-widening the suppression. *)
+let is_pocl_device (dev : Device.t) =
+  Device.is_opencl dev
+  && List.exists
+       (fun p -> String.starts_with ~prefix:p (String.lowercase_ascii dev.name))
+       pocl_device_name_prefixes
+
 (** KNOWN-ISSUE label for the CPU-OpenCL float32 transcendental flake. *)
 let cpu_opencl_float32_math_label =
   "CPU-OpenCL float32 transcendentals (sin/cos/exp/sqrt) are miscompiled by \
@@ -466,6 +492,9 @@ let cpu_opencl_math_lane_width = 4
     failure must also match the flake's SHAPE. [`Known_issue] iff ALL of
 
     - [is_cpu_opencl_device dev] — the ICD really reports CL_DEVICE_TYPE=CPU;
+    - [not (is_pocl_device dev)] — pocl is the conformant CPU ICD added to the
+      CI image so these tests regain real coverage (#79), so it is never
+      excused: any wrongness from pocl is a hard failure whatever its shape;
     - [first_bad_index >= cpu_opencl_math_lane_width] (= 4) — the scalar
       prologue is intact. A wrong intrinsic-name mapping or a swapped operand in
       an emitter is wrong from element 0, and a kernel that never executed is
@@ -483,8 +512,10 @@ let cpu_opencl_math_lane_width = 4
     CPU-OpenCL device is excused — e.g. a dropped final work-group leaving the
     0.0 pre-fill in the buffer tail. That is the deliberate trade that
     suppresses the flake. It is still covered on Native, Interpreter and every
-    GPU device; it is NOT covered on CI's only OpenCL device, which is why
-    adding a conformant CPU ICD (pocl) to the CI image is tracked separately.
+    GPU device — and, since pocl joined the CI image, on a conformant CPU OpenCL
+    device too, which is the point of the [is_pocl_device] carve-out: the
+    residual now applies only to the Intel runtime, not to "CPU OpenCL" as a
+    class.
 
     Suppression review: this KNOWN-ISSUE exists only until the CI OpenCL ICD is
     fixed or replaced (task #74). Re-evaluate by 2027-01-01, or earlier if the
@@ -511,7 +542,8 @@ let classify_cpu_opencl_math_result ~dev ~(shape : float_check_shape)
        Gated on [total > 0]: under --no-verify nothing was compared (see
        [float_check_not_verified]), and claiming a CORRECT result there would be
        a misleading expiry signal. *)
-    if is_cpu_opencl_device dev && shape.total > 0 then
+    if is_cpu_opencl_device dev && (not (is_pocl_device dev)) && shape.total > 0
+    then
       Printf.printf
         "NOTE: known-issue device produced a CORRECT result — re-evaluate the \
          CPU-OpenCL suppression (task #74)\n\
@@ -520,6 +552,11 @@ let classify_cpu_opencl_math_result ~dev ~(shape : float_check_shape)
   end
   else if
     is_cpu_opencl_device dev
+    (* pocl is a conformant ICD and is in the CI image precisely so that the
+       tests this suppression soft-fails get real coverage from SOMETHING
+       (#79). Excusing pocl would defeat that, so it is explicitly outside the
+       suppression: a pocl miscomputation is always a hard failure. *)
+    && (not (is_pocl_device dev))
     && shape.bad_count < shape.total
     &&
     match shape.first_bad_index with

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -74,6 +74,15 @@
  (deps ../../codegen/Sarek_ir_ptx_expr.ml)
  (libraries sarek.codegen alcotest unix str))
 
+; WGSL identifier escaping: injectivity + legality of escape_wgsl_name, and
+; coverage of the WGSL keyword/reserved-word table. Pure string-level test —
+; no naga, no device — complementing the whole-shader naga sweep in
+; test_shader_recursion_vector below.
+
+(test
+ (name test_wgsl_escape)
+ (libraries sarek.codegen alcotest))
+
 ; Shader-validation gate for recursion + vector-parameter helpers.
 ; GLSL assembled with glslangValidator; WGSL validated with naga if present,
 ; else skipped cleanly (mirrors the ptxas gate above). CPU-only, no device.

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -483,7 +483,14 @@ let glslang_ok glsl =
   match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
 
 (** Validate WGSL with naga (front-end + validation). naga infers the input
-    language from the [.wgsl] extension. *)
+    language from the [.wgsl] extension.
+
+    Invocation note: naga-cli's [--validate] takes a numeric ValidationFlags
+    BITMASK, not a keyword, so the former ["--validate all"] made naga exit
+    non-zero on argument parsing ("invalid digit found in string") for every
+    input — the gate could not ever have passed once naga was on PATH. With a
+    single positional argument and no output file, naga performs full validation
+    by default and prints "Validation successful". *)
 let naga_ok wgsl =
   let base = Filename.temp_file "sarek_wgsl_" "" in
   let src = base ^ ".wgsl" in
@@ -492,10 +499,7 @@ let naga_ok wgsl =
   output_string oc wgsl ;
   close_out oc ;
   let cmd =
-    Printf.sprintf
-      "naga --validate all %s >%s 2>&1"
-      (Filename.quote src)
-      (Filename.quote err)
+    Printf.sprintf "naga %s >%s 2>&1" (Filename.quote src) (Filename.quote err)
   in
   let rc = Unix.system cmd in
   let out = read_file err in

--- a/sarek/tests/unit/test_wgsl_escape.ml
+++ b/sarek/tests/unit/test_wgsl_escape.ml
@@ -1,0 +1,232 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Unit tests for Sarek_ir_wgsl.escape_wgsl_name.
+ *
+ * Two properties, both of which were violated before this suite existed:
+ *
+ *   1. INJECTIVITY. Distinct source identifiers must not collide on one WGSL
+ *      name. This is the property with teeth: two colliding `var` declarations
+ *      in one block produce a shader that is perfectly VALID, so naga accepts
+ *      it, the validation sweep passes, and every read after the second
+ *      declaration silently resolves to the wrong binding. There is no
+ *      diagnostic anywhere in the pipeline for this failure — only a wrong
+ *      numeric answer at runtime — which is why it is pinned here rather than
+ *      left to the shader-validation gate.
+ *
+ *   2. LEGALITY. The escaped name must actually be a WGSL identifier: not a
+ *      keyword or reserved word, not `_`, and not `__`-prefixed.
+ *
+ * The reserved-word table these tests exercise is not a transcription from
+ * memory. It was built by running every candidate through `naga` (the same
+ * validator ci/assert-toolchain.sh pins) as `var <name> : i32` in a minimal
+ * compute shader and keeping the ones it rejected. `test_shader_recursion_
+ * vector.ml` runs naga over whole generated shaders; this suite is the fast,
+ * naga-free complement that runs on a developer machine with no tooling.
+ ******************************************************************************)
+
+module W = Sarek_codegen.Sarek_ir_wgsl
+
+let esc = W.escape_wgsl_name
+
+(* --------------------------------------------------------------------- *)
+(* 1. Injectivity                                                        *)
+(* --------------------------------------------------------------------- *)
+
+(* The exact pairs the previous escaping merged. Each is a distinct pair of
+   legal source identifiers that mapped to one WGSL name:
+     "__i" and "sarek__i" -> "sarek__i"   (double-underscore rule)
+     "_"   and "sarek_"   -> "sarek_"     (bare-underscore rule)
+     "if"  and "ifv"      -> "ifv"        (keyword 'v'-suffix rule)
+   Each rule contributed its own collision, so all three are pinned. *)
+let collision_pairs =
+  [
+    ("__i", "sarek__i");
+    ("_", "sarek_");
+    ("if", "ifv");
+    ("__v0", "sarek__v0");
+    ("fallthrough", "fallthroughv");
+    ("sarek_gid", "gid");
+    ("sarek_fmod", "fmod");
+  ]
+
+let test_no_collisions () =
+  List.iter
+    (fun (a, b) ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%S and %S must not collide (both -> %S)" a b (esc a))
+        false
+        (esc a = esc b))
+    collision_pairs
+
+(* Injectivity over a corpus, rather than only over the known-bad pairs: every
+   reserved word, each one prefixed, and the shapes the frontend actually
+   generates. A duplicate anywhere in the image is a failure. *)
+let corpus =
+  W.wgsl_reserved_keywords
+  @ List.map (fun k -> "sarek_" ^ k) W.wgsl_reserved_keywords
+  @ List.map (fun k -> k ^ "v") W.wgsl_reserved_keywords
+  @ ["_"; "__"; "___"; "__i"; "__v0"; "__m3"; "sarek_"; "sarek__"; "sarek___i"]
+  @ ["i"; "x"; "acc"; "gid"; "idx"; "tmp0"; "sarek"; "sarekx"; "sarek_x"]
+
+let test_injective_over_corpus () =
+  let seen = Hashtbl.create 512 in
+  List.iter
+    (fun name ->
+      let e = esc name in
+      match Hashtbl.find_opt seen e with
+      | Some other when other <> name ->
+          Alcotest.failf
+            "escape_wgsl_name is not injective: %S and %S both map to %S"
+            other
+            name
+            e
+      | _ -> Hashtbl.replace seen e name)
+    corpus
+
+(* --------------------------------------------------------------------- *)
+(* 2. Legality of the result                                             *)
+(* --------------------------------------------------------------------- *)
+
+let test_result_is_never_reserved () =
+  List.iter
+    (fun k ->
+      Alcotest.(check bool)
+        (Printf.sprintf "esc %S = %S must not itself be reserved" k (esc k))
+        false
+        (List.mem (esc k) W.wgsl_reserved_keywords))
+    W.wgsl_reserved_keywords
+
+let test_result_has_no_reserved_prefix () =
+  List.iter
+    (fun name ->
+      let e = esc name in
+      Alcotest.(check bool)
+        (Printf.sprintf "esc %S = %S must not start with __" name e)
+        false
+        (String.starts_with ~prefix:"__" e) ;
+      Alcotest.(check bool)
+        (Printf.sprintf "esc %S = %S must not be a bare _" name e)
+        false
+        (e = "_"))
+    corpus
+
+(* --------------------------------------------------------------------- *)
+(* 3. The keyword table itself                                           *)
+(* --------------------------------------------------------------------- *)
+
+(* Regression for the six current WGSL keywords the table omitted. A source
+   variable named `alias` or `enable` was emitted verbatim and no WebGPU
+   implementation accepts the result. *)
+let newly_covered_keywords =
+  [
+    "alias";
+    "const_assert";
+    "continuing";
+    "diagnostic";
+    "enable";
+    "requires";
+    (* reserved words — same class, and these are plausible OCaml names *)
+    "ref";
+    "set";
+    "get";
+    "from";
+    "shared";
+    "filter";
+    "target";
+    "where";
+    "match";
+    "use";
+    "union";
+    "static";
+  ]
+
+let test_keyword_table_covers () =
+  List.iter
+    (fun k ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%S must be in the reserved table" k)
+        true
+        (List.mem k W.wgsl_reserved_keywords) ;
+      Alcotest.(check bool)
+        (Printf.sprintf "%S must be rewritten, not emitted verbatim" k)
+        false
+        (esc k = k))
+    newly_covered_keywords
+
+let test_no_duplicates_in_table () =
+  let sorted = List.sort compare W.wgsl_reserved_keywords in
+  let rec dup = function
+    | a :: (b :: _ as tl) -> if a = b then Some a else dup tl
+    | _ -> None
+  in
+  match dup sorted with
+  | Some d -> Alcotest.failf "duplicate entry in wgsl_reserved_keywords: %S" d
+  | None -> ()
+
+(* Generator-minted names must round-trip unchanged. rename_scalar_shadowing_
+   locals puts sarek_scalar_shadow_* names back into the IR as ordinary
+   variables, so they reach escape_wgsl_name a second time on the way out;
+   without the exemption they came out as sarek_sarek_scalar_shadow_width_1 and
+   the WGSL shadowing gate in test_shader_recursion_vector.ml failed. Escaping
+   must be idempotent on them specifically. *)
+let generated_names =
+  [
+    "sarek_scalar_shadow_width_1";
+    "sarek_scalar_shadow_if_0";
+    "sarek_scalar_shadow_sarek_x_2";
+  ]
+
+let test_generated_names_are_fixed_points () =
+  List.iter
+    (fun n ->
+      Alcotest.(check string)
+        (Printf.sprintf "%S must round-trip unchanged" n)
+        n
+        (esc n) ;
+      Alcotest.(check string)
+        (Printf.sprintf "%S must be idempotent under a second escape" n)
+        (esc n)
+        (esc (esc n)))
+    generated_names
+
+(* Ordinary identifiers must survive untouched — an escaping pass that renames
+   everything would satisfy injectivity and be useless to read. *)
+let test_plain_names_untouched () =
+  List.iter
+    (fun n ->
+      Alcotest.(check string) (Printf.sprintf "%S is left alone" n) n (esc n))
+    ["i"; "x"; "acc"; "idx"; "tmp0"; "my_var"; "gid"; "sarek"; "sarekx"]
+
+let () =
+  let open Alcotest in
+  run
+    "Sarek_ir_wgsl escaping"
+    [
+      ( "injectivity",
+        [
+          test_case "known collision pairs" `Quick test_no_collisions;
+          test_case "injective over corpus" `Quick test_injective_over_corpus;
+        ] );
+      ( "legality",
+        [
+          test_case "result never reserved" `Quick test_result_is_never_reserved;
+          test_case
+            "result has no reserved prefix"
+            `Quick
+            test_result_has_no_reserved_prefix;
+        ] );
+      ( "keyword_table",
+        [
+          test_case "covers WGSL keywords" `Quick test_keyword_table_covers;
+          test_case "no duplicates" `Quick test_no_duplicates_in_table;
+          test_case "plain names untouched" `Quick test_plain_names_untouched;
+          test_case
+            "generated names are fixed points"
+            `Quick
+            test_generated_names_are_fixed_points;
+        ] );
+    ]

--- a/scripts/check-formal-proofs.sh
+++ b/scripts/check-formal-proofs.sh
@@ -50,6 +50,45 @@ EXPECTED_PROJECTS=3
 
 cd "$(dirname "$0")/.."
 
+# Writability pre-flight.
+#
+# This script rebuilds in place: it deletes committed .vo files and regenerates
+# CoqMakefile next to the sources. In CI that happens inside a container whose
+# user need not own the mounted checkout — rocq/rocq-prover runs as `rocq`
+# (uid 1000) while a GitHub-hosted runner owns the workspace as `runner`
+# (uid 1001), and a uid-1000 process cannot write a uid-1001 0755 directory.
+# Without this probe the first symptom is an EACCES from `rm` several steps
+# later, which reads like a broken proof rather than a broken mount.
+#
+# This cannot be caught by running the script locally: a developer's checkout is
+# already owned by the user running it. That is precisely why it is asserted.
+probe=".formal-write-probe.$$"
+if ! : > "$probe" 2>/dev/null; then
+  echo "::error::$(pwd) is not writable by uid $(id -u). This script rebuilds \
+the proofs in place. In CI, mount a checkout owned by the container's user (see \
+the formal-proofs job in .github/workflows/ci.yml)."
+  exit 1
+fi
+rm -f "$probe"
+
+# Refuse to run on a formal/ tree that already has uncommitted changes.
+#
+# Step 6 restores the tree with `git checkout -- .` because the build rewrites
+# ~68 extracted .ml/.mli files. That restore cannot tell build output from work
+# in progress, so on a dirty tree it would silently destroy a developer's
+# uncommitted edits. Refusing here is what makes the restore safe: after this
+# check, any drift observed later must have been produced by the build.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  dirty=$(git status --porcelain -- formal | grep -v '^?? ' || true)
+  if [ -n "$dirty" ] && [ "${FORMAL_ALLOW_DIRTY:-0}" != "1" ]; then
+    echo "::error::formal/ has uncommitted changes to tracked files. This \
+script rebuilds in place and restores the tree afterwards, which would discard \
+them. Commit or stash first, or set FORMAL_ALLOW_DIRTY=1 to accept the loss."
+    printf '%s\n' "$dirty" | sed 's/^/    /'
+    exit 1
+  fi
+fi
+
 if command -v rocq >/dev/null 2>&1; then
   ROCQ=rocq
 elif command -v coqc >/dev/null 2>&1; then
@@ -93,6 +132,42 @@ cannot determine the logical path to check."
   (
     cd "$proj"
 
+    # Restore the working tree on EVERY exit path, installed BEFORE the first
+    # destructive step.
+    #
+    # `make -f CoqMakefile` re-runs extraction, and the extracted .ml/.mli files
+    # are committed in ocamlformat-formatted form while extraction emits them
+    # raw. A full run therefore rewrites ~68 tracked files with semantically
+    # identical but differently formatted output, and also leaves a regenerated
+    # CoqMakefile behind. Harmless on a throwaway CI checkout, destructive for
+    # anyone running this documented gate on their own tree.
+    #
+    # As a trap rather than a final step because the interesting exits are the
+    # early ones: a failed compile or a failed kernel re-check used to leave the
+    # committed .vo files deleted and the tree rewritten, and — now that this
+    # script refuses to start on a dirty formal/ — that residue would block the
+    # very next run with a message about uncommitted changes the developer never
+    # made. Restoring unconditionally keeps a failed run repeatable.
+    #
+    # Safe precisely because of the dirty-tree check above: the tree was clean
+    # when this started, so anything to restore was produced by this script.
+    # The lia/nia caches are untracked build residue the tactics drop next to
+    # the sources; they would otherwise be left behind.
+    restore_tree() {
+      rm -f .lia.cache .nia.cache
+      if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        drift=$(git status --porcelain -- . 2>/dev/null | grep -v '^?? ' || true)
+        if [ -n "$drift" ]; then
+          n=$(printf '%s\n' "$drift" | wc -l)
+          echo "  NOTE: the build rewrote $n tracked file(s) (extraction output" \
+               "vs the ocamlformat-formatted committed copies); restoring them."
+          git checkout -- . 2>/dev/null || \
+            echo "  WARNING: could not restore; tree left dirty."
+        fi
+      fi
+    }
+    trap restore_tree EXIT
+
     # 1. Delete every committed build artefact. A .vo that is never rebuilt is
     #    an unverified binary blob, and re-checking it would only prove it is
     #    self-consistent, not that it matches the .v beside it.
@@ -125,25 +200,44 @@ cannot determine the logical path to check."
     # 4. Kernel re-check. This is the load-bearing step: it re-verifies the
     #    proof terms independently of the elaborator that built them, and
     #    reports the axioms they rest on.
+    #    `set +e` around the capture is load-bearing, not defensive habit.
+    #    `out=$(rocq check ...)` is a plain assignment in a command body, not an
+    #    `if` condition, so `set -e` applies to it in full. `rocqchk` exits
+    #    non-zero when it finds an error, so on a REAL kernel-check failure the
+    #    subshell died on this very line — before the diagnostics below could
+    #    run — and because `2>&1` had redirected the checker's entire output
+    #    into `$out`, that output was discarded with it. The job still failed
+    #    (no false pass), but reported none of the context this step exists to
+    #    provide. Untested until now because the committed proofs all pass.
+    set +e
     if [ -n "$ROCQ" ]; then
       out=$(rocq check -R theories "$logical" theories/*.vo 2>&1)
     else
       out=$(coqchk -R theories "$logical" theories/*.vo 2>&1)
     fi
+    rc=$?
+    set -e
     printf '%s\n' "$out" | tail -3
+    # Two independent conditions, both fatal: a non-zero exit from the checker,
+    # and the absence of its success marker. Neither implies the other — a
+    # checker that dies on a missing .vo exits non-zero without ever printing a
+    # verdict, and a truncated or partial run can exit 0 having checked nothing.
+    #
     # Substring match on the variable, NOT `printf ... | grep -q`: grep -q exits
     # on its first match and closes the pipe, printf takes SIGPIPE (141), and
     # `set -o pipefail` propagates that as a failure. With `rocq check` output
     # running to thousands of lines this fires reliably, and the check would
     # report a failure on a run where every proof passed.
     case "$out" in
-      *"Modules were successfully checked"*) : ;;
-      *)
-        echo "::error::kernel re-check FAILED for $proj"
-        printf '%s\n' "$out"
-        exit 1
-        ;;
+      *"Modules were successfully checked"*) marker=1 ;;
+      *) marker=0 ;;
     esac
+    if [ "$rc" -ne 0 ] || [ "$marker" -ne 1 ]; then
+      echo "::error::kernel re-check FAILED for $proj (exit $rc, success marker \
+present: $marker)"
+      printf '%s\n' "$out"
+      exit 1
+    fi
 
     # 5. Report what the proofs assume. `rocq check` lists axioms rather than
     #    rejecting them, and this repository has one sanctioned escape hatch
@@ -162,34 +256,18 @@ cannot determine the logical path to check."
     # awk, not bc: bc is not installed in the rocq/rocq-prover image, and under
     # `set -euo pipefail` its absence failed the job AFTER every proof had
     # already been checked — a green result reported as red.
-    theorems=$(grep -rhcE "^(Theorem|Lemma|Corollary|Proposition|Remark|Fact) " \
-                 theories/*.v | awk '{s += $1} END {print s + 0}')
+    #
+    # `|| true` for the same reason: `grep -c` exits 1 when NO file matched, and
+    # under pipefail that status propagates out of the assignment and `set -e`
+    # kills the run. This is a reporting line, not a gate — a project with no
+    # Theorem/Lemma must print 0, not fail a run whose proofs all checked.
+    theorems=$({ grep -rhcE "^(Theorem|Lemma|Corollary|Proposition|Remark|Fact) " \
+                   theories/*.v || true; } | awk '{s += $1} END {print s + 0}')
     echo "  kernel-verified statements in theories/: $theorems"
 
-    # 6. Put the working tree back.
-    #
-    #    `make -f CoqMakefile` also re-runs extraction, and the extracted .ml /
-    #    .mli files are committed in ocamlformat-formatted form while extraction
-    #    emits them raw. A full run therefore rewrites ~68 tracked files
-    #    (~2.5k insertions / ~4.4k deletions) with semantically identical but
-    #    differently formatted output. Harmless on a throwaway CI checkout,
-    #    destructive for anyone running this documented gate on their own tree.
-    #    Report the drift so it stays visible, then restore.
-    #    The lia/nia decision-procedure caches are pure build residue that the
-    #    tactics drop next to the sources; they are untracked and would
-    #    otherwise be left behind in a developer's tree.
-    rm -f .lia.cache .nia.cache
-
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-      drift=$(git status --porcelain -- . 2>/dev/null | grep -v '^?? ' || true)
-      if [ -n "$drift" ]; then
-        n=$(printf '%s\n' "$drift" | wc -l)
-        echo "  NOTE: the build rewrote $n tracked file(s) (extraction output vs" \
-             "the ocamlformat-formatted committed copies); restoring them."
-        git checkout -- . 2>/dev/null || \
-          echo "  WARNING: could not restore; tree left dirty."
-      fi
-    fi
+    # 6. The working tree is put back by the restore_tree EXIT trap installed
+    #    at the top of this subshell, so that it also runs on the failure paths
+    #    above. See the comment there.
   )
   checked=$((checked + 1))
 done

--- a/scripts/check-formal-proofs.sh
+++ b/scripts/check-formal-proofs.sh
@@ -43,6 +43,11 @@
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
+# How many formal/ projects must be found and checked. Pinned so that a project
+# silently disappearing (a moved _CoqProject, a bad merge) fails the gate
+# instead of quietly shrinking its scope.
+EXPECTED_PROJECTS=3
+
 cd "$(dirname "$0")/.."
 
 if command -v rocq >/dev/null 2>&1; then
@@ -91,11 +96,22 @@ cannot determine the logical path to check."
     # 1. Delete every committed build artefact. A .vo that is never rebuilt is
     #    an unverified binary blob, and re-checking it would only prove it is
     #    self-consistent, not that it matches the .v beside it.
+    #
+    #    The generated makefile and its dependency files go too, and that is not
+    #    tidiness — it is the stale-generated-artefact hazard this script exists
+    #    to catch, biting the script itself. The tracked .CoqMakefile.d files
+    #    hard-code /usr/lib/ocaml/rocq-runtime/rocqworker, the path of a
+    #    system-packaged Rocq. That path exists on a distro install and does not
+    #    exist in the opam-based rocq/rocq-prover image, so reusing them fails
+    #    the build with "No rule to make target" before a single proof is
+    #    checked.
     find . \( -name '*.vo' -o -name '*.vok' -o -name '*.vos' \
-              -o -name '*.glob' \) -exec rm -f {} +
+              -o -name '*.glob' -o -name '*.CoqMakefile.d' \
+              -o -name 'CoqMakefile' -o -name 'CoqMakefile.conf' \) \
+         -exec rm -f {} +
 
-    # 2. Regenerate the makefile from _CoqProject rather than trusting the
-    #    committed CoqMakefile, which is itself generated and could be stale.
+    # 2. Regenerate the makefile from _CoqProject. Never reuse the committed
+    #    CoqMakefile: see above.
     if [ -n "$ROCQ" ]; then
       rocq makefile -f _CoqProject -o CoqMakefile
     else
@@ -115,11 +131,19 @@ cannot determine the logical path to check."
       out=$(coqchk -R theories "$logical" theories/*.vo 2>&1)
     fi
     printf '%s\n' "$out" | tail -3
-    if ! printf '%s\n' "$out" | grep -q "Modules were successfully checked"; then
-      echo "::error::kernel re-check FAILED for $proj"
-      printf '%s\n' "$out"
-      exit 1
-    fi
+    # Substring match on the variable, NOT `printf ... | grep -q`: grep -q exits
+    # on its first match and closes the pipe, printf takes SIGPIPE (141), and
+    # `set -o pipefail` propagates that as a failure. With `rocq check` output
+    # running to thousands of lines this fires reliably, and the check would
+    # report a failure on a run where every proof passed.
+    case "$out" in
+      *"Modules were successfully checked"*) : ;;
+      *)
+        echo "::error::kernel re-check FAILED for $proj"
+        printf '%s\n' "$out"
+        exit 1
+        ;;
+    esac
 
     # 5. Report what the proofs assume. `rocq check` lists axioms rather than
     #    rejecting them, and this repository has one sanctioned escape hatch
@@ -129,17 +153,61 @@ cannot determine the logical path to check."
     #    three proof-ledger.json files currently disagree with each other about
     #    the axiom and theorem counts, so there is no single trustworthy
     #    expected value to compare against yet.
-    if printf '%s\n' "$out" | grep -qiE "^\s*\*\*\* |axiom"; then
+    assumptions=$(printf '%s\n' "$out" | grep -iE "^\s*\*\*\* |axiom" || true)
+    if [ -n "$assumptions" ]; then
       echo "  assumptions reported by the kernel checker:"
-      printf '%s\n' "$out" | grep -iE "^\s*\*\*\* |axiom" | sed 's/^/    /'
+      printf '%s\n' "$assumptions" | sed 's/^/    /'
     fi
 
+    # awk, not bc: bc is not installed in the rocq/rocq-prover image, and under
+    # `set -euo pipefail` its absence failed the job AFTER every proof had
+    # already been checked — a green result reported as red.
     theorems=$(grep -rhcE "^(Theorem|Lemma|Corollary|Proposition|Remark|Fact) " \
-                 theories/*.v | paste -sd+ | bc)
+                 theories/*.v | awk '{s += $1} END {print s + 0}')
     echo "  kernel-verified statements in theories/: $theorems"
+
+    # 6. Put the working tree back.
+    #
+    #    `make -f CoqMakefile` also re-runs extraction, and the extracted .ml /
+    #    .mli files are committed in ocamlformat-formatted form while extraction
+    #    emits them raw. A full run therefore rewrites ~68 tracked files
+    #    (~2.5k insertions / ~4.4k deletions) with semantically identical but
+    #    differently formatted output. Harmless on a throwaway CI checkout,
+    #    destructive for anyone running this documented gate on their own tree.
+    #    Report the drift so it stays visible, then restore.
+    #    The lia/nia decision-procedure caches are pure build residue that the
+    #    tactics drop next to the sources; they are untracked and would
+    #    otherwise be left behind in a developer's tree.
+    rm -f .lia.cache .nia.cache
+
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      drift=$(git status --porcelain -- . 2>/dev/null | grep -v '^?? ' || true)
+      if [ -n "$drift" ]; then
+        n=$(printf '%s\n' "$drift" | wc -l)
+        echo "  NOTE: the build rewrote $n tracked file(s) (extraction output vs" \
+             "the ocamlformat-formatted committed copies); restoring them."
+        git checkout -- . 2>/dev/null || \
+          echo "  WARNING: could not restore; tree left dirty."
+      fi
+    fi
   )
   checked=$((checked + 1))
 done
 
 echo
+# A gate that passes when it found nothing to check is the exact failure mode
+# this script was written to remove. Moving the three _CoqProject files aside
+# used to yield "OK: 0 formal project(s)" and exit 0.
+if [ "$checked" -eq 0 ]; then
+  echo "::error::no formal/ project had a _CoqProject — nothing was verified. \
+This gate must never pass vacuously."
+  exit 1
+fi
+if [ "$checked" -ne "$EXPECTED_PROJECTS" ]; then
+  echo "::error::expected $EXPECTED_PROJECTS formal projects, checked $checked. \
+If a project was added or removed on purpose, update EXPECTED_PROJECTS at the \
+top of this script."
+  exit 1
+fi
+
 echo "OK: $checked formal project(s) rebuilt from source and kernel-re-checked."

--- a/scripts/check-formal-proofs.sh
+++ b/scripts/check-formal-proofs.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+# ---------------------------------------------------------------------------
+# Machine-check the Rocq proofs under formal/ (task #45).
+#
+# WHAT THIS REPLACES
+#
+# CI's only enforcement of the "0 admits" guarantee was a grep over the .v
+# sources, and the committed .vo files were never re-verified on a branch. A grep
+# is a lexical check pretending to be a proof: it cannot tell whether the files
+# still COMPILE, whether a tactic silently stopped closing its goal, or whether a
+# committed .vo actually corresponds to the .v next to it. A .vo could be stale,
+# hand-edited, or built from different sources, and every gate in the repository
+# would have stayed green.
+#
+# This script does the two things only the toolchain can do:
+#
+#   1. rebuilds every .v FROM SCRATCH (the committed .vo files are deleted first,
+#      so they cannot vouch for themselves), and
+#   2. runs `rocq check`, the standalone kernel re-checker, over the results.
+#      `rocq check` re-verifies every proof term against the kernel without
+#      trusting the elaborator that produced it, and prints the axioms each
+#      module depends on.
+#
+# The grep gate in .github/workflows/ci.yml is kept as well: it is instant, it
+# runs without a Rocq toolchain, and it catches an `admit.` in review before this
+# heavier job gets to it. The two are complementary — the grep is the fast lexical
+# tripwire, this is the proof.
+#
+# MEASURED COST (Rocq 9.1.1, 16-core workstation, cold: all .vo deleted)
+#   rocq c   (all three projects)   ~11 s total
+#   rocq check                       codegen-ptx 17.1 s
+#                                    convergence-safety 11.3 s
+#                                    type-safety 11.0 s
+#   ------------------------------------------------------------------
+#   total                           ~50 s of CPU work.
+# That is cheap enough that there is no argument for keeping the grep-only
+# arrangement. The toolchain is NOT added to ci/Dockerfile: the official
+# rocq/rocq-prover image already ships the exact version these proofs were
+# developed against, so the proof job runs in that container instead of growing
+# the main image by a Rocq build.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if command -v rocq >/dev/null 2>&1; then
+  ROCQ=rocq
+elif command -v coqc >/dev/null 2>&1; then
+  # Rocq 9 renamed the driver; fall back for a Coq 8.x toolchain, which will
+  # most likely fail to compile these sources and say so loudly.
+  ROCQ=""
+else
+  echo "::error::no rocq/coqc on PATH. This gate needs a real proof checker — \
+that is the entire point of #45. Run it in the rocq/rocq-prover container (see \
+.github/workflows/ci.yml)."
+  exit 1
+fi
+
+echo "== toolchain"
+if [ -n "$ROCQ" ]; then
+  rocq --version
+else
+  coqc --version
+fi
+
+projects=$(find formal -mindepth 1 -maxdepth 1 -type d | sort)
+if [ -z "$projects" ]; then
+  echo "::error::no formal/ projects found — this gate would pass vacuously."
+  exit 1
+fi
+
+checked=0
+
+for proj in $projects; do
+  [ -f "$proj/_CoqProject" ] || continue
+  echo
+  echo "== $proj"
+
+  logical=$(grep -oP '^-R\s+theories\s+\K\S+' "$proj/_CoqProject" || true)
+  if [ -z "$logical" ]; then
+    echo "::error::$proj/_CoqProject has no '-R theories <LogicalName>' line; \
+cannot determine the logical path to check."
+    exit 1
+  fi
+
+  (
+    cd "$proj"
+
+    # 1. Delete every committed build artefact. A .vo that is never rebuilt is
+    #    an unverified binary blob, and re-checking it would only prove it is
+    #    self-consistent, not that it matches the .v beside it.
+    find . \( -name '*.vo' -o -name '*.vok' -o -name '*.vos' \
+              -o -name '*.glob' \) -exec rm -f {} +
+
+    # 2. Regenerate the makefile from _CoqProject rather than trusting the
+    #    committed CoqMakefile, which is itself generated and could be stale.
+    if [ -n "$ROCQ" ]; then
+      rocq makefile -f _CoqProject -o CoqMakefile
+    else
+      coq_makefile -f _CoqProject -o CoqMakefile
+    fi
+
+    # 3. Compile. Any Admitted/admit that the grep gate missed, any broken
+    #    proof, any missing dependency fails here.
+    make -f CoqMakefile -j"$(nproc)"
+
+    # 4. Kernel re-check. This is the load-bearing step: it re-verifies the
+    #    proof terms independently of the elaborator that built them, and
+    #    reports the axioms they rest on.
+    if [ -n "$ROCQ" ]; then
+      out=$(rocq check -R theories "$logical" theories/*.vo 2>&1)
+    else
+      out=$(coqchk -R theories "$logical" theories/*.vo 2>&1)
+    fi
+    printf '%s\n' "$out" | tail -3
+    if ! printf '%s\n' "$out" | grep -q "Modules were successfully checked"; then
+      echo "::error::kernel re-check FAILED for $proj"
+      printf '%s\n' "$out"
+      exit 1
+    fi
+
+    # 5. Report what the proofs assume. `rocq check` lists axioms rather than
+    #    rejecting them, and this repository has one sanctioned escape hatch
+    #    (`Parameter` in AGpuSemantics.v — see the admit gate's comment in
+    #    .github/workflows/ci.yml), so this is reported for review rather than
+    #    enforced at zero. Enforcing a specific allowlist is a follow-up: the
+    #    three proof-ledger.json files currently disagree with each other about
+    #    the axiom and theorem counts, so there is no single trustworthy
+    #    expected value to compare against yet.
+    if printf '%s\n' "$out" | grep -qiE "^\s*\*\*\* |axiom"; then
+      echo "  assumptions reported by the kernel checker:"
+      printf '%s\n' "$out" | grep -iE "^\s*\*\*\* |axiom" | sed 's/^/    /'
+    fi
+
+    theorems=$(grep -rhcE "^(Theorem|Lemma|Corollary|Proposition|Remark|Fact) " \
+                 theories/*.v | paste -sd+ | bc)
+    echo "  kernel-verified statements in theories/: $theorems"
+  )
+  checked=$((checked + 1))
+done
+
+echo
+echo "OK: $checked formal project(s) rebuilt from source and kernel-re-checked."


### PR DESCRIPTION
> **Revised after review.** The first revision was built and run in a real image; the pocl premise did not survive contact and both new CI jobs failed to start. pocl is split out to a separate experimental PR and every blocker is fixed. Details in the second commit. Sections below reflect the current state.

## The problem: gates that were green because they never ran

Every codegen-validation gate in this repository self-skips when its tool is absent. That is correct on a developer machine and catastrophic in CI: `ci/Dockerfile` is based on `intel/oneapi-runtime` and carried **none** of `ptxas`, `libnvrtc`, CUDA headers, `glslangValidator` or `naga`. So the gates printed `SKIP` and CI reported success having validated nothing.

The concrete cost: the f16 work shipped a generated `#include <cuda_fp16.h>` that NVRTC cannot resolve — NVRTC has no filesystem include path unless one is passed explicitly. Nothing in CI compiled the generated CUDA-C, so it was caught only when a reviewer fed the source to a real NVRTC by hand.

Merges #84 (nvrtc gate), #51 (gate debt), #45 (grep standing in for a proof). **#79 (no trustworthy OpenCL ICD) is deferred** — see below.

## Size, measured

Summed `docker history` layer sizes, a build of this file against a build of the previous `ci/Dockerfile`:

| | total | delta |
|---|---|---|
| baseline (`main`) | 4483 MB | — |
| **this revision** | **4834 MB** | **+351 MB** |
| first revision (pocl + spirv-tools) | 5118 MB | +635 MB |

The first revision claimed ~290 MB and was wrong; review measured ~630 MB, which matches the 635 MB above. Removing pocl accounts for the 284 MB difference.

Breakdown of the +351 MB: CUDA layer 304 MB, glslang layer 35.8 MB, naga 6.8 MB, `gnupg` (needed for the NVIDIA apt keyring) 5 MB, symlink/ldconfig 0.1 MB.

Per-package, now from `dpkg-query Installed-Size` **inside the built image** rather than estimated from `.deb` payloads:

| package | installed | note |
|---|---|---|
| `cuda-nvcc-12-6` | 147.6 MB | `ptxas` 31 MB, `nvlink` 31 MB, `nvcc` 23 MB |
| `cuda-nvrtc-12-6` | 60.5 MB | `libnvrtc.so.12` |
| `cuda-nvvm-12-6` | 56.1 MB | **hard dependency of cuda-nvcc**; missing from the first revision's table |
| `cuda-cccl-12-6` | 12.4 MB | dependency of `cudart-dev` |
| `cuda-cudart-dev-12-6` | 6.8 MB | `cuda_fp16.h` and the header tree |
| `cuda-crt` / `cuda-cudart` / config / `driver-dev` | ~2.2 MB | |
| `glslang-tools` | 7.4 MB | |
| `spirv-tools` | 25.5 MB | see below |
| `naga` 30.0.0 | 6.8 MB | multi-stage build, binary only |

No multi-GB `cuda-toolkit` metapackage. `cuda-nvrtc-dev-12-6` (93 MB of static libs) is left out: Sarek dlopens NVRTC and needs no headers. `ptxas` and NVRTC are **host-side** compilers — no device, no driver, no `/dev/nvidia*` — so device enumeration is unchanged.

**`spirv-tools` could not be dropped.** On jammy `glslang-tools` has a hard `Depends: spirv-tools`, so its 25.5 MB arrives whether asked for or not. It is no longer listed explicitly and the comment no longer claims `spirv-val` as a capability, because nothing in this repo uses it — but it cannot actually be removed without losing `glslangValidator`.

**naga: included, not skipped.** No apt package and no upstream prebuilt; the alternatives were a Rust toolchain or Dawn's `tint` (CMake + depot_tools, far more expensive). Built in a throwaway `rust:1.90-slim-bookworm` stage so only the 6.8 MB binary lands in the final image. Review confirmed the stage is genuinely discarded — no cargo, rustc or rustup in the result. Given WGSL had **zero executable validation anywhere**, this was worth it.

## #79 deferred: pocl is not usable on jammy

The first revision added pocl as a second, conformant CPU ICD and pinned `make e2e-fast` to it. Measured in the built image, pocl 1.8 + LLVM 11 on jammy **cannot compile a single kernel**:

```
error: unknown target CPU 'generic'
device: pthread-x86_64-pc-linux-gnu-generic
```

So pinning made `test_float32_sin_pure` and `test_math_intrinsics` **SKIP**, while `make e2e-fast` logged 11 errors and still exited 0 — strictly worse than the status quo. Meanwhile the Intel oneAPI ICD it was routing around computed sin/cos/exp/sqrt **correctly** there (worst relative error 1.3e-07), and SPOC's own #74 expiry NOTE fired to say the known-issue device produced a correct result.

Removed from this PR: the install, the `vendors-pocl`/`vendors-intel` ICD split, the `OCL_ICD_VENDORS` pinning, and the ICD checks in `assert-toolchain.sh`. pocl moves to a separate experimental PR that installs it **unpinned** and logs whether it can compile a kernel on the actual GitHub runner (Ice Lake / Zen 3, where LLVM 11 may resolve a real target CPU and where #74's flake was originally seen).

`Test_helpers.is_pocl_device` **stays, inert**, with its comments corrected to say so. It is the precondition for that PR: without it, a conformant CPU ICD would be swallowed by the #74 carve-out and buy no coverage at all. Its tests pin the behaviour now so the experimental PR cannot land that regression silently.

## The presence assertion is the load-bearing part

`ci/assert-toolchain.sh` runs early and fails fast. Without it, one bad edit to `ci/Dockerfile` silently returns the whole suite to green-but-vacuous with nobody noticing.

It **runs** each tool rather than looking it up on `PATH` — a present-but-broken binary skips just as silently as an absent one: `ptxas --version` plus assembling a probe module; a C probe that `dlopen`s `libnvrtc.so{,.12,.11}` and calls `nvrtcVersion`, exactly the path `Cuda_nvrtc.ml` uses; locating `cuda_fp16.h`; `glslangValidator --version` plus compiling a probe shader; `naga --version` plus validating a probe WGSL.

Review confirmed the negative controls work: removing `ptxas`, `libnvrtc`, `naga` or `glslangValidator` each turns it red with the right message.

**In the rebuilt image: 8/8 checks pass** (was 3 of 12 failing; the count drops to 8 because the four ICD checks left with pocl).

## Two gates went RED the moment their tool appeared

Both real, both fixed, neither weakened.

**1. The WGSL sweep could never have passed.** It invoked `naga --validate all`, but naga's `--validate` takes a numeric `ValidationFlags` *bitmask*, so naga exited non-zero during argument parsing (`invalid digit found in string`) for every input. Corrected to the positional form.

**2. With naga running, the WGSL backend emitted invalid shaders.** `Sarek_tailrec_elim` renames eliminated loop parameters to `"__" ^ name`, and WGSL reserves that prefix (§4.4.1):

```
error: Identifier starts with a reserved prefix: `__i`
20 │     var __i : i32 = 0i;
   │         ^^^ invalid identifier
```

Every kernel whose recursion lowers to a loop produced WGSL that **no WebGPU implementation would accept**. C-family targets accept the name, which is why only WGSL was affected and the byte-exact goldens never noticed. `escape_wgsl_name` now rewrites it — and, added in review, a bare `_`, the other identifier form WGSL reserves. Red-on-mutation confirmed by review: disabling the rewrite turns 2 tests red with the message above.

## What each gate now actually checks

| gate | tool | verifies |
|---|---|---|
| `test_ptx_snapshot.ml` | ptxas | emitted PTX **assembles** to a cubin (8 kernels incl. SoA) |
| `test_codegen_golden.ml` glsl sweep | glslangValidator | all 22 GLSL goldens compile to SPIR-V |
| `test_codegen_golden.ml` wgsl sweep | naga | all 6 WGSL goldens pass front-end + validation |
| `test_shader_recursion_vector.ml` | glslang + naga | recursion/vector/shadowing regressions on both shader backends |
| **`test_cuda_nvrtc_gate.ml`** (new) | NVRTC | emitted CUDA-C **compiles** and the module **contains its kernel**, 17 kernels |

All four pass inside the real image (review: ptxas 62, golden 75 incl. 6 wgsl-validate, shader-recursion 10, nvrtc 17/17).

The nvrtc gate is new — CUDA-C had no executable validation anywhere. It compiles through `Cuda_nvrtc.compile_to_ptx`, the entry point production uses. Two controls: prepending the historical `#include <cuda_fp16.h>` turns all 17 red with `catastrophic error: could not open source file "cuda_fp16.h" (no directories in search list)`; and the post-review `.entry <kern_name>` assertion turns all 17 red when the expected entry name is corrupted, so a module that compiles but carries no kernel now fails. (`.entry <name>` naming verified under the image's CUDA 12.6, not just the host's 13.3. The previous `length > 0 && length > 32` was redundant and unfireable — NVRTC's PTX header alone clears 32 bytes.)

## #45: a real `rocq check`, not a grep

The "0 admits" guarantee was a grep over `.v` sources, and the committed `.vo` files were never re-verified on a branch. A grep cannot tell whether the sources still compile, whether a tactic quietly stopped closing its goal, or whether a `.vo` matches the `.v` beside it.

`scripts/check-formal-proofs.sh` deletes every `.vo` (so they cannot vouch for themselves), regenerates the makefile from `_CoqProject`, rebuilds from source, and runs `rocq check`.

**Verified: the gate runs green in `rocq/rocq-prover:9.1.1` in 38 s**, all three projects (codegen-ptx 79 kernel-verified statements, convergence-safety 111, type-safety 90), with the tree clean afterwards.

Four things review found and this revision fixes:

- **The job could not start.** A job-level `container:` does not work: GitHub Actions discards the image ENTRYPOINT (`["opam","exec","--"]`) and runs steps through `docker exec sh -e -c`, so the opam switch's `bin/` never reaches `PATH` and rocq/coqc/rocqchk all look MISSING (the real binaries are in `/home/rocq/.opam/4.14.2+flambda/bin`). Adding `options: --user root` to fix workspace permissions breaks opam independently, because the switch belongs to `rocq` under `/home/rocq`. Replaced with `docker run`, which honours the ENTRYPOINT and matches how every other step in this workflow invokes a container.
- **`bc` is not in the image**, and under `set -euo pipefail` its absence failed the job *after* every proof had already been checked — a green result reported as red. Now `awk`.
- **Stale generated makefiles.** The script deleted only `.vo/.vok/.vos/.glob`, leaving tracked `.CoqMakefile.d` files that hard-code `/usr/lib/ocaml/rocq-runtime/rocqworker` — a system-Rocq path that exists on a distro install and not in the opam image, so the build died with `No rule to make target` before a single proof ran. This was the script's own documented hazard biting the script. `CoqMakefile`, `CoqMakefile.conf` and `.CoqMakefile.d` are now deleted and regenerated.
- **It passed vacuously.** Moving the three `_CoqProject` files aside yielded `OK: 0 formal project(s)` and exit 0. It now fails on zero and pins `EXPECTED_PROJECTS=3`. Verified: exits 1 with the `_CoqProject` files moved aside.

Also: the build re-runs extraction over `ocamlformat`-formatted committed copies and rewrote ~66 tracked files per project. Harmless on a throwaway CI checkout, destructive for anyone running the documented gate on their own tree — the drift is now reported and the files restored, and the lia/nia caches are cleaned up.

The grep gate stays as the fast lexical tripwire. **Left as follow-up:** enforcing an axiom/theorem-count allowlist — the three `proof-ledger.json` files disagree with each other about those counts, so there is no trustworthy expected value yet.

## Other review fixes

- **`find` vs symlink.** `assert-toolchain.sh` reported `cuda_fp16.h` missing on an image where it was plainly present: `/usr/local/cuda` is a symlink and GNU find will not descend into a symlinked starting point. Now `find -L`. The Dockerfile's own in-build check used a trailing slash so it descended, but piped to `head -1`, which exits 0 with no hits — vacuous either way. It now captures the result and asserts it is non-empty.
- **`grep -q` on a pipe.** `clinfo | grep -q` made grep close the pipe, `clinfo` die of SIGPIPE (141), and `set -o pipefail` propagate it, so those checks failed unconditionally regardless of state. Gone with the ICD section — but the same shape existed twice in `check-formal-proofs.sh` over multi-thousand-line `rocq check` output, and both are now `case` substring matches on the captured variable. Swept the repo for the pattern; the remaining hits are pre-existing and out of scope.
- **`.dockerignore`** added. Honest note: with buildkit and a Dockerfile that COPYs nothing from context, the measured transfer was already 739 B, so this is preventative rather than a measured saving.

## Verified vs pending

**Verified in the rebuilt image:** `assert-toolchain.sh` 8/8; the formal-proofs gate green in the official container in 38 s with a clean tree; the vacuity guard exits 1; `.entry` naming under CUDA 12.6.

**Verified locally with real tools** (host has CUDA 13.3, glslang 16.3, naga 30.0.0): all four static gates green, both nvrtc controls red-on-mutation, full `dune build @runtest`, `shellcheck` clean on both scripts, `ci.yml` parses.

**Pending the first CI run:** the workflow wiring itself — that the `docker run` form of the formal-proofs job behaves the same on a GitHub runner as it does here, and that the `Assert codegen toolchain` step slots in correctly ahead of the build.

**Pre-existing, unrelated:** `test_static_tag_erasure` fails locally on Vulkan/RADV NAVI31 (returns zeros). Confirmed identical on pristine `main`; real-GPU only, does not run on the CPU-only CI runner.

Do not merge without a human look — this changes CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WGSL identifier escaping for reserved and invalid names to produce correct, non-colliding shader identifiers.
  - Tightened the handling of POCL CPU OpenCL known-issue behavior so it doesn’t mask incorrect results.
  - Updated shader validation invocation to avoid tool argument-parsing problems.

- **Testing & CI**
  - Added an NVRTC compile gate covering representative CUDA-C kernel cases.
  - Added fail-fast toolchain checks to prevent silent “skip” outcomes.
  - Added a full formal-proofs rebuild-and-verify job.
  - Reduced Docker build context to improve CI reliability and speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->