### PR TITLE
test(df64): make the precision gates able to fail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,9 +50,14 @@
   deviations as an explicit expected-failure band — upper end 2^-23, twice the
   float32 unit roundoff — keyed on driver identity (Mesa RADV, Mesa ANV) in
   `Test_helpers.df64_known_deviation`. Degrading past plain float32 now FAILs
-  even on an allowlisted device. Red-proved by replacing `df64_mul` with a
-  plain float32 multiply: the old gate reported PASS on both RADV devices and
-  Native (1.43e-07 vs tol 2.38e-07), the new gate FAILs there.
+  even on an allowlisted device, and so does an allowlisted device that starts
+  MEETING the contract (strict XPASS, as in pytest's `xfail(strict=True)`) —
+  the run goes red naming the match arm to delete, so the allowlist cannot rot
+  behind a green exit code. Red-proved twice: replacing `df64_mul` with a plain
+  float32 multiply (old gate PASS on both RADV devices and Native at 1.43e-07
+  vs tol 2.38e-07, new gate FAIL), and adding a bogus allowlist entry for an op
+  that already meets the contract (all three tests exit 1 with the stale-entry
+  message).
 - Indexed kernel-argument container with strict launch validation, honored
   across all six backends (out-of-order/sparse `set_arg` now correct)
 - Unambiguous, collision-resistant compile-cache keys (kernel name included,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,21 @@
   AMD-only measurements to "CUDA/PTX", which is why this went unseen. NOTE
   `df64_sqrt` on NVIDIA remains above tolerance; see the `KNOWN RESIDUAL`
   block in `sarek/Sarek_df64/Sarek_df64.ml`.
+- df64 precision gates could not distinguish a working df64 from a collapsed
+  one. `test_df64`, `test_real64` and `test_real64_single_source` all widened
+  their tolerance to `0x1p-22` (2.38e-07 — four times the float32 unit
+  roundoff) on the backends with a documented deviation, so a df64 that had
+  degraded all the way to plain float32 (measured 5.84e-08 on RADV) and one
+  meeting its contract (9.07e-15) both read PASS. The widening also keyed on
+  the bare `Vulkan` framework tag, sweeping in NVIDIA Vulkan, which meets the
+  full contract. All three tests now hold every device to the derived contract
+  bound (2^-47 add/sub, 2^-46 mul/div/sqrt) and express the documented
+  deviations as an explicit expected-failure band — upper end 2^-23, twice the
+  float32 unit roundoff — keyed on driver identity (Mesa RADV, Mesa ANV) in
+  `Test_helpers.df64_known_deviation`. Degrading past plain float32 now FAILs
+  even on an allowlisted device. Red-proved by replacing `df64_mul` with a
+  plain float32 multiply: the old gate reported PASS on both RADV devices and
+  Native (1.43e-07 vs tol 2.38e-07), the new gate FAILs there.
 - Indexed kernel-argument container with strict launch validation, honored
   across all six backends (out-of-order/sparse `set_arg` now correct)
 - Unambiguous, collision-resistant compile-cache keys (kernel name included,

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -66,13 +66,18 @@
  * and 1.42e-14 (2^-46) for mul/div/sqrt.
  *
  * Those tolerances now apply to EVERY device (task #118). The deviating
- * entries below are not given a wider ceiling: they are an allowlist of
+ * entries below are not given a wider ceiling: they are an allowlist of STRICT
  * expected failures in Test_helpers.df64_known_deviation, checked against a
  * two-sided band whose upper end is 2^-23 (twice the float32 unit roundoff)
- * and reported as KNOWN-DEVIATION, never as PASS. Degrading further than plain
- * float32 therefore FAILs even on an allowlisted device, and a device that is
- * NOT on the allowlist - including NVIDIA Vulkan - is held to the full
- * contract. Before that change the deviating backends were checked against
+ * and reported as KNOWN-DEVIATION, never as PASS. Consequences:
+ *   - degrading further than plain float32 FAILs even on an allowlisted device;
+ *   - a device NOT on the allowlist - NVIDIA Vulkan included - is held to the
+ *     full contract;
+ *   - an allowlisted device that starts MEETING the contract also fails the
+ *     run (strict XPASS), naming the match arm to delete. So if a Mesa release
+ *     fixes RADV's fma, the tests go red until the entry below is pruned -
+ *     deliberately, so the allowlist cannot rot while the suite stays green.
+ * Before that change the deviating backends were checked against
  * 2^-22 = 2.38e-07, which a fully collapsed df64 (~5.8e-08) also satisfied:
  * the gate could not tell the bug from the fix.
  *

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -65,6 +65,17 @@
  * test's max relative errors; its tolerance is 7.11e-15 (2^-47) for add/sub
  * and 1.42e-14 (2^-46) for mul/div/sqrt.
  *
+ * Those tolerances now apply to EVERY device (task #118). The deviating
+ * entries below are not given a wider ceiling: they are an allowlist of
+ * expected failures in Test_helpers.df64_known_deviation, checked against a
+ * two-sided band whose upper end is 2^-23 (twice the float32 unit roundoff)
+ * and reported as KNOWN-DEVIATION, never as PASS. Degrading further than plain
+ * float32 therefore FAILs even on an allowlisted device, and a device that is
+ * NOT on the allowlist - including NVIDIA Vulkan - is held to the full
+ * contract. Before that change the deviating backends were checked against
+ * 2^-22 = 2.38e-07, which a fully collapsed df64 (~5.8e-08) also satisfied:
+ * the gate could not tell the bug from the fix.
+ *
  *   Interpreter, sequential and parallel (any host)
  *       full contract. mul 9.07e-15, div 5.08e-15, sqrt 8.53e-15.
  *

--- a/sarek/tests/e2e/test_df64.ml
+++ b/sarek/tests/e2e/test_df64.ml
@@ -180,18 +180,18 @@ let report_op_stats dev =
       in
       (* [`Xpass] counts as a failure: a stale allowlist entry that only printed
          a warning would leave the exit code at 0 and rot unnoticed. See the
-         "WHY [`Xpass] IS HARD" note on Test_helpers.classify_df64_result. *)
-      (match status with `Fail | `Xpass _ -> incr failures | _ -> ()) ;
+         "WHY [`Xpass] IS HARD" note on Test_helpers.classify_df64_result.
+         Suppressed statuses also raise a GitHub Actions annotation, so a df64
+         collapse on an allowlisted driver is visible on the checks page and not
+         only in the raw log. *)
+      if Test_helpers.df64_status_is_failure status then incr failures ;
+      Test_helpers.annotate_df64_status ~framework ~device ~op ~err ~tol status ;
       Printf.printf
         "  %-6s max rel err %.3g (tol %.3g) %s [%s]\n%!"
         op
         err
         tol
-        (match status with
-        | `Pass -> "PASS"
-        | `Xpass msg -> msg
-        | `Known_deviation label -> label
-        | `Fail -> "FAIL")
+        (Test_helpers.string_of_df64_status status)
         framework)
     op_stats ;
   Hashtbl.reset op_stats

--- a/sarek/tests/e2e/test_df64.ml
+++ b/sarek/tests/e2e/test_df64.ml
@@ -165,18 +165,32 @@ let check ~dev:_ ~op ~tol _i got expected =
   | Some (prev, _) -> if err > prev then Hashtbl.replace op_stats op (err, tol)
   | None -> Hashtbl.replace op_stats op (err, tol)
 
+(* [of_i32] is not a df64 op and keeps its own literal tolerance; every df64
+   arithmetic op goes through the shared classifier in Test_helpers. *)
 let report_op_stats dev =
+  let framework = dev.Device.framework and device = dev.Device.name in
   Hashtbl.iter
     (fun op (err, tol) ->
-      let ok = err <= tol in
-      if not ok then incr failures ;
+      let status, tol =
+        match op with
+        | "add" | "sub" | "mul" | "div" | "sqrt" ->
+            ( Test_helpers.classify_df64_result ~framework ~device ~op ~err,
+              Test_helpers.df64_tol_for_op op )
+        | _ -> ((if err <= tol then `Pass else `Fail), tol)
+      in
+      (match status with `Fail -> incr failures | _ -> ()) ;
       Printf.printf
         "  %-6s max rel err %.3g (tol %.3g) %s [%s]\n%!"
         op
         err
         tol
-        (if ok then "PASS" else "FAIL")
-        dev.Device.framework)
+        (match status with
+        | `Pass -> "PASS"
+        | `Xpass label ->
+            "XPASS - deviation gone, prune the allowlist: " ^ label
+        | `Known_deviation label -> label
+        | `Fail -> "FAIL")
+        framework)
     op_stats ;
   Hashtbl.reset op_stats
 
@@ -223,54 +237,26 @@ let run_ops_test dev =
     ~grid
     () ;
   Transfer.flush dev ;
-  let tol_add =
-    0x1p-47
-    (* Knuth add: ~2 ulp at 2^-48 *)
-  in
-  let tol_mul =
-    0x1p-46
-    (* fast mul drops the lo*lo term: ~4 ulp *)
-  in
-  let tol_dv =
-    0x1p-46
-    (* div/sqrt include a rounded correction step *)
-  in
-  (* Per-backend deviations from the extended-precision contract:
-     - Native evaluates Sarek float32 at OCaml binary64 precision, so the
-       error-free transformations cancel (lo = 0) and df64 degenerates to
-       plain f32 storage precision (~2^-24 relative).  Harmless (Native has
-       real f64) but documented here.
-     - Vulkan (RADV + glslang, and Mesa ANV on Intel): add/sub/sqrt meet the
-       strict contract since float locals are declared [precise], but mul/div
-       lose the two_prod error term because RADV's GLSL [fma] is not
-       correctly rounded. This is NOT the ptxas contraction bug that cost
-       CUDA/PTX and NVIDIA OpenCL their precision; see the PER-BACKEND STATUS
-       and "Contraction barrier" blocks in Sarek_df64.ml.
-     Both are reported as KNOWN-DEVIATION, not silently widened.
+  (* Tolerances and the per-backend deviation allowlist both live in
+     [Test_helpers] now (task #118), so test_df64, test_real64 and
+     test_real64_single_source cannot drift apart. The bounds are derived there
+     from the algorithms' error analysis; the deviating backends are held to a
+     two-sided BAND and reported as KNOWN-DEVIATION rather than being handed a
+     widened ceiling.
 
-     LIMITATION: the widening below keys on [dev.framework] alone, so it
-     applies to EVERY Vulkan device. NVIDIA Vulkan actually meets the full
-     contract (9.07e-15 mul on a GTX 1070), but is checked here against
-     f32_tol, so a future contraction-class regression on NVIDIA Vulkan would
-     pass silently - the same blind spot that hid the CUDA/PTX collapse. The
-     widening should be keyed on the driver/device (RADV, ANV) rather than on
-     "Vulkan". Not changed here: it needs an NVIDIA device to validate, and
-     narrowing it blind risks turning the suite red for the wrong reason. *)
-  let f32_tol = 0x1p-22 in
-  let tol_sqrt = tol_dv in
-  let tol_mul, tol_dv, tol_sqrt, tol_add, deviation =
-    match dev.Device.framework with
-    | "Native" -> (f32_tol, f32_tol, f32_tol, f32_tol, true)
-    | "Vulkan" -> (f32_tol, f32_tol, tol_sqrt, tol_add, true)
-    | _ -> (tol_mul, tol_dv, tol_sqrt, tol_add, false)
-  in
-  if deviation then
-    Printf.printf
-      "  note: %s backend has a KNOWN precision deviation (see test source);\n\
-      \        degraded ops are checked against f32-level tolerance %.3g\n\
-       %!"
-      dev.Device.framework
-      f32_tol ;
+     What was wrong before: the deviating backends were checked against
+     [0x1p-22] = 2.38e-07, four times the float32 unit roundoff. A fully
+     collapsed df64 (5.84e-08 on RADV) and a working one (9.07e-15) both read
+     PASS, so the gate could not distinguish the bug from the fix. The old
+     widening also keyed on the bare "Vulkan" framework tag, which swept in
+     NVIDIA Vulkan — a backend that meets the full contract — and would have
+     hidden a contraction-class regression there. The allowlist in
+     [Test_helpers.df64_known_deviation] is keyed on driver identity (RADV,
+     ANV) instead. *)
+  let tol_add = Test_helpers.df64_tol_add_sub in
+  let tol_mul = Test_helpers.df64_tol_mul_div_sqrt in
+  let tol_dv = tol_mul in
+  let tol_sqrt = tol_mul in
   for i = 0 to n_ops - 1 do
     let x = read_df64 a i and y = read_df64 b i in
     check ~dev ~op:"add" ~tol:tol_add i (read_df64 add_o i) (x +. y) ;
@@ -289,7 +275,13 @@ let run_ops_test dev =
       incr failures ;
       Printf.printf "  FAIL [%s] lt[%d]\n%!" dev.Device.framework i
     end ;
-    check ~dev ~op:"of_i32" ~tol:1e-7 i (Vector.get conv_o i) (float_of_int i)
+    (* Exact, not approximate: every index here is below [n_ops] = 4096 < 2^24,
+       so it is representable in binary32 with no rounding, [df64_of_int32]
+       stores it as (hi = i, lo = 0) and [df64_to_float32] returns hi. The
+       tolerance is therefore 0 — a literal 1e-7 here was another f32-grade
+       gate on a df64 test. Measured 0 on all seven devices enumerated on the
+       campaign workstation. *)
+    check ~dev ~op:"of_i32" ~tol:0.0 i (Vector.get conv_o i) (float_of_int i)
   done ;
   report_op_stats dev
 
@@ -346,7 +338,18 @@ let run_dot_test dev =
     "  dot(2^20): df64 rel err %.3g (f32: %.3g)\n%!"
     df64_err
     f32_err ;
-  (* Worst-case error of n df64 adds is ~n*2^-48; 1e-9 leaves headroom. *)
+  (* Worst-case error of n df64 adds is ~n*2^-48 = 2^20 * 2^-48 = 3.7e-09, so
+     1e-9 is already tighter than the proven bound and is met only because the
+     rounding errors random-walk rather than accumulate.
+
+     THIS GATE DOES NOT DISCRIMINATE a collapsed df64: measured 1.41e-10 on
+     RADV (where mul/div ARE collapsed) versus 2.89e-13 on OpenCL/rusticl and
+     the interpreter — both under 1e-9. It is a smoke test that df64
+     accumulation beats float32 accumulation (3.07e-04 here), nothing more.
+     The discriminating gate is the elementwise ops test above; do not read a
+     green line here as evidence that df64 is intact. Tightening this number
+     to separate 1.41e-10 from 2.89e-13 would be curve-fitting to one dataset,
+     not a derived bound, so it is left alone. *)
   if df64_err > 1e-9 then begin
     incr failures ;
     Printf.printf

--- a/sarek/tests/e2e/test_df64.ml
+++ b/sarek/tests/e2e/test_df64.ml
@@ -178,7 +178,10 @@ let report_op_stats dev =
               Test_helpers.df64_tol_for_op op )
         | _ -> ((if err <= tol then `Pass else `Fail), tol)
       in
-      (match status with `Fail -> incr failures | _ -> ()) ;
+      (* [`Xpass] counts as a failure: a stale allowlist entry that only printed
+         a warning would leave the exit code at 0 and rot unnoticed. See the
+         "WHY [`Xpass] IS HARD" note on Test_helpers.classify_df64_result. *)
+      (match status with `Fail | `Xpass _ -> incr failures | _ -> ()) ;
       Printf.printf
         "  %-6s max rel err %.3g (tol %.3g) %s [%s]\n%!"
         op
@@ -186,8 +189,7 @@ let report_op_stats dev =
         tol
         (match status with
         | `Pass -> "PASS"
-        | `Xpass label ->
-            "XPASS - deviation gone, prune the allowlist: " ^ label
+        | `Xpass msg -> msg
         | `Known_deviation label -> label
         | `Fail -> "FAIL")
         framework)

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -795,4 +795,103 @@ let classify_cpu_opencl_math_result ~dev ~(shape : float_check_shape)
 let github_warning ~title msg =
   Printf.printf "::warning title=%s::%s\n%!" title msg
 
+(* ========================================================================== *)
+(* df64 / real64 status reporting                                             *)
+(* ========================================================================== *)
+
+(** Human-readable text for a df64/real64 status, as printed in the per-op line.
+
+    [`Known_issue], [`Known_deviation] and [`Xpass] all carry a ready-to-print
+    message from their classifier, so they print it verbatim. *)
+let string_of_df64_status = function
+  | `Pass -> "PASS"
+  | `Known_issue s | `Known_deviation s | `Xpass s -> s
+  | `Fail -> "FAIL"
+
+(** [true] iff the status must count towards the test's failure total.
+
+    [`Xpass] is included: a stale allowlist entry that only warned would leave
+    the exit code at 0 and rot unnoticed. See the "WHY [`Xpass] IS HARD" note on
+    [classify_df64_result]. *)
+let df64_status_is_failure = function `Fail | `Xpass _ -> true | _ -> false
+
+(** Emit the GitHub Actions annotation for a non-[`Pass], non-[`Fail] df64 or
+    real64 status.
+
+    Without this, a suppression exists only in the raw log: a df64 collapse on
+    RADV would be invisible on the checks page even though the run is green by
+    design, which is the same visibility gap audit finding #74 / F3 closed for
+    the CPU-OpenCL known-issue. [`Fail] needs no annotation — it already turns
+    the job red — and [`Xpass] gets one *in addition to* failing the run, so the
+    stale entry is visible without opening the log. *)
+let annotate_df64_status ~framework ~device ~op ~err ~tol status =
+  match status with
+  | `Pass | `Fail -> ()
+  | `Xpass msg -> github_warning ~title:"df64 STALE ALLOWLIST ENTRY" msg
+  | (`Known_deviation label | `Known_issue label) as s ->
+      let kind =
+        match s with
+        | `Known_deviation _ -> "df64 KNOWN-DEVIATION"
+        | _ -> "fp64 KNOWN-ISSUE"
+      in
+      github_warning
+        ~title:kind
+        (Printf.sprintf
+           "%s / %s / %s: max rel err %.3g exceeds the tolerance %.3g and is \
+            SUPPRESSED as an expected failure — %s"
+           framework
+           device
+           op
+           err
+           tol
+           label)
+
+(* ========================================================================== *)
+(* real64 per-substrate tolerance and classification                          *)
+(* ========================================================================== *)
+
+(* Shared by test_real64 and test_real64_single_source, which previously carried
+   byte-identical copies of both functions. Keeping two copies is the same drift
+   risk that produced the f32-grade df64 tolerances in the first place: the df64
+   classifier moved here, but these two wrappers were left behind.
+
+   Parameterised on a plain [~native_f64] flag rather than on
+   [Sarek_real64.substrate], so [test_helpers] does not have to take a
+   dependency on sarek.real64 (it is linked into many tests that have no use for
+   it). Callers pass [substrate = Real64.Native_f64]. *)
+
+(** Relative tolerance for the native binary64 substrate. Not the df64 contract:
+    this path runs real IEEE-754 binary64 instructions, so it is held to a
+    binary64-grade bound with room for one fused/reassociated operation. *)
+let real64_native_f64_tol = 1e-12
+
+(** Per-op relative tolerance for a real64 pass. The df64 substrate gets the
+    derived df64 contract bound with NO per-backend widening; deviations are
+    expressed as strict expected failures in [df64_known_deviation]. *)
+let real64_tol_for ~native_f64 ~op =
+  if native_f64 then real64_native_f64_tol else df64_tol_for_op op
+
+(** Classify one real64 op.
+
+    The two substrates need different classifiers and must not be crossed:
+
+    - [Fallback_df64] uses no fp64 instruction at all, so the rusticl fp64
+      KNOWN-ISSUE cannot apply to it, and that classifier's 1e-5 envelope would
+      swallow a total df64 collapse whole.
+    - [Native_f64] is the only path that can hit the rusticl div/sqrt error, and
+      only for div/sqrt; +, -, * stay exact there. *)
+let classify_real64_result ~native_f64 ~framework ~device ~op ~err =
+  if native_f64 then
+    classify_fp64_result
+      ~framework
+      ~device
+      ~within_tol:(err <= real64_native_f64_tol)
+      ~transcendental:(op = "div" || op = "sqrt")
+      ~exact_ok:true
+      ~max_rel:err
+      ~non_finite:(not (Float.is_finite err))
+      ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+      ()
+  else classify_df64_result ~framework ~device ~op ~err
+
 module Benchmarks = Benchmarks

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -440,6 +440,15 @@ let is_anv_device ~framework ~device =
   framework = "Vulkan"
   && string_contains ~needle:"intel" (String.lowercase_ascii device)
 
+(** One entry of the df64 deviation allowlist.
+
+    - [entry]: the match arm in [df64_known_deviation] that produced this, in a
+      form a reader can find and delete. Surfaced verbatim in the strict-XPASS
+      failure message, so it must stay in step with the arm that returns it.
+    - [label]: the KNOWN-DEVIATION text printed when the deviation is observed
+      as expected. *)
+type df64_deviation = {entry : string; label : string}
+
 (** The documented df64 deviation for [(framework, device, op)], if any.
 
     This is an ALLOWLIST: every device not named here — including NVIDIA Vulkan,
@@ -447,15 +456,31 @@ let is_anv_device ~framework ~device =
     580.119.02) — is held to the strict bound. That is the task #118 fix for the
     LIMITATION previously recorded in test_df64.ml: the old gate keyed on the
     bare ["Vulkan"] framework tag, so a contraction-class regression on NVIDIA
-    Vulkan would have passed silently. *)
+    Vulkan would have passed silently.
+
+    Each arm is an EXPECTED FAILURE in the strict sense (pytest's
+    [xfail(strict=True)]): observing the deviation is tolerated, and NOT
+    observing it fails the run. See [classify_df64_result]. *)
 let df64_known_deviation ~framework ~device ~op =
   match (framework, op) with
   | "Native", _ ->
-      (* The Native backend runs Sarek float32 as OCaml binary64, so every
-         error-free transformation cancels (lo = 0) and df64 degenerates to
-         plain float32 storage precision. Affects ALL ops, and is harmless in
-         practice because Native has real binary64. *)
-      Some "KNOWN-DEVIATION (Native evaluates float32 at binary64; EFTs cancel)"
+      (* NOT AN OPEN BUG. The Native backend runs Sarek float32 as OCaml
+         binary64, so every error-free transformation cancels identically
+         (lo = 0) and df64 degenerates to plain float32 storage precision. That
+         is structural, not a defect to be chased: df64 exists to buy extra
+         precision on devices that lack binary64, and Native HAS binary64, so
+         running df64 there is POINTLESS rather than broken. Nothing downstream
+         is wrong — anyone wanting precision on Native uses float64 (or
+         Sarek_real64, which selects Native_f64 there automatically). The entry
+         covers all five ops because the cancellation is the same for all
+         five. *)
+      Some
+        {
+          entry = "Native, _ (all ops)";
+          label =
+            "KNOWN-DEVIATION (Native evaluates float32 at binary64; EFTs \
+             cancel — df64 on Native is pointless, not broken)";
+        }
   | "Vulkan", ("mul" | "div") when is_radv_device ~framework ~device ->
       (* RADV's GLSL [fma] is not correctly rounded, so TwoProd's error term is
          lost. NOT the ptxas contraction bug (add/sub/sqrt are unaffected and
@@ -463,9 +488,17 @@ let df64_known_deviation ~framework ~device ~op =
          GLSL [precise] qualifier that Sarek_ir_glsl.ml emits on float locals.
          Measured on AMD Radeon RX 7900 XTX (RADV NAVI31), Mesa 26.1.4-arch3.1,
          Vulkan 1.4.354, kernel 7.1.2-3-cachyos: mul 5.84e-08, div 5.86e-08. *)
-      Some "KNOWN-DEVIATION (RADV fma not correctly rounded)"
+      Some
+        {
+          entry = "Vulkan, (mul|div) when is_radv_device";
+          label = "KNOWN-DEVIATION (RADV fma not correctly rounded)";
+        }
   | "Vulkan", ("mul" | "div") when is_anv_device ~framework ~device ->
-      Some "KNOWN-DEVIATION (Mesa ANV mul/div, unmeasured cause)"
+      Some
+        {
+          entry = "Vulkan, (mul|div) when is_anv_device";
+          label = "KNOWN-DEVIATION (Mesa ANV mul/div, unmeasured cause)";
+        }
   | _ -> None
 
 (** Strict df64 contract bound for [op]. *)
@@ -476,24 +509,52 @@ let df64_tol_for_op = function
 (** Classify one df64 op's worst relative error.
 
     - [`Pass]: within the strict contract bound, and no deviation was expected.
-    - [`Xpass label]: within the strict bound on a device the allowlist expects
-      to deviate. Reported loudly, NOT counted as a failure: the code/driver got
-      better and [df64_known_deviation] needs pruning. (Choosing not to fail
-      here is deliberate — an unrelated driver upgrade should not turn the suite
-      red — but it does mean the allowlist can only be pruned by someone reading
-      the output.)
+    - [`Xpass msg]: within the strict bound on a device the allowlist expects to
+      deviate. {b This is a FAILURE} — the allowlist entry is stale and must be
+      deleted. Callers MUST count it towards their failure total and exit
+      nonzero; [msg] already names the arm to remove.
     - [`Known_deviation label]: over the contract bound, on the allowlist, and
-      inside the collapsed band. An explicit expected failure.
+      inside the collapsed band. An expected failure, tolerated.
     - [`Fail]: everything else, including a non-finite error and any error above
-      [df64_collapsed_ceiling] on an allowlisted device. *)
+      [df64_collapsed_ceiling] on an allowlisted device.
+
+    WHY [`Xpass] IS HARD (strict xfail). An earlier revision of this classifier
+    printed XPASS and left the run green, on the reasoning that an unrelated
+    driver upgrade should not turn CI red. That was wrong for the same reason
+    the [test_cuda_f16_sass] / mma-probe bug was wrong (PR #300): a status that
+    is printed but leaves the exit code at 0 is indistinguishable from a pass to
+    everything that consumes the exit code, so the allowlist rots silently and
+    the suite goes on claiming a deviation that no longer exists. It is also
+    what pytest's [xfail(strict=True)] default exists to prevent.
+
+    The cost is small and bounded: the GitHub CI runners have no GPU, so the
+    RADV and ANV arms never evaluate there and cannot flake CI, and when this
+    does fire on a workstation the fix is deleting one match arm from
+    [df64_known_deviation]. *)
 let classify_df64_result ~framework ~device ~op ~err =
   let tol = df64_tol_for_op op in
   let deviation = df64_known_deviation ~framework ~device ~op in
   if Float.is_finite err && err <= tol then
-    match deviation with Some label -> `Xpass label | None -> `Pass
+    match deviation with
+    | Some {entry; label} ->
+        `Xpass
+          (Printf.sprintf
+             "XPASS (STALE ALLOWLIST ENTRY) - %s / %s / %s now MEETS the df64 \
+              contract (%.3g <= %.3g), but Test_helpers.df64_known_deviation \
+              still expects a deviation there. DELETE the match arm [%s]. Was: \
+              %s"
+             framework
+             device
+             op
+             err
+             tol
+             entry
+             label)
+    | None -> `Pass
   else
     match deviation with
-    | Some label when Float.is_finite err && err <= df64_collapsed_ceiling ->
+    | Some {label; _} when Float.is_finite err && err <= df64_collapsed_ceiling
+      ->
         `Known_deviation label
     | _ -> `Fail
 

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -346,6 +346,158 @@ let classify_fp64_result ~framework ~device ~within_tol ~transcendental
   else `Fail
 
 (* ========================================================================== *)
+(* df64 (double-float) precision classification                               *)
+(* ========================================================================== *)
+
+(* Single source of truth for the Sarek_df64 precision gates, shared by
+   test_df64, test_real64 and test_real64_single_source.
+
+   WHY THIS EXISTS (task #118). All three tests previously widened the
+   tolerance to [0x1p-22] (2.38e-07) on the backends with a documented df64
+   deviation. 0x1p-22 is FOUR TIMES the float32 unit roundoff, so a df64 that
+   had collapsed all the way to plain float32 (measured 5.84e-08 on RADV) and a
+   df64 that met its contract (measured 9.07e-15) BOTH read as PASS. The gate
+   could not tell the bug from the fix — the "threshold wider than the effect"
+   failure mode. It is also how the real-NVIDIA contraction collapse survived
+   in CUDA/PTX and OpenCL undetected.
+
+   The replacement never widens a ceiling. A deviating (framework, device, op)
+   is checked against a two-sided BAND and reported as an explicit
+   KNOWN-DEVIATION, never as PASS:
+
+     err <= df64 contract bound      -> XPASS  (the deviation is gone; the
+                                                allowlist below is stale)
+     contract < err <= collapsed ceiling, and on the allowlist
+                                     -> KNOWN-DEVIATION (expected failure)
+     anything else                   -> FAIL
+
+   So a device that degrades BEYOND plain float32 now fails, a device NOT on
+   the allowlist is always held to the full contract, and a driver fix is
+   surfaced instead of being absorbed. *)
+
+(** Relative-error bound of [df64_add] / [df64_sub].
+
+    Derivation, not a round number. A df64 value is an unevaluated pair of
+    binary32s [hi + lo] with [|lo| <= ulp(hi)/2], i.e. a ~2p = 48-bit
+    significand (p = 24 for binary32). Sarek_df64's add/sub are the Knuth/Dekker
+    two_sum + quick_two_sum sequence, whose classical bound for the
+    double-double form is 2 ulp of the 2p-bit format, i.e. 2 * 2^-(2p) * 2 =
+    2^-(2p-1) = 2^-47 for p = 24. Measured worst case on the contract-meeting
+    backends: add 5.33e-15, sub 6.51e-15, against 2^-47 = 7.11e-15. *)
+let df64_tol_add_sub = 0x1p-47
+
+(** Relative-error bound of [df64_mul] / [df64_div] / [df64_sqrt].
+
+    Same derivation, one binade looser: the fast two_prod-based multiply drops
+    the [lo*lo] cross term and div/sqrt close with a single rounded Newton /
+    Karp correction, which costs the low word its last bit — 4 ulp of the 48-bit
+    format, i.e. 2^-(2p-2) = 2^-46 for p = 24. Measured worst case on the
+    contract-meeting backends: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14,
+    against 2^-46 = 1.42e-14. *)
+let df64_tol_mul_div_sqrt = 0x1p-46
+
+(** Ceiling of the COLLAPSED band: the worst relative error a df64 op may show
+    while still being explainable as "the extended-precision machinery was lost
+    and only float32 information survived".
+
+    Derivation: the binary32 unit roundoff is u = 2^-24 = 5.96e-08. When
+    TwoProd's error term is lost, [df64_mul] degenerates to a value carrying at
+    most one correctly-rounded binary32 product plus a lo word that no longer
+    corrects it, so the relative error is that of a chain of at most two
+    binary32 roundings: 2u = 2^-23 = 1.19e-07. Measured collapsed values sit
+    just under ONE u — 5.84e-08 (mul) and 5.86e-08 (div) on RADV, 5.9e-08 on
+    Native — so 2u is a real ceiling with one rounding of headroom and not a
+    round number chosen to fit. Anything above it is worse than plain float32
+    and is a genuine FAIL even on an allowlisted device. *)
+let df64_collapsed_ceiling = 0x1p-23
+
+(** [true] iff [device] is a Mesa RADV (AMD Vulkan) device.
+
+    Keyed on the Vulkan [deviceName], which RADV builds as
+    ["AMD Radeon RX 7900 XTX (RADV NAVI31)"] / ["... (RADV RAPHAEL_MENDOCINO)"]
+    — the ["RADV"] token is inserted by the driver itself, not by the board
+    vendor. Same discipline (and same caveat) as [is_rusticl_device]: a driver
+    rename reopens the gate as a plain FAIL, which is the safe direction. *)
+let is_radv_device ~framework ~device =
+  framework = "Vulkan"
+  && string_contains ~needle:"radv" (String.lowercase_ascii device)
+
+(** [true] iff [device] is a Mesa ANV (Intel Vulkan) device.
+
+    ANV reports the marketing name only
+    (["Intel(R) UHD Graphics 630 (CFL GT2)"]) with no driver token, so this
+    matches the vendor string. That is looser than [is_radv_device] and it is
+    the weakest predicate here: it would also match a future non-Mesa Intel
+    Vulkan driver.
+
+    NOT VERIFIED ON THE TASK #118 HARDWARE — there is no Intel GPU on the
+    campaign workstation (RX 7900 XTX + Raphael iGPU only). The entry is carried
+    over from the measurement recorded in Sarek_df64.ml's PER-BACKEND STATUS
+    (UHD Graphics 630, CFL GT2, Mesa ANV: mul/div ~5.8e-08, same shape as RADV).
+    It must be re-measured, and narrowed to a driver token, the first time an
+    Intel device runs this suite. *)
+let is_anv_device ~framework ~device =
+  framework = "Vulkan"
+  && string_contains ~needle:"intel" (String.lowercase_ascii device)
+
+(** The documented df64 deviation for [(framework, device, op)], if any.
+
+    This is an ALLOWLIST: every device not named here — including NVIDIA Vulkan,
+    which meets the full contract (mul 9.07e-15 on a GTX 1070 Max-Q, driver
+    580.119.02) — is held to the strict bound. That is the task #118 fix for the
+    LIMITATION previously recorded in test_df64.ml: the old gate keyed on the
+    bare ["Vulkan"] framework tag, so a contraction-class regression on NVIDIA
+    Vulkan would have passed silently. *)
+let df64_known_deviation ~framework ~device ~op =
+  match (framework, op) with
+  | "Native", _ ->
+      (* The Native backend runs Sarek float32 as OCaml binary64, so every
+         error-free transformation cancels (lo = 0) and df64 degenerates to
+         plain float32 storage precision. Affects ALL ops, and is harmless in
+         practice because Native has real binary64. *)
+      Some "KNOWN-DEVIATION (Native evaluates float32 at binary64; EFTs cancel)"
+  | "Vulkan", ("mul" | "div") when is_radv_device ~framework ~device ->
+      (* RADV's GLSL [fma] is not correctly rounded, so TwoProd's error term is
+         lost. NOT the ptxas contraction bug (add/sub/sqrt are unaffected and
+         meet the contract on the same device). Mesa also does not honour the
+         GLSL [precise] qualifier that Sarek_ir_glsl.ml emits on float locals.
+         Measured on AMD Radeon RX 7900 XTX (RADV NAVI31), Mesa 26.1.4-arch3.1,
+         Vulkan 1.4.354, kernel 7.1.2-3-cachyos: mul 5.84e-08, div 5.86e-08. *)
+      Some "KNOWN-DEVIATION (RADV fma not correctly rounded)"
+  | "Vulkan", ("mul" | "div") when is_anv_device ~framework ~device ->
+      Some "KNOWN-DEVIATION (Mesa ANV mul/div, unmeasured cause)"
+  | _ -> None
+
+(** Strict df64 contract bound for [op]. *)
+let df64_tol_for_op = function
+  | "add" | "sub" -> df64_tol_add_sub
+  | _ -> df64_tol_mul_div_sqrt
+
+(** Classify one df64 op's worst relative error.
+
+    - [`Pass]: within the strict contract bound, and no deviation was expected.
+    - [`Xpass label]: within the strict bound on a device the allowlist expects
+      to deviate. Reported loudly, NOT counted as a failure: the code/driver got
+      better and [df64_known_deviation] needs pruning. (Choosing not to fail
+      here is deliberate — an unrelated driver upgrade should not turn the suite
+      red — but it does mean the allowlist can only be pruned by someone reading
+      the output.)
+    - [`Known_deviation label]: over the contract bound, on the allowlist, and
+      inside the collapsed band. An explicit expected failure.
+    - [`Fail]: everything else, including a non-finite error and any error above
+      [df64_collapsed_ceiling] on an allowlisted device. *)
+let classify_df64_result ~framework ~device ~op ~err =
+  let tol = df64_tol_for_op op in
+  let deviation = df64_known_deviation ~framework ~device ~op in
+  if Float.is_finite err && err <= tol then
+    match deviation with Some label -> `Xpass label | None -> `Pass
+  else
+    match deviation with
+    | Some label when Float.is_finite err && err <= df64_collapsed_ceiling ->
+        `Known_deviation label
+    | _ -> `Fail
+
+(* ========================================================================== *)
 (* CPU-OpenCL float32 math-intrinsic classification                           *)
 (* ========================================================================== *)
 

--- a/sarek/tests/e2e/test_real64.ml
+++ b/sarek/tests/e2e/test_real64.ml
@@ -119,49 +119,27 @@ let rel_error got expected =
   if expected = 0.0 then Stdlib.abs_float got
   else Stdlib.abs_float ((got -. expected) /. expected)
 
-(* Per-op relative tolerance for a (substrate, framework). Native f64 gets the
-   full binary64 contract; df64 gets Sarek_df64's derived contract bound from
-   [Test_helpers], with NO per-backend widening.
+(* Per-op tolerance and per-op classification both live in [Test_helpers] now,
+   as [real64_tol_for] / [classify_real64_result]. They used to be a
+   byte-identical copy in this file and in test_real64_single_source.ml — the
+   same duplication-drift risk that produced the f32-grade df64 tolerances this
+   PR removes. See those functions for the substrate split (the rusticl fp64
+   KNOWN-ISSUE applies only to Native_f64, never to the df64 fallback) and for
+   the task #118 rationale (no per-backend widening; deviations are strict
+   expected failures keyed on driver identity). *)
+let native_f64 substrate = substrate = Real64.Native_f64
 
-   Task #118: this used to widen to [0x1p-22] = 2.38e-07 (four times the
-   float32 unit roundoff) on Native and on every Vulkan device, which made a
-   collapsed df64 and a working df64 indistinguishable — both PASS. The
-   documented deviations are now expressed as an explicit expected-failure band
-   keyed on driver identity in [Test_helpers.df64_known_deviation], not as a
-   looser ceiling. *)
 let tol_for ~(substrate : Real64.substrate) ~framework:_ ~op =
-  match substrate with
-  | Real64.Native_f64 -> 1e-12
-  | Real64.Fallback_df64 -> Test_helpers.df64_tol_for_op op
+  Test_helpers.real64_tol_for ~native_f64:(native_f64 substrate) ~op
 
-(* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
-   div/sqrt KNOWN-ISSUE, or a genuine FAIL. The classifier, the transcendental
-   envelope and the rusticl-identity gate all live in [Test_helpers] now (audit
-   #52 / F4, F5); see [Test_helpers.classify_fp64_result] for the full rationale.
-
-   Only the Native_f64 substrate can hit the rusticl div/sqrt error: WITHOUT
-   RUSTICL_FEATURES=fp64 OpenCL reports fp64=false and real64 selects the exact
-   df64 fallback (never annotated); WITH it, Native_f64 is selected and only
-   div/sqrt carry the ~1e-8 error while +, -, * stay exact. [transcendental] is
-   therefore [Native_f64 && (div|sqrt)]. A non-finite result forces FAIL. *)
-let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol =
-  match substrate with
-  | Real64.Fallback_df64 ->
-      (* The df64 fallback has its own classifier: the rusticl fp64 KNOWN-ISSUE
-         cannot apply here (the fallback uses no fp64 instruction at all), and
-         its 1e-5 envelope would swallow a total df64 collapse. *)
-      Test_helpers.classify_df64_result ~framework ~device ~op ~err
-  | Real64.Native_f64 ->
-      Test_helpers.classify_fp64_result
-        ~framework
-        ~device
-        ~within_tol:(err <= tol)
-        ~transcendental:(op = "div" || op = "sqrt")
-        ~exact_ok:true
-        ~max_rel:err
-        ~non_finite:(not (Float.is_finite err))
-        ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
-        ()
+let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol:_
+    =
+  Test_helpers.classify_real64_result
+    ~native_f64:(native_f64 substrate)
+    ~framework
+    ~device
+    ~op
+    ~err
 
 (* ========== One pass on one device with one substrate ========== *)
 
@@ -238,19 +216,17 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
       let tol = tol_for ~substrate ~framework ~op in
       let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
       (* [`Xpass] counts as a failure: see the "WHY [`Xpass] IS HARD" note on
-         Test_helpers.classify_df64_result. *)
-      (match status with `Fail | `Xpass _ -> incr failures | _ -> ()) ;
+         Test_helpers.classify_df64_result. Suppressed statuses also raise a
+         GitHub Actions annotation, so a deviation is visible on the checks page
+         and not only in the raw log. *)
+      if Test_helpers.df64_status_is_failure status then incr failures ;
+      Test_helpers.annotate_df64_status ~framework ~device ~op ~err ~tol status ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
         err
         tol
