### PR TITLE
docs(fp): cross-backend FP contraction policy; drop inert CUDA barrier; guard nvrtc FP flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,31 @@
   model restated for the aligned ABI (0 admits)
 - float32 `fma` intrinsic on all backends; GLSL `precise` qualifier on
   float locals
+- `docs/fp-contraction-policy.md` — cross-backend floating-point contraction
+  policy: what each backend may contract, what actually prevents it, and
+  whether that mechanism is verified or merely believed. The interpreter is
+  named as the cross-backend oracle. Linked from every site that previously
+  carried an ad-hoc contraction comment.
+- FP-conformance guard on the CUDA/nvrtc path: `-use_fast_math`, `-ftz=true`,
+  `--prec-div=false` and `--prec-sqrt=false` are now REJECTED at the point an
+  option array reaches `nvrtcCompileProgram` (`--fmad=true` warns). They flush
+  binary32 subnormals or downgrade div/sqrt, and no later flag undoes that.
+  `sarek-cuda/test/test_cuda_fp_conformance.ml` reproduces the hazard
+  host-side (`-ftz=true` turns `FMUL`/`FADD` into `FMUL.FTZ`/`FADD.FTZ` at
+  sm_90, CUDA 13.3) and each of its four cases was proved red by mutation.
 - ZLUDA/AMD support for the CUDA/PTX backend (PTX launch ABI fix)
 - T3-SEMANTIC milestone lock for both formal projects; conformance +
   mutation tests wired into `dune runtest`
+
+### Changed
+
+- The CUDA branch of `sarek_f32_barrier` no longer emits
+  `asm volatile("" : "+f"(x))`. That barrier was inert: the assembly template
+  is empty, NVVM erases it, and the cubins are byte-identical with and without
+  it — re-measured on CUDA 13.3 for sm_75 through sm_121. What keeps the f32
+  multiply out of the f16 narrowing on NVIDIA is `ptxas`, machine-checked by
+  `test_cuda_f16_sass`. The AMDGPU `"+v"` barrier, which IS load-bearing, is
+  unchanged. Removing a no-op that read as protection; no behaviour change.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,11 @@
   model restated for the aligned ABI (0 admits)
 - float32 `fma` intrinsic on all backends; GLSL `precise` qualifier on
   float locals
+- CI installs `cuda-nvdisasm-12-6` and `ci/assert-toolchain.sh` asserts
+  `nvdisasm` (version + a ptxas→nvdisasm probe). It was absent from the built
+  image, so `test_cuda_f16_sass` — the gate the NVIDIA f16 guarantee rests on,
+  and the only one that could surface a 12.6-vs-13.3 ptxas divergence —
+  self-skipped in CI while reporting green.
 - `docs/fp-contraction-policy.md` — cross-backend floating-point contraction
   policy: what each backend may contract, what actually prevents it, and
   whether that mechanism is verified or merely believed. The interpreter is
@@ -25,7 +30,11 @@
   carried an ad-hoc contraction comment.
 - FP-conformance guard on the CUDA/nvrtc path: `-use_fast_math`, `-ftz=true`,
   `--prec-div=false` and `--prec-sqrt=false` are now REJECTED at the point an
