### PR TITLE
fix(sarek/codegen): emit sqrt.rn.f32 for the f32 sqrt intrinsic (df64_sqrt residual: measured closed on sm_61)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,11 +107,14 @@
   Dumping the generated PTX showed `sqrt.approx.f32` (~1 ulp) was the only
   non-correctly-rounded instruction in the whole `df64_sqrt` body, where it
   serves as the Newton seed. This is a global change: every f32 sqrt in every
-  PTX kernel is now correctly rounded. Measured on a GTX 1070 Max-Q (sm_61,
-  CUDA 12.9, driver 580.119.02): `df64_sqrt` 1.42e-14 (failing) → 8.53e-15 in
-  `test_df64`, and 1.68e-14 (failing) → 8.87e-15 in `test_real64`'s df64
-  fallback — both bit-identical to the interpreter, so the seed was the whole
-  defect on this path. Costs ~12% kernel time on a sqrt-dominated benchmark
+  PTX kernel is now correctly rounded. Measured worst-case relative error over
+  each test's own input set, on a GTX 1070 Max-Q (sm_61, CUDA 12.9, driver
+  580.119.02): `df64_sqrt` 1.42e-14 (failing) → 8.53e-15 in `test_df64`, and
+  1.68e-14 (failing) → 8.87e-15 in `test_real64`'s df64 fallback. Both post-fix
+  figures coincide with the interpreter's for the same inputs — agreement
+  between summary statistics, not element-wise identity — so the seed accounted
+  for the whole gap these tests can see. Sampled maxima on one device and
+  toolchain, not bounds. Costs ~12% kernel time on a sqrt-dominated benchmark
   (`bench_nbody` n=4096: 1.535 ms → 1.722 ms); `rsqrt` is unchanged for code
   that wants the fast form. The same bug class remains open in the OpenCL
   backend (no `-cl-fp32-correctly-rounded-divide-sqrt`, sqrt 1.81e-14) and the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,17 @@
   policy: what each backend may contract, what actually prevents it, and
   whether that mechanism is verified or merely believed. The interpreter is
   named as the cross-backend oracle. Linked from every site that previously
-  carried an ad-hoc contraction comment.
+  carried an ad-hoc contraction comment. §7 ("what cannot be verified without
+  NVIDIA hardware") is now partly closed: an f16 kernel HAS been executed on
+  an NVIDIA GPU — GTX 1070 Max-Q, sm_61, CUDA 12.9, driver 580.119.02 —
+  agreeing with the interpreter on all 63488 finite binary16 inputs, with a
+  liveness control (63085 mismatches on deliberately mismatched kernels)
+  proving the sweep can go red. That also settles the tie-rounding question
+  the section named, exercises the *driver's* ptxas rather than the offline
+  one, adds a second toolkit version (12.9, between CI's 12.6 and the
+  document's 13.3), and independently confirms on hardware that the CUDA
+  barrier removed in #110 was inert. sm_61 is below the sm_75…sm_121 range
+  the host-side sweeps cover, so it is a new sample, not a repeat.
 - FP-conformance guard on the CUDA/nvrtc path: `-use_fast_math`, `-ftz=true`,
   `--prec-div=false` and `--prec-sqrt=false` are now REJECTED at the point an
   option array reaches `nvrtcCompileProgram` (`--fmad=true` warns). The guard
@@ -102,7 +112,7 @@
   `test_df64`, and 1.68e-14 (failing) → 8.87e-15 in `test_real64`'s df64
   fallback — both bit-identical to the interpreter, so the seed was the whole
   defect on this path. Costs ~12% kernel time on a sqrt-dominated benchmark
-  (`bench_nbody` n=4096: 1.543 ms → 1.731 ms); `rsqrt` is unchanged for code
+  (`bench_nbody` n=4096: 1.535 ms → 1.722 ms); `rsqrt` is unchanged for code
   that wants the fast form. The same bug class remains open in the OpenCL
   backend (no `-cl-fp32-correctly-rounded-divide-sqrt`, sqrt 1.81e-14) and the
   Vulkan backend (1.68e-14 on NVIDIA); see the `KNOWN RESIDUAL` block in

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,9 +70,7 @@
   (`test_df64_no_contraction`) asserts the emitted PTX contains no
   contractable `mul.f32`. The df64 per-backend precision table now names the
   device and toolchain behind every figure — the previous table generalised
-  AMD-only measurements to "CUDA/PTX", which is why this went unseen. NOTE
-  `df64_sqrt` on NVIDIA remains above tolerance; see the `KNOWN RESIDUAL`
-  block in `sarek/Sarek_df64/Sarek_df64.ml`.
+  AMD-only measurements to "CUDA/PTX", which is why this went unseen.
 - df64 precision gates could not distinguish a working df64 from a collapsed
   one. `test_df64`, `test_real64` and `test_real64_single_source` all widened
   their tolerance to `0x1p-22` (2.38e-07 — four times the float32 unit
@@ -93,6 +91,16 @@
   vs tol 2.38e-07, new gate FAIL), and adding a bogus allowlist entry for an op
   that already meets the contract (all three tests exit 1 with the stale-entry
   message).
+- PTX backend emits `sqrt.rn.f32` rather than `sqrt.approx.f32` for the float32
+  `sqrt` intrinsic — the same correctness fix already applied to division
+  (`div.approx.f32` → `div.rn.f32`, audit finding M2), which had missed `sqrt`.
+  Dumping the generated PTX showed `sqrt.approx.f32` (~1 ulp) was the only
+  non-correctly-rounded instruction in the whole `df64_sqrt` body, where it
+  serves as the Newton seed. This is a global change: every f32 sqrt in every
+  PTX kernel is now correctly rounded. NOTE the resulting NVIDIA precision has
+  NOT been remeasured — `df64_sqrt` was above tolerance before this change and
+  the new figure is unknown; see the `KNOWN RESIDUAL` block in
+  `sarek/Sarek_df64/Sarek_df64.ml`.
 - Indexed kernel-argument container with strict launch validation, honored
   across all six backends (out-of-order/sparse `set_arg` now correct)
 - Unambiguous, collision-resistant compile-cache keys (kernel name included,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,9 +97,15 @@
   Dumping the generated PTX showed `sqrt.approx.f32` (~1 ulp) was the only
   non-correctly-rounded instruction in the whole `df64_sqrt` body, where it
   serves as the Newton seed. This is a global change: every f32 sqrt in every
-  PTX kernel is now correctly rounded. NOTE the resulting NVIDIA precision has
-  NOT been remeasured — `df64_sqrt` was above tolerance before this change and
-  the new figure is unknown; see the `KNOWN RESIDUAL` block in
+  PTX kernel is now correctly rounded. Measured on a GTX 1070 Max-Q (sm_61,
+  CUDA 12.9, driver 580.119.02): `df64_sqrt` 1.42e-14 (failing) → 8.53e-15 in
+  `test_df64`, and 1.68e-14 (failing) → 8.87e-15 in `test_real64`'s df64
+  fallback — both bit-identical to the interpreter, so the seed was the whole
+  defect on this path. Costs ~12% kernel time on a sqrt-dominated benchmark
+  (`bench_nbody` n=4096: 1.543 ms → 1.731 ms); `rsqrt` is unchanged for code
+  that wants the fast form. The same bug class remains open in the OpenCL
+  backend (no `-cl-fp32-correctly-rounded-divide-sqrt`, sqrt 1.81e-14) and the
+  Vulkan backend (1.68e-14 on NVIDIA); see the `KNOWN RESIDUAL` block in
   `sarek/Sarek_df64/Sarek_df64.ml`.
 - Indexed kernel-argument container with strict launch validation, honored
   across all six backends (out-of-order/sparse `set_arg` now correct)

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -119,8 +119,11 @@ Legend for the evidence column:
   `Ptx_codegen_error`), so there is nothing to rely on there yet.
 - **`Sarek_df64` meeting its precision contract on CUDA/PTX and OpenCL on
   NVIDIA Pascal, and on OpenCL on AMD** — `sqrt` on CUDA/PTX is now included
-  (8.53e-15, executed; it was the `sqrt.approx.f32` seed). The OpenCL and
-  Vulkan `sqrt` residuals recorded in `Sarek_df64`'s header are still open.
+  (measured worst-case 8.53e-15 over `test_df64`'s input set on GTX 1070 Max-Q
+  / sm_61 / CUDA 12.9; the cause was the `sqrt.approx.f32` seed). These are
+  sampled maxima on named devices, not bounds — see the caveat at the top of
+  `Sarek_df64`'s PRECISION CONTRACT. The OpenCL and Vulkan `sqrt` residuals
+  recorded in that header are still open.
 - **No `-use_fast_math` / `-ftz=true` reaching nvrtc**, enforced rather than
   documented (§5) — in **both** the inline (`--ftz=true`) and the separated
   (`--ftz true`) spelling, and fail-closed on a bare `--ftz` whose value cannot
@@ -441,11 +444,21 @@ architectures ranges, same answer.
 - **`FMUL.FTZ` was observed, subnormal divergence was not.** §5 shows the flag
   changes the instruction; it does not show a wrong answer, because that
   requires running the kernel.
-- **`Sarek_df64`'s `sqrt` residual on NVIDIA** (1.42e-14 CUDA/PTX, 1.68e-14 /
-  1.81e-14 in `test_real64`) is unexplained. The leading hypothesis —
-  `sqrt.approx.f32` as the Newton seed — has a one-line experiment
-  (`sqrt.rn.f32` instead) that needs an NVIDIA device to evaluate. Recorded in
-  `Sarek_df64`'s header; do not promote it to a cause.
+- **`Sarek_df64`'s `sqrt` residual — CUDA/PTX resolved, OpenCL and Vulkan still
+  open.** The one-line experiment this bullet used to describe as needing an
+  NVIDIA device has been run. On CUDA/PTX the `sqrt.approx.f32` Newton seed was
+  the cause: emitting `sqrt.rn.f32` moves the measured worst-case relative error
+  from 1.42e-14 to 8.53e-15 in `test_df64` and from 1.68e-14 to 8.87e-15 in
+  `test_real64` (GTX 1070 Max-Q / sm_61 / CUDA 12.9), each figure being the max
+  over that test's own input set. Both coincide with the interpreter's figure
+  for the same inputs — agreement between summary statistics, not a
+  demonstration of element-wise identity. The OpenCL residual (1.81e-14) is the **same
+  bug class in a different backend** — `clBuildProgram` is called with no
+  options and OpenCL's default permits a 3-ulp `sqrt`; adding
+  `-cl-fp32-correctly-rounded-divide-sqrt` moves it to 8.87e-15, measured on the
+  same device, tracked as #136. The **Vulkan** residual (1.68e-14 on NVIDIA,
+  while Intel UHD 630 passes at 1.17e-14) has no established cause — that one is
+  still "do not promote a hypothesis to a cause".
 - **Metal is entirely unverified** (no Apple hardware), and it is the one
   backend currently compiled with fast math on.
 

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -94,7 +94,7 @@ Legend for the evidence column:
 |---|---|---|---|
 | **Interpreter** | nothing — it is the oracle | it evaluates the IR directly | executed (any host) |
 | **HIP / AMDGPU** | `a*b+c`; **and**, below the FP flags, an f32 multiply into an f32→f16 narrowing, plus f32 add demotion to binary16 | two mechanisms, both required: `-ffp-contract=off` forced **last** in the hiprtc option array (`Hip_rtc.base_options` / `hiprtc_options`), *and* the `asm volatile("" : "+v"(x))` opacity barrier on every narrowing's argument (`Sarek_ir_cuda.sarek_f32_barrier_decl`) | executed (quoted), RX 7900 XTX / gfx1100, ROCm hiprtc: exhaustive sweep of all 63488 finite binary16 inputs — 620 device/interpreter disagreements before the barrier, 0 after. See the caveat in the opening section about the separate, inconsistent "373" |