-        (match status with
-        | `Pass -> "PASS"
-        | `Known_issue s -> s
-        | `Known_deviation s -> s
-        | `Xpass msg -> msg
-        | `Fail -> "FAIL"))
+        (Test_helpers.string_of_df64_status status))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 
 (* ========== Main ========== *)

--- a/sarek/tests/e2e/test_real64.ml
+++ b/sarek/tests/e2e/test_real64.ml
@@ -120,24 +120,19 @@ let rel_error got expected =
   else Stdlib.abs_float ((got -. expected) /. expected)
 
 (* Per-op relative tolerance for a (substrate, framework). Native f64 gets the
-   full binary64 contract; df64 follows Sarek_df64's per-backend table (Native
-   and Vulkan mul/div collapse to f32 storage precision - a documented,
-   inherited deviation, not a silent widening). *)
-let f32_tol = 0x1p-22
+   full binary64 contract; df64 gets Sarek_df64's derived contract bound from
+   [Test_helpers], with NO per-backend widening.
 
-let tol_for ~(substrate : Real64.substrate) ~framework ~op =
+   Task #118: this used to widen to [0x1p-22] = 2.38e-07 (four times the
+   float32 unit roundoff) on Native and on every Vulkan device, which made a
+   collapsed df64 and a working df64 indistinguishable — both PASS. The
+   documented deviations are now expressed as an explicit expected-failure band
+   keyed on driver identity in [Test_helpers.df64_known_deviation], not as a
+   looser ceiling. *)
+let tol_for ~(substrate : Real64.substrate) ~framework:_ ~op =
   match substrate with
   | Real64.Native_f64 -> 1e-12
-  | Real64.Fallback_df64 -> (
-      let base =
-        match op with
-        | "add" | "sub" -> 0x1p-47
-        | _ -> 0x1p-46 (* mul / div / sqrt *)
-      in
-      match (framework, op) with
-      | "Native", _ -> f32_tol
-      | "Vulkan", ("mul" | "div") -> f32_tol
-      | _ -> base)
+  | Real64.Fallback_df64 -> Test_helpers.df64_tol_for_op op
 
 (* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
    div/sqrt KNOWN-ISSUE, or a genuine FAIL. The classifier, the transcendental
@@ -150,17 +145,23 @@ let tol_for ~(substrate : Real64.substrate) ~framework ~op =
    div/sqrt carry the ~1e-8 error while +, -, * stay exact. [transcendental] is
    therefore [Native_f64 && (div|sqrt)]. A non-finite result forces FAIL. *)
 let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol =
-  Test_helpers.classify_fp64_result
-    ~framework
-    ~device
-    ~within_tol:(err <= tol)
-    ~transcendental:
-      (substrate = Real64.Native_f64 && (op = "div" || op = "sqrt"))
-    ~exact_ok:true
-    ~max_rel:err
-    ~non_finite:(not (Float.is_finite err))
-    ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
-    ()
+  match substrate with
+  | Real64.Fallback_df64 ->
+      (* The df64 fallback has its own classifier: the rusticl fp64 KNOWN-ISSUE
+         cannot apply here (the fallback uses no fp64 instruction at all), and
+         its 1e-5 envelope would swallow a total df64 collapse. *)
+      Test_helpers.classify_df64_result ~framework ~device ~op ~err
+  | Real64.Native_f64 ->
+      Test_helpers.classify_fp64_result
+        ~framework
+        ~device
+        ~within_tol:(err <= tol)
+        ~transcendental:(op = "div" || op = "sqrt")
+        ~exact_ok:true
+        ~max_rel:err
+        ~non_finite:(not (Float.is_finite err))
+        ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+        ()
 
 (* ========== One pass on one device with one substrate ========== *)
 
@@ -236,9 +237,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
       let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
-      (match status with
-      | `Fail -> incr failures
-      | `Pass | `Known_issue _ -> ()) ;
+      (match status with `Fail -> incr failures | _ -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
@@ -247,6 +246,8 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
         (match status with
         | `Pass -> "PASS"
         | `Known_issue s -> s
+        | `Known_deviation s -> s
+        | `Xpass s -> "XPASS - deviation gone, prune the allowlist: " ^ s
         | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 

--- a/sarek/tests/e2e/test_real64.ml
+++ b/sarek/tests/e2e/test_real64.ml
@@ -237,7 +237,9 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
       let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
-      (match status with `Fail -> incr failures | _ -> ()) ;
+      (* [`Xpass] counts as a failure: see the "WHY [`Xpass] IS HARD" note on
+         Test_helpers.classify_df64_result. *)
+      (match status with `Fail | `Xpass _ -> incr failures | _ -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
@@ -247,7 +249,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
         | `Pass -> "PASS"
         | `Known_issue s -> s
         | `Known_deviation s -> s
-        | `Xpass s -> "XPASS - deviation gone, prune the allowlist: " ^ s
+        | `Xpass msg -> msg
         | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 

--- a/sarek/tests/e2e/test_real64_single_source.ml
+++ b/sarek/tests/e2e/test_real64_single_source.ml
@@ -89,45 +89,27 @@ let rel_error got expected =
   if expected = 0.0 then Stdlib.abs_float got
   else Stdlib.abs_float ((got -. expected) /. expected)
 
-(* Task #118: this used to widen to [0x1p-22] = 2.38e-07 (four times the
-   float32 unit roundoff) on Native and on every Vulkan device, so a collapsed
-   df64 and a working df64 both read PASS. The documented deviations are now an
-   explicit expected-failure band keyed on driver identity in
-   [Test_helpers.df64_known_deviation]; the bounds themselves are derived in
-   [Test_helpers] from the df64 algorithms' error analysis. *)
+(* Per-op tolerance and per-op classification both live in [Test_helpers] now,
+   as [real64_tol_for] / [classify_real64_result]. They used to be a
+   byte-identical copy in this file and in test_real64_single_source.ml — the
+   same duplication-drift risk that produced the f32-grade df64 tolerances this
+   PR removes. See those functions for the substrate split (the rusticl fp64
+   KNOWN-ISSUE applies only to Native_f64, never to the df64 fallback) and for
+   the task #118 rationale (no per-backend widening; deviations are strict
+   expected failures keyed on driver identity). *)
+let native_f64 substrate = substrate = Real64.Native_f64
+
 let tol_for ~(substrate : Real64.substrate) ~framework:_ ~op =
-  match substrate with
-  | Real64.Native_f64 -> 1e-12
-  | Real64.Fallback_df64 -> Test_helpers.df64_tol_for_op op
+  Test_helpers.real64_tol_for ~native_f64:(native_f64 substrate) ~op
 
-(* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
-   div/sqrt KNOWN-ISSUE, or a genuine FAIL. The classifier, the transcendental
-   envelope and the rusticl-identity gate all live in [Test_helpers] now (audit
-   #52 / F4, F5); see [Test_helpers.classify_fp64_result] for the full rationale.
-
-   Only the Native_f64 substrate can hit the rusticl div/sqrt error: WITHOUT
-   RUSTICL_FEATURES=fp64 OpenCL reports fp64=false and real64 selects the exact
-   df64 fallback (never annotated); WITH it, Native_f64 is selected and only
-   div/sqrt carry the ~1e-8 error while +, -, * stay exact. [transcendental] is
-   therefore [Native_f64 && (div|sqrt)]. A non-finite result forces FAIL. *)
-let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol =
-  match substrate with
-  | Real64.Fallback_df64 ->
-      (* The df64 fallback uses no fp64 instruction, so the rusticl fp64
-         KNOWN-ISSUE cannot apply and its 1e-5 envelope would swallow a total
-         df64 collapse. *)
-      Test_helpers.classify_df64_result ~framework ~device ~op ~err
-  | Real64.Native_f64 ->
-      Test_helpers.classify_fp64_result
-        ~framework
-        ~device
-        ~within_tol:(err <= tol)
-        ~transcendental:(op = "div" || op = "sqrt")
-        ~exact_ok:true
-        ~max_rel:err
-        ~non_finite:(not (Float.is_finite err))
-        ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
-        ()
+let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol:_
+    =
+  Test_helpers.classify_real64_result
+    ~native_f64:(native_f64 substrate)
+    ~framework
+    ~device
+    ~op
+    ~err
 
 (* ========== One pass on one device with one substrate ===================== *)
 
@@ -198,19 +180,17 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
       let tol = tol_for ~substrate ~framework ~op in
       let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
       (* [`Xpass] counts as a failure: see the "WHY [`Xpass] IS HARD" note on
