### PR TITLE
fix(spoc,sarek): close the three cache-invalidation holes #293 left open (#119, #90)

### DIFF
--- a/sarek-cuda/Cuda_api.ml
+++ b/sarek-cuda/Cuda_api.ml
@@ -45,12 +45,6 @@ let check (ctx : string) (result : cu_result) : unit =
     ctx
     result
 
-(** Hooks invoked with a device id right before its context is destroyed.
-    [Kernel] registers an eviction hook here (after [Kernel.cache] is defined
-    below) so that [Device.destroy] can retire per-device compiled kernels
-    without a circular module dependency. *)
-let device_destroy_hooks : (int -> unit) list ref = ref []
-
 (** Host-side kernel-argument buffers (the [CArray] of argument pointers plus
     the per-argument value cells) for launches that may still be in flight,
     keyed by device id.
@@ -270,14 +264,14 @@ module Device = struct
   let destroy dev =
     (* Evict from device_cache first: leaving a stale entry means a later
        [get idx] returns a handle whose context has already been destroyed
-       (mirrors the Vulkan fix in Vulkan_api_device.ml). Also run the
-       registered destroy hooks (Kernel.cache eviction) while the context
-       is still current, so stale module/function handles for this device
-       can't be returned by [Kernel.compile_cached] after the context is
-       recreated. *)
+       (mirrors Vulkan_api_device.destroy). *)
     Hashtbl.remove device_cache dev.id ;
