### PR TITLE
fix(build): declare js_of_ocaml deps and derive them from opam metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,16 @@ USER opam
 WORKDIR /home/opam/Sarek
 
 # 1. Update opam and install build deps
-# We use --debug to see what's happening if it fails
 RUN opam update
-RUN opam install -y dune ppxlib ctypes ctypes-foreign alcotest ocamlfind ocaml-compiler-libs
+# Build deps come from the project's own opam metadata rather than a hand-kept
+# list. The hardcoded list silently drifted from reality — js_of_ocaml-ppx is
+# needed by the public sarek.webgpu_runtime library and was absent, so this
+# image build failed on `Library "js_of_ocaml-ppx" not found` while every local
+# build passed. Deriving them from dune-project makes the declaration
+# load-bearing instead of decorative.
+COPY --chown=opam:opam *.opam dune-project ./
+RUN opam install -y . --deps-only
+RUN opam install -y ocamlfind ocaml-compiler-libs
 
 # 2. Install Jupyter and ZeroMQ
 RUN opam install -y conf-zmq zmq zmq-lwt jupyter

--- a/dune-project
+++ b/dune-project
@@ -51,8 +51,13 @@ Install sarek-cuda, sarek-opencl, or sarek-vulkan for GPU execution.")
   (ppxlib (>= 0.22.0))
   (ctypes (>= 0.24.0))
   (ctypes-foreign (>= 0.24.0))
+  ; sarek.webgpu_runtime / sarek.transpile_web are public libraries, so they are
+  ; part of @install — js_of_ocaml is a hard runtime dep, not a test-only one.
+  (js_of_ocaml (>= 6.0.0))
+  (js_of_ocaml-ppx (>= 6.0.0))
   (yojson :with-test)
   (alcotest :with-test)
+  (qcheck-core :with-test)
   (bisect_ppx :with-test)))
 
 ; CUDA backend plugin

--- a/sarek.opam
+++ b/sarek.opam
@@ -20,8 +20,11 @@ depends: [
   "ppxlib" {>= "0.22.0"}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}
+  "js_of_ocaml" {>= "6.0.0"}
+  "js_of_ocaml-ppx" {>= "6.0.0"}
   "yojson" {with-test}
   "alcotest" {with-test}
+  "qcheck-core" {with-test}
   "bisect_ppx" {with-test}
   "odoc" {with-doc}
 ]

--- a/sarek/core_js/webgpu/dune
+++ b/sarek/core_js/webgpu/dune
@@ -2,7 +2,10 @@
 ;
 ; Depends on js_of_ocaml and sarek_transpile (for the driver). No ctypes, no unix.
 ;
-; Only built explicitly; not included in @install or dune runtest by default.
+; NOTE: this library has a public_name, so it IS part of @install — an earlier
+; version of this comment claimed otherwise, and the release Docker image build
+; broke on the undeclared js_of_ocaml-ppx dependency as a result. Only the
+; test/lessons/spike-worker targets below are build-on-demand.
 ;   dune build sarek/core_js/webgpu/
 ;   dune build sarek/core_js/webgpu/test/runtime_driver.bc.js
 


### PR DESCRIPTION
Unblocks #294 and #296, both of which fail `build-and-push` on `Library "js_of_ocaml-ppx" not found` for reasons unrelated to their diffs. Closes #114 in part.

## Two causes, not one

**The declaration was missing.** `js_of_ocaml` / `js_of_ocaml-ppx` are used by five `dune` files and declared in no `.opam` and not in `dune-project`. `sarek.webgpu_runtime` and `sarek.transpile_web` have `public_name`s, so they are part of `@install` — these are hard runtime deps. `qcheck-core` (formal/*/test) was undeclared too.

**Declaring them would not have fixed it.** The `Dockerfile` never read the project's opam metadata — it installed a hardcoded list that had silently drifted. It now uses `opam install . --deps-only`, which makes the declaration load-bearing instead of decorative.

Also fixes a comment in `sarek/core_js/webgpu/dune` asserting the library is "not included in @install". It has a `public_name`, so it is — and that mistaken belief is why the gap survived.

## Verification

Built the release image locally. A local `dune build` proves nothing here: the dev switch already has these packages installed, which is exactly why this never surfaced outside CI.

- `opam install -y . --deps-only` resolves and installs `js_of_ocaml{,-compiler,-ppx}` 6.4.1
- `dune build @install && dune install` — the step that failed in CI — completes (`#16 DONE 5.4s`)
- zero occurrences of `not found` across the 1224-line build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release build reliability by ensuring all declared JavaScript and WebGPU dependencies are installed correctly.
  * Fixed dependency handling for the WebGPU runtime during installation.

* **Chores**
  * Updated package metadata with required JavaScript libraries and testing support.
  * Build environments now install dependencies directly from the project’s package declarations, reducing configuration drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->