### PR TITLE
fix(sarek/df64): stop ptxas contracting away the TwoProd split

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,20 @@
 
 ### Fixed
 
+- `Sarek_df64` silently ran at plain float32 precision on real NVIDIA
+  hardware (CUDA/PTX and NVIDIA OpenCL): `ptxas` contracted the multiply in
+  `two_prod` into the `add`/`sub` of the `quick_two_sum` closing `df64_mul`,
+  rebuilding the exact product and cancelling the TwoProd error term.
+  `mul`/`div`/`sqrt` degraded from ~2^-47 to ~2^-24 with no error reported.
+  `two_prod` now forms its product with `fma a b 0.0`, which cannot be fused
+  again. Measured on a GTX 1070 (sm_61, CUDA 12.9): mul 5.92e-08 → 9.07e-15,
+  div 5.64e-08 → 5.08e-15, throughput unchanged. A CPU-only regression guard
+  (`test_df64_no_contraction`) asserts the emitted PTX contains no
+  contractable `mul.f32`. The df64 per-backend precision table now names the
+  device and toolchain behind every figure — the previous table generalised
+  AMD-only measurements to "CUDA/PTX", which is why this went unseen. NOTE
+  `df64_sqrt` on NVIDIA remains above tolerance; see the `KNOWN RESIDUAL`
+  block in `sarek/Sarek_df64/Sarek_df64.ml`.
 - Indexed kernel-argument container with strict launch validation, honored
   across all six backends (out-of-order/sparse `set_arg` now correct)
 - Unambiguous, collision-resistant compile-cache keys (kernel name included,

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -49,36 +49,48 @@
  * a real-NVIDIA collapse to ~2^-24 went unnoticed. Do not restate a result
  * more broadly than it was measured.
  *
- * Measured by sarek/tests/e2e/test_df64.ml unless noted:
+ * Measured by sarek/tests/e2e/test_df64.ml. "mul/div/sqrt" below are that
+ * test's max relative errors; its tolerance is 7.11e-15 (2^-47) for add/sub
+ * and 1.42e-14 (2^-46) for mul/div/sqrt.
  *
  *   Interpreter, sequential and parallel (any host)
- *       full contract (~2^-47). Emulates float32 rounding, incl. Float.fma.
+ *       full contract. mul 9.07e-15, div 5.08e-15, sqrt 8.53e-15.
+ *
+ *   CUDA/PTX on NVIDIA Pascal
+ *   (GTX 1070 Max-Q, sm_61, CUDA 12.9, driver 580.119.02)
+ *       mul 9.07e-15, div 5.08e-15 - contract met.
+ *       sqrt 1.42e-14 - marginally OVER the 1.42e-14 tolerance, still failing.
+ *       Before the contraction barrier: mul 5.92e-08, div 5.64e-08,
+ *       sqrt 2.88e-08, i.e. plain float32.
+ *
+ *   OpenCL on NVIDIA Pascal (same GPU and driver)
+ *       mul 9.07e-15, div 5.08e-15, sqrt 9.80e-15 - contract met.
+ *       Before the barrier it showed the same collapse as CUDA/PTX
+ *       (mul 5.92e-08, div 5.85e-08, sqrt 2.88e-08). No OpenCL-specific
+ *       change was needed: FP_CONTRACT is defeated by the same barrier.
+ *
+ *   Vulkan on NVIDIA Pascal (same GPU and driver)
+ *       mul 9.07e-15, div 5.08e-15, sqrt 1.24e-14 - contract met, and met
+ *       before the barrier too. NVIDIA's GLSL [fma] is exact and the
+ *       [precise] qualifier on float locals already blocked contraction.
  *
  *   OpenCL on AMD (RX 7900 XTX and Raphael iGPU, Mesa rusticl/radeonsi)
- *       full contract (~2^-47).
- *
- *   CUDA/PTX on NVIDIA Pascal (GTX 1070, sm_61, CUDA 12.9, driver 580.119.02)
- *       full contract expected after the contraction barrier below; the fix
- *       is verified in SASS offline (ptxas 12.9 -arch=sm_61 -O3) but has NOT
- *       yet been re-run on the device. Before the fix: mul 5.92e-08,
- *       div 5.64e-08, sqrt 2.88e-08 - i.e. plain float32.
+ *       full contract. mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14.
  *
  *   CUDA/PTX on AMD through ZLUDA (RX 7900 XTX)
- *       full contract (~2^-47). NOT evidence for real NVIDIA hardware.
- *
- *   OpenCL on NVIDIA Pascal (GTX 1070)
- *       UNVERIFIED after the fix. Before the fix it showed the same
- *       ~2^-24 collapse as CUDA/PTX on that GPU.
+ *       full contract. NOT evidence for real NVIDIA hardware - this is the
+ *       configuration whose result was previously generalised to "CUDA/PTX".
  *
  *   Vulkan on AMD (RX 7900 XTX and Raphael iGPU, Mesa RADV)
- *       add/sub/sqrt meet the contract - float locals carry the GLSL
- *       [precise] qualifier - but mul/div degrade to ~2^-24 because RADV's
+ *       add/sub/sqrt meet the contract, mul/div degrade to ~5.8e-08. RADV's
  *       GLSL [fma] is not correctly rounded, so TwoProd's error term is lost.
- *       Unfixed, and distinct from the ptxas contraction bug below.
+ *       UNFIXED, and unrelated to the contraction bug - the barrier below
+ *       does not help, and extending it to two_sum/quick_two_sum makes RADV
+ *       strictly worse (see "Contraction barrier").
  *
- *   Vulkan on NVIDIA Pascal (GTX 1070)
- *       meets the contract (mul 9.07e-15) - NVIDIA's GLSL [fma] is exact and
- *       [precise] blocks contraction. Measured before the fix.
+ *   Vulkan on Intel (UHD Graphics 630, CFL GT2, Mesa ANV)
+ *       add/sub/sqrt meet the contract, mul/div degrade to ~5.8e-08, same
+ *       shape as RADV. UNFIXED, unmeasured cause.
  *
  *   Native (OCaml host code)
  *       evaluates float32 at OCaml binary64 precision, so the error-free
@@ -87,6 +99,18 @@
  *       but do not use df64 for extra precision there.
  *
  *   Metal, WGSL: UNTESTED.
+ *
+ * KNOWN RESIDUAL: df64_sqrt on NVIDIA
+ *   After the contraction barrier, sqrt still lands just above the 2^-46
+ *   tolerance on some NVIDIA paths: 1.42e-14 (CUDA/PTX, test_df64) and
+ *   1.68e-14 / 1.81e-14 (CUDA/PTX and OpenCL, test_real64's df64 fallback).
+ *   This is NOT the contraction bug - that cost sqrt 2.88e-08, and the
+ *   barrier removed it. It is a separate margin problem in the Karp/Newton
+ *   correction, and it pre-dates the barrier: Vulkan on the same GPU, which
+ *   was never affected by contraction, already failed test_real64's sqrt at
+ *   1.68e-14 beforehand. Devices generally land at 1.0e-14..1.8e-14 for sqrt
+ *   where the interpreter reaches 8.5e-15. Unresolved; do not paper over it
+ *   by widening the tolerance.
  *
  * References:
  *   - T.J. Dekker, "A floating-point technique for extending the available
@@ -145,6 +169,14 @@ let float x = float_of_int (Int32.to_int x)
  * so every add and subtract downstream of a [two_prod] has nothing to contract
  * with. One instruction changes (FMUL -> FFMA, same rate on NVIDIA); the SASS
  * instruction count for df64_mul and df64_sqrt is unchanged at sm_61.
+ *
+ * CONFIRMED ON HARDWARE (GTX 1070 Max-Q, sm_61, CUDA 12.9, driver
+ * 580.119.02), not only in SASS: CUDA/PTX mul 5.92e-08 -> 9.07e-15 and
+ * div 5.64e-08 -> 5.08e-15; NVIDIA OpenCL mul 5.92e-08 -> 9.07e-15,
+ * div 5.85e-08 -> 5.08e-15, sqrt 2.88e-08 -> 9.80e-15. The same barrier
+ * fixes OpenCL with no OpenCL-specific change. Throughput on that GPU is
+ * unchanged: the df64 poly benchmark runs 6.04 ms before and 6.03 ms after
+ * (CUDA/PTX, 2^20 x 512 iters, steady state of 3 runs).
  *
  * WHY IT IS NOT APPLIED MORE WIDELY. Rewriting [two_sum] and [quick_two_sum]
  * in terms of [fma] as well was tried and MEASURED TO REGRESS RADV/Vulkan

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -25,17 +25,29 @@
  *   Sarek_df64.Host to fill/read them.
  *
  * PRECISION CONTRACT
- *   - Relative error of add/sub/mul/div/sqrt: ~2^-48 .. 2^-47 (48-49
- *     significant bits), i.e. roughly double the 24-bit float32 precision.
- *   - Exponent range is that of float32 (~1e-38 .. ~3e38 normalised);
- *     overflow/underflow follow float32, NOT IEEE-754 binary64.
+ *   - Relative error, per operation, as actually measured by test_df64.ml on
+ *     a backend that meets the contract (see PER-BACKEND STATUS for which):
+ *     add 5.3e-15, sub 6.5e-15 (~2^-47); mul 9.1e-15, div 5.1e-15
+ *     (~2^-46.6 .. 2^-47.8); sqrt 8.5e-15 at best, but see KNOWN RESIDUAL -
+ *     it reaches 1.8e-14 on some NVIDIA paths. Roughly double the 24-bit
+ *     float32 precision. This is a measured range, NOT a proven bound: do
+ *     not quote a single "2^-47" figure for the whole op set.
+ *   - Exponent range is that of float32 (~1e-38 .. ~3e38 normalised).
+ *     Underflow follows float32. OVERFLOW DOES NOT: once a leading product
+ *     or sum reaches an infinity, the error term becomes an infinity of the
+ *     opposite sign and the closing quick_two_sum yields NaN, where plain
+ *     float32 would have given a signed infinity. Keep operands well inside
+ *     the float32 range. (Pre-existing, and unchanged by the contraction
+ *     barrier - verified bit-identical before and after it.)
  *   - Requires IEEE-exact float32 ops and a correctly rounded float32 fma
  *     (used for exact TwoProd error extraction). The interpreter emulates
  *     float32 rounding (incl. Float.fma-based fma) and meets the contract.
  *   - Also requires that the backend compiler NOT contract a multiply into a
- *     neighbouring add or subtract. That is not the default anywhere, so the
- *     transformations below are written to make it impossible rather than to
- *     ask for it; see "Contraction barrier".
+ *     neighbouring add or subtract. Every backend here contracts BY DEFAULT,
+ *     so the transformations below are written to make contraction
+ *     impossible rather than to ask the compiler to refrain; see
+ *     "Contraction barrier". That barrier covers df64's own bodies only -
+ *     read "CALLER-SIDE HAZARD" there for what it does not cover.
  *   - Results are NOT bit-exact with IEEE-754 binary64 arithmetic.
  *
  * PER-BACKEND STATUS
@@ -59,7 +71,9 @@
  *   CUDA/PTX on NVIDIA Pascal
  *   (GTX 1070 Max-Q, sm_61, CUDA 12.9, driver 580.119.02)
  *       mul 9.07e-15, div 5.08e-15 - contract met.
- *       sqrt 1.42e-14 - marginally OVER the 1.42e-14 tolerance, still failing.
+ *       sqrt 1.42e-14 - AT the 1.42e-14 (2^-46) tolerance boundary; both
+ *       print as 1.42e-14 at three significant figures, and the measured
+ *       value is the larger of the two, so the test records it as failing.
  *       Before the contraction barrier: mul 5.92e-08, div 5.64e-08,
  *       sqrt 2.88e-08, i.e. plain float32.
  *
@@ -100,17 +114,47 @@
  *
  *   Metal, WGSL: UNTESTED.
  *
- * KNOWN RESIDUAL: df64_sqrt on NVIDIA
- *   After the contraction barrier, sqrt still lands just above the 2^-46
- *   tolerance on some NVIDIA paths: 1.42e-14 (CUDA/PTX, test_df64) and
+ * KNOWN RESIDUAL: df64_sqrt on NVIDIA (tracked separately; NOT fixed here)
+ *   After the contraction barrier, sqrt still lands at or just above the
+ *   2^-46 tolerance on some NVIDIA paths: 1.42e-14 (CUDA/PTX, test_df64) and
  *   1.68e-14 / 1.81e-14 (CUDA/PTX and OpenCL, test_real64's df64 fallback).
- *   This is NOT the contraction bug - that cost sqrt 2.88e-08, and the
- *   barrier removed it. It is a separate margin problem in the Karp/Newton
- *   correction, and it pre-dates the barrier: Vulkan on the same GPU, which
- *   was never affected by contraction, already failed test_real64's sqrt at
- *   1.68e-14 beforehand. Devices generally land at 1.0e-14..1.8e-14 for sqrt
- *   where the interpreter reaches 8.5e-15. Unresolved; do not paper over it
- *   by widening the tolerance.
+ *
+ *   It is NOT the contraction bug - that cost sqrt 2.88e-08, and the barrier
+ *   removed it - and it pre-dates the barrier: Vulkan on the same GPU, never
+ *   affected by contraction, already failed test_real64's sqrt at 1.68e-14
+ *   beforehand. Across the devices measured here sqrt spans 8.5e-15
+ *   (interpreter) to 1.81e-14, with NVIDIA OpenCL at 9.80e-15 and AMD OpenCL
+ *   at 1.08e-14 - it is NOT uniformly poor, and that spread is itself part of
+ *   the evidence below.
+ *
+ *   THE CAUSE IS NOT ESTABLISHED. Do not repeat any cause below as fact
+ *   until it has been measured; the reason this library's precision claim
+ *   went wrong for four years is that a plausible-sounding statement was
+ *   recorded as a finding.
+ *
+ *   Leading hypothesis, on circumstantial evidence only: the PTX backend
+ *   lowers the float32 [sqrt] intrinsic to [sqrt.approx.f32]
+ *   (sarek/codegen/Sarek_ir_ptx_expr.ml), which is ~1 ulp rather than
+ *   correctly rounded. df64_sqrt uses that result as the Newton seed [y],
+ *   and a Karp correction step squares the seed error, so a 2^-23 seed error
+ *   lands near 2^-46 - the observed magnitude. Three observations fit:
+ *     - the interpreter runs the identical algorithm with a correctly
+ *       rounded sqrt and reaches 8.53e-15;
+ *     - on the SAME GPU, OpenCL reaches 9.80e-15 while CUDA/PTX sits at
+ *       1.42e-14, a backend split that an algorithmic margin problem in the
+ *       Karp/Newton step could not produce;
+ *     - the identical bug class was already found and fixed one operator
+ *       over: [div.approx.f32] was replaced by [div.rn.f32] in the same
+ *       emitter precisely because it "eroded Sarek_df64's error budget"
+ *       (audit finding M2). [sqrt.rn.f32] exists and is already emitted
+ *       elsewhere in that file.
+ *   The cheap experiment is to swap [sqrt.approx.f32] for [sqrt.rn.f32] and
+ *   re-measure on NVIDIA; it was NOT run here (no NVIDIA device attached to
+ *   this working tree) and it is out of scope for the contraction fix.
+ *   Note this also means the "IEEE-exact float32 ops" requirement above is
+ *   currently NOT met by the PTX backend for [sqrt].
+ *
+ *   Unresolved; do not paper over it by widening the tolerance.
  *
  * References:
  *   - T.J. Dekker, "A floating-point technique for extending the available
@@ -157,12 +201,33 @@ let float x = float_of_int (Int32.to_int x)
  * result is (true product + p.lo), and the relative error jumps from ~2^-47 to
  * ~2^-24 - plain float32. Simulating that instruction sequence in float32
  * reproduces the hardware failure exactly: 5.92e-08 measured, 5.92e-08
- * simulated, against 7.28e-15 for the same code uncontracted.
+ * simulated. The same simulation run uncontracted gives 7.28e-15. NOTE that
+ * figure is from the simulation harness, not from test_df64, and it does not
+ * match the 9.07e-15 this header quotes for measured mul; the two were never
+ * reconciled to a common input set. Use it as evidence that contraction is
+ * the mechanism, not as a precision figure.
  *
  * The [fma] inside [two_prod] is NOT the casualty - ptxas keeps it and the
  * error term is correct. It is the surrounding add/sub that get fused. This is
  * also why add/sub survived while mul/div/sqrt collapsed: contraction needs a
- * multiply to fuse, and [df64_add]'s inputs are loads, not products.
+ * multiply to fuse, and in the failing kernels [df64_add]'s inputs were loads,
+ * not products.
+ *
+ * CALLER-SIDE HAZARD - what this barrier does NOT cover. [@sarek.module]
+ * bodies are inlined into the calling kernel, so the barrier only guarantees
+ * that df64's OWN code hands the compiler no fusable multiply. A caller can
+ * still reintroduce the exact pattern by passing a live float32 product into
+ * an add-based entry point:
+ *
+ *     df64_add_f32 acc (x *. y)     (* [two_sum acc.hi b] with b a mul.f32 *)
+ *
+ * Here ptxas may fuse the caller's multiply into [two_sum]'s leading add, and
+ * the error-free transformation breaks the same way. A [let] binding does NOT
+ * help - contraction happens well below the source level. The fix is to deny
+ * the multiply in the caller too: write [mul_rn x y] (or [two_prod x y] if the
+ * error term is wanted) instead of [x *. y] on any product that flows into a
+ * df64 entry point. The regression guard cannot see this case: its kernels
+ * contain no caller-level float multiply.
  *
  * THE FIX. Deny the compiler the multiply. [mul_rn] computes the same product
  * through [fma], which is already fused and therefore cannot be fused again,
@@ -184,14 +249,32 @@ let float x = float_of_int (Int32.to_int x)
  * 8.17e-08 on RX 7900 XTX, Mesa RADV): RADV's GLSL [fma] is not correctly
  * rounded, which is exactly the pre-existing Vulkan mul/div deviation recorded
  * in the header. Confining the barrier to [two_prod] keeps the new dependency
- * inside the one transformation that already required a correct [fma], so no
- * backend is newly exposed.
+ * inside the one transformation that already required a correct [fma].
+ *
+ * That is not quite "no backend is newly exposed", and the difference is worth
+ * stating precisely: before, [two_prod]'s HIGH limb was [fl(a*b)] on every
+ * backend regardless of fma quality, and only the low limb depended on the
+ * fma. Now the high limb is [fma a b 0.0] too, so on a backend whose [fma] is
+ * not correctly rounded (RADV, and by inference ANV) the high limb can in
+ * principle differ from [fl(a*b)]. No measurable impact: those backends were
+ * already at ~5.8e-08 for mul/div before this change and are byte-identical
+ * after it. The exposure is newly present but not newly observable.
  ******************************************************************************)
 
 (** [a * b], correctly rounded, and - unlike [a *. b] - not a multiply the
-    backend can fuse into a later add or subtract. Value-identical to [a *. b]
-    except that a zero result is always [+0.0] (fma adds [+0.0]); nothing below
-    depends on that sign. See the comment block above before changing this. *)
+    backend can fuse into a later add or subtract.
+
+    Value-identical to [a *. b] on every input, with exactly one exception: an
+    EXACTLY zero product ([+0.0 *. -1.0] and friends) comes back [+0.0] here
+    rather than [-0.0], because the fma adds [+0.0]. A nonzero product that
+    UNDERFLOWS to zero keeps its sign under both forms - the fma rounds the
+    exact product once, so the sign survives. Verified over the signed zeros,
+    infinities, NaN, subnormals and 3e6 random float32 pairs: the exact-zero
+    sign is the only divergence, and it is not observable at any df64 entry
+    point, because the [quick_two_sum] that closes [df64_mul]/[df64_mul_f32]
+    adds [+0.0] to it and yields [+0.0] either way.
+
+    See the comment block above before changing this. *)
 let[@sarek.module] mul_rn (a : float32) (b : float32) : float32 = fma a b 0.0
 
 (******************************************************************************
@@ -362,11 +445,14 @@ module Host = struct
     let s = a +% b in
     {hi = s; lo = b -% (s -% a)}
 
-  (* [a *% b] rather than the device's [mul_rn a b]: the contraction barrier is
-     a codegen concern, and OCaml never contracts. The two agree on every
-     value except a zero product's sign. *)
+  (* Mirrors the device [mul_rn]: OCaml never contracts, so the barrier is not
+     needed here for its own sake, but this module's contract is to be a
+     bit-faithful op-for-op reference. Using [a *% b] instead would diverge
+     from the device on an exactly-zero product's sign. *)
+  let mul_rn a b = fma_f32 a b 0.0
+
   let two_prod a b =
-    let p = a *% b in
+    let p = mul_rn a b in
     {hi = p; lo = fma_f32 a b (-.p)}
 
   let neg a = {hi = -.a.hi; lo = -.a.lo}

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -32,18 +32,61 @@
  *   - Requires IEEE-exact float32 ops and a correctly rounded float32 fma
  *     (used for exact TwoProd error extraction). The interpreter emulates
  *     float32 rounding (incl. Float.fma-based fma) and meets the contract.
+ *   - Also requires that the backend compiler NOT contract a multiply into a
+ *     neighbouring add or subtract. That is not the default anywhere, so the
+ *     transformations below are written to make it impossible rather than to
+ *     ask for it; see "Contraction barrier".
  *   - Results are NOT bit-exact with IEEE-754 binary64 arithmetic.
  *
- * Per-backend status (measured by sarek/tests/e2e/test_df64.ml):
- *   - OpenCL, CUDA/PTX, Interpreter: full contract (~2^-47).
- *   - Native: evaluates float32 at OCaml binary64 precision, so the
- *     error-free transformations cancel and results degrade to plain f32
- *     storage precision (~2^-24). Harmless in practice - Native has real
- *     float64 - but do not use df64 for extra precision there.
- *   - Vulkan: add/sub/sqrt meet the contract (float locals are emitted
- *     with the GLSL [precise] qualifier); mul/div currently degrade to
- *     ~2^-24 on RADV (fma error-term loss in composed helpers, under
- *     investigation).
+ * PER-BACKEND STATUS
+ *
+ * Precision is a property of the backend COMPILER AND THE DEVICE, not of this
+ * source. Every line below names the hardware and toolchain it was measured
+ * on; a backend measured on one vendor says nothing about the same backend on
+ * another. An earlier version of this header claimed "OpenCL, CUDA/PTX,
+ * Interpreter: full contract" without naming hardware - that had only ever
+ * been run on an AMD box (CUDA/PTX through ZLUDA, AMD OpenCL), and it is why
+ * a real-NVIDIA collapse to ~2^-24 went unnoticed. Do not restate a result
+ * more broadly than it was measured.
+ *
+ * Measured by sarek/tests/e2e/test_df64.ml unless noted:
+ *
+ *   Interpreter, sequential and parallel (any host)
+ *       full contract (~2^-47). Emulates float32 rounding, incl. Float.fma.
+ *
+ *   OpenCL on AMD (RX 7900 XTX and Raphael iGPU, Mesa rusticl/radeonsi)
+ *       full contract (~2^-47).
+ *
+ *   CUDA/PTX on NVIDIA Pascal (GTX 1070, sm_61, CUDA 12.9, driver 580.119.02)
+ *       full contract expected after the contraction barrier below; the fix
+ *       is verified in SASS offline (ptxas 12.9 -arch=sm_61 -O3) but has NOT
+ *       yet been re-run on the device. Before the fix: mul 5.92e-08,
+ *       div 5.64e-08, sqrt 2.88e-08 - i.e. plain float32.
+ *
+ *   CUDA/PTX on AMD through ZLUDA (RX 7900 XTX)
+ *       full contract (~2^-47). NOT evidence for real NVIDIA hardware.
+ *
+ *   OpenCL on NVIDIA Pascal (GTX 1070)
+ *       UNVERIFIED after the fix. Before the fix it showed the same
+ *       ~2^-24 collapse as CUDA/PTX on that GPU.
+ *
+ *   Vulkan on AMD (RX 7900 XTX and Raphael iGPU, Mesa RADV)
+ *       add/sub/sqrt meet the contract - float locals carry the GLSL
+ *       [precise] qualifier - but mul/div degrade to ~2^-24 because RADV's
+ *       GLSL [fma] is not correctly rounded, so TwoProd's error term is lost.
+ *       Unfixed, and distinct from the ptxas contraction bug below.
+ *
+ *   Vulkan on NVIDIA Pascal (GTX 1070)
+ *       meets the contract (mul 9.07e-15) - NVIDIA's GLSL [fma] is exact and
+ *       [precise] blocks contraction. Measured before the fix.
+ *
+ *   Native (OCaml host code)
+ *       evaluates float32 at OCaml binary64 precision, so the error-free
+ *       transformations cancel and results degrade to plain f32 storage
+ *       precision (~2^-24). Harmless in practice - Native has real float64 -
+ *       but do not use df64 for extra precision there.
+ *
+ *   Metal, WGSL: UNTESTED.
  *
  * References:
  *   - T.J. Dekker, "A floating-point technique for extending the available
@@ -71,6 +114,55 @@ let fma = Float.fma
 let float x = float_of_int (Int32.to_int x)
 
 (******************************************************************************
+ * Contraction barrier
+ *
+ * An error-free transformation is only error-free if the backend compiler
+ * evaluates it as written. Floating-point CONTRACTION - fusing a multiply into
+ * a neighbouring add or subtract - is enabled by default in PTX, CUDA C and
+ * OpenCL C, and it silently destroys these transformations.
+ *
+ * WHAT WAS MEASURED (sm_61 / GTX 1070, ptxas 12.9 -arch=sm_61 -O3, offline).
+ * The [quick_two_sum p.hi err] that closes [df64_mul] compiled to
+ *
+ *     FFMA R11, a_hi,  b_hi, err    ; "s"       = fl(a_hi*b_hi + err)
+ *     FFMA R0,  a_hi, -b_hi, R11    ; "s - p_hi"
+ *
+ * Both operands were rebuilt from the EXACT product a_hi*b_hi instead of the
+ * rounded [p.hi] that [two_prod] had just separated from its error term. Since
+ * [err] already carries that rounding error, adding it back doubles it: the
+ * result is (true product + p.lo), and the relative error jumps from ~2^-47 to
+ * ~2^-24 - plain float32. Simulating that instruction sequence in float32
+ * reproduces the hardware failure exactly: 5.92e-08 measured, 5.92e-08
+ * simulated, against 7.28e-15 for the same code uncontracted.
+ *
+ * The [fma] inside [two_prod] is NOT the casualty - ptxas keeps it and the
+ * error term is correct. It is the surrounding add/sub that get fused. This is
+ * also why add/sub survived while mul/div/sqrt collapsed: contraction needs a
+ * multiply to fuse, and [df64_add]'s inputs are loads, not products.
+ *
+ * THE FIX. Deny the compiler the multiply. [mul_rn] computes the same product
+ * through [fma], which is already fused and therefore cannot be fused again,
+ * so every add and subtract downstream of a [two_prod] has nothing to contract
+ * with. One instruction changes (FMUL -> FFMA, same rate on NVIDIA); the SASS
+ * instruction count for df64_mul and df64_sqrt is unchanged at sm_61.
+ *
+ * WHY IT IS NOT APPLIED MORE WIDELY. Rewriting [two_sum] and [quick_two_sum]
+ * in terms of [fma] as well was tried and MEASURED TO REGRESS RADV/Vulkan
+ * (add 5.33e-15 -> 1.15e-07, sub 6.51e-15 -> 1.06e-07, sqrt 1.08e-14 ->
+ * 8.17e-08 on RX 7900 XTX, Mesa RADV): RADV's GLSL [fma] is not correctly
+ * rounded, which is exactly the pre-existing Vulkan mul/div deviation recorded
+ * in the header. Confining the barrier to [two_prod] keeps the new dependency
+ * inside the one transformation that already required a correct [fma], so no
+ * backend is newly exposed.
+ ******************************************************************************)
+
+(** [a * b], correctly rounded, and - unlike [a *. b] - not a multiply the
+    backend can fuse into a later add or subtract. Value-identical to [a *. b]
+    except that a zero result is always [+0.0] (fma adds [+0.0]); nothing below
+    depends on that sign. See the comment block above before changing this. *)
+let[@sarek.module] mul_rn (a : float32) (b : float32) : float32 = fma a b 0.0
+
+(******************************************************************************
  * Error-free transformations (Dekker 1971, Knuth TAOCP v2 4.2.2)
  ******************************************************************************)
 
@@ -90,7 +182,7 @@ let[@sarek.module] quick_two_sum (a : float32) (b : float32) : df64 =
 
 (** Split-free TwoProd via fma: [a * b] as an exact [hi + lo] pair, 3 flops. *)
 let[@sarek.module] two_prod (a : float32) (b : float32) : df64 =
-  let p = a *. b in
+  let p = mul_rn a b in
   let err = fma a b (0.0 -. p) in
   {hi = p; lo = err}
 
@@ -238,6 +330,9 @@ module Host = struct
     let s = a +% b in
     {hi = s; lo = b -% (s -% a)}
 
+  (* [a *% b] rather than the device's [mul_rn a b]: the contraction barrier is
+     a codegen concern, and OCaml never contracts. The two agree on every
+     value except a zero product's sign. *)
   let two_prod a b =
     let p = a *% b in
     {hi = p; lo = fma_f32 a b (-.p)}

--- a/sarek/Sarek_real64/Sarek_real64.ml
+++ b/sarek/Sarek_real64/Sarek_real64.ml
@@ -33,14 +33,25 @@
  *   - Native f64 path  : full IEEE-754 binary64 (~2^-52 relative), i.e.
  *     at-least-f64-comparable precision. This is the existing, fully-working
  *     f64 kernel path (writable f64 literals via the `G` suffix since PR #240).
- *   - df64 fallback    : ~2^-47..2^-46 relative on backends with IEEE-exact
- *     float32 + fma (OpenCL, CUDA/PTX, Interpreter) - "significantly better
- *     than f32, near-f64". Exponent range is that of float32, NOT binary64,
- *     and results are NOT bit-exact with binary64. On Native the error-free
- *     transformations collapse to plain f32 storage precision (~2^-24), and
- *     on Vulkan mul/div currently degrade likewise (see Sarek_df64 for the
- *     full per-backend table). These are the df64 contract's known
- *     deviations, inherited verbatim.
+ *   - df64 fallback    : ~2^-47..2^-46 relative on a backend AND DEVICE whose
+ *     float32 ops are IEEE-exact, whose fma is correctly rounded, and whose
+ *     compiler does not contract a multiply into a neighbouring add -
+ *     "significantly better than f32, near-f64". Exponent range is that of
+ *     float32, NOT binary64; results are NOT bit-exact with binary64; and
+ *     overflow yields NaN rather than a signed infinity.
+ *
+ *     DO NOT name backends here. Precision is a property of the backend
+ *     compiler AND the device, so "OpenCL" or "CUDA/PTX" alone is not a
+ *     meaningful qualifier - an earlier version of this line listed
+ *     "(OpenCL, CUDA/PTX, Interpreter)" on the strength of measurements
+ *     taken only on an AMD box, and a total collapse to ~2^-24 on real
+ *     NVIDIA hardware went unnoticed for four years as a result.
+ *     Sarek_df64's PER-BACKEND STATUS block is the single source of truth
+ *     and names the hardware and toolchain behind every figure; consult it
+ *     rather than restating it, and note it also records a still-unresolved
+ *     sqrt residual on NVIDIA. On Native the error-free transformations
+ *     collapse to plain f32 storage precision (~2^-24). These are the df64
+ *     contract's known deviations, inherited verbatim.
  *
  * EXPOSED OPERATION SET
  *   The op set is the INTERSECTION of what both substrates provide:

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -654,7 +654,7 @@
 (executable
  (name test_df64_no_contraction)
  (modules test_df64_no_contraction)
- (libraries sarek sarek.stdlib sarek.df64 sarek.codegen spoc_core)
+ (libraries sarek sarek.stdlib sarek.df64 sarek.codegen spoc.ir spoc_core)
  (preprocessor_deps
   (file ../../Sarek_df64/Sarek_df64.ml))
  (preprocess

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -648,6 +648,25 @@
  (action
   (run %{dep:test_df64.exe})))
 
+; CPU-only codegen guard: asserts df64 emits no contractable multiply.
+; See the header of test_df64_no_contraction.ml.
+
+(executable
+ (name test_df64_no_contraction)
+ (modules test_df64_no_contraction)
+ (libraries sarek sarek.stdlib sarek.df64 sarek.codegen spoc_core)
+ (preprocessor_deps
+  (file ../../Sarek_df64/Sarek_df64.ml))
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_df64_no_contraction.exe})))
+
 (executable
  (name test_real64)
  (modules test_real64)

--- a/sarek/tests/e2e/test_df64.ml
+++ b/sarek/tests/e2e/test_df64.ml
@@ -240,11 +240,22 @@ let run_ops_test dev =
        error-free transformations cancel (lo = 0) and df64 degenerates to
        plain f32 storage precision (~2^-24 relative).  Harmless (Native has
        real f64) but documented here.
-     - Vulkan (RADV + glslang): add/sub/sqrt meet the strict contract since
-       float locals are declared [precise], but mul/div still lose the
-       two_prod error term when composed through df64_mul/df64_div helper
-       chains (under investigation; suspected driver-side fma handling).
-     Both are reported as KNOWN-DEVIATION, not silently widened. *)
+     - Vulkan (RADV + glslang, and Mesa ANV on Intel): add/sub/sqrt meet the
+       strict contract since float locals are declared [precise], but mul/div
+       lose the two_prod error term because RADV's GLSL [fma] is not
+       correctly rounded. This is NOT the ptxas contraction bug that cost
+       CUDA/PTX and NVIDIA OpenCL their precision; see the PER-BACKEND STATUS
+       and "Contraction barrier" blocks in Sarek_df64.ml.
+     Both are reported as KNOWN-DEVIATION, not silently widened.
+
+     LIMITATION: the widening below keys on [dev.framework] alone, so it
+     applies to EVERY Vulkan device. NVIDIA Vulkan actually meets the full
+     contract (9.07e-15 mul on a GTX 1070), but is checked here against
+     f32_tol, so a future contraction-class regression on NVIDIA Vulkan would
+     pass silently - the same blind spot that hid the CUDA/PTX collapse. The
+     widening should be keyed on the driver/device (RADV, ANV) rather than on
+     "Vulkan". Not changed here: it needs an NVIDIA device to validate, and
+     narrowing it blind risks turning the suite red for the wrong reason. *)
   let f32_tol = 0x1p-22 in
   let tol_sqrt = tol_dv in
   let tol_mul, tol_dv, tol_sqrt, tol_add, deviation =

--- a/sarek/tests/e2e/test_df64_no_contraction.ml
+++ b/sarek/tests/e2e/test_df64_no_contraction.ml
@@ -1,0 +1,122 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Codegen guard for the Sarek_df64 contraction barrier. CPU-only: generates
+ * PTX from the IR and inspects the string, no CUDA device required.
+ *
+ * WHY THIS TEST EXISTS
+ *
+ * df64's error-free transformations are only exact if the backend compiler
+ * does not fuse a multiply into a neighbouring add or subtract. ptxas does
+ * exactly that by default, and on sm_61 (GTX 1070, CUDA 12.9) it rebuilt the
+ * exact product a.hi*b.hi inside the quick_two_sum closing df64_mul, undoing
+ * the TwoProd split and collapsing mul/div/sqrt from ~2^-47 to ~2^-24 - plain
+ * float32. Nothing failed loudly; the numbers were simply single precision.
+ *
+ * Sarek_df64.two_prod therefore forms its product with [fma _ _ 0.0], which is
+ * already fused and so cannot be fused again. This test asserts the property
+ * that fix delivers, at the only place it is observable without the hardware:
+ * the emitted PTX for a df64 kernel must contain no unqualified [mul.f32],
+ * because every such instruction is a licence for ptxas to contract.
+ *
+ * It is deliberately a PTX-string assertion rather than a precision check:
+ * the precision check (test_df64.ml) passes on every device this project can
+ * reach locally, which is precisely how the sm_61 regression went unnoticed.
+ ******************************************************************************)
+
+[@@@warning "-32-33-34-69"]
+
+module Vector = Spoc_core.Vector
+
+type float32 = float
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+let%sarek_include _ = "../../Sarek_df64/Sarek_df64.ml"
+
+let mul_kernel =
+  [%kernel
+    fun (a : Sarek_df64.df64 vector)
+        (b : Sarek_df64.df64 vector)
+        (out : Sarek_df64.df64 vector)
+        (n : int32) ->
+      let open Sarek_df64 in
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < n then out.(tid) <- df64_mul a.(tid) b.(tid)]
+
+let sqrt_kernel =
+  [%kernel
+    fun (a : Sarek_df64.df64 vector) (out : Sarek_df64.df64 vector) (n : int32) ->
+      let open Sarek_df64 in
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < n then out.(tid) <- df64_sqrt a.(tid)]
+
+let div_kernel =
+  [%kernel
+    fun (a : Sarek_df64.df64 vector)
+        (b : Sarek_df64.df64 vector)
+        (out : Sarek_df64.df64 vector)
+        (n : int32) ->
+      let open Sarek_df64 in
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < n then out.(tid) <- df64_div a.(tid) b.(tid)]
+
+let ptx_of (_, kirc) =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir ->
+      Sarek_codegen.Sarek_ir_ptx.generate_with_types
+        ~types:ir.Sarek_ir_types.kern_types
+        ir
+  | None -> failwith "kernel has no IR"
+
+(* Count occurrences of [needle] in [hay] (no Str dependency here). *)
+let count needle hay =
+  let nl = String.length needle and hl = String.length hay in
+  let rec go i acc =
+    if i + nl > hl then acc
+    else if String.sub hay i nl = needle then go (i + 1) (acc + 1)
+    else go (i + 1) acc
+  in
+  go 0 0
+
+let failures = ref 0
+
+let check name ptx =
+  (* An unqualified [mul.f32] is contractable; [mul.rn.f32] and [fma.rn.f32]
+     are not. df64 code must emit none of the former. *)
+  let contractable = count "mul.f32 " ptx in
+  let fused = count "fma.rn.f32 " ptx in
+  let ok = contractable = 0 && fused > 0 in
+  Printf.printf
+    "  %-10s contractable mul.f32 = %d (want 0), fma.rn.f32 = %d (want > 0) \
+     %s\n\
+     %!"
+    name
+    contractable
+    fused
+    (if ok then "PASS" else "FAIL") ;
+  if not ok then begin
+    incr failures ;
+    if contractable > 0 then
+      Printf.printf
+        "    -> df64 %s emits a contractable multiply; ptxas may fuse it into \
+         the\n\
+        \       following add/sub and silently degrade df64 to float32.\n\
+        \       See \"Contraction barrier\" in sarek/Sarek_df64/Sarek_df64.ml.\n\
+         %!"
+        name
+  end
+
+let () =
+  print_endline "Sarek_df64 PTX contraction guard:" ;
+  check "df64_mul" (ptx_of mul_kernel) ;
+  check "df64_div" (ptx_of div_kernel) ;
+  check "df64_sqrt" (ptx_of sqrt_kernel) ;
+  if !failures = 0 then print_endline "test_df64_no_contraction PASSED"
+  else begin
+    Printf.printf "test_df64_no_contraction FAILED (%d failures)\n" !failures ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_df64_no_contraction.ml
+++ b/sarek/tests/e2e/test_df64_no_contraction.ml
@@ -27,8 +27,6 @@
  * reach locally, which is precisely how the sm_61 regression went unnoticed.
  ******************************************************************************)
 