-         Test_helpers.classify_df64_result. *)
-      (match status with `Fail | `Xpass _ -> incr failures | _ -> ()) ;
+         Test_helpers.classify_df64_result. Suppressed statuses also raise a
+         GitHub Actions annotation, so a deviation is visible on the checks page
+         and not only in the raw log. *)
+      if Test_helpers.df64_status_is_failure status then incr failures ;
+      Test_helpers.annotate_df64_status ~framework ~device ~op ~err ~tol status ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
         err
         tol
-        (match status with
-        | `Pass -> "PASS"
-        | `Known_issue s -> s
-        | `Known_deviation s -> s
-        | `Xpass msg -> msg
-        | `Fail -> "FAIL"))
+        (Test_helpers.string_of_df64_status status))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 
 (* ========== Main ========== *)

--- a/sarek/tests/e2e/test_real64_single_source.ml
+++ b/sarek/tests/e2e/test_real64_single_source.ml
@@ -89,17 +89,16 @@ let rel_error got expected =
   if expected = 0.0 then Stdlib.abs_float got
   else Stdlib.abs_float ((got -. expected) /. expected)
 
-let f32_tol = 0x1p-22
-
-let tol_for ~(substrate : Real64.substrate) ~framework ~op =
+(* Task #118: this used to widen to [0x1p-22] = 2.38e-07 (four times the
+   float32 unit roundoff) on Native and on every Vulkan device, so a collapsed
+   df64 and a working df64 both read PASS. The documented deviations are now an
+   explicit expected-failure band keyed on driver identity in
+   [Test_helpers.df64_known_deviation]; the bounds themselves are derived in
+   [Test_helpers] from the df64 algorithms' error analysis. *)
+let tol_for ~(substrate : Real64.substrate) ~framework:_ ~op =
   match substrate with
   | Real64.Native_f64 -> 1e-12
-  | Real64.Fallback_df64 -> (
-      let base = match op with "add" | "sub" -> 0x1p-47 | _ -> 0x1p-46 in
-      match (framework, op) with
-      | "Native", _ -> f32_tol
-      | "Vulkan", ("mul" | "div") -> f32_tol
-      | _ -> base)
+  | Real64.Fallback_df64 -> Test_helpers.df64_tol_for_op op
 
 (* Classify one op's outcome: PASS within tolerance, the documented rusticl fp64
    div/sqrt KNOWN-ISSUE, or a genuine FAIL. The classifier, the transcendental
@@ -112,17 +111,23 @@ let tol_for ~(substrate : Real64.substrate) ~framework ~op =
    div/sqrt carry the ~1e-8 error while +, -, * stay exact. [transcendental] is
    therefore [Native_f64 && (div|sqrt)]. A non-finite result forces FAIL. *)
 let op_status ~(substrate : Real64.substrate) ~framework ~device ~op ~err ~tol =
-  Test_helpers.classify_fp64_result
-    ~framework
-    ~device
-    ~within_tol:(err <= tol)
-    ~transcendental:
-      (substrate = Real64.Native_f64 && (op = "div" || op = "sqrt"))
-    ~exact_ok:true
-    ~max_rel:err
-    ~non_finite:(not (Float.is_finite err))
-    ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
-    ()
+  match substrate with
+  | Real64.Fallback_df64 ->
+      (* The df64 fallback uses no fp64 instruction, so the rusticl fp64
+         KNOWN-ISSUE cannot apply and its 1e-5 envelope would swallow a total
+         df64 collapse. *)
+      Test_helpers.classify_df64_result ~framework ~device ~op ~err
+  | Real64.Native_f64 ->
+      Test_helpers.classify_fp64_result
+        ~framework
+        ~device
+        ~within_tol:(err <= tol)
+        ~transcendental:(op = "div" || op = "sqrt")
+        ~exact_ok:true
+        ~max_rel:err
+        ~non_finite:(not (Float.is_finite err))
+        ~label:"KNOWN-ISSUE (rusticl fp64 sqrt/div)"
+        ()
 
 (* ========== One pass on one device with one substrate ===================== *)
 
@@ -192,9 +197,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
       let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
-      (match status with
-      | `Fail -> incr failures
-      | `Pass | `Known_issue _ -> ()) ;
+      (match status with `Fail -> incr failures | _ -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
@@ -203,6 +206,8 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
         (match status with
         | `Pass -> "PASS"
         | `Known_issue s -> s
+        | `Known_deviation s -> s
+        | `Xpass s -> "XPASS - deviation gone, prune the allowlist: " ^ s
         | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 

--- a/sarek/tests/e2e/test_real64_single_source.ml
+++ b/sarek/tests/e2e/test_real64_single_source.ml
@@ -197,7 +197,9 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
       let err = try Hashtbl.find worst op with Not_found -> 0.0 in
       let tol = tol_for ~substrate ~framework ~op in
       let status = op_status ~substrate ~framework ~device ~op ~err ~tol in
-      (match status with `Fail -> incr failures | _ -> ()) ;
+      (* [`Xpass] counts as a failure: see the "WHY [`Xpass] IS HARD" note on
+         Test_helpers.classify_df64_result. *)
+      (match status with `Fail | `Xpass _ -> incr failures | _ -> ()) ;
       Printf.printf
         "    %-5s max rel err %.3g (tol %.3g) %s\n%!"
         op
