### PR TITLE
test: report skipped tests as skipped instead of green

### DIFF
--- a/sarek-cuda/test/test_cuda_f16_nvrtc.ml
+++ b/sarek-cuda/test/test_cuda_f16_nvrtc.ml
@@ -125,8 +125,10 @@ let compile src =
   | exception e -> Error (Printexc.to_string e)
 
 let test_f16_source_compiles () =
-  if not (nvrtc_ready ()) then
-    Printf.printf "  [SKIP] f16 nvrtc compile: %s\n" (skip_reason ())
+  if not (nvrtc_ready ()) then begin
+    Printf.printf "  [SKIP] f16 nvrtc compile: %s\n" (skip_reason ()) ;
+    Alcotest.skip ()
+  end
   else
     let src = gen (f16_scale_kernel ()) in
     (* Precondition: this really is the f16 source shape under test. *)
@@ -152,8 +154,10 @@ let test_f16_source_compiles () =
             ptx
 
 let test_f32_source_still_compiles () =
-  if not (Sarek_cuda.Cuda_nvrtc.is_available ()) then
-    Printf.printf "  [SKIP] f32 nvrtc compile: libnvrtc not loadable\n"
+  if not (Sarek_cuda.Cuda_nvrtc.is_available ()) then begin
+    Printf.printf "  [SKIP] f32 nvrtc compile: libnvrtc not loadable\n" ;
+    Alcotest.skip ()
+  end
   else
     let src = gen (f32_scale_kernel ()) in
     match compile src with

--- a/sarek-cuda/test/test_cuda_f16_sass.ml
+++ b/sarek-cuda/test/test_cuda_f16_sass.ml
@@ -170,9 +170,49 @@ let write_file path contents =
   output_string oc contents ;
   close_out oc
 
+(** Why the toolchain produced no SASS for an architecture. The distinction is
+    load-bearing: [Unknown_arch] is an environment gap and a legitimate skip,
+    while [Tool_error] means ptxas or nvdisasm rejected work this test generated
+    — a real failure that must not be folded into the skip bucket. Before this
+    split every nonzero exit read as "arch not supported", so a ptxas that
+    rejected the generated PTX outright made the gate report a green pass having
+    checked nothing. *)
+type tool_failure = Unknown_arch of string | Tool_error of string
+
+let failure_message = function Unknown_arch m | Tool_error m -> m
+
+(* ptxas reports an unrecognised target as
+   [ptxas fatal : Value 'sm_XXX' is not defined for option 'gpu-name'],
+   an architecture it was not built for as "Unsupported gpu architecture",
+   and an unassemblable .target directive as "Unsupported .target". Anything
+   else is a genuine assembler error. If a future toolkit invents new
+   wording the effect is a hard failure with the message quoted verbatim,
+   which is the safe direction: a new phrase gets noticed and added here,
+   rather than joining a silent skip bucket. *)
+let contains_sub s sub =
+  let n = String.length sub and l = String.length s in
+  let rec go i = i + n <= l && (String.sub s i n = sub || go (i + 1)) in
+  n = 0 || go 0
+
+let classify_ptxas_error msg =
+  if
+    contains_sub msg "is not defined for option"
+    || contains_sub msg "Unsupported gpu architecture"
+    || contains_sub msg "Unsupported .target"
+  then Unknown_arch msg
+  else Tool_error msg
+
+(* nvdisasm's own "I do not know this SM" wording. *)
+let classify_nvdisasm_error msg =
+  if
+    contains_sub msg "Unrecognized SM version"
+    || contains_sub msg "Unsupported SM version"
+    || contains_sub msg "unsupported architecture"
+  then Unknown_arch msg
+  else Tool_error msg
+
 (** [sass_of_ptx ~arch ptx] assembles [ptx] for [arch] and disassembles the
-    result. [Error msg] when the architecture is unknown to the local ptxas or
-    either tool fails. *)
+    result. See {!tool_failure} for the two error kinds. *)
 let sass_of_ptx ~arch ptx =
   let base = Filename.temp_file "sarek_f16_sass_" "" in
   let src = base ^ ".ptx" and obj = base ^ ".cubin" in
@@ -205,8 +245,19 @@ let sass_of_ptx ~arch ptx =
           in
           match rc with
           | Unix.WEXITED 0 -> Ok (read_file out)