-[@@@warning "-32-33-34-69"]
-
 module Vector = Spoc_core.Vector
 
 type float32 = float
@@ -49,7 +47,9 @@ let mul_kernel =
 
 let sqrt_kernel =
   [%kernel
-    fun (a : Sarek_df64.df64 vector) (out : Sarek_df64.df64 vector) (n : int32) ->
+    fun (a : Sarek_df64.df64 vector)
+        (out : Sarek_df64.df64 vector)
+        (n : int32) ->
       let open Sarek_df64 in
       let tid = thread_idx_x + (block_idx_x * block_dim_x) in
       if tid < n then out.(tid) <- df64_sqrt a.(tid)]
@@ -63,6 +63,16 @@ let div_kernel =
       let open Sarek_df64 in
       let tid = thread_idx_x + (block_idx_x * block_dim_x) in
       if tid < n then out.(tid) <- df64_div a.(tid) b.(tid)]
+
+(* df64_of_int32 is the fourth caller of two_prod, and the only one outside
+   mul/div/sqrt. It is covered so that the guard tracks two_prod's call sites
+   rather than a hand-picked three. *)
+let of_int32_kernel =
+  [%kernel
+    fun (out : Sarek_df64.df64 vector) (n : int32) ->
+      let open Sarek_df64 in
+      let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+      if tid < n then out.(tid) <- df64_of_int32 tid]
 
 let ptx_of (_, kirc) =
   match kirc.Sarek.Kirc_types.body_ir with