@@ -207,7 +209,7 @@ let run_pass (dev : Device.t) ~(substrate : Real64.substrate) =
         | `Pass -> "PASS"
         | `Known_issue s -> s
         | `Known_deviation s -> s
-        | `Xpass s -> "XPASS - deviation gone, prune the allowlist: " ^ s
+        | `Xpass msg -> msg
         | `Fail -> "FAIL"))
     ["add"; "sub"; "mul"; "div"; "sqrt"]
 


### PR DESCRIPTION
## The defect

Every df64 precision gate in the suite widened its tolerance to `0x1p-22` = **2.38e-07** on the backends with a documented deviation. That is *four times* the binary32 unit roundoff, so it sits above the entire float32 error range. Consequence, measured on this workstation:

| df64 state | measured rel err | old gate (tol 2.38e-07) |
|---|---|---|
| collapsed to plain f32 (RADV mul) | 5.84e-08 | **PASS** |
| meeting the contract (OpenCL mul) | 9.07e-15 | **PASS** |

The gate could not tell the bug from the fix. It is the same shape of blind spot that let the `ptxas` contraction collapse survive on real NVIDIA hardware for four years — and the old widening keyed on the bare `"Vulkan"` framework string, so it also swept in NVIDIA Vulkan, a backend that *does* meet the contract. `test_df64.ml` carried a comment saying exactly this and declining to fix it.