-| **CUDA / nvrtc (f16 narrowing)** | in principle the same fusion — but NVIDIA has no fused multiply-and-convert-to-f16 instruction to fuse *into* | **nothing Sarek emits.** `ptxas` simply declines to absorb `cvt.rn.f16.f32` | machine-code, CUDA 13.3 host tools, sm_75…sm_121 — see §4. Machine-checked by `test_cuda_f16_sass`, which until this change **self-skipped in CI** for want of `nvdisasm` (§7) |
+| **CUDA / nvrtc (f16 narrowing)** | in principle the same fusion — but NVIDIA has no fused multiply-and-convert-to-f16 instruction to fuse *into* | **nothing Sarek emits.** `ptxas` simply declines to absorb `cvt.rn.f16.f32` | **executed**, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: exhaustive sweep of all 63488 finite binary16 inputs, 0 device/interpreter disagreements, with a liveness control proving the sweep can go red (§7). Also machine-code, CUDA 13.3 host tools, sm_75…sm_121 — see §4. Machine-checked by `test_cuda_f16_sass`, which until this change **self-skipped in CI** for want of `nvdisasm` (§7) |
 | **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C | **no flag** — Sarek passes an empty build-option string. Same `mul_rn`-by-construction defence as CUDA | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
@@ -110,11 +110,17 @@ Legend for the evidence column:
 **You may rely on, today:**
 
 - **f32 arithmetic agreeing with the interpreter on HIP/AMDGPU**, including f16
-  round-trips. This is the only backend where the f16 discipline has been
-  confirmed by execution.
+  round-trips.
+- **The f16 discipline agreeing with the interpreter on NVIDIA**, via the
+  CUDA/C (nvrtc) path — executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver
+  580.119.02, exhaustive over all 63488 finite binary16 inputs, **0**
+  disagreements (§7). Note this is the **CUDA/C** path: the PTX backend
+  refuses kernel-level f16 by design (`#57` slice 2, a located
+  `Ptx_codegen_error`), so there is nothing to rely on there yet.
 - **`Sarek_df64` meeting its precision contract on CUDA/PTX and OpenCL on
-  NVIDIA Pascal, and on OpenCL on AMD** — with the `sqrt` residual recorded in
-  `Sarek_df64`'s header still open.
+  NVIDIA Pascal, and on OpenCL on AMD** — `sqrt` on CUDA/PTX is now included
+  (8.53e-15, executed; it was the `sqrt.approx.f32` seed). The OpenCL and
+  Vulkan `sqrt` residuals recorded in `Sarek_df64`'s header are still open.
 - **No `-use_fast_math` / `-ftz=true` reaching nvrtc**, enforced rather than
   documented (§5) — in **both** the inline (`--ftz=true`) and the separated
   (`--ftz true`) spelling, and fail-closed on a bare `--ftz` whose value cannot
@@ -129,8 +135,9 @@ Legend for the evidence column:
 - **Vulkan `fma` being correctly rounded.** On Mesa RADV it is not, and
   `Sarek_df64` mul/div is ~5.8e-08 there — a *documented*, unfixed deviation,
   not a bug to rediscover.
-- **f16 on NVIDIA hardware.** The codegen question is settled at machine-code
-  level; no f16 kernel has ever been executed on an NVIDIA GPU (§7).
+- **f16 on NVIDIA through the PTX backend.** The CUDA/C path is now confirmed
+  by execution (above), but `Sarek_ir_ptx` still refuses kernel-level f16
+  outright, so "f16 works on CUDA" is true only of CUDA/C.
 - **A product you compute yourself staying unfused across a `Sarek_df64`
   boundary.** `[@sarek.module]` bodies are inlined into your kernel, so
   `df64_add_f32 acc (x *. y)` re-creates the exact fusable pattern the library
@@ -362,26 +369,64 @@ declaration only*.
 
 ---
 
-## 7. What cannot be verified without NVIDIA hardware
+## 7. What NVIDIA hardware settled, and what is still open
 
-There is no NVIDIA GPU on the machine this policy was written on. Host-side
-`ptxas`/`nvdisasm`/`nvcc` (CUDA 13.3) cover more architectures than any single
-GPU would, but they cover a different question. Explicitly still open:
+This section was written when there was no NVIDIA GPU on this project's
+machines. A GTX 1070 Max-Q (**sm_61 Pascal, CUDA 12.9, driver 580.119.02**)
+became available on 2026-07-26 and closed two of its three bullets. Note sm_61
+is *below* the sm_75…sm_121 range the host-side sweeps cover, so it is a
+genuinely different sample rather than a repeat.
 
