### PR TITLE
fix(vulkan): root ctypes allocations across FFI calls — repairs the standing e2e failure

### DIFF
--- a/sarek-vulkan/Vulkan_api_device.ml
+++ b/sarek-vulkan/Vulkan_api_device.ml
@@ -74,11 +74,17 @@ let get_or_create_instance () =
   | None ->
       (* Application info *)
       let app_info = make vk_application_info in
+      (* Held explicitly rather than written through ctypes' [string_opt] view:
+         that view allocates an anonymous C buffer rooted only by the fat
+         pointer [setf] discards, so the name would dangle by the time the
+         loader reads it in vkCreateInstance. *)
+      let app_name = CArray.of_string "Sarek" in
+      let engine_name = CArray.of_string "SPOC" in
       setf app_info app_info_sType (u32 vk_structure_type_application_info) ;
       setf app_info app_info_pNext null ;
-      setf app_info app_info_pApplicationName (Some "Sarek") ;
+      setf app_info app_info_pApplicationName (CArray.start app_name) ;
       setf app_info app_info_applicationVersion (Unsigned.UInt32.of_int 1) ;
-      setf app_info app_info_pEngineName (Some "SPOC") ;
+      setf app_info app_info_pEngineName (CArray.start engine_name) ;
       setf app_info app_info_engineVersion (Unsigned.UInt32.of_int 1) ;
       (* Vulkan 1.2 *)
       setf
@@ -108,6 +114,11 @@ let get_or_create_instance () =
 
       let inst = allocate vk_instance_ptr (from_voidp vk_instance null) in
       check "vkCreateInstance" (vkCreateInstance (addr create_info) null inst) ;
+      (* [create_info] holds bare addresses into these; keep them reachable
+         until the driver has finished reading them. *)
+      ignore (Sys.opaque_identity app_info) ;
+      ignore (Sys.opaque_identity app_name) ;
+      ignore (Sys.opaque_identity engine_name) ;
       instance_ref := Some !@inst ;
       !@inst
 
@@ -264,11 +275,11 @@ let get idx =
          features are left at their default (false), matching the previous
          pEnabledFeatures = null behaviour.
 
-         [enabled_features] is bound in this function's scope (not inside
-         the [if]) so the ctypes-managed memory it owns stays alive - and
-         therefore [addr enabled_features] stays valid - across the
-         [vkCreateDevice] call below; a binding local to the [if] branch
-         would let the GC reclaim it before the FFI call runs. *)
+         NOTE: hoisting this binding out of the [if] does NOT by itself keep
+         [addr enabled_features] valid across [vkCreateDevice] - in OCaml a
+         value dies after its last USE, not at the end of its scope, so the
+         GC may reclaim it the moment [setf] has copied the bare address in.
+         The explicit keep-alives after the call are what make it safe. *)
       let enabled_features = make vk_physical_device_features in
       if supports_fp64 then begin
         let enabled_bools = getf enabled_features phys_features_bools in
@@ -290,6 +301,10 @@ let get idx =
       check
         "vkCreateDevice"
         (vkCreateDevice phys_dev (addr dev_create_info) null device) ;
+      (* [dev_create_info] holds bare addresses into all three. *)
+      ignore (Sys.opaque_identity enabled_features) ;
+      ignore (Sys.opaque_identity queue_create_info) ;
+      ignore (Sys.opaque_identity queue_priority) ;
 
       (* Get compute queue *)
       let queue = allocate vk_queue_ptr (from_voidp vk_queue null) in

--- a/sarek-vulkan/Vulkan_api_kernel.ml
+++ b/sarek-vulkan/Vulkan_api_kernel.ml
@@ -171,10 +171,19 @@ let create_shader_module device spirv =
        (addr create_info)
        null
        shader_module) ;
+  (* [create_info.pCode] holds a bare address into [code]; [setf] dropped the
+     fat pointer that rooted it, so [code] must be kept reachable across the
+     call or the GC may free the SPIR-V out from under the driver. *)
+  ignore (Sys.opaque_identity code) ;
   !@shader_module
 
 (** Compile GLSL source to compute pipeline *)
 let compile device ~name ~source =