-  option array reaches `nvrtcCompileProgram` (`--fmad=true` warns). They flush
+  option array reaches `nvrtcCompileProgram` (`--fmad=true` warns). The guard
+  screens the whole ARRAY, because nvrtc accepts an option and its value as two
+  elements: `["--ftz"; "true"]` compiled a subnormal-flushing kernel past a
+  per-element check (confirmed against libnvrtc 13.3, `.ftz` in the emitted
+  PTX). A value-taking name consumes the next element and is fail-closed. They flush
   binary32 subnormals or downgrade div/sqrt, and no later flag undoes that.
   `sarek-cuda/test/test_cuda_fp_conformance.ml` reproduces the hazard
   host-side (`-ftz=true` turns `FMUL`/`FADD` into `FMUL.FTZ`/`FADD.FTZ` at
@@ -37,11 +46,15 @@
 ### Changed
 
 - The CUDA branch of `sarek_f32_barrier` no longer emits
-  `asm volatile("" : "+f"(x))`. That barrier was inert: the assembly template
-  is empty, NVVM erases it, and the cubins are byte-identical with and without
-  it — re-measured on CUDA 13.3 for sm_75 through sm_121. What keeps the f32
-  multiply out of the f16 narrowing on NVIDIA is `ptxas`, machine-checked by
-  `test_cuda_f16_sass`. The AMDGPU `"+v"` barrier, which IS load-bearing, is
+  `asm volatile("" : "+f"(x))`. At an f16 narrowing it contributes zero PTX
+  instructions, so `ptxas` receives an identical instruction stream and the
+  cubins are byte-identical with and without it — re-measured on CUDA 13.3 for
+  sm_75 through sm_121. What keeps the f32 multiply out of the narrowing on
+  NVIDIA is `ptxas`, machine-checked by `test_cuda_f16_sass`. NOTE the same
+  barrier is *not* inert at a `mul`→`add` site (PTX `mul.f32`+`add.f32` instead
+  of `fma.rn.f32`), but `ptxas -O1`+ re-contracts that under the default
+  `-fmad=true`, so it is still not a usable contraction barrier on NVIDIA — use
+  `Sarek_df64`'s `mul_rn`. The AMDGPU `"+v"` barrier, which IS load-bearing, is
   unchanged. Removing a no-op that read as protection; no behaviour change.
 
 ### Fixed

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -132,6 +132,19 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # image, dependencies included, not estimates from the .deb payloads:
 #   cuda-nvcc-12-6       147.6 MB  ptxas 31 MB, nvlink 31 MB, nvcc 23 MB,
 #                                  libnvptxcompiler_static.a 60 MB
+#   cuda-nvdisasm-12-6              nvdisasm — the SASS disassembler. NOT part of
+#                                  cuda-nvcc, which is why it was missing: the
+#                                  built image was checked and `command -v
+#                                  nvdisasm` came back empty while ptxas and nvcc
+#                                  were present. Without it
+#                                  sarek-cuda/test/test_cuda_f16_sass.ml
+#                                  self-skips, and that gate is the ONLY thing
+#                                  standing behind the f16 f32-discipline
+#                                  guarantee on NVIDIA (see
+#                                  docs/fp-contraction-policy.md section 4) — and
+#                                  the only thing that could ever surface a
+#                                  12.6-vs-13.3 ptxas divergence, since 12.6 is
+#                                  exercised here and nowhere else.
 #   cuda-nvrtc-12-6       60.5 MB  libnvrtc.so.12 + builtins
 #   cuda-nvvm-12-6        56.1 MB  hard dependency of cuda-nvcc (cicc/libnvvm);
 #                                  not requested, not optional
@@ -156,6 +169,7 @@ RUN curl -fsSLO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2
   && rm cuda-keyring_1.1-1_all.deb \
   && apt-get update && apt-get install --no-install-recommends -y \
        "cuda-nvcc-${CUDA_APT_SERIES}" \
+       "cuda-nvdisasm-${CUDA_APT_SERIES}" \
        "cuda-nvrtc-${CUDA_APT_SERIES}" \
        "cuda-cudart-dev-${CUDA_APT_SERIES}" \
   && rm -rf /var/lib/apt/lists/*

--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -46,7 +46,7 @@ set -uo pipefail
 # is tautological by construction and can never report a gap on its own.
 #
 # The Rocq section below is deliberately NOT counted; see its comment.
-EXPECTED_CHECKS=10
+EXPECTED_CHECKS=12
 
 failures=0
 checks=0

--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -16,6 +16,10 @@
 #   sarek-cuda/test/test_cuda_nvrtc_gate.ml       -> libnvrtc
 #     opencl_validation_sweep                     -> clang (OpenCL C)
 #   sarek/tests/unit/test_opencl_gate.ml          -> clang (OpenCL C)
+#   sarek-cuda/test/test_cuda_f16_sass.ml         -> ptxas + nvdisasm
+#   sarek-cuda/test/test_cuda_fp_conformance.ml   -> nvcc + nvdisasm (hazard
+#                                                    control only; the guard
+#                                                    checks run everywhere)
 #
 # That skip is correct behaviour for a developer machine, which legitimately has
 # none of these installed. It is a disaster in CI: the previous image carried
@@ -104,6 +108,52 @@ PTX
     ok "ptxas assembled a probe module"
   else
     fail "ptxas is on PATH but cannot assemble a trivial module:
+$out"
+  fi
+  rm -rf "$tmpdir"
+fi
+
+# --------------------------------------------------------------------------
+section "nvdisasm (SASS disassembler — host-side, no GPU required)"
+# WHY THIS IS ASSERTED. nvdisasm ships in cuda-nvdisasm, NOT in cuda-nvcc, and
+# it was absent from the built image while ptxas and nvcc were present. That is
+# the quiet kind of gap: sarek-cuda/test/test_cuda_f16_sass.ml skips cleanly
+# without it, so CI went green while the f16 f32-discipline gate validated
+# nothing. That gate is what stands behind the NVIDIA half of
+# docs/fp-contraction-policy.md — the CUDA "+f" barrier was deleted on the
+# strength of it — and it is also the only gate that could ever surface a
+# 12.6-vs-13.3 ptxas divergence, because 12.6 is exercised here and nowhere
+# else.
+if ! command -v nvdisasm >/dev/null 2>&1; then
+  checks=$((checks + 1))
+  fail "nvdisasm is not on PATH. The f16 SASS conformance gate in \
+test_cuda_f16_sass.ml will self-skip and CI will validate nothing about \
+f32-discipline in generated f16 kernels. Install cuda-nvdisasm-12-6 (see \
+ci/Dockerfile)."
+else
+  run_check "nvdisasm --version" nvdisasm --version
+  # Positive control: assemble a probe and disassemble it, so this proves the
+  # ptxas -> nvdisasm chain the gate actually walks, not just a version banner.
+  tmpdir=$(mktemp -d)
+  cat >"$tmpdir/probe.ptx" <<'PTX'
+.version 7.0
+.target sm_75
+.address_size 64
+.visible .entry probe(.param .u64 p)
+{
+  .reg .u64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  ret;
+}
+PTX
+  checks=$((checks + 1))
+  if ptxas --compile-only --gpu-name sm_75 -o "$tmpdir/probe.cubin" \
+       "$tmpdir/probe.ptx" >/dev/null 2>&1 &&
+     out=$(nvdisasm -c "$tmpdir/probe.cubin" 2>&1) &&
+     printf '%s' "$out" | grep -q 'probe'; then
+    ok "nvdisasm disassembled a probe cubin"
+  else
+    fail "nvdisasm is on PATH but cannot disassemble a freshly assembled cubin:
 $out"
   fi
   rm -rf "$tmpdir"

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -1,0 +1,328 @@
+# Floating-point contraction policy
+
+_Cross-backend policy for what a Sarek DSL author may rely on when a device
+compiler is free to fuse, reassociate or flush floating-point operations._
+
+**Status:** normative for this repository. **Issue:** #116 (absorbs #110, #111).
+**Date:** 2026-07-25.
+
+Three separate defects in this project came from the same place — the gap
+between the floating-point semantics we assumed a backend had and the ones it
+actually had:
+
+- **HIP/AMDGPU.** An ISel combine fused an f32 multiply into the f32→f16
+  narrowing that consumed it (`v_fma_mixlo_f16`) and demoted an f32 add to
+  binary16 (`v_add_f16`). 620 of 63488 finite binary16 inputs disagreed with the
+  interpreter. `-ffp-contract=off` did not prevent it: the combine sits below
+  the C-level FP controls.
+- **CUDA/ptxas.** `ptxas` contracted the multiply that closes `quick_two_sum`
+  into *both* of its consumers, collapsing `df64` mul/div from ~9e-15 to
+  5.92e-08 — plain float32. It survived four years.
+- **Vulkan/GLSL.** Vulkan `mul`/`div` degrade to ~5.8e-08 on Mesa RADV
+  (measured here, RX 7900 XTX, Mesa 26.1.4-arch3.1) and on Mesa ANV (quoted,
+  Intel UHD Graphics 630). Attributed to a `fma` that is not correctly rounded,
+  *not* to contraction — but the two failure modes look identical from the
+  outside, and telling them apart took a separate measurement.
+
+This document states, per backend, what the compiler is permitted to contract,
+what mechanism (if any) actually prevents it, whether that mechanism is
+**verified** or merely **believed**, and what a DSL author may rely on.
+
+---
+
+## 1. The rule
+
+**Sarek's floating-point semantics are IEEE-754 with every operation rounded as
+written. `float32` arithmetic rounds to binary32 at every step; `float16`
+arithmetic is performed in binary32 and narrowed by an explicit
+round-to-nearest-even step; subnormals are not flushed; division and square
+root are correctly rounded.**
+
+**The interpreter is the oracle.** `sarek/interp/` evaluates the IR with
+float32 rounding emulated at every operation — `Sarek_float32.to_float32`
+rounds each result through an `Int32` bit round-trip, and `fma` is
+`Float.fma` — and it is the definition of what a Sarek program means. (The
+intermediate is OCaml's binary64. For `+`, `-`, `*`, `/` and `sqrt` the double
+rounding is benign, because binary64 carries more than `2p+2` bits of a
+binary32 operand; for the transcendentals it is a rounding the oracle owns and
+the device does not have to match bit-for-bit.) When a device
+result and the interpreter result differ, **the device is wrong** — that is the
+direction of the obligation, and it is why the interpreter is not merely
+"another backend". Every backend gate in this repository is ultimately an
+agreement-with-the-interpreter gate.
+
+Three corollaries, each of which has been violated at least once:
+
+1. **Contraction is not a performance knob, it is a semantic change.** Fusing
+   `a*b + c` removes a rounding the DSL promised. For ordinary code the
+   difference is one ulp; for an error-free transformation (Dekker/Knuth
+   TwoSum, TwoProd) it destroys the algorithm outright.
+2. **A flag that names the hazard is not a mechanism that prevents it.**
+   `-ffp-contract=off` did nothing for the AMDGPU combine. Verify at the
+   machine-code level or do not claim it.
+3. **A guarantee you have not measured on the device *and toolchain* you are
+   claiming it for is not a guarantee.** "Verified on CUDA/PTX" was once
+   recorded on the strength of a run through ZLUDA on an AMD GPU. Name the
+   device and the toolchain, every time.
+
+---
+
+## 2. Per-backend table
+
+Legend for the evidence column:
+
+| tier | meaning |
+|---|---|
+| **executed** | ran on the named device and agreed with the interpreter |
+| **machine-code** | the emitted ISA was inspected and has the required shape; nothing was executed |
+| **compiler-output** | an intermediate representation was inspected (PTX, SPIR-V); the layer below is not constrained |
+| **by-construction** | the source hands the compiler nothing it can contract; no flag is relied on |
+| **unverified** | believed, documented, or inherited from a vendor's documentation — not measured here |
+
+| backend | what the compiler may contract | what actually prevents it | evidence |
+|---|---|---|---|
+| **Interpreter** | nothing — it is the oracle | it evaluates the IR directly | executed (any host) |
+| **HIP / AMDGPU** | `a*b+c`; **and**, below the FP flags, an f32 multiply into an f32→f16 narrowing, plus f32 add demotion to binary16 | two mechanisms, both required: `-ffp-contract=off` forced **last** in the hiprtc option array (`Hip_rtc.base_options` / `hiprtc_options`), *and* the `asm volatile("" : "+v"(x))` opacity barrier on every narrowing's argument (`Sarek_ir_cuda.sarek_f32_barrier_decl`) | executed, RX 7900 XTX / gfx1100, ROCm hiprtc: exhaustive sweep of all finite binary16 inputs, 373 disagreements before, 0 after |
+| **CUDA / nvrtc (f16 narrowing)** | in principle the same fusion | **nothing Sarek emits.** `ptxas` simply declines to absorb `cvt.rn.f16.f32` | machine-code, CUDA 13.3 host tools, sm_75…sm_121 — see §4 |
+| **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
+| **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
+| **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C | **no flag** — Sarek passes an empty build-option string. Same `mul_rn`-by-construction defence as CUDA | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
+| **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` | compiler-output (measured, §6): glslc 2026.2 / SPIRV-Tools 1.4.350.1 emits 2 `NoContraction` decorations for the generated matmul shader, 0 with `precise` stripped. **Whether a given driver honours `NoContraction` is NOT established here** — see §6. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, measured on RX 7900 XTX, Mesa 26.1.4-arch3.1 |
+| **Metal** | Metal's default compile options enable fast math | **nothing.** `Metal_api` passes a null `MTLCompileOptions`, and `Metal_bindings.mtl_device_new_library_with_source` *ignores its `_options` argument entirely* | unverified — no Apple hardware in this project's CI or on the machine this policy was written on. Treat Metal float results as outside the guarantee |
+| **WGSL** | unconstrained | nothing | unverified, untested |
+| **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
+
+---
+
+## 3. What a DSL author may rely on
+
+**You may rely on, today:**
+
+- **f32 arithmetic agreeing with the interpreter on HIP/AMDGPU**, including f16
+  round-trips. This is the only backend where the f16 discipline has been
+  confirmed by execution.
+- **`Sarek_df64` meeting its precision contract on CUDA/PTX and OpenCL on
+  NVIDIA Pascal, and on OpenCL on AMD** — with the `sqrt` residual recorded in
+  `Sarek_df64`'s header still open.
+- **No `-use_fast_math` / `-ftz=true` reaching nvrtc**, enforced rather than
+  documented (§5).
+
+**You may NOT rely on:**
+
+- **Metal or WGSL float semantics at all.** Metal in particular compiles with
+  fast math on, unopposed.
+- **Vulkan `fma` being correctly rounded.** On Mesa RADV it is not, and
+  `Sarek_df64` mul/div is ~5.8e-08 there — a *documented*, unfixed deviation,
+  not a bug to rediscover.
+- **f16 on NVIDIA hardware.** The codegen question is settled at machine-code
+  level; no f16 kernel has ever been executed on an NVIDIA GPU (§7).
+- **A product you compute yourself staying unfused across a `Sarek_df64`
+  boundary.** `[@sarek.module]` bodies are inlined into your kernel, so
+  `df64_add_f32 acc (x *. y)` re-creates the exact fusable pattern the library
+  removed from its own code. Write `mul_rn x y` (or `two_prod x y`) instead.
+  A `let` binding does **not** help — contraction happens far below source
+  level. This is the one hazard in this document that lives in *caller* code,
+  and no gate in this repository can see it.
+
+**If you are adding a backend or a compiler flag:** an FP-relaxing flag is a
+semantic change to every kernel, so it needs an interpreter-agreement argument
+before it goes in, not after. If a backend's option array can be influenced
+from outside, guard it at the point the array is handed to the compiler — not
+at the caller — so that the guard also covers whatever the *next* maintainer
+adds. `Cuda_nvrtc.check_fp_conformance` and `Hip_rtc.hiprtc_options` are the
+two worked examples.
+
+---
+
+## 4. CUDA f16: the barrier was inert, and has been removed (#110)
+
+The AMDGPU fix added an opacity barrier around every f32→f16 narrowing. A
+PTX-flavoured variant, `asm volatile("" : "+f"(x))`, was added to the non-HIP
+branch of `sarek_f32_barrier` at the same time — on the assumption that what
+was needed on one target was probably needed on the other.
+
+It was doing nothing. The assembly template is empty, NVVM erases the block and
+coalesces the register, and the emitted machine code is unchanged.
+
+**Measured for this change** (CUDA 13.3, `nvcc`/`ptxas`/`nvdisasm` V13.3.73,
+host-side, **no NVIDIA device**), on the current output of
+`Sarek_ir_cuda.generate` for the `f16_midround` kernel, with the `"+f"` asm and
+with the branch reduced to `return x;`:
+
+| arch | cubin | SASS |
+|---|---|---|
+| sm_75, sm_80, sm_86, sm_89, sm_90, sm_100, sm_120, sm_121 | **byte-identical** (`cmp`) on all eight | identical (`diff` on `nvdisasm -c`) |
+
+and the arithmetic stream in the *identity* variant is still unfused:
+
+```
+HADD2.F32             R0, -RZ, R2.H0_H0   ; f16 -> f32 widening (exact)
+FMUL                  R0, R0, 1.10000002  ; the f32 multiply, intact
+F2FP.F16.F32.PACK_AB  R0, RZ, R0          ; separate f32 -> f16 narrowing
+HADD2.F32             R0, -RZ, R0.H0_H0
+FADD                  R0, R0, 1000        ; the f32 add, NOT demoted
+F2FP.F16.F32.PACK_AB  R0, RZ, R0
+```
+
+(sm_90; sm_75 emits `F2F.F16.F32` instead of the packed `F2FP` form — both are
+single-instruction conversions.)
+
+**Decision: remove the `"+f"` asm; keep the identity function.** The function
+itself must stay, because the same generated source is compiled by both hiprtc
+and nvrtc under an `#if`. What was deleted is the *pretence*. A call site
+reading `__float2half(sarek_f32_barrier(x))` advertised a protection that did
+not exist on NVIDIA, and this repository has already paid three times for the
+distance between advertised and actual FP semantics.
+
+**Nothing was depending on the code shape.** Two independent checks, both run
+after the removal: the machine-code comparison above (byte-identical, so there
+is nothing to depend on), and the full `test_cuda_f16_sass` gate, which
+re-derives the SASS through generated CUDA → nvrtc → PTX → ptxas → cubin →
+nvdisasm and still reports `f32 discipline intact on 7/7 architectures`.
+
+**What actually holds the guarantee on NVIDIA is `ptxas`**, not anything Sarek
+emits: hand-written PTX with `mul.f32` / `cvt.rn.f16.f32` and no inline asm at
+all produces the same unfused sequence. That is a property of a third-party
+assembler, which is exactly the kind of property that must be machine-checked
+rather than assumed — `sarek-cuda/test/test_cuda_f16_sass.ml` is that check,
+and it carries a positive control (`__hmul`/`__hadd`, which *must* be
+classified as fused) so it cannot pass vacuously.
+
+Full per-architecture detail, flag sweep and residual risk:
+[`docs/optimization/cuda-f16-fusion-sass-audit.md`](optimization/cuda-f16-fusion-sass-audit.md).
+
+---
+
+## 5. CUDA: `-use_fast_math` / `-ftz=true` are refused (#111)
+
+`-use_fast_math` implies `--ftz=true --prec-div=false --prec-sqrt=false
+--fmad=true`. `-ftz=true` alone flushes binary32 subnormals. Unlike the HIP
+contraction case — where appending `-ffp-contract=off` *last* neutralises
+whatever the caller passed — there is no later flag that undoes subnormal
+flushing. So these are **rejected**, not warned about.
+
+`Cuda_nvrtc.check_fp_conformance` raises `Fp_conformance_violation` for
+`use_fast_math` (any spelling), `ftz=true|1`, `prec-div=false|0`,
+`prec-sqrt=false|0`. `fmad=true` **warns** rather than rejects, because it is
+nvrtc's default and rejecting it would reject the status quo; contraction is
+defeated by construction instead (§2). It is applied in two places: at the
+entry of `compile_to_ptx`, before libnvrtc is touched — so the check works on a
+host with no CUDA at all — and at `compile_with_string_opts`, the single point
+where any option array reaches `nvrtcCompileProgram`. The second placement is
+the one that matters: it screens flags this module adds *itself*, so a future
+maintainer's hardcoded flag is covered, not just a caller's.
+
+**The hazard is real, measured here** (CUDA 13.3, host-side, no device): the
+generated `f16_midround` kernel built for sm_90 has plain `FMUL`/`FADD` by
+default and `FMUL.FTZ`/`FADD.FTZ` under `-ftz=true`. `1e-5` is already lane 5
+of the `test_hip_f16` input array, so a divergence from the interpreter is
+reachable from data the suite already uses.
+
+**The guard has been seen to fire.** `sarek-cuda/test/test_cuda_fp_conformance.ml`
+holds four cases, and each was proved red by mutating the thing under test:
+
+| mutation | test that went red | message |
+|---|---|---|
+| drop `use_fast_math` from the reject list | rejection | `"-use_fast_math" must be refused on the CUDA path; the guard accepted it` |
+| match on option name, ignoring its value | acceptance | `"-ftz=false" is legitimate and must be accepted; the guard refused it` |
+| remove both `check_fp_conformance` calls from `compile_to_ptx` | end-to-end | `compile_to_ptx accepted -use_fast_math and compiled; the guard did not fire on the real entry point` |
+| build the "ftz" SASS variant without `-ftz=true` | hazard control | `control is broken: -ftz=true produced no FMUL.FTZ / FADD.FTZ, so the option this guard rejects has not been shown to change anything on this toolchain` |
+
+The third mutation is the informative one: with the guard removed,
+`compile_to_ptx` compiled `-use_fast_math` **successfully** on this host. The
+guard is the only thing standing between a caller and a flushed-subnormal
+kernel.
+
+---
+
+## 6. Vulkan/GLSL: `precise` is emitted, and honouring it is the driver's job
+
+`Sarek_ir_glsl.gen_var_decl` prefixes every `float`/`double` local with
+`precise`. The front end does lower it:
+
+**Measured** (glslc 2026.2, SPIRV-Tools 1.4.350.1, on the Sarek-generated
+`matrix_mul` compute shader taken verbatim from
+`benchmarks/descriptions/generated/matrix_mul_generated.md`): the SPIR-V carries
+**2 `NoContraction` decorations** on the accumulation `OpFMul`/`OpFAdd`, and
+**0** when `precise` is stripped from the same source.
+
+That is a **compiler-output** claim and it stops there. `NoContraction` is a
+requirement placed on the SPIR-V consumer, i.e. the driver. Whether a given
+driver honours it is a separate question that this measurement does not touch.
+
+**This is an open question in this repository, and the two things written down
+about it disagree.** `Sarek_ir_glsl.ml` says `precise` was added *because* RADV
+was observed simplifying error-free transformations without it — which implies
+RADV honours it. Campaign notes state the opposite, that Mesa ANV and RADV
+ignore it. Neither is backed by a recorded, reproducible measurement in-tree.
+**Do not restate either as fact.**
+
+What *is* measured, and what it does and does not tell us: **re-measured for
+this document on RX 7900 XTX under RADV, Mesa 26.1.4-arch3.1** (`test_df64`,
+2026-07-25) — mul 5.84e-08, div 5.86e-08, against add 5.33e-15, sub 6.51e-15,
+sqrt 1.08e-14, and the interpreter's mul 9.07e-15 / div 5.08e-15 on the same
+run. The same shape appears on the Raphael iGPU under RADV. `Sarek_df64` mul/div
+sat at ~5.8e-08 both **before and after** the
+`mul_rn` contraction barrier. Since that barrier works by removing the fusable
+multiply, a contraction-shaped failure would have been fixed by it. It was not.
+So RADV's deviation has a different cause, consistent with the recorded one —
+RADV's GLSL `fma` is not correctly rounded, which is independently supported by
+the measurement that extending `mul_rn` into `two_sum`/`quick_two_sum`
+*regressed* RADV (add 5.33e-15 → 1.15e-07). That argues RADV is not silently
+contracting; it does **not** establish that RADV honours `NoContraction`.
+
+**The experiment that would settle it** (not run): a kernel computing
+`precise float p = a*b; out = p + c;` and, separately, `out = fma(a,b,c)`, on
+inputs chosen so that `fl(fl(a*b)+c) ≠ fma(a,b,c)`, executed on RADV and on
+ANV. If the two kernels agree, the driver contracted despite `NoContraction`.
+Until that is run, treat Vulkan float32 as *contraction-safe by front-end
+declaration only*.
+
+---
+
+## 7. What cannot be verified without NVIDIA hardware
+
+There is no NVIDIA GPU on the machine this policy was written on. Host-side
+`ptxas`/`nvdisasm`/`nvcc` (CUDA 13.3) cover more architectures than any single
+GPU would, but they cover a different question. Explicitly still open:
+
+- **No f16 CUDA kernel has ever been executed on NVIDIA hardware.** The
+  interpreter-agreement claim for f16 is HIP-only. The remaining gap is narrow —
+  a hardware conversion-rounding question (does `F2FP.F16.F32` round to
+  nearest-even on ties?), not a codegen one — but it is not closed.
+- **Offline `ptxas` is not the driver JIT.** Sarek loads PTX through
+  `cuModuleLoadData`, so on a real machine the assembling compiler is the
+  *driver's* ptxas, a different build from `/opt/cuda/bin/ptxas`. Nothing here
+  constrains it.
+- **One toolkit version.** Every CUDA measurement in this document is CUDA 13.3.
+  CI runs 12.6. The result is stable across eight architectures and every
+  optimisation level and flag combination tried, which is an argument for it
+  being a durable `ptxas` property rather than a 13.3 accident — an argument,
+  not a measurement. **If the SASS gate ever fails on CI at 12.6 while passing
+  at 13.3, that difference is the finding.**
+- **`FMUL.FTZ` was observed, subnormal divergence was not.** §5 shows the flag
+  changes the instruction; it does not show a wrong answer, because that
+  requires running the kernel.
+- **`Sarek_df64`'s `sqrt` residual on NVIDIA** (1.42e-14 CUDA/PTX, 1.68e-14 /
+  1.81e-14 in `test_real64`) is unexplained. The leading hypothesis —
+  `sqrt.approx.f32` as the Newton seed — has a one-line experiment
+  (`sqrt.rn.f32` instead) that needs an NVIDIA device to evaluate. Recorded in
+  `Sarek_df64`'s header; do not promote it to a cause.
+- **Metal is entirely unverified** (no Apple hardware), and it is the one
+  backend currently compiled with fast math on.
+
+---
+
+## 8. Where the mechanisms live
+
+| file | what it carries |
+|---|---|
+| `sarek-hip/Hip_rtc.ml` | `-ffp-contract=off` forced last; warning for caller-supplied fast-math options |
+| `sarek/codegen/Sarek_ir_cuda.ml` | `sarek_f32_barrier` — load-bearing on HIP, a documented identity on NVIDIA |
+| `sarek-cuda/Cuda_nvrtc.ml` | `check_fp_conformance` — rejects subnormal-flushing / approximate-div options |
+| `sarek/Sarek_df64/Sarek_df64.ml` | the `mul_rn` contraction barrier, its per-backend precision table, and the caller-side hazard |
+| `sarek/codegen/Sarek_ir_glsl.ml` | `precise` on float locals → SPIR-V `NoContraction` |
+| `sarek-cuda/test/test_cuda_f16_sass.ml` | the f16 SASS gate (with positive control) |
+| `sarek-cuda/test/test_cuda_fp_conformance.ml` | the nvrtc FP-option guard and its hazard control |
+| `sarek-hip/test/test_hip_rtc_options.ml` | proves `-ffp-contract=off` stays last whatever the caller passes |
+| `sarek/tests/e2e/test_df64.ml` | the per-backend precision measurement this policy quotes |

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -12,9 +12,20 @@ actually had:
 
 - **HIP/AMDGPU.** An ISel combine fused an f32 multiply into the f32→f16
   narrowing that consumed it (`v_fma_mixlo_f16`) and demoted an f32 add to
-  binary16 (`v_add_f16`). 620 of 63488 finite binary16 inputs disagreed with the
-  interpreter. `-ffp-contract=off` did not prevent it: the combine sits below
-  the C-level FP controls.
+  binary16 (`v_add_f16`). **620 of 63488** finite binary16 inputs disagreed with
+  the interpreter, and 0 with the barrier in place (quoted from
+  `sarek-hip/test/test_hip_f16.ml`; measured on RX 7900 XTX / gfx1100).
+  `-ffp-contract=off` did not prevent it: the combine sits below the C-level FP
+  controls.
+
+  > **Do not quote "373" for this.** That figure appears in-tree for two *other*
+  > populations and the two uses are not consistent with each other:
+  > `test_hip_f16.ml` attributes it to inputs where the test's own old
+  > f64-intermediate reference disagreed with the f32 one (a harness question,
+  > not a device one), while `Hip_rtc.ml` attributes it to inputs on which
+  > `-ffp-contract=off` changed the result. One of those two is a slip and it is
+  > **not resolved here**. 620 is the barrier/ISel-combine count and is the only
+  > one this document uses.
 - **CUDA/ptxas.** `ptxas` contracted the multiply that closes `quick_two_sum`
   into *both* of its consumers, collapsing `df64` mul/div from ~9e-15 to
   5.92e-08 — plain float32. It survived four years.
@@ -82,8 +93,8 @@ Legend for the evidence column:
 | backend | what the compiler may contract | what actually prevents it | evidence |
 |---|---|---|---|
 | **Interpreter** | nothing — it is the oracle | it evaluates the IR directly | executed (any host) |
-| **HIP / AMDGPU** | `a*b+c`; **and**, below the FP flags, an f32 multiply into an f32→f16 narrowing, plus f32 add demotion to binary16 | two mechanisms, both required: `-ffp-contract=off` forced **last** in the hiprtc option array (`Hip_rtc.base_options` / `hiprtc_options`), *and* the `asm volatile("" : "+v"(x))` opacity barrier on every narrowing's argument (`Sarek_ir_cuda.sarek_f32_barrier_decl`) | executed, RX 7900 XTX / gfx1100, ROCm hiprtc: exhaustive sweep of all finite binary16 inputs, 373 disagreements before, 0 after |
-| **CUDA / nvrtc (f16 narrowing)** | in principle the same fusion | **nothing Sarek emits.** `ptxas` simply declines to absorb `cvt.rn.f16.f32` | machine-code, CUDA 13.3 host tools, sm_75…sm_121 — see §4 |
+| **HIP / AMDGPU** | `a*b+c`; **and**, below the FP flags, an f32 multiply into an f32→f16 narrowing, plus f32 add demotion to binary16 | two mechanisms, both required: `-ffp-contract=off` forced **last** in the hiprtc option array (`Hip_rtc.base_options` / `hiprtc_options`), *and* the `asm volatile("" : "+v"(x))` opacity barrier on every narrowing's argument (`Sarek_ir_cuda.sarek_f32_barrier_decl`) | executed (quoted), RX 7900 XTX / gfx1100, ROCm hiprtc: exhaustive sweep of all 63488 finite binary16 inputs — 620 device/interpreter disagreements before the barrier, 0 after. See the caveat in the opening section about the separate, inconsistent "373" |
+| **CUDA / nvrtc (f16 narrowing)** | in principle the same fusion — but NVIDIA has no fused multiply-and-convert-to-f16 instruction to fuse *into* | **nothing Sarek emits.** `ptxas` simply declines to absorb `cvt.rn.f16.f32` | machine-code, CUDA 13.3 host tools, sm_75…sm_121 — see §4. Machine-checked by `test_cuda_f16_sass`, which until this change **self-skipped in CI** for want of `nvdisasm` (§7) |
 | **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C | **no flag** — Sarek passes an empty build-option string. Same `mul_rn`-by-construction defence as CUDA | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
@@ -105,7 +116,11 @@ Legend for the evidence column:
   NVIDIA Pascal, and on OpenCL on AMD** — with the `sqrt` residual recorded in
   `Sarek_df64`'s header still open.
 - **No `-use_fast_math` / `-ftz=true` reaching nvrtc**, enforced rather than
-  documented (§5).
+  documented (§5) — in **both** the inline (`--ftz=true`) and the separated
+  (`--ftz true`) spelling, and fail-closed on a bare `--ftz` whose value cannot
+  be resolved. The first version of this guard was spelling-shaped and the
+  separated form went straight through it; that hole is closed and both
+  spellings are now regression-tested against real `libnvrtc`.
 
 **You may NOT rely on:**
 
@@ -134,15 +149,46 @@ two worked examples.
 
 ---
 
-## 4. CUDA f16: the barrier was inert, and has been removed (#110)
+## 4. CUDA f16: the barrier bought nothing *at the narrowing*, and has been removed (#110)
 
 The AMDGPU fix added an opacity barrier around every f32→f16 narrowing. A
 PTX-flavoured variant, `asm volatile("" : "+f"(x))`, was added to the non-HIP
 branch of `sarek_f32_barrier` at the same time — on the assumption that what
 was needed on one target was probably needed on the other.
 
-It was doing nothing. The assembly template is empty, NVVM erases the block and
-coalesces the register, and the emitted machine code is unchanged.
+It was buying nothing **at the narrowing site**, and the reason is not the one
+first recorded here. Two corrections, both measured:
+
+**NVVM does NOT erase the block.** The barriered PTX keeps the
+`// begin inline asm` / `// end inline asm` marker pair and allocates more
+virtual registers (`.reg .f32 %f<9>` against `%f<5>`). What is true, and is the
+argument that actually settles the deletion, is that the block contributes
+**zero PTX instructions**: the two modules differ only by those comment markers
+and virtual-register renumbering, so `ptxas` receives an *identical instruction
+stream* either way. The identical cubins are therefore structural, not a CUDA
+13.3 coincidence.
+
+**And the barrier is not inert in general** — only at a narrowing. Measured
+(CUDA 13.3, sm_90, host-side) on `out[i] = sarek_f32_barrier(a[i]*b[i]) + c[i]`:
+
+| | PTX | SASS (`-fmad=true`, the default) | SASS (`-fmad=false`) |
+|---|---|---|---|
+| without barrier | `fma.rn.f32` | `FFMA` | `FMUL` + `FADD` |
+| with barrier | `mul.f32` + `add.f32` | `FFMA` | `FMUL` + `FADD` |
+
+So at a mul→add site it **is** a real NVVM-level contraction barrier — and
+`ptxas -O1` and above **re-contract it back to `FFMA` anyway** (`-O0` and
+`--fmad=false` do not), leaving the cubins byte-identical again. The practical
+consequence is worth stating plainly, because it is a trap:
+
+> **Do not reach for `sarek_f32_barrier` to fix the caller-side `df64` hazard in
+> §3 on NVIDIA.** It protects the PTX and `ptxas` undoes it. `mul_rn` works
+> because an `fma` cannot be fused a second time — that is a property of the
+> instruction, not of a flag or a barrier.
+
+At the f16 narrowing there is nothing for either level to fuse in the first
+place: NVIDIA has no fused multiply-and-convert-to-f16 instruction, which is why
+the emitted code is unchanged there under every flag tried.
 
 **Measured for this change** (CUDA 13.3, `nvcc`/`ptxas`/`nvdisasm` V13.3.73,
 host-side, **no NVIDIA device**), on the current output of
@@ -203,7 +249,27 @@ flushing. So these are **rejected**, not warned about.
 
 `Cuda_nvrtc.check_fp_conformance` raises `Fp_conformance_violation` for
 `use_fast_math` (any spelling), `ftz=true|1`, `prec-div=false|0`,
-`prec-sqrt=false|0`. `fmad=true` **warns** rather than rejects, because it is
+`prec-sqrt=false|0`.
+
+**It screens the option ARRAY, not individual strings, and this is the whole
+design.** nvrtc accepts an option and its value as two separate array elements,
+so a per-element check is spelling-shaped and misses the separated form. The
+first version of this guard did exactly that. Measured through these bindings
+against real `libnvrtc.so.13.3`:
+
+| option array | compiles? | `.ftz` in PTX | old guard | current guard |
+|---|---|---|---|---|
+| `["--ftz=true"]` | — | — | REJECT | REJECT |
+| `["--ftz"; "true"]` | **yes** | **yes** | **accept** | REJECT |
+| `["-ftz"; "true"]` | **yes** | **yes** | **accept** | REJECT |
+| `["--prec-div"; "false"]` | yes | n/a | accept | REJECT |
+| `["--ftz"; "false"]` | yes | no | accept | accept |
+
+A value-taking name now consumes the following array element when there is no
+`=`, and is **fail-closed**: a bare `--ftz` whose value cannot be resolved is
+refused, because a guard that cannot tell what a flag is set to must not assume
+the safe answer. (`Hip_rtc.fp_relaxing_option_prefixes` never had this hole — it
+matches by prefix on options whose value is always inline.) `fmad=true` **warns** rather than rejects, because it is
 nvrtc's default and rejecting it would reject the status quo; contraction is
 defeated by construction instead (§2). It is applied in two places: at the
 entry of `compile_to_ptx`, before libnvrtc is touched — so the check works on a
@@ -227,6 +293,8 @@ holds four cases, and each was proved red by mutating the thing under test:
 | match on option name, ignoring its value | acceptance | `"-ftz=false" is legitimate and must be accepted; the guard refused it` |
 | remove both `check_fp_conformance` calls from `compile_to_ptx` | end-to-end | `compile_to_ptx accepted -use_fast_math and compiled; the guard did not fire on the real entry point` |
 | build the "ftz" SASS variant without `-ftz=true` | hazard control | `control is broken: -ftz=true produced no FMUL.FTZ / FADD.FTZ, so the option this guard rejects has not been shown to change anything on this toolchain` |
+| restore the per-element (spelling-shaped) matcher | rejection + end-to-end | the separated form compiles again, with `.ftz` in the PTX — the bypass reproduced on demand |
+| drop the option under test from the assembled array | assembled-array | `the assembled array no longer contains the option under test, so this check proves nothing` |
 
 The third mutation is the informative one: with the guard removed,
 `compile_to_ptx` compiled `-use_fast_math` **successfully** on this host. The
@@ -272,9 +340,23 @@ the measurement that extending `mul_rn` into `two_sum`/`quick_two_sum`
 contracting; it does **not** establish that RADV honours `NoContraction`.
 
 **The experiment that would settle it** (not run): a kernel computing
-`precise float p = a*b; out = p + c;` and, separately, `out = fma(a,b,c)`, on
-inputs chosen so that `fl(fl(a*b)+c) ≠ fma(a,b,c)`, executed on RADV and on
-ANV. If the two kernels agree, the driver contracted despite `NoContraction`.
+`precise float p = a*b; out = p + c;` and, separately, `out = fma(a,b,c)`,
+executed on RADV and on ANV. If the two kernels agree, the driver contracted
+despite `NoContraction`.
+
+Two things it must get right, or it will return a false "they agree":
+
+- **Choose the inputs against the device's MEASURED `fma`, not the correctly
+  rounded one.** This same document establishes that RADV's `fma` is not
+  correctly rounded, so inputs picked so that
+  `fl(fl(a*b)+c) ≠ fma_correct(a,b,c)` may still collide with what RADV's `fma`
+  actually returns. Read the device's `fma` result first, then select inputs on
+  which it differs from the separately-rounded form.
+- **ANV is not available here.** There is no Intel GPU on the machine this
+  policy was written on (AMD RX 7900 XTX and a Raphael iGPU only), so the ANV
+  half cannot be run without different hardware — the same class of gap as
+  everything in §7.
+
 Until that is run, treat Vulkan float32 as *contraction-safe by front-end
 declaration only*.
 
@@ -300,6 +382,17 @@ GPU would, but they cover a different question. Explicitly still open:
   being a durable `ptxas` property rather than a 13.3 accident — an argument,
   not a measurement. **If the SASS gate ever fails on CI at 12.6 while passing
   at 13.3, that difference is the finding.**
+
+  > **This was not actually being checked.** `nvdisasm` ships in `cuda-nvdisasm`,
+  > not in `cuda-nvcc`, and it was **absent from the built CI image** — verified
+  > by running `command -v nvdisasm` inside it, where `ptxas` and `nvcc` both
+  > resolve and `nvdisasm` does not. So `test_cuda_f16_sass` self-skipped in the
+  > only place 12.6 is exercised, and nothing could have surfaced a 12.6-vs-13.3
+  > divergence. Fixed in this change: `ci/Dockerfile` installs
+  > `cuda-nvdisasm-12-6` and `ci/assert-toolchain.sh` now fails the build when
+  > `nvdisasm` is missing or cannot disassemble a freshly assembled probe cubin.
+  > Until an image built with that change has run, **treat every "the gate
+  > checks this" statement in §4 as holding at CUDA 13.3 only.**
 - **`FMUL.FTZ` was observed, subnormal divergence was not.** §5 shows the flag
   changes the instruction; it does not show a wrong answer, because that
   requires running the kernel.

--- a/docs/optimization/cuda-f16-fusion-sass-audit.md
+++ b/docs/optimization/cuda-f16-fusion-sass-audit.md
@@ -39,9 +39,17 @@ caught the AMD bug, not a proxy for it.
 
 **CUDA never had the defect, on any architecture checked, and the barrier is
 inert there.** The `"+f"` barrier compiles down to an *empty* inline-asm block
-that NVVM erases entirely; the PTX instruction stream is identical with and
-without it, and the resulting cubins are byte-identical on all seven targets.
-The non-fusion comes from `ptxas`, not from the barrier.
+that contributes **zero PTX instructions**; the PTX instruction stream is
+identical with and without it, and the resulting cubins are byte-identical on
+all seven targets. The non-fusion comes from `ptxas`, not from the barrier.
+
+> **Correction (#116).** An earlier wording here said NVVM "erases" the block.
+> It does not: the barriered PTX keeps the `// begin/end inline asm` markers and
+> renumbers virtual registers (`%f<9>` against `%f<5>`, as the diff below in
+> fact shows). What is true is that it emits no instruction, so `ptxas` receives
+> an identical stream. And the barrier is inert only *at a narrowing* — at a
+> `mul`→`add` site it does suppress `fma.rn.f32` in the PTX, though `ptxas -O1`+
+> re-contracts it anyway. See `docs/fp-contraction-policy.md` §4.
 
 Claim tier: this shows **the fusion is absent from the SASS that ptxas 13.3
 emits for these targets**. It is *not* "verified on CUDA" — see

--- a/docs/optimization/cuda-f16-fusion-sass-audit.md
+++ b/docs/optimization/cuda-f16-fusion-sass-audit.md
@@ -4,6 +4,14 @@
 **Date:** 2026-07-25. **Host:** no NVIDIA GPU. **Toolchain:** CUDA 13.3,
 `ptxas`/`nvdisasm`/`nvcc` V13.3.73, `libnvrtc.so.13.3.33`.
 
+> **Superseded in one respect (#110).** The recommendation at the end of this
+> document — "removing it or keeping it is out of scope" — has since been
+> acted on: the inert `"+f"` barrier was **removed** from the non-HIP branch of
+> `sarek_f32_barrier`, after re-measuring byte-identical cubins on sm_75 through
+> sm_121 for the codegen's current output. Everything else here still stands.
+> The cross-backend rule, and what the other backends do about contraction, is
+> [`docs/fp-contraction-policy.md`](../fp-contraction-policy.md).
+
 ## The question
 
 #290 found that on HIP/gfx1100 the generated C was correct and the machine code

--- a/sarek-cuda/Cuda_nvrtc.ml
+++ b/sarek-cuda/Cuda_nvrtc.ml
@@ -351,7 +351,7 @@ let cuda_include_flags : string list Lazy.t =
     offending option and why it is refused. *)
 exception Fp_conformance_violation of string
 
-(** Options refused outright, with the reason.
+(** The floating-point option classes this path refuses, and why.
 
     The rule these encode: Sarek's DSL semantics are IEEE-754 binary32 with
     every operation rounded as written, and the interpreter implements exactly
@@ -376,47 +376,80 @@ exception Fp_conformance_violation of string
       correctly-rounded forms — the PTX emitter switched [div.approx.f32] to
       [div.rn.f32] for exactly this reason (audit finding M2).
 
-    [--fmad=true] is NOT in this list: it is nvrtc's default, so rejecting it
-    would reject the status quo. Contraction is instead defeated by construction
-    where it matters (see [Sarek_df64]'s contraction barrier). It is warned
-    about, so that a caller who sets it deliberately is told the guarantee it is
-    trading away. *)
-let fp_rejected_options : (string * (string option -> bool) * string) list =
-  let is_true = function Some ("true" | "1") -> true | _ -> false in
-  let is_false = function Some ("false" | "0") -> true | _ -> false in
-  let always _ = true in
+    [--fmad=true] is NOT refused: it is nvrtc's default, so refusing it would
+    refuse the status quo. Contraction is instead defeated by construction where
+    it matters (see [Sarek_df64]'s contraction barrier). It warns, so a caller
+    who sets it deliberately is told the guarantee it is trading away.
+
+    NVRTC ACCEPTS AN OPTION AND ITS VALUE AS TWO SEPARATE ARRAY ELEMENTS. An
+    earlier version of this guard matched [["--ftz=true"]] and walked straight
+    past [["--ftz"; "true"]] — executed against libnvrtc 13.3 through these
+    bindings, the separated form compiled and the PTX carried [.ftz] on the f32
+    arithmetic, with no exception and no warning. So the scan below is written
+    around the OPTION, not its spelling: a value-taking name consumes the next
+    array element when there is no [=], and is FAIL-CLOSED — [--ftz] with no
+    determinable value is refused, because a guard that cannot tell what a flag
+    is set to must not assume the safe answer.
+    ([Hip_rtc.fp_relaxing_option_prefixes] never had this hole; it matches by
+    prefix on options whose value is always inline.) *)
+
+type fp_verdict = Fp_reject of string | Fp_warn of string
+
+(** [(name, value_semantics, why)]. [value_semantics] answers "is this setting
+    dangerous?" given the resolved value, where [None] means the value could not
+    be determined. *)
+let fp_option_classes :
+    (string * (string option -> bool) * [`Reject | `Warn] * string) list =
+  (* Fail-closed on an indeterminate value: an unresolved [--ftz] is treated as
+     dangerous, not as safe. *)
+  let dangerous_unless_false = function
+    | Some ("false" | "0") -> false
+    | _ -> true
+  in
+  let dangerous_unless_true = function
+    | Some ("true" | "1") -> false
+    | _ -> true
+  in
   [
     ( "use_fast_math",
-      always,
+      (fun _ -> true),
+      `Reject,
       "implies --ftz=true --prec-div=false --prec-sqrt=false, which flush \
        binary32 subnormals and downgrade div/sqrt; the interpreter oracle does \
        neither" );
     ( "ftz",
-      is_true,
+      dangerous_unless_false,
+      `Reject,
       "flushes binary32 subnormals to zero (measured: FMUL.FTZ/FADD.FTZ in the \
        generated f16 kernel's SASS at sm_90, CUDA 13.3); the interpreter keeps \
        them, so device and oracle diverge" );
     ( "prec-div",
-      is_false,
+      dangerous_unless_true,
+      `Reject,
       "selects approximate binary32 division; Sarek_df64 requires the \
        correctly-rounded form (div.rn.f32)" );
     ( "prec-sqrt",
-      is_false,
+      dangerous_unless_true,
+      `Reject,
       "selects approximate binary32 square root; Sarek_df64's Newton/Karp step \
        squares the seed error and has no margin for it" );
-  ]
-
-let fp_warned_options : (string * (string option -> bool) * string) list =
-  [
     ( "fmad",
-      (function Some ("true" | "1") -> true | _ -> false),
+      dangerous_unless_false,
+      `Warn,
       "re-enables multiply-add contraction; Sarek_df64 defeats contraction by \
        construction (mul_rn) rather than by flag, but a caller-written kernel \
        that feeds a live float32 product into a df64 entry point is exposed" );
   ]
 
-(** Split an nvrtc option into its name (leading dashes stripped) and optional
-    value. [--ftz=true] -> [("ftz", Some "true")]; [-use_fast_math] ->
+(** Names that take a value, and may therefore carry it in the NEXT array
+    element. [use_fast_math] is a bare switch and is deliberately absent. *)
+let fp_value_taking_names =
+  List.filter_map
+    (fun (n, _, _, _) -> if n = "use_fast_math" then None else Some n)
+    fp_option_classes
+
+(** Split an nvrtc option into its name (leading dashes stripped) and inline
+    value, if any. [--ftz=true] -> [("ftz", Some "true")]; [-use_fast_math] ->
     [("use_fast_math", None)]. *)
 let split_nvrtc_option (opt : string) : string * string option =
   let n = String.length opt in
@@ -431,55 +464,104 @@ let split_nvrtc_option (opt : string) : string * string option =
       ( String.sub body 0 j,
         Some (String.sub body (j + 1) (String.length body - j - 1)) )
 
-(** The reason [opt] must be refused, or [None] if it is acceptable. Pure, so
-    the guard can be exercised without libnvrtc or a device. *)
-let fp_rejection_reason (opt : string) : string option =
-  let name, value = split_nvrtc_option opt in
-  List.find_map
-    (fun (n, matches, why) ->
-      if n = name && matches value then
-        Some
-          (Printf.sprintf
-             "nvrtc option %S is refused on the Sarek CUDA path: %s. Sarek's \
-              cross-backend oracle is the interpreter, which evaluates \
-              binary32 exactly as written; see docs/fp-contraction-policy.md."
-             opt
-             why)
-      else None)
-    fp_rejected_options
+let looks_like_option s = String.length s > 0 && s.[0] = '-'
 
-(** The warning for [opt], or [None]. Pure, for the same reason. *)
-let fp_warning_reason (opt : string) : string option =
-  let name, value = split_nvrtc_option opt in
+(** Scan a WHOLE option array, resolving values that live in a following
+    element. Pure, so it can be exercised without libnvrtc or a device — and
+    list-level, because the separated form is invisible to any per-element
+    check. *)
+let fp_scan (opts : string list) : fp_verdict list =
+  let rec go acc = function
+    | [] -> List.rev acc
+    | opt :: rest -> (
+        let name, inline_value = split_nvrtc_option opt in
+        (* The value may be the next array element: nvrtc accepts both
+           ["--ftz=true"] and ["--ftz"; "true"]. *)
+        let value, rest, rendered =
+          match inline_value with
+          | Some _ -> (inline_value, rest, opt)
+          | None -> (
+              match rest with
+              | v :: tl
+                when List.mem name fp_value_taking_names
+                     && not (looks_like_option v) ->
+                  (Some v, tl, opt ^ " " ^ v)
+              | _ -> (None, rest, opt))
+        in
+        match
+          List.find_map
+            (fun (n, dangerous, severity, why) ->
+              if n = name && dangerous value then Some (severity, why) else None)
+            fp_option_classes
+        with
+        | Some (`Reject, why) ->
+            go
+              (Fp_reject
+                 (Printf.sprintf
+                    "nvrtc option %S is refused on the Sarek CUDA path: %s. \
+                     Sarek's cross-backend oracle is the interpreter, which \
+                     evaluates binary32 exactly as written; see \
+                     docs/fp-contraction-policy.md."
+                    rendered
+                    why)
+              :: acc)
+              rest
+        | Some (`Warn, why) ->
+            go
+              (Fp_warn
+                 (Printf.sprintf
+                    "nvrtc option %S relaxes floating-point evaluation: %s. \
+                     See docs/fp-contraction-policy.md."
+                    rendered
+                    why)
+              :: acc)
+              rest
+        | None -> go acc rest)
+  in
+  go [] opts
+
+(** The reason the option array [opts] must be refused, or [None]. *)
+let fp_rejection_reason_list (opts : string list) : string option =
   List.find_map
-    (fun (n, matches, why) ->
-      if n = name && matches value then
-        Some
-          (Printf.sprintf
-             "nvrtc option %S relaxes floating-point evaluation: %s. See \
-              docs/fp-contraction-policy.md."
-             opt
-             why)
-      else None)
-    fp_warned_options
+    (function Fp_reject m -> Some m | Fp_warn _ -> None)
+    (fp_scan opts)
+
+(** Single-element convenience wrapper. Correct only for options that carry
+    their value inline — use {!fp_rejection_reason_list} for anything that might
+    be split across elements. *)
+let fp_rejection_reason (opt : string) : string option =
+  fp_rejection_reason_list [opt]
+
+let fp_warning_reason_list (opts : string list) : string option =
+  List.find_map
+    (function Fp_warn m -> Some m | Fp_reject _ -> None)
+    (fp_scan opts)
+
+let fp_warning_reason (opt : string) : string option =
+  fp_warning_reason_list [opt]
 
 (** Reject FP-relaxing options and warn about the merely risky ones.
 
-    Applied at the single point where an option array reaches
+    Applied to the WHOLE array, at the single point where an array reaches
     [nvrtcCompileProgram], so it covers options from any source — a caller, a
     future environment-variable escape hatch, or a hardcoded flag added by a
-    later maintainer. That placement is the point: the guard is against the
-    option existing at all, not against one particular way of supplying it. *)
+    later maintainer — and both spellings of every value-taking option. *)
 let check_fp_conformance (opts : string list) : unit =
   List.iter
-    (fun opt ->
-      match fp_rejection_reason opt with
-      | Some msg -> raise (Fp_conformance_violation msg)
-      | None -> (
-          match fp_warning_reason opt with
-          | Some msg -> Spoc_core.Log.warnf Spoc_core.Log.Kernel "%s" msg
-          | None -> ()))
-    opts
+    (function
+      | Fp_reject msg -> raise (Fp_conformance_violation msg)
+      | Fp_warn msg -> Spoc_core.Log.warnf Spoc_core.Log.Kernel "%s" msg)
+    (fp_scan opts)
+
+(** The exact option array this module hands to [nvrtcCompileProgram] for one
+    architecture attempt. Split out so the composition (caller options + the
+    module's own flags) can be screened in a test, not only the caller's half —
+    a hardcoded FP flag added here later must be caught the same way a caller's
+    is. *)
+let nvrtc_option_array ?arch ~(options : string list)
+    ~(include_opts : string list) () : string list =
+  (match arch with None -> [] | Some a -> ["--gpu-architecture=" ^ a])
+  @ options @ include_opts
 
 (** Compile CUDA source to PTX.
     @param source CUDA C source code
@@ -531,7 +613,7 @@ let compile_to_ptx ?(name = "kernel") ~arch ?(options = []) (source : string) :
      no-arch last resort) so a generated `#include <cuda_fp16.h>` resolves —
      nvrtc supplies no default include path of its own. Empty on a host with no
      CUDA headers, in which case the option array is exactly as before. *)
-  let include_opts = options @ Lazy.force cuda_include_flags in
+  let include_opts = Lazy.force cuda_include_flags in
 
   let compile_with_string_opts (opts : string list) =
     (* Chokepoint. Every array that reaches nvrtcCompileProgram passes here,
@@ -558,10 +640,14 @@ let compile_to_ptx ?(name = "kernel") ~arch ?(options = []) (source : string) :
         Spoc_core.Log.warn
           Spoc_core.Log.Kernel
           "NVRTC: falling back to no arch option" ;
-        (compile_with_string_opts include_opts, None)
+        ( compile_with_string_opts (nvrtc_option_array ~options ~include_opts ()),
+          None )
     | a :: rest -> (
         let opt_arch = "--gpu-architecture=" ^ a in
-        let res = compile_with_string_opts (opt_arch :: include_opts) in
+        let res =
+          compile_with_string_opts
+            (nvrtc_option_array ~arch:a ~options ~include_opts ())
+        in
         match res with
         | NVRTC_SUCCESS -> (res, Some a)
         | NVRTC_ERROR_INVALID_OPTION | NVRTC_ERROR_INVALID_INPUT ->
@@ -573,7 +659,14 @@ let compile_to_ptx ?(name = "kernel") ~arch ?(options = []) (source : string) :
         | other -> (other, Some a))
   in
 
-  let compile_result, used_arch = try_arch arch_candidates in
+  (* The chokepoint guard can raise from inside try_arch. Destroy the program
+     before the exception leaves, or the handle leaks. *)
+  let compile_result, used_arch =
+    try try_arch arch_candidates
+    with e ->
+      ignore (nvrtcDestroyProgram prog) ;
+      raise e
+  in
 
   (match used_arch with
   | Some a ->

--- a/sarek-cuda/Cuda_nvrtc.ml
+++ b/sarek-cuda/Cuda_nvrtc.ml
@@ -344,12 +344,159 @@ let cuda_include_flags : string list Lazy.t =
   lazy
     (List.map (fun d -> "--include-path=" ^ d) (Lazy.force cuda_include_paths))
 
+(** {2 Floating-point conformance guard}
+
+    Raised when an nvrtc option would change binary32 semantics in a way the
+    interpreter — Sarek's cross-backend oracle — cannot follow. Carries the
+    offending option and why it is refused. *)
+exception Fp_conformance_violation of string
+
+(** Options refused outright, with the reason.
+
+    The rule these encode: Sarek's DSL semantics are IEEE-754 binary32 with
+    every operation rounded as written, and the interpreter implements exactly
+    that. An option that FLUSHES SUBNORMALS or DOWNGRADES a division/square root
+    to an approximate form makes the device disagree with the interpreter on
+    inputs the test suite already uses, and — unlike HIP's contraction case,
+    where appending [-ffp-contract=off] last neutralises the caller — there is
+    no later flag that undoes it. So these are rejected rather than warned
+    about.
+
+    - [-use_fast_math] implies
+      [--ftz=true --prec-div=false --prec-sqrt=false --fmad=true] (CUDA nvrtc
+      documentation, [dependencies/Cuda/nvrtc.h]).
+    - [-ftz=true] flushes binary32 subnormals to zero. MEASURED, host-side on
+      CUDA 13.3 (nvcc/ptxas V13.3.73, no NVIDIA device): compiling the generated
+      [f16_midround] kernel for sm_90 with [-use_fast_math] or [-ftz=true] turns
+      [FMUL]/[FADD] into [FMUL.FTZ]/[FADD.FTZ]. [1e-5] is already lane 5 of the
+      [test_hip_f16] input array, so this is reachable from the existing test
+      data, not a hypothetical.
+    - [--prec-div=false] / [--prec-sqrt=false] select approximate division and
+      square root. Sarek_df64 already spends its whole error budget on the
+      correctly-rounded forms — the PTX emitter switched [div.approx.f32] to
+      [div.rn.f32] for exactly this reason (audit finding M2).
+
+    [--fmad=true] is NOT in this list: it is nvrtc's default, so rejecting it
+    would reject the status quo. Contraction is instead defeated by construction
+    where it matters (see [Sarek_df64]'s contraction barrier). It is warned
+    about, so that a caller who sets it deliberately is told the guarantee it is
+    trading away. *)
+let fp_rejected_options : (string * (string option -> bool) * string) list =
+  let is_true = function Some ("true" | "1") -> true | _ -> false in
+  let is_false = function Some ("false" | "0") -> true | _ -> false in
+  let always _ = true in
+  [
+    ( "use_fast_math",
+      always,
+      "implies --ftz=true --prec-div=false --prec-sqrt=false, which flush \
+       binary32 subnormals and downgrade div/sqrt; the interpreter oracle does \
+       neither" );
+    ( "ftz",
+      is_true,
+      "flushes binary32 subnormals to zero (measured: FMUL.FTZ/FADD.FTZ in the \
+       generated f16 kernel's SASS at sm_90, CUDA 13.3); the interpreter keeps \
+       them, so device and oracle diverge" );
+    ( "prec-div",
+      is_false,
+      "selects approximate binary32 division; Sarek_df64 requires the \
+       correctly-rounded form (div.rn.f32)" );
+    ( "prec-sqrt",
+      is_false,
+      "selects approximate binary32 square root; Sarek_df64's Newton/Karp step \
+       squares the seed error and has no margin for it" );
+  ]
+
+let fp_warned_options : (string * (string option -> bool) * string) list =
+  [
+    ( "fmad",
+      (function Some ("true" | "1") -> true | _ -> false),
+      "re-enables multiply-add contraction; Sarek_df64 defeats contraction by \
+       construction (mul_rn) rather than by flag, but a caller-written kernel \
+       that feeds a live float32 product into a df64 entry point is exposed" );
+  ]
+
+(** Split an nvrtc option into its name (leading dashes stripped) and optional
+    value. [--ftz=true] -> [("ftz", Some "true")]; [-use_fast_math] ->
+    [("use_fast_math", None)]. *)
+let split_nvrtc_option (opt : string) : string * string option =
+  let n = String.length opt in
+  let i = ref 0 in
+  while !i < n && opt.[!i] = '-' do
+    incr i
+  done ;
+  let body = String.sub opt !i (n - !i) in
+  match String.index_opt body '=' with
+  | None -> (body, None)
+  | Some j ->
+      ( String.sub body 0 j,
+        Some (String.sub body (j + 1) (String.length body - j - 1)) )
+
+(** The reason [opt] must be refused, or [None] if it is acceptable. Pure, so
+    the guard can be exercised without libnvrtc or a device. *)
+let fp_rejection_reason (opt : string) : string option =
+  let name, value = split_nvrtc_option opt in
+  List.find_map
+    (fun (n, matches, why) ->
+      if n = name && matches value then
+        Some
+          (Printf.sprintf
+             "nvrtc option %S is refused on the Sarek CUDA path: %s. Sarek's \
+              cross-backend oracle is the interpreter, which evaluates \
+              binary32 exactly as written; see docs/fp-contraction-policy.md."
+             opt
+             why)
+      else None)
+    fp_rejected_options
+
+(** The warning for [opt], or [None]. Pure, for the same reason. *)
+let fp_warning_reason (opt : string) : string option =
+  let name, value = split_nvrtc_option opt in
+  List.find_map
+    (fun (n, matches, why) ->
+      if n = name && matches value then
+        Some
+          (Printf.sprintf
+             "nvrtc option %S relaxes floating-point evaluation: %s. See \
+              docs/fp-contraction-policy.md."
+             opt
+             why)
+      else None)
+    fp_warned_options
+
+(** Reject FP-relaxing options and warn about the merely risky ones.
+
+    Applied at the single point where an option array reaches
+    [nvrtcCompileProgram], so it covers options from any source — a caller, a
+    future environment-variable escape hatch, or a hardcoded flag added by a
+    later maintainer. That placement is the point: the guard is against the
+    option existing at all, not against one particular way of supplying it. *)
+let check_fp_conformance (opts : string list) : unit =
+  List.iter
+    (fun opt ->
+      match fp_rejection_reason opt with
+      | Some msg -> raise (Fp_conformance_violation msg)
+      | None -> (
+          match fp_warning_reason opt with
+          | Some msg -> Spoc_core.Log.warnf Spoc_core.Log.Kernel "%s" msg
+          | None -> ()))
+    opts
+
 (** Compile CUDA source to PTX.
     @param source CUDA C source code
     @param name Optional program name
     @param arch Target architecture (e.g., "compute_75")
+    @param options
+      Extra nvrtc options, prepended to the ones this module supplies. Screened
+      by {!check_fp_conformance}: an option that would break binary32 agreement
+      with the interpreter raises {!Fp_conformance_violation} BEFORE any nvrtc
+      call, so the check is reachable on a host with no CUDA at all.
     @return PTX code as string *)
-let compile_to_ptx ?(name = "kernel") ~arch (source : string) : string =
+let compile_to_ptx ?(name = "kernel") ~arch ?(options = []) (source : string) :
+    string =
+  (* Fail fast, before touching libnvrtc: a bad flag is a programming error in
+     the caller, not a compilation failure. *)
+  check_fp_conformance options ;
+
   (* Create program *)
   let prog = allocate nvrtc_program_ptr (from_voidp nvrtc_program null) in
   check
@@ -384,9 +531,13 @@ let compile_to_ptx ?(name = "kernel") ~arch (source : string) : string =
      no-arch last resort) so a generated `#include <cuda_fp16.h>` resolves —
      nvrtc supplies no default include path of its own. Empty on a host with no
      CUDA headers, in which case the option array is exactly as before. *)
-  let include_opts = Lazy.force cuda_include_flags in
+  let include_opts = options @ Lazy.force cuda_include_flags in
 
   let compile_with_string_opts (opts : string list) =
+    (* Chokepoint. Every array that reaches nvrtcCompileProgram passes here,
+       including the ones this module builds itself, so a flag added later
+       anywhere in this function is screened too. *)
+    check_fp_conformance opts ;
     match opts with
     | [] -> nvrtcCompileProgram prog_handle 0 (from_voidp string null)
     | _ ->

--- a/sarek-cuda/test/dune
+++ b/sarek-cuda/test/dune
@@ -91,3 +91,14 @@
  (libraries sarek_cuda sarek.codegen spoc.ir alcotest str unix)
  (instrumentation
   (backend bisect_ppx)))
+
+; FP-conformance guard for the nvrtc option array (#111). Pure checks need no
+; toolchain; the FTZ hazard control uses host-side nvcc/nvdisasm (no device)
+; and skips without them.
+
+(test
+ (name test_cuda_fp_conformance)
+ (modules test_cuda_fp_conformance)
+ (libraries sarek_cuda sarek.codegen spoc.ir alcotest str unix)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek-cuda/test/test_cuda_fp_conformance.ml
+++ b/sarek-cuda/test/test_cuda_fp_conformance.ml
@@ -15,6 +15,12 @@
  *
  * NON-VACUITY. Three separate things keep this from being a test of a constant:
  *
+ *   0. THE SEPARATED SPELLING. nvrtc takes an option and its value as two array
+ *      elements, and the first version of this guard matched only the inline
+ *      form -- ["--ftz"; "true"] compiled a subnormal-flushing kernel with no
+ *      exception and no warning, confirmed against libnvrtc 13.3 through these
+ *      bindings. Both spellings of every value-taking option are now asserted,
+ *      as is the fail-closed behaviour of a bare ["--ftz"] with no value.
  *   1. NEGATIVE SIDE. Options that must stay accepted are asserted accepted --
  *      including [-ftz=false] and [--prec-div=true], which differ from the
  *      rejected forms only in the VALUE. A guard that matched on the option
@@ -96,58 +102,75 @@ let generated_source () =
 (* 1. Rejection                                                        *)
 (* ------------------------------------------------------------------ *)
 
-(* Every spelling nvcc/nvrtc accepts for the same hazard. Both dash forms,
-   because nvrtc takes either. *)
+(* Every spelling nvrtc accepts for the same hazard: both dash forms, both the
+   inline [--ftz=true] and the SEPARATED [--ftz; true] value, and the bare name
+   with no value at all (fail-closed). Each entry is a whole option ARRAY,
+   because the separated form is invisible to any per-element check. *)
 let must_reject =
   [
-    ("-use_fast_math", "subnormal");
-    ("--use_fast_math", "subnormal");
-    ("-ftz=true", "subnormal");
-    ("--ftz=true", "subnormal");
-    ("--ftz=1", "subnormal");
-    ("--prec-div=false", "division");
-    ("-prec-div=0", "division");
-    ("--prec-sqrt=false", "square root");
+    (["-use_fast_math"], "subnormal");
+    (["--use_fast_math"], "subnormal");
+    (["-ftz=true"], "subnormal");
+    (["--ftz=true"], "subnormal");
+    (["--ftz=1"], "subnormal");
+    (* the confirmed bypass *)
+    (["--ftz"; "true"], "subnormal");
+    (["-ftz"; "true"], "subnormal");
+    (["--ftz"; "1"], "subnormal");
+    (* fail-closed: a value we cannot resolve is not assumed safe *)
+    (["--ftz"], "subnormal");
+    (["--ftz"; "--std=c++17"], "subnormal");
+    (["--prec-div=false"], "division");
+    (["-prec-div=0"], "division");
+    (["--prec-div"; "false"], "division");
+    (["--prec-sqrt=false"], "square root");
+    (["--prec-sqrt"; "false"], "square root");
+    (* the real thing it protects: a full array with the hazard buried in it *)
+    ( ["--gpu-architecture=compute_75"; "--ftz"; "true"; "-I/opt/cuda/include"],
+      "subnormal" );
   ]
+
+let contains hay needle =
+  let n = String.length needle and h = String.length hay in
+  let rec go i = i + n <= h && (String.sub hay i n = needle || go (i + 1)) in
+  n = 0 || go 0
 
 let test_rejected () =
   List.iter
-    (fun (opt, needle) ->
-      match Nvrtc.fp_rejection_reason opt with
+    (fun (opts, needle) ->
+      let shown = String.concat " " opts in
+      match Nvrtc.fp_rejection_reason_list opts with
       | None ->
           Alcotest.failf
             "%S must be refused on the CUDA path; the guard accepted it"
-            opt
+            shown
       | Some msg ->
           (* Not merely "some error": the message must name the option and
              explain the hazard, or a caller cannot act on it. *)
-          let contains hay needle =
-            let n = String.length needle and h = String.length hay in
-            let rec go i =
-              i + n <= h && (String.sub hay i n = needle || go (i + 1))
-            in
-            n = 0 || go 0
-          in
-          if not (contains msg opt) then
+          (* The message must quote the OFFENDING option, wherever it sits in
+             the array -- a message naming only the first element would be
+             useless when the hazard is buried among include paths. *)
+          if not (List.exists (fun o -> contains msg o) opts) then
             Alcotest.failf
-              "rejection message for %S does not quote it: %s"
-              opt
+              "rejection message for %S quotes none of its options: %s"
+              shown
               msg ;
           if not (contains msg needle) then
             Alcotest.failf
               "rejection message for %S does not explain the hazard (expected \
                %S): %s"
-              opt
+              shown
               needle
               msg ;
           if not (contains msg "docs/fp-contraction-policy.md") then
             Alcotest.failf
               "rejection message for %S does not point at the policy: %s"
-              opt
+              shown
               msg)
     must_reject ;
   Printf.printf
-    "  guard rejects %d FP-relaxing option spellings, each with a reason\n"
+    "  guard rejects %d FP-relaxing option arrays (inline, separated and \
+     valueless spellings), each with a reason\n"
     (List.length must_reject)
 
 (* ------------------------------------------------------------------ *)
@@ -156,74 +179,119 @@ let test_rejected () =
 
 let must_accept =
   [
-    "--gpu-architecture=compute_75";
-    "--include-path=/opt/cuda/include";
-    "-I/opt/cuda/include";
-    "-DFOO=1";
-    "-ftz=false";
-    "--ftz=false";
-    "--prec-div=true";
-    "--prec-sqrt=true";
-    "-O3";
-    "--extra-device-vectorization";
-    "--std=c++17";
+    ["--gpu-architecture=compute_75"];
+    ["--include-path=/opt/cuda/include"];
+    ["-I/opt/cuda/include"];
+    ["-DFOO=1"];
+    ["-ftz=false"];
+    ["--ftz=false"];
+    (* the separated SAFE spellings must survive the separated-form handling *)
+    ["--ftz"; "false"];
+    ["-ftz"; "0"];
+    ["--prec-div=true"];
+    ["--prec-div"; "true"];
+    ["--prec-sqrt=true"];
+    ["--prec-sqrt"; "1"];
+    ["-O3"];
+    ["--extra-device-vectorization"];
+    ["--std=c++17"];
+    (* a realistic full array *)
+    ["--gpu-architecture=compute_90"; "--include-path=/opt/cuda/include"];
   ]
 
 let test_accepted () =
   List.iter
-    (fun opt ->
-      match Nvrtc.fp_rejection_reason opt with
+    (fun opts ->
+      match Nvrtc.fp_rejection_reason_list opts with
       | Some msg ->
           Alcotest.failf
             "%S is legitimate and must be accepted; the guard refused it: %s"
-            opt
+            (String.concat " " opts)
             msg
       | None -> ())
     must_accept ;
   (* --fmad=true is a real relaxation but is nvrtc's default, so it warns
      rather than rejects. Both halves matter: it must NOT reject, and it must
-     NOT be silent. *)
-  (match Nvrtc.fp_rejection_reason "--fmad=true" with
-  | Some msg -> Alcotest.failf "--fmad=true must warn, not reject: %s" msg
-  | None -> ()) ;
-  (match Nvrtc.fp_warning_reason "--fmad=true" with
-  | None -> Alcotest.fail "--fmad=true must produce a warning; it was silent"
-  | Some _ -> ()) ;
-  (match Nvrtc.fp_warning_reason "--fmad=false" with
-  | Some msg ->
-      Alcotest.failf
-        "--fmad=false is the safe setting and must be silent: %s"
-        msg
-  | None -> ()) ;
+     NOT be silent -- in BOTH spellings. *)
+  List.iter
+    (fun opts ->
+      let shown = String.concat " " opts in
+      (match Nvrtc.fp_rejection_reason_list opts with
+      | Some msg -> Alcotest.failf "%S must warn, not reject: %s" shown msg
+      | None -> ()) ;
+      match Nvrtc.fp_warning_reason_list opts with
+      | None -> Alcotest.failf "%S must produce a warning; it was silent" shown
+      | Some _ -> ())
+    [["--fmad=true"]; ["--fmad"; "true"]; ["-fmad"; "1"]] ;
+  List.iter
+    (fun opts ->
+      match Nvrtc.fp_warning_reason_list opts with
+      | Some msg ->
+          Alcotest.failf
+            "%S is the safe setting and must be silent: %s"
+            (String.concat " " opts)
+            msg
+      | None -> ())
+    [["--fmad=false"]; ["--fmad"; "false"]] ;
   Printf.printf
-    "  guard accepts %d legitimate options; --fmad=true warns, --fmad=false is \
-     silent\n"
+    "  guard accepts %d legitimate option arrays (incl. separated safe \
+     values); --fmad=true warns in both spellings, --fmad=false is silent\n"
     (List.length must_accept)
 
 (* ------------------------------------------------------------------ *)
 (* 3. End-to-end: the real entry point raises, with no CUDA needed     *)
 (* ------------------------------------------------------------------ *)
 
-let test_compile_to_ptx_raises () =
+let expect_refused ~what options =
   let src = generated_source () in
   match
-    Nvrtc.compile_to_ptx
-      ~name:"guarded"
-      ~arch:"compute_75"
-      ~options:["-use_fast_math"]
-      src
+    Nvrtc.compile_to_ptx ~name:"guarded" ~arch:"compute_75" ~options src
   with
   | _ptx ->
-      Alcotest.fail
-        "compile_to_ptx accepted -use_fast_math and compiled; the guard did \
-         not fire on the real entry point"
+      Alcotest.failf
+        "compile_to_ptx accepted %s and compiled; the guard did not fire on \
+         the real entry point"
+        what
   | exception Nvrtc.Fp_conformance_violation msg ->
-      Printf.printf "  compile_to_ptx refused -use_fast_math: %s\n" msg
+      Printf.printf "  compile_to_ptx refused %s: %s\n" what msg
   | exception e ->
       Alcotest.failf
-        "compile_to_ptx must raise Fp_conformance_violation; it raised %s \
-         (which means the guard did not run before libnvrtc was reached)"
+        "compile_to_ptx must raise Fp_conformance_violation for %s; it raised \
+         %s (which means the guard did not run before libnvrtc was reached)"
+        what
         (Printexc.to_string e)
+
+let test_compile_to_ptx_raises () =
+  expect_refused ~what:"-use_fast_math" ["-use_fast_math"] ;
+  (* The separated spelling, through the same entry point. This is the case
+     that compiled successfully before the guard was made option-shaped. *)
+  expect_refused ~what:"the separated form --ftz true" ["--ftz"; "true"]
+
+(* The CHOKEPOINT copy of the guard screens the array this module ASSEMBLES,
+   not just the caller's half. Exercised through [nvrtc_option_array], which is
+   the exact composition [compile_to_ptx] hands to nvrtcCompileProgram, so a
+   hazard introduced by this module's own flags is caught the same way. *)
+let test_assembled_array_is_screened () =
+  let assembled =
+    Nvrtc.nvrtc_option_array
+      ~arch:"compute_75"
+      ~options:["--ftz"; "true"]
+      ~include_opts:["--include-path=/opt/cuda/include"]
+      ()
+  in
+  (* Non-vacuity: the hazard must have SURVIVED assembly, not been dropped. *)
+  if not (List.mem "--ftz" assembled) then
+    Alcotest.failf
+      "the assembled array no longer contains the option under test (%s), so \
+       this check proves nothing"
+      (String.concat " " assembled) ;
+  match Nvrtc.fp_rejection_reason_list assembled with
+  | None ->
+      Alcotest.failf
+        "the array this module assembles (%s) is not screened; a hazard in the \
+         module's OWN flags would reach nvrtcCompileProgram"
+        (String.concat " " assembled)
+  | Some msg -> Printf.printf "  assembled option array is screened: %s\n" msg
 
 (* ------------------------------------------------------------------ *)
 (* 4. The hazard, measured (host tools only)                           *)
@@ -282,10 +350,14 @@ let sass_of ~dir ~tag ~extra_flags src =
     if rc <> 0 then None else Some (read_file sass)
 
 let test_ftz_hazard_is_real () =
-  if not (on_path "nvcc" && on_path "nvdisasm") then
+  if not (on_path "nvcc" && on_path "nvdisasm") then (
     Printf.printf
       "  [SKIP] FTZ hazard control: nvcc/nvdisasm not on PATH (host tools, no \
-       device needed)\n"
+       device needed)\n" ;
+    (* Alcotest.skip, not a bare return: a skipped gate that prints [OK] is
+       indistinguishable from a gate that ran, which is exactly the regression
+       commit cf58801b fixed. *)
+    Alcotest.skip ())
   else
     let dir = Filename.temp_file "sarek_fpc" "" in
     Sys.remove dir ;
@@ -297,7 +369,8 @@ let test_ftz_hazard_is_real () =
     with
     | None, _ | _, None ->
         Printf.printf
-          "  [SKIP] FTZ hazard control: the local nvcc could not build sm_90\n"
+          "  [SKIP] FTZ hazard control: the local nvcc could not build sm_90\n" ;
+        Alcotest.skip ()
     | Some plain, Some ftz ->
         if has_ftz_arith plain then
           Alcotest.fail
@@ -328,9 +401,13 @@ let () =
             `Quick
             test_accepted;
           Alcotest.test_case
-            "compile_to_ptx itself refuses -use_fast_math"
+            "compile_to_ptx itself refuses relaxing options, both spellings"
             `Quick
             test_compile_to_ptx_raises;
+          Alcotest.test_case
+            "the array this module assembles is screened too"
+            `Quick
+            test_assembled_array_is_screened;
           Alcotest.test_case
             "the flushed-subnormal hazard is real (SASS)"
             `Quick

--- a/sarek-cuda/test/test_cuda_fp_conformance.ml
+++ b/sarek-cuda/test/test_cuda_fp_conformance.ml
@@ -1,0 +1,339 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * FP-conformance guard for the CUDA/nvrtc path (#111).
+ *
+ * WHAT IS BEING GUARDED. Sarek's DSL semantics are IEEE-754 binary32 with every
+ * operation rounded as written, and the INTERPRETER is the cross-backend oracle
+ * that defines them (docs/fp-contraction-policy.md). [-use_fast_math] and
+ * [-ftz=true] flush binary32 subnormals; [--prec-div=false] / [--prec-sqrt=false]
+ * downgrade division and square root. None of those can be undone by a later
+ * flag, so [Cuda_nvrtc] refuses them instead of warning.
+ *
+ * NON-VACUITY. Three separate things keep this from being a test of a constant:
+ *
+ *   1. NEGATIVE SIDE. Options that must stay accepted are asserted accepted --
+ *      including [-ftz=false] and [--prec-div=true], which differ from the
+ *      rejected forms only in the VALUE. A guard that matched on the option
+ *      name alone would pass every rejection case and fail here.
+ *   2. END-TO-END. [compile_to_ptx ~options:["-use_fast_math"]] must raise. The
+ *      guard runs before libnvrtc is touched, so this fires on a host with no
+ *      CUDA installed -- the check is on the real entry point, not only on the
+ *      predicate.
+ *   3. THE HAZARD IS REAL, MEASURED HERE. When nvcc and nvdisasm are on PATH,
+ *      the generated f16 kernel is compiled twice and the SASS compared: with
+ *      [-ftz=true] the binary32 arithmetic must acquire [.FTZ], without it must
+ *      not. That is the divergence the guard exists to prevent, observed rather
+ *      than quoted. Skips cleanly with no CUDA toolchain; host tools only, no
+ *      NVIDIA device required.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Nvrtc = Sarek_cuda.Cuda_nvrtc
+
+(* ------------------------------------------------------------------ *)
+(* The kernel under measurement (same shape as test_cuda_f16_sass)     *)
+(* ------------------------------------------------------------------ *)
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let mk_kernel name params body =
+  {
+    kern_name = name;
+    kern_params = params;
+    kern_locals = [];
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let f16_midround_kernel () =
+  let out = make_var "out" (TVec TFloat16) in
+  let inp = make_var "inp" (TVec TFloat16) in
+  let idx = make_var "idx" TInt32 in
+  let narrowed_product =
+    ECast
+      ( TFloat16,
+        EBinop
+          ( Mul,
+            ECast (TFloat32, EArrayRead ("inp", EVar idx)),
+            EConst (CFloat32 1.1) ) )
+  in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar idx),
+            ECast
+              ( TFloat16,
+                EBinop
+                  ( Add,
+                    ECast (TFloat32, narrowed_product),
+                    EConst (CFloat32 1000.0) ) ) ) )
+  in
+  mk_kernel
+    "f16_midround"
+    [
+      DParam (out, Some {arr_elttype = TFloat16; arr_memspace = Global});
+      DParam (inp, Some {arr_elttype = TFloat16; arr_memspace = Global});
+    ]
+    body
+
+let generated_source () =
+  let k = f16_midround_kernel () in
+  Sarek_codegen.Sarek_ir_cuda.current_framework := None ;
+  Sarek_codegen.Sarek_ir_cuda.current_variants := [] ;
+  Sarek_codegen.Sarek_ir_cuda.generate_with_types ~types:k.kern_types k
+
+(* ------------------------------------------------------------------ *)
+(* 1. Rejection                                                        *)
+(* ------------------------------------------------------------------ *)
+
+(* Every spelling nvcc/nvrtc accepts for the same hazard. Both dash forms,
+   because nvrtc takes either. *)
+let must_reject =
+  [
+    ("-use_fast_math", "subnormal");
+    ("--use_fast_math", "subnormal");
+    ("-ftz=true", "subnormal");
+    ("--ftz=true", "subnormal");
+    ("--ftz=1", "subnormal");
+    ("--prec-div=false", "division");
+    ("-prec-div=0", "division");
+    ("--prec-sqrt=false", "square root");
+  ]
+
+let test_rejected () =
+  List.iter
+    (fun (opt, needle) ->
+      match Nvrtc.fp_rejection_reason opt with
+      | None ->
+          Alcotest.failf
+            "%S must be refused on the CUDA path; the guard accepted it"
+            opt
+      | Some msg ->
+          (* Not merely "some error": the message must name the option and
+             explain the hazard, or a caller cannot act on it. *)
+          let contains hay needle =
+            let n = String.length needle and h = String.length hay in
+            let rec go i =
+              i + n <= h && (String.sub hay i n = needle || go (i + 1))
+            in
+            n = 0 || go 0
+          in
+          if not (contains msg opt) then
+            Alcotest.failf
+              "rejection message for %S does not quote it: %s"
+              opt
+              msg ;
+          if not (contains msg needle) then
+            Alcotest.failf
+              "rejection message for %S does not explain the hazard (expected \
+               %S): %s"
+              opt
+              needle
+              msg ;
+          if not (contains msg "docs/fp-contraction-policy.md") then
+            Alcotest.failf
+              "rejection message for %S does not point at the policy: %s"
+              opt
+              msg)
+    must_reject ;
+  Printf.printf
+    "  guard rejects %d FP-relaxing option spellings, each with a reason\n"
+    (List.length must_reject)
+
+(* ------------------------------------------------------------------ *)
+(* 2. Acceptance — the half that makes rejection non-trivial           *)
+(* ------------------------------------------------------------------ *)
+
+let must_accept =
+  [
+    "--gpu-architecture=compute_75";
+    "--include-path=/opt/cuda/include";
+    "-I/opt/cuda/include";
+    "-DFOO=1";
+    "-ftz=false";
+    "--ftz=false";
+    "--prec-div=true";
+    "--prec-sqrt=true";
+    "-O3";
+    "--extra-device-vectorization";
+    "--std=c++17";
+  ]
+
+let test_accepted () =
+  List.iter
+    (fun opt ->
+      match Nvrtc.fp_rejection_reason opt with
+      | Some msg ->
+          Alcotest.failf
+            "%S is legitimate and must be accepted; the guard refused it: %s"
+            opt
+            msg
+      | None -> ())
+    must_accept ;
+  (* --fmad=true is a real relaxation but is nvrtc's default, so it warns
+     rather than rejects. Both halves matter: it must NOT reject, and it must
+     NOT be silent. *)
+  (match Nvrtc.fp_rejection_reason "--fmad=true" with
+  | Some msg -> Alcotest.failf "--fmad=true must warn, not reject: %s" msg
+  | None -> ()) ;
+  (match Nvrtc.fp_warning_reason "--fmad=true" with
+  | None -> Alcotest.fail "--fmad=true must produce a warning; it was silent"
+  | Some _ -> ()) ;
+  (match Nvrtc.fp_warning_reason "--fmad=false" with
+  | Some msg ->
+      Alcotest.failf
+        "--fmad=false is the safe setting and must be silent: %s"
+        msg
+  | None -> ()) ;
+  Printf.printf
+    "  guard accepts %d legitimate options; --fmad=true warns, --fmad=false is \
+     silent\n"
+    (List.length must_accept)
+
+(* ------------------------------------------------------------------ *)
+(* 3. End-to-end: the real entry point raises, with no CUDA needed     *)
+(* ------------------------------------------------------------------ *)
+
+let test_compile_to_ptx_raises () =
+  let src = generated_source () in
+  match
+    Nvrtc.compile_to_ptx
+      ~name:"guarded"
+      ~arch:"compute_75"
+      ~options:["-use_fast_math"]
+      src
+  with
+  | _ptx ->
+      Alcotest.fail
+        "compile_to_ptx accepted -use_fast_math and compiled; the guard did \
+         not fire on the real entry point"
+  | exception Nvrtc.Fp_conformance_violation msg ->
+      Printf.printf "  compile_to_ptx refused -use_fast_math: %s\n" msg
+  | exception e ->
+      Alcotest.failf
+        "compile_to_ptx must raise Fp_conformance_violation; it raised %s \
+         (which means the guard did not run before libnvrtc was reached)"
+        (Printexc.to_string e)
+
+(* ------------------------------------------------------------------ *)
+(* 4. The hazard, measured (host tools only)                           *)
+(* ------------------------------------------------------------------ *)
+
+let on_path tool =
+  match Unix.system (Printf.sprintf "command -v %s >/dev/null 2>&1" tool) with
+  | Unix.WEXITED 0 -> true
+  | _ -> false
+
+let read_file p =
+  let ic = open_in_bin p in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic ;
+  s
+
+let write_file p s =
+  let oc = open_out_bin p in
+  output_string oc s ;
+  close_out oc
+
+(* [.FTZ] on a binary32 arithmetic mnemonic. Deliberately anchored to FMUL and
+   FADD -- the two instructions the generated kernel actually contains -- so a
+   stray FTZ elsewhere cannot make the control pass. *)
+let ftz_arith_re = Str.regexp "F\\(MUL\\|ADD\\)\\.FTZ"
+
+let has_ftz_arith sass =
+  try
+    ignore (Str.search_forward ftz_arith_re sass 0) ;
+    true
+  with Not_found -> false
+
+let sass_of ~dir ~tag ~extra_flags src =
+  let cu = Filename.concat dir (tag ^ ".cu") in
+  let cubin = Filename.concat dir (tag ^ ".cubin") in
+  let sass = Filename.concat dir (tag ^ ".sass") in
+  write_file cu src ;
+  let rc =
+    Sys.command
+      (Printf.sprintf
+         "nvcc -arch=sm_90 -cubin %s -o %s %s >/dev/null 2>&1"
+         extra_flags
+         (Filename.quote cubin)
+         (Filename.quote cu))
+  in
+  if rc <> 0 then None
+  else
+    let rc =
+      Sys.command
+        (Printf.sprintf
+           "nvdisasm -c %s > %s 2>/dev/null"
+           (Filename.quote cubin)
+           (Filename.quote sass))
+    in
+    if rc <> 0 then None else Some (read_file sass)
+
+let test_ftz_hazard_is_real () =
+  if not (on_path "nvcc" && on_path "nvdisasm") then
+    Printf.printf
+      "  [SKIP] FTZ hazard control: nvcc/nvdisasm not on PATH (host tools, no \
+       device needed)\n"
+  else
+    let dir = Filename.temp_file "sarek_fpc" "" in
+    Sys.remove dir ;
+    Unix.mkdir dir 0o700 ;
+    let src = generated_source () in
+    match
+      ( sass_of ~dir ~tag:"plain" ~extra_flags:"" src,
+        sass_of ~dir ~tag:"ftz" ~extra_flags:"-ftz=true" src )
+    with
+    | None, _ | _, None ->
+        Printf.printf
+          "  [SKIP] FTZ hazard control: the local nvcc could not build sm_90\n"
+    | Some plain, Some ftz ->
+        if has_ftz_arith plain then
+          Alcotest.fail
+            "control is broken: the DEFAULT build already contains FMUL.FTZ / \
+             FADD.FTZ, so this measurement cannot distinguish the flag" ;
+        if not (has_ftz_arith ftz) then
+          Alcotest.fail
+            "control is broken: -ftz=true produced no FMUL.FTZ / FADD.FTZ, so \
+             the option this guard rejects has not been shown to change \
+             anything on this toolchain" ;
+        Printf.printf
+          "  FTZ hazard confirmed on this host: -ftz=true turns the generated \
+           kernel's binary32 FMUL/FADD into FMUL.FTZ/FADD.FTZ at sm_90 \
+           (default build has neither)\n"
+
+let () =
+  Alcotest.run
+    "cuda_fp_conformance"
+    [
+      ( "fp_guard",
+        [
+          Alcotest.test_case
+            "FP-relaxing nvrtc options are refused with a reason"
+            `Quick
+            test_rejected;
+          Alcotest.test_case
+            "legitimate options stay accepted"
+            `Quick
+            test_accepted;
+          Alcotest.test_case
+            "compile_to_ptx itself refuses -use_fast_math"
+            `Quick
+            test_compile_to_ptx_raises;
+          Alcotest.test_case
+            "the flushed-subnormal hazard is real (SASS)"
+            `Quick
+            test_ftz_hazard_is_real;
+        ] );
+    ]

--- a/sarek-hip/Hip_rtc.ml
+++ b/sarek-hip/Hip_rtc.ml
@@ -193,6 +193,10 @@ let check ctx result =
 
 (** Options forced onto EVERY hiprtc compilation.
 
+    The cross-backend rule this implements — and what every OTHER backend does
+    or fails to do about contraction — is [docs/fp-contraction-policy.md]. Read
+    it before changing anything here.
+
     [-ffp-contract=off] is a CONFORMANCE requirement, not a tuning choice. HIP
     (clang) defaults to [-ffp-contract=fast], which lets the backend fuse a
     multiply into the operation that consumes it — including an f32 multiply

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -200,6 +200,10 @@ let float x = float_of_int (Int32.to_int x)
 (******************************************************************************
  * Contraction barrier
  *
+ * Cross-backend policy this implements, including what each OTHER backend does
+ * about contraction and which of those claims are measured rather than
+ * believed: docs/fp-contraction-policy.md.
+ *
  * An error-free transformation is only error-free if the backend compiler
  * evaluates it as written. Floating-point CONTRACTION - fusing a multiply into
  * a neighbouring add or subtract - is enabled by default in PTX, CUDA C and

--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -747,7 +747,34 @@ let cuda_fp16_include =
     [volatile] local also works but spills to scratch, which is why it is not
     used. The price is the un-fused instruction count: 6 VALU ops instead of 2
     per f16 round-trip. Paid only inside kernels that actually narrow to f16 —
-    the declaration is emitted only under [kernel_uses_float16]. *)
+    the declaration is emitted only under [kernel_uses_float16].
+
+    NVIDIA BRANCH: DELIBERATELY EMPTY, and that is a statement about NVIDIA, not
+    an oversight. The non-HIP branch previously carried a PTX-flavoured
+    [asm volatile("" : "+f"(x))]. That barrier was INERT: the assembly template
+    is empty, NVVM erases the block and coalesces the register, and the
+    resulting cubins are byte-identical with and without it. Re-measured for
+    this file's current output on CUDA 13.3 (nvcc/ptxas/nvdisasm V13.3.73,
+    host-side, no NVIDIA device) for sm_75, sm_80, sm_86, sm_89, sm_90, sm_100,
+    sm_120 and sm_121: [cmp] on the cubin says byte-identical on all eight, and
+    the arithmetic stream stays
+    [HADD2.F32 / FMUL / F2FP.F16.F32 / HADD2.F32 / FADD / F2FP.F16.F32] — the
+    f32 multiply and the f32 add both intact and the narrowings separate — with
+    the asm and without it. It was removed rather than kept because a call site
+    reading [sarek_f32_barrier(...)] on the CUDA path advertised a protection
+    that did not exist, and the gap between assumed and actual FP semantics is
+    exactly what produced this bug class.
+
+    WHAT ACTUALLY HOLDS THE GUARANTEE ON NVIDIA: [ptxas] declines to absorb
+    [cvt.rn.f16.f32] into the operation feeding it — hand-written PTX with no
+    inline asm at all gives the same unfused SASS. That is a property of the
+    assembler, not of anything Sarek emits, so it is machine-checked rather than
+    assumed: [sarek-cuda/test/test_cuda_f16_sass.ml] walks generated CUDA ->
+    nvrtc -> PTX -> ptxas -> cubin -> nvdisasm -> SASS on every architecture the
+    local ptxas knows and fails if the discipline breaks. See
+    [docs/fp-contraction-policy.md] and
+    [docs/optimization/cuda-f16-fusion-sass-audit.md]. NO f16 kernel has been
+    EXECUTED on NVIDIA hardware; the claim is a machine-code claim. *)
 let sarek_f32_barrier_decl =
   {|#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)
 __device__ __forceinline__ float sarek_f32_barrier(float x) {
@@ -755,8 +782,12 @@ __device__ __forceinline__ float sarek_f32_barrier(float x) {
   return x;
 }
 #else
+/* NVIDIA: intentionally an identity. A PTX opacity barrier here would be an
+   empty asm block that NVVM erases (cubins byte-identical, measured on CUDA
+   13.3 for sm_75..sm_121). What keeps the f32 multiply out of the narrowing on
+   NVIDIA is ptxas itself, checked by test_cuda_f16_sass.ml — not this
+   function. See docs/fp-contraction-policy.md. */
 __device__ __forceinline__ float sarek_f32_barrier(float x) {
-  asm volatile("" : "+f"(x));
   return x;
 }
 #endif

--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -751,19 +751,42 @@ let cuda_fp16_include =
 
     NVIDIA BRANCH: DELIBERATELY EMPTY, and that is a statement about NVIDIA, not
     an oversight. The non-HIP branch previously carried a PTX-flavoured
-    [asm volatile("" : "+f"(x))]. That barrier was INERT: the assembly template
-    is empty, NVVM erases the block and coalesces the register, and the
-    resulting cubins are byte-identical with and without it. Re-measured for
-    this file's current output on CUDA 13.3 (nvcc/ptxas/nvdisasm V13.3.73,
-    host-side, no NVIDIA device) for sm_75, sm_80, sm_86, sm_89, sm_90, sm_100,
-    sm_120 and sm_121: [cmp] on the cubin says byte-identical on all eight, and
-    the arithmetic stream stays
+    [asm volatile("" : "+f"(x))]. AT A NARROWING it bought nothing, and it was
+    removed because a call site reading [sarek_f32_barrier(...)] on the CUDA
+    path advertised a protection that did not exist — the gap between assumed
+    and actual FP semantics is exactly what produced this bug class.
+
+    Measured for this file's current output on CUDA 13.3 (nvcc/ptxas/nvdisasm
+    V13.3.73, host-side, no NVIDIA device) for sm_75, sm_80, sm_86, sm_89,
+    sm_90, sm_100, sm_120 and sm_121: [cmp] on the cubin says byte-identical on
+    all eight, and the arithmetic stream stays
     [HADD2.F32 / FMUL / F2FP.F16.F32 / HADD2.F32 / FADD / F2FP.F16.F32] — the
     f32 multiply and the f32 add both intact and the narrowings separate — with