-- **No f16 CUDA kernel has ever been executed on NVIDIA hardware.** The
-  interpreter-agreement claim for f16 is HIP-only. The remaining gap is narrow —
-  a hardware conversion-rounding question (does `F2FP.F16.F32` round to
-  nearest-even on ties?), not a codegen one — but it is not closed.
-- **Offline `ptxas` is not the driver JIT.** Sarek loads PTX through
-  `cuModuleLoadData`, so on a real machine the assembling compiler is the
-  *driver's* ptxas, a different build from `/opt/cuda/bin/ptxas`. Nothing here
-  constrains it.
-- **One toolkit version.** Every CUDA measurement in this document is CUDA 13.3.
-  CI runs 12.6. The result is stable across eight architectures and every
-  optimisation level and flag combination tried, which is an argument for it
-  being a durable `ptxas` property rather than a 13.3 accident — an argument,
-  not a measurement. **If the SASS gate ever fails on CI at 12.6 while passing
-  at 13.3, that difference is the finding.**
+**CLOSED — f16 executed on NVIDIA hardware.** The interpreter-agreement claim
+for f16 is no longer HIP-only. Exhaustive over all **63488** finite binary16
+inputs, on the `f16_midround` kernel (the one whose mid-expression narrowing is
+the whole point of the discipline):
+
+| check | result |
+|---|---|
+| interpreter vs CPU reference | 0 / 63488 |
+| CUDA vs CPU reference | 0 / 63488 |
+| **CUDA == interpreter, bit-identical** | **0 / 63488** |
+| liveness control (`cuda(scale)` vs `interp(midround)`) | **63085 / 63488** — the sweep can go red |
+
+That also answers the narrow hardware question this bullet used to name: the
+conversion **does** round to nearest-even on ties, since the domain sweep
+contains the ties and none disagreed. At sm_61 the narrowing is `F2F.F16.F32`
+(the unpacked form §4 notes sm_75 emits) rather than the packed `F2FP`.
+
+A zero here would be worthless without the liveness control — see the last row.
+Reporting an exhaustive agreement without showing the harness can produce a
+nonzero is the failure mode this table is shaped to avoid.
+
+**CLOSED — the driver JIT agrees with offline `ptxas`.** These runs load PTX
+through `cuModuleLoadData`, so the assembling compiler was the *driver's* ptxas
+(580.119.02), not `/opt/cuda/bin/ptxas`. It produced interpreter-identical f16
+results and a `Sarek_df64` that meets its contract, so the driver JIT is no
+longer an unconstrained variable — on this driver and this architecture.
+
+**CLOSED — a second toolkit version.** These measurements are **CUDA 12.9**,
+between CI's 12.6 and this document's 13.3. The `ptxas`-declines-to-fuse
+property now has two independent toolkit samples rather than one.
+
+**Independently confirmed: the removed CUDA barrier really was inert.** §4
+concluded that from byte-identical cubins with no device. Executing the
+barrier-free codegen on real hardware gives the same 0/63488 — and while the
+barrier still existed, neutralising it left the sm_61 SASS **byte-identical**
+(`F2F.F32.F16.RZ / FMUL32I / F2F.F16.F32 / F2F.F32.F16.RZ / FADD /
+F2F.F16.F32`, every mandated rounding its own instruction). Two methods, two
+architectures ranges, same answer.
+
+**Still open:**
+
+- **f16 on the PTX backend.** `Sarek_ir_ptx` refuses kernel-level f16 (`#57`
+  slice 2). Everything above is the **CUDA/C** path.
+- **One GPU, one architecture.** sm_61 has no tensor cores, no bf16 and no FP8,
+  so nothing here constrains `mma`, bf16 or FP8 contraction, and no f16
+  *performance* claim can be made from it (f16 runs at 1/64 f32 rate on GP104).
+  Those need Ampere or newer.
+- **Still one driver.** The driver-JIT result above is 580.119.02 on Pascal.
+  **If the SASS gate ever fails on CI at 12.6 while passing at 13.3, that
+  difference is still the finding.**
 
   > **This was not actually being checked.** `nvdisasm` ships in `cuda-nvdisasm`,
   > not in `cuda-nvcc`, and it was **absent from the built CI image** — verified

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -28,8 +28,9 @@
  *   - Relative error, per operation, as actually measured by test_df64.ml on
  *     a backend that meets the contract (see PER-BACKEND STATUS for which):
  *     add 5.3e-15, sub 6.5e-15 (~2^-47); mul 9.1e-15, div 5.1e-15
- *     (~2^-46.6 .. 2^-47.8); sqrt 8.5e-15 at best, but see KNOWN RESIDUAL -
- *     it reaches 1.8e-14 on some NVIDIA paths. Roughly double the 24-bit
+ *     (~2^-46.6 .. 2^-47.8); sqrt 8.5e-15 on every backend that lowers it to
+ *     a correctly rounded f32 sqrt, but see KNOWN RESIDUAL - it still reaches
+ *     1.8e-14 on the NVIDIA OpenCL and Vulkan paths. Roughly double the 24-bit
  *     float32 precision. This is a measured range, NOT a proven bound: do
  *     not quote a single "2^-47" figure for the whole op set.
  *   - Exponent range is that of float32 (~1e-38 .. ~3e38 normalised).
@@ -86,23 +87,24 @@
  *
  *   CUDA/PTX on NVIDIA Pascal
  *   (GTX 1070 Max-Q, sm_61, CUDA 12.9, driver 580.119.02)
- *       mul 9.07e-15, div 5.08e-15 - contract met.
- *       sqrt 1.42e-14 - AT the 1.42e-14 (2^-46) tolerance boundary; both
- *       print as 1.42e-14 at three significant figures, and the measured
- *       value is the larger of the two, so the test records it as failing.
- *       STALE: this sqrt figure was measured while the PTX backend still
- *       lowered the f32 [sqrt] intrinsic to [sqrt.approx.f32]. That lowering
- *       has since been changed to [sqrt.rn.f32] and the figure has NOT been
- *       remeasured - see KNOWN RESIDUAL below. mul and div are unaffected by
- *       that change and still stand.
+ *       mul 9.07e-15, div 5.08e-15, sqrt 8.53e-15 - contract met.
+ *       The sqrt figure is post-[sqrt.rn.f32] and EXECUTED on that device
+ *       (2026-07-26). With the older [sqrt.approx.f32] lowering, measured on
+ *       the same box in the same session, it was 1.42e-14 and test_df64
+ *       recorded it as failing. 8.53e-15 is bit-for-bit the interpreter's
+ *       figure, which is the strongest form this claim can take: the device
+ *       now matches the software reference exactly.
  *       Before the contraction barrier: mul 5.92e-08, div 5.64e-08,
  *       sqrt 2.88e-08, i.e. plain float32.
  *
  *   OpenCL on NVIDIA Pascal (same GPU and driver)
- *       mul 9.07e-15, div 5.08e-15, sqrt 9.80e-15 - contract met.
- *       Before the barrier it showed the same collapse as CUDA/PTX
+ *       mul 9.07e-15, div 5.08e-15, sqrt 9.80e-15 - contract met in
+ *       test_df64. Before the barrier it showed the same collapse as CUDA/PTX
  *       (mul 5.92e-08, div 5.85e-08, sqrt 2.88e-08). No OpenCL-specific
  *       change was needed: FP_CONTRACT is defeated by the same barrier.
+ *       test_real64's df64 fallback still fails here at sqrt 1.81e-14; that
+ *       is the SAME bug class as the PTX one, in a different backend, and it
+ *       is not fixed - see KNOWN RESIDUAL.
  *
  *   Vulkan on NVIDIA Pascal (same GPU and driver)
  *       mul 9.07e-15, div 5.08e-15, sqrt 1.24e-14 - contract met, and met
@@ -135,11 +137,15 @@
  *
  *   Metal, WGSL: UNTESTED.
  *
- * KNOWN RESIDUAL: df64_sqrt on NVIDIA (cause found, fix landed, NOT remeasured)
+ * KNOWN RESIDUAL: df64_sqrt on NVIDIA
+ *   (CUDA/PTX: cause found, fixed, REMEASURED and closed 2026-07-26.
+ *    OpenCL and Vulkan: same bug class, still open.)
+ *
  *   After the contraction barrier, sqrt still landed at or just above the