@@ -82,17 +92,28 @@ let count needle hay =
   in
   go 0 0
 
+(* First line of [ptx] containing [needle], for a self-diagnosing failure. *)
+let first_line_with needle ptx =
+  let rec go = function
+    | [] -> None
+    | l :: tl -> if count needle l > 0 then Some (String.trim l) else go tl
+  in
+  go (String.split_on_char '\n' ptx)
+
 let failures = ref 0
 
 let check name ptx =
-  (* An unqualified [mul.f32] is contractable; [mul.rn.f32] and [fma.rn.f32]
-     are not. df64 code must emit none of the former. *)
+  (* An unqualified [mul.f32] is contractable; a rounding-qualified multiply
+     ([mul.rn.f32]) and [fma.rn.f32] are not, since PTX forbids fusing an
+     operation that carries an explicit rounding modifier. df64 must emit none
+     of the former. NB the emitter never currently produces [mul.rn.f32] - the
+     f32 [Mul] arm emits bare [mul.f32] (Sarek_ir_ptx_expr.ml) - so in practice
+     zero here means every float product went through the fma barrier. *)
   let contractable = count "mul.f32 " ptx in
   let fused = count "fma.rn.f32 " ptx in
   let ok = contractable = 0 && fused > 0 in
   Printf.printf