+  (* Same hazard as [launch] below: Vulkan reads through the pointers we store
+     into the *CreateInfo structs during the call, but [setf] keeps only the
+     bare address, dropping the fat pointer that rooted the referent. Every
+     such referent must stay reachable until the call returns. *)
+  let keep = Sys.opaque_identity in
   (* 1. Check cache for SPIR-V *)
   let driver_version =
     let maj, min, patch = device.Device.api_version in
@@ -265,6 +274,7 @@ let compile device ~name ~source =
        (addr dsl_create_info)
        null
        dsl) ;
+  ignore (keep bindings) ;
 
   (* Create pipeline layout *)
   let pl_create_info = make vk_pipeline_layout_create_info in
@@ -301,6 +311,8 @@ let compile device ~name ~source =
        (addr pl_create_info)
        null
        pipeline_layout) ;
+  ignore (keep push_constant_range) ;
+  ignore (keep dsl) ;
 
   (* Create compute pipeline *)
   let stage_info = make vk_pipeline_shader_stage_create_info in
@@ -315,7 +327,11 @@ let compile device ~name ~source =
     shader_stage_stage
     (Unsigned.UInt32.of_int vk_shader_stage_compute_bit) ;
   setf stage_info shader_stage_module shader_module ;
-  setf stage_info shader_stage_pName "main" ;
+  (* Held explicitly: [stage_info] is copied BY VALUE into [pipeline_info]
+     below, so even keeping [stage_info] alive would not root the entry-point
+     string buffer. *)
+  let entry_name = CArray.of_string "main" in
+  setf stage_info shader_stage_pName (CArray.start entry_name) ;
   setf stage_info shader_stage_pSpecializationInfo null ;
 
   let pipeline_info = make vk_compute_pipeline_create_info in
@@ -341,6 +357,8 @@ let compile device ~name ~source =
       pipeline
   in
   check "vkCreateComputePipelines" result ;
+  ignore (keep entry_name) ;
+  ignore (keep stage_info) ;
 
   (* Create descriptor pool *)
   let pool_size = make vk_descriptor_pool_size in
@@ -365,6 +383,7 @@ let compile device ~name ~source =
   check
     "vkCreateDescriptorPool"
     (vkCreateDescriptorPool device.Device.device (addr pool_info) null pool) ;
+  ignore (keep pool_size) ;
 
   (* Allocate persistent descriptor set *)
   let ds_ai = make vk_descriptor_set_allocate_info in
@@ -383,7 +402,7 @@ let compile device ~name ~source =
   check
     "vkAllocateDescriptorSets"
     (vkAllocateDescriptorSets device.Device.device (addr ds_ai) desc_set) ;