- *   2^-46 tolerance on some NVIDIA paths: 1.42e-14 (CUDA/PTX, test_df64) and
- *   1.68e-14 / 1.81e-14 (CUDA/PTX and OpenCL, test_real64's df64 fallback).
- *   Those are all pre-[sqrt.rn.f32] numbers.
+ *   2^-46 tolerance on several NVIDIA paths: 1.42e-14 (CUDA/PTX, test_df64),
+ *   1.68e-14 (CUDA/PTX, test_real64's df64 fallback), 1.81e-14 (OpenCL, same
+ *   test) and 1.68e-14 (Vulkan, same test). All four reproduced on a GTX 1070
+ *   Max-Q (sm_61, CUDA 12.9, driver 580.119.02) before any change.
  *
  *   It is NOT the contraction bug - that cost sqrt 2.88e-08, and the barrier
  *   removed it - and it pre-dates the barrier: Vulkan on the same GPU, never
@@ -149,12 +155,11 @@
  *   at 1.08e-14 - it is NOT uniformly poor, and that spread is itself part of
  *   the evidence below.
  *
- *   STATUS: the MECHANISM is established and the lowering has been changed.
- *   The RESULTING PRECISION HAS NOT BEEN REMEASURED on NVIDIA hardware.
- *   Keep those two apart. The reason this library's precision claim went
- *   wrong for four years is that a plausible-sounding statement was recorded
- *   as a finding, so nothing below may be upgraded from "emitted" to
- *   "measured" without a run on a real NVIDIA device.
+ *   STATUS: mechanism established, lowering changed, and the resulting
+ *   precision EXECUTED on NVIDIA hardware on 2026-07-26 (GTX 1070 Max-Q,
+ *   sm_61, CUDA 12.9, driver 580.119.02). Both CUDA/PTX rows are closed. The
+ *   OpenCL and Vulkan rows are NOT - they are the same bug class in backends
+ *   this change does not touch, and they are still failing.
  *
  *   ESTABLISHED (by dumping the generated PTX for a df64_sqrt kernel, offline,
  *   no device needed - see sarek/tests/e2e/test_df64_no_contraction.ml):
@@ -183,17 +188,39 @@
  *   into force for [sqrt] on PTX. This is a GLOBAL change - it affects every
  *   f32 sqrt in every PTX kernel, not only df64.
  *
- *   STILL OWED, on an sm_61 NVIDIA device:
- *     - test_df64 CUDA/PTX sqrt: was 1.42e-14, now ?
- *     - test_real64 df64-fallback sqrt: was 1.68e-14 / 1.81e-14, now ?
- *     - the throughput cost on an ordinary f32 sqrt kernel. Statically, at
- *       sm_86, [sqrt.rn.f32] is ~10 hot-path instructions (MUFU.RSQ + a
- *       Newton step) against ~4 for [sqrt.approx.f32] (MUFU.SQRT), plus a
- *       cold denormal/inf/nan slowpath subroutine that normal data never
- *       enters. Both issue exactly one MUFU op. Not yet timed on sm_61.
+ *   MEASURED on sm_61 / CUDA 12.9 (one line changed, everything else equal,
+ *   both directions built and executed in the same session):
+ *     - test_df64 CUDA/PTX sqrt:          1.42e-14 FAIL -> 8.53e-15 PASS
+ *       (test_df64 goes from FAILED(1) to PASSED as a whole)
+ *     - test_real64 CUDA/PTX fallback:    1.68e-14 FAIL -> 8.87e-15 PASS
+ *   Both land bit-for-bit on the interpreter's figure for the same input set
+ *   (8.53e-15 and 8.87e-15 respectively), so the seed was the entire defect
+ *   on this path - there is no second contributor left to find.
  *
- *   Until those are measured this stays open. Do not paper over it by
- *   widening the tolerance.
+ *   COST, measured (bench_nbody n=4096, sqrt-dominated inner loop, sm_61):
+ *   1.543 ms / 10.87 GFLOP/s with [sqrt.approx.f32] against 1.731 ms /
+ *   9.69 GFLOP/s with [sqrt.rn.f32] - about 12% more kernel time, stable to
+ *   ~0.2% across repeats. At sm_61 SASS the hot path goes from 1 MUFU.SQRT +
+ *   2 FMUL (18 instructions) to 1 MUFU.RSQ + 4 FMUL/FFMA and a not-taken
+ *   branch into a cold denormal/inf/nan slowpath (48 instructions). Both
+ *   issue exactly one MUFU on the hot path, which is why the cost is ~12%
+ *   and not ~2.7x. Correctness is the right trade here; code that wants the
+ *   fast form still has [rsqrt], which is unchanged.
+ *
+ *   STILL OPEN - the same bug class in two other backends, both measured
+ *   failing on the same GPU by test_real64's df64 fallback:
+ *     - OpenCL, sqrt 1.81e-14. CAUSE IDENTIFIED AND CONFIRMED BY EXPERIMENT:
+ *       the OpenCL backend calls clBuildProgram with NO build options
+ *       (Opencl_plugin_base.ml), and OpenCL's default permits a sqrt of up to
+ *       3 ulp. Building with [-cl-fp32-correctly-rounded-divide-sqrt] moves
+ *       it to 8.87e-15 PASS - executed on sm_61 on 2026-07-26. That one-line
+ *       change is deliberately NOT part of this fix; it is a different
+ *       backend and belongs in its own change.
+ *     - Vulkan, sqrt 1.68e-14. Same shape, cause not yet established. Note
+ *       Intel UHD 630 Vulkan passes at 1.17e-14 on the same test, so this is
+ *       NVIDIA-glslang-specific, not a Vulkan-wide property.
+ *
+ *   Do not paper over either by widening the tolerance.
  *
  * References:
  *   - T.J. Dekker, "A floating-point technique for extending the available

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -90,6 +90,11 @@
  *       sqrt 1.42e-14 - AT the 1.42e-14 (2^-46) tolerance boundary; both
  *       print as 1.42e-14 at three significant figures, and the measured
  *       value is the larger of the two, so the test records it as failing.
+ *       STALE: this sqrt figure was measured while the PTX backend still
+ *       lowered the f32 [sqrt] intrinsic to [sqrt.approx.f32]. That lowering
+ *       has since been changed to [sqrt.rn.f32] and the figure has NOT been
+ *       remeasured - see KNOWN RESIDUAL below. mul and div are unaffected by
+ *       that change and still stand.
  *       Before the contraction barrier: mul 5.92e-08, div 5.64e-08,
  *       sqrt 2.88e-08, i.e. plain float32.
  *
@@ -130,10 +135,11 @@
  *
  *   Metal, WGSL: UNTESTED.
  *
- * KNOWN RESIDUAL: df64_sqrt on NVIDIA (tracked separately; NOT fixed here)
- *   After the contraction barrier, sqrt still lands at or just above the
+ * KNOWN RESIDUAL: df64_sqrt on NVIDIA (cause found, fix landed, NOT remeasured)
+ *   After the contraction barrier, sqrt still landed at or just above the
  *   2^-46 tolerance on some NVIDIA paths: 1.42e-14 (CUDA/PTX, test_df64) and
  *   1.68e-14 / 1.81e-14 (CUDA/PTX and OpenCL, test_real64's df64 fallback).
+ *   Those are all pre-[sqrt.rn.f32] numbers.
  *
  *   It is NOT the contraction bug - that cost sqrt 2.88e-08, and the barrier
  *   removed it - and it pre-dates the barrier: Vulkan on the same GPU, never
@@ -143,17 +149,24 @@
  *   at 1.08e-14 - it is NOT uniformly poor, and that spread is itself part of
  *   the evidence below.
  *
- *   THE CAUSE IS NOT ESTABLISHED. Do not repeat any cause below as fact
- *   until it has been measured; the reason this library's precision claim
- *   went wrong for four years is that a plausible-sounding statement was
- *   recorded as a finding.
+ *   STATUS: the MECHANISM is established and the lowering has been changed.
+ *   The RESULTING PRECISION HAS NOT BEEN REMEASURED on NVIDIA hardware.
+ *   Keep those two apart. The reason this library's precision claim went
+ *   wrong for four years is that a plausible-sounding statement was recorded
+ *   as a finding, so nothing below may be upgraded from "emitted" to
+ *   "measured" without a run on a real NVIDIA device.
  *
- *   Leading hypothesis, on circumstantial evidence only: the PTX backend
- *   lowers the float32 [sqrt] intrinsic to [sqrt.approx.f32]
- *   (sarek/codegen/Sarek_ir_ptx_expr.ml), which is ~1 ulp rather than
- *   correctly rounded. df64_sqrt uses that result as the Newton seed [y],
- *   and a Karp correction step squares the seed error, so a 2^-23 seed error
- *   lands near 2^-46 - the observed magnitude. Three observations fit:
+ *   ESTABLISHED (by dumping the generated PTX for a df64_sqrt kernel, offline,
+ *   no device needed - see sarek/tests/e2e/test_df64_no_contraction.ml):
+ *   the PTX backend lowered the float32 [sqrt] intrinsic to [sqrt.approx.f32]
+ *   (~1 ulp, not correctly rounded), df64_sqrt used that as its Newton seed
+ *   [y], and [sqrt.approx.f32] was the ONLY non-correctly-rounded instruction
+ *   in the whole emitted df64_sqrt body - every other operation is
+ *   [fma.rn.f32] (the contraction barrier), [div.rn.f32] (audit finding M2),
+ *   or an exact add/sub. A Karp correction step cannot recover an error that
+ *   is already in its own seed.
+ *
+ *   Three observations fit that mechanism:
  *     - the interpreter runs the identical algorithm with a correctly
  *       rounded sqrt and reaches 8.53e-15;
  *     - on the SAME GPU, OpenCL reaches 9.80e-15 while CUDA/PTX sits at
@@ -162,15 +175,25 @@
  *     - the identical bug class was already found and fixed one operator
  *       over: [div.approx.f32] was replaced by [div.rn.f32] in the same
  *       emitter precisely because it "eroded Sarek_df64's error budget"
- *       (audit finding M2). [sqrt.rn.f32] exists and is already emitted
- *       elsewhere in that file.
- *   The cheap experiment is to swap [sqrt.approx.f32] for [sqrt.rn.f32] and
- *   re-measure on NVIDIA; it was NOT run here (no NVIDIA device attached to
- *   this working tree) and it is out of scope for the contraction fix.
- *   Note this also means the "IEEE-exact float32 ops" requirement above is
- *   currently NOT met by the PTX backend for [sqrt].
+ *       (audit finding M2). [sqrt.rn.f32] exists and was already emitted
+ *       elsewhere in that file (hypot).
  *
- *   Unresolved; do not paper over it by widening the tolerance.
+ *   DONE: the emitter now issues [sqrt.rn.f32] for the f32 [sqrt] intrinsic,
+ *   which also brings the "IEEE-exact float32 ops" requirement above back
+ *   into force for [sqrt] on PTX. This is a GLOBAL change - it affects every
+ *   f32 sqrt in every PTX kernel, not only df64.
+ *
+ *   STILL OWED, on an sm_61 NVIDIA device:
+ *     - test_df64 CUDA/PTX sqrt: was 1.42e-14, now ?
+ *     - test_real64 df64-fallback sqrt: was 1.68e-14 / 1.81e-14, now ?
+ *     - the throughput cost on an ordinary f32 sqrt kernel. Statically, at
+ *       sm_86, [sqrt.rn.f32] is ~10 hot-path instructions (MUFU.RSQ + a
+ *       Newton step) against ~4 for [sqrt.approx.f32] (MUFU.SQRT), plus a
+ *       cold denormal/inf/nan slowpath subroutine that normal data never
+ *       enters. Both issue exactly one MUFU op. Not yet timed on sm_61.
+ *
+ *   Until those are measured this stays open. Do not paper over it by
+ *   widening the tolerance.
  *
  * References:
  *   - T.J. Dekker, "A floating-point technique for extending the available

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -25,14 +25,20 @@
  *   Sarek_df64.Host to fill/read them.
  *
  * PRECISION CONTRACT
- *   - Relative error, per operation, as actually measured by test_df64.ml on
- *     a backend that meets the contract (see PER-BACKEND STATUS for which):
- *     add 5.3e-15, sub 6.5e-15 (~2^-47); mul 9.1e-15, div 5.1e-15
- *     (~2^-46.6 .. 2^-47.8); sqrt 8.5e-15 on every backend that lowers it to
- *     a correctly rounded f32 sqrt, but see KNOWN RESIDUAL - it still reaches
- *     1.8e-14 on the NVIDIA OpenCL and Vulkan paths. Roughly double the 24-bit
- *     float32 precision. This is a measured range, NOT a proven bound: do
- *     not quote a single "2^-47" figure for the whole op set.
+ *   - Worst-case relative error, per operation, as MEASURED by test_df64.ml
+ *     over ITS OWN input set, on the specific devices and toolchains listed in
+ *     PER-BACKEND STATUS: add 5.3e-15, sub 6.5e-15 (~2^-47); mul 9.1e-15,
+ *     div 5.1e-15 (~2^-46.6 .. 2^-47.8); sqrt 8.5e-15 on the devices where it
+ *     was measured after the correctly-rounded lowering, but see KNOWN
+ *     RESIDUAL - it still reaches 1.8e-14 on the NVIDIA OpenCL and Vulkan
+ *     paths. Roughly double the 24-bit float32 precision.
+ *
+ *     These are SAMPLED MAXIMA, not bounds and not guarantees. They say what
+ *     the worst input in one test happened to produce on one device under one
+ *     toolchain; a different input set, device or compiler may be worse. Do
+ *     not quote a single "2^-47" figure for the whole op set, and do not
+ *     restate any figure here for a device it was not measured on - that
+ *     generalisation is the exact mistake described under PER-BACKEND STATUS.
  *   - Exponent range is that of float32 (~1e-38 .. ~3e38 normalised).
  *     Underflow follows float32. OVERFLOW DOES NOT: once a leading product
  *     or sum reaches an infinity, the error term becomes an infinity of the
@@ -87,13 +93,22 @@
  *
  *   CUDA/PTX on NVIDIA Pascal
  *   (GTX 1070 Max-Q, sm_61, CUDA 12.9, driver 580.119.02)
- *       mul 9.07e-15, div 5.08e-15, sqrt 8.53e-15 - contract met.
+ *       Measured worst-case relative error over test_df64's input set:
+ *       mul 9.07e-15, div 5.08e-15, sqrt 8.53e-15 - contract met on this
+ *       device and toolchain.
  *       The sqrt figure is post-[sqrt.rn.f32] and EXECUTED on that device
  *       (2026-07-26). With the older [sqrt.approx.f32] lowering, measured on
  *       the same box in the same session, it was 1.42e-14 and test_df64
- *       recorded it as failing. 8.53e-15 is bit-for-bit the interpreter's
- *       figure, which is the strongest form this claim can take: the device
- *       now matches the software reference exactly.
+ *       recorded it as failing.
+ *       That 8.53e-15 equals the figure the interpreter reports for the same
+ *       input set. Read that precisely: it is agreement between two SUMMARY
+ *       STATISTICS - the max over the inputs - not a demonstration that the
+ *       device and the interpreter produce identical results element by
+ *       element. No per-element device-vs-interpreter comparison was run for
+ *       df64 (unlike the f16 sweep, which did compare bit patterns). What it
+ *       licenses is: the seed was large enough to account for the whole
+ *       pre-fix gap, and nothing detectable BY THIS TEST remains. It does not
+ *       license "the device matches the software reference".
  *       Before the contraction barrier: mul 5.92e-08, div 5.64e-08,
  *       sqrt 2.88e-08, i.e. plain float32.
  *
@@ -188,14 +203,19 @@
  *   into force for [sqrt] on PTX. This is a GLOBAL change - it affects every
  *   f32 sqrt in every PTX kernel, not only df64.
  *
- *   MEASURED on sm_61 / CUDA 12.9 (one line changed, everything else equal,
- *   both directions built and executed in the same session):
+ *   MEASURED worst-case relative error on a GTX 1070 Max-Q (sm_61, CUDA 12.9,
+ *   driver 580.119.02), one line changed and everything else equal, both
+ *   directions built and executed in the same session. Each figure is the max
+ *   over that test's own input set, on that one device and toolchain:
  *     - test_df64 CUDA/PTX sqrt:          1.42e-14 FAIL -> 8.53e-15 PASS
  *       (test_df64 goes from FAILED(1) to PASSED as a whole)
  *     - test_real64 CUDA/PTX fallback:    1.68e-14 FAIL -> 8.87e-15 PASS
- *   Both land bit-for-bit on the interpreter's figure for the same input set
- *   (8.53e-15 and 8.87e-15 respectively), so the seed was the entire defect
- *   on this path - there is no second contributor left to find.
+ *   Both post-fix figures coincide with what the interpreter reports for the
+ *   same input sets. That is agreement between two summary statistics, not
+ *   evidence of element-wise identity - no per-element comparison was run.
+ *   The honest reading: the seed accounted for the whole gap this test can
+ *   see, and no FURTHER contributor is detectable by it. A different input
+ *   set could still expose one.
  *
  *   COST, measured (bench_nbody n=4096, sqrt-dominated inner loop, sm_61):
  *   1.535 ms / 10.93 GFLOP/s with [sqrt.approx.f32] against 1.722 ms /

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -198,8 +198,8 @@
  *   on this path - there is no second contributor left to find.
  *
  *   COST, measured (bench_nbody n=4096, sqrt-dominated inner loop, sm_61):
- *   1.543 ms / 10.87 GFLOP/s with [sqrt.approx.f32] against 1.731 ms /
- *   9.69 GFLOP/s with [sqrt.rn.f32] - about 12% more kernel time, stable to
+ *   1.535 ms / 10.93 GFLOP/s with [sqrt.approx.f32] against 1.722 ms /
+ *   9.75 GFLOP/s with [sqrt.rn.f32] - about 12% more kernel time, stable to
  *   ~0.2% across repeats. At sm_61 SASS the hot path goes from 1 MUFU.SQRT +
  *   2 FMUL (18 instructions) to 1 MUFU.RSQ + 4 FMUL/FFMA and a not-taken
  *   branch into a cold denormal/inf/nan slowpath (48 instructions). Both

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1801,13 +1801,30 @@ and transcendental_intrinsic_handlers () :
         Some (intr_f32_op2 buf alloc "div.approx.f32" r_sin r_cos) );
     ( ["sqrt"],
       fun buf alloc env _path _name args ->
+        (* Correctly-rounded square root, for the same reason division is
+           (audit finding M2, [div.rn.f32] above): [sqrt.approx.f32] is ~1 ulp
+           rather than correctly rounded, which made PTX the only backend whose
+           f32 [sqrt] does not meet Sarek's "IEEE-exact float32 ops" contract.
+           The motivating case is Sarek_df64: [df64_sqrt] uses this
+           instruction's result as its Newton seed, and [sqrt.approx.f32] was
+           the ONLY non-correctly-rounded instruction in the whole emitted
+           df64_sqrt body -- every other op is fma.rn, div.rn, or an exact
+           add/sub. Executed on a GTX 1070 Max-Q (sm_61, CUDA 12.9): df64_sqrt
+           goes from 1.42e-14 (failing 2^-46) to 8.53e-15, the interpreter's
+           own figure, at a cost of ~12% on a sqrt-dominated kernel.
+
+           This is a GLOBAL choice, not a per-caller one: there is no separate
+           df64 sqrt IR node, so [df64_sqrt] and user code reach this same arm.
+           Fast approximate roots stay available to intrinsics that are already
+           documented as approximate -- [rsqrt] below keeps
+           [rsqrt.approx.f32]. *)
         Some
           (intr_unary_native
              buf
              alloc
              env
              "sqrt"
-             ~f32_op:(Some "sqrt.approx.f32")
+             ~f32_op:(Some "sqrt.rn.f32")
              ~f64_op:(Some "sqrt.rn.f64")
              args) );
     ( ["exp"],

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1809,9 +1809,11 @@ and transcendental_intrinsic_handlers () :
            instruction's result as its Newton seed, and [sqrt.approx.f32] was
            the ONLY non-correctly-rounded instruction in the whole emitted
            df64_sqrt body -- every other op is fma.rn, div.rn, or an exact
-           add/sub. Executed on a GTX 1070 Max-Q (sm_61, CUDA 12.9): df64_sqrt
-           goes from 1.42e-14 (failing 2^-46) to 8.53e-15, the interpreter's
-           own figure, at a cost of ~12% on a sqrt-dominated kernel.
+           add/sub. Executed on a GTX 1070 Max-Q (sm_61, CUDA 12.9): df64_sqrt's
+           measured worst-case relative error over test_df64's input set goes
+           from 1.42e-14 (failing 2^-46) to 8.53e-15, matching what the
+           interpreter reports for the same inputs, at a cost of ~12% on a
+           sqrt-dominated kernel. A sampled maximum on one device, not a bound.
 
            This is a GLOBAL choice, not a per-caller one: there is no separate
            df64 sqrt IR node, so [df64_sqrt] and user code reach this same arm.

--- a/sarek/tests/e2e/test_df64_no_contraction.ml
+++ b/sarek/tests/e2e/test_df64_no_contraction.ml
@@ -145,15 +145,28 @@ let check name ptx =
    correctly rounded, and it was the ONLY non-correctly-rounded instruction in
    the whole emitted df64_sqrt body -- every other op is fma.rn / div.rn / an
    exact add-sub. Same bug class as [div.approx.f32] (audit finding M2), one
-   operator over. This asserts the emitted-PTX property; the precision it buys
-   is measured by test_df64.ml on real NVIDIA hardware. *)
+   operator over.
+
+   SCOPE OF THIS ASSERTION: it proves which instruction is EMITTED, nothing
+   more. It does not measure precision, and the precision this buys on NVIDIA
+   hardware has NOT been remeasured since the lowering changed -- see the
+   KNOWN RESIDUAL block in sarek/Sarek_df64/Sarek_df64.ml for what is and is
+   not established.
+
+   Both needles are anchored with a leading space, because "sqrt.approx.f32"
+   is a SUBSTRING of "rsqrt.approx.f32": [rsqrt] deliberately keeps the
+   approximate form, and rsqrt is the textbook Newton seed for a square root,
+   so an unanchored count here would fail with a message asserting the exact
+   opposite of what happened the day someone reseeds df64_sqrt with it. The
+   [check] function above anchors for the same reason (trailing space on
+   "mul.f32 "). *)
 let check_sqrt_seed ptx =