-    the asm and without it. It was removed rather than kept because a call site
-    reading [sarek_f32_barrier(...)] on the CUDA path advertised a protection
-    that did not exist, and the gap between assumed and actual FP semantics is
-    exactly what produced this bug class.
+    the asm and without it.
+
+    WHY, precisely. The first version of this note got it wrong twice, and both
+    corrections matter to anyone reusing this function:
+
+    - NVVM does NOT erase the block. The barriered PTX keeps the
+      [// begin/end inline asm] marker pair and allocates more virtual registers
+      ([%f<9>] against [%f<5>]). What it contributes is ZERO PTX INSTRUCTIONS,
+      so ptxas receives an identical instruction stream either way — which makes
+      the identical cubins structural, not a 13.3 accident.
+    - The barrier is NOT inert in general. On
+      [out[i] = sarek_f32_barrier(a[i]*b[i]) + c[i]] it IS a real NVVM-level
+      contraction barrier: [mul.f32]+[add.f32] with it, [fma.rn.f32] without.
+      Measured at sm_90. But ptxas -O1 and above RE-CONTRACT that back to [FFMA]
+      under the default [-fmad=true] ([-O0] and [--fmad=false] do not), so the
+      cubins are byte-identical there too.
+
+    CONSEQUENCE, and it is a trap: do NOT reach for [sarek_f32_barrier] to fix
+    the caller-side df64 contraction hazard on NVIDIA. It protects the PTX and
+    ptxas undoes it. [Sarek_df64]'s [mul_rn] works because an fma cannot be
+    fused a second time — a property of the instruction, not of a barrier.
+
+    At the f16 narrowing there is nothing for either level to fuse in the first
+    place: NVIDIA has no fused multiply-and-convert-to-f16 instruction, which is
+    why the emitted code is unchanged there under every flag tried.
 
     WHAT ACTUALLY HOLDS THE GUARANTEE ON NVIDIA: [ptxas] declines to absorb
     [cvt.rn.f16.f32] into the operation feeding it — hand-written PTX with no
@@ -782,11 +805,14 @@ __device__ __forceinline__ float sarek_f32_barrier(float x) {
   return x;
 }
 #else
-/* NVIDIA: intentionally an identity. A PTX opacity barrier here would be an
-   empty asm block that NVVM erases (cubins byte-identical, measured on CUDA
-   13.3 for sm_75..sm_121). What keeps the f32 multiply out of the narrowing on
-   NVIDIA is ptxas itself, checked by test_cuda_f16_sass.ml — not this
-   function. See docs/fp-contraction-policy.md. */
+/* NVIDIA: intentionally an identity. A PTX opacity barrier here contributes
+   zero PTX instructions at a narrowing, so ptxas sees the same instruction
+   stream and the cubins are byte-identical (measured on CUDA 13.3, sm_75..
+   sm_121). What keeps the f32 multiply out of the narrowing on NVIDIA is ptxas
+   itself, checked by test_cuda_f16_sass.ml — not this function. NOTE the same
+   barrier IS load-bearing at PTX level for mul->add, but ptxas re-contracts
+   that under the default -fmad=true; do not reuse it as a general contraction
+   barrier here. See docs/fp-contraction-policy.md. */
 __device__ __forceinline__ float sarek_f32_barrier(float x) {
   return x;
 }

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -839,7 +839,21 @@ and gen_var_decl buf indent v_name v_type init_expr =
      NoContraction). Without it some drivers (observed: RADV via glslang)
      simplify error-free transformations like Dekker/Knuth TwoSum, breaking
      algorithms that rely on IEEE-exact rounding of each operation. This