-          | _ -> Error ("nvdisasm failed: " ^ try read_file err with _ -> ""))
-      | _ -> Error ("ptxas failed: " ^ try read_file err with _ -> ""))
+          | _ ->
+              (* ptxas accepted the target but nvdisasm did not. ptxas and
+                 nvdisasm are located independently by [on_path], so they can
+                 come from different CUDA installs: a newer ptxas assembling
+                 sm_100 whose cubin an older nvdisasm cannot read is an
+                 environment gap, not a defect. Classify it the same way. *)
+              Error
+                (classify_nvdisasm_error
+                   ("nvdisasm failed: " ^ try read_file err with _ -> "")))
+      | _ ->
+          Error
+            (classify_ptxas_error
+               ("ptxas failed: " ^ try read_file err with _ -> "")))
 
 (* ------------------------------------------------------------------ *)
 (* SASS classification                                                *)
@@ -327,18 +378,35 @@ let ptx_of_source ~name src =
     Each bullet is one half of what went wrong on AMDGPU, plus the count that
     catches a narrowing being folded AWAY rather than fused. *)
 let test_midround_sass_unfused () =
-  if not (ready ()) then
-    Printf.printf "  [SKIP] f16 SASS gate: %s\n" (skip_reason ())
+  if not (ready ()) then begin
+    Printf.printf "  [SKIP] f16 SASS gate: %s\n" (skip_reason ()) ;
+    Alcotest.skip ()
+  end
   else
     let src = gen (f16_midround_kernel ()) in
     match ptx_of_source ~name:"f16_midround" src with
     | Error e -> Alcotest.failf "nvrtc rejected the generated f16 kernel: %s" e
     | Ok ptx ->
         let checked = ref 0 in
+        let unusable = ref [] in
         List.iter
           (fun arch ->
             match sass_of_ptx ~arch ptx with
-            | Error e -> Printf.printf "  [SKIP] %s: %s\n" arch (String.trim e)
+            | Error (Tool_error e) ->
+                (* The toolchain knows this target and still refused the work
+                   this test generated. A real defect, not an environment
+                   gap: do not fold it into the skip bucket. *)
+                Alcotest.failf
+                  "%s: the local CUDA toolchain rejected the generated kernel: \
+                   %s"
+                  arch
+                  (String.trim e)
+            | Error (Unknown_arch e) ->
+                (* ptxas does not know this architecture. Legitimate per-arch
+                   skip; recorded so the zero-architecture case can report
+                   WHY nothing was checked instead of passing silently. *)
+                unusable := (arch, String.trim e) :: !unusable ;
+                Printf.printf "  [SKIP] %s: %s\n" arch (String.trim e)
             | Ok sass ->
                 incr checked ;
                 let insns = instructions sass in
@@ -393,10 +461,17 @@ let test_midround_sass_unfused () =
                     arch
                     (render insns))
           architectures ;
-        if !checked = 0 then
+        if !checked = 0 then begin
+          (* Zero architectures checked: the gate asserted nothing. Report a
+             SKIP status, never a pass. *)
           Printf.printf
             "  [SKIP] f16 SASS gate: local ptxas knows none of %s\n"
-            (String.concat ", " architectures)
+            (String.concat ", " architectures) ;
+          List.iter
+            (fun (arch, e) -> Printf.printf "    %s: %s\n" arch e)
+            (List.rev !unusable) ;
+          Alcotest.skip ()
+        end
         else
           Printf.printf
             "  f16 SASS gate: f32 discipline intact on %d/%d architectures\n"
@@ -407,8 +482,10 @@ let test_midround_sass_unfused () =
     fails, the gate above proves nothing: it would be asserting the absence of a
     pattern it cannot recognise. *)
 let test_classifier_detects_fusion () =
-  if not (ready ()) then
-    Printf.printf "  [SKIP] f16 SASS positive control: %s\n" (skip_reason ())
+  if not (ready ()) then begin
+    Printf.printf "  [SKIP] f16 SASS positive control: %s\n" (skip_reason ()) ;
+    Alcotest.skip ()
+  end
   else
     match ptx_of_source ~name:"f16_native_arith" positive_control_source with
     | Error e -> Alcotest.failf "nvrtc rejected the positive control: %s" e
@@ -418,14 +495,26 @@ let test_classifier_detects_fusion () =
         let arch =
           List.find_opt
             (fun a ->
-              match sass_of_ptx ~arch:a ptx with Ok _ -> true | _ -> false)
+              match sass_of_ptx ~arch:a ptx with
+              | Ok _ -> true
+              | Error (Unknown_arch _) -> false
+              | Error (Tool_error e) ->
+                  (* Same rule as the gate: a target the toolchain knows but
+                     could not process is a failure, not "no usable arch". *)
+                  Alcotest.failf
+                    "%s: the local CUDA toolchain rejected the positive \
+                     control: %s"
+                    a
+                    (String.trim e))
             architectures
         in
         match arch with