## Every f32-grade df64 tolerance found

Swept all backends (OpenCL, CUDA/PTX, Vulkan/GLSL, Metal, HIP, Native, Interpreter) for df64/real64 numeric gates. Four sites, all fixed:

| # | File | Constant | Applied to | Was | Now |
|---|---|---|---|---|---|
| 1 | `test_df64.ml:259` | `f32_tol = 0x1p-22` | Native (add/sub/mul/div/sqrt) + **all** Vulkan (mul/div) | 2.38e-07 ceiling | contract bound + expected-failure band |
| 2 | `test_real64.ml:126` | `f32_tol = 0x1p-22` | same, df64 substrate | 2.38e-07 ceiling | same |
| 3 | `test_real64_single_source.ml:92` | `f32_tol = 0x1p-22` | same, df64 substrate | 2.38e-07 ceiling | same |
| 4 | `test_df64.ml:292` | literal `1e-7` on `of_i32` | all devices | 1e-7 | **0.0** (exact) |

No other backend had a separate df64 gate — Metal, HIP and WGSL have no df64 test at all, and `test_df64_no_contraction` is a PTX-text assertion with no tolerance. `test_df64.ml`'s dot-product gate (1e-9) is *not* f32-grade but also does not discriminate (1.41e-10 collapsed vs 2.89e-13 working, both green); it is now commented as a smoke test only, with the reason a tighter number would be curve-fitting rather than a bound.