-     matches CUDA/OpenCL codegen semantics (no fast-math contraction). *)
+     matches CUDA/OpenCL codegen semantics (no fast-math contraction).
+
+     WHAT THIS DOES AND DOES NOT BUY, precisely. The FRONT END honours it:
+     measured with glslc 2026.2 / SPIRV-Tools 1.4.350.1 on the generated
+     matrix_mul shader, the SPIR-V carries 2 NoContraction decorations with
+     [precise] and 0 without. NoContraction is then a requirement on the SPIR-V
+     CONSUMER, i.e. the driver, and whether a given driver honours it is NOT
+     established in this repository — the note above and the campaign notes
+     disagree, and neither has a reproducible in-tree measurement behind it.
+     docs/fp-contraction-policy.md section 6 records the disagreement and the
+     experiment that would settle it. Do not restate either side as fact.
+
+     Separately and independently: RADV's GLSL [fma] is not correctly rounded,
+     so Sarek_df64 mul/div sit at ~5.8e-08 there whatever this qualifier does
+     (RX 7900 XTX, Mesa 26.1.4-arch3.1). *)
   (match v_type with
   | TFloat32 | TFloat64 -> Buffer.add_string buf "precise "
   | _ -> ()) ;

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -191,14 +191,18 @@ let test_f16_conversions () =
      value in a VGPR ahead of the ISel combine that fuses. *)
   check_contains "AMDGPU constraint" src "asm volatile(\"\" : \"+v\"(x))" ;
   (* NVIDIA is where it is NOT, and that asymmetry is asserted rather than left
-     to a reader's assumption (#110). The non-HIP branch used to carry a PTX
-     "+f" variant; it was an empty asm template that NVVM erased, so the cubins
-     were byte-identical with and without it — measured on CUDA 13.3
+     to a reader's assumption (#110), and it is scoped to the NARROWING: the
+     non-HIP branch used to carry a PTX "+f" variant, which contributes zero PTX
+     instructions there, so ptxas sees an identical instruction stream and the
+     cubins were byte-identical with and without it — measured on CUDA 13.3
      (nvcc/ptxas/nvdisasm V13.3.73, host-side, no NVIDIA device) for sm_75
      through sm_121. Keeping a no-op that reads as protection is what this
      assertion forbids. What actually keeps the multiply out of the narrowing
      on NVIDIA is ptxas, machine-checked by
-     sarek-cuda/test/test_cuda_f16_sass.ml; see docs/fp-contraction-policy.md. *)
+     sarek-cuda/test/test_cuda_f16_sass.ml. NOTE the same barrier is NOT inert
+     at a mul->add site (PTX mul.f32+add.f32 instead of fma.rn.f32) — but ptxas
+     re-contracts that under the default -fmad=true, so it is still not a usable
+     contraction barrier on NVIDIA. See docs/fp-contraction-policy.md. *)
   check_absent "no inert PTX barrier" src "\"+f\"" ;
   check_contains
     "NVIDIA branch documents why it is empty"

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -187,11 +187,23 @@ let test_f16_conversions () =
     "barrier is declared"
     src
     "__device__ __forceinline__ float sarek_f32_barrier(float x)" ;
