### PR TITLE
chore(review): ship the verdict schema contract + a verdict assembler

### DIFF
--- a/schema/review-json-schema.md
+++ b/schema/review-json-schema.md
@@ -54,9 +54,13 @@ Two ordering traps, both of which have already cost real rounds:
 - **`review-normalize.js` takes a JSON ARRAY of finding objects, never the verdict envelope.**
   Passing the envelope yields `finding file must be a JSON array` and nothing at the call site says
   which is expected. `review-verdict-assemble.js` checks this per-file and names the offending file.
-- **Skipping step 2 makes step 4 unable to detect a novel finding at all.** `first_seen_round` is
-  stamped during normalization against the prior ledger; without it, `isNovelStrikeFinding()`
-  returns false for every finding and no round ever strikes.
+- **Skipping step 2 makes step 4 unable to detect a novel finding at all.** Normalization is what
+  makes fingerprints stable, and stable fingerprints are what separate a novel finding from a
+  carried-forward one. Note that `first_seen_round` itself is **not** stamped by the normalizer —
+  `canonicalizeFindings()` rewrites only `fingerprint`, `fingerprint_v2`, `fid` and `status`, and
+  `schema/review-finding.schema.json` does not require the field — yet `isNovelStrikeFinding()`
+  returns false unless it is numeric and equals the round. A HIGH+ finding that arrives without it
+  is therefore permanently unstrikeable, which is why `review-verdict-assemble.js` refuses one.
 
 ---
 