-        | None -> Printf.printf "  [SKIP] positive control: no usable arch\n"
+        | None ->
+            Printf.printf "  [SKIP] positive control: no usable arch\n" ;
+            Alcotest.skip ()
         | Some arch -> (
             match sass_of_ptx ~arch ptx with
-            | Error e -> Alcotest.failf "%s: %s" arch e
+            | Error e -> Alcotest.failf "%s: %s" arch (failure_message e)
             | Ok sass ->
                 let insns = instructions sass in
                 let fused = binary16_arithmetic insns in

--- a/sarek-cuda/test/test_ptx_atomics_probe.ml
+++ b/sarek-cuda/test/test_ptx_atomics_probe.ml
@@ -68,7 +68,7 @@ let block_size = 256
 let test_atomics () =
   if not (Cuda_api.is_driver_available ()) then (
     Printf.printf "  [SKIP] no CUDA device\n%!" ;
-    ())
+    Alcotest.skip ())
   else begin
     Cuda_api.Device.init () ;
     let dev = Cuda_api.Device.get 0 in

--- a/sarek-cuda/test/test_ptx_dynshared_probe.ml
+++ b/sarek-cuda/test/test_ptx_dynshared_probe.ml
@@ -67,8 +67,12 @@ let make_dynshared_kernel () : kernel =
     kern_native_fn = None;
   }
 
-let test_dynshared () =
-  let ptx = Sarek_codegen.Sarek_ir_ptx.generate (make_dynshared_kernel ()) in
+let emitted_ptx () =
+  Sarek_codegen.Sarek_ir_ptx.generate (make_dynshared_kernel ())
+
+(* Static half: always runs, needs no driver. *)
+let test_dynshared_ptx () =
+  let ptx = emitted_ptx () in
   (* The declaration must be the extern (launch-sized) form. *)
   Alcotest.(check bool)
     "PTX declares extern .shared dynbuf"
@@ -79,9 +83,17 @@ let test_dynshared () =
      for i = 0 to String.length ptx - mlen do
        if String.sub ptx i mlen = marker then found := true
      done ;
-     !found) ;
-  if not (Cuda_api.is_driver_available ()) then
-    Printf.printf "  [SKIP] no CUDA device (PTX emission checked)\n%!"
+     !found)
+
+(* Device half: separate case so that skipping it does not report a green
+   [OK] on a name claiming the kernel executed. The static half above keeps
+   its own honest green. *)
+let test_dynshared () =
+  let ptx = emitted_ptx () in
+  if not (Cuda_api.is_driver_available ()) then begin
+    Printf.printf "  [SKIP] no CUDA device (PTX emission checked)\n%!" ;
+    Alcotest.skip ()
+  end
   else begin
     Cuda_api.Device.init () ;
     let dev = Cuda_api.Device.get 0 in