-  (* Both toolchains, because the register constraint is target-specific: "v"
-     for AMDGPU VGPRs, "f" for PTX .f32. A single-platform barrier would leave
-     the other backend silently fusing again. *)
+  (* AMDGPU is where the barrier is load-bearing: the "v" constraint pins the
+     value in a VGPR ahead of the ISel combine that fuses. *)
   check_contains "AMDGPU constraint" src "asm volatile(\"\" : \"+v\"(x))" ;
-  check_contains "PTX constraint" src "asm volatile(\"\" : \"+f\"(x))" ;
+  (* NVIDIA is where it is NOT, and that asymmetry is asserted rather than left
+     to a reader's assumption (#110). The non-HIP branch used to carry a PTX
+     "+f" variant; it was an empty asm template that NVVM erased, so the cubins
+     were byte-identical with and without it — measured on CUDA 13.3
+     (nvcc/ptxas/nvdisasm V13.3.73, host-side, no NVIDIA device) for sm_75
+     through sm_121. Keeping a no-op that reads as protection is what this
+     assertion forbids. What actually keeps the multiply out of the narrowing
+     on NVIDIA is ptxas, machine-checked by
+     sarek-cuda/test/test_cuda_f16_sass.ml; see docs/fp-contraction-policy.md. *)
+  check_absent "no inert PTX barrier" src "\"+f\"" ;
+  check_contains
+    "NVIDIA branch documents why it is empty"
+    src
+    "NVIDIA: intentionally an identity" ;
   ()
 
 let test_non_f16_kernel_unchanged () =