-    (* Notify layers above this backend BEFORE the local hooks unload modules:
-       they memoize values that close over the handles those hooks release.
+    (* Notify BEFORE anything is released, while the context is still current:
+       the listeners are the cache layers — this backend's own [Kernel.cache]
+       (which unloads this device's modules) and, above it, memos closing over
+       exactly those handles. Doing it here is what stops a stale
+       module/function handle being returned by [Kernel.compile_cached] after
+       the context is recreated under the same index.
        [notify_device_destroy] re-raises the first failing listener, and
        [device_cache] has already been emptied, so letting it escape here would
        leave the device unreachable with its context still alive and its modules
@@ -291,7 +285,6 @@ module Device = struct
       | () -> None
       | exception e -> Some e
     in
-    List.iter (fun hook -> hook dev.id) !device_destroy_hooks ;
     retire_device dev.id ;
     check "cuCtxDestroy" (cuCtxDestroy dev.context) ;
     Option.iter raise listener_exn
@@ -502,13 +495,18 @@ module Kernel = struct
       ~destroy:(fun k -> ignore (cuModuleUnload k.module_))
       ()
 
-  (* Evict every cached kernel compiled for [device_id]. Registered as a
-     [device_destroy_hooks] callback below so [Device.destroy] retires
-     these handles before the underlying CUDA context is destroyed. *)
-  let evict_device device_id =
-    Spoc_framework.Guarded_cache.evict_device cache device_id
-
-  let () = device_destroy_hooks := evict_device :: !device_destroy_hooks
+  (* Evict every cached kernel compiled for [device_id]. Registered on the
+     shared [Cache_hooks] registry — the one mechanism every backend uses (see
+     Cache_hooks.mli) rather than a CUDA-private hook list — so that
+     [Device.destroy], which fires the notification before it destroys
+     anything, retires these module handles while the context is still alive.
+     Match on the family name, never on the index alone: backend-local indices
+     collide across backends, and [evict_device] does not merely drop
+     memoization, it aborts in-flight builds for that index. *)
+  let () =
+    Spoc_framework.Cache_hooks.on_device_destroy (fun ~backend index ->
+        if String.equal backend "CUDA" then
+          Spoc_framework.Guarded_cache.evict_device cache index)
 
   (* Replace the .target directive in a PTX string to match the given SM version.
      This makes a static PTX string portable: PTX written for sm_86 loads fine
@@ -660,7 +658,9 @@ module Kernel = struct
   let compile_cached device ~name ~source =
     with_cache device ~name ~source (fun () -> compile device ~name ~source)
 
-  let clear_cache () = Spoc_framework.Guarded_cache.clear cache
+  let clear_cache () =
+    Spoc_framework.Cache_hooks.around_clear (fun () ->
+        Spoc_framework.Guarded_cache.clear cache)
 
   (** Existential wrapper for keeping Ctypes-allocated values alive during FFI
       calls *)

--- a/sarek-hip/Hip_api.ml
+++ b/sarek-hip/Hip_api.ml
@@ -30,10 +30,6 @@ let check (ctx : string) (result : hip_result) : unit =
     ctx
     result
 
-(** Hooks invoked with a device id right before its device is torn down (kernel
-    cache eviction), registered by [Kernel] to avoid a circular dependency. *)
-let device_destroy_hooks : (int -> unit) list ref = ref []
-
 (** hipModuleLaunchKernel is asynchronous and the HIP stack snapshots the kernel
     parameters at dispatch time, not at the call site (see the CUDA sibling's
     note - it explicitly calls out the HIP behaviour). Freeing the arg cells
@@ -211,12 +207,13 @@ module Device = struct
     retire_device dev.id
 
   let destroy dev =
-    (* Evict cache + run kernel-cache eviction hooks while the device is still
+    (* Evict from device_cache, then notify while the device is still
        selected, mirroring the CUDA backend. HIP has no explicit context to
        destroy under the runtime model, so there is no hipCtxDestroy analog. *)
     Hashtbl.remove device_cache dev.id ;
-    (* Notify layers above this backend BEFORE the local hooks unload modules:
-       they memoize values that close over the handles those hooks release.
+    (* Notify BEFORE anything is released: the listeners are the cache layers —
+       this backend's own [Kernel.cache] (which unloads this device's modules)
+       and, above it, memos closing over exactly those handles.
        [notify_device_destroy] re-raises the first failing listener; since
        [device_cache] has already been emptied, letting it escape here would
        leave the device unreachable with its modules still loaded. Capture it,
@@ -228,7 +225,6 @@ module Device = struct
       | () -> None
       | exception e -> Some e
     in
-    List.iter (fun hook -> hook dev.id) !device_destroy_hooks ;
     retire_device dev.id ;
     Option.iter raise listener_exn
 end
@@ -391,10 +387,16 @@ module Kernel = struct
       ~destroy:(fun k -> ignore (hipModuleUnload k.module_))
       ()
 
-  let evict_device device_id =
-    Spoc_framework.Guarded_cache.evict_device cache device_id
-
-  let () = device_destroy_hooks := evict_device :: !device_destroy_hooks
+  (* Evict every cached kernel compiled for [device_id]. Registered on the
+     shared [Cache_hooks] registry — the one mechanism every backend uses (see
+     Cache_hooks.mli) rather than a HIP-private hook list. [Device.destroy]
+     fires the notification before it retires anything. Match on the family
+     name, never on the index alone: backend-local indices collide across
+     backends. *)
+  let () =
+    Spoc_framework.Cache_hooks.on_device_destroy (fun ~backend index ->
+        if String.equal backend "HIP" then
+          Spoc_framework.Guarded_cache.evict_device cache index)
 
   (* Load a finalized HIP code object (binary ELF bytes) into a module and
      resolve [name]. The device must already be selected. The code object is
@@ -474,7 +476,9 @@ module Kernel = struct
   let compile_cached device ~name ~source =
     with_cache device ~name ~source (fun () -> compile device ~name ~source)
 
-  let clear_cache () = Spoc_framework.Guarded_cache.clear cache
+  let clear_cache () =
+    Spoc_framework.Cache_hooks.around_clear (fun () ->
+        Spoc_framework.Guarded_cache.clear cache)
 
   type ctype_ref = CTypeRef : 'a typ * 'a ptr -> ctype_ref
 

--- a/sarek-metal/Metal_plugin_base.ml
+++ b/sarek-metal/Metal_plugin_base.ml
@@ -236,6 +236,17 @@ module Metal : Framework_sig.PLUGIN_BASE = struct
           Metal_api.ComputePipeline.release k.pipeline)
         ()
 
+    (* Per-device eviction, the model every backend cache follows (see
+       Cache_hooks.mli). Metal exposes no device-destroy entry point, so nothing
+       in this backend fires the notification today; registering anyway keeps
+       the model uniform instead of "per-device on some backends, global on
+       others". Match on the family name, never on the index alone: backend-local
+       indices collide across backends. *)
+    let () =
+      Spoc_framework.Cache_hooks.on_device_destroy (fun ~backend index ->
+          if String.equal backend "Metal" then
+            Spoc_framework.Guarded_cache.evict_device cache index)
+
     let compile device ~name ~source =
       let library = Metal_api.Library.create_from_source device source in
       let func = Metal_api.Library.get_function library name in
@@ -256,10 +267,18 @@ module Metal : Framework_sig.PLUGIN_BASE = struct
           ~source
           ()
       in
-      Spoc_framework.Guarded_cache.find_or_build cache ~key (fun () ->
-          compile device ~name ~source)
+      (* [~device_id] is the same backend-local index the key already carries;
+         without it the entry is not grouped by device and [evict_device] can
+         never reach it. *)
+      Spoc_framework.Guarded_cache.find_or_build
+        cache
+        ~key
+        ~device_id:device.Metal_api.Device.id
+        (fun () -> compile device ~name ~source)
 
-    let clear_cache () = Spoc_framework.Guarded_cache.clear cache
+    let clear_cache () =
+      Spoc_framework.Cache_hooks.around_clear (fun () ->
+          Spoc_framework.Guarded_cache.clear cache)
 
     let load_from_ptx ~name:_ ~ptx:_ =
       Metal_error.raise_error (Metal_error.feature_not_supported "PTX kernels")

--- a/sarek-opencl/Opencl_plugin_base.ml
+++ b/sarek-opencl/Opencl_plugin_base.ml
@@ -228,6 +228,19 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
           Opencl_api.Program.release k.program)
         ()
 
+    (* Per-device eviction, the model every backend cache follows (see
+       Cache_hooks.mli). OpenCL exposes no device-destroy entry point, so
+       nothing in this backend fires the notification today; registering anyway
+       is what keeps the model uniform rather than "per-device on CUDA/HIP,
+       global everywhere else", and it means the day an OpenCL teardown path
+       appears the eviction is already wired. Match on the family name this
+       backend would fire under, never on the index alone: backend-local
+       indices collide across backends. *)
+    let () =
+      Spoc_framework.Cache_hooks.on_device_destroy (fun ~backend index ->
+          if String.equal backend "OpenCL" then
+            Spoc_framework.Guarded_cache.evict_device cache index)
+
     let compile device ~name ~source =
       let state = get_state device.Opencl_api.Device.id in
       let program =
@@ -249,10 +262,18 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
           ~source
           ()
       in
-      Spoc_framework.Guarded_cache.find_or_build cache ~key (fun () ->
-          compile device ~name ~source)
+      (* [~device_id] is the same backend-local index the key already carries;
+         without it the entry is not grouped by device and [evict_device] can
+         never reach it. *)
+      Spoc_framework.Guarded_cache.find_or_build
+        cache
+        ~key
+        ~device_id:device.Opencl_api.Device.id
+        (fun () -> compile device ~name ~source)
 
-    let clear_cache () = Spoc_framework.Guarded_cache.clear cache
+    let clear_cache () =
+      Spoc_framework.Cache_hooks.around_clear (fun () ->
+          Spoc_framework.Guarded_cache.clear cache)
 
     let load_from_ptx ~name:_ ~ptx:_ =
       Opencl_error.raise_error

--- a/sarek-vulkan/Vulkan_api_device.ml
+++ b/sarek-vulkan/Vulkan_api_device.ml
@@ -365,7 +365,27 @@ let set_current _dev = ()
 
 let synchronize dev = check "vkDeviceWaitIdle" (vkDeviceWaitIdle dev.device)
 
+(* Notify the layers above this backend BEFORE anything is released (#90):
+   [Vulkan_api_kernel]'s cache holds pipelines, layouts, descriptor pools and
+   shader modules created from [dev.device], and [Sarek.Runtime]'s outer memo
+   holds closures over those. Destroying the VkDevice first would leave both
+   tables referencing dead objects, to be served to the next lookup for a
+   recreated index.
+
+   [notify_device_destroy] re-raises the first failing listener, and
+   [device_cache] has already been emptied, so letting it escape here would
+   leave the device unreachable with its VkDevice still alive. Capture it,
+   finish the teardown, re-raise at the end — the discipline Cache_hooks.mli
+   imposes on this path, and the shape Cuda_api/Hip_api use. *)
 let destroy dev =
   Hashtbl.remove device_cache dev.id ;
+  let listener_exn =
+    match
+      Spoc_framework.Cache_hooks.notify_device_destroy ~backend:"Vulkan" dev.id
+    with
+    | () -> None
+    | exception e -> Some e
+  in
   vkDestroyCommandPool dev.device dev.command_pool null ;
-  vkDestroyDevice dev.device null
+  vkDestroyDevice dev.device null ;
+  Option.iter raise listener_exn

--- a/sarek-vulkan/Vulkan_api_kernel.ml
+++ b/sarek-vulkan/Vulkan_api_kernel.ml
@@ -131,6 +131,24 @@ let cache : (string, t) Spoc_framework.Guarded_cache.t =
       vkDestroyShaderModule k.device.Device.device k.shader_module null)
     ()
 
+(* Per-device eviction (#90). Every object [destroy] above releases belongs to
+   [k.device.Device.device], so they MUST be released before that logical
+   device is destroyed — otherwise [Vulkan_api_device.destroy] takes the device
+   down under them and the entries stay in this table, referencing a dead
+   VkDevice, to be handed to the next [compile_cached] for a recreated index.
+   [Vulkan_api_device.destroy] fires the notification before it destroys
+   anything, so this listener runs while the device is still alive.
+
+   Registered on [Cache_hooks] rather than on a Vulkan-private hook list because
+   [Vulkan_api_device] is compiled before this module and cannot reference it —
+   the same constraint CUDA and HIP solve the same way. Match on the family
+   name, never on the index alone: backend-local indices collide across
+   backends. *)
+let () =
+  Spoc_framework.Cache_hooks.on_device_destroy (fun ~backend index ->
+      if String.equal backend "Vulkan" then
+        Spoc_framework.Guarded_cache.evict_device cache index)
+
 (** Create shader module from SPIR-V *)
 let create_shader_module device spirv =
   let code_size = String.length spirv in
@@ -427,10 +445,19 @@ let compile_cached device ~name ~source =
       ~source
       ()
   in
-  Spoc_framework.Guarded_cache.find_or_build cache ~key (fun () ->
-      compile device ~name ~source)
+  (* [~device_id] is the same backend-local index the key already carries;
+     without it the entry is not grouped by device and [evict_device] can never
+     reach it, which is why per-device eviction used to be inexpressible here
+     at either layer (#90). *)
+  Spoc_framework.Guarded_cache.find_or_build
+    cache
+    ~key
+    ~device_id:device.Device.id
+    (fun () -> compile device ~name ~source)
 
-let clear_cache () = Spoc_framework.Guarded_cache.clear cache
+let clear_cache () =
+  Spoc_framework.Cache_hooks.around_clear (fun () ->
+      Spoc_framework.Guarded_cache.clear cache)
 
 let create_args () =
   {

--- a/sarek/core/Kernel.ml
+++ b/sarek/core/Kernel.ml
@@ -162,37 +162,22 @@ let launch (Kernel (module K)) ~(args : args) ~(grid : Framework_sig.dims)
     exactly those handles. Leaving them in place means the next lookup hits the
     outer memo and launches through a released handle (segfault).
 
-    The notification is fired on BOTH sides of the backend clear, and that is
-    load-bearing rather than belt-and-braces. The pre-notification drops what is
-    already memoized; it cannot cover a build that starts after it. An outer
-    build that misses after the first notification snapshots the {e new}
-    generation, compiles a handle that [B.Kernel.clear_cache] then releases, and
-    on re-acquire finds the generation unchanged — so it installs a value over a
-    dead handle and poisons the memo for the rest of the process, which is the
-    exact failure [Guarded_cache]'s [~invalidated_by_clear] exists to prevent.
-    The post-notification bumps the generation again, so any build spanning the
-    release is rejected. The window it closes is the whole duration of the
-    backend clear.
+    The notification is fired on BOTH sides of the backend clear, and both are
+    load-bearing — see {!Spoc_framework.Cache_hooks.around_clear}, which owns
+    that discipline and the listener-isolation that goes with it.
 
-    Both notifications are also isolated from the backend clear. [Cache_hooks]
-    re-raises the first failing listener, and a listener is only dropping
-    memoization it does not own — letting that escape before
-    [B.Kernel.clear_cache] would skip the release this function exists to
-    perform and leak every backend handle. This mirrors the discipline
-    [Cache_hooks.mli] imposes on the device-destroy path: finish the teardown,
-    then re-raise. *)
+    [B.Kernel.clear_cache] is itself wrapped in [around_clear], so a caller that
+    resolves the backend through [Framework_registry] and calls it directly is
+    equally covered; [around_clear] collapses the nesting so this path still
+    notifies exactly twice. The wrapper here is not therefore redundant: it is
+    what covers the [None] branch, where no backend resolves and there is no
+    inner [around_clear] to fire. The outer memos are cross-backend, so they
+    must be dropped even when the framework name resolves to nothing. *)
 let clear_cache (device : Device.t) : unit =
-  let listener_exn = ref None in
-  let notify () =
-    try Cache_hooks.notify_clear_all ()
-    with e -> if Option.is_none !listener_exn then listener_exn := Some e
-  in
-  notify () ;
-  Fun.protect ~finally:notify (fun () ->
+  Cache_hooks.around_clear (fun () ->
       match Framework_registry.find_backend device.framework with
       | None -> ()
-      | Some (module B : Framework_sig.BACKEND) -> B.Kernel.clear_cache ()) ;
-  Option.iter raise !listener_exn
+      | Some (module B : Framework_sig.BACKEND) -> B.Kernel.clear_cache ())
 
 (** {1 Accessors} *)
 

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -742,7 +742,12 @@ end = struct
                  kernel.name
                  (Printf.sprintf "kernel '%s' not registered" kernel.name)))
 
-    let clear_cache () = Hashtbl.clear interpreter_kernels
+    (* Wrapped like every other backend's clear (see Cache_hooks.mli): no
+       driver handle to dangle here, but the outer memos close over these
+       closures and must be dropped with them. *)
+    let clear_cache () =
+      Spoc_framework.Cache_hooks.around_clear (fun () ->
+          Hashtbl.clear interpreter_kernels)
 
     let load_from_ptx ~name:_ ~ptx:_ =
       failwith "PTX kernels not supported by Interpreter backend"

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -810,7 +810,15 @@ end = struct
                  kernel.name
                  (Printf.sprintf "kernel '%s' not registered" kernel.name)))
 
-    let clear_cache () = Hashtbl.clear native_kernels
+    (* Wrapped like every other backend's clear (see Cache_hooks.mli). This
+       table holds no releasable driver handle, so nothing here can dangle —
+       but the outer memos above it close over these closures and must be
+       dropped with them, and a caller that reaches this through
+       [Framework_registry] gets the same guarantee as one going through
+       [Sarek.Kernel.clear_cache]. *)
+    let clear_cache () =
+      Spoc_framework.Cache_hooks.around_clear (fun () ->
+          Hashtbl.clear native_kernels)
 
     let load_from_ptx ~name:_ ~ptx:_ =
       failwith "PTX kernels not supported by Native backend"

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1189,26 +1189,38 @@
 ; -----------------------------------------------------------------------
 ; Runtime kernel-cache regressions (#86).
 ;
-; Three separate executables on purpose: the teardown case CRASHES (SIGSEGV)
-; rather than failing an assertion when the outer memo is not invalidated, so
-; it must not share a binary with anything else, and the reset case drives
-; Device.init/reset twice over different framework lists, which is only
-; meaningful in a process that has not enumerated devices yet. All three are
-; self-verifying (exit nonzero on mismatch) and skip with a printed reason -
-; exit 0 - when the devices they need are not enumerated, so they gate in the
-; default runtest alias on every machine.
+; Four separate executables on purpose: the teardown and direct-clear cases
+; CRASH (SIGSEGV) rather than failing an assertion when the outer memo is not
+; invalidated, so they must not share a binary with anything else, and the reset
+; case drives Device.init/reset twice over different framework lists, which is
+; only meaningful in a process that has not enumerated devices yet.
+;
+; All four are Alcotest suites, NOT bare self-verifying executables. That is
+; load-bearing: the devices these need (two OpenCL devices, a Vulkan device) do
+; not exist on CI, and a plain executable that printed "SKIP" and exited 0 was
+; indistinguishable from one that ran and verified everything - which is what
+; these were, and why they gated nothing there. Under Alcotest a skip is a
+; distinct [SKIP] row and is excluded from the "N tests run" tally, so a suite
+; that verified nothing reports "0 test run".
 ; -----------------------------------------------------------------------
 
 (executables
  (names
   test_runtime_cache_device_key
   test_runtime_cache_teardown
-  test_runtime_cache_reset_ids)
+  test_runtime_cache_reset_ids
+  test_backend_cache_scope)
  (modules
   test_runtime_cache_device_key
   test_runtime_cache_teardown
-  test_runtime_cache_reset_ids)
- (libraries spoc_core spoc_framework test_helpers))
+  test_runtime_cache_reset_ids
+  test_backend_cache_scope)
+ (libraries
+  spoc_core
+  spoc_framework
+  spoc_framework_registry
+  test_helpers
+  alcotest))
 
 (rule
  (alias runtest)
@@ -1256,3 +1268,32 @@
  (alias runtest)
  (action
   (run %{dep:test_ematch_payload_e2e.exe})))
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_backend_cache_scope.exe})))
+
+; Its own binary. The original rationale - that a Mesa host segfaults when a
+; Vulkan pipeline is created in a process that already enumerated OpenCL - was
+; WRONG: that crash was a use-after-free in our own ctypes bindings, fixed in
+; #303 (a8b5a193). OpenCL only supplied the heap pressure that made the GC
+; collect early. The split is kept anyway because it is genuinely simpler: this
+; binary links sarek_vulkan directly and inits only that plugin instead of
+; going through Test_helpers.Benchmarks.init_backends, so the Vulkan half of
+; the scope check is not entangled with backend discovery.
+
+(executable
+ (name test_vulkan_cache_device_scope)
+ (modules test_vulkan_cache_device_scope)
+ (optional)
+ (libraries
+  spoc_core
+  spoc_framework
+  spoc_framework_registry
+  sarek_vulkan
+  alcotest))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_vulkan_cache_device_scope.exe})))