## Derivation of each new bound

All three constants now live once, in `Test_helpers`, with the derivation in a doc comment next to them.

**`df64_tol_add_sub = 0x1p-47`** — a df64 is an unevaluated pair of binary32 with `|lo| <= ulp(hi)/2`, i.e. a 2p = 48-bit significand (p = 24). add/sub are Knuth/Dekker `two_sum` + `quick_two_sum`, classical bound 2 ulp of the 2p-bit format = `2^-(2p-1)` = 2^-47 = 7.11e-15. Measured: add 5.33e-15, sub 6.51e-15.

**`df64_tol_mul_div_sqrt = 0x1p-46`** — one binade looser: the fast two_prod multiply drops the `lo*lo` cross term and div/sqrt close with a single rounded Newton/Karp correction, costing the low word its last bit — 4 ulp = `2^-(2p-2)` = 2^-46 = 1.42e-14. Measured: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14.

**`df64_collapsed_ceiling = 0x1p-23`** — the *upper* end of the expected-failure band. Binary32 unit roundoff is u = 2^-24 = 5.96e-08; with TwoProd's error term lost the result carries at most two binary32 roundings, so 2u = 2^-23 = 1.19e-07. Measured collapsed values sit just under **one** u (5.84e-08 mul, 5.86e-08 div on RADV; 5.9e-08 on Native), so this is a real ceiling with a rounding of headroom, not a number picked to fit.