### PR DESCRIPTION
Closes #116, #110, #111.

## Why

Floating-point contraction is the root cause behind three separate defects in this project, and there was no written policy. The three were: an AMDGPU ISel combine (`v_fma_mixlo_f16` + `v_add_f16`) that sits **below** `-ffp-contract` and made f16 narrowing disagree with the interpreter on 620 of 63488 finite binary16 inputs; `ptxas` contracting `quick_two_sum`'s multiply into both FFMA consumers, collapsing `df64` mul/div to plain f32 for four years; and the Vulkan mul/div deviation that looks exactly like contraction from the outside but is not.

All three lived in the gap between the FP semantics we assumed a backend had and the ones it actually had.

## `docs/fp-contraction-policy.md` (#116)

Per backend: what the compiler may contract, what mechanism (if any) actually prevents it, whether that mechanism is **verified** or merely **believed**, and what a Sarek DSL author may rely on. The interpreter is stated explicitly as the cross-backend oracle, including how it rounds and where its own double rounding is benign.

Evidence is tiered — `executed` / `machine-code` / `compiler-output` / `by-construction` / `unverified` — and every claim names the device **and** toolchain. Results measured elsewhere are labelled quoted.

Where a guarantee does not exist, the document says so rather than papering over it:

- **Metal** compiles with fast math on and `mtl_device_new_library_with_source` ignores its `_options` argument entirely. Metal float results are outside the guarantee.
- **WGSL** is unconstrained and untested.
- **Whether Mesa RADV/ANV honour `NoContraction` is unresolved**, and the two things written down about it in this repo contradict each other. The document records the disagreement, explains why the known RADV `df64` deviation has a *different* (fma-quality) cause, and writes down the experiment that would settle it. It does not pick a side.
- A caller-side hazard no gate in this repo can see: `df64_add_f32 acc (x *. y)` re-creates the fusable pattern the library removed from its own bodies.