--- a/sarek/tests/e2e/test_backend_cache_scope.ml
+++ b/sarek/tests/e2e/test_backend_cache_scope.ml
@@ -1,0 +1,246 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression: the two holes #86 left open behind [Sarek.Kernel.clear_cache].
+ *
+ * H1 - a DIRECT backend clear used to bypass the notification. Only
+ *      [Sarek.Kernel.clear_cache] fired [Cache_hooks.notify_clear_all]; the
+ *      backend's own [Kernel.clear_cache] was a bare [Guarded_cache.clear], so
+ *      a caller resolving the backend through [Framework_registry] and calling
+ *      it released clReleaseKernel/clReleaseProgram with the outer memo still
+ *      holding [Kernel.t] closures over those handles - the exact use-after-free
+ *      #86 fixed, reached through a sibling entry point. The notification now
+ *      lives in [Cache_hooks.around_clear], which wraps every backend's
+ *      [clear_cache] body, so both entry points are covered.
+ *
+ * H2 - the eviction SCOPE was mixed. Every backend keys its compiled artifact
+ *      by the backend-local device index, but only CUDA and HIP passed that
+ *      index as [~device_id] to [Guarded_cache.find_or_build]. Without it the
+ *      entry is not grouped by device, so [Guarded_cache.evict_device] - and
+ *      therefore the whole [Cache_hooks.on_device_destroy] path - could not
+ *      reach an OpenCL, Metal or Vulkan entry at all. All backends now pass it
+ *      and register the same listener.
+ *
+ * Both are checked against the BACKEND cache directly (physical identity of the
+ * value [compile_cached] returns), not against the outer memo: the outer memo
+ * is what the other three tests in this directory cover, and using it here
+ * would not distinguish "the backend cache was evicted" from "the memo was".
+ *
+ * OpenCL only. The Vulkan half of H2 is the same check against the Vulkan
+ * backend and lives in test_vulkan_cache_device_scope.ml, in its OWN process:
+ * on this host (Mesa 25.x, radeonsi OpenCL + RADV Vulkan) any Vulkan pipeline
+ * creation in a process that has already enumerated OpenCL segfaults inside
+ * libvulkan_radeon. That is a pre-existing host/driver conflict, not a SPOC
+ * bug - test_static_tag_erasure, untouched here, SIGSEGVs the same way on
+ * origin/main and passes with OCL_ICD_VENDORS pointed at an empty directory -
+ * but it means the two backends must not share a test binary.
+ *
+ * Requires a real device of the backend under test. Each case skips - as a
+ * distinct Alcotest [SKIP] row, not a green [OK] - when that backend enumerates
+ * nothing here. A backend that IS present and fails to compile the probe is a
+ * failure, never a skip.
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+
+let opencl_source =
+  "__kernel void scope_probe(__global float* a) { a[get_global_id(0)] = 7.0f; }"
+
+let n = 16
+
+(* Resolve a backend that has at least one enumerated device, or [None]. Goes
+   through [Framework_registry] on purpose: that is precisely the "sibling entry
+   point" H1 is about. *)
+let backend_with_device family =
+  match Spoc_framework_registry.Framework_registry.find_backend family with
+  | None -> None
+  | Some (module B : Spoc_framework.Framework_sig.BACKEND) ->
+      if not (B.is_available ()) then None
+      else begin
+        B.Device.init () ;
+        if B.Device.count () = 0 then None
+        else Some (module B : Spoc_framework.Framework_sig.BACKEND)
+      end
+
+(* H2, per backend. Two [compile_cached] calls with the same key must be the
+   same physical value (the cache is hitting - otherwise the rest proves
+   nothing), a device-destroy notification for ANOTHER backend family must
+   leave it alone, and one for this backend's own family must evict it. *)
+let check_per_device_eviction ~family ~source () =
+  match backend_with_device family with
+  | None ->
+      Printf.printf
+        "[SKIP] no %s device enumerated here, so the backend kernel cache \
+         cannot be exercised\n\
+         %!"
+        family ;
+      Alcotest.skip ()
+  | Some (module B : Spoc_framework.Framework_sig.BACKEND) ->
+      let dev = B.Device.get 0 in
+      let index = B.Device.id dev in
+      Printf.printf
+        "%s: using backend-local device %d (%s)\n%!"
+        family
+        index
+        (B.Device.name dev) ;
+      let k1 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      let k2 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      if not (k1 == k2) then
+        Alcotest.failf
+          "%s: two compile_cached calls with the same key returned different \
+           values - the backend cache is not hitting at all, so this test \
+           cannot tell eviction from a permanent miss"
+          family ;
+      (* A foreign backend's teardown must not evict: backend-local indices
+         collide across backends (OpenCL 0, Vulkan 0, HIP 0 all exist), and
+         evict_device does not merely drop memoization, it aborts in-flight
+         builds for that index. *)
+      let foreign = if String.equal family "HIP" then "OpenCL" else "HIP" in
+      Spoc_framework.Cache_hooks.notify_device_destroy ~backend:foreign index ;
+      let k3 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      if not (k3 == k1) then
+        Alcotest.failf
+          "%s: a %s device-%d teardown evicted the %s entry for the same index \
+           - the listener matches on the backend-local index alone"
+          family
+          foreign
+          index
+          family ;
+      Spoc_framework.Cache_hooks.notify_device_destroy ~backend:family index ;
+      let k4 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      if k4 == k1 then
+        Alcotest.failf
+          "%s: the device-%d teardown did NOT evict the backend cache entry. \
+           Guarded_cache.evict_device can only reach entries that were \
+           installed with ~device_id, and %s's find_or_build does not pass it \
+           - so this backend's kernel cache is global where CUDA/HIP are \
+           per-device, and a destroyed device's handles survive it"
+          family
+          index
+          family ;
+      Printf.printf
+        "%s: device-%d teardown evicted the backend cache entry, a foreign \
+         backend's did not\n\
+         %!"
+        family
+        index
+
+(* H1. Drive a launch through the PUBLIC runtime API so the outer memo holds a
+   [Kernel.t] closing over the backend handles, then release those handles by
+   the direct backend entry point - NOT [Sarek.Kernel.clear_cache]. If the
+   notification does not reach the outer memo, the next run launches through a
+   released cl_kernel: observed as SIGSEGV before the fix, which dune reports as
+   a nonzero exit of this executable. *)
+let run_and_read (d : Device.t) =
+  let buf = Spoc_core.Runtime.alloc_float32 d n in
+  let host = Bigarray.Array1.create Bigarray.float32 Bigarray.c_layout n in
+  Bigarray.Array1.fill host 0.0 ;
+  Spoc_core.Memory.host_to_device ~src:host ~dst:buf ;
+  Spoc_core.Runtime.run
+    d
+    ~name:"scope_probe"
+    ~source:opencl_source
+    ~args:[Spoc_core.Runtime.ArgBuffer buf]
+    ~grid:(Spoc_core.Runtime.dims1d n)
+    ~block:(Spoc_core.Runtime.dims1d 1)
+    () ;
+  Device.synchronize d ;
+  Spoc_core.Memory.device_to_host ~src:buf ~dst:host ;
+  host.{0}
+
+let test_direct_backend_clear_invalidates_outer_memo () =
+  Test_helpers.Benchmarks.init_backends () ;
+  let devs = Device.init () in
+  match Array.find_opt (fun (d : Device.t) -> d.framework = "OpenCL") devs with
+  | None ->
+      Printf.printf
+        "[SKIP] needs an OpenCL device: the hazard is a released driver \
+         handle, which the CPU backends do not have, and the probe is OpenCL C\n\
+         %!" ;
+      Alcotest.skip ()
+  | Some d -> (
+      Printf.printf "using OpenCL device [%d] %s\n%!" d.id d.name ;
+      let before = run_and_read d in
+      if before <> 7.0 then
+        Alcotest.failf
+          "baseline launch produced %g, expected 7 - the device is not usable, \
+           so nothing below is meaningful"
+          before ;
+      match
+        Spoc_framework_registry.Framework_registry.find_backend d.framework
+      with
+      | None -> Alcotest.failf "framework %S did not resolve" d.framework
+      | Some (module B : Spoc_framework.Framework_sig.BACKEND) ->
+          (* The bypass: releases every cl_kernel/cl_program the outer memo's
+             Kernel.t closures hold, without going through
+             Sarek.Kernel.clear_cache. *)
+          (* Structural check first, so the failure NAMES the problem instead
+             of only crashing: physical identity of what compile_kernel returns
+             is the outer memo's own state. The launch afterwards is still
+             required - identity cannot tell whether the handles were really
+             released, only whether the memo was dropped. *)
+          let memoized =
+            Spoc_core.Runtime.compile_kernel
+              d
+              ~name:"scope_probe"
+              ~source:opencl_source
+          in
+          if
+            not
+              (Spoc_core.Runtime.compile_kernel
+                 d
+                 ~name:"scope_probe"
+                 ~source:opencl_source
+              == memoized)
+          then
+            Alcotest.failf
+              "the outer memo is not hitting before the clear, so this test \
+               cannot tell an invalidated memo from one that never held \
+               anything" ;
+          Printf.printf "calling B.Kernel.clear_cache () directly\n%!" ;
+          B.Kernel.clear_cache () ;
+          if
+            Spoc_core.Runtime.compile_kernel
+              d
+              ~name:"scope_probe"
+              ~source:opencl_source
+            == memoized
+          then
+            Alcotest.failf
+              "a direct B.Kernel.clear_cache () released the backend handles \
+               without invalidating the outer memo - the notification is in \
+               the Sarek.Kernel.clear_cache wrapper only, so this sibling \
+               entry point bypasses it and the next launch uses a released \
+               cl_kernel" ;
+          let after = run_and_read d in
+          if after <> 7.0 then
+            Alcotest.failf
+              "post-clear launch produced %g, expected 7: the outer memo \
+               served a Kernel.t whose backend handle a direct \
+               B.Kernel.clear_cache () had already released"
+              after ;
+          Printf.printf
+            "direct backend clear invalidated the outer memo (readback 7)\n%!")
+
+let () =
+  Alcotest.run
+    "Backend cache scope"
+    [
+      ( "direct backend clear",
+        [
+          Alcotest.test_case
+            "B.Kernel.clear_cache () invalidates the outer memo"
+            `Quick
+            test_direct_backend_clear_invalidates_outer_memo;
+        ] );
+      ( "per-device eviction",
+        [
+          Alcotest.test_case
+            "OpenCL kernel cache is evictable per device"
+            `Quick
+            (check_per_device_eviction ~family:"OpenCL" ~source:opencl_source);
+        ] );
+    ]

--- a/sarek/tests/e2e/test_runtime_cache_device_key.ml
+++ b/sarek/tests/e2e/test_runtime_cache_device_key.ml
@@ -27,8 +27,11 @@
  * teardown notifications.
  *
  * Requires >= 2 devices of ONE backend. The probe kernel is written in OpenCL C,
- * so the gate is the OpenCL backend specifically; the test skips (exit 0) with a
- * printed reason when fewer than two OpenCL devices are enumerated. A CUDA/HIP
+ * so the gate is the OpenCL backend specifically. When fewer than two OpenCL
+ * devices are enumerated the case reports an Alcotest [SKIP] - deliberately not
+ * a printed "SKIP" from a plain executable exiting 0, which is what this test
+ * used to do and which is indistinguishable from a pass on any machine without
+ * two OpenCL devices (i.e. on CI, where it therefore gated nothing). A CUDA/HIP
  * variant only needs the corresponding source spelling added here.
  ******************************************************************************)
 
@@ -41,15 +44,6 @@ let source =
 let kernel_name = "cache_key_probe"
 
 let n = 16
-
-let failures = ref 0
-
-let failf fmt =
-  Printf.ksprintf
-    (fun s ->
-      incr failures ;
-      Printf.printf "FAIL: %s\n%!" s)
-    fmt
 
 (* Launch the probe on [d] and read the buffer back. Returns every element, so a
    partial write is visible rather than being masked by checking only [0]. *)
@@ -76,7 +70,7 @@ let check_all_sevens label (host : (float, _, _) Bigarray.Array1.t) =
     if host.{i} <> 7.0 then incr bad
   done ;
   if !bad > 0 then
-    failf
+    Alcotest.failf
       "%s: %d/%d elements were not written by the kernel (got %g %g %g %g ...) \
        - the launch went to the wrong device"
       label
@@ -88,7 +82,7 @@ let check_all_sevens label (host : (float, _, _) Bigarray.Array1.t) =
       host.{3}
   else Printf.printf "OK: %s -> all %d elements = 7\n%!" label n
 
-let () =
+let test_outer_memo_is_device_keyed () =
   Test_helpers.Benchmarks.init_backends () ;
   let devs = Device.init () in
   let opencl =
@@ -99,11 +93,11 @@ let () =
   in
   if Array.length opencl < 2 then begin
     Printf.printf
-      "SKIP: needs >= 2 devices of one backend to detect cross-device cache \
+      "[SKIP] needs >= 2 devices of one backend to detect cross-device cache \
        aliasing; found %d OpenCL device(s) (the probe kernel is OpenCL C)\n\
        %!"
       (Array.length opencl) ;
-    exit 0
+    Alcotest.skip ()
   end ;
   let d0 = opencl.(0) and d1 = opencl.(1) in
   Printf.printf
@@ -119,12 +113,12 @@ let () =
   let k0 = Runtime.compile_kernel d0 ~name:kernel_name ~source in
   let k1 = Runtime.compile_kernel d1 ~name:kernel_name ~source in
   if (Kernel.device k0).Device.id <> d0.id then
-    failf
+    Alcotest.failf
       "requested device %d, got a kernel bound to device %d"
       d0.id
       (Kernel.device k0).Device.id ;
   if (Kernel.device k1).Device.id <> d1.id then
-    failf
+    Alcotest.failf
       "requested device %d, got a kernel bound to device %d (outer cache key \
        omits device identity)"
       d1.id
@@ -142,14 +136,14 @@ let () =
      Kernel.t), the real backend's must evict it. *)
   let k0_again = Runtime.compile_kernel d0 ~name:kernel_name ~source in
   if not (k0_again == k0) then