-  let approx = count "sqrt.approx.f32" ptx in
-  let exact = count "sqrt.rn.f32" ptx in
+  let approx = count " sqrt.approx.f32 " ptx in
+  let exact = count " sqrt.rn.f32 " ptx in
   let ok = approx = 0 && exact > 0 in
   Printf.printf
     "  %-10s sqrt.approx.f32 = %d (want 0), sqrt.rn.f32 = %d (want > 0) %s\n%!"
-    "df64_sqrt"
+    "df64_seed"
     approx
     exact
     (if ok then "PASS" else "FAIL") ;
@@ -161,9 +174,8 @@ let check_sqrt_seed ptx =
     incr failures ;
     Printf.printf
       "    -> df64_sqrt's Newton seed is not correctly rounded; the Karp\n\
-      \       correction cannot recover the seed's error and df64_sqrt loses\n\
-      \       precision on PTX only. See \"KNOWN RESIDUAL\" in\n\
-      \       sarek/Sarek_df64/Sarek_df64.ml.\n\
+      \       correction cannot recover an error already in its own seed.\n\
+      \       See \"KNOWN RESIDUAL\" in sarek/Sarek_df64/Sarek_df64.ml.\n\
        %!"
   end
 

--- a/sarek/tests/e2e/test_df64_no_contraction.ml
+++ b/sarek/tests/e2e/test_df64_no_contraction.ml
@@ -148,10 +148,13 @@ let check name ptx =
    operator over.
 
    SCOPE OF THIS ASSERTION: it proves which instruction is EMITTED, nothing