-  ignore dsl_ptr ;
+  ignore (keep dsl_ptr) ;
   {
     shader_module;
     pipeline = !@pipeline;

--- a/sarek-vulkan/Vulkan_types.ml
+++ b/sarek-vulkan/Vulkan_types.ml
@@ -354,12 +354,12 @@ let app_info_sType = field vk_application_info "sType" uint32_t
 let app_info_pNext = field vk_application_info "pNext" (ptr void)
 
 let app_info_pApplicationName =
-  field vk_application_info "pApplicationName" string_opt
+  field vk_application_info "pApplicationName" (ptr char)
 
 let app_info_applicationVersion =
   field vk_application_info "applicationVersion" uint32_t
 
-let app_info_pEngineName = field vk_application_info "pEngineName" string_opt
+let app_info_pEngineName = field vk_application_info "pEngineName" (ptr char)
 
 let app_info_engineVersion = field vk_application_info "engineVersion" uint32_t
 
@@ -907,8 +907,12 @@ let shader_stage_stage =
 let shader_stage_module =
   field vk_pipeline_shader_stage_create_info "module" vk_shader_module
 
+(* [ptr char], not the [string] view: writing an OCaml string through the
+   [string] view allocates an anonymous C buffer whose only GC root is the fat
+   pointer that [setf] immediately discards, leaving pName dangling. Callers
+   must hold the [CArray.t] themselves and keep it alive past the FFI call. *)
 let shader_stage_pName =
-  field vk_pipeline_shader_stage_create_info "pName" string
+  field vk_pipeline_shader_stage_create_info "pName" (ptr char)
 
 let shader_stage_pSpecializationInfo =
   field vk_pipeline_shader_stage_create_info "pSpecializationInfo" (ptr void)

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -382,13 +382,30 @@
 ; would add verification beyond "it compiled".
 ;
 ; test_inline_pragma is also parked here (build-only): it is otherwise
-; self-verifying and CPU-safe, but running it on this session's real GPU
-; segfaulted reproducibly when Device.all () selected the OpenCL device for
-; a non-tail-recursive `pragma ["sarek.inline N"]` kernel (see
-; briefs/make-tests-actually-run-impl-notes.md). That is a genuine backend
-; crash, out of scope here (no sarek-opencl / codegen changes in this task).
-; Keeping it out of default `runtest` avoids nondeterministically crashing
-; the suite on machines where a GPU happens to be the first device.
+; self-verifying and CPU-safe, but it segfaults DETERMINISTICALLY (not
+; flakily) whenever an OpenCL device is present. Diagnosed 2026-07-25:
+;
+;   `pragma ["sarek.inline N"]` bounds the UNROLLING of a non-tail-recursive
+;   function but leaves a residual self-call, so the OpenCL backend emits a
+;   genuinely recursive device function:
+;
+;     int pow2(int n) { ... return (2 * (... (2 * pow2(n-1-1-1-1-1-1-1))))); }
+;
+;   OpenCL C forbids recursion. rusticl (Mesa 26.1.4) does not diagnose it;
+;   it tries to inline and overflows its own compiler stack - the crash is a
+;   ~30800-frame recursion inside libRusticlOpenCL on a `clctxworker` thread,
+;   with zero SPOC/OCaml frames on the stack.
+;
+; So the fix belongs in the OpenCL backend: either fully bound the recursion
+; (emit a depth-limited base case) or refuse with an explicit "Unsupported
+; construct" error the way the GLSL backend already does. Until then this
+; stays build-only.
+;
+; NOTE: this is NOT the ctypes-rooting use-after-free that was fixed in
+; sarek-vulkan (PR #303). That one also presented as a SIGSEGV, which is why
+; the two were once filed as one class. They are unrelated: this crash is
+; unchanged by that fix, is OpenCL-only, and disappears when the OpenCL ICD
+; is hidden.
 
 (alias
  (name compile-only)


### PR DESCRIPTION
## Summary

`test_static_tag_erasure` was the only failing rule in `sarek/tests/e2e/runtest`, and it failed on unmodified `origin/main` — so `dune runtest sarek/tests` exited 1 on *every* branch and no one could distinguish a real regression from the standing failure. This restores the gate.

**It is one bug, not two, and it is ours — not a driver bug.**

## Root cause

`Ctypes.setf` copies only the bare address into the C struct and drops the ctypes *fat pointer* that rooted the referent. In OCaml a value dies after its last **use**, not at the end of its scope, so the referent becomes unreachable the instant the address has been stored — and the GC may reclaim it before the driver reads through the pointer. Vulkan reads through these pointers *during* the call.

`launch` already defended against exactly this (`let keep = Sys.opaque_identity`, with a comment describing the hazard). `compile`, `create_shader_module`, `get_or_create_instance` and `get` did not.

Three distinct flavours were fixed:

1. **Dropped roots.** Referents stored into `*CreateInfo` structs and never used again: descriptor-set-layout `bindings`, SPIR-V `code`, `push_constant_range`, `pool_size`, `queue_create_info`, `queue_priority`, `enabled_features`. Each is now kept alive past its FFI call.

2. **Unrootable string views.** `pName`, `pApplicationName` and `pEngineName` were written through ctypes' `string` / `string_opt` views. Those views allocate an anonymous C buffer whose *only* GC root is the fat pointer `setf` immediately discards — there was no OCaml value a caller could have held. The fields are now `ptr char` with caller-held `CArray`s (`CArray.of_string` NUL-terminates, matching what the `string` view does internally). `pName` is doubly exposed, since `stage_info` is copied **by value** into `pipeline_info`, so rooting `stage_info` alone would not have helped.

3. **An incorrect prior fix.** The comment at `vkCreateDevice` asserted that binding `enabled_features` in the function scope rather than inside the `if` kept `addr enabled_features` valid across the call. It does not — scope is not liveness. Comment corrected and a real keep-alive added.

## Why the "Mesa OpenCL/Vulkan conflict" theory was a red herring

The crash *did* reliably disappear when the OpenCL ICD was hidden, which is why it looked like a `radeonsi`/`libvulkan_radeon` coexistence bug. It is not. Hiding the ICD merely removed rusticl's heap pressure, which was what pushed the GC into collecting early.

The discriminating experiment: with the **OpenCL ICD entirely absent**, shrinking the minor heap (`OCAMLRUNPARAM=s=4k`) reproduces the identical SIGSEGV at the identical call site. No second driver in the process, same crash. That rules out driver coexistence and pins it on GC timing.

There is therefore no upstream Mesa report to file, and no process isolation needed — the test stays in the shared executable and no case is skipped.

## Evidence

Hardware: RX 7900 XTX + Raphael iGPU, RADV Vulkan / radeonsi(rusticl) OpenCL, Mesa 26.1.4-arch3.1, Vulkan 1.4.354, kernel 7.1.2-3-cachyos. No NVIDIA GPU present.

| Configuration | Before | After |
|---|---|---|
| Default (both drivers) | 25/25 SIGSEGV | 19/19 exit 0 |
| `OCAMLRUNPARAM=s=4k`, OpenCL hidden | SIGSEGV | exit 0 |
| `OCAMLRUNPARAM=s=1k,o=0` | — | exit 0 |

Pre-fix backtraces landed in `vkCreateDescriptorSetLayout` (`Vulkan_api_kernel.compile`) and `vkCreateDevice` (`Vulkan_api_device.get`), both via `ctypes_call` → `ffi_call` → `libvulkan_radeon`.

### Red proof

Reverting a single line — `ignore (keep bindings)` — and rebuilding restores the crash **3/3** under `s=4k` with OpenCL absent, where the fixed build passes 3/3. The backtrace names the mutated site precisely:

```
Thread 1 "test_static_tag" received signal SIGSEGV, Segmentation fault.
#0  0x00007ffff5cf683e in ?? () from /usr/lib/libvulkan_radeon.so
#3  0x00007ffff7f6dc6e in ffi_call () from /usr/lib/libffi.so.8
#4  0x0000555555dd73ca in ctypes_call (...) at ffi_call_stubs.c:404
#7  0x00005555559adf3f in camlSarek_vulkan__Vulkan_api_kernel.compile_1944 ()
      at sarek-vulkan/Vulkan_api_kernel.ml:272
```

Line 272 is the `vkCreateDescriptorSetLayout` call that consumes `bindings`.

## On the reported `behaviour=FAIL` and the GLSL match-expression gap

The earlier `behaviour=FAIL` observation was **not** an independent GLSL codegen bug. It could not be reproduced in 25 pre-fix runs (all were SIGSEGV), and it is consistent with the same use-after-free landing on *reused* rather than *unmapped* memory — garbage descriptor bindings give wrong results instead of a crash. Post-fix, no run has produced a behaviour failure.

The GLSL match-expression payload-binding limitation Agent A pointed at is real but **cannot** produce `behaviour=FAIL`: the `arm-order-shadowed` case is deliberately gated to Native/Interpreter, so on Vulkan it reports a clean typed `SKIP (backend lacks the construct)`.

Two observations worth separate backlog items (**not** fixed here):

- **#73's EMatch fix is incomplete for GLSL.** Match *expressions* with payload binding still raise `Unsupported construct 'match-expression payload binding'` on the Vulkan backend. That is an honest, well-diagnosed error — but it is a gap, not a fix.
- **#75's OpenCL hole is worse than a gap.** The OpenCL backend does not diagnose this case; it emits *invalid C* and lets the driver's compiler catch it:
  ```
  input.cl:28:44: error: use of undeclared identifier 'r'
     28 |     dst[tid] = (1 ? (src[tid] + 100.0f) : (r * r));
  ```
  It is caught only because the vendor compiler happens to reject it. Silent bad codegen rescued by luck is strictly worse than GLSL's explicit refusal.

## Proof provenance per site — read this before trusting the set

Only **one** site is mechanically red-proven. The rest are fixed on a reading of ctypes' allocation model. A later reader should not mistake the whole set for verified.

| Site | Fix | Evidence |
|---|---|---|
| `bindings` (`vkCreateDescriptorSetLayout`) | keep-alive | **Red-proven** — mutation test below |
| `code` (SPIR-V, `vkCreateShaderModule`) | keep-alive | By inspection |
| `push_constant_range`, `dsl` (`vkCreatePipelineLayout`) | keep-alive | By inspection |
| `pool_size` (`vkCreateDescriptorPool`) | keep-alive | By inspection |
| `queue_create_info`, `queue_priority`, `enabled_features` (`vkCreateDevice`) | keep-alive | **Pre-fix crash observed** at this call under `s=4k`; individual referent not isolated |
| `pName` (`ptr char`) | field retype | By inspection — closes #124 |
| `pApplicationName`, `pEngineName` (`ptr char`) | field retype | By inspection |

Rationale for accepting the by-inspection ones, on the record: a latent dangling pointer that manifests only under a particular GC timing may not be deterministically triggerable at all, so requiring a per-site mutation test would in practice mean knowingly leaving unrooted referents in place. That is worse than fixing them on a correct reading of the allocation model. The model is not speculative — it is confirmed by the red proof at the one site where the timing *is* forceable.

Fix 2 (`pName`) closes **#124**, filed separately for exactly this ctypes `string`-view defect.

## `test_inline_pragma` (#80, #53) — a different bug, still open

Backlog #80 grouped this crash with `test_static_tag_erasure` as one class. **They are unrelated**; they only shared the SIGSEGV symptom.

`test_inline_pragma` is completely unchanged by this fix: 3/3 SIGSEGV on both `origin/main` and this branch, under default and `s=4k`; 3/3 exit 0 with the OpenCL ICD hidden. It is OpenCL-only, and this PR touches only `sarek-vulkan/`.

Cause: `pragma ["sarek.inline N"]` bounds the *unrolling* but leaves a residual self-call, so we emit a genuinely **recursive OpenCL device function**:

```c
int pow2(int n) {
  if ((n <= 0)) { return 1; }
  else { return (2 * (((n-1) <= 0) ? 1 : (2 * ( ... (2 * pow2((((((((n-1)-1)-1)-1)-1)-1)-1))) ... ))); }
}
```

OpenCL C forbids recursion. rusticl does not diagnose it — it tries to inline and overflows its own compiler stack: ~30,800 recursive frames inside `libRusticlOpenCL` on a `clctxworker` thread, with **zero** SPOC/OCaml frames.

So #80's Vulkan half is fixed here; its `test_inline_pragma` half is not, and **#53 stays parked** — but now for a precisely documented reason rather than an abandoned one. The dune comment has been updated with the diagnosis (it also wrongly claimed the crash was nondeterministic; it is deterministic whenever an OpenCL device is present). The real fix belongs in the OpenCL backend: either fully bound the recursion, or refuse with an explicit "Unsupported construct" error the way GLSL already does. Not attempted here.

## Result

`dune runtest sarek/tests` exits **0**. No test was disabled, skipped or weakened; the previously-failing case now genuinely passes on both Vulkan devices with both drivers loaded. `dune build @fmt` shows no drift in any file touched here (the three pre-existing offenders are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vulkan stability by preventing temporary data from becoming invalid during instance, device, shader, and pipeline creation.
  - Reduced the risk of crashes caused by prematurely released application names, engine names, shader entry points, and configuration data.

- **Documentation**
  - Clarified the known OpenCL inline-pragma crash and distinguished it from the resolved Vulkan stability issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->