-    failf
+    Alcotest.failf
       "device %d's entry was evicted with no teardown at all (cache is not \
        hitting)"
       d0.id ;
   Spoc_framework.Cache_hooks.notify_device_destroy ~backend:"HIP" d0.backend_id ;
   let after_foreign = Runtime.compile_kernel d0 ~name:kernel_name ~source in
   if not (after_foreign == k0) then
-    failf
+    Alcotest.failf
       "a HIP device-%d teardown evicted the OpenCL device-%d entry (hook \
        matches on the backend-local index alone)"
       d0.backend_id
@@ -165,7 +159,7 @@ let () =
     d0.backend_id ;
   let after_own = Runtime.compile_kernel d0 ~name:kernel_name ~source in
   if after_own == k0 then
-    failf
+    Alcotest.failf
       "the OpenCL device-%d teardown did NOT evict its own entry (listener is \
        a no-op)"
       d0.backend_id
@@ -188,8 +182,18 @@ let () =
        d0.id)
     (run_and_read d1) ;
 
-  if !failures > 0 then begin
-    Printf.printf "%d check(s) failed\n%!" !failures ;
-    exit 1
-  end ;
-  print_endline "test_runtime_cache_device_key: PASSED"
+  ()
+
+let () =
+  Alcotest.run
+    "Runtime cache device key"
+    [
+      ( "outer memo",
+        [
+          Alcotest.test_case
+            "is keyed by device identity and dropped by its own backend's \
+             teardown"
+            `Quick
+            test_outer_memo_is_device_keyed;
+        ] );
+    ]

--- a/sarek/tests/e2e/test_runtime_cache_reset_ids.ml
+++ b/sarek/tests/e2e/test_runtime_cache_reset_ids.ml
@@ -29,9 +29,11 @@
  *
  * Requires >= 2 OpenCL devices plus at least one other backend that enumerates
  * fewer devices than OpenCL does before it, so that some id actually changes
- * meaning. Skips with a printed reason (exit 0) otherwise - and, importantly,
- * skips only after checking that no id changed meaning, so it cannot pass by
- * silently failing to set up the hazard.
+ * meaning. Reports an Alcotest [SKIP] otherwise - and, importantly, skips only
+ * after checking that no id changed meaning, so it cannot pass by silently
+ * failing to set up the hazard. The [SKIP] matters: as a plain executable
+ * printing "SKIP" and exiting 0, this was indistinguishable from a pass on any
+ * machine without two OpenCL devices, i.e. on CI, where it gated nothing.
  ******************************************************************************)
 
 open Spoc_core
@@ -70,7 +72,7 @@ let run_and_count_unwritten (d : Device.t) =
 let snapshot () =
   Array.map (fun (d : Device.t) -> (d.id, d.framework, d.name)) !Device.devices
 
-let () =
+let test_outer_memo_dropped_by_device_reset () =
   Test_helpers.Benchmarks.init_backends () ;
 
   (* Init A: OpenCL alone, so its devices occupy ids 0..k-1. *)
@@ -79,29 +81,25 @@ let () =
   let opencl_count = Array.length before in
   if opencl_count < 2 then begin
     Printf.printf
-      "SKIP: needs >= 2 OpenCL devices for a reset to be able to move an id \
+      "[SKIP] needs >= 2 OpenCL devices for a reset to be able to move an id \
        between two of them; found %d (the probe kernel is OpenCL C)\n\
        %!"
       opencl_count ;
-    exit 0
+    Alcotest.skip ()
   end ;
 
   (* Warm the outer memo for every OpenCL id under init A's numbering. *)
   Array.iter
     (fun (d : Device.t) ->
       let bad = run_and_count_unwritten d in
-      if bad > 0 then begin
-        Printf.printf
-          "FAIL: baseline run on init-A id %d (%s) left %d/%d elements \
-           unwritten; the test cannot distinguish a stale hit from a broken \
-           device\n\
-           %!"
+      if bad > 0 then
+        Alcotest.failf
+          "baseline run on init-A id %d (%s) left %d/%d elements unwritten; \
+           the test cannot distinguish a stale hit from a broken device"
           d.id
           d.name
           bad
-          n ;
-        exit 1
-      end)
+          n)
     !Device.devices ;
   Printf.printf
     "init A: warmed the memo for %d OpenCL device(s)\n%!"
@@ -125,7 +123,7 @@ let () =
   match collision with
   | None ->
       Printf.printf
-        "SKIP: no OpenCL id changed meaning across the reset on this machine, \
+        "[SKIP] no OpenCL id changed meaning across the reset on this machine, \
          so the hazard is not reachable here (init A ids: %s / init B ids: %s)\n\
          %!"
         (String.concat
@@ -138,7 +136,7 @@ let () =
            (List.map
               (fun (id, fw, _) -> Printf.sprintf "%d:%s" id fw)
               (Array.to_list after))) ;
-      exit 0
+      Alcotest.skip ()
   | Some (id, _, name) ->
       Printf.printf
         "id %d denoted a different OpenCL device before the reset; it now \
@@ -151,15 +149,24 @@ let () =
           (Array.find_opt (fun (dev : Device.t) -> dev.id = id) !Device.devices)
       in
       let bad = run_and_count_unwritten d in
-      if bad > 0 then begin
-        Printf.printf
-          "FAIL: %d/%d elements were not written - the outer memo served id \
-           %d's pre-reset entry, which is bound to a different physical device\n\
-           %!"
+      if bad > 0 then
+        Alcotest.failf
+          "%d/%d elements were not written - the outer memo served id %d's \
+           pre-reset entry, which is bound to a different physical device"
           bad
           n
           id ;
-        exit 1
-      end ;
-      Printf.printf "OK: all %d elements = 7 after the reset\n%!" n ;
-      print_endline "test_runtime_cache_reset_ids: PASSED"
+      Printf.printf "OK: all %d elements = 7 after the reset\n%!" n
+
+let () =
+  Alcotest.run
+    "Runtime cache reset ids"
+    [
+      ( "outer memo",
+        [
+          Alcotest.test_case
+            "does not survive Device.reset re-numbering the global id space"
+            `Quick
+            test_outer_memo_dropped_by_device_reset;
+        ] );
+    ]