-   more. It does not measure precision, and the precision this buys on NVIDIA
-   hardware has NOT been remeasured since the lowering changed -- see the
-   KNOWN RESIDUAL block in sarek/Sarek_df64/Sarek_df64.ml for what is and is
-   not established.
+   more -- it does not measure precision, and it runs with no device. The
+   precision it buys HAS since been measured, on a GTX 1070 Max-Q (sm_61,
+   CUDA 12.9): df64_sqrt goes from 1.42e-14 (failing) to 8.53e-15, the
+   interpreter's own figure. Keep the two claims apart anyway: if this
+   assertion ever goes red the seed is wrong again, whatever any precision
+   test happens to say on whatever device CI has that day. See the KNOWN
+   RESIDUAL block in sarek/Sarek_df64/Sarek_df64.ml.
 
    Both needles are anchored with a leading space, because "sqrt.approx.f32"
    is a SUBSTRING of "rsqrt.approx.f32": [rsqrt] deliberately keeps the

--- a/sarek/tests/e2e/test_df64_no_contraction.ml
+++ b/sarek/tests/e2e/test_df64_no_contraction.ml
@@ -141,11 +141,38 @@ let check name ptx =
         name
   end
 
+(* The Newton seed of df64_sqrt. [sqrt.approx.f32] is ~1 ulp rather than
+   correctly rounded, and it was the ONLY non-correctly-rounded instruction in
+   the whole emitted df64_sqrt body -- every other op is fma.rn / div.rn / an
+   exact add-sub. Same bug class as [div.approx.f32] (audit finding M2), one
+   operator over. This asserts the emitted-PTX property; the precision it buys
+   is measured by test_df64.ml on real NVIDIA hardware. *)
+let check_sqrt_seed ptx =
+  let approx = count "sqrt.approx.f32" ptx in
+  let exact = count "sqrt.rn.f32" ptx in
+  let ok = approx = 0 && exact > 0 in
+  Printf.printf
+    "  %-10s sqrt.approx.f32 = %d (want 0), sqrt.rn.f32 = %d (want > 0) %s\n%!"
+    "df64_sqrt"
+    approx
+    exact
+    (if ok then "PASS" else "FAIL") ;
+  if not ok then begin
+    incr failures ;
+    Printf.printf
+      "    -> df64_sqrt's Newton seed is not correctly rounded; the Karp\n\
+      \       correction cannot recover the seed's error and df64_sqrt loses\n\
+      \       precision on PTX only. See \"KNOWN RESIDUAL\" in\n\
+      \       sarek/Sarek_df64/Sarek_df64.ml.\n\
+       %!"
+  end
+
 let () =
   print_endline "Sarek_df64 PTX contraction guard:" ;
   check "df64_mul" (ptx_of mul_kernel) ;
   check "df64_div" (ptx_of div_kernel) ;
   check "df64_sqrt" (ptx_of sqrt_kernel) ;
+  check_sqrt_seed (ptx_of sqrt_kernel) ;
   check "df64_of_i32" (ptx_of of_int32_kernel) ;
   if !failures = 0 then print_endline "test_df64_no_contraction PASSED"
   else begin

--- a/sarek/tests/e2e/test_df64_no_contraction.ml
+++ b/sarek/tests/e2e/test_df64_no_contraction.ml
@@ -150,8 +150,9 @@ let check name ptx =
    SCOPE OF THIS ASSERTION: it proves which instruction is EMITTED, nothing
    more -- it does not measure precision, and it runs with no device. The
    precision it buys HAS since been measured, on a GTX 1070 Max-Q (sm_61,
-   CUDA 12.9): df64_sqrt goes from 1.42e-14 (failing) to 8.53e-15, the
-   interpreter's own figure. Keep the two claims apart anyway: if this
+   CUDA 12.9): df64_sqrt's worst-case relative error over test_df64's input
+   set goes from 1.42e-14 (failing) to 8.53e-15, which is the figure the
+   interpreter reports for the same inputs. Keep the two claims apart: if this
    assertion ever goes red the seed is wrong again, whatever any precision
    test happens to say on whatever device CI has that day. See the KNOWN
    RESIDUAL block in sarek/Sarek_df64/Sarek_df64.ml.

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -800,6 +800,35 @@ let test_f32_div_correctly_rounded () =
   if contains ptx "div.approx.f32" then
     Alcotest.fail "plain f32 division must not use div.approx.f32"
 
+(** Plain f32 [sqrt] is correctly rounded, for the same reason division is: the
+    sqrt intrinsic must emit sqrt.rn.f32, not the ~1-ulp sqrt.approx.f32 (which
+    remains reserved for already-approximate intrinsics like rsqrt).
+
+    This lives here, next to the div case, rather than only in the df64 guard:
+    the df64 guard reaches this lowering through a df64_sqrt kernel, so
+    rewriting df64_sqrt would silently un-assert it. sqrt.approx.f32 shipped for
+    years because NOTHING asserted the f32 sqrt lowering anywhere. *)
+let test_f32_sqrt_correctly_rounded () =
+  let out = make_var "out" (TVec TFloat32) in
+  let a = make_var "a" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let av = EArrayRead ("a", EVar tid) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar tid),
+            EIntrinsic (["Sarek_stdlib"; "Gpu"], "sqrt", [av]) ) )
+  in
+  let mk v = DParam (v, Some {arr_elttype = TFloat32; arr_memspace = Global}) in
+  let k = base_kernel "f32_sqrt" [mk out; mk a] body [] in
+  let ptx = Sarek_ir_ptx.generate k in
+  assert_contains ptx "sqrt.rn.f32" ;
+  (* Anchored: "sqrt.approx.f32" is a substring of "rsqrt.approx.f32". *)
+  if contains ptx " sqrt.approx.f32 " then
+    Alcotest.fail "plain f32 sqrt must not use sqrt.approx.f32"
+
 (** Int64 comparison family, Not/BitNot and min/max must be class-aware (audit
     finding H2): the old code emitted setp.*.s32 / not.b32 / min.s32 on %rd
     (64-bit) registers - invalid PTX, rejected at module load. *)