-    "  %-10s contractable mul.f32 = %d (want 0), fma.rn.f32 = %d (want > 0) \
-     %s\n\
+    "  %-10s contractable mul.f32 = %d (want 0), fma.rn.f32 = %d (want > 0) %s\n\
      %!"
     name
     contractable
@@ -100,12 +121,22 @@ let check name ptx =
     (if ok then "PASS" else "FAIL") ;
   if not ok then begin
     incr failures ;
-    if contractable > 0 then
+    if contractable > 0 then begin
       Printf.printf
         "    -> df64 %s emits a contractable multiply; ptxas may fuse it into \
          the\n\
         \       following add/sub and silently degrade df64 to float32.\n\
         \       See \"Contraction barrier\" in sarek/Sarek_df64/Sarek_df64.ml.\n\
+         %!"
+        name ;
+      match first_line_with "mul.f32 " ptx with
+      | Some l -> Printf.printf "       first offending line: %s\n%!" l
+      | None -> ()
+    end ;
+    if fused = 0 then
+      Printf.printf
+        "    -> df64 %s emits no fma.rn.f32 at all; the TwoProd error extraction\n\
+        \       is missing entirely, which is a worse failure than contraction.\n\
          %!"
         name
   end
@@ -115,6 +146,7 @@ let () =
   check "df64_mul" (ptx_of mul_kernel) ;
   check "df64_div" (ptx_of div_kernel) ;
   check "df64_sqrt" (ptx_of sqrt_kernel) ;