--- a/sarek/tests/e2e/test_runtime_cache_teardown.ml
+++ b/sarek/tests/e2e/test_runtime_cache_teardown.ml
@@ -20,9 +20,11 @@
  * (and every other case in it) down.
  *
  * Requires the OpenCL backend (the probe kernel is OpenCL C) and at least one
- * OpenCL device; skips with a printed reason otherwise. Native/Interpreter are
- * deliberately not accepted: they hold no releasable driver handle, so the test
- * would pass vacuously.
+ * OpenCL device; reports an Alcotest [SKIP] otherwise. Not a printed "SKIP"
+ * from a plain executable exiting 0, which is what this used to be and which is
+ * indistinguishable from a pass on a machine with no OpenCL device (i.e. on
+ * CI). Native/Interpreter are deliberately not accepted: they hold no
+ * releasable driver handle, so the test would pass vacuously.
  ******************************************************************************)
 
 open Spoc_core
@@ -54,44 +56,77 @@ let run_and_read (d : Device.t) label =
   Printf.printf "  [%s] readback[0] = %g\n%!" label host.{0} ;
   host.{0}
 
-let () =
+let test_outer_memo_dropped_by_backend_teardown () =
   Test_helpers.Benchmarks.init_backends () ;
   let devs = Device.init () in
   match Array.find_opt (fun (d : Device.t) -> d.framework = "OpenCL") devs with
   | None ->
       Printf.printf
-        "SKIP: needs an OpenCL device (the probe kernel is OpenCL C and the \
+        "[SKIP] needs an OpenCL device (the probe kernel is OpenCL C and the \
          hazard is a released driver handle, which CPU backends do not have)\n\
          %!" ;
-      exit 0
+      Alcotest.skip ()
   | Some d ->
       Printf.printf "using OpenCL device [%d] %s\n%!" d.id d.name ;
       let before = run_and_read d "before clear_cache" in
-      if before <> 7.0 then begin
-        Printf.printf "FAIL: baseline launch produced %g, expected 7\n%!" before ;
-        exit 1
-      end ;
+      if before <> 7.0 then
+        Alcotest.failf
+          "baseline launch produced %g, expected 7 - the device is not usable, \
+           so nothing below is meaningful"
+          before ;
+      (* Structural check FIRST, before anything is launched. Without it this
+         test's only signal is the SIGSEGV below, which names nothing: dune
+         reports a nonzero exit and the reader has to work out why. Physical
+         identity of what [Runtime.compile_kernel] returns is the memo's own
+         state, so a stale entry is reported here as a message instead of as a
+         crash. The launch that follows still has to happen: this identity check
+         cannot tell whether the RELEASE actually occurred, only whether the
+         memo was dropped. *)
+      let memoized = Runtime.compile_kernel d ~name:kernel_name ~source in
+      if not (Runtime.compile_kernel d ~name:kernel_name ~source == memoized)
+      then
+        Alcotest.failf
+          "the outer memo is not hitting at all before the clear, so this test \
+           cannot tell an invalidated memo from a memo that never held \
+           anything" ;
       (* Releases the backend handles the outer memo closed over. *)
       Printf.printf "calling Kernel.clear_cache\n%!" ;
       Kernel.clear_cache d ;
       Printf.printf "clear_cache returned\n%!" ;
+      if Runtime.compile_kernel d ~name:kernel_name ~source == memoized then
+        Alcotest.failf
+          "Kernel.clear_cache released the backend handles but the outer memo \
+           still holds the Kernel.t that closes over them: the next launch \
+           goes through a released cl_kernel. Cache_hooks.notify_clear_all did \
+           not reach Runtime's on_clear_all listener" ;
       (* Must recompile, not serve the stale closure. SIGSEGV here before the
          fix. *)
       let after = run_and_read d "after clear_cache" in