## #110 — the CUDA `"+f"` barrier is removed

**Recommendation: delete it** (keeping the identity function, which the shared `#if` source needs for HIP). It advertised a protection that did not exist on NVIDIA, and this repo has paid three times for exactly that distance between advertised and actual semantics.

**The argument that settles it is structural, not a CUDA-13.3 coincidence.** At the call site the asm block contributes **zero PTX instructions** — the emitted PTX differs only by `// begin/end inline asm` markers and virtual-register renumbering (`%f<9>` vs `%f<5>`), so `ptxas` receives an *identical instruction stream* either way. The byte-identical cubins follow from that, they are not evidence for it. (Credit to the adversarial review for this framing; my original wording said "NVVM erases the block", which is **wrong** — NVVM keeps it. Corrected everywhere, including in the #107 audit doc that first said it.)

Supporting measurements (CUDA 13.3, `nvcc`/`ptxas`/`nvdisasm` V13.3.73, host-side, **no NVIDIA device**), on the codegen's current output:

- cubins **byte-identical** (`cmp`) with the asm and with `return x;` on **sm_75, sm_80, sm_86, sm_89, sm_90, sm_100, sm_120, sm_121**; SASS identical under `diff`.
- The identity variant is still unfused: `HADD2.F32 / FMUL / F2FP.F16.F32 / HADD2.F32 / FADD / F2FP.F16.F32`.
- The full `test_cuda_f16_sass` gate still reports `f32 discipline intact on 7/7 architectures`.

**"Inert" is now scoped to the narrowing, because in general it is false.** Measured at sm_90 on `out[i] = sarek_f32_barrier(a[i]*b[i]) + c[i]`:

| | PTX | SASS (`-fmad=true`, default) | SASS (`-fmad=false`) |
|---|---|---|---|
| without barrier | `fma.rn.f32` | `FFMA` | `FMUL` + `FADD` |
| with barrier | `mul.f32` + `add.f32` | `FFMA` | `FMUL` + `FADD` |

So at a `mul`→`add` site it **is** a real NVVM-level contraction barrier — and `ptxas -O1`+ re-contracts it back to `FFMA` anyway, leaving the cubins identical again. The trap this creates is now stated at every site: **do not reuse `sarek_f32_barrier` against the caller-side `df64` hazard on NVIDIA** — it protects the PTX and `ptxas` undoes it; `mul_rn` works because an `fma` cannot be fused twice. At the f16 narrowing there is nothing for either level to fuse: NVIDIA has no fused multiply-and-convert-to-f16.

## #111 — the guard, after a confirmed bypass was closed

**The first version was spelling-shaped and had a real hole.** nvrtc accepts an option and its value as two array elements; the guard matched only the inline form. Reproduced here against **real `libnvrtc.so.13.3`** through the repo's own bindings:

| option array | compiles? | `.ftz` in emitted PTX | guard as first shipped | guard now |
|---|---|---|---|---|
| `["--ftz=true"]` | — | — | REJECT | REJECT |
| `["--ftz"; "true"]` | **yes** | **yes** | **accept** ← bypass | REJECT |
| `["-ftz"; "true"]` | **yes** | **yes** | **accept** ← bypass | REJECT |
| `["--prec-div"; "false"]` | yes | n/a | accept | REJECT |
| `["--ftz"; "false"]` (safe) | yes | no | accept | accept |

The scan is now **list-level**: a value-taking name consumes the following array element when there is no `=`, and is **fail-closed** — a bare `--ftz` whose value cannot be resolved is refused, because a guard that cannot tell what a flag is set to must not assume the safe answer. (`Hip_rtc.fp_relaxing_option_prefixes` never had this hole; it matches by prefix on options whose value is always inline.) The safe separated forms are asserted still accepted, so the fix cannot degenerate into name-only matching.

`Cuda_nvrtc.check_fp_conformance` rejects `use_fast_math` (any spelling), `ftz=true|1`, `prec-div=false|0`, `prec-sqrt=false|0`; `fmad=true` warns. Applied at **the point an option array reaches `nvrtcCompileProgram`** — so it screens flags this module adds itself — plus a fail-fast copy at `compile_to_ptx` entry that works on a host with no CUDA. `compile_to_ptx` now destroys the nvrtc program if the chokepoint guard raises, instead of leaking the handle.

**The hazard is real, measured here:** the generated `f16_midround` kernel at sm_90 has plain `FMUL`/`FADD` by default and `FMUL.FTZ`/`FADD.FTZ` under `-ftz=true`.

**Red proved on every check**, by mutating the thing under test:

| mutation | went red | message |
|---|---|---|
| drop `use_fast_math` from the reject list | rejection | `"-use_fast_math" must be refused on the CUDA path; the guard accepted it` |
| match on option name, ignore its value | acceptance | `"-ftz=false" is legitimate and must be accepted; the guard refused it` |
| remove both `check_fp_conformance` calls | end-to-end | `compile_to_ptx accepted -use_fast_math and compiled; the guard did not fire on the real entry point` |
| build the "ftz" SASS variant without `-ftz=true` | hazard control | `control is broken: -ftz=true produced no FMUL.FTZ / FADD.FTZ ...` |
| restore the per-element matcher | end-to-end | the separated form compiles again with `.ftz` in the PTX — the bypass reproduced on demand |
| drop the option under test from the assembled array | assembled-array | `the assembled array no longer contains the option under test, so this check proves nothing` |
| reinstate the `"+f"` asm | golden (#110) | `no inert PTX barrier: expected NOT to find "\"+f\""` |

**Skip-as-pass fixed.** `test_ftz_hazard_is_real` printed `[SKIP]` and returned, which Alcotest reports as `[OK]` — regressing the convention landed one commit earlier on this branch (`cf58801b`). Now `Alcotest.skip ()`, verified both ways: with the tools present it measures and prints `[OK]`; with `nvcc`/`nvdisasm` off `PATH` the runner prints `[SKIP]`.

## CI was not running the gate this PR depends on

`nvdisasm` ships in `cuda-nvdisasm`, **not** in `cuda-nvcc`. Confirmed by running `command -v nvdisasm` inside the built CI image, where `ptxas` and `nvcc` both resolve and `nvdisasm` does not. So `test_cuda_f16_sass` — the machine-check the entire #110 argument substitutes for the deleted barrier — **self-skipped in CI while reporting green**, and nothing could ever have surfaced a 12.6-vs-13.3 `ptxas` divergence, since 12.6 is exercised only there.

`ci/Dockerfile` now installs `cuda-nvdisasm-12-6`, and `ci/assert-toolchain.sh` asserts `nvdisasm` with a `ptxas`→`nvdisasm` probe (not just a version banner). Proved red against the CI image as it exists today:

```
::error::nvdisasm is not on PATH. The f16 SASS conformance gate in
test_cuda_f16_sass.ml will self-skip and CI will validate nothing about
f32-discipline in generated f16 kernels. Install cuda-nvdisasm-12-6.
```

and green on this host. Until an image built with this change has run, every "the gate checks this" statement holds at **CUDA 13.3 only** — §7 of the policy says so.

## Two numbers reconciled

The doc quoted **620** and **373** four lines apart. 620 is the device/interpreter disagreement count from the AMDGPU fusion (`test_hip_f16.ml`) and is now the only figure used, labelled quoted. **373** appears in-tree for two *other* populations that are not consistent with each other — `Hip_rtc.ml` attributes it to inputs where `-ffp-contract=off` changed the result, `test_hip_f16.ml` to inputs where the test's own old f64-intermediate reference disagreed with the f32 one. One is a slip; the doc flags it as unresolved rather than picking.

## Fresh measurements taken for this PR

- RX 7900 XTX under **RADV, Mesa 26.1.4-arch3.1**: `df64` mul 5.84e-08, div 5.86e-08, add 5.33e-15, sub 6.51e-15, sqrt 1.08e-14 — against the interpreter's mul 9.07e-15 / div 5.08e-15 in the same run.
- RX 7900 XTX under **Mesa radeonsi OpenCL**: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 (contract met).
- **glslc 2026.2 / SPIRV-Tools 1.4.350.1**: the Sarek-generated `matrix_mul` shader yields 2 `NoContraction` decorations with `precise`, 0 without.
- **CUDA 13.3 host tools**: the 8-architecture cubin comparison, the FTZ hazard, and the `mul`→`add` PTX/SASS table above.
- **libnvrtc 13.3 through the repo's bindings**: the separated-form bypass, reproduced and then closed.
- **The built CI image**: `nvdisasm` absent while `ptxas`/`nvcc` present.

## Not verified — needs NVIDIA hardware

- **No f16 CUDA kernel has ever been executed on an NVIDIA GPU.** The f16 interpreter-agreement claim is HIP-only; what is settled is the machine code.
- Offline `ptxas` is not the **driver JIT** that assembles the PTX `cuModuleLoadData` loads.
- Every CUDA figure here is **CUDA 13.3**; CI runs 12.6. If the SASS gate ever fails at 12.6 while passing at 13.3, that difference is the finding.
- `FMUL.FTZ` was observed; a **wrong answer** from subnormal flushing was not — that needs execution.
- `Sarek_df64`'s **`sqrt` residual on NVIDIA** (1.42e-14 / 1.68e-14 / 1.81e-14) stays unexplained; the `sqrt.approx.f32` hypothesis needs a device to test.
- **Metal is entirely unverified** (no Apple hardware) and is the one backend currently compiled with fast math on.
- Whether **RADV/ANV honour `NoContraction`** — the experiment is written down, not run. **ANV needs hardware this machine does not have** (AMD only), and the doc now also warns that its inputs must be chosen against the device's *measured* `fma`, since RADV's is not correctly rounded and a naive choice can return a false "they agree".

## Verification

Full `dune build` clean. Green after the change: `test_cuda_fp_conformance`, `test_cuda_f16_sass`, `test_cuda_f16_nvrtc`, `test_cuda_nvrtc_gate`, `test_cuda_f16_golden`, `test_codegen_golden`, `test_hip_rtc_options`, `test_df64` (all exit 0). No behaviour change on any path except the two intended ones.

Note: `dune build @fmt` also wants to reformat `sarek/core/Device.ml`, `sarek/interp/Sarek_float32.ml` and `sarek/tests/unit/test_ir_layout.ml`. That drift is pre-existing on `main` and untouched here, to keep the diff readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