+  check "df64_of_i32" (ptx_of of_int32_kernel) ;
   if !failures = 0 then print_endline "test_df64_no_contraction PASSED"
   else begin
     Printf.printf "test_df64_no_contraction FAILED (%d failures)\n" !failures ;


### PR DESCRIPTION
## What was wrong

On a **GTX 1070 Max-Q (sm_61), CUDA 12.9, driver 580.119.02**, df64 mul/div/sqrt ran at plain float32 precision. `test_df64`, `test_real64` and `test_real64_single_source` all failed. NVIDIA OpenCL showed the same pattern on the same GPU; Vulkan on that GPU did not.

## Where the error term actually dies

Not where it looked like. The working hypothesis was that a compiler folded `fma(a, b, -(a*b))` to identically zero. **It does not** — `two_prod`'s fma is emitted correctly and reaches SASS intact at every opt level (`-O0`..`-O4`), on ptxas 12.9/sm_61 and 13.3/sm_86, with `--fmad=false` too.

What ptxas rewrites is the **`quick_two_sum` that closes `df64_mul`**. Given `mul.f32 p, a_hi, b_hi` then `add.f32 s, p, err` and `sub.f32 d, s, p`, it contracts the multiply into *both* consumers:

```
FFMA R11, a_hi,  b_hi, err     ; s       = fl(a_hi*b_hi + err)
FFMA R0,  a_hi, -b_hi, R11     ; s - p_hi
```