@@ -134,6 +146,10 @@ let () =
     [
       ( "dynshared",
         [
+          Alcotest.test_case
+            "PTX declares the extern .shared region"
+            `Quick
+            test_dynshared_ptx;
           Alcotest.test_case
             "extern .shared region sized at launch works"
             `Quick

--- a/sarek-cuda/test/test_ptx_external.ml
+++ b/sarek-cuda/test/test_ptx_external.ml
@@ -86,8 +86,10 @@ let make_host_array size f =
 let test_vector_add () =
   if not (Cuda_api.is_driver_available ()) then (
     Printf.printf "  [SKIP] no CUDA device\n%!" ;
-    (* Alcotest skip not available without raising; just pass *)
-    ())
+    (* Alcotest.skip () raises Test.Skip, which the runner reports as a
+       distinct [SKIP] status. Returning unit instead renders as a green
+       [OK] under this test case's name, which claims the launch verified. *)
+    Alcotest.skip ())
   else begin
     Cuda_api.Device.init () ;
     let dev = Cuda_api.Device.get 0 in

--- a/sarek-cuda/test/test_ptx_localarr_probe.ml
+++ b/sarek-cuda/test/test_ptx_localarr_probe.ml
@@ -93,16 +93,20 @@ let make_localarr_kernel () : kernel =
     kern_native_fn = None;
   }
 
-let test_localarr () =
-  let ptx = Sarek_codegen.Sarek_ir_ptx.generate (make_localarr_kernel ()) in
-  let contains_sub s sub =
-    let n = String.length sub in
-    let found = ref false in
-    for i = 0 to String.length s - n do
-      if String.sub s i n = sub then found := true
-    done ;
-    !found
-  in
+let emitted_ptx () =
+  Sarek_codegen.Sarek_ir_ptx.generate (make_localarr_kernel ())
+
+let contains_sub s sub =
+  let n = String.length sub in
+  let found = ref false in
+  for i = 0 to String.length s - n do
+    if String.sub s i n = sub then found := true
+  done ;
+  !found
+
+(* Static half: always runs, needs no driver. *)
+let test_localarr_ptx () =
+  let ptx = emitted_ptx () in
   Alcotest.(check bool)
     "PTX declares .local tmp"
     true
@@ -114,9 +118,16 @@ let test_localarr () =
   Alcotest.(check bool)
     "PTX loads via ld.local"
     true
-    (contains_sub ptx "ld.local.f32") ;
-  if not (Cuda_api.is_driver_available ()) then
-    Printf.printf "  [SKIP] no CUDA device (PTX emission checked)\n%!"
+    (contains_sub ptx "ld.local.f32")
+
+(* Device half: separate case so that skipping it does not report a green
+   [OK] on a name claiming the kernel executed. *)
+let test_localarr () =
+  let ptx = emitted_ptx () in
+  if not (Cuda_api.is_driver_available ()) then begin
+    Printf.printf "  [SKIP] no CUDA device (PTX emission checked)\n%!" ;
+    Alcotest.skip ()
+  end
   else begin
     Cuda_api.Device.init () ;
     let dev = Cuda_api.Device.get 0 in
@@ -168,6 +179,10 @@ let () =
     [
       ( "localarr",
         [
+          Alcotest.test_case
+            "PTX declares and uses the .local array"
+            `Quick
+            test_localarr_ptx;
           Alcotest.test_case
             ".local array declare/fill/sum executes correctly"
             `Quick

--- a/sarek-cuda/test/test_ptx_mma_probe.ml
+++ b/sarek-cuda/test/test_ptx_mma_probe.ml
@@ -161,8 +161,14 @@ let run_wmma_load dev =
   with e -> Error (Printexc.to_string e)
 
 let test_mma () =
-  if not (Cuda_api.is_driver_available ()) then
-    Printf.printf "  [SKIP] no CUDA device\n%!"
+  if not (Cuda_api.is_driver_available ()) then begin
+    Printf.printf "  [SKIP] no CUDA device\n%!" ;
+    (* Report a distinct SKIP status to the runner. Printing alone is not
+       enough: Alcotest captures stdout, so a printed skip that returns
+       normally renders as a green [OK] under the test case's name — which
+       here asserts the mma executed correctly. *)
+    Alcotest.skip ()
+  end
   else begin
     Cuda_api.Device.init () ;
     let dev = Cuda_api.Device.get 0 in
@@ -196,7 +202,8 @@ let test_mma () =
         Printf.printf
           "  [SKIP] tensor-core mma not available on this driver (see \
            docs/optimization/l15b-mma-probe.md)\n\
-           %!"
+           %!" ;
+        Alcotest.skip ()
   end
 
 let () =

--- a/sarek-cuda/test/test_ptx_stride_spike.ml
+++ b/sarek-cuda/test/test_ptx_stride_spike.ml
@@ -70,7 +70,7 @@ let block_size = 256
 let test_stride12 () =
   if not (Cuda_api.is_driver_available ()) then (
     Printf.printf "  [SKIP] no CUDA device\n%!" ;
-    ())
+    Alcotest.skip ())
   else begin
     Cuda_api.Device.init () ;
     let dev = Cuda_api.Device.get 0 in

--- a/sarek-hip/test/test_hip_f16_argcheck.ml
+++ b/sarek-hip/test/test_hip_f16_argcheck.ml
@@ -138,6 +138,7 @@ let test_match_still_runs dev =
 let () =
   Printf.printf "test_hip_f16_argcheck (#57 slice 1 review)\n" ;
   let devices = Device.init () in
+  let exercised = ref 0 in
   if Array.length devices = 0 then print_endline "    [SKIP] no devices"
   else
     Array.iter
@@ -147,11 +148,21 @@ let () =
           List.mem dev.Device.framework ["HIP"; "CUDA"; "Native"; "Interpreter"]
         then begin
           Printf.printf "  %s: %s\n" dev.Device.framework dev.Device.name ;
+          incr exercised ;
           test_mismatch_rejected dev ;
           test_match_still_runs dev
         end)
       devices ;
-  if !failures = 0 then print_endline "test_hip_f16_argcheck PASSED"
+  (* Without this the suite prints PASSED after checking nothing at all: the
+     per-device filter can exclude every enumerated device and the loop then
+     runs zero assertions, which is indistinguishable from a real pass. *)
+  if !exercised = 0 && Array.length devices > 0 then
+    print_endline
+      "    [SKIP] no enumerated device implements device-side f16 (HIP / CUDA \
+       / Native / Interpreter) — 0 checks ran" ;
+  if !failures = 0 && !exercised = 0 then
+    print_endline "test_hip_f16_argcheck SKIPPED (no eligible device)"
+  else if !failures = 0 then print_endline "test_hip_f16_argcheck PASSED"
   else begin
     Printf.printf "test_hip_f16_argcheck FAILED (%d)\n" !failures ;
     exit 1

--- a/sarek-opencl/test/test_opencl_cache_two_kernels.ml
+++ b/sarek-opencl/test/test_opencl_cache_two_kernels.ml
@@ -60,9 +60,11 @@ let run_kernel_and_read_result device ~name =
   result.{0}
 
 let test_two_kernels_one_source_resolve_independently () =
-  if not (Backend.is_available ()) then
+  if not (Backend.is_available ()) then begin
     Printf.printf
-      "[SKIP] No OpenCL device available - skipping hardware cache test\n%!"
+      "[SKIP] No OpenCL device available - skipping hardware cache test\n%!" ;
+    Alcotest.skip ()
+  end
   else begin
     Backend.Device.init () ;
     let device = Backend.Device.get 0 in

--- a/sarek-opencl/test/test_opencl_ffi_check_funnel.ml
+++ b/sarek-opencl/test/test_opencl_ffi_check_funnel.ml
@@ -25,10 +25,12 @@ __kernel void real_kernel(__global float *out) {
 |}
 
 let test_invalid_kernel_name_raises_canonical_backend_error () =
-  if not (Opencl_api.is_available ()) then
+  if not (Opencl_api.is_available ()) then begin
     Printf.printf
       "[SKIP] No OpenCL device available - skipping hardware check-funnel test\n\
-       %!"
+       %!" ;
+    Alcotest.skip ()
+  end
   else begin
     Opencl_api.Device.init () ;
     let device = Opencl_api.Device.get 0 in

--- a/sarek-vulkan/test/test_vulkan_cache_two_kernels.ml
+++ b/sarek-vulkan/test/test_vulkan_cache_two_kernels.ml
@@ -58,9 +58,11 @@ let compile_and_read_result device ~name =
   (compiled, result.{0})
 
 let test_two_kernel_names_one_source_do_not_alias () =
-  if not (Vulkan_api.is_available ()) then
+  if not (Vulkan_api.is_available ()) then begin
     Printf.printf
-      "[SKIP] No Vulkan device available - skipping hardware cache test\n%!"
+      "[SKIP] No Vulkan device available - skipping hardware cache test\n%!" ;
+    Alcotest.skip ()
+  end
   else begin
     Device.init () ;
     let device = Device.get 0 in

--- a/sarek-vulkan/test/test_vulkan_ffi_check_funnel.ml
+++ b/sarek-vulkan/test/test_vulkan_ffi_check_funnel.ml
@@ -27,10 +27,12 @@ module Memory = Vulkan_api_memory
 let absurd_element_count = 1 lsl 40
 
 let test_absurd_allocation_raises_canonical_backend_error () =
-  if not (Vulkan_api.is_available ()) then
+  if not (Vulkan_api.is_available ()) then begin
     Printf.printf
       "[SKIP] No Vulkan device available - skipping hardware check-funnel test\n\
-       %!"
+       %!" ;
+    Alcotest.skip ()
+  end
   else begin
     Device.init () ;
     let device = Device.get 0 in

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -2224,12 +2224,18 @@ let glsl_validation_tests () =
               Printf.printf
                 "  SKIP (excluded): glsl/%s — %s\n%!"
                 kernel_name
-                reason
+                reason ;
+              (* An excluded golden is not validated. Report SKIP so the
+                 exclusion list is visible in the runner output instead of
+                 hiding behind a green [OK] on a "glsl-validate/*" name. *)
+              Alcotest.skip ()
           | None -> (
               Gen_glsl.reset_state () ;
               let glsl = Gen_glsl.generate_with_types ~types:k.kern_types k in
-              if not (Lazy.force glslang_available) then
-                Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+              if not (Lazy.force glslang_available) then begin
+                Printf.printf "  SKIP: glslangValidator not on PATH\n%!" ;
+                Alcotest.skip ()
+              end
               else
                 match glslang_ok glsl with
                 | Ok () ->
@@ -2258,12 +2264,15 @@ let wgsl_validation_tests () =
               Printf.printf
                 "  SKIP (excluded): wgsl/%s — %s\n%!"
                 kernel_name
-                reason
+                reason ;
+              Alcotest.skip ()
           | None -> (
               Gen_wgsl.reset_state () ;
               let wgsl = Gen_wgsl.generate_with_types ~types:k.kern_types k in
-              if not (Lazy.force naga_available) then
-                Printf.printf "  SKIP: naga not on PATH\n%!"
+              if not (Lazy.force naga_available) then begin
+                Printf.printf "  SKIP: naga not on PATH\n%!" ;
+                Alcotest.skip ()
+              end
               else
                 match naga_ok wgsl with
                 | Ok () -> Printf.printf "  naga OK: %s\n%!" kernel_name

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -2340,8 +2340,10 @@ let soa_field_sum_kernel () =
     []
 
 let test_ptxas_assembles () =
-  if not (Lazy.force ptxas_available) then
-    Printf.printf "  SKIP: ptxas not on PATH (CPU-only environment)\n%!"
+  if not (Lazy.force ptxas_available) then begin
+    Printf.printf "  SKIP: ptxas not on PATH (CPU-only environment)\n%!" ;
+    Alcotest.skip ()
+  end
   else begin
     let ia = make_var "ia" (TVec TInt32) in
     let la = make_var "la" (TVec TInt64) in

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -521,8 +521,14 @@ let test_glsl_recursion_vector_validates () =
     Alcotest.failf
       "vector-parameter helper must be inlined, found a residual call/def:\n%s"
       glsl ;
-  if not (Lazy.force glslang_available) then
-    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  if not (Lazy.force glslang_available) then begin
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!" ;
+    (* This suite is the "validation-gate": every case is named for a check
+       the external validator performs. Without the validator the case has
+       not made that check, so report SKIP rather than a green [OK]. The
+       static assertions above still ran and still fail loudly. *)
+    Alcotest.skip ()
+  end
   else
     match glslang_ok glsl with
     | Ok () -> Printf.printf "  glslangValidator OK: recursion_vector\n%!"
@@ -542,8 +548,10 @@ let test_wgsl_recursion_vector_validates () =
     Alcotest.failf
       "vector-parameter helper must be inlined, found a residual call/def:\n%s"
       wgsl ;
-  if not (Lazy.force naga_available) then
-    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!"
+  if not (Lazy.force naga_available) then begin
+    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!" ;
+    Alcotest.skip ()
+  end
   else
     match naga_ok wgsl with
     | Ok () -> Printf.printf "  naga OK: recursion_vector\n%!"
@@ -568,8 +576,14 @@ let test_glsl_local_buffer_name_collision () =
       "expected the colliding local to be alpha-renamed (sarek_inl_local_*):\n\
        %s"
       glsl ;
-  if not (Lazy.force glslang_available) then
-    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  if not (Lazy.force glslang_available) then begin
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!" ;
+    (* This suite is the "validation-gate": every case is named for a check
+       the external validator performs. Without the validator the case has
+       not made that check, so report SKIP rather than a green [OK]. The
+       static assertions above still ran and still fail loudly. *)
+    Alcotest.skip ()
+  end
   else
     match glslang_ok glsl with
     | Ok () -> Printf.printf "  glslangValidator OK: collision_vector\n%!"
@@ -592,8 +606,10 @@ let test_wgsl_local_buffer_name_collision () =
       "expected the colliding local to be alpha-renamed (sarek_inl_local_*):\n\
        %s"
       wgsl ;
-  if not (Lazy.force naga_available) then
-    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!"
+  if not (Lazy.force naga_available) then begin
+    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!" ;
+    Alcotest.skip ()
+  end
   else
     match naga_ok wgsl with
     | Ok () -> Printf.printf "  naga OK: collision_vector\n%!"
@@ -625,8 +641,14 @@ let test_glsl_transpose_naive_pc_shadow_validates () =
     Alcotest.failf
       "a scalar-param-shadowing local declaration survived unrenamed:\n%s"
       glsl ;
-  if not (Lazy.force glslang_available) then
-    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  if not (Lazy.force glslang_available) then begin
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!" ;
+    (* This suite is the "validation-gate": every case is named for a check
+       the external validator performs. Without the validator the case has
+       not made that check, so report SKIP rather than a green [OK]. The
+       static assertions above still ran and still fail loudly. *)
+    Alcotest.skip ()
+  end
   else
     match glslang_ok glsl with
     | Ok () -> Printf.printf "  glslangValidator OK: transpose_naive\n%!"
@@ -646,8 +668,10 @@ let test_glsl_transpose_naive_pc_shadow_validates () =
 let test_wgsl_transpose_naive_validates () =
   let k = transpose_naive_kernel () in
   let wgsl = Sarek_ir_wgsl.generate k in
-  if not (Lazy.force naga_available) then
-    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!"
+  if not (Lazy.force naga_available) then begin
+    Printf.printf "  SKIP: naga not on PATH (WGSL validation skipped)\n%!" ;
+    Alcotest.skip ()
+  end
   else
     match naga_ok wgsl with
     | Ok () -> Printf.printf "  naga OK: transpose_naive\n%!"
@@ -687,9 +711,13 @@ let test_wgsl_scalar_shadow_mut_local () =
       "expected the mutable local declaration to use the renamed name:\n%s"
       wgsl ;
   if not (Lazy.force naga_available) then
+    (* Deliberately NOT Alcotest.skip (), unlike the "…validates" cases in
+       this suite: this case is named for the emitted-text property and the
+       three assertions above have already established it. Only the extra
+       naga cross-check is missing, so a green [OK] here is honest. *)
     Printf.printf
-      "  codegen-golden OK: wgsl_scalar_shadow_mut (naga absent — WGSL \
-       assertion is on emitted text, not runtime)\n\
+      "  [SKIP] naga not on PATH — wgsl_scalar_shadow_mut checked its \
+       emitted-text assertions only\n\
        %!"
   else
     match naga_ok wgsl with
@@ -721,8 +749,14 @@ let test_glsl_match_pattern_pc_shadow_validates () =
       "a scalar-param-shadowing match binder declaration survived unrenamed:\n\
        %s"
       k ;
-  if not (Lazy.force glslang_available) then
-    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  if not (Lazy.force glslang_available) then begin
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!" ;
+    (* This suite is the "validation-gate": every case is named for a check
+       the external validator performs. Without the validator the case has
+       not made that check, so report SKIP rather than a green [OK]. The
+       static assertions above still ran and still fail loudly. *)
+    Alcotest.skip ()
+  end
   else
     match glslang_ok k with
     | Ok () -> Printf.printf "  glslangValidator OK: match_pc_shadow\n%!"
@@ -751,8 +785,14 @@ let test_glsl_vec_len_shadow_validates () =
     Alcotest.failf
       "a vector-_len-shadowing local declaration survived unrenamed:\n%s"
       k ;
-  if not (Lazy.force glslang_available) then
-    Printf.printf "  SKIP: glslangValidator not on PATH\n%!"
+  if not (Lazy.force glslang_available) then begin
+    Printf.printf "  SKIP: glslangValidator not on PATH\n%!" ;
+    (* This suite is the "validation-gate": every case is named for a check
+       the external validator performs. Without the validator the case has
+       not made that check, so report SKIP rather than a green [OK]. The
+       static assertions above still ran and still fail loudly. *)
+    Alcotest.skip ()
+  end
   else
     match glslang_ok k with
     | Ok () -> Printf.printf "  glslangValidator OK: vec_len_shadow\n%!"


### PR DESCRIPTION
## The defect

Alcotest captures stdout. A test case that printed `[SKIP] no CUDA device` and returned rendered as a green `[OK]` **under its own test-case name**, indistinguishable from a real run. The worst instance, `test_ptx_mma_probe`:

```
  [OK]          mma          0   mma.sync tensor-core matmul executes correctly.

Test Successful in 0.000s. 1 test run.
```

on a machine with no CUDA driver at all. Establishing which of six CUDA probes had actually executed required re-running each executable with `-v`.

After:

```
  [SKIP]        mma          0   mma.sync tensor-core matmul executes correctly.

Test Successful in 0.000s. 0 test run.
```

## What changed

Alcotest 1.9.1 (the pinned version) has `Alcotest.skip : unit -> 'a`, added in 1.7.0. Every environment-conditional skip inside an Alcotest case now calls it **after** printing its reason, so the reason survives in the log and the runner reports a distinct `[SKIP]` status.

`Alcotest.skip ()` raises, so a skipped case is excluded from the `N tests run` tally. That is the suite-level signal, for free: a suite that skipped everything reports `0 test run`, a suite that ran everything reports its full count. No framework needed.

**No legitimate skip becomes a failure.** Skipping on Pascal, on a CPU-only box, or without `ptxas`/`naga` is correct and stays exit 0.

Where only *part* of a case could run, the case was split rather than relabelled, so the half that does run keeps an honest green:

| file | before | after |
|---|---|---|
| `test_ptx_dynshared_probe` | 1 case, green, PTX checked but never launched | `[OK] PTX declares the extern .shared region` + `[SKIP] extern .shared region sized at launch works` |
| `test_ptx_localarr_probe` | 1 case, green, 3 PTX assertions but never launched | `[OK] PTX declares and uses the .local array` + `[SKIP] .local array declare/fill/sum executes correctly` |

## Two cases were swallowing a real failure, not skipping

**`test_cuda_f16_sass`** folded every `ptxas`/`nvdisasm` error into "this architecture is unsupported":

```ocaml
| Error e -> Printf.printf "  [SKIP] %s: %s\n" arch (String.trim e)
```

A `ptxas` that rejected the *generated PTX* — a real codegen defect — landed in the same bucket as an unknown `sm_` name. Every architecture failing left `checked = 0`, and the gate then printed a `[SKIP]` line and **returned green having verified nothing**. That is the same shape as the convergence gate that passed because it was given nothing to check.

Errors are now typed. `Unknown_arch` (matched against `ptxas`'s and `nvdisasm`'s actual unknown-target wording: `is not defined for option`, `Unsupported gpu architecture`, `Unsupported .target`, `Unrecognized SM version`, …) stays a per-architecture skip. Anything else fails, quoting the tool's message verbatim — so a new phrasing from a future toolkit gets noticed and added, rather than silently joining the skip bucket. `checked = 0` now reports `[SKIP]` and lists why each architecture was unusable. The non-vacuity positive control applies the same rule instead of treating any error as "no usable arch".

`nvdisasm` failures are classified too, not hard-failed: `ptxas` and `nvdisasm` are located independently by `command -v`, so a newer `ptxas` assembling `sm_100` whose cubin an older `nvdisasm` cannot read is an environment gap. (Caught by the fresh-read review.)

**`test_hip_f16_argcheck`** printed `PASSED` after running **zero** assertions whenever its per-device filter (`HIP`/`CUDA`/`Native`/`Interpreter`) excluded every enumerated device — no `[SKIP]` line at all. It now counts exercised devices and reports `SKIPPED (no eligible device)`.

## Corpus sweep

`grep -rn '[SKIP]' --include=*.ml` found 33 sites in 20 files, but the green-lie only exists inside Alcotest cases — bare test executables print their skip to stdout, which `dune runtest` shows. So the sweep boundary is "every Alcotest case that can skip", which also caught 3 files the `[SKIP]` grep missed because they spell it `SKIP:`:

- `test_codegen_golden` — **6 `wgsl-validate/*` cases were reporting green with `naga` absent.** Also the documented per-case `validation_exclusions` list, which is empty today but would have been invisible.
- `test_ptx_snapshot` — `ptxas assembles regression kernels`, green without `ptxas`.
- `test_shader_recursion_vector` — 3 of 10 cases in a suite literally named `validation-gate` were green with `naga` absent.

Deliberately **not** converted: `test_wgsl_scalar_shadow_mut_local`. Its name is about an emitted-text property and its three assertions establish it; only the extra `naga` cross-check is missing, so a green `[OK]` is honest there. Its message was reworded (it had a copy-pasted `codegen-golden OK:` prefix from another suite).

Bare executables (HIP, Vulkan e2e, `test_runtime_cache_*`) were left alone: they already print a visible skip and exit 0, and making the *aggregate* CI result distinguish them needs CI changes, not source changes — see #119.

## Gates

- `dune runtest`: **exit 1**, one failing rule, `sarek/tests/e2e/dune:845-848 test_static_tag_erasure` — the known pre-existing integrated-RADV failure (#80). That file is not in this diff.
- `dune build @fmt`: **exit 1**, three drifting files — `sarek/core/Device.ml`, `sarek/interp/Sarek_float32.ml`, `sarek/tests/unit/test_ir_layout.ml` — all pre-existing, none touched here. Every file in this diff is `ocamlformat`-clean.
- `dune build` on all 16 edited executables: **exit 0**.
- OpenCL, Vulkan and HIP devices are present on this host: those suites still **run** and pass, so the non-skip path is verified untouched, not just assumed.

## Review

Unscoped fresh read of the diff plus a `codex` cross-runtime pass. Both independently flagged the `ptxas` error-string classification; the fresh read additionally caught the `nvdisasm` toolchain-mismatch false-red, the missed sibling case in `test_shader_recursion_vector`, and a duplicated skip line in `test_hip_f16_argcheck`. All three are fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