-      if after <> 7.0 then begin
-        Printf.printf
-          "FAIL: post-clear launch produced %g, expected 7\n%!"
+      if after <> 7.0 then
+        Alcotest.failf
+          "post-clear launch produced %g, expected 7: the outer memo served a \
+           Kernel.t whose backend handle Kernel.clear_cache had already \
+           released"
           after ;
-        exit 1
-      end ;
       (* And a second clear/run cycle, to confirm the invalidation is not a
          one-shot. *)
       Kernel.clear_cache d ;
       let again = run_and_read d "after a second clear_cache" in
-      if again <> 7.0 then begin
-        Printf.printf
-          "FAIL: second post-clear launch produced %g, expected 7\n%!"
-          again ;
-        exit 1
-      end ;
-      print_endline "test_runtime_cache_teardown: PASSED"
+      if again <> 7.0 then
+        Alcotest.failf
+          "second post-clear launch produced %g, expected 7: the invalidation \
+           is one-shot"
+          again
+
+let () =
+  Alcotest.run
+    "Runtime cache teardown"
+    [
+      ( "outer memo",
+        [
+          Alcotest.test_case
+            "is dropped by Kernel.clear_cache, repeatably"
+            `Quick
+            test_outer_memo_dropped_by_backend_teardown;
+        ] );
+    ]

--- a/sarek/tests/e2e/test_vulkan_cache_device_scope.ml
+++ b/sarek/tests/e2e/test_vulkan_cache_device_scope.ml
@@ -1,0 +1,187 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression: the Vulkan kernel cache must be evictable PER DEVICE (#90).
+ *
+ * Vulkan used to be the worst case of the mixed eviction scope #86 left behind.
+ * Its cache key carries the backend-local device index like everyone else's,
+ * but it passed no [~device_id] to [Guarded_cache.find_or_build], so the entry
+ * was never grouped by device and [Guarded_cache.evict_device] could not reach
+ * it - and [Vulkan_api_device.destroy] fired no notification either. Per-device
+ * eviction was therefore inexpressible at BOTH layers, which is what #90
+ * records. Everything the cache's [destroy] releases (pipeline, layout,
+ * descriptor pool and set layout, shader module) belongs to the VkDevice that
+ * [destroy] is about to take down, so the entries outlived their VkDevice and
+ * would be handed to the next lookup for a recreated index.
+ *
+ * This is the Vulkan half of test_backend_cache_scope.ml and is a SEPARATE
+ * EXECUTABLE for a driver reason, not a stylistic one: on this host (Mesa,
+ * radeonsi OpenCL + RADV Vulkan) creating a Vulkan compute pipeline in a
+ * process that has already enumerated OpenCL segfaults inside
+ * libvulkan_radeon. Pre-existing and unrelated to the cache work -
+ * test_static_tag_erasure SIGSEGVs identically on origin/main and passes with
+ * OCL_ICD_VENDORS pointed at an empty directory - but it means the two
+ * backends cannot share a test binary.
+ *
+ * Skips - as a distinct Alcotest [SKIP] row, not a green [OK] - when no Vulkan
+ * device is enumerated. A Vulkan device that IS present and fails to compile
+ * the probe is a failure, never a skip.
+ ******************************************************************************)
+
+let source =
+  {|#version 450
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(std430, set=0, binding = 0) buffer BufferA {
+    float a[];
+};
+
+void main() {
+    a[gl_GlobalInvocationID.x] = 7.0;
+}
+|}
+
+(* Registers the Vulkan backend WITHOUT going through
+   Test_helpers.Benchmarks.init_backends, which would pull in OpenCL - see the
+   header for why that is not survivable in this process. *)
+let () = Sarek_vulkan.Vulkan_plugin.init ()
+
+let test_vulkan_cache_is_evictable_per_device () =
+  match Spoc_framework_registry.Framework_registry.find_backend "Vulkan" with
+  | None ->
+      Printf.printf "[SKIP] the Vulkan backend is not registered\n%!" ;
+      Alcotest.skip ()
+  | Some (module B : Spoc_framework.Framework_sig.BACKEND) ->
+      if not (B.is_available ()) then begin
+        Printf.printf "[SKIP] no usable Vulkan driver on this host\n%!" ;
+        Alcotest.skip ()
+      end ;
+      B.Device.init () ;
+      if B.Device.count () = 0 then begin
+        Printf.printf "[SKIP] no Vulkan device enumerated here\n%!" ;
+        Alcotest.skip ()
+      end ;
+      let dev = B.Device.get 0 in
+      let index = B.Device.id dev in
+      Printf.printf
+        "Vulkan: using backend-local device %d (%s)\n%!"
+        index
+        (B.Device.name dev) ;
+      let k1 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      let k2 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      if not (k1 == k2) then
+        Alcotest.failf
+          "two compile_cached calls with the same key returned different \
+           values - the Vulkan cache is not hitting at all, so this test \
+           cannot tell eviction from a permanent miss" ;
+      (* Backend-local indices collide across backends (OpenCL 0, Vulkan 0, HIP
+         0 all exist), and evict_device does not merely drop memoization - it
+         aborts in-flight builds for that index. A foreign teardown must not
+         touch this entry. *)
+      Spoc_framework.Cache_hooks.notify_device_destroy ~backend:"HIP" index ;
+      let k3 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      if not (k3 == k1) then
+        Alcotest.failf
+          "a HIP device-%d teardown evicted the Vulkan entry for the same \
+           index - the listener matches on the backend-local index alone"
+          index ;
+      Spoc_framework.Cache_hooks.notify_device_destroy ~backend:"Vulkan" index ;
+      let k4 = B.Kernel.compile_cached dev ~name:"scope_probe" ~source in
+      if k4 == k1 then
+        Alcotest.failf
+          "the Vulkan device-%d teardown did NOT evict the backend cache \
+           entry. Guarded_cache.evict_device can only reach entries installed \
+           with ~device_id, and Vulkan's find_or_build does not pass it - so \
+           the pipeline, layouts, descriptor pool and shader module for a \
+           destroyed VkDevice survive it (#90)"
+          index ;
+      Printf.printf
+        "Vulkan: device-%d teardown evicted the cache entry, a foreign \
+         backend's did not\n\
+         %!"
+        index
+
+(* The other half of #90: it is [Vulkan_api_device.destroy] that must FIRE the
+   notification, and nothing did before. Driven through the real destroy path
+   rather than a hand-fired notify, because the ordering is the property -
+   everything the cache releases belongs to the VkDevice being destroyed, so the
+   eviction has to happen while it is still alive.
+
+   Observable without reaching into the cache: [destroy] empties Vulkan's
+   [device_cache], so [get 0] afterwards builds a NEW VkDevice under the same
+   index. A surviving cache entry would then be served to it, carrying a
+   pipeline belonging to the destroyed VkDevice. Physical identity distinguishes
+   the two.
+
+   Runs after the case above and destroys the device, so it is declared last. *)
+module VDev = Sarek_vulkan.Vulkan_api.Device
+
+let test_device_destroy_evicts_the_cache () =
+  match Spoc_framework_registry.Framework_registry.find_backend "Vulkan" with
+  | None ->
+      Printf.printf "[SKIP] the Vulkan backend is not registered\n%!" ;
+      Alcotest.skip ()
+  | Some (module B : Spoc_framework.Framework_sig.BACKEND) ->
+      if not (B.is_available ()) then begin
+        Printf.printf "[SKIP] no usable Vulkan driver on this host\n%!" ;
+        Alcotest.skip ()
+      end ;
+      B.Device.init () ;
+      if B.Device.count () = 0 then begin
+        Printf.printf "[SKIP] no Vulkan device enumerated here\n%!" ;
+        Alcotest.skip ()
+      end ;
+      let dev = VDev.get 0 in
+      let k1 =
+        Sarek_vulkan.Vulkan_api.Kernel.compile_cached
+          dev
+          ~name:"scope_probe"
+          ~source
+      in
+      if
+        not
+          (Sarek_vulkan.Vulkan_api.Kernel.compile_cached
+             dev
+             ~name:"scope_probe"
+             ~source
+          == k1)
+      then
+        Alcotest.failf
+          "the Vulkan cache is not hitting before the destroy, so this test \
+           cannot tell eviction from a permanent miss" ;
+      VDev.destroy dev ;
+      let dev' = VDev.get 0 in
+      let k2 =
+        Sarek_vulkan.Vulkan_api.Kernel.compile_cached
+          dev'
+          ~name:"scope_probe"
+          ~source
+      in
+      if k2 == k1 then
+        Alcotest.failf
+          "Vulkan_api_device.destroy left the kernel cache entry in place: the \
+           recreated device 0 was handed a pipeline, layouts, descriptor pool \
+           and shader module belonging to the VkDevice that was just destroyed \
+           (#90 - destroy fires no Cache_hooks.notify_device_destroy)" ;
+      Printf.printf "Vulkan: Vulkan_api_device.destroy evicted the cache\n%!"
+
+let () =
+  Alcotest.run
+    "Vulkan cache device scope"
+    [
+      ( "per-device eviction",
+        [
+          Alcotest.test_case
+            "Vulkan kernel cache is evictable per device"
+            `Quick
+            test_vulkan_cache_is_evictable_per_device;
+          Alcotest.test_case
+            "Vulkan_api_device.destroy fires the notification"
+            `Quick
+            test_device_destroy_evicts_the_cache;
+        ] );
+    ]

--- a/spoc/framework/Cache_hooks.ml
+++ b/spoc/framework/Cache_hooks.ml
@@ -43,3 +43,29 @@ let notify_device_destroy ~backend device_id =
 let notify_clear_all () =
   let hooks = Mutex.protect mutex (fun () -> !clear_all_hooks) in
   run_all hooks
+
+(* Nesting depth of [around_clear] on THIS domain. Per-domain, not global: a
+   concurrent clear on another domain is a genuinely separate teardown and must
+   still notify. Within one domain the nesting is always
+   [Sarek.Kernel.clear_cache] -> [B.Kernel.clear_cache], and both would
+   otherwise notify, giving four notifications where the contract says two. *)
+let clear_depth = Domain.DLS.new_key (fun () -> 0)
+
+let around_clear f =
+  let depth = Domain.DLS.get clear_depth in
+  if depth > 0 then f ()
+  else begin
+    Domain.DLS.set clear_depth (depth + 1) ;
+    let listener_exn = ref None in
+    let notify () =
+      try notify_clear_all ()
+      with e -> if Option.is_none !listener_exn then listener_exn := Some e
+    in
+    notify () ;
+    Fun.protect
+      ~finally:(fun () ->
+        notify () ;
+        Domain.DLS.set clear_depth depth)
+      f ;
+    Option.iter raise !listener_exn
+  end

--- a/spoc/framework/Cache_hooks.mli
+++ b/spoc/framework/Cache_hooks.mli
@@ -25,28 +25,39 @@
     callbacks run outside the lock. If a callback raises, the remaining
     callbacks still run and the first exception is re-raised afterwards.
 
-    {2 What actually notifies today — this back-channel is not yet universal}
+    {2 What actually notifies today}
 
-    Registering a listener does {b not} mean every handle release will reach it.
-    The current coverage is exactly:
+    - {!notify_clear_all} is fired by {!around_clear}, which wraps the body of
+      {e every} backend's [Kernel.clear_cache] — so it fires whether the caller
+      goes through [Sarek.Kernel.clear_cache] or resolves the backend itself
+      through [Framework_registry.find_backend] and calls
+      [B.Kernel.clear_cache ()] directly. It is also fired by
+      [Sarek.Device.reset], which retires the global device id space without
+      clearing anything.
+    - {!notify_device_destroy} is fired by every backend that has a
+      device-destroy entry point: CUDA ([Cuda_api.Device.destroy]), HIP
+      ([Hip_api.Device.destroy]) and Vulkan ([Vulkan_api_device.destroy]).
+      OpenCL and Metal expose no device-destroy entry point at all, so there is
+      nothing for them to notify {e from} — but their kernel caches register the
+      same listener as everyone else, so a notification aimed at them is
+      honoured if one is ever fired.
 
-    - {!notify_clear_all} is fired by [Sarek.Kernel.clear_cache] (on both sides
-      of the backend clear) and by [Sarek.Device.reset]. Those are the only
-      notifying entry points. A caller that resolves a backend through
-      [Framework_registry.find_backend] and calls [B.Kernel.clear_cache ()]
-      {e directly} releases the handles without notifying anything, and an outer
-      memo will then serve a released handle — the same failure this module
-      exists to prevent, through a sibling entry point. Go through
-      [Sarek.Kernel.clear_cache].
-    - {!notify_device_destroy} is fired by the CUDA and HIP backends only.
-      Vulkan has a device-destroy path ([Vulkan_api_device.destroy]) and does
-      {e not} fire it; its kernel cache also passes no [~device_id] to
-      {!Guarded_cache.find_or_build}, so per-device eviction is not expressible
-      there at either layer. OpenCL and Metal expose no device-destroy entry
-      point at all, so there is nothing for them to notify from.
+    Every backend kernel cache is per-device on both sides: its key carries the
+    backend-local device index (via {!Compile_cache.make_key}) and it passes
+    that same index as [~device_id] to {!Guarded_cache.find_or_build}, so
+    {!Guarded_cache.evict_device} can reach its entries. Listeners may rely on
+    that uniformity.
 
-    Treat this list as the contract, not as an implementation detail: a listener
-    that assumes total coverage is wrong today.
+    {2 Backend obligations}
+
+    A new backend must, for its kernel cache:
+    - wrap its [Kernel.clear_cache] body in {!around_clear};
+    - pass [~device_id] (the backend-local index, the same one that goes into
+      the cache key) to {!Guarded_cache.find_or_build};
+    - register an {!on_device_destroy} listener that evicts that index when
+      [~backend] equals its own family name;
+    - fire {!notify_device_destroy} from its device-destroy path, if it has one,
+      {e before} it releases anything — see below.
 
     {2 Notifying from a teardown path}
 
@@ -56,8 +67,8 @@
     these from [Device.destroy] must therefore
     {b complete its teardown first and re-raise afterwards} — capture the
     exception, unload modules, retire streams, destroy the context, then let it
-    out. The CUDA and HIP backends do exactly this; copy that shape in any new
-    backend. *)
+    out. The CUDA, HIP and Vulkan backends do exactly this; copy that shape in
+    any new backend. *)
 
 (** [on_device_destroy f] registers [f], called as [f ~backend index] whenever a
     device is being torn down.
@@ -82,5 +93,30 @@ val notify_device_destroy : backend:string -> int -> unit
 val on_clear_all : (unit -> unit) -> unit
 
 (** [notify_clear_all ()] runs every callback registered with {!on_clear_all}.
-    Called before a backend clears its own cache. *)
+    Prefer {!around_clear}, which fires it on both sides of the clear. *)
 val notify_clear_all : unit -> unit
+
+(** [around_clear clear] runs [clear] with a {!notify_clear_all} on {e each}
+    side of it, and is how a backend's [Kernel.clear_cache] must be written.
+    Putting the notification here rather than in the caller is what makes a
+    direct [B.Kernel.clear_cache ()] safe: the handles are never released
+    without the layers above being told.
+
+    Both notifications are load-bearing. The first drops what is already
+    memoized, but cannot cover an outer build that {e starts} after it: such a
+    build snapshots the new generation, closes over a handle [clear] then
+    releases, and on re-acquire would find the generation unchanged and install
+    a value over a dead handle. The second bumps the generation again, so any
+    build spanning the release is rejected (see {!Guarded_cache.find_or_build}'s
+    [~invalidated_by_clear]).
+
+    A listener failure is isolated from [clear] and re-raised only after it has
+    completed: a listener owns no handles, so letting it escape early would skip
+    the release [clear] exists to perform and leak every backend handle. If
+    [clear] itself raises, that exception wins.
+
+    Nested calls on the same domain notify once, not twice per level:
+    [Sarek.Kernel.clear_cache] wraps the backend's own [clear_cache], and the
+    contract is two notifications per teardown, not four. Nesting is tracked per
+    domain, so a concurrent clear on another domain still notifies. *)
+val around_clear : (unit -> unit) -> unit

--- a/spoc/framework/test/test_cache_hooks.ml
+++ b/spoc/framework/test/test_cache_hooks.ml
@@ -54,10 +54,71 @@ let test_all_listeners_run_and_first_failure_is_reported () =
         (List.mem tag !ran))
     ["a"; "b"; "c"]
 
+(* [around_clear] is where the clear notification lives, so that a DIRECT
+   backend clear cannot bypass it. Three properties, each of which a backend
+   depends on. *)
+
+let test_around_clear_notifies_on_both_sides () =
+  let events = ref [] in
+  CH.on_clear_all (fun () -> events := "notify" :: !events) ;
+  CH.around_clear (fun () -> events := "clear" :: !events) ;
+  (* The pre-notification drops what is memoized now; only the post one rejects
+     a build that spans the handle release (Guarded_cache ~invalidated_by_clear).
+     Neither alone is sufficient. *)
+  Alcotest.(check (list string))
+    "notify, clear, notify"
+    ["notify"; "clear"; "notify"]
+    (List.rev !events)
+
+let test_around_clear_nesting_collapses () =
+  let n = ref 0 in
+  CH.on_clear_all (fun () -> incr n) ;
+  (* Sarek.Kernel.clear_cache wraps the backend's own clear_cache, which is
+     itself wrapped. The contract is two notifications per teardown, not two per
+     nesting level. *)
+  CH.around_clear (fun () -> CH.around_clear (fun () -> ())) ;
+  Alcotest.(check int) "two notifications, not four" 2 !n
+
+exception Boom
+
+(* Runs LAST in the suite: [Cache_hooks] has no unregister, so the listener this
+   case installs would otherwise poison every case declared after it. For the
+   same reason it catches any exception rather than [Boom] specifically — by the
+   time it runs, the notification cases above have also installed a raising
+   listener, and [run_all] re-raises whichever failed first. *)
+let test_around_clear_isolates_a_failing_listener () =
+  let cleared = ref false in
+  CH.on_clear_all (fun () -> raise Boom) ;
+  let raised =
+    try
+      CH.around_clear (fun () -> cleared := true) ;
+      false
+    with _ -> true
+  in
+  (* A listener owns no handles: letting it escape early would skip the release
+     the clear exists to perform and leak every backend handle. It must still be
+     reported, just afterwards. *)
+  Alcotest.(check bool) "the clear still ran" true !cleared ;
+  Alcotest.(check bool) "the failure is re-raised afterwards" true raised
+
 let () =
   Alcotest.run
     "Cache_hooks"
     [
+      (* Declaration order is execution order, and the registry has no
+         unregister: every case that installs a RAISING listener must come after
+         every case that counts or orders notifications. *)
+      ( "around_clear",
+        [
+          Alcotest.test_case
+            "notifies on both sides of the clear"
+            `Quick
+            test_around_clear_notifies_on_both_sides;
+          Alcotest.test_case
+            "nested scopes notify once, not per level"
+            `Quick
+            test_around_clear_nesting_collapses;
+        ] );
       ( "notification",
         [
           Alcotest.test_case
@@ -68,5 +129,12 @@ let () =
             "a failing listener does not skip the others"
             `Quick
             test_all_listeners_run_and_first_failure_is_reported;
+        ] );
+      ( "around_clear failure isolation",
+        [
+          Alcotest.test_case
+            "a failing listener does not abort the clear"
+            `Quick
+            test_around_clear_isolates_a_failing_listener;
         ] );
     ]


### PR DESCRIPTION
Closes #119. Also closes #90.

PR #293 fixed the device-blind `Runtime.compile_kernel` cache and its missing teardown invalidation, but left three holes open. This closes all three.

## The three holes, as they were

**H1 — a direct backend clear bypasses the notification entirely.**
Every backend's `Kernel.clear_cache` was a bare `Guarded_cache.clear`:
`sarek-opencl/Opencl_plugin_base.ml:255`, `sarek-metal/Metal_plugin_base.ml:262`, `sarek-vulkan/Vulkan_api_kernel.ml:414`, `sarek-cuda/Cuda_api.ml:663`, `sarek-hip/Hip_api.ml:477`. `Cache_hooks.notify_clear_all` was fired only by the *wrapper* at `sarek/core/Kernel.ml:184`. `Framework_registry.find_backend` is public, so `B.Kernel.clear_cache ()` released every `cl_kernel`/`cl_program`/`VkPipeline`/`CUmodule` with `Runtime.kernel_cache` still holding `Kernel.t` closures over them — the same use-after-free #293 fixed, through a sibling entry point. `spoc/framework/Cache_hooks.mli:33-40` documented it as a known hole.

**H2 — the eviction scope was mixed.**
`~device_id` was passed to `Guarded_cache.find_or_build` by CUDA (`sarek-cuda/Cuda_api.ml:649`) and HIP (`sarek-hip/Hip_api.ml:471`) only — not by OpenCL (`sarek-opencl/Opencl_plugin_base.ml:252`), Metal (`sarek-metal/Metal_plugin_base.ml:259`) or Vulkan (`sarek-vulkan/Vulkan_api_kernel.ml:409`). Since `keys_by_device` is populated *only* from that argument, `Guarded_cache.evict_device` could not reach an OpenCL, Metal or Vulkan entry at all: those three caches were per-device in their *keys* but global in their *eviction*. Recorded at `Cache_hooks.mli:41-46`.

**H3 — both e2e tests were vacuous on CI.**
`sarek/tests/e2e/test_runtime_cache_device_key.ml:100-107` and `test_runtime_cache_reset_ids.ml:80-87` / `:126-141` (and `test_runtime_cache_teardown.ml:61-66`) printed `SKIP:` and `exit 0`. Under `(rule (alias runtest) (action (run ...)))` at `sarek/tests/e2e/dune:1196-1209` that is byte-for-byte indistinguishable from a run that verified everything. CI has no GPU (and pocl was dropped in 859c8601), so all three skipped and the alias went green having checked nothing.

## The scope decision — per-device, everywhere

Justified from how the backends actually key their compiled artifacts: every one of them folds the backend-local device index into `Compile_cache.make_key` (`Cuda_api.ml:641`, `Hip_api.ml:462`, `Opencl_plugin_base.ml:245`, `Metal_plugin_base.ml:253`, `Vulkan_api_kernel.ml:404`). A compiled artifact is per-device *by construction*, so eviction granularity should match keying granularity rather than being coarser. Going global instead would mean a single device teardown throws away every other device's compiled kernels — and, since `evict_device` aborts in-flight builds, would make one device's teardown raise inside another device's healthy compile.

So all five backends now pass `~device_id`, and all five register the **same** `Cache_hooks.on_device_destroy` listener matching on their own family name. CUDA's and HIP's private `device_destroy_hooks` lists are deleted in favour of it — one mechanism, not two. OpenCL and Metal expose no device-destroy entry point at all, so nothing fires for them today; their listeners are wired but inert, and the `.mli` says so rather than leaving it implicit.

## #90 is closed, not deferred

The scope decision made it tractable. With `~device_id` passed, per-device eviction is now expressible in `Vulkan_api_kernel`; and `Vulkan_api_device.destroy` now fires `notify_device_destroy` *before* releasing anything, with the capture-finish-re-raise shape `Cache_hooks.mli` requires. Ordering is the whole property: every object the Vulkan cache's `destroy` releases (pipeline, pipeline layout, descriptor pool, descriptor set layout, shader module) belongs to the VkDevice being torn down. Both layers are covered by executed tests.

## Red-proof

Device: **AMD RX 7900 XTX** — Mesa `radeonsi` OpenCL (2 devices: the dGPU and the 7950X iGPU), **RADV** Vulkan, DRM 3.64, kernel 7.1.2-3-cachyos. **No NVIDIA GPU**, so CUDA is compile-only here.

Each mechanism was mutated and the covering test required to fail:

| mutation | test | result |
|---|---|---|
| `Runtime`'s `on_clear_all` listener unregistered | teardown + direct-clear | FAIL — *"Kernel.clear_cache released the backend handles but the outer memo still holds the Kernel.t that closes over them… notify_clear_all did not reach Runtime's on_clear_all listener"* |
| outer memo key drops the device | device_key | FAIL — *"requested device 1, got a kernel bound to device 0 (outer cache key omits device identity)"* |
| `Device.reset` stops notifying | reset_ids | FAIL — *"16/16 elements were not written - the outer memo served id 1's pre-reset entry, which is bound to a different physical device"* |
| `around_clear` stops notifying | teardown + direct-clear | FAIL — *"a direct B.Kernel.clear_cache () released the backend handles without invalidating the outer memo - the notification is in the Sarek.Kernel.clear_cache wrapper only…"* |
| `Guarded_cache.clear` evicts nothing | teardown | FAIL (same named assertion) |
| OpenCL drops `~device_id` | backend_cache_scope | FAIL — *"OpenCL: the device-0 teardown did NOT evict the backend cache entry. Guarded_cache.evict_device can only reach entries that were installed with ~device_id…"* |
| Vulkan drops `~device_id` | vulkan_cache_device_scope | FAIL — *"…so the pipeline, layouts, descriptor pool and shader module for a destroyed VkDevice survive it (#90)"* |
| `Vulkan_api_device.destroy` stops notifying | vulkan_cache_device_scope | FAIL — *"Vulkan_api_device.destroy left the kernel cache entry in place: the recreated device 0 was handed a pipeline… belonging to the VkDevice that was just destroyed"* |

The two crash-shaped cases previously had SIGSEGV as their *only* signal, which names nothing. Both now assert on the physical identity of what `Runtime.compile_kernel` returns *before* the crash-prone launch, so they report the problem in words and still keep the launch (identity alone cannot prove the handles were really released).

**Skip is now visible.** Simulating a device-less CI box (`OCL_ICD_VENDORS` at an empty directory, Vulkan ICD hidden):

```
Testing `Runtime cache device key'.
  [SKIP]        outer memo          0   is keyed by device identity and dropp...
Test Successful in 0.000s. 0 test run.
```

— against the previous `SKIP: …` + `exit 0`, which dune reported as a plain green.

## Not verified on this hardware

- **CUDA and HIP.** Compile-only (no NVIDIA GPU; the HIP arm was not exercised at runtime). Their `~device_id` wiring predates this PR; what is new for them is that eviction moved from a private hook list onto `Cache_hooks`. Reviewed, compiled, not executed.
- **Metal.** Compiles on Linux; no Apple hardware here.
- The CUDA/HIP/Metal listener registrations are code-review-only.

## Pre-existing issue found, deliberately not fixed here

`sarek/tests/e2e/test_static_tag_erasure.exe` **SIGSEGVs on origin/main** (cf58801b, unmodified, standalone) inside `libvulkan_radeon` during `vkCreateComputePipelines`, and passes with `OCL_ICD_VENDORS` pointed at an empty directory. It is a Mesa-level conflict: creating a Vulkan compute pipeline in a process that already enumerated radeonsi OpenCL crashes. It is the only failing rule in `@sarek/tests/e2e/runtest` both before and after this PR. It is why the Vulkan scope test is its own executable that links `sarek_vulkan` directly and never initialises OpenCL.

Separately, `Vulkan_types.ml:910` declares `pName` with ctypes' `string` view; `setf` stores a pointer to a ctypes-managed buffer that becomes unreachable as soon as `setf` returns, so `vkCreateComputePipelines` reads the entry-point name out of memory whose finaliser may already have run. I could not produce a red/green for it — the Mesa crash above masks it — so I have not shipped a speculative fix. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