Both operands get rebuilt from the **exact** product instead of the rounded `p.hi` that `two_prod` had just separated out. `err` already carries that rounding error, so adding it back doubles it: the result is `(true product + p.lo)`, relative error 2^-24.

Simulating that instruction sequence in float32 reproduced the hardware number bit-for-bit (5.92e-08 vs 7.28e-15 uncontracted) *before* the GPU was available. It also explains the add/sub asymmetry directly: contraction needs a multiply to fuse with, and `df64_add`'s `quick_two_sum` inputs come from loads.

## What Vulkan does differently

The GLSL backend already emits `precise float` on every float local (`Sarek_ir_glsl.ml:850`), which forbids contraction — that is why Vulkan on the 1070 met the contract all along. The PTX backend has no equivalent and emits unqualified `add.f32`/`sub.f32`/`mul.f32`.

## The fix

`two_prod` forms its product with `fma a b 0.0` instead of `a *. b`. An fma is already fused and cannot be fused again, so nothing downstream has a multiply left to contract with. Two functional lines, no new intrinsic, no per-backend flag.

**Confined to `two_prod` on purpose.** Writing `two_sum`/`quick_two_sum` in fma form as well was tried and **regressed RADV/Vulkan** — add 5.33e-15 → 1.15e-07, sub → 1.06e-07, sqrt → 8.17e-08 — because RADV's GLSL `fma` is the broken one. Keeping the barrier inside `two_prod` adds no dependency it did not already have.