**`of_i32` = 0.0** — every index is < 4096 < 2^24, exactly representable in binary32, so `df64_of_int32` → `df64_to_float32` is exact. Measured 0 on all seven devices, and on ZLUDA CUDA/PTX.

## What replaced the widening

No ceiling was widened. A deviating `(framework, device, op)` is checked against a two-sided band and reported as an explicit expected failure:

```
err <= contract bound                          -> XPASS (allowlist is stale)
contract < err <= 2^-23, on the allowlist      -> KNOWN-DEVIATION
anything else                                  -> FAIL
```

The allowlist (`Test_helpers.df64_known_deviation`) is keyed on **driver identity**, following the existing `is_rusticl_device` precedent, not on the framework tag: Mesa RADV, Mesa ANV, and the Native backend. Everything else — NVIDIA Vulkan included — gets the strict bound. Degrading past plain float32 now FAILs *even on an allowlisted device*.

`XPASS` is **hard** — strict xfail, as in pytest's `xfail(strict=True)` default. An allowlisted device that starts *meeting* the contract fails the run and names the match arm to delete. An earlier revision of this PR printed XPASS and left the exit code at 0; that is the same shape as the bug PR #300 (`cf58801b`) fixed in `test_cuda_f16_sass` and the mma probe — a status that never reaches the exit code is indistinguishable from a pass to everything that consumes it, so the allowlist rots while the suite keeps claiming a deviation that no longer exists. Strictness is cheap here: the GitHub CI runners have no GPU, so the RADV and ANV arms never evaluate in CI and cannot flake it, and when it fires on a workstation the fix is deleting one match arm.

## Red proof 1 — collapsed df64

`df64_mul` temporarily replaced with its f32 equivalent — `{hi = mul_rn a.hi b.hi; lo = 0.0}` — nothing else changed. **New gate**, 7 failures, exit 1:

```
Device: AMD Radeon RX 7900 XTX (radeonsi, navi31, ...) [OpenCL]
  mul    max rel err 1.43e-07 (tol 1.42e-14) FAIL [OpenCL]
Device: AMD Radeon RX 7900 XTX (RADV NAVI31) [Vulkan]
  mul    max rel err 1.43e-07 (tol 1.42e-14) FAIL [Vulkan]
Device: AMD Ryzen 9 7950X ... (RADV RAPHAEL_MENDOCINO) [Vulkan]
  mul    max rel err 1.43e-07 (tol 1.42e-14) FAIL [Vulkan]
Device: CPU Native (Parallel, 32 cores) [Native]
  mul    max rel err 1.43e-07 (tol 1.42e-14) FAIL [Native]
Device: CPU Interpreter (Sequential) [Interpreter]
  mul    max rel err 1.43e-07 (tol 1.42e-14) FAIL [Interpreter]
test_df64 FAILED (7 failures)
```

**Old gate, identical degraded kernel** — the point of the whole PR:

```
Device: AMD Radeon RX 7900 XTX (radeonsi, navi31, ...) [OpenCL]
  mul    max rel err 1.43e-07 (tol 1.42e-14) FAIL [OpenCL]
Device: AMD Radeon RX 7900 XTX (RADV NAVI31) [Vulkan]
  mul    max rel err 1.43e-07 (tol 2.38e-07) PASS [Vulkan]        <-- collapse invisible
Device: AMD Ryzen 9 7950X ... (RADV RAPHAEL_MENDOCINO) [Vulkan]
  mul    max rel err 1.43e-07 (tol 2.38e-07) PASS [Vulkan]        <-- collapse invisible
Device: CPU Native (Parallel, 32 cores) [Native]
  mul    max rel err 1.43e-07 (tol 2.38e-07) PASS [Native]        <-- collapse invisible
```

Also red-proved with `df64_add` degraded to `{hi = a.hi +. b.hi; lo = 0.0}` as well: add 1.88e-06, sub 1.57e-06, div 1.14e-07, mul 1.43e-07 — 31 failures, and the dot-product gate fires too. Both degradations were reverted; `Sarek_df64.ml` is byte-identical to `origin/main` apart from the header note.

Note that the degraded mul lands at 1.43e-07, *above* the 1.19e-07 collapsed ceiling, so it FAILs rather than being absorbed as a KNOWN-DEVIATION on RADV. That is the upper band doing its job.

### Red proof 2 — strict XPASS

A bogus allowlist arm added for RADV `sqrt`, an op that already meets the contract on that driver. All three tests exit **1**:

```
test_df64                  EXIT=1   test_df64 FAILED (2 failures)
test_real64                EXIT=1   test_real64 FAILED (2 failures)
test_real64_single_source  EXIT=1   test_real64_single_source FAILED (2 failures)
```

```
sqrt   max rel err 1.08e-14 (tol 1.42e-14) XPASS (STALE ALLOWLIST ENTRY) -
Vulkan / AMD Radeon RX 7900 XTX (RADV NAVI31) / sqrt now MEETS the df64
contract (1.08e-14 <= 1.42e-14), but Test_helpers.df64_known_deviation still
expects a deviation there. DELETE the match arm [BOGUS RED-PROOF ARM - REMOVE].
Was: KNOWN-DEVIATION (bogus red-proof entry) [Vulkan]
```

Two failures per test — one per RADV device. Bogus arm reverted; the real arms name themselves the same way (`Vulkan, (mul|div) when is_radv_device`).

## Per-device pass/fail reality

All measured on this workstation: AMD Radeon RX 7900 XTX + AMD Ryzen 9 7950X (Raphael iGPU), Mesa **26.1.4-arch3.1**, Vulkan 1.4.354, kernel 7.1.2-3-cachyos, ZLUDA v7-preview.3 + CUDA 13.3 for the CUDA/PTX path, `RUSTICL_FEATURES=fp64` where the fp64 substrate is exercised.

| Device / framework | add | sub | mul | div | sqrt |
|---|---|---|---|---|---|
| RX 7900 XTX — OpenCL (rusticl/radeonsi) | PASS 5.33e-15 | PASS 6.51e-15 | PASS 9.07e-15 | PASS 5.08e-15 | PASS 1.08e-14 |
| Raphael iGPU — OpenCL (rusticl/radeonsi) | PASS | PASS | PASS | PASS | PASS |
| RX 7900 XTX — CUDA/PTX (ZLUDA) | PASS 5.33e-15 | PASS 6.51e-15 | PASS 9.07e-15 | PASS 5.08e-15 | PASS 1.08e-14 |
| Raphael — CUDA/PTX (ZLUDA) | PASS | PASS | PASS | PASS | PASS |
| RX 7900 XTX — **Vulkan (RADV)** | PASS 5.33e-15 | PASS 6.51e-15 | **KNOWN-DEVIATION 5.84e-08** | **KNOWN-DEVIATION 5.86e-08** | PASS 1.08e-14 |
| Raphael — **Vulkan (RADV)** | PASS | PASS | **KNOWN-DEVIATION** | **KNOWN-DEVIATION** | PASS |
| CPU **Native** | **KNOWN-DEVIATION 5.82e-08** | **KNOWN-DEVIATION** | **KNOWN-DEVIATION** | **KNOWN-DEVIATION** | **KNOWN-DEVIATION** |
| CPU Interpreter (sequential) | PASS | PASS | PASS 9.07e-15 | PASS 5.08e-15 | PASS 8.53e-15 |
| CPU Interpreter (parallel, 32 cores) | PASS | PASS | PASS | PASS | PASS |

`test_df64`, `test_real64`, `test_real64_single_source`, `test_df64_no_contraction`, `test_float64_kernel_arith`, `test_ktype_record_f64_arith`: all exit 0 with the strict classifier, with and without ZLUDA, with and without `RUSTICL_FEATURES=fp64`.

The two RADV mul/div entries are **not fixed** — they are a real driver deviation, now recorded as a strict expected failure naming the driver instead of being hidden under a wide tolerance. RADV's GLSL `fma` is not correctly rounded and Mesa does not honour the `precise` qualifier `Sarek_ir_glsl.ml` emits, so the TwoProd error term is lost; no tolerance was weakened to accommodate it.

The five Native entries are a different thing and the source now says so plainly: df64 on Native is **pointless, not broken**. Native runs Sarek float32 as OCaml binary64, so the error-free transformations cancel *structurally* — it is not a defect to chase, and it has no downstream consequence because Native has real binary64 (and `Sarek_real64` selects `Native_f64` there automatically). The entry covers all five ops because the cancellation is identical for all five, and the 2^-23 collapsed ceiling still bounds it. Worded to stop a later reader filing it as an open bug.

## Review disposition (CodeRabbit)

**Rejected — NVIDIA `sqrt` allowlist arm.** Full reasoning [in the thread](https://github.com/mathiasbourgoin/Sarek/pull/301#discussion_r3651057469). Short version: NVIDIA OpenCL `sqrt` is 9.80e-15 against a 1.42e-14 bound, so the contract is **met** and an arm there would be stale on arrival — and under strict XPASS it would hard-fail every NVIDIA OpenCL run. NVIDIA CUDA/PTX `sqrt` sits exactly on the boundary at 1.42e-14, which the header records as failing; that is the open residual #117, not a driver quirk to waive. `test_real64`'s fallback `sqrt` at 1.68e-14 / 1.81e-14 is the same #117 residual, with a fix already in flight as **#298** (`sqrt.approx.f32` → `sqrt.rn.f32`) — allowlisting it would suppress exactly that defect and go stale the moment #298 lands. The governing rule: an allowlist arm is a strict expected failure and therefore a claim about a specific device, so it must be **earned by measurement, never transcribed from a documentation table**. No NVIDIA GPU on this host, so no NVIDIA arm.

**Accepted — both nitpicks**, in `b45ba906`:

- `tol_for` / `op_status` were byte-identical across the two real64 tests — the same drift risk this PR exists to remove. Now `Test_helpers.real64_tol_for` / `classify_real64_result`, parameterised on a plain `~native_f64` flag so `test_helpers` gains no dependency on `sarek.real64`. Status reporting is shared too (`string_of_df64_status`, `df64_status_is_failure`), so the three print sites cannot drift on which statuses are fatal.
- `Known_deviation` / `Known_issue` / `Xpass` now emit a `github_warning` via `Test_helpers.annotate_df64_status`, so a suppression is visible on the checks page and not only in the raw log. The docstring CodeRabbit quoted about XPASS not failing was already stale — XPASS **both warns and fails**; `Pass` and `Fail` are not annotated (`Fail` already turns the job red).

Re-verified on the hardware below: `test_df64`, `test_real64` and `test_real64_single_source` produce output byte-identical to the pre-refactor run once the new `::warning` lines are excluded — RADV mul/div still KNOWN-DEVIATION at 5.84e-08 / 5.86e-08, everything else unchanged. Strict XPASS re-proved red through the new shared path (temporary bogus RADV `sqrt` arm → all three tests exit 1, 2 failures each, STALE ALLOWLIST ENTRY annotation emitted; arm reverted).

## Could not verify

- **Mesa ANV (Intel)** — no Intel GPU on this host. The ANV allowlist entry is carried over from the measurement already recorded in `Sarek_df64.ml` (UHD Graphics 630, CFL GT2). It is also the weakest predicate here: it matches the vendor string `"intel"`, not a driver token, because ANV reports no driver token in `deviceName`. Flagged in the source as needing re-measurement and narrowing the first time an Intel device runs this suite.
- **NVIDIA (any framework)** — no NVIDIA GPU on this box. The tightening that now holds NVIDIA Vulkan to the strict bound is therefore unexercised. It is the safe direction (strict by default, deviation by explicit allowlist), and the figures in `Sarek_df64.ml` say NVIDIA Vulkan meets it (mul 9.07e-15 on a GTX 1070 Max-Q, driver 580.119.02), but that is a citation, not a measurement I made.
- **Metal, WGSL, HIP** — no df64 coverage exists to sweep, and no hardware here.
- The **known NVIDIA `df64_sqrt` residual** (1.42e-14, at the 2^-46 boundary) is untouched by this PR and unreproducible here; it remains tracked in `Sarek_df64.ml`'s `KNOWN RESIDUAL` block.

## Pre-existing, not touched

- `test_static_tag_erasure` **fails deterministically** on unmodified `origin/main`, and *additionally* segfaults intermittently under RADV. 3 runs on a clean `origin/main` checkout of the affected files: `FAILED` (exit 1, `behaviour=FAIL`), `SIGSEGV`, `SIGSEGV`. **This is a stronger claim than the existing backlog item**, which treats it as a segfault flake: the run that did not crash still reported a real behaviour failure, so there is a deterministic bug underneath the crash, not just an unstable test. Unrelated to df64 — GLSL match-expression payload binding. Not fixed here; it is why `dune runtest sarek/tests` exits 1 on both branches.
- `dune build @fmt` reports drift in `sarek/core/Device.ml`, `sarek/interp/Sarek_float32.ml`, `sarek/tests/unit/test_ir_layout.ml` on `origin/main`. Not touched by this PR; the six files it does touch are format-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved double-float precision gating to reliably distinguish correct df64 behavior from float32-collapsed variants.
  - Enforced stricter df64/Real64 contracts across devices, with documented deviation handling no longer masking stale allowlists.
- **Testing**
  - Centralized per-op tolerance selection and status classification (including `KNOWN-DEVIATION` and `XPASS`), and now treat `XPASS` as a failure.
  - Tightened conversion and substrate-specific reporting for df64 fallback vs native Real64.
- **Documentation**
  - Updated precision-gate and change notes to reflect the new global device behavior and tolerance/reporting bands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