@@ -2826,6 +2855,10 @@ let () =
             "plain f32 division emits div.rn.f32"
             `Quick
             test_f32_div_correctly_rounded;
+          Alcotest.test_case
+            "plain f32 sqrt emits sqrt.rn.f32"
+            `Quick
+            test_f32_sqrt_correctly_rounded;
           Alcotest.test_case
             "ECast matrix: bool setp/selp + i32<->i64 cvt pairs"
             `Quick


### PR DESCRIPTION
Settles the `df64_sqrt` residual left open by #297. **Now measured on real
NVIDIA hardware** — the gap this PR shipped with is closed.

All numbers below were executed on a **GTX 1070 Max-Q, sm_61 (Pascal), CUDA
12.9, driver 580.119.02**, one line changed and everything else held equal,
both directions built and run in the same session. Every `dune build` exit code
was checked before any test result was read.

> **Rebased onto current `main` and fully re-measured.** #310's intrinsic
> registry refactor moved this arm, and #302/#306/#308/#309/#312 landed
> alongside — including new df64 expected-failure gates that change what PASS
> means. Every figure below was re-executed on the rebased tree, not carried
> over. All precision results are identical; the `bench_nbody` figures are the
> rebased tree's own (1.535 → 1.722 ms, was 1.543 → 1.731 pre-rebase, same
> ~12%). `dune build` → 0, `dune build @fmt` → **0**.

## Before / after, executed

The premise reproduced exactly — the recorded figures were not stale or
mis-transcribed:

| test | before (`sqrt.approx.f32`) | after (`sqrt.rn.f32`) |
|---|---|---|
| `test_df64`, CUDA/PTX sqrt | **1.42e-14 FAIL** | **8.53e-15 PASS** |
| `test_real64`, CUDA/PTX df64-fallback sqrt | **1.68e-14 FAIL** | **8.87e-15 PASS** |
| `test_df64` overall | `FAILED (1 failures)` | `PASSED` |
| `test_real64` overall | `FAILED (3 failures)` | `FAILED (2 failures)` |

Every figure is a **measured worst-case relative error over that test's own
input set**, on one device and one toolchain — a sampled maximum, not a bound
and not a guarantee.

Both after-figures **coincide with what the interpreter reports for the same
inputs** (8.53e-15 and 8.87e-15). Read precisely, that is agreement between two
summary statistics, not a demonstration that device and interpreter agree
element by element — no per-element comparison was run for df64, unlike the f16
sweep further down, which did compare bit patterns. What it licenses: the seed
accounted for the whole gap *these tests can see*, so there is no partial fix to
report. It does not license "the device matches the software reference".

### The pass is not inherited from a widened band

Worth stating plainly, because it is the distinction #301 was built to make
visible. `test_df64` passes here under `main`'s **stricter** gates, not the old
ones: the tolerance now applies to every device, deviations are a strict
expected-failure allowlist reported as `KNOWN-DEVIATION` rather than `PASS`, and
**NVIDIA Vulkan is no longer allowlisted** — it is held to the full contract and
meets it at 1.24e-14. So `sqrt` going green on CUDA/PTX is a real move to
8.53e-15, not a threshold that grew to meet it. As far as I can tell this is the
first result to exercise that machinery.

`test_real64` still has 2 failures. They are **not** this bug and **not** on
this code path — see "What this does not fix".

Untouched, as expected: mul 9.07e-15, div 5.08e-15, add 5.33e-15, sub 6.51e-15
before and after.

## PTX and SASS: the change survives ptxas

We have twice been burned by an emitter change ptxas silently undid, so both
levels were inspected rather than assumed.

**PTX.** The generated diff for a `df64_sqrt` kernel is exactly one line, and
nothing else in the body moved:

```
-     sqrt.approx.f32 %f9, %f2;
+     sqrt.rn.f32 %f9, %f2;
```

`f32_hypot` and `f32_rsqrt` PTX are byte-identical before and after.

**SASS**, assembled with `ptxas -arch=sm_61` and disassembled with `nvdisasm`,
both at CUDA 12.9 (the local box's ptxas 13.3 cannot target sm_61 at all — min
sm_75 — so this is the only machine that could produce it):

| kernel | before | after |
|---|---|---|
| bare f32 `sqrt` | 18 instrs, **1 MUFU.SQRT**, 2 FMUL | 48 instrs, **1 MUFU.RSQ** hot + 4 FMUL/FFMA + cold slowpath |
| `df64_sqrt` | 162 instrs, 1 MUFU.SQRT + 1 MUFU.RSQ + 2 MUFU.RCP | 186 instrs, 3 MUFU.RSQ + 2 MUFU.RCP, **no MUFU.SQRT** |
| `f32_hypot` | 54 instrs, 2 MUFU.RSQ | 54 instrs, identical |

`MUFU.SQRT` is gone from the emitted machine code. ptxas honored the change.

The sm_61 hot path is exactly the shape the sm_86 estimate in the original body
predicted:

```
MUFU.RSQ R4, R2 ;
ISETP.GT.U32.AND P0, PT, R5, c[0x2][0x0], PT ;
@!P0 BRA `(.L_x_1) ;                                 <- normal data skips
CAL `($__internal_0_$__cuda_sm20_sqrt_rn_f32_slowpath) ;
.L_x_1:
FMUL.FTZ R3, R2, R4 ; FMUL.FTZ R4, R4, 0.5 ;
FFMA R2, R3, -R3, R2 ; FFMA R4, R2, R4, R3 ;
```

One MUFU on the hot path either way — the SFU is the throughput-limiting
resource and it is not doubled. The extra instructions are cheap ALU plus a
uniformly not-taken branch into the denormal/inf/nan slowpath.

## Cost, measured

`bench_nbody` n=4096 (sqrt-dominated inner loop: `1.0 /. (sqrt dist2 *. dist2)`),
CUDA/PTX on sm_61, median of 20 iterations after 5 warmup:

| | median kernel time | throughput |
|---|---|---|
| `sqrt.approx.f32` | 1.535 ms | 10.93 GFLOP/s |
| `sqrt.rn.f32` | 1.722 ms | 9.75 GFLOP/s |

**~12% more kernel time**, stable to ~0.2% across repeated runs (before:
1.5368 / 1.5349 ms; after: 1.7209 / 1.7240 ms). Not free, and worth it
— this is the difference between an f32 `sqrt` that meets the documented
"IEEE-exact float32 ops" contract and one that does not. Code that wants the
fast form still has `rsqrt`, unchanged.

## The `hypot` inconsistency: which call site reaches which lowering

Established by dumping PTX per intrinsic rather than by reading the emitter.
Line numbers are post-#310, on current `main`:

| surface intrinsic | registry arm | lowering | correct? |
|---|---|---|---|
| `Float32.sqrt` (and every `df64_sqrt`, via the same node) | `["sqrt"]` `:1802` | was `sqrt.approx.f32` `:1810`, now `sqrt.rn.f32` | yes, now |
| `Float32.hypot` | `["hypot"]` `:2020` | `sqrt.rn.f32` `:2021` already | yes, unchanged |
| `Float32.rsqrt` | `["rsqrt"]` `:1953` | `rsqrt.approx.f32` `:1950`→`:1967` | yes — deliberate |

**Re-checked after the registry refactor, as asked.** The three are disjoint
singleton name-lists — `grep` for any name-list containing `sqrt` returns
exactly `["sqrt"]` and `["rsqrt"]`, and `hypot` owns its own arm. The refactor
did not move ownership. It also *improved* the guarantee: `ptx_intrinsic_sweep`
now machine-checks that "emitter name sets partition the intrinsics", which the
old `match name with` form could not assert. The PTX dumps confirm behaviour
end-to-end: `f32_hypot.ptx` and `f32_rsqrt.ptx` are byte-identical before and
after this change on the rebased tree.

**The split was accidental, not a per-caller policy.** `hypot` is not a
"precision-sensitive caller" that someone singled out; it is a *separate emitter
arm* that happens to open-code `sqrt(x²+y²)` and was written later, spelling the
correctly-rounded form because that is the obvious one to write. The `sqrt` arm
predates it and kept the approximate spelling. `div` went through this exact
history already: `div.approx.f32` → `div.rn.f32` under audit finding M2, in this
same file, for this same reason. `sqrt` was missed in that sweep.

**So the fix should be global, not per-caller.** Concretely:

- There is no separate df64 sqrt IR node — `df64_sqrt` calls the *same* `sqrt`
  intrinsic as user code. A per-caller decision would require a new IR intrinsic
  plumbed through all six backends, and would leave ordinary PTX f32 `sqrt`
  silently non-conforming.
- The approximate form remains reachable and documented: `rsqrt` keeps
  `rsqrt.approx.f32` and is verified unchanged by this PR. That is the escape
  hatch for code that wants speed, and it is the textbook Newton seed anyway.
- Nothing in the tree passes `-use_fast_math` / `-prec-sqrt=false`, so nothing
  downstream re-approximates this.

## What this does NOT fix — same bug class, two other backends

`test_real64` still fails twice on this GPU, and being explicit about it matters
more than a clean scoreboard:

- **OpenCL, sqrt 1.81e-14.** *Cause identified and confirmed by experiment.* The
  OpenCL backend calls `clBuildProgram` with **no build options**
  (`Opencl_plugin_base.ml:236`, `?(options = "")`), and the OpenCL default
  permits a `sqrt` of up to 3 ulp. Rebuilding with
  `-cl-fp32-correctly-rounded-divide-sqrt` moves it to **8.87e-15 PASS**,
  executed on this same box — the same 3→1 backend result as the PTX fix. Now
  **filed as #136**, and deliberately not in this PR: different backend, its own
  review, and it deserves its own cost measurement given the CUDA equivalent
  cost ~12%. It also explains
  the clue in the original writeup — OpenCL scoring 9.80e-15 in `test_df64`
  while failing `test_real64` was never "OpenCL is fine", it was a different
  input range crossing a looser bound.
- **Vulkan, sqrt 1.68e-14 on NVIDIA.** Same shape, cause not established. Intel
  UHD 630 Vulkan passes at 1.17e-14 on the same test, so this is
  NVIDIA-glslang-specific rather than a Vulkan-wide property.

Both are recorded in the `KNOWN RESIDUAL` block. No tolerance was widened
anywhere.

## Since this is the only NVIDIA GPU we have had access to: f16 EXECUTED

`docs/fp-contraction-policy.md` §7 said outright: *"No f16 CUDA kernel has ever
been executed on NVIDIA hardware."* One has now, and this PR updates the doc
accordingly — §7 goes from three open bullets to one.

Exhaustive sweep of the `midround` kernel (the one whose mid-expression
narrowing is the whole point of the "store f16, compute f32" discipline) over
**all 63488 finite binary16 values**, sm_61 / CUDA 12.9:

```
    interpreter vs CPU reference (midround)    : OK (0 / 63488 mismatches)
    CUDA vs CPU reference (midround)           : OK (0 / 63488 mismatches)
    CUDA == interpreter (bit-identical f16)    : OK (0 / 63488 mismatches)
    CUDA == interpreter (scale)                : OK (0 / 63488 mismatches)