Rejected: `.rn` modifiers in the PTX emitter (SASS-verified to work, but PTX-only and would disable FFMA contraction for *every* kernel); Dekker splitting (does not address this bug — the casualty is `quick_two_sum`, not `two_prod`).

## Confirmed on the hardware — sm_61 / CUDA 12.9 / driver 580.119.02

BEFORE = `origin/main`, AFTER = this branch, both run on the GTX 1070 from detached worktrees. `test_df64` max relative error:

| device | op | before | after | tol |
|---|---|---|---|---|
| CUDA/PTX | mul | 5.92e-08 ❌ | **9.07e-15** ✅ | 1.42e-14 |
| CUDA/PTX | div | 5.64e-08 ❌ | **5.08e-15** ✅ | 1.42e-14 |
| CUDA/PTX | sqrt | 2.88e-08 ❌ | **1.42e-14** ❌ | 1.42e-14 |
| OpenCL | mul | 5.92e-08 ❌ | **9.07e-15** ✅ | 1.42e-14 |
| OpenCL | div | 5.85e-08 ❌ | **5.08e-15** ✅ | 1.42e-14 |
| OpenCL | sqrt | 2.88e-08 ❌ | **9.80e-15** ✅ | 1.42e-14 |
| Vulkan | mul | 9.07e-15 ✅ | 9.07e-15 ✅ | — |