@@ -102,7 +106,7 @@ $ echo $?
 `violations: []`, exit `0`. The gate passed because it was never given anything to check, and that
 outcome is byte-identical to a genuine pass everywhere a caller looks (exit code, `violations`,
 `cause`). The two knobs that produce it are [`round`](#round) and
-[`rounds_audit[].strike`](#roundsauditstrike) — read those two sections before writing a verdict by
+[`rounds_audit[].strike`](#rounds_auditstrike) — read those two sections before writing a verdict by
 hand.
 
 ---
@@ -113,14 +117,14 @@ Exactly ten. Anything else in the envelope is prose-enforced only.
 
 | Key | Absent | Malformed | What it drives |
 |---|---|---|---|
-| `round` | **skips strike + rounds_audit + trace checks**, warns, still exit 0 | non-number / negative / non-finite → exit 2 | strike classification, `rounds_audit` completeness, trace obligation |
+| `round` | **skips strike + rounds_audit + trace checks**, warns, and exits 0 *unless something else independently violates* (a `no_go_round` at the cap still exits 1) | non-number / negative / non-finite → exit 2 | strike classification, `rounds_audit` completeness, trace obligation |
 | `no_go_round` | defaults to `0` + warning; round-cap can never fire | non-number / negative → exit 2 | the round-cap violation (`no_go_round >= --max-rounds`) |
 | `cycle` | `null`, legacy-safe | non-number → `null`, never fatal | `(cycle, round)` scoping of trace lines |
 | `findings` | `[]`, legacy-safe | present but not an array → exit 2 | ratchet, unencodable-finding, strike classification, red/green |
 | `rounds_audit` | treated as `[]` | non-array → treated as `[]` | past strikes, loop-back completeness, trace obligation |
 | `task` | see below | not a `validSlug` **on a trace-obligated round** → exit 2 | derives the trace + journal sibling paths |
 | `mode` | no scope-gate trace line is required | any value other than `"full"` → same as absent | requires a `scope-gate` trace line when `"full"` |
-| `normalized_by` | no `normalizer` trace line required; triggers the omit-everything warning | any truthy value behaves alike | requires a `normalizer` trace line |
+| `normalized_by` | no `normalizer` trace line required; triggers the omit-everything warning **only if the round is also un-obligated** | any truthy value behaves alike | requires a `normalizer` trace line |
 | `cross_runtime` | no warnings, no corroboration | non-object → ignored | degraded-bookkeeping warnings, journal corroboration |
 | `streak_override` | no override | anything not `{round: <this round>, by: "human"}` → no override | forces this round's `strike` to `false` |
 
@@ -147,6 +151,13 @@ fan-out, empty `rounds_audit`, new cross-runtime probe, `cycle + 1`.
 the `rounds_audit` completeness check, and all trace checks, emits three warnings, and exits 0.
 `scripts/review-verdict-assemble.js` refuses to emit a verdict without it.
 
+**Skipping a round is the quieter half of the same hole.** `computeStreakViolation()` walks
+`round, round-1, …` and stops at the first entry that is not `true`; `computeStrikeMap()` only
+knows about rounds that have a `rounds_audit` entry. Jumping from round 3 to round 7 therefore
+leaves rounds 4–6 absent from the map and erases the streak — with **no** warning, because
+`computeMissingStrikeWarnings()` only inspects entries that exist. The assembler refuses any
+`--round` other than the one the lifecycle witness derives.
+
 Never conflate `round` with `no_go_round` — separate counters, separate reset rules.
 
 ### `no_go_round`
@@ -154,7 +165,10 @@ Never conflate `round` with `no_go_round` — separate counters, separate reset 
 Integer ≥ 0. The **qualifying-only** round-cap backstop: reset to `0` on `GO`, incremented on a
 finding-driven `NO-GO` outside `category: "scope"`. Compared against `--max-rounds`
 (`tunables.max_no_go_rounds`, default 5) to produce the `round-cap` violation. Absent → `0` with a
-warning, which means the cap can never fire; that is a second, quieter vacuity path.
+warning, which means the cap can never fire; that is a second, quieter vacuity path. A counter
+that is *present* but never advances is the same hole with no warning at all, so the assembler
+requires each NO-GO verdict's `--no-go-round` to either hold or advance by exactly one relative to
+the prior verdict.
 
 ### `cycle`
 
@@ -226,7 +240,9 @@ round-1 entry is a warning in prose, not a violation. Write the entry anyway.
 `briefs/<task>-review-trace.jsonl` with ≥1 line for `(task, cycle, round)`, plus one line per
 claimed invocation. Omit it only for a round that genuinely predates the trace mechanism. Never
 fabricate a trace line for a tool that did not run (FR-177/C-3) — running the missed tool is the
-only repair.
+only repair. Because omitting the stamp *removes* the trace obligation rather than failing it,
+`review-verdict-assemble.js` stamps `"1.0"` unconditionally and rejects any other
+`--trace-schema-version`: a round it assembles is a round that ran now, so it always commits.
 
 #### `rounds_audit[].strike`
 
@@ -269,7 +285,11 @@ node scripts/review-verdict-assemble.js --write-strike \
 ```
 
 That command refuses any non-boolean `current_round_strike` — which is also how it catches a gate
-report produced from a verdict that had no `round` (the gate reports `null` there).
+report produced from a verdict that had no `round` (the gate reports `null` there). It additionally
+refuses a report whose `round` does not match the verdict's, and one missing `config.strikes` or
+`trace`: the gate emits both on every exit code it reports on (see §"Gate report") precisely so a
+caller can detect a stale gate script, and a boolean strike computed under superseded rules is
+indistinguishable from a real one once journaled.
 
 Round 1 never strikes. Escalation fires when the last `--strikes` consecutive rounds (all ≥ 2) each
 struck; a strike-free round resets the streak, and non-consecutive strikes never accumulate.
@@ -293,7 +313,8 @@ round-based fixtures keep passing.
 
 `"express" | "fast" | "full"`, read from `briefs/<task>-impl.md`. The gate reads it for exactly one
 thing: `mode === "full"` requires a `scope-gate` trace line on the round. Any other value, including
-absent, requires nothing.
+absent, requires nothing — a typo (`"Full"`) reads to the gate exactly like an omission, so the
+assembler rejects anything outside the three-value enum instead of passing it through.
 
 > **Name collision.** The gate's own *report* also has a `mode`, whose values are
 > `"static" | "full"` (whether `--static` was passed). Same key name, different enum, and `"full"`
@@ -305,7 +326,10 @@ The `normalizer_version` string from `scripts/review-normalize.js` (currently `"
 truthy value **obligates a `normalizer` trace line** for the round — the normalizer self-appends it
 when given `--task`, `--round` and `--cycle` together (all three, or it appends nothing). A
 non-legacy round with neither a trace obligation nor `normalized_by` triggers the loud
-"omit-everything posture" warning (FR-180).
+"omit-everything posture" warning (FR-180) — `computeOmitEverythingWarning()` returns null as soon
+as *either* is present, so it is not an absent-`normalized_by` detector on its own. An
+assembler-produced round always stamps `trace_schema_version` and is therefore always obligated,
+which means it can never raise this warning; it is a signal about hand-written verdicts.
 
 ### `cross_runtime`
 
@@ -331,6 +355,13 @@ handles a strict subset:
 
 Cross-runtime runs are **never** listed in `specialists_run` — the gate corroborates them through
 this field and the `cross-runtime` trace event instead.
+
+> **Assembler gap (known, not fixed here).** `review-verdict-assemble.js` can only *inherit*
+> `cross_runtime` from the prior verdict — `{}` on a fresh cycle — because it has no flag for
+> probe state. A round that really ran a `codex`/`opencode` probe cannot record it without editing
+> the verdict by hand, which is the hand-derivation this tool exists to remove, on the one field
+> that drives `unattested-invocation` (exit 1). Adding a validated probe-state input belongs with
+> the D1 work, not here.
 
 ### `streak_override`
 
@@ -393,7 +424,18 @@ Nothing validates either enum. A typo in `type` routes nowhere; `roster-run` rea
 
 ## Gate report
 
-Persisted verbatim to `briefs/<task>-gate-report.json` each round. Emitted on **every** exit code.
+Persisted verbatim to `briefs/<task>-gate-report.json` each round. Emitted on every exit code the
+gate *reports* on — 0, 1, 3, the legacy skip, and the inconclusive-red/green flavour of 2.
+
+> **Not on an input-rejection exit 2.** `main()` prints the report only after `validateArgsAndReview()`
+> and the `trace.fail` check have passed, so an absent/malformed verdict, an unknown flag, or an
+> invalid `task` slug on a trace-obligated round produces **no report at all**:
+> ```
+> $ node scripts/check-review-convergence.js briefs/nope.json --static 2>/dev/null | wc -c
+> 0
+> ```
+> That matters because `--write-strike` now hard-depends on a report. There is nothing to write back
+> from on those paths — fix the input and re-gate; do not hand-write a report to satisfy the tool.
 
 ```json
 {
@@ -442,7 +484,7 @@ does not exist, or where the enforcer requires something the prose never states.
 | # | Discrepancy | Consequence |
 |---|---|---|
 | D1 | Prose: "any `cross_runtime_findings` entry that is CRITICAL or HIGH (OPEN) sets `status: NO-GO`". The gate never reads `cross_runtime_findings`. | A HIGH cross-runtime finding is invisible to the gate. Only the prose-level mirror into `findings` puts it under the ratchet — forget the mirror and it is unenforced. |
-| D2 | Prose treats `no_go_reason.type` as the routing key. Nothing validates it, and the gate never reads `no_go_reason` at all. | A typo silently routes nowhere. |
+| D2 | Prose treats `no_go_reason.type` as the routing key. The gate never reads `no_go_reason` at all. | A typo silently routes nowhere. Unresolved in the enforcer; `review-verdict-assemble.js` validates both enums at assembly time, so a typo is caught for verdicts it produces — a hand-written one is still unchecked. |
 | D3 | Prose says `strike` is "populated after the gate reports it"; it never says the value must be a *boolean*, and the gate's completeness check does not require it. | `strike: null` passes the completeness check and silently defeats streak escalation. Live in this repo: `briefs/f16-dsl-slice1-review.json`. |
 | D4 | Prose lists `task` as an ordinary field. The gate makes it load-bearing for path derivation and fails **closed (exit 2)** on an invalid slug once the round is trace-obligated. | An innocuous-looking `task` edit turns a working round into a hard degraded-input failure. |
 | D5 | `mode` means `express\|fast\|full` in the verdict and `static\|full` in the gate report. | Copying one into the other silently changes what the gate demands. |
@@ -470,8 +512,10 @@ Two more notes on the enforcer itself, neither a discrepancy:
 `scripts/review-bundle.manifest.json` and verified by `node scripts/review-bundle-verify.js`. Do
 not hand-edit them; see `scripts/REVIEW-BUNDLE.md`.
 
-This document and `scripts/review-verdict-assemble.js` (+ its test) are **repo-local** and
-deliberately absent from the manifest, so a bundle upgrade neither overwrites nor flags them.
+This document, `scripts/review-verdict-assemble.js`, its rule layer
+`scripts/lib/review-verdict-rules.js`, and the test are **repo-local** and deliberately absent from
+the manifest, so a bundle upgrade neither overwrites nor flags them. Note the path: the rule layer
+sits directly in `scripts/lib/`, *not* in the bundle-owned `scripts/lib/review/`.
 
 The assembler's own checks — including the round-cap / streak / `strike: null` cases tabulated
 above, each red-on-mutation against the real gate — run standalone, no test framework:

--- a/schema/review-json-schema.md
+++ b/schema/review-json-schema.md
@@ -1,0 +1,535 @@
+# `briefs/<task>-review.json` — the review verdict envelope
+
+The contract for the review verdict. Cited as authoritative by
+`schema/review-finding.schema.json`, by `roster-review` (five times), and by
+`scripts/lib/review/*.js`. Until this file existed, every verdict was hand-derived from skill
+prose, and the keys the convergence gate needs were routinely absent — see
+[Why this document exists](#why-this-document-exists).
+
+The nested shapes live in real JSON Schema files and are not restated here:
+
+| Shape | File |
+|---|---|
+| one entry of `findings[]` / `cross_runtime_findings[]` | `schema/review-finding.schema.json` |
+| one line of `briefs/<task>-review-trace.jsonl` | `schema/review-trace.schema.json` |
+
+The envelope itself has no machine-checkable schema. `scripts/check-review-convergence.js` is its
+only enforcer, and it enforces ten keys (below). Everything else in the envelope is enforced by
+prose alone.
+
+---
+
+## Pipeline order
+
+**The order is load-bearing.** Fingerprints must be stable before "novel finding" means anything,
+and `strike` is an *output* of the gate, so it cannot be present when the gate runs.
+
+```
+1. specialists            each emits a JSON ARRAY of findings
+                          (schema/review-finding.schema.json)
+        │
+2. normalize              node scripts/review-normalize.js <array-file...> --ledger <prior findings>
+                          --round N --cycle N --task <slug> [--gate-report] [--prior]
+                          → canonical `fingerprint`, `fingerprint_v2`, `fid`; ledger carry-forward;
+                            reobserved / reopened / pending-check dispositions
+        │
+3. assemble the verdict   node scripts/review-verdict-assemble.js --task … --round … --cycle …
+                          → briefs/<task>-review.json.draft, with `strike` ABSENT
+        │
+4. gate                   node scripts/check-review-convergence.js <draft> --max-rounds N --strikes N
+                          → JSON report on stdout; persist verbatim to
+                            briefs/<task>-gate-report.json
+        │
+5. write strikes back     node scripts/review-verdict-assemble.js --write-strike
+                          --verdict <draft> --gate-report <report>
+                          → copies the gate's boolean `current_round_strike` into
+                            rounds_audit[round].strike
+        │
+6. persist + route        rename the draft to briefs/<task>-review.json, then route on
+                          `status` / `no_go_reason` (roster-review "Output Contract")
+```
+
+Two ordering traps, both of which have already cost real rounds:
+
+- **`review-normalize.js` takes a JSON ARRAY of finding objects, never the verdict envelope.**
+  Passing the envelope yields `finding file must be a JSON array` and nothing at the call site says
+  which is expected. `review-verdict-assemble.js` checks this per-file and names the offending file.
+- **Skipping step 2 makes step 4 unable to detect a novel finding at all.** `first_seen_round` is
+  stamped during normalization against the prior ledger; without it, `isNovelStrikeFinding()`
+  returns false for every finding and no round ever strikes.
+
+---
+
+## Order of authority
+
+Where sources disagree, the earlier one wins for *what happens*, and the disagreement is recorded
+in [Prose/enforcer discrepancies](#proseenforcer-discrepancies) rather than silently resolved.
+
+1. **`scripts/check-review-convergence.js` and `scripts/lib/review/*.js`** — the enforcer. Its
+   expectations *are* the schema for the ten keys it reads.
+2. **`schema/review-finding.schema.json`, `schema/review-trace.schema.json`** — machine-checked
+   nested shapes.
+3. **`roster-review` prose** (`.agents/skills/roster-review/SKILL.md`, mirrored to
+   `.claude/commands/roster-review.md` and `.harness/skills/roster-review.md`) — field semantics
+   and intent, plus every key the gate does not read.
+
+---
+
+## Why this document exists
+
+`scripts/check-review-convergence.js` degrades silently, not loudly, on an under-populated verdict.
+Reproduced on a real hand-written verdict in this repo:
+
+```console
+$ node scripts/check-review-convergence.js briefs/make-tests-actually-run-review.json --static
+{
+  "round": null,
+  "legacy_round": true,
+  "current_round_strike": null,
+  "cause": null,
+  "warnings": [
+    "legacy review.json: no_go_round key absent — treating as round 0",
+    "legacy review.json: round key absent — skipping strike and rounds_audit checks (B-8)",
+    "legacy review.json: round key absent — trace checks skipped (B-8)"
+  ],
+  "violations": [],
+  ...
+}
+$ echo $?
+0
+```
+
+`violations: []`, exit `0`. The gate passed because it was never given anything to check, and that
+outcome is byte-identical to a genuine pass everywhere a caller looks (exit code, `violations`,
+`cause`). The two knobs that produce it are [`round`](#round) and
+[`rounds_audit[].strike`](#roundsauditstrike) — read those two sections before writing a verdict by
+hand.
+
+---
+
+## Keys the gate reads (enforced)
+
+Exactly ten. Anything else in the envelope is prose-enforced only.
+
+| Key | Absent | Malformed | What it drives |
+|---|---|---|---|
+| `round` | **skips strike + rounds_audit + trace checks**, warns, still exit 0 | non-number / negative / non-finite → exit 2 | strike classification, `rounds_audit` completeness, trace obligation |
+| `no_go_round` | defaults to `0` + warning; round-cap can never fire | non-number / negative → exit 2 | the round-cap violation (`no_go_round >= --max-rounds`) |
+| `cycle` | `null`, legacy-safe | non-number → `null`, never fatal | `(cycle, round)` scoping of trace lines |
+| `findings` | `[]`, legacy-safe | present but not an array → exit 2 | ratchet, unencodable-finding, strike classification, red/green |
+| `rounds_audit` | treated as `[]` | non-array → treated as `[]` | past strikes, loop-back completeness, trace obligation |
+| `task` | see below | not a `validSlug` **on a trace-obligated round** → exit 2 | derives the trace + journal sibling paths |
+| `mode` | no scope-gate trace line is required | any value other than `"full"` → same as absent | requires a `scope-gate` trace line when `"full"` |
+| `normalized_by` | no `normalizer` trace line required; triggers the omit-everything warning | any truthy value behaves alike | requires a `normalizer` trace line |
+| `cross_runtime` | no warnings, no corroboration | non-object → ignored | degraded-bookkeeping warnings, journal corroboration |
+| `streak_override` | no override | anything not `{round: <this round>, by: "human"}` → no override | forces this round's `strike` to `false` |
+
+Everything the gate does **not** read: `status`, `date`, `summary`, `auto_fixes_applied`,
+`no_go_reason`, `cross_runtime_findings`, `escalation_needed`, `escalation_reason`. Those are real
+fields with real consumers — just not this one.
+
+---
+
+### `round`
+
+Integer ≥ 1 (the gate accepts `0`, but round 1 is the first round of a cycle). The **physical
+per-cycle verdict counter**. Derived by the lifecycle witness, never by hand:
+
+```bash
+node scripts/lib/review/review-lifecycle.js --prior briefs/<task>-review.json   # → {round, cycle, fresh_cycle}
+```
+
+Two events only (INV-3): a persisted `GO` verdict keeps its cycle-final `round` / `rounds_audit` /
+`cross_runtime` for auditability; the *next* cycle then initializes fresh — `round: 1`, full
+fan-out, empty `rounds_audit`, new cross-runtime probe, `cycle + 1`.
+
+**Absence is the vacuity hole (B-8).** With no `round` key the gate skips strike classification,
+the `rounds_audit` completeness check, and all trace checks, emits three warnings, and exits 0.
+`scripts/review-verdict-assemble.js` refuses to emit a verdict without it.
+
+Never conflate `round` with `no_go_round` — separate counters, separate reset rules.
+
+### `no_go_round`
+
+Integer ≥ 0. The **qualifying-only** round-cap backstop: reset to `0` on `GO`, incremented on a
+finding-driven `NO-GO` outside `category: "scope"`. Compared against `--max-rounds`
+(`tunables.max_no_go_rounds`, default 5) to produce the `round-cap` violation. Absent → `0` with a
+warning, which means the cap can never fire; that is a second, quieter vacuity path.
+
+### `cycle`
+
+Integer ≥ 1. Scopes trace lines. Absent or non-numeric is legacy-safe (`null`) and never fatal on
+its own — but on a **trace-obligated** round, `null` makes every numerically-stamped trace line
+classify as prior-cycle, leaving zero current-round lines and producing a `missing-trace`
+violation (exit 3). If you obligate the trace, supply `cycle`.
+
+### `findings[]`
+
+Cumulative across rounds within a cycle. Base shape: `schema/review-finding.schema.json`. Carry
+prior entries forward **verbatim**, updating only `status` and the round-tracking fields; reset to
+`[]` on `GO` after promoting red-verified checks.
+
+Keys the gate reads from a finding: `severity`, `category`, `status`, `first_seen_round`,
+`resolved_round`, `reopened_at_round`, `check`, `check_encodable`, `fingerprint`, `fid`, `path`,
+`line`, `pre_fix_sha`, `red_verified`, `check_blob`.
+
+Enforced rules, all scoped to `severity ∈ {CRITICAL, HIGH}` (`HIGH_PLUS`):
+
+- **ratchet** — `RESOLVED` with `resolved_round > first_seen_round` and `check` null/absent →
+  `resolved-without-check` / `cause: unencodable-finding`.
+- **provenance** — `RESOLVED` with a missing or non-numeric `first_seen_round` or `resolved_round`
+  → `missing-round-provenance` / `cause: unencodable-finding`. Missing provenance cannot be waved
+  through as a same-round raise+resolve.
+- **unencodable** — `check_encodable: false` and not `ACCEPTED` → `cause: unencodable-finding`.
+- **strike** — counts toward this round's strike when `first_seen_round == round`, `category !=
+  "scope"`, `status != "ACCEPTED"`, and not same-round-resolved; **or** when
+  `reopened_at_round == round` (E-4).
+- **red/green** — in full (non-`--static`) mode, every finding with a string `check` is executed:
+  red against `pre_fix_sha` in a `git archive` scratch tree, green on the current tree. `check`
+  must be a **node-runnable file path** (`node <path>`); a spec-level `CHECK-N` id with no file is
+  recorded but not executed. `pre_fix_sha: null` (dirty tree) → flagged, `red_verified` stays
+  `null`, not a violation.
+
+`ACCEPTED` is a permanent waiver — state it that way to the human, never "skip for now".
+
+### `rounds_audit[]`
+
+Append-only, one entry per round **including `GO` rounds**, retained on `GO`. Prior entries are
+never rewritten (`review-verdict-assemble.js` refuses).
+
+```json
+{
+  "round": 2,
+  "reviewed_sha": "17e9bbc7…",
+  "fix_sha": "55148469…",
+  "fix_sha_reason": "dirty-tree",
+  "specialists_run": [{ "name": "reviewer", "selection_reason": "always (owner), loop-back round 2" }],
+  "strike": false,
+  "trace_schema_version": "1.0"
+}
+```
+
+| Field | Requirement (enforced from `round` ≥ 2) |
+|---|---|
+| `round` | number; the entry is found by `round === review.round` |
+| `reviewed_sha` | must be **defined** (any value); absent → `process-incomplete`, exit 3 |
+| `fix_sha` | must be **defined**; `null` is allowed only with a non-empty `fix_sha_reason` (EC-8, dirty tree) |
+| `fix_sha_reason` | required non-empty string when `fix_sha` is `null` |
+| `specialists_run` | non-empty array; **every** element needs a non-empty `selection_reason` |
+| `strike` | boolean — see below. Not part of the completeness check |
+| `trace_schema_version` | `"1.0"` on new rounds. **Presence obligates the trace checks** |
+
+On `round == 1` none of this is enforced (`computeMissingAuditViolation` returns early) — a missing
+round-1 entry is a warning in prose, not a violation. Write the entry anyway.
+
+`trace_schema_version` is a *commitment*: stamping it obligates the round to have a matching
+`briefs/<task>-review-trace.jsonl` with ≥1 line for `(task, cycle, round)`, plus one line per
+claimed invocation. Omit it only for a round that genuinely predates the trace mechanism. Never
+fabricate a trace line for a tool that did not run (FR-177/C-3) — running the missed tool is the
+only repair.
+
+#### `rounds_audit[].strike`
+
+**Boolean. Never `null`, never absent once the round has been gated.** This is the single most
+dangerous field in the envelope.
+
+`computeStrikeMap()` reads past strikes with
+`if (typeof entry.strike === "boolean") strikeByRound.set(entry.round, entry.strike)`. A `null`
+therefore never lands in the map, `Map.get()` returns `undefined`, and
+`computeStreakViolation()`'s `strikeByRound.get(r) !== true` test **silently resets the streak**.
+
+Verified behaviour, on a five-round verdict where every round carries a novel HIGH finding:
+
+| Verdict | Gate result |
+|---|---|
+| `strike` boolean throughout | exit **1**, `cause: novel-finding-streak` — and it fires at **round 3**, not round 5 |
+| `strike: null` on round 4 only | exit 1, `cause: round-cap`; the streak is gone; one warning |
+| `strike: null` on every round, `no_go_round: 2` | exit **0**, `violations: []`, `cause: null` — total escape, three warnings |
+
+The third row is the real-world failure: five rounds, every round striking,
+`current_round_strike: true` in the report, and the gate still reports no violation. A live example
+of the shape that produces it is `briefs/f16-dsl-slice1-review.json` (`round: 3`, `strike: null` on
+all three entries).
+
+Two further sharp edges:
+
+- A `null` on the **current** round's entry produces **no warning at all** —
+  `computeMissingStrikeWarnings()` skips entries with `round >= currentRound`, and the current
+  round's strike is recomputed fresh anyway. It becomes a silent streak reset one round later,
+  once that round is a past round.
+- The only warning you get for a past-round `null` is inside the JSON report, on a run whose exit
+  code may well be `0`. It is not a violation.
+
+**Therefore: `strike` is written by the gate, not the author.** Assemble the draft with the key
+ABSENT, run the gate, then copy the report's boolean `current_round_strike` into the entry:
+
+```bash
+node scripts/review-verdict-assemble.js --write-strike \
+  --verdict briefs/<task>-review.json.draft --gate-report briefs/<task>-gate-report.json
+```
+
+That command refuses any non-boolean `current_round_strike` — which is also how it catches a gate
+report produced from a verdict that had no `round` (the gate reports `null` there).
+
+Round 1 never strikes. Escalation fires when the last `--strikes` consecutive rounds (all ≥ 2) each
+struck; a strike-free round resets the streak, and non-consecutive strikes never accumulate.
+
+### `task`
+
+The task slug, validated by `validSlug()` from `scripts/lib/xruntime/xruntime-journal.js`. Used to
+derive two sibling paths from `path.dirname(<review.json path>)` — never by suffix-stripping:
+
+- `briefs/<task>-review-trace.jsonl`
+- `briefs/<task>-xruntime.jsonl`
+
+**Load-bearing, and the failure is a hard exit 2.** On a round with a `round` key, an invalid or
+absent `task` fails closed *if* the round is trace-obligated — either by
+`trace_schema_version` on the current entry, or by *any* `*-review-trace.jsonl` already existing in
+the review directory (A-2: blanking `task` must not disguise an obligated round as a legacy skip).
+With neither prong, an absent `task` falls through to the B-8 skip so the ~40 pre-existing
+round-based fixtures keep passing.
+
+### `mode`
+
+`"express" | "fast" | "full"`, read from `briefs/<task>-impl.md`. The gate reads it for exactly one
+thing: `mode === "full"` requires a `scope-gate` trace line on the round. Any other value, including
+absent, requires nothing.
+
+> **Name collision.** The gate's own *report* also has a `mode`, whose values are
+> `"static" | "full"` (whether `--static` was passed). Same key name, different enum, and `"full"`
+> means different things in the two documents. Do not copy one into the other.
+
+### `normalized_by`
+
+The `normalizer_version` string from `scripts/review-normalize.js` (currently `"2.0.0"`). Any
+truthy value **obligates a `normalizer` trace line** for the round — the normalizer self-appends it
+when given `--task`, `--round` and `--cycle` together (all three, or it appends nothing). A
+non-legacy round with neither a trace obligation nor `normalized_by` triggers the loud
+"omit-everything posture" warning (FR-180).
+
+### `cross_runtime`
+
+An object keyed by runtime name (`codex`, `opencode`, …), each value a state object:
+
+```json
+{ "codex": { "status": "healthy", "reason": null, "config_digest": "…", "round": 2, "ts": "…", "actor": "…" } }
+```
+
+Prose statuses: `healthy`, `degraded`, `skipped-degraded`, `skipped-human`, `blocked`. The gate
+handles a strict subset:
+
+- **warning** — a `status: "degraded"` entry missing `reason` or missing `config_digest`. Nothing
+  else is warned about, and no status value is validated.
+- **corroboration** — for `status ∈ {healthy, degraded, skipped-human}` **and**
+  `entry.round === review.round`, there must be a line in `briefs/<task>-xruntime.jsonl` with a
+  matching `runtime`, `cycle`, and `digest`. No match → `unattested-invocation`, exit 1.
+  `skipped-degraded` and `blocked` are never corroborated.
+
+> **Key asymmetry, easy to get wrong:** the verdict writes `config_digest`; the journal writes
+> `digest`. Same value, different key. The gate matches `cross_runtime[rt].config_digest` against
+> `journalEntry.digest` — never `config_digest` against `config_digest`.
+
+Cross-runtime runs are **never** listed in `specialists_run` — the gate corroborates them through
+this field and the `cross-runtime` trace event instead.
+
+### `streak_override`
+
+```json
+{ "round": 3, "by": "human" }
+```
+
+Valid only when `round === review.round` **and** `by === "human"`. A valid override forces this
+round's `strike` to `false` instead of recomputing it, so a later `--static` re-check still passes.
+It is current-round-only — the next verdict's `round` increment retires it, and a new streak must
+fully re-accumulate. **The round-cap escalation is never overridable.** Offer the override only
+when the gate's `cause` is `novel-finding-streak`, never for `round-cap`, and never for
+`unattested-invocation` (INV-8).
+
+---
+
+## Keys the gate does not read (prose-enforced)
+
+| Key | Type | Notes |
+|---|---|---|
+| `task` | string | also in the enforced set — listed there |
+| `date` | string | full ISO-8601 (`2026-07-25T10:00:22Z`), not a day-only string |
+| `status` | `"GO" \| "NO-GO"` | **the gate never reads this.** `scripts/lib/review/review-lifecycle.js` does: `status === "GO"` is what makes the next cycle fresh |
+| `summary` | string | human-facing |
+| `auto_fixes_applied` | integer | count of step-2 mechanical corrections |
+| `no_go_reason` | object \| null | see below — the routing key, and entirely unenforced |
+| `cross_runtime_findings` | array | canonical finding shape, augment-only, never merged into `findings` and never rewritten after intake. A CRITICAL/HIGH OPEN entry here is supposed to force `NO-GO`, but the gate never looks at this array |
+| `escalation_needed` | boolean | Express/Fast mode-escalation signal; informational, never blocks `GO` |
+| `escalation_reason` | string \| null | required in spirit when `escalation_needed` is true; nothing checks it |
+
+### `no_go_reason`
+
+`null` on `GO`. On `NO-GO`:
+
+```json
+{ "type": "design-not-converging", "cause": "novel-finding-streak", "failed_acs": ["AC-3", "FR-021"] }
+```
+
+- **`type`** — the routing key. Values recognized by `roster-review`'s Output Contract and
+  `roster-run`'s routing table:
+
+  | `type` | Route |
+  |---|---|
+  | `out-of-scope-change` | `/roster-implement` (a human `ACCEPT` on the scope finding is the escape hatch) |
+  | `spec-ac-failure` | `/roster-spec` — populate `failed_acs` from each finding's `acs` |
+  | `cross-runtime-finding` | `/roster-implement`; mirror the entry into `findings` so it enters the ratchet |
+  | `design-not-converging` | `/roster-spec`, minimal-freeze profile |
+  | `review-integrity-failure` | re-run the claimed tooling for real — **never** `/roster-spec`, never streak-override (FR-175/INV-8) |
+
+- **`cause`** — mirrors the gate report's top-level `cause` when the gate drove the `NO-GO`:
+  `unencodable-finding`, `unattested-invocation`, `novel-finding-streak`, `round-cap`.
+  `process-incomplete` is **never** a top-level `cause` and never routes.
+- **`failed_acs`** — `AC-N` / `FR-NNN` for a `specs/<task-slug>.md` contract, `S<N>` claim ids for
+  `kb/spec.md`.
+
+Nothing validates either enum. A typo in `type` routes nowhere; `roster-run` reads it with
+`jq -r '.no_go_reason.type // "none"'` and falls through.
+
+---
+
+## Gate report
+
+Persisted verbatim to `briefs/<task>-gate-report.json` each round. Emitted on **every** exit code.
+
+```json
+{
+  "mode": "static | full",
+  "no_go_round": 2, "max_rounds": 5, "legacy_no_go_round": false,
+  "round": 3, "legacy_round": false,
+  "current_round_strike": true,
+  "config": { "max_rounds": 5, "strikes": 2, "static": true },
+  "cause": "novel-finding-streak",
+  "warnings": [], "violations": [], "checks": [],
+  "trace": { "obligated": true, "lines_seen": 9, "schema_version": "1.0", "skipped": false }
+}
+```
+
+Before trusting any other field, confirm **both** `config.strikes` and `trace` are present. Either
+one absent means a stale gate script: do not persist, surface "gate script out of date", stop.
+
+### Exit codes
+
+| Exit | Meaning | Action |
+|---|---|---|
+| 0 | no violations, no degraded input | proceed |
+| 1 | design violation — `cause` is `unencodable-finding` / `unattested-invocation` / `novel-finding-streak` / `round-cap` | `NO-GO` regardless of the human verdict; route per `cause` |
+| 2 | degraded input: absent/malformed verdict, unknown flag, inconclusive red/green, malformed current-cycle trace line | fail closed; block the route-back, surface to the human |
+| 3 | `process-incomplete` only — incomplete/absent `rounds_audit` entry, or `missing-trace` | repair per `violations[].detail`, re-gate, max 2 attempts, never bump `round`, never route |
+
+`cause` precedence (FR-059/B-5, extended FR-174):
+
+```
+unencodable-finding  >  unattested-invocation  >  novel-finding-streak  >  round-cap
+```
+
+**This precedence surprises people.** On a verdict that violates both the streak rule and the
+round cap, `cause` is `novel-finding-streak` and *not* `round-cap`, even though `round-cap` is in
+`violations[]`. In practice a genuinely non-converging review escalates at **round 3** on the
+streak, so `round-cap` is only ever the top-level cause when the streak has been broken — which,
+given the previous section, most often means a `strike: null`.
+
+---
+
+## Prose/enforcer discrepancies
+
+Recorded, not resolved. Each is a place where `roster-review` prose implies an enforcement that
+does not exist, or where the enforcer requires something the prose never states.
+
+| # | Discrepancy | Consequence |
+|---|---|---|
+| D1 | Prose: "any `cross_runtime_findings` entry that is CRITICAL or HIGH (OPEN) sets `status: NO-GO`". The gate never reads `cross_runtime_findings`. | A HIGH cross-runtime finding is invisible to the gate. Only the prose-level mirror into `findings` puts it under the ratchet — forget the mirror and it is unenforced. |
+| D2 | Prose treats `no_go_reason.type` as the routing key. Nothing validates it, and the gate never reads `no_go_reason` at all. | A typo silently routes nowhere. |
+| D3 | Prose says `strike` is "populated after the gate reports it"; it never says the value must be a *boolean*, and the gate's completeness check does not require it. | `strike: null` passes the completeness check and silently defeats streak escalation. Live in this repo: `briefs/f16-dsl-slice1-review.json`. |
+| D4 | Prose lists `task` as an ordinary field. The gate makes it load-bearing for path derivation and fails **closed (exit 2)** on an invalid slug once the round is trace-obligated. | An innocuous-looking `task` edit turns a working round into a hard degraded-input failure. |
+| D5 | `mode` means `express\|fast\|full` in the verdict and `static\|full` in the gate report. | Copying one into the other silently changes what the gate demands. |
+| D6 | Prose does not state that stamping `normalized_by` creates a `normalizer` trace obligation, nor that the normalizer self-appends only when `--task`, `--round` **and** `--cycle` are all given. | Two of three flags → no trace line → `unattested-invocation` (exit 1) on a round that really did normalize. |
+| D7 | `findings[].status` is `OPEN\|RESOLVED\|ACCEPTED` per `schema/review-finding.schema.json`, and `review-normalize.js` *rejects* anything else. The gate accepts any string (it only tests `=== "RESOLVED"` / `=== "ACCEPTED"`). | Hand-written verdicts in this repo carry `status: "OPEN-FOR-HUMAN"` and `category: "ci"` (`briefs/make-tests-actually-run-review.json`). The gate tolerates them; the normalizer would have rejected them. Enforcement depends on which tool you ran. |
+| D8 | Prose describes the ratchet's exemptions (same-round raise+resolve, `ACCEPTED`) but not the FIX-2 hardening: *missing* round provenance on a `RESOLVED` HIGH+ finding is itself an `unencodable-finding` violation. | A verdict that omits `resolved_round` reads as lenient and gates as a design violation. |
+| D9 | Prose says `cross_runtime` entries persist `config_digest`; the journal writes the same value under `digest`. Documented in code comments only. | Writing `digest` in the verdict (or `config_digest` in the journal) breaks corroboration and yields `unattested-invocation`. |
+| D10 | Prose does not mention that an absent `no_go_round` defaults to `0` with a warning. | The round-cap backstop cannot fire on a verdict that omits it — a second, quieter vacuity path alongside the `round` one. |
+| D11 | Prose does not mention that an absent/non-numeric `cycle` filters every numerically-stamped trace line out as prior-cycle. | A trace-obligated round with no `cycle` fails as `missing-trace` (exit 3) even though the lines are on disk. |
+
+Two more notes on the enforcer itself, neither a discrepancy:
+
+- In `computeFindingViolations()`, `const accepted = f.status === "ACCEPTED"` is then tested as
+  `if (f.status === "RESOLVED" && !accepted)`. `!accepted` is necessarily true inside that branch —
+  redundant, harmless, and it does match the prose (an `ACCEPTED` finding is never ratchet-checked).
+- `check_encodable: false` is only a violation on `CRITICAL`/`HIGH`. On a `MEDIUM` it is ignored.
+
+---
+
+## Distribution
+
+`scripts/check-review-convergence.js`, `scripts/review-normalize.js`, `scripts/lib/review/*`,
+`scripts/lib/xruntime/*`, `schema/review-finding.schema.json` and
+`schema/review-trace.schema.json` are **upstream-owned bundle files**, sentinelled by
+`scripts/review-bundle.manifest.json` and verified by `node scripts/review-bundle-verify.js`. Do
+not hand-edit them; see `scripts/REVIEW-BUNDLE.md`.
+
+This document and `scripts/review-verdict-assemble.js` (+ its test) are **repo-local** and
+deliberately absent from the manifest, so a bundle upgrade neither overwrites nor flags them.
+
+The assembler's own checks — including the round-cap / streak / `strike: null` cases tabulated
+above, each red-on-mutation against the real gate — run standalone, no test framework:
+
+```bash
+node scripts/review-verdict-assemble.test.js   # exit 0 = green
+node scripts/review-bundle-verify.js           # bundle integrity, no network
+```
+
+They are deliberately not wired into `make test-all`: that target runs the GPU suites, and this
+contract must stay checkable on a machine with no GPU.
+
+> **Known gap:** the bundle files themselves are untracked in this repository — present in the
+> working tree, absent from git. `review-verdict-assemble.js` requires
+> `scripts/lib/review/review-lifecycle.js` and shells out to `scripts/review-normalize.js`, so a
+> fresh clone gets this document and the assembler but not their dependencies, and must run the
+> bundle installer first. Committing 22 upstream-owned generated files is a separate decision from
+> shipping this contract.
+
+---
+
+## Minimal valid verdict
+
+Round 1, `GO`, nothing outstanding — the smallest envelope that makes the gate run its real checks
+rather than take the legacy skip. Produce it with the assembler, not by hand.
+
+```json
+{
+  "task": "example-task",
+  "date": "2026-07-25T10:00:22.000Z",
+  "status": "GO",
+  "mode": "full",
+  "round": 1,
+  "cycle": 1,
+  "no_go_round": 0,
+  "auto_fixes_applied": 0,
+  "findings": [],
+  "cross_runtime_findings": [],
+  "cross_runtime": {},
+  "rounds_audit": [
+    {
+      "round": 1,
+      "reviewed_sha": "64f5d605a4952cc4036e5cff5d4437cdd17e465f",
+      "fix_sha": "64f5d605a4952cc4036e5cff5d4437cdd17e465f",
+      "specialists_run": [{ "name": "reviewer", "selection_reason": "always (owner), round 1 full fan-out" }],
+      "trace_schema_version": "1.0",
+      "strike": false
+    }
+  ],
+  "no_go_reason": null,
+  "summary": "No findings.",
+  "escalation_needed": false,
+  "escalation_reason": null,
+  "normalized_by": "2.0.0"
+}
+```
+
+With `trace_schema_version: "1.0"` and `mode: "full"` this round is trace-obligated, so
+`briefs/example-task-review-trace.jsonl` must carry, for `(task, cycle 1, round 1)`, at least a
+`scope-gate` line, a `specialist` line with `actor: "reviewer"`, and — because `normalized_by` is
+set — a `normalizer` line.

--- a/scripts/lib/review-verdict-rules.js
+++ b/scripts/lib/review-verdict-rules.js
@@ -1,0 +1,409 @@
+// scripts/lib/review-verdict-rules.js — CommonJS, repo-local.
+//
+// The rule + validation layer of scripts/review-verdict-assemble.js, split out
+// so each file stays under the repo's 500-line limit (the same split
+// scripts/lib/review/review-convergence-rules.js made out of
+// check-review-convergence.js). Contract: schema/review-json-schema.md.
+//
+// Responsibility boundary: this module owns WHAT a valid verdict is — the
+// closed enums, the lifecycle-continuity rules, the rounds_audit append-only
+// rules, the normalizer-disposition application, and envelope construction.
+// review-verdict-assemble.js keeps CLI parsing, file I/O, and orchestration.
+//
+// Repo-local like its caller: deliberately absent from
+// scripts/review-bundle.manifest.json, so a bundle upgrade neither overwrites
+// nor flags it.
+//
+// `fail()` exits the process (2) rather than throwing: every caller here is a
+// fail-closed refusal on the way to writing a verdict, and a half-written
+// verdict is the outcome this whole tool exists to prevent.
+"use strict";
+
+const { buildLedgerIndex, findLedgerEntry } = require("./review/normalize-rules");
+const { validSlug } = require("./xruntime/xruntime-journal");
+const TRACE_SCHEMA_VERSION = "1.0";
+const STATUSES = new Set(["GO", "NO-GO"]);
+// schema/review-json-schema.md §`mode`. The gate reads `mode` for exactly one
+// thing — `mode === "full"` obligates a scope-gate trace line — so ANY other
+// string, including a typo, silently drops that obligation.
+const MODES = new Set(["express", "fast", "full"]);
+// schema/review-json-schema.md §`no_go_reason`. Closed enums in the prose,
+// validated by nothing (D2) — a typo routes nowhere. The gate never reads
+// them, so this is the only place the typo can be caught.
+const NO_GO_TYPES = new Set([
+  "out-of-scope-change",
+  "spec-ac-failure",
+  "cross-runtime-finding",
+  "design-not-converging",
+  "review-integrity-failure",
+]);
+const NO_GO_CAUSES = new Set(["unencodable-finding", "unattested-invocation", "novel-finding-streak", "round-cap"]);
+const HIGH_PLUS = new Set(["CRITICAL", "HIGH"]);
+
+function fail(message) {
+  process.stderr.write(`review-verdict-assemble: ${message}\n`);
+  process.exit(2);
+}
+
+function warn(message) {
+  process.stderr.write(`review-verdict-assemble: warning: ${message}\n`);
+}
+
+function parseCount(raw, flag) {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) fail(`${flag} must be a non-negative integer (got ${JSON.stringify(raw)})`);
+  return n;
+}
+
+// ── phase 1 validation ───────────────────────────────────────────────────
+function validateAssembleArgs(args) {
+  if (!args.task) fail("--task <slug> is required");
+  // Same validator the gate uses. An invalid slug is not cosmetic: the gate
+  // hard-fails exit 2 on a trace-obligated round (and every round this tool
+  // assembles is obligated), and `--task` also composes the default --prior /
+  // --out paths, so `../x` would write outside briefs/.
+  if (!validSlug(args.task)) {
+    fail(`--task ${JSON.stringify(args.task)} is not a valid slug (validSlug(), scripts/lib/xruntime/xruntime-journal.js) — the gate exits 2 on a trace-obligated round with an unusable task, and the slug composes the briefs/ paths`);
+  }
+  if (args.round === undefined) {
+    fail("--round <n> is required — a verdict without `round` makes check-review-convergence.js skip strike and rounds_audit checks entirely (B-8), so the gate passes vacuously. That refusal is the whole point of this tool.");
+  }
+  if (args.cycle === undefined) fail("--cycle <n> is required (the trace mechanism scopes lines by (cycle, round))");
+  if (!STATUSES.has(args.status)) fail(`--status must be one of ${[...STATUSES].join(" | ")}`);
+  if (!args.reviewedSha) fail("--reviewed-sha <sha> is required (rounds_audit completeness, FR-078)");
+  if (!args.fixSha === !args.fixShaReason) {
+    fail("exactly one of --fix-sha <sha> or --fix-sha-reason <text> is required (EC-8: a dirty tree records null + a reason, never a guessed sha)");
+  }
+  if (args.specialists.length === 0) {
+    fail("at least one --specialist <name>=<selection_reason> is required — \"why did this specialist run this round\" must always be answerable");
+  }
+  if (args.status === "NO-GO" && !args.noGoType) fail("--no-go-type is required on a NO-GO verdict");
+  if (args.status === "GO" && args.noGoType) fail("--no-go-type is meaningless on a GO verdict");
+  if (args.noGoType && !NO_GO_TYPES.has(args.noGoType)) {
+    fail(`--no-go-type must be one of ${[...NO_GO_TYPES].join(" | ")} (got ${JSON.stringify(args.noGoType)}) — it is the routing key, and roster-run falls through on an unrecognised value (D2)`);
+  }
+  if (args.noGoCause && !NO_GO_CAUSES.has(args.noGoCause)) {
+    fail(`--no-go-cause must be one of ${[...NO_GO_CAUSES].join(" | ")} (got ${JSON.stringify(args.noGoCause)}) — it mirrors the gate report's top-level cause, and process-incomplete is never one`);
+  }
+  // schema/review-json-schema.md §streak_override: the gate honours an
+  // override only when `by === "human"` (isValidStreakOverride). Any other
+  // actor writes an override that does nothing while the verdict claims one —
+  // a misleading artifact in the one place a human audits a waiver.
+  if (args.streakOverrideBy && args.streakOverrideBy !== "human") {
+    fail(`--streak-override-by must be "human" (got ${JSON.stringify(args.streakOverrideBy)}) — the gate ignores any other actor, so the override would be recorded but inert`);
+  }
+  if (args.status === "GO" && args.noGoRound !== undefined && parseCount(args.noGoRound, "--no-go-round") !== 0) {
+    fail("--no-go-round must be 0 (or omitted) on a GO verdict — no_go_round resets on GO");
+  }
+  if (args.status === "NO-GO" && args.noGoRound === undefined) {
+    fail("--no-go-round <n> is required on a NO-GO verdict — it is the round-cap backstop counter and is NOT derivable from `round` (the two are separate counters with separate reset rules)");
+  }
+  // Both of these select which gate checks run at all, so neither may be a
+  // free-form string. An unrecognised --mode reads to the gate exactly like an
+  // absent one (no scope-gate obligation); a trace_schema_version other than
+  // the one the trace mechanism speaks — including omitting the key — leaves
+  // the round un-obligated, so the specialist/scope trace checks never fire
+  // while the verdict still looks schema-valid.
+  if (!MODES.has(args.mode)) {
+    fail(`--mode must be one of ${[...MODES].join(" | ")} (got ${JSON.stringify(args.mode)}) — an unrecognised mode drops the Full-mode scope-gate trace obligation silently`);
+  }
+  if (args.traceSchemaVersion !== TRACE_SCHEMA_VERSION) {
+    fail(`--trace-schema-version must be ${JSON.stringify(TRACE_SCHEMA_VERSION)} (got ${JSON.stringify(args.traceSchemaVersion)}) — a newly assembled round always commits to the trace checks; omitting the stamp is only legitimate for a round that genuinely predates the trace mechanism, which this tool cannot assemble`);
+  }
+}
+
+function parseSpecialists(specs) {
+  return specs.map((raw) => {
+    const idx = raw.indexOf("=");
+    if (idx <= 0) fail(`--specialist must be <name>=<selection_reason> (got ${JSON.stringify(raw)})`);
+    const name = raw.slice(0, idx).trim();
+    const selection_reason = raw.slice(idx + 1).trim();
+    if (!name || !selection_reason) fail(`--specialist ${JSON.stringify(raw)} has an empty name or selection_reason`);
+    return { name, selection_reason };
+  });
+}
+
+// ── phase 2: write the gate-reported strike back ────────────────────────
+// `strike` is the one field this tool cannot compute: it is the gate's own
+// output. Refusing a non-boolean here is what keeps `strike: null` — which
+// makes computeStrikeMap()'s Map.get() return undefined and thus silently
+// resets the novel-finding streak — out of every verdict this tool touches.
+// `config` ({max_rounds, strikes, static}) and `trace` (FR-176) are the gate's
+// own documented anti-stale-script signal, emitted on every exit code it
+// reports on — including the legacy skip (see the header of
+// check-review-convergence.js). A report missing either came from a gate
+// predating the current strike semantics, so its boolean
+// `current_round_strike` was computed under other rules: a stale `false` is
+// indistinguishable from a genuine one once journaled, and silently breaks the
+// streak the next round evaluates.
+//
+// (An input-rejection exit 2 emits no report at all — there is nothing to
+// write back from on that path, and nothing should be invented.)
+function assertGateReportIsCurrent(report) {
+  const stale = (what) =>
+    fail(`gate report has ${what} — it came from a stale check-review-convergence.js (the current gate emits both config and trace on every exit code it reports on, including the legacy skip). Re-run the gate with the current script; refusing to journal a strike computed under unknown rules.`);
+  if (!report.config || typeof report.config !== "object" || typeof report.config.strikes !== "number") {
+    stale("no numeric config.strikes");
+  }
+  if (!report.trace || typeof report.trace !== "object") stale("no `trace` block (FR-176)");
+}
+
+// ── rounds_audit carry-forward (append-only) ─────────────────────────────
+// Prior entries are copied through verbatim; a prior entry for the round being
+// assembled is a refusal, not an overwrite — that would mean the round counter
+// never advanced (scripts/lib/review/review-lifecycle.js owns the bump).
+function carryForwardRoundsAudit(priorEntries, round) {
+  const carried = [];
+  for (const entry of priorEntries) {
+    if (!entry || typeof entry !== "object") fail("prior rounds_audit contains a non-object entry — refusing to carry forward unverifiable state");
+    if (entry.round === round) {
+      fail(`prior verdict already has a rounds_audit entry for round ${round} — rounds_audit is append-only, and this round was already journaled. If the prior gate run exited 3, repair the draft and RE-GATE that round (never bump \`round\`); only a completed round advances the counter.`);
+    }
+    if (typeof entry.round === "number" && entry.round > round) {
+      fail(`prior verdict has a rounds_audit entry for round ${entry.round}, which is ahead of --round ${round} — refusing to assemble a verdict that would look like it went backwards`);
+    }
+    // A carried entry for round >= 2 with no boolean `strike` is a round whose
+    // phase 2 (--write-strike) never ran. computeStrikeMap() cannot see it, so
+    // the streak resets across it and the gate's only signal is a warning on a
+    // run that may well exit 0 — the exact silent pass this tool exists to
+    // prevent. Refusing here is the only place the two-phase protocol has
+    // teeth. (Round 1 never strikes, so its entry is exempt.)
+    if (typeof entry.round === "number" && entry.round >= 2 && typeof entry.strike !== "boolean") {
+      fail(`prior rounds_audit entry for round ${entry.round} has no boolean \`strike\` (${JSON.stringify(entry.strike)}) — that round was never completed with --write-strike, and carrying it forward silently resets the novel-finding streak. Re-gate round ${entry.round} and write its strike before assembling round ${round}.`);
+    }
+    carried.push(entry);
+  }
+  return carried;
+}
+
+function buildAuditEntry(args, round, specialists) {
+  const entry = { round, reviewed_sha: args.reviewedSha };
+  entry.fix_sha = args.fixSha ? args.fixSha : null;
+  if (!args.fixSha) entry.fix_sha_reason = args.fixShaReason;
+  entry.specialists_run = specialists;
+  // Always stamped: validateAssembleArgs() has already pinned it to "1.0", and
+  // the stamp is what obligates the round to the trace checks.
+  entry.trace_schema_version = args.traceSchemaVersion;
+  // NOTE: `strike` is deliberately ABSENT, not null. It is written by
+  // --write-strike after the gate reports current_round_strike.
+  return entry;
+}
+
+function buildNoGoReason(args) {
+  if (args.status === "GO") return null;
+  const reason = { type: args.noGoType };
+  if (args.noGoCause) reason.cause = args.noGoCause;
+  if (args.failedAcs.length > 0) reason.failed_acs = args.failedAcs;
+  return reason;
+}
+
+function buildVerdict({ args, round, cycle, normalized, roundsAudit, crossRuntime, crossRuntimeFindings }) {
+  const verdict = {
+    task: args.task,
+    date: new Date().toISOString(),
+    status: args.status,
+    mode: args.mode,
+    round,
+    cycle,
+    no_go_round: args.noGoRound === undefined ? 0 : parseCount(args.noGoRound, "--no-go-round"),
+    auto_fixes_applied: parseCount(args.autoFixes, "--auto-fixes"),
+    findings: normalized.findings,
+    cross_runtime_findings: crossRuntimeFindings,
+    cross_runtime: crossRuntime,
+    rounds_audit: roundsAudit,
+    no_go_reason: buildNoGoReason(args),
+    summary: args.summary || "",
+    escalation_needed: args.escalationNeeded,
+    escalation_reason: args.escalationReason || null,
+    normalized_by: normalized.normalizer_version,
+  };
+  if (args.streakOverrideBy) verdict.streak_override = { round, by: args.streakOverrideBy };
+  return verdict;
+}
+
+// Surfaces the normalizer's non-verdict outputs (they have no home in
+// review.json and must not vanish silently, FR-100).
+function reportNormalizerSideChannels(normalized) {
+  for (const w of normalized.warnings || []) warn(`review-normalize: ${w}`);
+  for (const d of normalized.probable_duplicates || []) {
+    warn(`review-normalize: probable duplicate needs owner adjudication: ${JSON.stringify(d)}`);
+  }
+  const rejected = normalized.rejected || [];
+  if (rejected.length === 0) return;
+  for (const r of rejected) warn(`review-normalize: REJECTED (schema-invalid) finding: ${r.reason}`);
+  // Unconditional — there is deliberately no escape hatch. A malformed
+  // HIGH/CRITICAL that never reaches `findings` is one the gate cannot
+  // classify as a novel strike, so the round does not strike, the streak does
+  // not accumulate, and the verdict looks clean. The stderr warnings above are
+  // not durable, so "warn and continue" would be silent loss, fail-open.
+  fail(`${rejected.length} finding(s) were rejected as schema-invalid by review-normalize.js — fix them against schema/review-finding.schema.json. There is deliberately no flag to drop them: a dropped HIGH/CRITICAL cannot strike, so the gate would report a clean round it never saw.`);
+}
+
+// The normalizer PROPOSES dispositions and never mutates ledger status itself
+// (single-executor principle) — so somebody downstream must apply them, and
+// this tool is that somebody. `normalize()` returns
+// `findings = ledger.concat(genuinelyNew)`: a re-reported RESOLVED finding is
+// NOT in `findings`, it is in `dispositions.reopened`. Ignore that and
+// `isReopenedStrikeFinding()` (`f.reopened_at_round === round`) can never fire
+// on anything this tool emits, so E-4 is dead and a regression-heavy loop-back
+// round is invisible to two-strike escalation.
+//
+// Matching reuses the normalizer's own buildLedgerIndex/findLedgerEntry so the
+// identity rule cannot drift from the one that produced the disposition.
+function applyDispositions(normalized) {
+  const dispositions = normalized.dispositions || {};
+  const pending = Array.isArray(dispositions.pending_check) ? dispositions.pending_check : [];
+  const reopened = Array.isArray(dispositions.reopened) ? dispositions.reopened : [];
+
+  for (const r of normalized.reobservations || []) {
+    warn(`review-normalize: reobserved (carry-forward noise, not a fresh finding): ${r.fingerprint}`);
+  }
+
+  // pending-check is genuinely undecidable until THIS round's gate run has
+  // produced a report — the normalizer says so explicitly. Applying it either
+  // way would be a guess, and dropping it loses a possible regression, so it
+  // is a refusal with the repair spelled out.
+  if (pending.length > 0) {
+    fail(
+      `${pending.length} finding(s) are in the normalizer's pending-check disposition: a RESOLVED ledger entry with a linked check that the supplied gate report has no entry for, re-reported this round. Whether it is a regression is only knowable from a gate report that covers that check. Re-gate the prior round so briefs/<task>-gate-report.json carries the check, then re-assemble. Fingerprints: ${pending.map((p) => p.fingerprint).join(", ")}`
+    );
+  }
+
+  if (reopened.length === 0) return;
+  const index = buildLedgerIndex(normalized.findings);
+  for (const body of reopened) {
+    const entry = findLedgerEntry(body, index);
+    if (!entry) {
+      fail(`normalizer reopened ${body.fingerprint} but no matching entry is in the normalized findings — refusing to emit a verdict that would drop a reopened HIGH+ finding`);
+    }
+    Object.assign(entry, body);
+    warn(`review-normalize: REOPENED ${body.fingerprint} (was RESOLVED in round ${body.reopened_from_round}) — applied to findings, so it counts toward this round's strike (E-4)`);
+  }
+}
+
+// `first_seen_round` is NOT stamped by the normalizer — canonicalizeFindings()
+// rewrites only fingerprint/fingerprint_v2/fid/status, and
+// schema/review-finding.schema.json does not require the field. But
+// isNovelStrikeFinding() returns false unless it is numeric and equals the
+// round, so a HIGH+ finding that arrives without it can NEVER strike: the
+// round is silently unstrikeable and the streak never accumulates. Scoped to
+// HIGH+ because that is exactly the set the strike rule looks at.
+function assertStrikeableFindings(findings, round) {
+  const unclassifiable = findings.filter(
+    (f) => f && HIGH_PLUS.has(f.severity) && (typeof f.first_seen_round !== "number" || f.first_seen_round > round)
+  );
+  if (unclassifiable.length === 0) return;
+  fail(
+    `${unclassifiable.length} CRITICAL/HIGH finding(s) have a missing or future first_seen_round: ` +
+      `${unclassifiable.map((f) => `${f.fingerprint} (${JSON.stringify(f.first_seen_round)})`).join(", ")}. ` +
+      "isNovelStrikeFinding() requires a numeric first_seen_round equal to the round, so these can never strike — " +
+      `the round would be silently unstrikeable. Stamp first_seen_round: ${round} on findings raised this round.`
+  );
+}
+
+// INV-5/E-7: cross_runtime_findings is augment-only and never rewritten after
+// intake — but the normalizer only ever sees THIS round's input files, so
+// taking its output verbatim drops every prior round's entries. Carried within
+// a cycle, reset on a fresh one (like `findings`).
+function carryForwardCrossRuntime(prior, freshCycle, current) {
+  const priorEntries = !freshCycle && prior && Array.isArray(prior.cross_runtime_findings) ? prior.cross_runtime_findings : [];
+  const seen = new Set(priorEntries.map((f) => (f && (f.fid || f.fingerprint)) || ""));
+  const appended = current.filter((f) => !seen.has((f && (f.fid || f.fingerprint)) || ""));
+  return priorEntries.concat(appended);
+}
+
+// roster-review's Output Contract: an OPEN CRITICAL/HIGH forces NO-GO. The
+// gate never reads `status`, so nothing downstream catches a GO that carries
+// one — and deriveRoundState() then treats the next cycle as fresh and resets
+// the ledger to [], deleting the finding from the only file that held it.
+function assertGoIsClean(args, findings) {
+  if (args.status !== "GO") return;
+  const open = findings.filter((f) => f && HIGH_PLUS.has(f.severity) && f.status !== "RESOLVED" && f.status !== "ACCEPTED");
+  if (open.length === 0) return;
+  fail(
+    `--status GO with ${open.length} open CRITICAL/HIGH finding(s): ${open.map((f) => f.fingerprint).join(", ")}. ` +
+      "An open HIGH+ forces NO-GO (roster-review Output Contract). The gate does not read `status`, so this would " +
+      "pass; and the next cycle resets findings to [] on a GO, deleting them. RESOLVE or human-ACCEPT them first."
+  );
+}
+
+// Cross-checks --round/--cycle/--no-go-round against the lifecycle witness
+// rather than re-deriving the rule here. FAIL-CLOSED, not advisory: all three
+// are inputs the gate uses to decide how much to check, so a wrong one buys
+// silence rather than a wrong answer.
+//
+//   --round  computeStreakViolation() walks `round, round-1, …` for
+//     consecutive `true`s, and computeStrikeMap() only knows rounds that have
+//     a rounds_audit entry. Jumping 3 -> 7 leaves 4-6 absent, so
+//     `strikeByRound.get(r) !== true` short-circuits and the streak is erased
+//     — silently, since computeMissingStrikeWarnings() only inspects entries
+//     that EXIST. carryForwardRoundsAudit() already refuses a repeated or
+//     backwards round; this refuses the forward jump.
+//   --cycle  scopes trace lines by (cycle, round); a wrong one hides them.
+//   --no-go-round  the round-cap backstop, caller-supplied and never derived,
+//     so a value that never advances never trips the cap.
+//
+// Legacy exception: a prior NO-GO verdict with no `round` derives `null` — the
+// state this tool exists to migrate away from, unverifiable, so it warns.
+function enforceLifecycle(prior, derived, round, cycle, args) {
+  if (derived.round === null) {
+    warn(
+      "prior verdict has no `round` key (legacy) — round continuity cannot be verified against " +
+        "scripts/lib/review/review-lifecycle.js. This round re-establishes it."
+    );
+  } else if (derived.round !== round) {
+    fail(
+      `--round ${round} but scripts/lib/review/review-lifecycle.js derives ${derived.round} from the prior verdict. ` +
+        "Rounds are physical and consecutive: a skipped round leaves a hole in rounds_audit that erases the " +
+        "novel-finding streak (computeStreakViolation walks consecutive rounds and stops at the first non-true)."
+    );
+  }
+  if (derived.cycle !== null && derived.cycle !== cycle) {
+    fail(
+      `--cycle ${cycle} but scripts/lib/review/review-lifecycle.js derives ${derived.cycle} from the prior verdict — ` +
+        "the trace mechanism scopes lines by (cycle, round), so a wrong cycle hides this round's trace lines."
+    );
+  }
+  enforceNoGoRound(prior, derived, args);
+}
+
+// no_go_round counts only QUALIFYING (NO-GO) rounds and resets to 0 on GO, so
+// it is not derivable from `round`. What IS checkable is its step: relative to
+// the prior verdict it may only stay put or advance by one, and a fresh cycle
+// (no prior, or a prior GO) starts from 0.
+function enforceNoGoRound(prior, derived, args) {
+  if (args.status === "GO") return; // already pinned to 0 by validateAssembleArgs
+  const priorNoGoRound = !derived.freshCycle && prior && typeof prior.no_go_round === "number" ? prior.no_go_round : 0;
+  const noGoRound = parseCount(args.noGoRound, "--no-go-round");
+  if (noGoRound !== priorNoGoRound && noGoRound !== priorNoGoRound + 1) {
+    fail(
+      `--no-go-round ${noGoRound} does not follow the prior verdict's ${priorNoGoRound} — it may only hold or ` +
+        "advance by one per NO-GO verdict. A no_go_round that never advances never reaches --max-rounds, which " +
+        "disables the round-cap backstop entirely."
+    );
+  }
+}
+module.exports = {
+  TRACE_SCHEMA_VERSION,
+  STATUSES,
+  MODES,
+  NO_GO_TYPES,
+  NO_GO_CAUSES,
+  HIGH_PLUS,
+  fail,
+  warn,
+  parseCount,
+  validateAssembleArgs,
+  parseSpecialists,
+  assertGateReportIsCurrent,
+  carryForwardRoundsAudit,
+  buildAuditEntry,
+  buildNoGoReason,
+  buildVerdict,
+  reportNormalizerSideChannels,
+  applyDispositions,
+  assertStrikeableFindings,
+  carryForwardCrossRuntime,
+  assertGoIsClean,
+  enforceLifecycle,
+};

--- a/scripts/review-verdict-assemble.js
+++ b/scripts/review-verdict-assemble.js
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+// scripts/review-verdict-assemble.js — CommonJS, repo-local tool (NOT part of
+// the upstream review-tool bundle; it is absent from
+// scripts/review-bundle.manifest.json by design and survives a bundle upgrade).
+//
+// Assembles a schema-valid briefs/<task>-review.json draft so no verdict is
+// ever hand-derived. Contract: schema/review-json-schema.md (the same document
+// scripts/lib/review/*.js and skills/pipeline/roster-review.md cite).
+//
+// WHY THIS EXISTS: check-review-convergence.js silently degrades to a no-op on
+// a verdict that lacks `round` ("legacy review.json: round key absent —
+// skipping strike and rounds_audit checks (B-8)", violations: [], exit 0). A
+// hand-written verdict under-populates exactly the keys the gate needs, so the
+// anti-vacuity gate was itself vacuous. This tool refuses to emit a verdict
+// without `round`, and never emits `strike: null` (which silently resets
+// novel-finding-streak detection — see schema/review-json-schema.md §"strike").
+//
+// PIPELINE ORDER (also documented at the top of the schema doc — the order is
+// load-bearing: without normalization first, "novel finding" is uncomputable
+// because fingerprints are not stable):
+//
+//   specialists emit findings  →  normalize the ARRAY  →  assemble the verdict
+//     →  run the gate  →  write strikes back  →  route on the verdict
+//
+// This tool owns steps 2, 3 and 5. It delegates step 2 wholesale to
+// scripts/review-normalize.js (fingerprinting is never reimplemented here).
+//
+// TWO PHASES — because `strike` is only knowable AFTER the gate reports it:
+//
+//   1) assemble:      node scripts/review-verdict-assemble.js --task <slug> --round <n>
+//                       --cycle <n> --status <GO|NO-GO> --reviewed-sha <sha>
+//                       (--fix-sha <sha> | --fix-sha-reason <text>)
+//                       --specialist <name>=<selection_reason> [...]
+//                       [--findings <file.json> ...] [--out <path>] ...
+//      → writes the draft with NO `strike` key on the current round's entry
+//        (absent, never null — a null would be silently accepted here and
+//        would silently reset the streak once the round becomes a past round).
+//
+//   2) write-strike:  node scripts/review-verdict-assemble.js --write-strike
+//                       --verdict <draft path> --gate-report <gate stdout json>
+//      → copies the gate's boolean `current_round_strike` into the entry for
+//        the gate report's own `round`. Refuses anything non-boolean.
+//
+// Between them, run the gate exactly as roster-review §5.5 prescribes:
+//   node scripts/check-review-convergence.js <draft> --max-rounds N --strikes N
+//
+// Exit codes: 0 success; 2 usage or degraded input (fail-closed, never a
+// half-written verdict).
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const { deriveRoundState } = require("./lib/review/review-lifecycle");
+
+const NORMALIZER = path.resolve(__dirname, "review-normalize.js");
+const TRACE_SCHEMA_VERSION = "1.0";
+const STATUSES = new Set(["GO", "NO-GO"]);
+
+function fail(message) {
+  process.stderr.write(`review-verdict-assemble: ${message}\n`);
+  process.exit(2);
+}
+
+function warn(message) {
+  process.stderr.write(`review-verdict-assemble: warning: ${message}\n`);
+}
+
+// ── argument parsing ─────────────────────────────────────────────────────
+const VALUE_FLAGS = {
+  "--task": "task",
+  "--round": "round",
+  "--cycle": "cycle",
+  "--status": "status",
+  "--mode": "mode",
+  "--reviewed-sha": "reviewedSha",
+  "--fix-sha": "fixSha",
+  "--fix-sha-reason": "fixShaReason",
+  "--no-go-round": "noGoRound",
+  "--no-go-type": "noGoType",
+  "--no-go-cause": "noGoCause",
+  "--summary": "summary",
+  "--auto-fixes": "autoFixes",
+  "--escalation-reason": "escalationReason",
+  "--streak-override-by": "streakOverrideBy",
+  "--trace-schema-version": "traceSchemaVersion",
+  "--prior": "prior",
+  "--out": "out",
+  "--gate-report": "gateReport",
+  "--verdict": "verdict",
+};
+
+function emptyArgs() {
+  return {
+    findings: [],
+    specialists: [],
+    failedAcs: [],
+    traceSchemaVersion: TRACE_SCHEMA_VERSION,
+    mode: "full",
+    autoFixes: "0",
+    writeStrike: false,
+    escalationNeeded: false,
+    allowRejected: false,
+  };
+}
+
+function parseArgs(argv) {
+  const out = emptyArgs();
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--findings") out.findings.push(requireValue(argv, ++i, a));
+    else if (a === "--specialist") out.specialists.push(requireValue(argv, ++i, a));
+    else if (a === "--failed-ac") out.failedAcs.push(requireValue(argv, ++i, a));
+    else if (a === "--write-strike") out.writeStrike = true;
+    else if (a === "--escalation-needed") out.escalationNeeded = true;
+    else if (a === "--allow-rejected") out.allowRejected = true;
+    else if (VALUE_FLAGS[a]) out[VALUE_FLAGS[a]] = requireValue(argv, ++i, a);
+    else fail(`unknown flag or stray argument: ${a}`);
+  }
+  return out;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === undefined || value.startsWith("--")) fail(`${flag} requires a value`);
+  return value;
+}
+
+function parseCount(raw, flag) {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) fail(`${flag} must be a non-negative integer (got ${JSON.stringify(raw)})`);
+  return n;
+}
+
+function readJsonFile(filePath, label) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(resolved)) fail(`${label} not found: ${filePath}`);
+  try {
+    return JSON.parse(fs.readFileSync(resolved, "utf8"));
+  } catch (e) {
+    fail(`${label} is not valid JSON: ${e.message}`);
+  }
+}
+
+// ── phase 2: write the gate-reported strike back ────────────────────────
+// `strike` is the one field this tool cannot compute: it is the gate's own
+// output. Refusing a non-boolean here is what keeps `strike: null` — which
+// makes computeStrikeMap()'s Map.get() return undefined and thus silently
+// resets the novel-finding streak — out of every verdict this tool touches.
+function runWriteStrike(args) {
+  if (!args.verdict) fail("--write-strike requires --verdict <path>");
+  if (!args.gateReport) fail("--write-strike requires --gate-report <path>");
+
+  const verdictPath = path.resolve(process.cwd(), args.verdict);
+  const verdict = readJsonFile(args.verdict, "--verdict file");
+  const report = readJsonFile(args.gateReport, "--gate-report file");
+
+  if (typeof report.current_round_strike !== "boolean") {
+    fail(
+      `gate report field current_round_strike is ${JSON.stringify(report.current_round_strike)}, not a boolean — ` +
+        "refusing to write a non-boolean strike (a null strike silently resets novel-finding-streak detection). " +
+        "A null here means the gate took the B-8 legacy path: the verdict it gated had no `round` key."
+    );
+  }
+  if (typeof report.round !== "number") fail("gate report field round is not a number — is this the report for this verdict?");
+  if (verdict.round !== report.round) {
+    fail(`gate report round (${report.round}) does not match verdict round (${verdict.round}) — wrong report file`);
+  }
+
+  const entry = (Array.isArray(verdict.rounds_audit) ? verdict.rounds_audit : []).find((e) => e && e.round === report.round);
+  if (!entry) fail(`no rounds_audit entry for round ${report.round} — assemble the draft first`);
+
+  entry.strike = report.current_round_strike;
+  fs.writeFileSync(verdictPath, `${JSON.stringify(verdict, null, 2)}\n`);
+  process.stdout.write(
+    `${JSON.stringify({ ok: true, verdict: args.verdict, round: report.round, strike: entry.strike }, null, 2)}\n`
+  );
+}
+
+// ── phase 1 validation ───────────────────────────────────────────────────
+function validateAssembleArgs(args) {
+  if (!args.task) fail("--task <slug> is required");
+  if (args.round === undefined) {
+    fail("--round <n> is required — a verdict without `round` makes check-review-convergence.js skip strike and rounds_audit checks entirely (B-8), so the gate passes vacuously. That refusal is the whole point of this tool.");
+  }
+  if (args.cycle === undefined) fail("--cycle <n> is required (the trace mechanism scopes lines by (cycle, round))");
+  if (!STATUSES.has(args.status)) fail(`--status must be one of ${[...STATUSES].join(" | ")}`);
+  if (!args.reviewedSha) fail("--reviewed-sha <sha> is required (rounds_audit completeness, FR-078)");
+  if (!args.fixSha === !args.fixShaReason) {
+    fail("exactly one of --fix-sha <sha> or --fix-sha-reason <text> is required (EC-8: a dirty tree records null + a reason, never a guessed sha)");
+  }
+  if (args.specialists.length === 0) {
+    fail("at least one --specialist <name>=<selection_reason> is required — \"why did this specialist run this round\" must always be answerable");
+  }
+  if (args.status === "NO-GO" && !args.noGoType) fail("--no-go-type is required on a NO-GO verdict");
+  if (args.status === "GO" && args.noGoType) fail("--no-go-type is meaningless on a GO verdict");
+  if (args.status === "GO" && args.noGoRound !== undefined && parseCount(args.noGoRound, "--no-go-round") !== 0) {
+    fail("--no-go-round must be 0 (or omitted) on a GO verdict — no_go_round resets on GO");
+  }
+  if (args.status === "NO-GO" && args.noGoRound === undefined) {
+    fail("--no-go-round <n> is required on a NO-GO verdict — it is the round-cap backstop counter and is NOT derivable from `round` (the two are separate counters with separate reset rules)");
+  }
+}
+
+function parseSpecialists(specs) {
+  return specs.map((raw) => {
+    const idx = raw.indexOf("=");
+    if (idx <= 0) fail(`--specialist must be <name>=<selection_reason> (got ${JSON.stringify(raw)})`);
+    const name = raw.slice(0, idx).trim();
+    const selection_reason = raw.slice(idx + 1).trim();
+    if (!name || !selection_reason) fail(`--specialist ${JSON.stringify(raw)} has an empty name or selection_reason`);
+    return { name, selection_reason };
+  });
+}
+
+// ── normalization (delegated, never reimplemented) ───────────────────────
+// review-normalize.js takes each positional file as a JSON **ARRAY of finding
+// objects** — NOT the verdict envelope. Passing a verdict yields "finding file
+// must be a JSON array"; nothing at its call site says so, which is exactly
+// the friction this wrapper removes.
+function runNormalizer({ findingFiles, ledger, round, cycle, task, priorPath, gateReportPath }) {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "review-verdict-"));
+  const ledgerPath = path.join(scratch, "ledger.json");
+  fs.writeFileSync(ledgerPath, JSON.stringify(ledger));
+
+  const argv = findingFiles.slice();
+  argv.push("--ledger", ledgerPath, "--round", String(round), "--cycle", String(cycle), "--task", task);
+  if (priorPath) argv.push("--prior", priorPath);
+  if (gateReportPath && fs.existsSync(path.resolve(process.cwd(), gateReportPath))) {
+    argv.push("--gate-report", gateReportPath);
+  }
+
+  let stdout;
+  try {
+    stdout = execFileSync(process.execPath, [NORMALIZER, ...argv], { encoding: "utf8", cwd: process.cwd() });
+  } catch (e) {
+    fail(`scripts/review-normalize.js failed (exit ${e.status}): ${String(e.stderr || e.message).trim()}`);
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+
+  try {
+    return JSON.parse(stdout);
+  } catch (e) {
+    fail(`scripts/review-normalize.js emitted unparseable stdout: ${e.message}`);
+  }
+}
+
+// Each positional --findings file must already be a JSON array of finding
+// objects. Checked here so the failure names the offending file instead of
+// surfacing as the normalizer's context-free "finding file must be a JSON array".
+function assertFindingFilesAreArrays(files) {
+  for (const file of files) {
+    const parsed = readJsonFile(file, `--findings file ${file}`);
+    if (!Array.isArray(parsed)) {
+      fail(`--findings ${file} is a JSON ${Array.isArray(parsed) ? "array" : typeof parsed} — review-normalize.js requires a JSON ARRAY of finding objects, not a verdict envelope`);
+    }
+  }
+}
+
+// ── rounds_audit carry-forward (append-only) ─────────────────────────────
+// Prior entries are copied through verbatim; a prior entry for the round being
+// assembled is a refusal, not an overwrite — that would mean the round counter
+// never advanced (scripts/lib/review/review-lifecycle.js owns the bump).
+function carryForwardRoundsAudit(priorEntries, round) {
+  const carried = [];
+  for (const entry of priorEntries) {
+    if (!entry || typeof entry !== "object") fail("prior rounds_audit contains a non-object entry — refusing to carry forward unverifiable state");
+    if (entry.round === round) {
+      fail(`prior verdict already has a rounds_audit entry for round ${round} — rounds_audit is append-only. Bump the round via \`node scripts/lib/review/review-lifecycle.js --prior <verdict>\` instead of rewriting it.`);
+    }
+    if (typeof entry.round === "number" && entry.round > round) {
+      fail(`prior verdict has a rounds_audit entry for round ${entry.round}, which is ahead of --round ${round} — refusing to assemble a verdict that would look like it went backwards`);
+    }
+    carried.push(entry);
+  }
+  return carried;
+}
+
+function buildAuditEntry(args, round, specialists) {
+  const entry = { round, reviewed_sha: args.reviewedSha };
+  entry.fix_sha = args.fixSha ? args.fixSha : null;
+  if (!args.fixSha) entry.fix_sha_reason = args.fixShaReason;
+  entry.specialists_run = specialists;
+  if (args.traceSchemaVersion !== "none") entry.trace_schema_version = args.traceSchemaVersion;
+  // NOTE: `strike` is deliberately ABSENT, not null. It is written by
+  // --write-strike after the gate reports current_round_strike.
+  return entry;
+}
+
+function buildNoGoReason(args) {
+  if (args.status === "GO") return null;
+  const reason = { type: args.noGoType };
+  if (args.noGoCause) reason.cause = args.noGoCause;
+  if (args.failedAcs.length > 0) reason.failed_acs = args.failedAcs;
+  return reason;
+}
+
+function buildVerdict({ args, round, cycle, normalized, roundsAudit, crossRuntime }) {
+  const verdict = {
+    task: args.task,
+    date: new Date().toISOString(),
+    status: args.status,
+    mode: args.mode,
+    round,
+    cycle,
+    no_go_round: args.noGoRound === undefined ? 0 : parseCount(args.noGoRound, "--no-go-round"),
+    auto_fixes_applied: parseCount(args.autoFixes, "--auto-fixes"),
+    findings: normalized.findings,
+    cross_runtime_findings: normalized.cross_runtime_findings,
+    cross_runtime: crossRuntime,
+    rounds_audit: roundsAudit,
+    no_go_reason: buildNoGoReason(args),
+    summary: args.summary || "",
+    escalation_needed: args.escalationNeeded,
+    escalation_reason: args.escalationReason || null,
+    normalized_by: normalized.normalizer_version,
+  };
+  if (args.streakOverrideBy) verdict.streak_override = { round, by: args.streakOverrideBy };
+  return verdict;
+}
+
+// Surfaces the normalizer's non-verdict outputs (they have no home in
+// review.json and must not vanish silently, FR-100).
+function reportNormalizerSideChannels(args, normalized) {
+  for (const w of normalized.warnings || []) warn(`review-normalize: ${w}`);
+  for (const d of normalized.probable_duplicates || []) {
+    warn(`review-normalize: probable duplicate needs owner adjudication: ${JSON.stringify(d)}`);
+  }
+  const rejected = normalized.rejected || [];
+  if (rejected.length === 0) return;
+  for (const r of rejected) warn(`review-normalize: REJECTED (schema-invalid) finding: ${r.reason}`);
+  if (!args.allowRejected) {
+    fail(`${rejected.length} finding(s) were rejected as schema-invalid by review-normalize.js — fix them against schema/review-finding.schema.json, or pass --allow-rejected to drop them deliberately`);
+  }
+}
+
+// Cross-checks --round/--cycle against the lifecycle witness rather than
+// re-deriving the rule here. Advisory (a warning), matching review-normalize.js's
+// own treatment of the same disagreement.
+function checkLifecycle(prior, round, cycle) {
+  const derived = deriveRoundState(prior);
+  if (derived.round !== null && derived.round !== round) {
+    warn(`--round ${round} but scripts/lib/review/review-lifecycle.js derives ${derived.round} from the prior verdict`);
+  }
+  if (derived.cycle !== null && derived.cycle !== cycle) {
+    warn(`--cycle ${cycle} but scripts/lib/review/review-lifecycle.js derives ${derived.cycle} from the prior verdict`);
+  }
+  return derived;
+}
+
+function runAssemble(args) {
+  validateAssembleArgs(args);
+  const round = parseCount(args.round, "--round");
+  const cycle = parseCount(args.cycle, "--cycle");
+  if (round < 1) fail("--round must be >= 1 (round 1 is the first round of a cycle)");
+  if (cycle < 1) fail("--cycle must be >= 1");
+
+  const priorPath = args.prior || `briefs/${args.task}-review.json`;
+  const priorExists = fs.existsSync(path.resolve(process.cwd(), priorPath));
+  const prior = priorExists ? readJsonFile(priorPath, "--prior file") : null;
+  const derived = checkLifecycle(prior, round, cycle);
+
+  // Carry-forward is validated BEFORE the normalizer runs so an append-only
+  // violation fails fast instead of after a full normalization pass.
+  const roundsAudit = carryForwardRoundsAudit(derived.roundsAudit, round).concat([
+    buildAuditEntry(args, round, parseSpecialists(args.specialists)),
+  ]);
+
+  assertFindingFilesAreArrays(args.findings);
+  const normalized = runNormalizer({
+    findingFiles: args.findings,
+    ledger: Array.isArray(prior && prior.findings) && !derived.freshCycle ? prior.findings : [],
+    round,
+    cycle,
+    task: args.task,
+    priorPath: priorExists ? priorPath : null,
+    gateReportPath: args.gateReport || `briefs/${args.task}-gate-report.json`,
+  });
+  reportNormalizerSideChannels(args, normalized);
+
+  const verdict = buildVerdict({
+    args,
+    round,
+    cycle,
+    normalized,
+    roundsAudit,
+    crossRuntime: derived.crossRuntime,
+  });
+
+  const outPath = path.resolve(process.cwd(), args.out || `briefs/${args.task}-review.json.draft`);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(verdict, null, 2)}\n`);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ok: true,
+        draft: path.relative(process.cwd(), outPath),
+        round,
+        cycle,
+        findings: verdict.findings.length,
+        cross_runtime_findings: verdict.cross_runtime_findings.length,
+        strike: "absent — run the gate, then --write-strike",
+        next: "node scripts/check-review-convergence.js <draft> --max-rounds <n> --strikes <n>",
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  if (args.writeStrike) runWriteStrike(args);
+  else runAssemble(args);
+  process.exit(0);
+}
+
+module.exports = { parseArgs, parseSpecialists, carryForwardRoundsAudit, buildAuditEntry, buildVerdict, main };
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/scripts/review-verdict-assemble.js
+++ b/scripts/review-verdict-assemble.js
@@ -15,37 +15,49 @@
 // without `round`, and never emits `strike: null` (which silently resets
 // novel-finding-streak detection — see schema/review-json-schema.md §"strike").
 //
-// PIPELINE ORDER (also documented at the top of the schema doc — the order is
-// load-bearing: without normalization first, "novel finding" is uncomputable
-// because fingerprints are not stable):
+// FAIL-CLOSED ON OBLIGATION, not just on shape. Emitting a schema-valid
+// envelope is not enough: several of its fields are what the gate consults to
+// decide WHETHER to run a check at all (`round`, `cycle`, `no_go_round`,
+// `mode`, `trace_schema_version`, and the completeness of `findings`). A wrong
+// one buys silence, not a wrong answer — so every one of them is validated
+// against the lifecycle witness or a closed enum here, never passed through.
+//
+// PIPELINE ORDER (also at the top of the schema doc; load-bearing, because
+// without normalization first "novel finding" is uncomputable — fingerprints
+// are not yet stable):
 //
 //   specialists emit findings  →  normalize the ARRAY  →  assemble the verdict
 //     →  run the gate  →  write strikes back  →  route on the verdict
 //
-// This tool owns steps 2, 3 and 5. It delegates step 2 wholesale to
+// This tool owns steps 2, 3 and 5, delegating step 2 wholesale to
 // scripts/review-normalize.js (fingerprinting is never reimplemented here).
 //
 // TWO PHASES — because `strike` is only knowable AFTER the gate reports it:
 //
-//   1) assemble:      node scripts/review-verdict-assemble.js --task <slug> --round <n>
-//                       --cycle <n> --status <GO|NO-GO> --reviewed-sha <sha>
-//                       (--fix-sha <sha> | --fix-sha-reason <text>)
-//                       --specialist <name>=<selection_reason> [...]
-//                       [--findings <file.json> ...] [--out <path>] ...
+//   1) assemble:     --task <slug> --round <n> --cycle <n> --status <GO|NO-GO>
+//                    --reviewed-sha <sha> (--fix-sha <sha> | --fix-sha-reason
+//                    <text>) --specialist <name>=<reason> [...]
+//                    [--findings <file.json> ...] [--out <path>] ...
 //      → writes the draft with NO `strike` key on the current round's entry
-//        (absent, never null — a null would be silently accepted here and
-//        would silently reset the streak once the round becomes a past round).
+//        (absent, never null — a null is silently accepted downstream and
+//        resets the streak once the round becomes a past round).
 //
-//   2) write-strike:  node scripts/review-verdict-assemble.js --write-strike
-//                       --verdict <draft path> --gate-report <gate stdout json>
+//   2) write-strike: --write-strike --verdict <draft> --gate-report <json>
 //      → copies the gate's boolean `current_round_strike` into the entry for
-//        the gate report's own `round`. Refuses anything non-boolean.
+//        the report's own `round`. Refuses anything non-boolean, a mismatched
+//        round, or a report from a stale gate script.
 //
 // Between them, run the gate exactly as roster-review §5.5 prescribes:
 //   node scripts/check-review-convergence.js <draft> --max-rounds N --strikes N
 //
-// Exit codes: 0 success; 2 usage or degraded input (fail-closed, never a
-// half-written verdict).
+// The rule layer — the closed enums, the lifecycle-continuity and append-only
+// rules, disposition application, envelope construction — lives in
+// scripts/lib/review-verdict-rules.js (repo-local too, and likewise absent
+// from the bundle manifest). This file keeps CLI parsing, I/O, and
+// orchestration.
+//
+// Exit codes: 0 success; 2 usage or degraded input (never a half-written
+// verdict).
 "use strict";
 
 const fs = require("fs");
@@ -53,19 +65,26 @@ const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 const { deriveRoundState } = require("./lib/review/review-lifecycle");
+const {
+  TRACE_SCHEMA_VERSION,
+  fail,
+  warn,
+  parseCount,
+  validateAssembleArgs,
+  parseSpecialists,
+  assertGateReportIsCurrent,
+  carryForwardRoundsAudit,
+  buildAuditEntry,
+  buildVerdict,
+  reportNormalizerSideChannels,
+  applyDispositions,
+  assertStrikeableFindings,
+  carryForwardCrossRuntime,
+  assertGoIsClean,
+  enforceLifecycle,
+} = require("./lib/review-verdict-rules");
 
 const NORMALIZER = path.resolve(__dirname, "review-normalize.js");
-const TRACE_SCHEMA_VERSION = "1.0";
-const STATUSES = new Set(["GO", "NO-GO"]);
-
-function fail(message) {
-  process.stderr.write(`review-verdict-assemble: ${message}\n`);
-  process.exit(2);
-}
-
-function warn(message) {
-  process.stderr.write(`review-verdict-assemble: warning: ${message}\n`);
-}
 
 // ── argument parsing ─────────────────────────────────────────────────────
 const VALUE_FLAGS = {
@@ -101,7 +120,6 @@ function emptyArgs() {
     autoFixes: "0",
     writeStrike: false,
     escalationNeeded: false,
-    allowRejected: false,
   };
 }
 
@@ -114,8 +132,9 @@ function parseArgs(argv) {
     else if (a === "--failed-ac") out.failedAcs.push(requireValue(argv, ++i, a));
     else if (a === "--write-strike") out.writeStrike = true;
     else if (a === "--escalation-needed") out.escalationNeeded = true;
-    else if (a === "--allow-rejected") out.allowRejected = true;
-    else if (VALUE_FLAGS[a]) out[VALUE_FLAGS[a]] = requireValue(argv, ++i, a);
+    else if (a === "--allow-rejected") {
+      fail("--allow-rejected was removed: a schema-invalid finding is never droppable. Fix the finding against schema/review-finding.schema.json instead.");
+    } else if (VALUE_FLAGS[a]) out[VALUE_FLAGS[a]] = requireValue(argv, ++i, a);
     else fail(`unknown flag or stray argument: ${a}`);
   }
   return out;
@@ -125,12 +144,6 @@ function requireValue(argv, index, flag) {
   const value = argv[index];
   if (value === undefined || value.startsWith("--")) fail(`${flag} requires a value`);
   return value;
-}
-
-function parseCount(raw, flag) {
-  const n = Number(raw);
-  if (!Number.isInteger(n) || n < 0) fail(`${flag} must be a non-negative integer (got ${JSON.stringify(raw)})`);
-  return n;
 }
 
 function readJsonFile(filePath, label) {
@@ -143,11 +156,6 @@ function readJsonFile(filePath, label) {
   }
 }
 
-// ── phase 2: write the gate-reported strike back ────────────────────────
-// `strike` is the one field this tool cannot compute: it is the gate's own
-// output. Refusing a non-boolean here is what keeps `strike: null` — which
-// makes computeStrikeMap()'s Map.get() return undefined and thus silently
-// resets the novel-finding streak — out of every verdict this tool touches.
 function runWriteStrike(args) {
   if (!args.verdict) fail("--write-strike requires --verdict <path>");
   if (!args.gateReport) fail("--write-strike requires --gate-report <path>");
@@ -167,6 +175,7 @@ function runWriteStrike(args) {
   if (verdict.round !== report.round) {
     fail(`gate report round (${report.round}) does not match verdict round (${verdict.round}) — wrong report file`);
   }
+  assertGateReportIsCurrent(report);
 
   const entry = (Array.isArray(verdict.rounds_audit) ? verdict.rounds_audit : []).find((e) => e && e.round === report.round);
   if (!entry) fail(`no rounds_audit entry for round ${report.round} — assemble the draft first`);
@@ -176,42 +185,6 @@ function runWriteStrike(args) {
   process.stdout.write(
     `${JSON.stringify({ ok: true, verdict: args.verdict, round: report.round, strike: entry.strike }, null, 2)}\n`
   );
-}
-
-// ── phase 1 validation ───────────────────────────────────────────────────
-function validateAssembleArgs(args) {
-  if (!args.task) fail("--task <slug> is required");
-  if (args.round === undefined) {
-    fail("--round <n> is required — a verdict without `round` makes check-review-convergence.js skip strike and rounds_audit checks entirely (B-8), so the gate passes vacuously. That refusal is the whole point of this tool.");
-  }
-  if (args.cycle === undefined) fail("--cycle <n> is required (the trace mechanism scopes lines by (cycle, round))");
-  if (!STATUSES.has(args.status)) fail(`--status must be one of ${[...STATUSES].join(" | ")}`);
-  if (!args.reviewedSha) fail("--reviewed-sha <sha> is required (rounds_audit completeness, FR-078)");
-  if (!args.fixSha === !args.fixShaReason) {
-    fail("exactly one of --fix-sha <sha> or --fix-sha-reason <text> is required (EC-8: a dirty tree records null + a reason, never a guessed sha)");
-  }
-  if (args.specialists.length === 0) {
-    fail("at least one --specialist <name>=<selection_reason> is required — \"why did this specialist run this round\" must always be answerable");
-  }
-  if (args.status === "NO-GO" && !args.noGoType) fail("--no-go-type is required on a NO-GO verdict");
-  if (args.status === "GO" && args.noGoType) fail("--no-go-type is meaningless on a GO verdict");
-  if (args.status === "GO" && args.noGoRound !== undefined && parseCount(args.noGoRound, "--no-go-round") !== 0) {
-    fail("--no-go-round must be 0 (or omitted) on a GO verdict — no_go_round resets on GO");
-  }
-  if (args.status === "NO-GO" && args.noGoRound === undefined) {
-    fail("--no-go-round <n> is required on a NO-GO verdict — it is the round-cap backstop counter and is NOT derivable from `round` (the two are separate counters with separate reset rules)");
-  }
-}
-
-function parseSpecialists(specs) {
-  return specs.map((raw) => {
-    const idx = raw.indexOf("=");
-    if (idx <= 0) fail(`--specialist must be <name>=<selection_reason> (got ${JSON.stringify(raw)})`);
-    const name = raw.slice(0, idx).trim();
-    const selection_reason = raw.slice(idx + 1).trim();
-    if (!name || !selection_reason) fail(`--specialist ${JSON.stringify(raw)} has an empty name or selection_reason`);
-    return { name, selection_reason };
-  });
 }
 
 // ── normalization (delegated, never reimplemented) ───────────────────────
@@ -254,100 +227,9 @@ function assertFindingFilesAreArrays(files) {
   for (const file of files) {
     const parsed = readJsonFile(file, `--findings file ${file}`);
     if (!Array.isArray(parsed)) {
-      fail(`--findings ${file} is a JSON ${Array.isArray(parsed) ? "array" : typeof parsed} — review-normalize.js requires a JSON ARRAY of finding objects, not a verdict envelope`);
+      fail(`--findings ${file} is a JSON ${parsed === null ? "null" : typeof parsed} — review-normalize.js requires a JSON ARRAY of finding objects, not a verdict envelope`);
     }
   }
-}
-
-// ── rounds_audit carry-forward (append-only) ─────────────────────────────
-// Prior entries are copied through verbatim; a prior entry for the round being
-// assembled is a refusal, not an overwrite — that would mean the round counter
-// never advanced (scripts/lib/review/review-lifecycle.js owns the bump).
-function carryForwardRoundsAudit(priorEntries, round) {
-  const carried = [];
-  for (const entry of priorEntries) {
-    if (!entry || typeof entry !== "object") fail("prior rounds_audit contains a non-object entry — refusing to carry forward unverifiable state");
-    if (entry.round === round) {
-      fail(`prior verdict already has a rounds_audit entry for round ${round} — rounds_audit is append-only. Bump the round via \`node scripts/lib/review/review-lifecycle.js --prior <verdict>\` instead of rewriting it.`);
-    }
-    if (typeof entry.round === "number" && entry.round > round) {
-      fail(`prior verdict has a rounds_audit entry for round ${entry.round}, which is ahead of --round ${round} — refusing to assemble a verdict that would look like it went backwards`);
-    }
-    carried.push(entry);
-  }
-  return carried;
-}
-
-function buildAuditEntry(args, round, specialists) {
-  const entry = { round, reviewed_sha: args.reviewedSha };
-  entry.fix_sha = args.fixSha ? args.fixSha : null;
-  if (!args.fixSha) entry.fix_sha_reason = args.fixShaReason;
-  entry.specialists_run = specialists;
-  if (args.traceSchemaVersion !== "none") entry.trace_schema_version = args.traceSchemaVersion;
-  // NOTE: `strike` is deliberately ABSENT, not null. It is written by
-  // --write-strike after the gate reports current_round_strike.
-  return entry;
-}
-
-function buildNoGoReason(args) {
-  if (args.status === "GO") return null;
-  const reason = { type: args.noGoType };
-  if (args.noGoCause) reason.cause = args.noGoCause;
-  if (args.failedAcs.length > 0) reason.failed_acs = args.failedAcs;
-  return reason;
-}
-
-function buildVerdict({ args, round, cycle, normalized, roundsAudit, crossRuntime }) {
-  const verdict = {
-    task: args.task,
-    date: new Date().toISOString(),
-    status: args.status,
-    mode: args.mode,
-    round,
-    cycle,
-    no_go_round: args.noGoRound === undefined ? 0 : parseCount(args.noGoRound, "--no-go-round"),
-    auto_fixes_applied: parseCount(args.autoFixes, "--auto-fixes"),
-    findings: normalized.findings,
-    cross_runtime_findings: normalized.cross_runtime_findings,
-    cross_runtime: crossRuntime,
-    rounds_audit: roundsAudit,
-    no_go_reason: buildNoGoReason(args),
-    summary: args.summary || "",
-    escalation_needed: args.escalationNeeded,
-    escalation_reason: args.escalationReason || null,
-    normalized_by: normalized.normalizer_version,
-  };
-  if (args.streakOverrideBy) verdict.streak_override = { round, by: args.streakOverrideBy };
-  return verdict;
-}
-
-// Surfaces the normalizer's non-verdict outputs (they have no home in
-// review.json and must not vanish silently, FR-100).
-function reportNormalizerSideChannels(args, normalized) {
-  for (const w of normalized.warnings || []) warn(`review-normalize: ${w}`);
-  for (const d of normalized.probable_duplicates || []) {
-    warn(`review-normalize: probable duplicate needs owner adjudication: ${JSON.stringify(d)}`);
-  }
-  const rejected = normalized.rejected || [];
-  if (rejected.length === 0) return;
-  for (const r of rejected) warn(`review-normalize: REJECTED (schema-invalid) finding: ${r.reason}`);
-  if (!args.allowRejected) {
-    fail(`${rejected.length} finding(s) were rejected as schema-invalid by review-normalize.js — fix them against schema/review-finding.schema.json, or pass --allow-rejected to drop them deliberately`);
-  }
-}
-
-// Cross-checks --round/--cycle against the lifecycle witness rather than
-// re-deriving the rule here. Advisory (a warning), matching review-normalize.js's
-// own treatment of the same disagreement.
-function checkLifecycle(prior, round, cycle) {
-  const derived = deriveRoundState(prior);
-  if (derived.round !== null && derived.round !== round) {
-    warn(`--round ${round} but scripts/lib/review/review-lifecycle.js derives ${derived.round} from the prior verdict`);
-  }
-  if (derived.cycle !== null && derived.cycle !== cycle) {
-    warn(`--cycle ${cycle} but scripts/lib/review/review-lifecycle.js derives ${derived.cycle} from the prior verdict`);
-  }
-  return derived;
 }
 
 function runAssemble(args) {
@@ -360,13 +242,17 @@ function runAssemble(args) {
   const priorPath = args.prior || `briefs/${args.task}-review.json`;
   const priorExists = fs.existsSync(path.resolve(process.cwd(), priorPath));
   const prior = priorExists ? readJsonFile(priorPath, "--prior file") : null;
-  const derived = checkLifecycle(prior, round, cycle);
+  const derived = deriveRoundState(prior);
 
   // Carry-forward is validated BEFORE the normalizer runs so an append-only
-  // violation fails fast instead of after a full normalization pass.
+  // violation fails fast instead of after a full normalization pass. It also
+  // runs BEFORE enforceLifecycle() so that re-emitting an already-journaled
+  // round reports the specific append-only refusal rather than the generic
+  // round-mismatch one.
   const roundsAudit = carryForwardRoundsAudit(derived.roundsAudit, round).concat([
     buildAuditEntry(args, round, parseSpecialists(args.specialists)),
   ]);
+  enforceLifecycle(prior, derived, round, cycle, args);
 
   assertFindingFilesAreArrays(args.findings);
   const normalized = runNormalizer({
@@ -378,7 +264,10 @@ function runAssemble(args) {
     priorPath: priorExists ? priorPath : null,
     gateReportPath: args.gateReport || `briefs/${args.task}-gate-report.json`,
   });
-  reportNormalizerSideChannels(args, normalized);
+  reportNormalizerSideChannels(normalized);
+  applyDispositions(normalized);
+  assertStrikeableFindings(normalized.findings, round);
+  assertGoIsClean(args, normalized.findings);
 
   const verdict = buildVerdict({
     args,
@@ -387,6 +276,7 @@ function runAssemble(args) {
     normalized,
     roundsAudit,
     crossRuntime: derived.crossRuntime,
+    crossRuntimeFindings: carryForwardCrossRuntime(prior, derived.freshCycle, normalized.cross_runtime_findings),
   });
 
   const outPath = path.resolve(process.cwd(), args.out || `briefs/${args.task}-review.json.draft`);

--- a/scripts/review-verdict-assemble.test.js
+++ b/scripts/review-verdict-assemble.test.js
@@ -241,7 +241,12 @@ check("MUTATION: all-null strikes below the cap escape the gate entirely (exit 0
   assert.strictEqual(escaped.report.warnings.length, 3);
 });
 
-check("MUTATION: dropping `round` makes the gate skip strike/audit/trace checks (exit 0)", () => {
+// NOTE the exit code: dropping `round` removes the strike/rounds_audit/trace
+// checks, but `no_go_round` (5) still trips the round cap on its own, so the
+// gate exits 1 here for a reason that has nothing to do with the skipped
+// checks. That is what makes the skip dangerous — below the cap (see the
+// preceding case, which sets no_go_round: 2) the same mutation exits 0.
+check("MUTATION: dropping `round` skips strike/audit/trace checks; only round-cap survives (exit 1)", () => {
   const dir = scratch();
   const { final } = driveRounds(dir, 5);
   const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
@@ -334,6 +339,212 @@ check("every specialist entry carries a non-empty selection_reason", () => {
   assert.match(run(ASSEMBLE, base, dir).stderr, /at least one --specialist/);
   assert.match(run(ASSEMBLE, [...base, "--specialist", "reviewer="], dir).stderr, /empty name or selection_reason/);
   assert.match(run(ASSEMBLE, [...base, "--specialist", "reviewer"], dir).stderr, /<name>=<selection_reason>/);
+});
+
+// ── fail-closed on the inputs that decide WHICH gate checks run ──────────
+// Each of the four below is a lever that leaves the verdict schema-valid while
+// switching a gate check off. The assembler must refuse the lever, not emit a
+// verdict the gate will silently under-check.
+
+check("--write-strike refuses a gate report from a stale gate script (no config.strikes / no trace)", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 1);
+  const stale = path.join(dir, "briefs", "stale-report.json");
+
+  // Boolean strike, right round — everything the old checks looked at. Only
+  // the absent `config`/`trace` reveal a gate that predates the current rules.
+  fs.writeFileSync(stale, JSON.stringify({ round: 1, current_round_strike: false }));
+  const noConfig = run(ASSEMBLE, ["--write-strike", "--verdict", final, "--gate-report", stale], dir);
+  assert.strictEqual(noConfig.status, 2);
+  assert.match(noConfig.stderr, /no numeric config\.strikes/);
+
+  fs.writeFileSync(stale, JSON.stringify({ round: 1, current_round_strike: false, config: { strikes: 2 } }));
+  const noTrace = run(ASSEMBLE, ["--write-strike", "--verdict", final, "--gate-report", stale], dir);
+  assert.strictEqual(noTrace.status, 2);
+  assert.match(noTrace.stderr, /no `trace` block/);
+
+  // and nothing was written: the persisted strike is still the real gate's
+  // `false`, not a value copied out of the stale report.
+  assert.strictEqual(JSON.parse(fs.readFileSync(final, "utf8")).rounds_audit[0].strike, false);
+});
+
+check("refuses a SKIPPED round — the hole would erase the streak", () => {
+  const dir = scratch();
+  driveRounds(dir, 2);
+  const r = assembleRound(dir, 4); // lifecycle derives 3
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /--round 4 but .*derives 3/);
+  assert.match(r.stderr, /erases the novel-finding streak/);
+  assert.strictEqual(fs.existsSync(path.join(dir, "briefs", `${TASK}-review.json.draft`)), false,
+    "a refused round must not leave a draft behind");
+});
+
+check("refuses a --no-go-round that does not hold or advance by one", () => {
+  const dir = scratch();
+  driveRounds(dir, 2); // prior no_go_round === 2
+  const jump = assembleRound(dir, 3, ["--no-go-round", "9"]);
+  assert.strictEqual(jump.status, 2);
+  assert.match(jump.stderr, /does not follow the prior verdict's 2/);
+
+  const frozen = assembleRound(dir, 3, ["--no-go-round", "1"]);
+  assert.strictEqual(frozen.status, 2, "a counter that goes backwards disables the round cap");
+  assert.match(frozen.stderr, /disables the round-cap backstop/);
+
+  // holding is legitimate (a NO-GO round that does not qualify)
+  assert.strictEqual(assembleRound(dir, 3, ["--no-go-round", "2"]).status, 0);
+});
+
+check("refuses the trace-obligation levers: unknown --mode, non-1.0 --trace-schema-version", () => {
+  const dir = scratch();
+  const bogusMode = assembleRound(dir, 1, ["--mode", "Full"]);
+  assert.strictEqual(bogusMode.status, 2, "'Full' !== 'full' — the gate would drop the scope-gate obligation");
+  assert.match(bogusMode.stderr, /--mode must be one of express \| fast \| full/);
+
+  const noTrace = assembleRound(dir, 1, ["--trace-schema-version", "none"]);
+  assert.strictEqual(noTrace.status, 2);
+  assert.match(noTrace.stderr, /--trace-schema-version must be "1\.0"/);
+
+  // and the stamp is unconditional on a round that does assemble
+  assert.strictEqual(assembleRound(dir, 1).status, 0);
+  const entry = JSON.parse(fs.readFileSync(path.join(dir, "briefs", `${TASK}-review.json.draft`), "utf8")).rounds_audit[0];
+  assert.strictEqual(entry.trace_schema_version, "1.0");
+});
+
+check("--allow-rejected no longer exists: a schema-invalid finding is never droppable", () => {
+  const dir = scratch();
+  const bad = path.join("briefs", "bad.json");
+  fs.writeFileSync(path.join(dir, bad), JSON.stringify([{ severity: "HIGH", summary: "no other required keys" }]));
+  const r = run(ASSEMBLE, ["--task", TASK, "--round", "1", "--cycle", "1", "--status", "GO",
+    "--reviewed-sha", "a", "--fix-sha", "b", "--specialist", "reviewer=always",
+    "--findings", bad, "--allow-rejected"], dir);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /--allow-rejected was removed/);
+  assert.strictEqual(fs.existsSync(path.join(dir, "briefs", `${TASK}-review.json.draft`)), false);
+});
+
+check("refuses to carry forward a past round whose --write-strike never ran", () => {
+  const dir = scratch();
+  const final = path.join(dir, "briefs", `${TASK}-review.json`);
+  driveRounds(dir, 2);
+
+  // Simulate the two-phase protocol being half-applied: round 2 was gated but
+  // its strike was never written back. computeStrikeMap() cannot see the entry,
+  // so the streak resets across it and the gate's only signal is a warning on
+  // a run that may exit 0.
+  const v = JSON.parse(fs.readFileSync(final, "utf8"));
+  delete v.rounds_audit.find((e) => e.round === 2).strike;
+  fs.writeFileSync(final, JSON.stringify(v, null, 2));
+
+  const r = assembleRound(dir, 3);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /round 2 has no boolean `strike`/);
+  assert.match(r.stderr, /silently resets the novel-finding streak/);
+});
+
+// ── findings must survive intake, and must be classifiable ───────────────
+
+check("applies the normalizer's REOPENED disposition so E-4 can actually fire", () => {
+  const dir = scratch();
+  const final = path.join(dir, "briefs", `${TASK}-review.json`);
+  driveRounds(dir, 1);
+
+  // Mark round 1's HIGH as RESOLVED with no linked check. INV-2: a RESOLVED
+  // entry with no check can never be verified, so re-reporting it next round
+  // is always a reopen, never carry-forward noise.
+  const v1 = JSON.parse(fs.readFileSync(final, "utf8"));
+  v1.findings[0].status = "RESOLVED";
+  v1.findings[0].resolved_round = 1;
+  fs.writeFileSync(final, JSON.stringify(v1, null, 2));
+
+  // Round 2 re-reports the SAME finding (same fingerprint), not a novel one.
+  const reReport = [Object.assign(highFinding(1), { first_seen_round: 1 })];
+  fs.writeFileSync(path.join(dir, "briefs", "reviewer-r2.json"), JSON.stringify(reReport));
+  const a = run(ASSEMBLE, ["--task", TASK, "--round", "2", "--cycle", "1", "--status", "NO-GO",
+    "--mode", "full", "--reviewed-sha", "reviewed-2", "--fix-sha", "fix-2",
+    "--specialist", "reviewer=always (owner) on round 2", "--no-go-round", "2",
+    "--no-go-type", "design-not-converging", "--findings", path.join("briefs", "reviewer-r2.json")], dir);
+  assert.strictEqual(a.status, 0, a.stderr);
+  assert.match(a.stderr, /REOPENED .* applied to findings/);
+
+  const draft = JSON.parse(fs.readFileSync(path.join(dir, "briefs", `${TASK}-review.json.draft`), "utf8"));
+  const f = draft.findings.find((x) => x.fingerprint === reReport[0].fingerprint);
+  assert.strictEqual(f.status, "OPEN", "the reopened body must replace the RESOLVED ledger entry");
+  assert.strictEqual(f.reopened_at_round, 2);
+
+  // and the gate can now see it: isReopenedStrikeFinding() keys on exactly this.
+  appendTraces(dir, 2);
+  const g = gate(path.join(dir, "briefs", `${TASK}-review.json.draft`));
+  assert.strictEqual(g.report.current_round_strike, true,
+    "a reopened HIGH must strike (E-4) — it never can if dispositions are dropped");
+});
+
+check("refuses a CRITICAL/HIGH finding with no first_seen_round (silently unstrikeable)", () => {
+  const dir = scratch();
+  const bare = Object.assign(highFinding(1), {});
+  delete bare.first_seen_round;
+  fs.writeFileSync(path.join(dir, "briefs", "bare.json"), JSON.stringify([bare]));
+  const r = run(ASSEMBLE, ["--task", TASK, "--round", "1", "--cycle", "1", "--status", "NO-GO",
+    "--reviewed-sha", "a", "--fix-sha", "b", "--specialist", "reviewer=always",
+    "--no-go-round", "1", "--no-go-type", "design-not-converging",
+    "--findings", path.join("briefs", "bare.json")], dir);
+  // The normalizer does NOT stamp first_seen_round, and isNovelStrikeFinding()
+  // requires it — so without this refusal the round can never strike at all.
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /missing or future first_seen_round/);
+});
+
+check("refuses GO while a CRITICAL/HIGH is still OPEN", () => {
+  const dir = scratch();
+  fs.writeFileSync(path.join(dir, "briefs", "open.json"), JSON.stringify([highFinding(1)]));
+  const r = run(ASSEMBLE, ["--task", TASK, "--round", "1", "--cycle", "1", "--status", "GO",
+    "--reviewed-sha", "a", "--fix-sha", "b", "--specialist", "reviewer=always",
+    "--findings", path.join("briefs", "open.json")], dir);
+  assert.strictEqual(r.status, 2, "the gate never reads `status`, so nothing else would catch this");
+  assert.match(r.stderr, /open CRITICAL\/HIGH finding/);
+});
+
+check("carries cross_runtime_findings forward within a cycle (augment-only)", () => {
+  const dir = scratch();
+  const final = path.join(dir, "briefs", `${TASK}-review.json`);
+  driveRounds(dir, 1);
+  const v1 = JSON.parse(fs.readFileSync(final, "utf8"));
+  v1.cross_runtime_findings = [Object.assign(highFinding(1), {
+    specialist: "codex-xruntime", fingerprint: "src/xr.ml:1:correctness", path: "src/xr.ml", line: 1,
+  })];
+  fs.writeFileSync(final, JSON.stringify(v1, null, 2));
+
+  assert.strictEqual(assembleRound(dir, 2).status, 0);
+  const draft = JSON.parse(fs.readFileSync(path.join(dir, "briefs", `${TASK}-review.json.draft`), "utf8"));
+  assert.strictEqual(draft.cross_runtime_findings.length, 1,
+    "round 2 supplied no cross-runtime findings, so round 1's must still be there");
+  assert.strictEqual(draft.cross_runtime_findings[0].fingerprint, "src/xr.ml:1:correctness");
+});
+
+// ── the remaining caller-controlled enums ────────────────────────────────
+check("refuses an invalid --task slug (gate exit 2, and it composes the briefs/ paths)", () => {
+  const dir = scratch();
+  const base = ["--round", "1", "--cycle", "1", "--status", "GO", "--reviewed-sha", "a",
+    "--fix-sha", "b", "--specialist", "reviewer=always"];
+  for (const bad of ["My Task", "../pwned"]) {
+    const r = run(ASSEMBLE, ["--task", bad, ...base], dir);
+    assert.strictEqual(r.status, 2, `--task ${JSON.stringify(bad)} was accepted`);
+    assert.match(r.stderr, /is not a valid slug/);
+  }
+  assert.strictEqual(fs.existsSync(path.join(dir, "..", "pwned-review.json.draft")), false);
+});
+
+check("refuses a typo'd --no-go-type / --no-go-cause and a non-human streak override", () => {
+  const dir = scratch();
+  const base = ["--task", TASK, "--round", "1", "--cycle", "1", "--reviewed-sha", "a",
+    "--fix-sha", "b", "--specialist", "reviewer=always"];
+  const noGo = [...base, "--status", "NO-GO", "--no-go-round", "1"];
+
+  assert.match(run(ASSEMBLE, [...noGo, "--no-go-type", "desgin-not-converging"], dir).stderr,
+    /--no-go-type must be one of/);
+  assert.match(run(ASSEMBLE, [...noGo, "--no-go-type", "design-not-converging",
+    "--no-go-cause", "process-incomplete"], dir).stderr, /--no-go-cause must be one of/);
+  assert.match(run(ASSEMBLE, [...base, "--status", "GO", "--streak-override-by", "reviewer-agent"], dir).stderr,
+    /--streak-override-by must be "human"/);
 });
 
 process.stdout.write(`\n${passes} passed, ${failures} failed\n`);

--- a/scripts/review-verdict-assemble.test.js
+++ b/scripts/review-verdict-assemble.test.js
@@ -104,7 +104,7 @@ function appendTraces(dir, round) {
   }
 }
 
-function gate(dir, verdictPath, args = []) {
+function gate(verdictPath, args = []) {
   const r = spawnSync(process.execPath, [GATE, verdictPath, "--max-rounds", "5", "--strikes", "2", "--static", ...args], {
     cwd: REPO,
     encoding: "utf8",
@@ -123,7 +123,7 @@ function driveRounds(dir, upto) {
     const a = assembleRound(dir, round);
     assert.strictEqual(a.status, 0, `assemble round ${round} failed: ${a.stderr}`);
     appendTraces(dir, round);
-    last = gate(dir, draft);
+    last = gate(draft);
     fs.writeFileSync(report, last.raw);
     const w = run(ASSEMBLE, ["--write-strike", "--verdict", draft, "--gate-report", report], dir);
     assert.strictEqual(w.status, 0, `write-strike round ${round} failed: ${w.stderr}`);
@@ -164,7 +164,7 @@ check("round 1 emits no `strike` key until the gate reports it, then a boolean",
 
   appendTraces(dir, 1);
   const report = path.join(dir, "briefs", `${TASK}-gate-report.json`);
-  fs.writeFileSync(report, gate(dir, draft).raw);
+  fs.writeFileSync(report, gate(draft).raw);
   assert.strictEqual(run(ASSEMBLE, ["--write-strike", "--verdict", draft, "--gate-report", report], dir).status, 0);
   assert.strictEqual(JSON.parse(fs.readFileSync(draft, "utf8")).rounds_audit[0].strike, false);
 });
@@ -215,7 +215,7 @@ check("MUTATION: strike:null on a past round silently resets the streak (round-c
   verdict.rounds_audit.find((e) => e.round === 4).strike = null;
   fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
 
-  const mutated = gate(dir, final);
+  const mutated = gate(final);
   assert.strictEqual(mutated.report.cause, "round-cap", "the streak must have been reset by the null");
   assert.deepStrictEqual(mutated.report.violations.map((v) => v.type), ["round-cap"]);
   assert.match(mutated.report.warnings.join("\n"), /round 4 lacks a boolean strike field/);
@@ -230,7 +230,7 @@ check("MUTATION: all-null strikes below the cap escape the gate entirely (exit 0
   verdict.no_go_round = 2; // below --max-rounds, as in the real five-round PR
   fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
 
-  const escaped = gate(dir, final);
+  const escaped = gate(final);
   // Documented defect (schema/review-json-schema.md §strike): five striking
   // rounds, `current_round_strike: true`, and the gate still reports no
   // violation. Warnings only. This is why `strike` must be a boolean.
@@ -248,7 +248,7 @@ check("MUTATION: dropping `round` makes the gate skip strike/audit/trace checks 
   delete verdict.round;
   fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
 
-  const skipped = gate(dir, final);
+  const skipped = gate(final);
   assert.strictEqual(skipped.report.legacy_round, true);
   assert.strictEqual(skipped.report.current_round_strike, null);
   assert.match(skipped.report.warnings.join("\n"), /round key absent — skipping strike and rounds_audit checks/);

--- a/scripts/review-verdict-assemble.test.js
+++ b/scripts/review-verdict-assemble.test.js
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+// scripts/review-verdict-assemble.test.js — zero-dependency, node-runnable.
+//
+//   node scripts/review-verdict-assemble.test.js
+//
+// Exercises scripts/review-verdict-assemble.js end-to-end against the REAL
+// scripts/check-review-convergence.js — the point is not that the assembler's
+// own units work, it is that the verdicts it emits make the gate run its real
+// checks instead of taking the B-8 legacy skip. Each case below therefore
+// asserts on the gate's exit code and top-level `cause`, and the round-cap /
+// novel-finding-streak cases are red-on-mutation: flipping one `strike` to
+// null (or dropping `round`) changes the asserted outcome.
+//
+// Repo-local test (the upstream review-tool bundle does not own it).
+"use strict";
+
+const assert = require("assert");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const REPO = path.resolve(__dirname, "..");
+const ASSEMBLE = path.join(REPO, "scripts", "review-verdict-assemble.js");
+const GATE = path.join(REPO, "scripts", "check-review-convergence.js");
+const TRACE = path.join(REPO, "scripts", "lib", "review", "review-trace.js");
+const TASK = "assemble-selftest";
+
+let failures = 0;
+let passes = 0;
+
+function check(name, fn) {
+  try {
+    fn();
+    passes += 1;
+    process.stdout.write(`  ok   ${name}\n`);
+  } catch (e) {
+    failures += 1;
+    process.stdout.write(`  FAIL ${name}\n       ${e.message.split("\n")[0]}\n`);
+  }
+}
+
+function scratch() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "assemble-test-"));
+  fs.mkdirSync(path.join(dir, "briefs"));
+  return dir;
+}
+
+function highFinding(round) {
+  return {
+    severity: "HIGH",
+    confidence: 4,
+    path: `src/round${round}.ml`,
+    line: round * 10,
+    category: "correctness",
+    summary: `novel HIGH finding first raised in round ${round}`,
+    evidence: `src/round${round}.ml line ${round * 10} — quoted code`,
+    fix: "fix it",
+    fingerprint: `src/round${round}.ml:${round * 10}:correctness`,
+    specialist: "reviewer",
+    first_seen_round: round,
+    status: "OPEN",
+  };
+}
+
+function run(cmd, argv, cwd) {
+  const r = spawnSync(process.execPath, [cmd, ...argv], { cwd, encoding: "utf8" });
+  return { status: r.status, stdout: r.stdout || "", stderr: r.stderr || "" };
+}
+
+function assembleRound(dir, round, extra = []) {
+  const findingsFile = path.join("briefs", `reviewer-r${round}.json`);
+  fs.writeFileSync(path.join(dir, findingsFile), JSON.stringify([highFinding(round)]));
+  return run(
+    ASSEMBLE,
+    [
+      "--task", TASK,
+      "--round", String(round),
+      "--cycle", "1",
+      "--status", "NO-GO",
+      "--mode", "full",
+      "--reviewed-sha", `reviewed-${round}`,
+      "--fix-sha", `fix-${round}`,
+      "--specialist", `reviewer=always (owner) on round ${round}`,
+      "--no-go-round", String(round),
+      "--no-go-type", "design-not-converging",
+      "--findings", findingsFile,
+      ...extra,
+    ],
+    dir
+  );
+}
+
+// The scope-gate and specialist trace lines the gate demands for a Full-mode
+// round. Appended here because the corresponding tools really did run in the
+// scenario under test — never fabricate one for a tool that did not run
+// (FR-177/C-3); this test is the only place a synthetic append is legitimate.
+function appendTraces(dir, round) {
+  for (const [event, actor] of [["scope-gate", "check-scope-diff.sh"], ["specialist", "reviewer"]]) {
+    execFileSync(process.execPath, [
+      TRACE, "--root", dir, "--task", TASK, "--round", String(round),
+      "--cycle", "1", "--event", event, "--actor", actor, "--outcome", "ran",
+    ]);
+  }
+}
+
+function gate(dir, verdictPath, args = []) {
+  const r = spawnSync(process.execPath, [GATE, verdictPath, "--max-rounds", "5", "--strikes", "2", "--static", ...args], {
+    cwd: REPO,
+    encoding: "utf8",
+  });
+  return { status: r.status, report: JSON.parse(r.stdout), raw: r.stdout };
+}
+
+// Drives round 1..`upto` through assemble → traces → gate → --write-strike →
+// promote, returning the last gate result and the persisted verdict path.
+function driveRounds(dir, upto) {
+  const draft = path.join(dir, "briefs", `${TASK}-review.json.draft`);
+  const final = path.join(dir, "briefs", `${TASK}-review.json`);
+  const report = path.join(dir, "briefs", `${TASK}-gate-report.json`);
+  let last = null;
+  for (let round = 1; round <= upto; round++) {
+    const a = assembleRound(dir, round);
+    assert.strictEqual(a.status, 0, `assemble round ${round} failed: ${a.stderr}`);
+    appendTraces(dir, round);
+    last = gate(dir, draft);
+    fs.writeFileSync(report, last.raw);
+    const w = run(ASSEMBLE, ["--write-strike", "--verdict", draft, "--gate-report", report], dir);
+    assert.strictEqual(w.status, 0, `write-strike round ${round} failed: ${w.stderr}`);
+    fs.renameSync(draft, final);
+  }
+  return { last, final };
+}
+
+process.stdout.write("review-verdict-assemble\n");
+
+// ── the anti-vacuity contract ────────────────────────────────────────────
+check("refuses to emit a verdict without --round (the B-8 vacuous-gate hole)", () => {
+  const dir = scratch();
+  const r = run(ASSEMBLE, ["--task", TASK, "--cycle", "1", "--status", "GO", "--reviewed-sha", "a",
+    "--fix-sha", "b", "--specialist", "reviewer=always"], dir);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /--round <n> is required/);
+});
+
+check("gate runs its REAL checks on an assembled verdict — no legacy skip", () => {
+  const dir = scratch();
+  const { last } = driveRounds(dir, 1);
+  assert.strictEqual(last.report.legacy_round, false, "gate took the legacy path");
+  assert.strictEqual(last.report.legacy_no_go_round, false);
+  assert.strictEqual(last.report.trace.obligated, true, "trace checks were skipped");
+  assert.strictEqual(last.report.trace.skipped, false);
+  assert.deepStrictEqual(last.report.warnings, [], `unexpected warnings: ${JSON.stringify(last.report.warnings)}`);
+  assert.strictEqual(last.status, 0);
+  assert.strictEqual(last.report.current_round_strike, false, "round 1 must never strike");
+});
+
+check("round 1 emits no `strike` key until the gate reports it, then a boolean", () => {
+  const dir = scratch();
+  const draft = path.join(dir, "briefs", `${TASK}-review.json.draft`);
+  assert.strictEqual(assembleRound(dir, 1).status, 0);
+  const pre = JSON.parse(fs.readFileSync(draft, "utf8"));
+  assert.ok(!("strike" in pre.rounds_audit[0]), "`strike` must be ABSENT pre-gate, never null");
+
+  appendTraces(dir, 1);
+  const report = path.join(dir, "briefs", `${TASK}-gate-report.json`);
+  fs.writeFileSync(report, gate(dir, draft).raw);
+  assert.strictEqual(run(ASSEMBLE, ["--write-strike", "--verdict", draft, "--gate-report", report], dir).status, 0);
+  assert.strictEqual(JSON.parse(fs.readFileSync(draft, "utf8")).rounds_audit[0].strike, false);
+});
+
+check("--write-strike refuses a non-boolean current_round_strike (never writes null)", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 1);
+  const bogus = path.join(dir, "briefs", "legacy-report.json");
+  fs.writeFileSync(bogus, JSON.stringify({ round: 1, current_round_strike: null }));
+  const r = run(ASSEMBLE, ["--write-strike", "--verdict", final, "--gate-report", bogus], dir);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /not a boolean/);
+});
+
+// ── strike escalation, red-on-mutation ───────────────────────────────────
+check("round 2 strikes but does not yet violate (round 1 can never strike)", () => {
+  const dir = scratch();
+  const { last } = driveRounds(dir, 2);
+  assert.strictEqual(last.report.current_round_strike, true);
+  assert.strictEqual(last.report.cause, null);
+  assert.strictEqual(last.status, 0);
+});
+
+check("two consecutive striking rounds escalate: cause novel-finding-streak, exit 1", () => {
+  const dir = scratch();
+  const { last } = driveRounds(dir, 3);
+  assert.strictEqual(last.report.cause, "novel-finding-streak");
+  assert.strictEqual(last.status, 1);
+});
+
+check("five novel rounds: round-cap AND streak both fire; streak wins on precedence", () => {
+  const dir = scratch();
+  const { last, final } = driveRounds(dir, 5);
+  assert.strictEqual(last.status, 1);
+  const types = last.report.violations.map((v) => v.type).sort();
+  assert.deepStrictEqual(types, ["novel-finding-streak", "round-cap"]);
+  // FR-059/B-5 precedence: novel-finding-streak outranks round-cap, so
+  // `cause` is NOT "round-cap" even though the cap is violated.
+  assert.strictEqual(last.report.cause, "novel-finding-streak");
+  const audit = JSON.parse(fs.readFileSync(final, "utf8")).rounds_audit;
+  assert.deepStrictEqual(audit.map((e) => e.strike), [false, true, true, true, true]);
+});
+
+check("MUTATION: strike:null on a past round silently resets the streak (round-cap only)", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 5);
+  const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
+  verdict.rounds_audit.find((e) => e.round === 4).strike = null;
+  fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
+
+  const mutated = gate(dir, final);
+  assert.strictEqual(mutated.report.cause, "round-cap", "the streak must have been reset by the null");
+  assert.deepStrictEqual(mutated.report.violations.map((v) => v.type), ["round-cap"]);
+  assert.match(mutated.report.warnings.join("\n"), /round 4 lacks a boolean strike field/);
+  assert.strictEqual(mutated.status, 1);
+});
+
+check("MUTATION: all-null strikes below the cap escape the gate entirely (exit 0)", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 5);
+  const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
+  for (const entry of verdict.rounds_audit) entry.strike = null;
+  verdict.no_go_round = 2; // below --max-rounds, as in the real five-round PR
+  fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
+
+  const escaped = gate(dir, final);
+  // Documented defect (schema/review-json-schema.md §strike): five striking
+  // rounds, `current_round_strike: true`, and the gate still reports no
+  // violation. Warnings only. This is why `strike` must be a boolean.
+  assert.strictEqual(escaped.report.current_round_strike, true);
+  assert.deepStrictEqual(escaped.report.violations, []);
+  assert.strictEqual(escaped.report.cause, null);
+  assert.strictEqual(escaped.status, 0);
+  assert.strictEqual(escaped.report.warnings.length, 3);
+});
+
+check("MUTATION: dropping `round` makes the gate skip strike/audit/trace checks (exit 0)", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 5);
+  const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
+  delete verdict.round;
+  fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
+
+  const skipped = gate(dir, final);
+  assert.strictEqual(skipped.report.legacy_round, true);
+  assert.strictEqual(skipped.report.current_round_strike, null);
+  assert.match(skipped.report.warnings.join("\n"), /round key absent — skipping strike and rounds_audit checks/);
+  assert.strictEqual(skipped.status, 1, "only round-cap survives, via no_go_round");
+});
+
+// ── carry-forward + delegation contracts ─────────────────────────────────
+check("rounds_audit is carried forward append-only and prior entries are untouched", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 3);
+  const audit = JSON.parse(fs.readFileSync(final, "utf8")).rounds_audit;
+  assert.deepStrictEqual(audit.map((e) => e.round), [1, 2, 3]);
+  assert.strictEqual(audit[0].reviewed_sha, "reviewed-1", "round 1's entry was rewritten");
+  assert.strictEqual(audit[1].reviewed_sha, "reviewed-2");
+  for (const entry of audit) assert.strictEqual(entry.trace_schema_version, "1.0");
+});
+
+check("refuses to re-emit a round the prior verdict already journaled", () => {
+  const dir = scratch();
+  driveRounds(dir, 2);
+  const r = assembleRound(dir, 2);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /append-only/);
+});
+
+check("findings are cumulative and carry forward across rounds", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 3);
+  const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
+  assert.strictEqual(verdict.findings.length, 3);
+  assert.deepStrictEqual(verdict.findings.map((f) => f.first_seen_round), [1, 2, 3]);
+  for (const f of verdict.findings) assert.ok(typeof f.fid === "string" && f.fid.length > 0, "normalizer did not stamp fid");
+  assert.strictEqual(typeof verdict.normalized_by, "string");
+});
+
+check("rejects the verdict ENVELOPE where review-normalize.js needs a findings ARRAY", () => {
+  const dir = scratch();
+  const { final } = driveRounds(dir, 1);
+  const r = run(ASSEMBLE, ["--task", "other", "--round", "1", "--cycle", "1", "--status", "GO",
+    "--reviewed-sha", "a", "--fix-sha", "b", "--specialist", "reviewer=always",
+    "--findings", path.relative(dir, final)], dir);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /JSON ARRAY of finding objects, not a verdict envelope/);
+});
+
+check("fails closed on a schema-invalid finding rather than dropping it", () => {
+  const dir = scratch();
+  const bad = path.join("briefs", "bad.json");
+  fs.writeFileSync(path.join(dir, bad), JSON.stringify([{ severity: "HIGH", summary: "no other required keys" }]));
+  const r = run(ASSEMBLE, ["--task", TASK, "--round", "1", "--cycle", "1", "--status", "GO",
+    "--reviewed-sha", "a", "--fix-sha", "b", "--specialist", "reviewer=always", "--findings", bad], dir);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /rejected as schema-invalid/);
+});
+
+check("requires exactly one of --fix-sha / --fix-sha-reason", () => {
+  const dir = scratch();
+  const base = ["--task", TASK, "--round", "1", "--cycle", "1", "--status", "GO",
+    "--reviewed-sha", "a", "--specialist", "reviewer=always"];
+  assert.strictEqual(run(ASSEMBLE, base, dir).status, 2);
+  assert.strictEqual(run(ASSEMBLE, [...base, "--fix-sha", "b", "--fix-sha-reason", "dirty-tree"], dir).status, 2);
+  const ok = run(ASSEMBLE, [...base, "--fix-sha-reason", "dirty-tree"], dir);
+  assert.strictEqual(ok.status, 0, ok.stderr);
+  const entry = JSON.parse(fs.readFileSync(path.join(dir, "briefs", `${TASK}-review.json.draft`), "utf8")).rounds_audit[0];
+  assert.strictEqual(entry.fix_sha, null);
+  assert.strictEqual(entry.fix_sha_reason, "dirty-tree");
+});
+
+check("requires --no-go-round on NO-GO and forbids a non-zero one on GO", () => {
+  const dir = scratch();
+  const base = ["--task", TASK, "--round", "1", "--cycle", "1", "--reviewed-sha", "a",
+    "--fix-sha", "b", "--specialist", "reviewer=always"];
+  assert.match(run(ASSEMBLE, [...base, "--status", "NO-GO", "--no-go-type", "design-not-converging"], dir).stderr,
+    /--no-go-round <n> is required/);
+  assert.match(run(ASSEMBLE, [...base, "--status", "GO", "--no-go-round", "3"], dir).stderr,
+    /must be 0 \(or omitted\) on a GO verdict/);
+});
+
+check("every specialist entry carries a non-empty selection_reason", () => {
+  const dir = scratch();
+  const base = ["--task", TASK, "--round", "1", "--cycle", "1", "--status", "GO",
+    "--reviewed-sha", "a", "--fix-sha", "b"];
+  assert.match(run(ASSEMBLE, base, dir).stderr, /at least one --specialist/);
+  assert.match(run(ASSEMBLE, [...base, "--specialist", "reviewer="], dir).stderr, /empty name or selection_reason/);
+  assert.match(run(ASSEMBLE, [...base, "--specialist", "reviewer"], dir).stderr, /<name>=<selection_reason>/);
+});
+
+process.stdout.write(`\n${passes} passed, ${failures} failed\n`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## What

Ships the two missing halves of the review pipeline's verdict contract (skill-health P2):

- **`schema/review-json-schema.md`** — the `briefs/<task>-review.json` envelope contract. It was cited as authoritative by `roster-review` (five times) and by `schema/review-finding.schema.json`, and it was **absent from the repo**.
- **`scripts/review-verdict-assemble.js`** — makes the contract executable, so no verdict is hand-derived again.
- **`scripts/review-verdict-assemble.test.js`** — 18 assertions, each red-on-mutation against the real gate.

The P3 gate tightening (fail closed on an under-populated verdict) is **deliberately not here** — the gate is an upstream-owned, manifest-sentinelled bundle file.

## Why

`check-review-convergence.js` degrades *silently* on the input a hand-written verdict produces:

```console
$ node scripts/check-review-convergence.js briefs/make-tests-actually-run-review.json --static
  "warnings": ["legacy review.json: round key absent — skipping strike and rounds_audit checks (B-8)", ...]
  "violations": []
$ echo $?
0
```

`violations: []`, exit 0 — an anti-vacuity gate that passes because it was never given anything to check, with an outcome byte-identical to a genuine pass at every point a caller looks. That is how a PR ran five review rounds, each producing novel findings, without the gate ever routing back to `/roster-spec`.

The root cause was a missing contract, not a missing check. The verdict-level keys existed only inside skill prose.

## Derivation

Ground truth in authority order: (a) what the gate actually reads, (b) the two nested JSON Schemas, (c) the skill prose. The gate reads exactly **ten** envelope keys — `cross_runtime`, `cycle`, `findings`, `mode`, `no_go_round`, `normalized_by`, `round`, `rounds_audit`, `streak_override`, `task`. Everything else in the envelope is prose-enforced only.

Where (a) and (c) disagree, **both are documented and the disagreement is flagged** — eleven entries, D1..D11. The largest:

| | |
|---|---|
| **D1** | Prose: "any `cross_runtime_findings` entry that is CRITICAL or HIGH (OPEN) sets `NO-GO`". The gate **never reads `cross_runtime_findings`**. Enforcement rests entirely on the prose-level mirror into `findings`. |
| **D3** | Prose never says `strike` must be a *boolean*, and the completeness check does not require it. `strike: null` passes and silently defeats streak escalation. Live in this repo: `briefs/f16-dsl-slice1-review.json` (round 3, `strike: null` on all three entries). |
| **D5** | `mode` is `express\|fast\|full` in the verdict and `static\|full` in the gate report. Same key, different enum, and `full` means different things. |
| **D7** | Gate accepts any `findings[].status` string; `review-normalize.js` rejects anything outside `OPEN\|RESOLVED\|ACCEPTED`. All 3 findings in a real shipped verdict here are schema-invalid — the gate tolerated them, the normalizer rejects 3/3. |

## Pipeline order (deliverable 3, at the top of the doc)

```
specialists → normalize the ARRAY → assemble the verdict → gate → write strikes back → route
```

Two traps documented: `review-normalize.js` takes a JSON **array**, not the envelope (nothing at the call site says so); and skipping normalization makes "novel finding" uncomputable because `first_seen_round` is stamped there.

## Verification

**Round-trip — real checks, no legacy skip.** Assembled from real findings, then gated:

```console
$ node scripts/check-review-convergence.js briefs/verdict-schema-demo-review.json.draft --max-rounds 5 --strikes 2 --static
  "legacy_round": false,   "trace": {"obligated": true, "lines_seen": 3, "skipped": false},
  "cause": null, "warnings": [], "violations": []
$ echo $?
0
```

No `legacy ... skipping` line, trace obligated. An intermediate run before the scope-gate/specialist trace lines existed correctly returned exit **1** / `cause: unattested-invocation` — the gate has teeth once the keys are there.

**Round-cap / streak.** Five rounds, each with a novel HIGH finding, driven through the real tools:

| round | `current_round_strike` | `cause` | violations | exit |
|---|---|---|---|---|
| 1 | false | null | — | 0 |
| 2 | true | null | — | 0 |
| 3 | true | `novel-finding-streak` | streak | **1** |
| 4 | true | `novel-finding-streak` | streak | **1** |
| 5 | true | `novel-finding-streak` | round-cap **+** streak | **1** |

Final `rounds_audit` strikes: `[false, true, true, true, true]`.

Two deviations from the expected shape, both **documented design, not defects**: escalation fires at **round 3**, not round 5; and at round 5 `cause` is `novel-finding-streak`, not `round-cap`, because FR-059/B-5 precedence puts the streak above the cap. `round-cap` is in `violations[]` either way.

**`strike: null`, confirmed empirically rather than assumed:**

| mutation | result |
|---|---|
| `null` on past round 4 | streak silently reset → `cause: round-cap`, exit 1, one warning |
| `null` on the **current** round | **no warning at all**; becomes a silent reset one round later |
| `null` everywhere, `no_go_round: 2` | five striking rounds, `current_round_strike: true`, `violations: []`, `cause: null`, **exit 0** — total escape |

That last row is the real-world failure reproduced end to end. It is a defect class *independent* of the missing-`round` legacy skip: a verdict that has `round` still escapes if `strike` is null. Hence the two-phase design — the assembler emits the key **absent**, and `--write-strike` refuses any non-boolean `current_round_strike`.

The doc's own "minimal valid verdict" example is extracted from the markdown and gated in CI-able form: exit 0, zero warnings, trace obligated.

## Test status

- `node scripts/review-verdict-assemble.test.js` → **18 passed, 0 failed**
- `node scripts/review-bundle-verify.js` → OK, 22 files sha-matched (no manifest-owned file touched)
- `node --check` clean on both new scripts

**Pre-existing failure, unrelated and not fixed here:** `dune build @sarek/tests/runtest` exits 1 on a GPU-driver fault — `Fatal error: exception [Vulkan Runtime] Context error during vkAllocateDescriptorSets: VK_ERROR_UNKNOWN(-1000069000)` on the integrated `RADV RAPHAEL_MENDOCINO` device, in `test_real64*`. It reproduces on a tree with **zero** OCaml modifications (this branch changes only markdown and JS), so it is environmental/driver, not a compilation or lint error introduced here. Flagging rather than papering over.

## Note on distribution

The entire review-tool bundle (`check-review-convergence.js`, `review-normalize.js`, `scripts/lib/**`, `schema/*.schema.json`, 22 files) is **untracked in git** — present in the working tree, absent from the repository. This PR adds only the three repo-local files, so a fresh clone gets the contract and the assembler but must run the bundle installer to get their dependencies. Committing 22 upstream-owned generated files is a separate decision and is not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooling to assemble validated review verdict drafts across rounds.
  * Added support for persisting gate results back into verdict records.
  * Added detailed documentation for verdict structure, validation rules, audit history, and gate outcomes.

* **Tests**
  * Added end-to-end coverage for verdict assembly, multi-round escalation, validation failures, trace requirements, and audit persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->