```

**Disagreement count: 0.** For reference, the same sweep on HIP reported
620/63488 before the AMDGPU barrier landed.

Two things had to be settled before that zero means anything:

1. **The gate is not blind.** A liveness control comparing `cuda(scale)` against
   `interp(midround)` reports **63085 / 63488 mismatches** — the execute →
   readback → compare pipeline is live.
2. **The zero is not an artefact of the barrier that used to be there.** The
   sweep above was re-run on the rebased tree, where #110 has already **removed**
   the CUDA `"+f"` barrier — same 0/63488. And while the barrier still existed,
   neutralizing it left the sm_61 SASS **byte-identical**:
   ```
   F2F.F32.F16.RZ / FMUL32I / F2F.F16.F32 / F2F.F32.F16.RZ / FADD / F2F.F16.F32
   ```
   Every mandated rounding survives as its own instruction either way. So this
   **independently confirms #110 on hardware**, where #110 concluded inertness
   from byte-identical cubins with no device — and at **sm_61, which is below
   the sm_75…sm_121 range** those host-side sweeps cover. Two methods, two
   architecture ranges, same answer.

This also closes two more of §7's bullets as a side effect:

- **the tie-rounding question it named** (*does the conversion round to
  nearest-even on ties?*) — the sweep domain contains the ties and none
  disagreed;
- **"offline `ptxas` is not the driver JIT"** — these runs load PTX through
  `cuModuleLoadData`, so the *driver's* ptxas (580.119.02) assembled them;
- and CUDA **12.9** adds a second toolkit sample between CI's 12.6 and the
  document's 13.3.

Route note: this runs through the **CUDA/C (nvrtc)** plugin. The **PTX backend
refuses kernel-level f16 by design** — `#57 slice 2`, a located
`Ptx_codegen_error`, not a crash. So "f16 executed on NVIDIA" is true of the
CUDA/C path and remains false of CUDA/PTX — the policy doc now says exactly
that instead of letting "f16 works on CUDA" stand unqualified.

## Cannot be settled on Pascal

sm_61 has no tensor cores, no bf16, and no FP8. f16 arithmetic runs at 1/64 f32
rate on GP104, so **no f16 performance number from this box means anything** and
none is quoted — only correctness, which does. The `mma`/tensor-core and
bf16/FP8 contraction questions stay open and need Ampere or newer.

## The change itself

One line in `sarek/codegen/Sarek_ir_ptx_expr.ml`: `sqrt.approx.f32` →
`sqrt.rn.f32`, with the rationale recorded next to the matching `div.rn.f32`
comment.

Plus the regression coverage that did not exist — **nothing in the tree asserted
the f32 sqrt lowering at all**, which is how this survived the M2 sweep:

- `test_ptx_snapshot.ml` — an f32 `sqrt` case next to the existing `div.rn.f32`
  one. Red-on-mutation: `Expected PTX to contain "sqrt.rn.f32" but it did not`,
  exit 1.
- `test_df64_no_contraction.ml` — the df64 seed check (CPU-only, no device).
  Red-on-mutation: `sqrt.approx.f32 = 1 (want 0)`, exit 1.

Both needles are anchored with a leading space, because `sqrt.approx.f32` is a
substring of `rsqrt.approx.f32` — `rsqrt` deliberately keeps the approximate
form, so an unanchored count would one day fail while printing the opposite of
what happened.

Kept as a device-independent guard on purpose: if that assertion goes red the
seed is wrong again, whatever a precision test happens to say on whatever GPU CI
has that day.

## Portability

`sqrt.rn.f32` needs sm_20+ / PTX ISA 1.4+. `div.rn.f32`, already emitted
unconditionally by this backend, imposes exactly the same floor, so this adds no
new minimum target — and it is now confirmed to assemble and run correctly at
the bottom of the range we can actually reach, sm_61. ZLUDA also exports
`__zluda_ptx_impl_sqrt_rn_f32`, so the AMD PTX path is fine.

## Gates (literal exit codes, re-run on the REBASED tree, sm_61 / CUDA 12.9)

- `dune build` → **0**
- `dune build @fmt` → **0** (main's #312 fix held; this PR adds no drift)
- `test_df64` → **0** (was **1**) — and note it now passes under main's
  *stricter* gates, where NVIDIA Vulkan is no longer allowlisted and is held to
  the full contract (1.24e-14 PASS)
- `test_real64` → **1** (3 failures → **2**; both remaining are the OpenCL and
  Vulkan backends above, neither on this code path)
- `test_df64_no_contraction` → **0**, all five arms PASS incl. `df64_seed
  sqrt.approx.f32 = 0, sqrt.rn.f32 = 1`
- `dune build @sarek/tests/unit/runtest` → **0**
- f16 exhaustive sweep → **0**, with the liveness control red as required

## Review

Unscoped fresh read + `codex` cross-runtime (`healthy`, exit 0) on the code
change. Both independently flagged that the prose originally shipped with this
change overclaimed a hardware measurement that did not exist; the fresh read
additionally caught the `rsqrt` substring collision in the guard. Both were
fixed early — and the measurement they were right to demand is now here.

**CodeRabbit**, two findings, both taken:

1. *Remove the obsolete pre-fix `sqrt` bullet from §7.* Done — and swept the
   rest of the policy doc and the source headers for other sentences describing
   the pre-fix world rather than fixing the one line. §7's bullet had said the
   residual was "unexplained" with an experiment that "needs an NVIDIA device to
   evaluate"; it now states the resolved CUDA/PTX part and keeps OpenCL (#136)
   and Vulkan separate, with the "do not promote a hypothesis to a cause"
   warning left where it still applies — Vulkan.
2. *Use measured-error wording.* Taken, and it turned out to be worse than the
   flagged line. The header claimed 8.53e-15 was "bit-for-bit the interpreter's
   figure … the device now matches the software reference exactly". What was
   measured is that two **summary statistics** coincide; **no per-element
   device-vs-interpreter comparison was ever run for df64**. That is the same
   over-restatement this header exists to prevent — a result stated more broadly
   than what was measured — so the fix would have reintroduced the shape of the
   original four-year defect. Every site now reads "measured worst-case relative
   error over that test's input set, on the named device and toolchain", and
   `PRECISION CONTRACT` says outright that these are sampled maxima, not bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PTX single-precision square-root accuracy by using correctly rounded operations.
  * Resolved `df64_sqrt` accuracy issues on CUDA/PTX, with documented performance trade-offs.
  * Added regression coverage to prevent approximate square-root instructions from returning.
* **Documentation**
  * Updated floating-point contraction guidance with NVIDIA hardware validation.
  * Clarified CUDA, PTX, OpenCL, and Vulkan support boundaries and remaining limitations.
  * Added measured accuracy results and expanded hardware/toolchain evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->