`test_df64` on that host: **6 failures → 1**. add/sub/of_i32 unchanged and passing throughout.

**NVIDIA OpenCL is fixed by the same barrier**, with no OpenCL-specific change — the `#pragma OPENCL FP_CONTRACT OFF` held in reserve is not needed.

**Throughput unchanged.** df64 poly bench (2^20 × 512 iters), steady state of 3 runs on the 1070: CUDA/PTX **6.04 → 6.03 ms**; NVIDIA OpenCL 5.30 → 5.50 ms (+3.9%). sm_61 SASS instruction counts: `df64_mul` 36 → 36, `df64_sqrt` 162 → 162, `df64_div` 234 → 240.

## Known residual — `df64_sqrt`, not fixed here

`sqrt` still lands just above the 2^-46 tolerance on some NVIDIA paths: **1.42e-14** (CUDA/PTX, `test_df64`) and **1.68e-14 / 1.81e-14** (CUDA/PTX and OpenCL, `test_real64`'s df64 fallback). `test_real64` goes 7 failures → 3, all of them this.

This is **not** the contraction bug — that cost sqrt 2.88e-08 and is gone (a 2×10⁶ improvement). It is a separate margin problem in the Karp/Newton correction, and it **pre-dates this work**: Vulkan on the same GPU, never affected by contraction, already failed `test_real64`'s sqrt at 1.68e-14 on `origin/main`. Devices generally land 1.0e-14–1.8e-14 for sqrt where the interpreter reaches 8.5e-15.

Recorded in the header, deliberately **not** papered over by widening the tolerance. It wants its own investigation.

## Regression guard

`test_df64_no_contraction` — CPU-only, asserts df64 kernels emit no unqualified `mul.f32`. Red on mutation: reverting `two_prod` fails it for mul, div **and** sqrt. The precision test passes on every device on the AMD dev box, which is how this stayed invisible; this asserts the property in the PTX directly.

No regression on the AMD box either — every number byte-identical to baseline across OpenCL ×2, Vulkan/RADV ×2, Native, Interpreter ×2. `dune build @sarek/tests/e2e/runtest` green.

## Header claim corrected

The per-backend status claimed *"OpenCL, CUDA/PTX, Interpreter: full contract (~2^-47)"* with no hardware named. That had only ever been measured on the AMD box — CUDA/PTX through ZLUDA, AMD OpenCL — and it is why nobody looked at real NVIDIA. Every line now names the device and toolchain it was measured on, carries the actual number, and marks what is untested. A Vulkan-on-Intel row (UHD 630, Mesa ANV) is added: mul/div degrade the same way RADV does.

## Still unverified

- **Metal and WGSL**: untested, as before.
- **Vulkan on Intel**: the mul/div degradation is measured but its cause is not; assumed to be the same unfused-`fma` problem as RADV, not confirmed.
- **RADV mul/div**: unfixed and out of scope here.
- The driver JIT was never isolated from offline ptxas; the end-to-end hardware run makes that distinction moot for this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved df64 reliability on GPU backends by preventing unsafe multiply/add/sub contraction that can break error-free transformations.
  * Updated internal df64 product handling to use a contraction-barrier operation for correct TwoProd error extraction.

* **Documentation**
  * Expanded the df64 precision contract to clearly state backend compilation constraints and measured toolchain behavior expectations.

* **Tests**
  * Added a CPU-only e2e regression that inspects emitted PTX to confirm no contractable `mul.f32` appears and a barrier `fma.rn.f32` does.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->