### PR TITLE
fix(review-tools): make the convergence gate and mandated steps fail closed (#98, #104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
           set -e
           node scripts/review-verdict-assemble.test.js
           node scripts/xruntime-caller-fault.test.js
+          # The #98 local patch's covering test. It is what attests that the
+          # convergence gate still fails closed, so it has to be a test something
+          # actually runs — a `make` target nobody invokes is not that.
+          node scripts/check-review-convergence-hardening.test.js
+          node scripts/check-mandated-steps.test.js
           node scripts/check-alcotest-registration.test.js
           ./scripts/check-review-bundle-tracked.test.sh
           ./scripts/agent-worktree-bootstrap.test.sh

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,24 @@ test_sarek_core:
 test-all: test test_spoc test_sarek_core test_interpreter test_negative check-opam-clean
 	@echo "=== All tests passed ==="
 
+# Review-pipeline gate contracts. Kept OUT of test-all on purpose: test-all runs
+# the GPU suites, and these must stay checkable on a machine with no GPU. Node
+# only, no framework, no network.
+#
+# Each suite constructs inputs that SHOULD be rejected and asserts the refusal —
+# schema/review-json-schema.md and schema/mandated-steps-schema.md are the
+# contracts under test. They need the review-tool bundle installed
+# (scripts/REVIEW-BUNDLE.md) and FAIL rather than skip when it is absent, because
+# a skipped contract check reads exactly like a passing one.
+.PHONY: test-review-tools
+test-review-tools:
+	@echo "=== Review-pipeline gate contracts (no GPU, no network) ==="
+	node scripts/review-verdict-assemble.test.js
+	node scripts/check-review-convergence-hardening.test.js
+	node scripts/check-mandated-steps.test.js
+	node scripts/review-bundle-verify.js
+	@echo "=== Review-tool contracts hold ==="
+
 # E2E tests - quick verification with small datasets comparing GPU vs native CPU
 # removed test for v2 compatibilit: test_histogram
 E2E_TESTS = test_stencil test_matrix_mul test_reduce  \

--- a/schema/mandated-steps-schema.md
+++ b/schema/mandated-steps-schema.md
@@ -79,10 +79,44 @@ node scripts/check-mandated-steps.js --task <slug> --phase implement
 |---|---|
 | `plan` | `human-gate` |
 | `implement` | `preflight` |
-| `review` | `preflight`, `scope-gate`, `xruntime` |
+| `review` | — (see below) |
 | `qa` | `preflight` |
 | `ship` | `preflight`, `human-gate` |
 | `intake` `question` `research` `spec` | — (records are still validated) |
+
+### Why `review` mandates nothing — measured, not assumed
+
+The first draft mandated `scope-gate` and `xruntime` on `review`. Measuring against the real
+artifacts in `briefs/` before shipping killed that:
+
+| Signal | Count |
+|---|---|
+| verdict files | 36 |
+| journaled `rounds_audit` rounds | 30 |
+| review trace files | 16 |
+| `scope-gate` trace events | 9 |
+| `cross-runtime` trace events | **1** |
+| verdicts recording `cross_runtime` | 3 (0 with `status: "healthy"`) |
+
+The requirement would have fired on nearly every round. Under this ledger a `skipped` record
+discharges it, so it would never have been *unsatisfiable* — but a requirement discharged by
+boilerplate nine rounds out of ten is an alarm people learn to paste past, which is the same
+failure as one they learn to ignore.
+
+The decisive reason is the second one: **both obligations already have an authoritative enforcer.**
+`review-trace-rules.js` requires a `scope-gate` trace line whenever `mode === "full"`
+(`computeRequiredCoverage`) and corroborates every claimed probe against the xruntime journal
+(`computeCrossRuntimeCorroboration`, exit 1 `unattested-invocation`). Mandating them here as well
+would be a second, weaker record of a fact that already has a stronger one — and two records of the
+same fact drift apart.
+
+Both remain **recordable**, opt-in via `--require scope-gate,xruntime`. `degraded-specialist` is
+recordable but never required: a step that may legitimately never occur cannot have its absence
+read as a skip.
+
+(Method borrowed from PR #305's F9, which measured a proposed phase-order rule against 34 real
+ledgers, found it flagged 7 legitimately, and shipped it as a documented limitation rather than an
+alarm.)
 
 `--require <step,step>` overrides the table. An **unknown phase is rejected**, never defaulted to
 "nothing required" — that default would itself be a gate that cannot fail, since a typo'd phase

--- a/schema/mandated-steps-schema.md
+++ b/schema/mandated-steps-schema.md
@@ -1,0 +1,103 @@
+# `briefs/<task>-steps.jsonl` — the mandated-step ledger
+
+The contract for recording that a mandated pipeline step ran, or that it was skipped and why.
+Enforced by `scripts/check-mandated-steps.js`; rules in `scripts/lib/mandated-steps-rules.js`;
+proof-of-rejection cases in `scripts/check-mandated-steps.test.js`.
+
+## Why this exists
+
+A mandated step that is skipped without leaving a record is **indistinguishable from one that ran
+and passed**. Nothing in the artifacts separates the two, so the skip reads as a pass forever after.
+
+Three real instances, all from the same friction log:
+
+- `roster-run` Step 4 mandates `/roster-doctor preflight` before any phase that builds or tests. It
+  was not run across an entire day of implementation work — and the environment had three real
+  problems it would have surfaced: a local `main` three commits stale, a wedged Docker daemon, and
+  a partially-upgraded opam switch breaking a bytecode link. Nothing recorded that it had not run.
+- The `roster-ship` human gate was skipped under a standing autonomy delegation. Legitimate — but
+  it entered the record as though a human had answered, erasing exactly the distinction the gate
+  exists to preserve.
+- The cross-runtime pass, mandatory on every Fast/Full PR, was disabled by its own circuit breaker
+  on a caller-side fault; the round then looked like one on which cross-runtime simply had nothing
+  to say.
+
+This is the same defect as the review gate's silent degradation
+(`schema/review-json-schema.md` §"Why this document exists"), one level up: a green that means
+"not checked", not "checked out".
+
+**Skipping is allowed. Skipping silently is not.**
+
+## Record shape
+
+One JSON object per line. Append with the tool — never hand-write the file:
+
+```bash
+node scripts/check-mandated-steps.js --record --task <slug> \
+  --step preflight --outcome ran --result READY --actor agent
+
+node scripts/check-mandated-steps.js --record --task <slug> \
+  --step human-gate --outcome skipped --actor agent \
+  --reason "standing autonomy delegation for session 2026-07-25; user AFK"
+```
+
+| Field | Rule |
+|---|---|
+| `ts` | full ISO-8601, stamped by the writer |
+| `task` | the task slug; a record stamped with another task is rejected |
+| `step` | one of the known ids below. An **unknown id is rejected** — a typo can never stand in for the step it resembles |
+| `outcome` | `ran` \| `skipped` |
+| `actor` | `human` \| `agent` — a skip must be attributable |
+| `result` | required when `outcome: ran`: `READY` \| `NOT-READY` \| `PASS` \| `FAIL` \| `N/A` |
+| `reason` | required when `outcome: skipped`, and when `result` is `NOT-READY` or `FAIL` |
+| `phase` | optional, informational |
+
+`NOT-READY` is a first-class recordable result: a preflight that ran and found the environment
+broken is evidence, and must not be indistinguishable from one that found it healthy.
+
+### Known steps
+
+| Step | Meaning |
+|---|---|
+| `preflight` | `/roster-doctor preflight` — required before any phase that builds or tests |
+| `human-gate` | the human validation quiz (`rules/human-validation.md`). **Human-only** |
+| `xruntime` | the cross-runtime review pass (mandatory on Fast/Full PRs) |
+| `scope-gate` | `check-scope-diff.sh` — the out-of-scope-change gate |
+| `degraded-specialist` | a conditional specialist selected but unable to run. Repeatable |
+
+**`human-gate` may not be recorded as `ran` by `actor: "agent"`.** An agent proceeding under a
+standing delegation records `outcome: "skipped"`, `actor: "agent"`, with the delegation as its
+reason — so an agent's decision is never journaled as a human's.
+
+## Checking
+
+```bash
+node scripts/check-mandated-steps.js --task <slug> --phase implement
+```
+
+| Phase | Mandates |
+|---|---|
+| `plan` | `human-gate` |
+| `implement` | `preflight` |
+| `review` | `preflight`, `scope-gate`, `xruntime` |
+| `qa` | `preflight` |
+| `ship` | `preflight`, `human-gate` |
+| `intake` `question` `research` `spec` | — (records are still validated) |
+
+`--require <step,step>` overrides the table. An **unknown phase is rejected**, never defaulted to
+"nothing required" — that default would itself be a gate that cannot fail, since a typo'd phase
+would demand nothing.
+
+| Exit | Meaning |
+|---|---|
+| 0 | every mandated step has exactly one valid record |
+| 1 | a mandated step has no record, or a record is invalid — the gate's "no" |
+| 2 | usage error, unknown phase/step, or an unreadable/malformed ledger — fail closed |
+
+An **absent ledger is exit 1** with every requirement listed, never exit 0: "no file" is the
+strongest possible form of "nothing was recorded". A malformed line is exit 2, never a silently
+dropped record — dropping it would reintroduce the defect on the checker's own side.
+
+Deliberately **not** enforced: whether a `reason` is a *good* reason. That is a human judgement.
+What is enforced is that one exists, that it is attributable, and that an agent's decision is never
+recorded as a human's.

--- a/schema/review-json-schema.md
+++ b/schema/review-json-schema.md
@@ -142,12 +142,12 @@ green you used to be getting is the point of the table.
 | `round` | exit 2 unless `--allow-legacy` | non-number / negative / non-finite → exit 2 | skipped strike + `rounds_audit` + trace checks, warned, exit 0 |
 | `no_go_round` | exit 2 unless `--allow-legacy` | non-number / negative → exit 2 | defaulted to `0`; the cap could never fire |
 | `cycle` | exit 2 (non-legacy) | non-number / `< 1` → exit 2 | `null`; every trace line classified as prior-cycle |
-| `findings` | `[]`, legacy-safe | present but not an array → exit 2 | already fail-closed (FIX-A/CGF-1) |
-| `rounds_audit` | treated as `[]` | non-array → exit 2; a gap in rounds `2..round-1` → exit 3 | non-array read as `[]`; a gap erased the streak |
+| `findings` | exit 2 (non-legacy) | non-array → exit 2; a non-object **element** → exit 2 | absent read as `[]`; elements unchecked |
+| `rounds_audit` | exit 2 (non-legacy) | non-array → exit 2; a non-object element or one with no numeric `round` → exit 2; a gap in rounds `2..round-1` → exit 3 | absent/non-array read as `[]`; a gap erased the streak; elements unchecked |
 | `task` | exit 2 (non-legacy) | not a `validSlug` → exit 2 | load-bearing only on a trace-obligated round |
-| `mode` | no scope-gate trace line required | outside `express\|fast\|full` → exit 2 | any other value read exactly like absent |
+| `mode` | exit 2 (non-legacy) | outside `express\|fast\|full` → exit 2 | absent **dropped** the scope-gate trace obligation (G15); any other value read exactly like absent |
 | `normalized_by` | exit 2 (non-legacy) | non-string / empty → exit 2 | a conditional warning |
-| `cross_runtime` | no corroboration | non-object → exit 2; unknown `status` → exit 2; `digest` without `config_digest` → exit 2 | non-object ignored; statuses unvalidated |
+| `cross_runtime` | exit 2 (non-legacy) | non-object or `null` → exit 2; unknown **or absent** entry `status` → exit 2; `digest` without `config_digest` → exit 2 | non-object ignored; `null` explicitly exempted; statuses unvalidated |
 | `streak_override` | no override | anything not `{round: <this round>, by: "human"}` → no override | unchanged |
 
 Three more keys are **validated but not acted on** — they route, and an unvalidated routing key is a
@@ -155,9 +155,9 @@ step that silently does nothing:
 
 | Key | Rule |
 |---|---|
-| `status` | outside `GO\|NO-GO` → exit 2. `GO` while the gate reports a design violation → `go-with-design-violation`, exit 1 |
+| `status` | **absent → exit 2** (its absence disarmed the GO-consistency check entirely, G15); outside `GO\|NO-GO` → exit 2. `GO` while the gate reports a design violation → `go-with-design-violation`, exit 1 |
 | `no_go_reason` | absent on a `NO-GO` → exit 2; `type` outside the routing enum → exit 2; `cause` outside the cause enum → exit 2 |
-| `cross_runtime_findings` | non-array → exit 2; entries are ratchet-checked like `findings`; a `CRITICAL`/`HIGH` `OPEN` entry not mirrored into `findings[]` → `unmirrored-cross-runtime-finding`, exit 1 |
+| `cross_runtime_findings` | **absent → exit 2**; non-array or a non-object element → exit 2; entries are ratchet-checked like `findings`; a `CRITICAL`/`HIGH` `OPEN` entry not mirrored into `findings[]` → `unmirrored-cross-runtime-finding`, exit 1 |
 
 Findings in **both** arrays must carry a `status` inside `OPEN\|RESOLVED\|ACCEPTED`; anything else is
 exit 2, because the gate only ever compares against `RESOLVED` and `ACCEPTED` and a near-miss
@@ -580,6 +580,38 @@ Three further holes, found auditing the same file and not previously recorded:
 | G3 | An absent `round` skipped strike, `rounds_audit` and trace checks and exited 0. | Exit 2 unless `--allow-legacy` records the skip. |
 | G5 | A **gap** in `rounds_audit` (e.g. round 3 → round 7) left the skipped rounds out of the strike map and erased the streak, with no warning, because `computeMissingStrikeWarnings()` only inspects entries that exist. | `missing-past-audit` over `2..round-1` → exit 3. |
 | G13 | `rounds_audit` and `cross_runtime` were coerced (`Array.isArray(x) ? x : []`, `typeof x === "object" \|\| return`), so a wrong type emptied the check instead of failing it. | Present-but-wrong-type → exit 2. |
+
+### G14/G15 — the hardening module had the defect it was written to fix
+
+Found in review (finding F4) *after* D1–D11 and G3/G5/G13 were closed and green.
+
+`checkEnvelopeKeys()` guarded `mode` and `status` with `has(review, key) && !VALID.has(value)` —
+**inspecting only keys that exist** — three lines below a comment calling these keys ones "whose
+omission used to remove an obligation rather than fail one". So the fix closed the malformed half
+and left the omission half open:
+
+```console
+mode: "Full" (typo)  ->  exit 2, "not one of express | fast | full (D5)"
+mode key OMITTED     ->  exit 0, violations: []
+```
+
+The dropped obligation was real: `review-trace-rules.js` requires the `scope-gate` trace line only
+when `mode === "full"`, so omitting the key *removed* the requirement. `status` omitted likewise
+disarmed the GO-consistency check outright, whose first line is `if (review.status !== "GO")`.
+
+The treatment inside a single function was inconsistent — **3 of 5**. `cycle`, `task` and
+`normalized_by` did check absence; `mode` and `status` did not. That inconsistency is the tell:
+each guard was hand-written, so "is it required" and "is it well-formed" were two independent
+decisions per key, and getting three of five right looked complete.
+
+| # | Hole | Now |
+|---|---|---|
+| G14 | Element types were unchecked inside typed containers. Every consumer opens with `if (!e \|\| typeof e !== "object") continue`, so a `null` or `"x"` element in `findings` / `cross_runtime_findings` / `rounds_audit` is skipped **in silence** — not a missing entry, an entry that cannot be seen. It surfaced as a `missing-past-audit` gap only when G5 happened to notice the hole left behind. | Malformed element → exit 2, naming the index. A `rounds_audit` element with no numeric `round` is rejected for the same reason. |
+| G15 | Absence-blindness in the required-key guards themselves (`mode`, `status`), plus the lesser members: an omitted `cross_runtime_findings` / `rounds_audit` / `cross_runtime` / `findings` key, a `cross_runtime` entry with **no** `status` (never corroborated, so a probe that did not run reads like one that did), and an explicit `!== null` carve-out that granted `cross_runtime: null` exactly the "silently ignored" treatment the same function's message condemned. | All exit 2. Presence and well-formedness are now **one** table-driven decision per key (`REQUIRED_ENVELOPE_KEYS`), so a key cannot be added with half a guard. |
+
+**The general lesson, which is the same one G5 taught:** a check written as "if the value is wrong,
+fail" is structurally incapable of noticing that there is no value. Writing these by hand produces
+absence-blindness by default — not occasionally.
 
 Two more notes on the enforcer itself, neither a discrepancy:
 

--- a/schema/review-json-schema.md
+++ b/schema/review-json-schema.md
@@ -14,8 +14,10 @@ The nested shapes live in real JSON Schema files and are not restated here:
 | one line of `briefs/<task>-review-trace.jsonl` | `schema/review-trace.schema.json` |
 
 The envelope itself has no machine-checkable schema. `scripts/check-review-convergence.js` is its
-only enforcer, and it enforces ten keys (below). Everything else in the envelope is enforced by
-prose alone.
+only enforcer. It reads ten keys for its own decisions (below) and, since the fail-closed hardening
+(`scripts/lib/review-gate-hardening.js`), it also *validates* the routing keys it does not act on —
+`status`, `no_go_reason`, `cross_runtime_findings` — because an unvalidated routing key is a step
+that silently does nothing. Everything still outside that set is enforced by prose alone.
 
 ---
 
@@ -81,8 +83,8 @@ in [Prose/enforcer discrepancies](#proseenforcer-discrepancies) rather than sile
 
 ## Why this document exists
 
-`scripts/check-review-convergence.js` degrades silently, not loudly, on an under-populated verdict.
-Reproduced on a real hand-written verdict in this repo:
+`scripts/check-review-convergence.js` used to degrade silently, not loudly, on an under-populated
+verdict. Reproduced at the time on a real hand-written verdict in this repo:
 
 ```console
 $ node scripts/check-review-convergence.js briefs/make-tests-actually-run-review.json --static
@@ -104,33 +106,65 @@ $ echo $?
 ```
 
 `violations: []`, exit `0`. The gate passed because it was never given anything to check, and that
-outcome is byte-identical to a genuine pass everywhere a caller looks (exit code, `violations`,
-`cause`). The two knobs that produce it are [`round`](#round) and
-[`rounds_audit[].strike`](#rounds_auditstrike) — read those two sections before writing a verdict by
-hand.
+outcome was byte-identical to a genuine pass everywhere a caller looks (exit code, `violations`,
+`cause`).
+
+**That is now a refusal.** The same verdict exits `2`, prints no report at all, and says why:
+
+```console
+$ node scripts/check-review-convergence.js briefs/make-tests-actually-run-review.json --static
+check-review-convergence: review.json has no `round` key — the gate would skip strike
+classification, the rounds_audit completeness check and every trace check, then exit 0 with
+violations: [] (B-8 vacuity, schema/review-json-schema.md §round). Assemble the verdict with
+scripts/review-verdict-assemble.js, or pass --allow-legacy to authorize the skip — it is then
+RECORDED as legacy_skip_authorized in the report and --write-strike refuses that report.
+$ echo $?
+2
+```
+
+The escape hatch survives, but it is a **recorded** skip rather than a silent one: `--allow-legacy`
+stamps `legacy_skip_authorized: true` into the report, and
+`review-verdict-assemble.js --write-strike` refuses to journal a strike from it. An unrecorded skip
+is indistinguishable from a pass; a recorded one is not. Read [`round`](#round) and
+[`rounds_audit[].strike`](#rounds_auditstrike) before writing a verdict by hand — better still,
+don't write one by hand.
 
 ---
 
 ## Keys the gate reads (enforced)
 
-Exactly ten. Anything else in the envelope is prose-enforced only.
+Ten drive decisions. **Every "Absent" and "Malformed" cell below is a refusal, not a default.** The
+old behaviour is kept in the last column, because most of these were silent — and knowing which
+green you used to be getting is the point of the table.
 
-| Key | Absent | Malformed | What it drives |
+| Key | Absent | Malformed | Was (silent) |
 |---|---|---|---|
-| `round` | **skips strike + rounds_audit + trace checks**, warns, and exits 0 *unless something else independently violates* (a `no_go_round` at the cap still exits 1) | non-number / negative / non-finite → exit 2 | strike classification, `rounds_audit` completeness, trace obligation |
-| `no_go_round` | defaults to `0` + warning; round-cap can never fire | non-number / negative → exit 2 | the round-cap violation (`no_go_round >= --max-rounds`) |
-| `cycle` | `null`, legacy-safe | non-number → `null`, never fatal | `(cycle, round)` scoping of trace lines |
-| `findings` | `[]`, legacy-safe | present but not an array → exit 2 | ratchet, unencodable-finding, strike classification, red/green |
-| `rounds_audit` | treated as `[]` | non-array → treated as `[]` | past strikes, loop-back completeness, trace obligation |
-| `task` | see below | not a `validSlug` **on a trace-obligated round** → exit 2 | derives the trace + journal sibling paths |
-| `mode` | no scope-gate trace line is required | any value other than `"full"` → same as absent | requires a `scope-gate` trace line when `"full"` |
-| `normalized_by` | no `normalizer` trace line required; triggers the omit-everything warning **only if the round is also un-obligated** | any truthy value behaves alike | requires a `normalizer` trace line |
-| `cross_runtime` | no warnings, no corroboration | non-object → ignored | degraded-bookkeeping warnings, journal corroboration |
-| `streak_override` | no override | anything not `{round: <this round>, by: "human"}` → no override | forces this round's `strike` to `false` |
+| `round` | exit 2 unless `--allow-legacy` | non-number / negative / non-finite → exit 2 | skipped strike + `rounds_audit` + trace checks, warned, exit 0 |
+| `no_go_round` | exit 2 unless `--allow-legacy` | non-number / negative → exit 2 | defaulted to `0`; the cap could never fire |
+| `cycle` | exit 2 (non-legacy) | non-number / `< 1` → exit 2 | `null`; every trace line classified as prior-cycle |
+| `findings` | `[]`, legacy-safe | present but not an array → exit 2 | already fail-closed (FIX-A/CGF-1) |
+| `rounds_audit` | treated as `[]` | non-array → exit 2; a gap in rounds `2..round-1` → exit 3 | non-array read as `[]`; a gap erased the streak |
+| `task` | exit 2 (non-legacy) | not a `validSlug` → exit 2 | load-bearing only on a trace-obligated round |
+| `mode` | no scope-gate trace line required | outside `express\|fast\|full` → exit 2 | any other value read exactly like absent |
+| `normalized_by` | exit 2 (non-legacy) | non-string / empty → exit 2 | a conditional warning |
+| `cross_runtime` | no corroboration | non-object → exit 2; unknown `status` → exit 2; `digest` without `config_digest` → exit 2 | non-object ignored; statuses unvalidated |
+| `streak_override` | no override | anything not `{round: <this round>, by: "human"}` → no override | unchanged |
 
-Everything the gate does **not** read: `status`, `date`, `summary`, `auto_fixes_applied`,
-`no_go_reason`, `cross_runtime_findings`, `escalation_needed`, `escalation_reason`. Those are real
-fields with real consumers — just not this one.
+Three more keys are **validated but not acted on** — they route, and an unvalidated routing key is a
+step that silently does nothing:
+
+| Key | Rule |
+|---|---|
+| `status` | outside `GO\|NO-GO` → exit 2. `GO` while the gate reports a design violation → `go-with-design-violation`, exit 1 |
+| `no_go_reason` | absent on a `NO-GO` → exit 2; `type` outside the routing enum → exit 2; `cause` outside the cause enum → exit 2 |
+| `cross_runtime_findings` | non-array → exit 2; entries are ratchet-checked like `findings`; a `CRITICAL`/`HIGH` `OPEN` entry not mirrored into `findings[]` → `unmirrored-cross-runtime-finding`, exit 1 |
+
+Findings in **both** arrays must carry a `status` inside `OPEN\|RESOLVED\|ACCEPTED`; anything else is
+exit 2, because the gate only ever compares against `RESOLVED` and `ACCEPTED` and a near-miss
+escapes both the ratchet and the waiver.
+
+Still unread and prose-enforced only: `date`, `summary`, `auto_fixes_applied`, `escalation_needed`,
+`escalation_reason`.
 
 ---
 
@@ -147,16 +181,20 @@ Two events only (INV-3): a persisted `GO` verdict keeps its cycle-final `round` 
 `cross_runtime` for auditability; the *next* cycle then initializes fresh — `round: 1`, full
 fan-out, empty `rounds_audit`, new cross-runtime probe, `cycle + 1`.
 
-**Absence is the vacuity hole (B-8).** With no `round` key the gate skips strike classification,
-the `rounds_audit` completeness check, and all trace checks, emits three warnings, and exits 0.
-`scripts/review-verdict-assemble.js` refuses to emit a verdict without it.
+**Absence was the vacuity hole (B-8).** With no `round` key the gate skipped strike classification,
+the `rounds_audit` completeness check and all trace checks, emitted three warnings, and exited 0.
+It is now **exit 2 unless `--allow-legacy`** is passed, which records the skip (see
+[Gate report](#gate-report)). `scripts/review-verdict-assemble.js` still refuses to emit a verdict
+without it, so the flag is for pre-schema fixtures, never for new work.
 
-**Skipping a round is the quieter half of the same hole.** `computeStreakViolation()` walks
+**Skipping a round was the quieter half of the same hole.** `computeStreakViolation()` walks
 `round, round-1, …` and stops at the first entry that is not `true`; `computeStrikeMap()` only
-knows about rounds that have a `rounds_audit` entry. Jumping from round 3 to round 7 therefore
-leaves rounds 4–6 absent from the map and erases the streak — with **no** warning, because
-`computeMissingStrikeWarnings()` only inspects entries that exist. The assembler refuses any
-`--round` other than the one the lifecycle witness derives.
+knows about rounds that have a `rounds_audit` entry. Jumping from round 3 to round 7 left rounds
+4–6 absent from the map and erased the streak — with **no** warning, because
+`computeMissingStrikeWarnings()` only inspects entries that exist. A gap anywhere in
+`2..round-1` is now a `missing-past-audit` violation (`process-incomplete`, exit 3), repairable by
+journaling the missing round. The assembler additionally refuses any `--round` other than the one
+the lifecycle witness derives.
 
 Never conflate `round` with `no_go_round` — separate counters, separate reset rules.
 
@@ -247,34 +285,37 @@ only repair. Because omitting the stamp *removes* the trace obligation rather th
 #### `rounds_audit[].strike`
 
 **Boolean. Never `null`, never absent once the round has been gated.** This is the single most
-dangerous field in the envelope.
+dangerous field in the envelope, and a non-boolean is now **exit 2**.
 
 `computeStrikeMap()` reads past strikes with
 `if (typeof entry.strike === "boolean") strikeByRound.set(entry.round, entry.strike)`. A `null`
 therefore never lands in the map, `Map.get()` returns `undefined`, and
-`computeStreakViolation()`'s `strikeByRound.get(r) !== true` test **silently resets the streak**.
+`computeStreakViolation()`'s `strikeByRound.get(r) !== true` test **silently reset the streak**.
 
-Verified behaviour, on a five-round verdict where every round carries a novel HIGH finding:
+Verified behaviour, on a five-round verdict where every round carries a novel HIGH finding —
+before, and after:
 
-| Verdict | Gate result |
-|---|---|
-| `strike` boolean throughout | exit **1**, `cause: novel-finding-streak` — and it fires at **round 3**, not round 5 |
-| `strike: null` on round 4 only | exit 1, `cause: round-cap`; the streak is gone; one warning |
-| `strike: null` on every round, `no_go_round: 2` | exit **0**, `violations: []`, `cause: null` — total escape, three warnings |
+| Verdict | Was | Now |
+|---|---|---|
+| `strike` boolean throughout | exit **1**, `cause: novel-finding-streak`, firing at **round 3** not round 5 | unchanged |
+| `strike: null` on round 4 only | exit 1, `cause: round-cap`; the streak gone; one warning | **exit 2**, no report, `rounds_audit entry for round 4 has strike null` |
+| `strike: null` on every round, `no_go_round: 2` | exit **0**, `violations: []`, `cause: null` — total escape, three warnings | **exit 2**, no report |
 
-The third row is the real-world failure: five rounds, every round striking,
-`current_round_strike: true` in the report, and the gate still reports no violation. A live example
-of the shape that produces it is `briefs/f16-dsl-slice1-review.json` (`round: 3`, `strike: null` on
-all three entries).
+The third row was the real-world failure: five rounds, every round striking,
+`current_round_strike: true` in the report, and the gate still reporting no violation. A live
+example of the shape that produced it is `briefs/f16-dsl-slice1-review.json` (`round: 3`,
+`strike: null` on all three entries) — it now fails the gate, and the repair is to re-gate each
+round and journal its strike.
 
-Two further sharp edges:
+The two sharp edges that made it so quiet, both now closed:
 
-- A `null` on the **current** round's entry produces **no warning at all** —
+- A `null` on the **current** round's entry produced **no warning at all** —
   `computeMissingStrikeWarnings()` skips entries with `round >= currentRound`, and the current
-  round's strike is recomputed fresh anyway. It becomes a silent streak reset one round later,
-  once that round is a past round.
-- The only warning you get for a past-round `null` is inside the JSON report, on a run whose exit
-  code may well be `0`. It is not a violation.
+  round's strike is recomputed fresh anyway. It became a silent streak reset one round later, once
+  that round was a past round. The boolean check covers the current round's entry too, whenever
+  `strike` is *present*; **absent** on the round being gated is still correct and required.
+- The only signal for a past-round `null` was a warning inside a JSON report, on a run whose exit
+  code was often `0`.
 
 **Therefore: `strike` is written by the gate, not the author.** Assemble the draft with the key
 ABSENT, run the gate, then copy the report's boolean `current_round_strike` into the entry:
@@ -455,15 +496,29 @@ gate *reports* on — 0, 1, 3, the legacy skip, and the inconclusive-red/green f
   "no_go_round": 2, "max_rounds": 5, "legacy_no_go_round": false,
   "round": 3, "legacy_round": false,
   "current_round_strike": true,
+  "legacy_skip_authorized": false,
   "config": { "max_rounds": 5, "strikes": 2, "static": true },
+  "hardening": { "version": "1.0.0" },
   "cause": "novel-finding-streak",
   "warnings": [], "violations": [], "checks": [],
   "trace": { "obligated": true, "lines_seen": 9, "schema_version": "1.0", "skipped": false }
 }
 ```
 
-Before trusting any other field, confirm **both** `config.strikes` and `trace` are present. Either
-one absent means a stale gate script: do not persist, surface "gate script out of date", stop.
+Before trusting any other field, confirm **all three** of `config.strikes`, `trace` and
+`hardening.version` are present. Any one absent means a stale gate script: do not persist, surface
+"gate script out of date", stop.
+
+### `legacy_skip_authorized` — the recorded skip
+
+`true` when `--allow-legacy` suppressed the fail-closed refusal for an absent `round` or an absent
+`no_go_round`. It means: *this run was authorized to skip checks it could not perform, and is not
+evidence that they passed.* `review-verdict-assemble.js --write-strike` refuses such a report
+outright — journaling a strike from a gate run that skipped strike classification would convert a
+recorded skip straight back into an indistinguishable pass.
+
+Pass the flag only for a genuinely pre-schema fixture. For anything else, the fix is to assemble
+the verdict rather than to authorize the skip.
 
 ### Exit codes
 
@@ -471,8 +526,16 @@ one absent means a stale gate script: do not persist, surface "gate script out o
 |---|---|---|
 | 0 | no violations, no degraded input | proceed |
 | 1 | design violation — `cause` is `unencodable-finding` / `unattested-invocation` / `novel-finding-streak` / `round-cap` | `NO-GO` regardless of the human verdict; route per `cause` |
-| 2 | degraded input: absent/malformed verdict, unknown flag, inconclusive red/green, malformed current-cycle trace line | fail closed; block the route-back, surface to the human |
-| 3 | `process-incomplete` only — incomplete/absent `rounds_audit` entry, or `missing-trace` | repair per `violations[].detail`, re-gate, max 2 attempts, never bump `round`, never route |
+| 2 | degraded input: absent/malformed verdict, unknown flag, inconclusive red/green, malformed current-cycle trace line, **or any of the fail-closed envelope rules above** | fail closed; block the route-back, surface to the human. **No report is emitted** — there is nothing to persist |
+| 3 | `process-incomplete` only — incomplete/absent `rounds_audit` entry for the current round, a **gap** in rounds `2..round-1`, or `missing-trace` | repair per `violations[].detail`, re-gate, max 2 attempts, never bump `round`, never route |
+
+Two violation types are newer than the four causes above and reuse them:
+
+| Type | Cause | Exit |
+|---|---|---|
+| `unmirrored-cross-runtime-finding` | `unencodable-finding` | 1 |
+| `go-with-design-violation` | inherited from the first design violation found | 1 |
+| `missing-past-audit` | `process-incomplete` | 3 |
 
 `cause` precedence (FR-059/B-5, extended FR-174):
 
@@ -488,24 +551,35 @@ given the previous section, most often means a `strike: null`.
 
 ---
 
-## Prose/enforcer discrepancies
+## Prose/enforcer discrepancies — resolved
 
-Recorded, not resolved. Each is a place where `roster-review` prose implies an enforcement that
-does not exist, or where the enforcer requires something the prose never states.
+Each row was a place where `roster-review` prose implied an enforcement that did not exist, or
+where the enforcer required something the prose never stated. **All eleven are now enforced**, by
+`scripts/lib/review-gate-hardening.js`, and each has a proof-of-rejection case in
+`scripts/check-review-convergence-hardening.test.js` — the gate has been watched failing on every
+one of them.
 
-| # | Discrepancy | Consequence |
+| # | Discrepancy | Was (silent) | Now |
+|---|---|---|---|
+| D1 | Prose: "any `cross_runtime_findings` entry that is CRITICAL or HIGH (OPEN) sets `status: NO-GO`". The gate never read the array. | A HIGH cross-runtime finding was invisible; only the prose-level mirror into `findings` put it under the ratchet, and forgetting the mirror was unenforced. | The array is ratchet-checked like `findings`, and a `CRITICAL`/`HIGH` `OPEN` entry with no mirror is `unmirrored-cross-runtime-finding` (exit 1). |
+| D2 | Prose treats `no_go_reason.type` as the routing key; the gate never read `no_go_reason` or `status`. | A typo routed nowhere. Caught only for assembler-produced verdicts. | `type`/`cause` enums and the `status` enum are validated (exit 2); a `GO` asserted over a design violation is `go-with-design-violation` (exit 1). |
+| D3 | Prose says `strike` is "populated after the gate reports it" but never that it must be a **boolean**. | `strike: null` passed the completeness check and defeated streak escalation. Live here: `briefs/f16-dsl-slice1-review.json`. | Non-boolean on any gated round → exit 2. Absent on the round being gated is still correct. |
+| D4 | Prose lists `task` as an ordinary field; the gate made it load-bearing only once the round was trace-obligated. | On any other round, a blanked `task` fell through to the B-8 skip. | Required and `validSlug`-checked on every non-legacy round (exit 2). |
+| D5 | `mode` means `express\|fast\|full` in the verdict and `static\|full` in the gate report. | Copying one into the other silently changed what the gate demanded. | Outside the verdict enum → exit 2, with the collision named in the message. |
+| D6 | Prose does not state that stamping `normalized_by` creates a `normalizer` trace obligation, nor that the normalizer self-appends only when `--task`, `--round` **and** `--cycle` are all given. | Absent `normalized_by` was a conditional warning, on a verdict whose fingerprints were therefore unstable. | Absent/empty on a non-legacy round → exit 2: strike classification on an unnormalized verdict is not a result. |
+| D7 | `findings[].status` is `OPEN\|RESOLVED\|ACCEPTED` per `schema/review-finding.schema.json`; the gate accepted any string (it only tests `=== "RESOLVED"` / `=== "ACCEPTED"`). | `status: "OPEN-FOR-HUMAN"` (live here) matched neither branch. Enforcement depended on which tool you ran. | Enum-checked in **both** finding arrays → exit 2. |
+| D8 | Prose describes the ratchet's exemptions but not the FIX-2 hardening: *missing* round provenance on a `RESOLVED` HIGH+ finding is itself an `unencodable-finding` violation. | — | **Not a hole**: the enforcer is *stricter* than the prose, so nothing escapes. Resolved by this documentation only. |
+| D9 | Prose says `cross_runtime` entries persist `config_digest`; the journal writes the same value under `digest`. | Writing the journal's key into the verdict broke corroboration silently; no status value was validated at all. | `digest` without `config_digest` → exit 2 with the asymmetry explained; unknown `status` → exit 2. |
+| D10 | Prose does not mention that an absent `no_go_round` defaults to `0` with a warning. | The round cap could never fire — a second, quieter vacuity path alongside `round`. | Exit 2 unless `--allow-legacy` records the skip. |
+| D11 | Prose does not mention that an absent/non-numeric `cycle` filters every numerically-stamped trace line out as prior-cycle. | A trace-obligated round with no `cycle` failed as `missing-trace` even with the lines on disk. | Absent or non-numeric/`< 1` on a non-legacy round → exit 2. |
+
+Three further holes, found auditing the same file and not previously recorded:
+
+| # | Hole | Now |
 |---|---|---|
-| D1 | Prose: "any `cross_runtime_findings` entry that is CRITICAL or HIGH (OPEN) sets `status: NO-GO`". The gate never reads `cross_runtime_findings`. | A HIGH cross-runtime finding is invisible to the gate. Only the prose-level mirror into `findings` puts it under the ratchet — forget the mirror and it is unenforced. |
-| D2 | Prose treats `no_go_reason.type` as the routing key. The gate never reads `no_go_reason` at all. | A typo silently routes nowhere. Unresolved in the enforcer; `review-verdict-assemble.js` validates both enums at assembly time, so a typo is caught for verdicts it produces — a hand-written one is still unchecked. |
-| D3 | Prose says `strike` is "populated after the gate reports it"; it never says the value must be a *boolean*, and the gate's completeness check does not require it. | `strike: null` passes the completeness check and silently defeats streak escalation. Live in this repo: `briefs/f16-dsl-slice1-review.json`. |
-| D4 | Prose lists `task` as an ordinary field. The gate makes it load-bearing for path derivation and fails **closed (exit 2)** on an invalid slug once the round is trace-obligated. | An innocuous-looking `task` edit turns a working round into a hard degraded-input failure. |
-| D5 | `mode` means `express\|fast\|full` in the verdict and `static\|full` in the gate report. | Copying one into the other silently changes what the gate demands. |
-| D6 | Prose does not state that stamping `normalized_by` creates a `normalizer` trace obligation, nor that the normalizer self-appends only when `--task`, `--round` **and** `--cycle` are all given. | Two of three flags → no trace line → `unattested-invocation` (exit 1) on a round that really did normalize. |
-| D7 | `findings[].status` is `OPEN\|RESOLVED\|ACCEPTED` per `schema/review-finding.schema.json`, and `review-normalize.js` *rejects* anything else. The gate accepts any string (it only tests `=== "RESOLVED"` / `=== "ACCEPTED"`). | Hand-written verdicts in this repo carry `status: "OPEN-FOR-HUMAN"` and `category: "ci"` (`briefs/make-tests-actually-run-review.json`). The gate tolerates them; the normalizer would have rejected them. Enforcement depends on which tool you ran. |
-| D8 | Prose describes the ratchet's exemptions (same-round raise+resolve, `ACCEPTED`) but not the FIX-2 hardening: *missing* round provenance on a `RESOLVED` HIGH+ finding is itself an `unencodable-finding` violation. | A verdict that omits `resolved_round` reads as lenient and gates as a design violation. |
-| D9 | Prose says `cross_runtime` entries persist `config_digest`; the journal writes the same value under `digest`. Documented in code comments only. | Writing `digest` in the verdict (or `config_digest` in the journal) breaks corroboration and yields `unattested-invocation`. |
-| D10 | Prose does not mention that an absent `no_go_round` defaults to `0` with a warning. | The round-cap backstop cannot fire on a verdict that omits it — a second, quieter vacuity path alongside the `round` one. |
-| D11 | Prose does not mention that an absent/non-numeric `cycle` filters every numerically-stamped trace line out as prior-cycle. | A trace-obligated round with no `cycle` fails as `missing-trace` (exit 3) even though the lines are on disk. |
+| G3 | An absent `round` skipped strike, `rounds_audit` and trace checks and exited 0. | Exit 2 unless `--allow-legacy` records the skip. |
+| G5 | A **gap** in `rounds_audit` (e.g. round 3 → round 7) left the skipped rounds out of the strike map and erased the streak, with no warning, because `computeMissingStrikeWarnings()` only inspects entries that exist. | `missing-past-audit` over `2..round-1` → exit 3. |
+| G13 | `rounds_audit` and `cross_runtime` were coerced (`Array.isArray(x) ? x : []`, `typeof x === "object" \|\| return`), so a wrong type emptied the check instead of failing it. | Present-but-wrong-type → exit 2. |
 
 Two more notes on the enforcer itself, neither a discrepancy:
 
@@ -524,17 +598,25 @@ Two more notes on the enforcer itself, neither a discrepancy:
 `scripts/review-bundle.manifest.json` and verified by `node scripts/review-bundle-verify.js`. Do
 not hand-edit them; see `scripts/REVIEW-BUNDLE.md`.
 
-This document, `scripts/review-verdict-assemble.js`, its rule layer
-`scripts/lib/review-verdict-rules.js`, and the test are **repo-local** and deliberately absent from
-the manifest, so a bundle upgrade neither overwrites nor flags them. Note the path: the rule layer
-sits directly in `scripts/lib/`, *not* in the bundle-owned `scripts/lib/review/`.
+This document, `scripts/review-verdict-assemble.js`, `scripts/check-mandated-steps.js`, their rule
+layers `scripts/lib/review-verdict-rules.js`, `scripts/lib/review-gate-hardening.js` and
+`scripts/lib/mandated-steps-rules.js`, and the three tests are **repo-local** and deliberately
+absent from the manifest, so a bundle upgrade neither overwrites nor flags them. Note the path: the
+rule layers sit directly in `scripts/lib/`, *not* in the bundle-owned `scripts/lib/review/`.
 
-The assembler's own checks — including the round-cap / streak / `strike: null` cases tabulated
-above, each red-on-mutation against the real gate — run standalone, no test framework:
+`check-review-convergence.js` requires `scripts/lib/review-gate-hardening.js`. That is the one
+place a bundle file depends on a repo-local one, and it is deliberate: the hardening rules are this
+repo's contract with the gate, and keeping them out of the bundle means a bundle upgrade cannot
+silently restore any of the eleven holes.
+
+The checks run standalone, no test framework. Each constructs the input that should be rejected and
+asserts the refusal:
 
 ```bash
-node scripts/review-verdict-assemble.test.js   # exit 0 = green
-node scripts/review-bundle-verify.js           # bundle integrity, no network
+node scripts/review-verdict-assemble.test.js              # assembler ↔ real gate, red-on-mutation
+node scripts/check-review-convergence-hardening.test.js   # D1..D11 + G3/G5/G13 proof-of-rejection
+node scripts/check-mandated-steps.test.js                 # recorded-skip ledger
+node scripts/review-bundle-verify.js                      # bundle integrity, no network
 ```
 
 They are deliberately not wired into `make test-all`: that target runs the GPU suites, and this

--- a/scripts/check-mandated-steps.js
+++ b/scripts/check-mandated-steps.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// scripts/check-mandated-steps.js — CommonJS, repo-local tool.
+//
+// Records and verifies the mandated-step ledger, `briefs/<task>-steps.jsonl`.
+// Rules live in scripts/lib/mandated-steps-rules.js; this file is CLI, I/O and
+// orchestration only.
+//
+// WHY: a mandated step that is skipped without a record is indistinguishable
+// from one that ran and passed. Preflight, human gates and degraded specialists
+// could all be skipped silently. Making the skip *recordable* is half of it;
+// making the ABSENCE of a required record a failure is the half that has teeth.
+//
+// TWO MODES
+//
+//   record — append one schema-valid record (never hand-write the JSONL):
+//     node scripts/check-mandated-steps.js --record --task <slug> \
+//       --step preflight --outcome ran --result READY --actor agent
+//     node scripts/check-mandated-steps.js --record --task <slug> \
+//       --step human-gate --outcome skipped --actor agent \
+//       --reason "standing autonomy delegation, session 2026-07-25"
+//
+//   check — verify the ledger against what the phase mandates:
+//     node scripts/check-mandated-steps.js --task <slug> --phase implement
+//
+// Exit contract:
+//   0 = every mandated step has a valid record
+//   1 = a mandated step has no record, or a record is invalid — the gate's "no"
+//   2 = usage error / unreadable or malformed ledger (fail closed)
+//
+// An absent ledger is exit 1 with every requirement listed, never exit 0: "no
+// file" is the strongest possible form of "nothing was recorded".
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { evaluate, STEPS, OUTCOMES, ACTORS, RESULTS } = require("./lib/mandated-steps-rules");
+
+const VALUE_FLAGS = {
+  "--task": "task",
+  "--phase": "phase",
+  "--ledger": "ledger",
+  "--step": "step",
+  "--outcome": "outcome",
+  "--result": "result",
+  "--actor": "actor",
+  "--reason": "reason",
+  "--require": "require",
+};
+
+function usage(message) {
+  process.stderr.write(`check-mandated-steps: ${message}\n`);
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const args = { record: false };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === "--record") {
+      args.record = true;
+    } else if (Object.prototype.hasOwnProperty.call(VALUE_FLAGS, flag)) {
+      const value = argv[++i];
+      if (value === undefined || value.startsWith("--")) usage(`${flag} requires a value`);
+      args[VALUE_FLAGS[flag]] = value;
+    } else {
+      usage(`unknown flag or stray argument: ${flag}`);
+    }
+  }
+  return args;
+}
+
+function ledgerPath(args) {
+  if (args.ledger) return path.resolve(process.cwd(), args.ledger);
+  if (!args.task) usage("--task <slug> is required (or pass --ledger <path>)");
+  return path.resolve(process.cwd(), "briefs", `${args.task}-steps.jsonl`);
+}
+
+// A malformed line is exit 2, never a skipped line. Silently dropping an
+// unparseable record would reintroduce the defect on the checker's own side.
+function readLedger(file) {
+  if (!fs.existsSync(file)) return [];
+  let raw;
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch (e) {
+    usage(`cannot read ledger ${file}: ${e.message}`);
+  }
+  const records = [];
+  raw.split("\n").forEach((line, index) => {
+    if (line.trim() === "") return;
+    try {
+      records.push(JSON.parse(line));
+    } catch (e) {
+      usage(`ledger line ${index + 1} is not valid JSON: ${e.message}`);
+    }
+  });
+  return records;
+}
+
+function runRecord(args) {
+  if (!args.task) usage("--record requires --task <slug>");
+  if (!args.step) usage("--record requires --step <id>");
+  if (!Object.prototype.hasOwnProperty.call(STEPS, args.step)) {
+    usage(`--step ${JSON.stringify(args.step)} is not a known step — known: ${Object.keys(STEPS).join(", ")}`);
+  }
+  if (!OUTCOMES.has(args.outcome)) usage(`--outcome must be one of ${[...OUTCOMES].join(" | ")}`);
+  if (!ACTORS.has(args.actor)) usage(`--actor must be one of ${[...ACTORS].join(" | ")}`);
+  if (args.outcome === "skipped" && !(args.reason && args.reason.trim() !== "")) {
+    usage("--outcome skipped requires --reason <text> — an unreasoned skip is exactly what this ledger exists to prevent");
+  }
+  if (args.outcome === "ran" && !RESULTS.has(args.result)) {
+    usage(`--outcome ran requires --result <${[...RESULTS].join("|")}>`);
+  }
+
+  const record = {
+    ts: new Date().toISOString(),
+    task: args.task,
+    step: args.step,
+    outcome: args.outcome,
+    actor: args.actor,
+  };
+  if (args.outcome === "ran") record.result = args.result;
+  if (args.reason) record.reason = args.reason;
+  if (args.phase) record.phase = args.phase;
+
+  const file = ledgerPath(args);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, `${JSON.stringify(record)}\n`);
+  process.stdout.write(`${JSON.stringify({ ok: true, ledger: path.relative(process.cwd(), file), record }, null, 2)}\n`);
+  process.exit(0);
+}
+
+function runCheck(args) {
+  if (!args.phase && !args.require) usage("--phase <name> is required (or --require <step,step>)");
+  const file = ledgerPath(args);
+  const records = readLedger(file);
+  const result = evaluate({
+    records,
+    phase: args.phase,
+    require: args.require ? args.require.split(",").map((s) => s.trim()).filter(Boolean) : null,
+    task: args.task,
+  });
+  if (result.usageError) usage(result.usageError);
+
+  const report = {
+    ledger: path.relative(process.cwd(), file),
+    ledger_exists: fs.existsSync(file),
+    phase: args.phase || null,
+    required: result.required,
+    records: records.length,
+    missing: result.missing,
+    invalid: result.invalid,
+    ok: result.ok,
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (!result.ok) {
+    for (const message of result.missing.concat(result.invalid)) {
+      process.stderr.write(`check-mandated-steps: ${message}\n`);
+    }
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  if (args.record) runRecord(args);
+  else runCheck(args);
+}
+
+module.exports = { parseArgs, readLedger, main };
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/scripts/check-mandated-steps.js
+++ b/scripts/check-mandated-steps.js
@@ -131,13 +131,30 @@ function runRecord(args) {
 }
 
 function runCheck(args) {
-  if (!args.phase && !args.require) usage("--phase <name> is required (or --require <step,step>)");
+  // A flag that was GIVEN and a flag that was omitted are different things, and
+  // collapsing them is how `--require ""` came to mean "require the phase
+  // defaults" — on a phase that mandates nothing, an explicit request for a
+  // requirement silently became exit 0 with required: []. Same shape as the
+  // trailing/empty `--expect-phase` opt-out. So: given-but-empty is a usage
+  // error, never a fallback.
+  const requireGiven = args.require !== undefined;
+  const phaseGiven = args.phase !== undefined;
+  if (phaseGiven && args.phase.trim() === "") {
+    usage("--phase was given but is empty — an empty phase cannot select a requirement set");
+  }
+  if (requireGiven && args.require.split(",").every((s) => s.trim() === "")) {
+    usage(
+      `--require was given but names no steps (${JSON.stringify(args.require)}) — it would silently fall back to the phase defaults, so an explicit requirement would be discharged by nothing`
+    );
+  }
+  if (!phaseGiven && !requireGiven) usage("--phase <name> is required (or --require <step,step>)");
+
   const file = ledgerPath(args);
   const records = readLedger(file);
   const result = evaluate({
     records,
     phase: args.phase,
-    require: args.require ? args.require.split(",").map((s) => s.trim()).filter(Boolean) : null,
+    require: requireGiven ? args.require.split(",").map((s) => s.trim()).filter(Boolean) : null,
     task: args.task,
   });
   if (result.usageError) usage(result.usageError);

--- a/scripts/check-mandated-steps.test.js
+++ b/scripts/check-mandated-steps.test.js
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+// scripts/check-mandated-steps.test.js — zero-dependency, node-runnable:
+//
+//   node scripts/check-mandated-steps.test.js
+//
+// Same discipline as scripts/check-review-convergence-hardening.test.js: each
+// case constructs the ledger that SHOULD be rejected and proves the real
+// scripts/check-mandated-steps.js rejects it with the right exit code and a
+// message that names the missing or malformed record.
+//
+// The three scenarios that motivated the tool are reproduced literally:
+//   - preflight never run across a day of implementation work
+//   - a human gate skipped under a standing autonomy delegation
+//   - a specialist disabled by its own breaker
+"use strict";
+
+const assert = require("assert");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const REPO = path.resolve(__dirname, "..");
+const TOOL = path.join(REPO, "scripts", "check-mandated-steps.js");
+const TASK = "steps-selftest";
+
+let failures = 0;
+let passes = 0;
+
+function check(name, fn) {
+  try {
+    fn();
+    passes += 1;
+    process.stdout.write(`  ok   ${name}\n`);
+  } catch (e) {
+    failures += 1;
+    process.stdout.write(`  FAIL ${name}\n       ${e.message.split("\n")[0]}\n`);
+  }
+}
+
+function scratch() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mandated-steps-"));
+  fs.mkdirSync(path.join(dir, "briefs"));
+  return dir;
+}
+
+function run(argv, cwd) {
+  const r = spawnSync(process.execPath, [TOOL, ...argv], { cwd, encoding: "utf8" });
+  return { status: r.status, stdout: r.stdout || "", stderr: r.stderr || "" };
+}
+
+function record(dir, argv) {
+  return run(["--record", "--task", TASK, ...argv], dir);
+}
+
+function checkPhase(dir, phase, extra = []) {
+  return run(["--task", TASK, "--phase", phase, ...extra], dir);
+}
+
+function writeLedger(dir, lines) {
+  fs.writeFileSync(path.join(dir, "briefs", `${TASK}-steps.jsonl`), lines.map((l) => (typeof l === "string" ? l : JSON.stringify(l))).join("\n") + "\n");
+}
+
+process.stdout.write("check-mandated-steps\n");
+
+// ── the core rule: absence is a failure ──────────────────────────────────
+check("an absent ledger fails, listing every mandated step (never exit 0)", () => {
+  const dir = scratch();
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1, "no ledger at all must never read as a pass");
+  assert.match(r.stderr, /no record for mandated step "preflight"/);
+  assert.strictEqual(JSON.parse(r.stdout).ledger_exists, false);
+});
+
+check("SCENARIO: a full implement phase with preflight never run fails", () => {
+  // The literal friction: an entire day of implementation work with
+  // /roster-doctor preflight never invoked, and nothing in the record saying so.
+  const dir = scratch();
+  assert.strictEqual(record(dir, ["--step", "scope-gate", "--outcome", "ran", "--result", "PASS", "--actor", "agent"]).status, 0);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /no record for mandated step "preflight"/);
+  assert.match(r.stderr, /indistinguishable from one that ran and passed/);
+});
+
+check("recording the preflight as RAN satisfies the requirement", () => {
+  const dir = scratch();
+  assert.strictEqual(record(dir, ["--step", "preflight", "--outcome", "ran", "--result", "READY", "--actor", "agent"]).status, 0);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 0, r.stderr);
+});
+
+check("recording the preflight as SKIPPED with a reason also satisfies it", () => {
+  // Skipping is allowed. Skipping silently is not.
+  const dir = scratch();
+  const w = record(dir, ["--step", "preflight", "--outcome", "skipped", "--actor", "agent", "--reason", "no build or test in this doc-only phase"]);
+  assert.strictEqual(w.status, 0);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 0, r.stderr);
+  assert.match(JSON.parse(w.stdout).record.reason, /doc-only/);
+});
+
+check("a preflight that ran and found NOT-READY is recordable evidence, and needs a reason", () => {
+  const dir = scratch();
+  const bad = record(dir, ["--step", "preflight", "--outcome", "ran", "--result", "NOT-READY", "--actor", "agent"]);
+  assert.strictEqual(bad.status, 0, "the writer accepts it; the checker is what demands the reason");
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /reports NOT-READY with no `reason`/);
+});
+
+// ── unreasoned skips ─────────────────────────────────────────────────────
+check("the writer refuses --outcome skipped with no --reason", () => {
+  const dir = scratch();
+  const r = record(dir, ["--step", "preflight", "--outcome", "skipped", "--actor", "agent"]);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /requires --reason/);
+});
+
+check("the checker refuses a hand-written skip with no reason", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "skipped", actor: "agent" }]);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /outcome "skipped" with no `reason`/);
+});
+
+check("the checker refuses an empty-string reason", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "skipped", actor: "agent", reason: "   " }]);
+  assert.strictEqual(checkPhase(dir, "implement").status, 1);
+});
+
+// ── SCENARIO: the human gate under a standing delegation ─────────────────
+check("SCENARIO: an agent may not record the human gate as RAN", () => {
+  const dir = scratch();
+  writeLedger(dir, [
+    { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
+    { ts: "2026-07-25T10:01:00Z", task: TASK, step: "human-gate", outcome: "ran", result: "PASS", actor: "agent" },
+  ]);
+  const r = checkPhase(dir, "ship");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /this step is human-only/);
+  assert.match(r.stderr, /never journaled as a human's/);
+});
+
+check("SCENARIO: the same gate skipped under a recorded delegation passes", () => {
+  const dir = scratch();
+  writeLedger(dir, [
+    { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
+    {
+      ts: "2026-07-25T10:01:00Z",
+      task: TASK,
+      step: "human-gate",
+      outcome: "skipped",
+      actor: "agent",
+      reason: "standing autonomy delegation for session 2026-07-25; user AFK",
+    },
+  ]);
+  const r = checkPhase(dir, "ship");
+  assert.strictEqual(r.status, 0, r.stderr);
+});
+
+check("a human-answered gate is recordable as RAN by a human actor", () => {
+  const dir = scratch();
+  writeLedger(dir, [
+    { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
+    { ts: "2026-07-25T10:01:00Z", task: TASK, step: "human-gate", outcome: "ran", result: "PASS", actor: "human" },
+  ]);
+  assert.strictEqual(checkPhase(dir, "ship").status, 0);
+});
+
+// ── SCENARIO: the breaker-disabled cross-runtime pass ────────────────────
+check("SCENARIO: a review round with cross-runtime breaker-skipped must say so", () => {
+  const dir = scratch();
+  writeLedger(dir, [
+    { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
+    { ts: "2026-07-25T10:00:30Z", task: TASK, step: "scope-gate", outcome: "ran", result: "PASS", actor: "agent" },
+  ]);
+  const missing = checkPhase(dir, "review");
+  assert.strictEqual(missing.status, 1);
+  assert.match(missing.stderr, /no record for mandated step "xruntime"/);
+
+  assert.strictEqual(
+    record(dir, [
+      "--step", "xruntime", "--outcome", "skipped", "--actor", "agent",
+      "--reason", "circuit breaker: runtime degraded this cycle with unchanged digest",
+    ]).status,
+    0
+  );
+  assert.strictEqual(checkPhase(dir, "review").status, 0);
+});
+
+check("a degraded specialist is repeatable — several may be recorded in one phase", () => {
+  const dir = scratch();
+  writeLedger(dir, [
+    { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
+    { ts: "2026-07-25T10:00:30Z", task: TASK, step: "degraded-specialist", outcome: "skipped", actor: "agent", reason: "type-design-analyzer: spawn-error" },
+    { ts: "2026-07-25T10:00:40Z", task: TASK, step: "degraded-specialist", outcome: "skipped", actor: "agent", reason: "silent-failure-hunter: timeout" },
+  ]);
+  assert.strictEqual(checkPhase(dir, "qa").status, 0);
+});
+
+// ── the typo hole: a near-miss must not stand in for the real step ───────
+check("a typo'd step id is rejected AND leaves the real step missing", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: TASK, step: "prefligt", outcome: "ran", result: "READY", actor: "agent" }]);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /unknown step "prefligt"/);
+  assert.match(r.stderr, /no record for mandated step "preflight"/, "the typo must not satisfy the requirement it resembles");
+});
+
+check("the writer refuses an unknown --step outright", () => {
+  const dir = scratch();
+  const r = record(dir, ["--step", "preflght", "--outcome", "ran", "--result", "READY", "--actor", "agent"]);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /not a known step/);
+});
+
+// ── enum + duplicate + integrity rules ───────────────────────────────────
+check("an outcome outside ran|skipped is rejected", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "partial", actor: "agent" }]);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /has outcome "partial"/);
+});
+
+check("an unattributable record (no actor) is rejected", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY" }]);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /a skip must be attributable/);
+});
+
+check("a `ran` record with no result is rejected — it must say what it found", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", actor: "agent" }]);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /must say what it found/);
+});
+
+check("a record with no timestamp is rejected", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" }]);
+  assert.match(checkPhase(dir, "implement").stderr, /has no `ts` timestamp/);
+});
+
+check("two records for one step are rejected — one of them is not evidence", () => {
+  const dir = scratch();
+  writeLedger(dir, [
+    { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "skipped", actor: "agent", reason: "in a hurry" },
+    { ts: "2026-07-25T10:05:00Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
+  ]);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /is recorded twice/);
+});
+
+check("a record stamped with another task is rejected", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: "some-other-task", step: "preflight", outcome: "ran", result: "READY", actor: "agent" }]);
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 1);
+  assert.match(r.stderr, /is stamped task "some-other-task"/);
+});
+
+// ── the checker's own fail-closed behaviour ──────────────────────────────
+check("a malformed ledger line is exit 2, never a silently dropped record", () => {
+  const dir = scratch();
+  fs.writeFileSync(path.join(dir, "briefs", `${TASK}-steps.jsonl`), '{"step":"preflight"\n');
+  const r = checkPhase(dir, "implement");
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /is not valid JSON/);
+});
+
+check("an unknown phase is rejected, not defaulted to `nothing required`", () => {
+  const dir = scratch();
+  const r = checkPhase(dir, "implemnt");
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /unknown phase "implemnt"/);
+  assert.match(r.stderr, /Refusing to default/);
+});
+
+check("--require names an unknown step and is rejected", () => {
+  const dir = scratch();
+  const r = run(["--task", TASK, "--require", "preflight,nonsense"], dir);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /unknown step\(s\): nonsense/);
+});
+
+check("a phase with no mandated steps still validates the records it has", () => {
+  const dir = scratch();
+  writeLedger(dir, [{ ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "skipped", actor: "agent" }]);
+  const r = checkPhase(dir, "spec");
+  assert.strictEqual(r.status, 1, "an empty requirement set must not make the checker vacuous");
+  assert.match(r.stderr, /with no `reason`/);
+});
+
+process.stdout.write(`\n${passes} passed, ${failures} failed\n`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/check-mandated-steps.test.js
+++ b/scripts/check-mandated-steps.test.js
@@ -300,6 +300,42 @@ check("an unknown phase is rejected, not defaulted to `nothing required`", () =>
   assert.match(r.stderr, /Refusing to default/);
 });
 
+// ── the empty/trailing flag class ────────────────────────────────────────
+// A flag GIVEN and a flag OMITTED are different things. Collapsing them made
+// `--require ""` mean "use the phase defaults", so on a phase that mandates
+// nothing an explicit requirement was discharged by nothing: exit 0,
+// required: []. Same shape as the trailing/empty `--expect-phase` opt-out.
+check("an empty or comma-only --require is refused, never a fallback", () => {
+  const dir = scratch();
+  for (const value of ["", ",", " ", ",,"]) {
+    const r = run(["--task", TASK, "--phase", "review", "--require", value], dir);
+    assert.strictEqual(r.status, 2, `--require ${JSON.stringify(value)} must be a usage error, got exit ${r.status}`);
+    assert.match(r.stderr, /names no steps/);
+  }
+  // The control, and the reason this mattered: `review` mandates nothing, so an
+  // empty ledger is a legitimate exit 0 here. That is exactly the clean pass the
+  // fallback used to hand back for `--require ","` — indistinguishable from a
+  // genuine one, on the phase where it was most likely to be reached for.
+  const ok = run(["--task", TASK, "--phase", "review"], dir);
+  assert.strictEqual(ok.status, 0, "review mandates nothing, so an empty ledger is a real pass");
+});
+
+check("an empty --phase is refused", () => {
+  const dir = scratch();
+  const r = run(["--task", TASK, "--phase", ""], dir);
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /--phase was given but is empty/);
+});
+
+check("a trailing value-flag with no value is refused", () => {
+  const dir = scratch();
+  for (const flag of ["--phase", "--require", "--task", "--step"]) {
+    const r = run(["--task", TASK, flag], dir);
+    assert.strictEqual(r.status, 2, `trailing ${flag} must be a usage error, got exit ${r.status}`);
+    assert.match(r.stderr, /requires a value/);
+  }
+});
+
 check("--require names an unknown step and is rejected", () => {
   const dir = scratch();
   const r = run(["--task", TASK, "--require", "preflight,nonsense"], dir);

--- a/scripts/check-mandated-steps.test.js
+++ b/scripts/check-mandated-steps.test.js
@@ -171,13 +171,15 @@ check("a human-answered gate is recordable as RAN by a human actor", () => {
 });
 
 // ── SCENARIO: the breaker-disabled cross-runtime pass ────────────────────
-check("SCENARIO: a review round with cross-runtime breaker-skipped must say so", () => {
+check("SCENARIO: cross-runtime breaker-skip is recordable, via explicit --require", () => {
+  // `review` mandates neither scope-gate nor xruntime by default — the trace
+  // mechanism owns both, and the measurement in mandated-steps-rules.js showed
+  // requiring them here would fire on nearly every round. They stay opt-in.
   const dir = scratch();
   writeLedger(dir, [
     { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
-    { ts: "2026-07-25T10:00:30Z", task: TASK, step: "scope-gate", outcome: "ran", result: "PASS", actor: "agent" },
   ]);
-  const missing = checkPhase(dir, "review");
+  const missing = run(["--task", TASK, "--require", "xruntime"], dir);
   assert.strictEqual(missing.status, 1);
   assert.match(missing.stderr, /no record for mandated step "xruntime"/);
 
@@ -188,7 +190,20 @@ check("SCENARIO: a review round with cross-runtime breaker-skipped must say so",
     ]).status,
     0
   );
-  assert.strictEqual(checkPhase(dir, "review").status, 0);
+  assert.strictEqual(run(["--task", TASK, "--require", "xruntime"], dir).status, 0);
+});
+
+check("MEASURED: `review` mandates nothing by default (the trace mechanism owns it)", () => {
+  // Red-on-mutation for the measurement decision itself: if someone re-adds
+  // scope-gate/xruntime to the review defaults, this goes red and they have to
+  // read why. A ledger with only a preflight record must satisfy `review`.
+  const dir = scratch();
+  writeLedger(dir, [
+    { ts: "2026-07-25T10:00:22Z", task: TASK, step: "preflight", outcome: "ran", result: "READY", actor: "agent" },
+  ]);
+  const r = checkPhase(dir, "review");
+  assert.strictEqual(r.status, 0, `review must not mandate steps the trace mechanism owns: ${r.stderr}`);
+  assert.deepStrictEqual(JSON.parse(r.stdout).required, []);
 });
 
 check("a degraded specialist is repeatable — several may be recorded in one phase", () => {

--- a/scripts/check-review-bundle-tracked.sh
+++ b/scripts/check-review-bundle-tracked.sh
@@ -166,6 +166,14 @@ const REQUIRED = [
   ["scripts/lib/xruntime/xruntime-journal.js", "isCallerFault", "#102 breaker exemption"],
   ["scripts/lib/xruntime/xruntime-contract.js", "OUTPUT_CONTRACT", "#102 --emit-contract"],
   ["scripts/lib/review/review-lifecycle.js", "expected \"GO\" or \"NO-GO\"", "verdict-status gate"],
+  // #98. The gate is the one bundle-owned file the fail-closed hardening
+  // patches; scripts/lib/review-gate-hardening.js is repo-local by design, so an
+  // upgrade cannot touch it — but it CAN overwrite the require and the wiring
+  // that reach it, which would restore every hole silently and leave the module
+  // sitting there unused.
+  ["scripts/check-review-convergence.js", "review-gate-hardening", "#98 hardening module is required"],
+  ["scripts/check-review-convergence.js", "evaluateHardening", "#98 hardening is actually invoked, not merely imported"],
+  ["scripts/check-review-convergence.js", "legacy_skip_authorized", "#98 recorded-skip marker reaches the report"],
 ];
 // Identifier-like markers match on word boundaries. Plain String.includes let
 // FAULT_BY_OUTCOMEX satisfy FAULT_BY_OUTCOME — a renamed symbol reads as an

--- a/scripts/check-review-bundle-tracked.test.sh
+++ b/scripts/check-review-bundle-tracked.test.sh
@@ -63,6 +63,14 @@ module.exports = { OUTPUT_CONTRACT };
 ' ;;
     scripts/lib/review/review-lifecycle.js)
       printf '%s\n' 'const MSG = `expected "GO" or "NO-GO"`;' ;;
+    scripts/check-review-convergence.js)
+      # #98 fail-closed hardening, modelled as APPLIED. All three markers are
+      # real code: the require path, the call, and the report field. A comment
+      # would not satisfy the guard, which strips them before matching.
+      printf 'const { evaluateHardening } = require("./lib/review-gate-hardening");
+function main() { const h = evaluateHardening({}); return { legacy_skip_authorized: false, h }; }
+module.exports = { main };
+' ;;
     *) printf 'content of %s\n' "$1" ;;
   esac
 }

--- a/scripts/check-review-convergence-hardening.test.js
+++ b/scripts/check-review-convergence-hardening.test.js
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+// scripts/check-review-convergence-hardening.test.js — zero-dependency,
+// node-runnable:
+//
+//   node scripts/check-review-convergence-hardening.test.js
+//
+// Every case here constructs an input that SHOULD be rejected and proves the
+// REAL scripts/check-review-convergence.js rejects it, with the right exit code
+// and a message that names the hole. A gate nobody has watched fail is exactly
+// the bug this suite exists to prevent, so assertions are on the refusal, never
+// merely on "not exit 0".
+//
+// The control case (BASE) is load-bearing in the other direction: it proves the
+// fixture passes cleanly, so each rejection below is attributable to the single
+// field that case mutates and not to the fixture being broken all along.
+//
+// Coverage map — schema/review-json-schema.md §"Prose/enforcer discrepancies":
+//
+//   G1  D3   rounds_audit[].strike must be a boolean          (named in the task)
+//   G2  D1   cross_runtime_findings is read at last           (named in the task)
+//   G3  —    absent `round` is refused, not silently skipped
+//   G4  D10  absent `no_go_round` is refused
+//   G5  —    a rounds_audit gap erases the streak
+//   G6  D7   finding `status` enum
+//   G7  D2   `status` / `no_go_reason` routing keys
+//   G8  D5   verdict `mode` enum (and the gate-report `mode` collision)
+//   G9  D4   `task` is load-bearing on every non-legacy round
+//   G10 D11  `cycle` presence and type
+//   G11 D6   `normalized_by` — an unnormalized verdict has no stable fingerprints
+//   G12 D9   cross_runtime config_digest/digest asymmetry + status enum
+//   G13 —    blind container coercions (rounds_audit / cross_runtime)
+//
+//   D8 is deliberately absent: it records the enforcer being STRICTER than the
+//   prose (missing round provenance is already a violation), which is not a
+//   hole. It is resolved by documentation, not by a gate.
+//
+// Repo-local test. It requires the upstream review-tool bundle to be installed
+// (scripts/check-review-convergence.js and scripts/lib/review/*); if it is not,
+// this file exits non-zero rather than reporting a skip as a pass.
+"use strict";
+
+const assert = require("assert");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const REPO = path.resolve(__dirname, "..");
+const GATE = path.join(REPO, "scripts", "check-review-convergence.js");
+
+if (!fs.existsSync(GATE)) {
+  process.stderr.write(
+    `check-review-convergence-hardening.test.js: ${path.relative(REPO, GATE)} is not installed.\n` +
+      "This is a FAILURE, not a skip: the contract under test is unverified. Install the review-tool\n" +
+      "bundle (scripts/REVIEW-BUNDLE.md) and re-run.\n"
+  );
+  process.exit(2);
+}
+
+let failures = 0;
+let passes = 0;
+
+function check(name, fn) {
+  try {
+    fn();
+    passes += 1;
+    process.stdout.write(`  ok   ${name}\n`);
+  } catch (e) {
+    failures += 1;
+    process.stdout.write(`  FAIL ${name}\n       ${e.message.split("\n")[0]}\n`);
+  }
+}
+
+let scratchDir = null;
+function scratch() {
+  if (!scratchDir) scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "gate-hardening-"));
+  return scratchDir;
+}
+
+let seq = 0;
+function writeVerdict(verdict) {
+  seq += 1;
+  const dir = path.join(scratch(), `case-${seq}`);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${verdict.task || "unnamed"}-review.json`);
+  fs.writeFileSync(file, JSON.stringify(verdict, null, 2));
+  return file;
+}
+
+function runGate(verdictPath, args = []) {
+  const r = spawnSync(process.execPath, [GATE, verdictPath, "--max-rounds", "5", "--strikes", "2", "--static", ...args], {
+    cwd: REPO,
+    encoding: "utf8",
+  });
+  return { status: r.status, stdout: r.stdout || "", stderr: r.stderr || "" };
+}
+
+// Asserts a fail-closed refusal: exit 2, NO report on stdout (a report is what
+// a caller persists and treats as a result), and a stderr message matching
+// `pattern`. The empty-stdout assertion matters as much as the exit code — the
+// original defect was a report that looked exactly like a passing one.
+function rejects(verdict, pattern, args = []) {
+  const r = runGate(writeVerdict(verdict), args);
+  assert.strictEqual(r.status, 2, `expected exit 2, got ${r.status}. stderr: ${r.stderr}`);
+  assert.strictEqual(r.stdout, "", "an input-rejection must emit no gate report");
+  assert.match(r.stderr, pattern, `message did not name the hole. stderr: ${r.stderr}`);
+  return r;
+}
+
+// Asserts the gate reported (exit 0/1/3) and returns the parsed report.
+function reports(verdict, args = []) {
+  const r = runGate(writeVerdict(verdict), args);
+  assert.notStrictEqual(r.stdout, "", `expected a gate report, got exit ${r.status}. stderr: ${r.stderr}`);
+  return { status: r.status, report: JSON.parse(r.stdout) };
+}
+
+function auditEntry(round, extra = {}) {
+  return Object.assign(
+    {
+      round,
+      reviewed_sha: `reviewed-${round}`,
+      fix_sha: `fix-${round}`,
+      specialists_run: [{ name: "reviewer", selection_reason: "always (owner)" }],
+    },
+    extra
+  );
+}
+
+// The §"Minimal valid verdict" shape, minus `trace_schema_version` so the round
+// carries no trace obligation (no trace file exists beside these fixtures) and
+// the base case is a clean exit 0.
+function base(overrides = {}) {
+  return Object.assign(
+    {
+      task: "gate-hardening-selftest",
+      date: "2026-07-25T10:00:22.000Z",
+      status: "GO",
+      mode: "full",
+      round: 1,
+      cycle: 1,
+      no_go_round: 0,
+      auto_fixes_applied: 0,
+      findings: [],
+      cross_runtime_findings: [],
+      cross_runtime: {},
+      rounds_audit: [auditEntry(1)],
+      no_go_reason: null,
+      summary: "No findings.",
+      escalation_needed: false,
+      escalation_reason: null,
+      normalized_by: "2.0.0",
+    },
+    overrides
+  );
+}
+
+function finding(overrides = {}) {
+  return Object.assign(
+    {
+      severity: "HIGH",
+      confidence: 4,
+      path: "src/thing.ml",
+      line: 42,
+      category: "correctness",
+      summary: "a HIGH finding",
+      evidence: "src/thing.ml:42",
+      fix: "fix it",
+      fingerprint: "src/thing.ml:42:correctness",
+      specialist: "reviewer",
+      status: "OPEN",
+      first_seen_round: 1,
+    },
+    overrides
+  );
+}
+
+process.stdout.write("check-review-convergence hardening (fail-closed)\n");
+
+// ── control ──────────────────────────────────────────────────────────────
+check("CONTROL: the base fixture passes cleanly (exit 0, no violations)", () => {
+  const { status, report } = reports(base());
+  assert.strictEqual(status, 0, `base fixture is not clean: ${JSON.stringify(report.violations)}`);
+  assert.deepStrictEqual(report.violations, []);
+  assert.strictEqual(report.legacy_skip_authorized, false);
+  assert.strictEqual(typeof report.hardening.version, "string", "report must carry hardening.version (stale-script signal)");
+});
+
+// ── G1 / D3 — the named all-null-strike escape ───────────────────────────
+check("G1 rejects strike:null on a gated past round", () => {
+  rejects(
+    base({
+      round: 3,
+      rounds_audit: [auditEntry(1, { strike: false }), auditEntry(2, { strike: null }), auditEntry(3)],
+    }),
+    /rounds_audit entry for round 2 has strike null/
+  );
+});
+
+check("G1 rejects a non-boolean strike written onto the round being gated", () => {
+  rejects(
+    base({ round: 2, rounds_audit: [auditEntry(1, { strike: false }), auditEntry(2, { strike: null })] }),
+    /rounds_audit entry for round 2 has strike null/
+  );
+});
+
+check("G1 rejects strike: \"false\" — the string, not the boolean", () => {
+  rejects(
+    base({ round: 3, rounds_audit: [auditEntry(1, { strike: false }), auditEntry(2, { strike: "false" }), auditEntry(3)] }),
+    /has strike "false"/
+  );
+});
+
+check("G1 CONTROL: strike ABSENT on the round being gated is correct, not rejected", () => {
+  // The pipeline requires exactly this: the gate computes the strike, so the
+  // draft must not pre-empt it. A rule that rejected this would be unusable.
+  const { status } = reports(base({ round: 2, rounds_audit: [auditEntry(1, { strike: false }), auditEntry(2)] }));
+  assert.strictEqual(status, 0);
+});
+
+// ── G2 / D1 — the named unread cross_runtime_findings array ──────────────
+check("G2 rejects a HIGH OPEN cross_runtime finding that was never mirrored into findings[]", () => {
+  const { status, report } = reports(base({ status: "NO-GO", no_go_reason: { type: "cross-runtime-finding" }, cross_runtime_findings: [finding()] }));
+  assert.strictEqual(status, 1);
+  const violation = report.violations.find((v) => v.type === "unmirrored-cross-runtime-finding");
+  assert.ok(violation, `expected unmirrored-cross-runtime-finding, got ${JSON.stringify(report.violations)}`);
+  assert.strictEqual(violation.cause, "unencodable-finding");
+  assert.strictEqual(report.cause, "unencodable-finding");
+});
+
+check("G2 CONTROL: the same finding mirrored into findings[] is accepted", () => {
+  const { status, report } = reports(base({ cross_runtime_findings: [finding()], findings: [finding()] }));
+  assert.strictEqual(status, 0, JSON.stringify(report.violations));
+});
+
+check("G2 applies the ratchet to cross_runtime_findings, not only to findings[]", () => {
+  // A RESOLVED HIGH+ with no round provenance is an unencodable-finding
+  // violation in findings[]. Before D1 it was invisible in this array.
+  const { status, report } = reports(
+    base({
+      status: "NO-GO",
+      no_go_reason: { type: "cross-runtime-finding" },
+      cross_runtime_findings: [finding({ status: "RESOLVED", first_seen_round: undefined })],
+    })
+  );
+  assert.strictEqual(status, 1);
+  assert.ok(report.violations.some((v) => v.type === "missing-round-provenance"), JSON.stringify(report.violations));
+});
+
+check("G2 rejects a non-array cross_runtime_findings", () => {
+  rejects(base({ cross_runtime_findings: {} }), /cross_runtime_findings is present but not an array/);
+});
+
+check("G2 CONTROL: a MEDIUM cross-runtime finding does not need mirroring", () => {
+  const { status } = reports(base({ cross_runtime_findings: [finding({ severity: "MEDIUM" })] }));
+  assert.strictEqual(status, 0);
+});
+
+// ── G3 — absent `round`, the P3 vacuity core ─────────────────────────────
+check("G3 rejects a verdict with no `round` key", () => {
+  const verdict = base();
+  delete verdict.round;
+  rejects(verdict, /no `round` key/);
+});
+
+check("G3 the --allow-legacy skip is authorized AND recorded, never silent", () => {
+  const verdict = base();
+  delete verdict.round;
+  const { status, report } = reports(verdict, ["--allow-legacy"]);
+  assert.strictEqual(status, 0);
+  assert.strictEqual(report.legacy_skip_authorized, true, "an authorized skip must be visible in the artifact");
+  assert.strictEqual(report.current_round_strike, null);
+});
+
+// ── G4 / D10 — absent `no_go_round`, the quieter vacuity path ────────────
+check("G4 rejects a verdict with no `no_go_round` key (the cap could never fire)", () => {
+  const verdict = base();
+  delete verdict.no_go_round;
+  rejects(verdict, /no `no_go_round` key/);
+});
+
+// ── G5 — a rounds_audit gap erases the streak silently ───────────────────
+check("G5 rejects a rounds_audit that skips a past round", () => {
+  const { status, report } = reports(
+    base({
+      round: 4,
+      rounds_audit: [auditEntry(1, { strike: false }), auditEntry(3, { strike: true }), auditEntry(4)],
+    })
+  );
+  assert.strictEqual(status, 3, "a missing past entry is repairable — process-incomplete, never routed");
+  const violation = report.violations.find((v) => v.type === "missing-past-audit");
+  assert.ok(violation, JSON.stringify(report.violations));
+  assert.match(violation.detail, /round 2/);
+  assert.strictEqual(report.cause, null, "process-incomplete is never a top-level cause");
+});
+
+// ── G6 / D7 — finding status enum ────────────────────────────────────────
+check("G6 rejects a finding status outside OPEN|RESOLVED|ACCEPTED", () => {
+  // Live in this repo: briefs/make-tests-actually-run-review.json carries
+  // status "OPEN-FOR-HUMAN", which matches neither of the gate's two tests.
+  rejects(base({ findings: [finding({ status: "OPEN-FOR-HUMAN" })] }), /has status "OPEN-FOR-HUMAN"/);
+});
+
+check("G6 rejects a near-miss of ACCEPTED, which would read as un-waived", () => {
+  rejects(base({ findings: [finding({ status: "ACCEPTED-BY-HUMAN" })] }), /findings entry .* has status "ACCEPTED-BY-HUMAN"/);
+});
+
+check("G6 applies the status enum to cross_runtime_findings too", () => {
+  rejects(
+    base({ cross_runtime_findings: [finding({ status: "open" })] }),
+    /cross_runtime_findings entry .* has status "open"/
+  );
+});
+
+// ── G7 / D2 — the routing keys the gate never read ───────────────────────
+check("G7 rejects a typo'd no_go_reason.type (it would route nowhere)", () => {
+  rejects(
+    base({ status: "NO-GO", no_go_reason: { type: "design-not-convering" } }),
+    /no_go_reason.type is "design-not-convering"/
+  );
+});
+
+check("G7 rejects a NO-GO verdict with no no_go_reason at all", () => {
+  rejects(base({ status: "NO-GO", no_go_reason: null }), /status NO-GO with no no_go_reason/);
+});
+
+check("G7 rejects a status outside GO|NO-GO", () => {
+  rejects(base({ status: "PASS" }), /field status is "PASS"/);
+});
+
+check("G7 rejects a no_go_reason.cause outside the closed cause enum", () => {
+  rejects(
+    base({ status: "NO-GO", no_go_reason: { type: "design-not-converging", cause: "process-incomplete" } }),
+    /no_go_reason.cause is "process-incomplete"/
+  );
+});
+
+check("G7 flags a verdict asserting GO while the gate reports a design violation", () => {
+  const { status, report } = reports(base({ status: "GO", findings: [finding({ check_encodable: false })] }));
+  assert.strictEqual(status, 1);
+  assert.ok(report.violations.some((v) => v.type === "go-with-design-violation"), JSON.stringify(report.violations));
+});
+
+// ── G8 / D5 — the mode enum and the report-mode name collision ───────────
+check("G8 rejects a capitalised mode typo (it silently drops the scope-gate obligation)", () => {
+  rejects(base({ mode: "Full" }), /field mode is "Full"/);
+});
+
+check("G8 rejects the gate REPORT's mode enum copied into the verdict", () => {
+  const r = rejects(base({ mode: "static" }), /field mode is "static"/);
+  assert.match(r.stderr, /name collision/, "the message must explain the collision, not just reject");
+});
+
+// ── G9 / D4 — task is load-bearing on every non-legacy round ─────────────
+check("G9 rejects an absent task on a non-legacy round", () => {
+  const verdict = base();
+  delete verdict.task;
+  rejects(verdict, /field task is undefined, not a valid slug/);
+});
+
+check("G9 rejects a path-traversing task slug", () => {
+  rejects(base({ task: "../escape" }), /not a valid slug/);
+});
+
+// ── G10 / D11 — cycle presence and type ──────────────────────────────────
+check("G10 rejects an absent cycle", () => {
+  const verdict = base();
+  delete verdict.cycle;
+  rejects(verdict, /no `cycle` key/);
+});
+
+check("G10 rejects a stringly-typed cycle (it silently became null)", () => {
+  rejects(base({ cycle: "1" }), /field cycle is "1"/);
+});
+
+// ── G11 / D6 — an unnormalized verdict has no stable fingerprints ────────
+check("G11 rejects a verdict that never went through review-normalize.js", () => {
+  const verdict = base();
+  delete verdict.normalized_by;
+  rejects(verdict, /normalized_by is absent or empty/);
+});
+
+check("G11 rejects an empty normalized_by", () => {
+  rejects(base({ normalized_by: "   " }), /normalized_by is absent or empty/);
+});
+
+// ── G12 / D9 — cross_runtime key asymmetry and status enum ───────────────
+check("G12 rejects the journal's `digest` key written into the verdict", () => {
+  const r = rejects(
+    base({ cross_runtime: { codex: { status: "healthy", digest: "abc123", round: 1 } } }),
+    /carries `digest` but not `config_digest`/
+  );
+  assert.match(r.stderr, /corroboration\s+silently finds nothing/);
+});
+
+check("G12 rejects an unrecognised cross_runtime status (never corroborated, never warned)", () => {
+  rejects(base({ cross_runtime: { codex: { status: "ok", config_digest: "abc123" } } }), /status is "ok"/);
+});
+
+check("G12 CONTROL: the documented five statuses are accepted", () => {
+  for (const status of ["healthy", "degraded", "skipped-degraded", "skipped-human", "blocked"]) {
+    const { status: exit } = reports(base({ cross_runtime: { codex: { status, config_digest: "abc", reason: "r" } } }));
+    assert.notStrictEqual(exit, 2, `status ${status} must not be degraded input`);
+  }
+});
+
+// ── G13 — blind container coercions ──────────────────────────────────────
+check("G13 rejects a non-array rounds_audit (it was silently read as [])", () => {
+  rejects(base({ rounds_audit: {} }), /rounds_audit is present but not an array/);
+});
+
+check("G13 rejects a non-object cross_runtime (it was silently ignored)", () => {
+  rejects(base({ cross_runtime: [] }), /cross_runtime is present but not an object/);
+});
+
+// ── teardown ─────────────────────────────────────────────────────────────
+if (scratchDir) fs.rmSync(scratchDir, { recursive: true, force: true });
+
+process.stdout.write(`\n${passes} passed, ${failures} failed\n`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/check-review-convergence-hardening.test.js
+++ b/scripts/check-review-convergence-hardening.test.js
@@ -516,6 +516,119 @@ check("F4 CONTROL: every required key present and well-formed still passes", () 
   assert.strictEqual(status, 0);
 });
 
+// ── the local-patch declaration must be TRUE ─────────────────────────────
+//
+// This file is the `tests` reference of the `backlog #98` entry in
+// scripts/review-bundle.manifest.json's local_patches[], so it is the right
+// place to verify that the entry is not lying. The bundle's guard checks the
+// declaration from the outside; these check it from the inside, and both halves
+// matter for a different reason:
+//
+//   present-in-patched  — a marker that is not there makes the guard report a
+//                         revert that did not happen: a false alarm, which is
+//                         how a correct guard gets mistaken for a broken tool.
+//   absent-in-pristine  — a marker that upstream ALSO contains can never go
+//                         missing, so the guard can never detect a real revert.
+//                         This is the half people skip, and skipping it makes
+//                         the whole mechanism a no-op that reports success.
+//   non-empty           — an empty needle matches every file, silently turning
+//                         the marker mechanism into a no-op reporting success.
+//                         (A guard bug found and fixed on #305; asserted here
+//                         so a future edit cannot reintroduce it from this side.)
+//
+// I verified all three by hand when drafting the entry. Doing it by hand is the
+// wrong shape for precisely the reason this whole task keeps re-teaching, so it
+// is mechanical now.
+const PATCH_REF = "backlog #98";
+const INTENDED_MARKERS = ["review-gate-hardening", "legacy_skip_authorized", "--allow-legacy"];
+
+function readManifest() {
+  const file = path.join(REPO, "scripts", "review-bundle.manifest.json");
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+// Markers as declared, or as intended if the entry has not landed yet. The
+// not-yet-landed branch is NOT a skip: it asserts the declaration will be true
+// at the moment it is made, which is the whole point of landing the entry
+// atomically with the wiring.
+function markersUnderTest() {
+  const manifest = readManifest();
+  const declared = manifest && Array.isArray(manifest.local_patches)
+    ? manifest.local_patches.find((p) => p && p.ref === PATCH_REF)
+    : null;
+  if (!declared) return { markers: INTENDED_MARKERS, paths: ["scripts/check-review-convergence.js"], declared: false };
+  const markers = Array.isArray(declared.markers)
+    ? declared.markers
+    : Object.values(declared.markers || {}).flat();
+  return { markers, paths: declared.paths, declared: true };
+}
+
+check("local-patch markers are non-empty (an empty needle matches everything)", () => {
+  const { markers } = markersUnderTest();
+  assert.ok(markers.length > 0, "a reapply_on_upgrade patch with no markers cannot detect its own revert");
+  for (const marker of markers) {
+    assert.strictEqual(typeof marker, "string", `marker ${JSON.stringify(marker)} is not a string`);
+    assert.notStrictEqual(marker.trim(), "", "an empty marker matches every file and silently no-ops the mechanism");
+  }
+});
+
+check("local-patch markers are PRESENT in every patched path", () => {
+  const { markers, paths } = markersUnderTest();
+  for (const rel of paths) {
+    const file = path.join(REPO, rel);
+    assert.ok(fs.existsSync(file), `declared patch path does not exist: ${rel}`);
+    const body = fs.readFileSync(file, "utf8");
+    for (const marker of markers) {
+      assert.ok(body.includes(marker), `marker ${JSON.stringify(marker)} is absent from ${rel} — the guard would report a revert that did not happen`);
+    }
+  }
+});
+
+check("local-patch markers are ABSENT from the pristine upstream file", () => {
+  // The half people skip. A marker upstream ALSO contains can never go missing,
+  // so it can never detect a revert.
+  //
+  // The first version of this check compared against the merge-base and did
+  // `if (upstream.status !== 0) continue` when the path was not tracked there.
+  // Pre-#305 that is every path, so it ran ZERO assertions and reported ok — a
+  // vacuous gate, inside the test whose subject is markers that must be able to
+  // fail. Now it always asserts something real and says which tier it got.
+  const { markers, paths } = markersUnderTest();
+  const mergeBase = spawnSync("git", ["merge-base", "HEAD", "origin/main"], { cwd: REPO, encoding: "utf8" });
+  const base = mergeBase.status === 0 ? mergeBase.stdout.trim() : null;
+
+  let compared = 0;
+  for (const rel of base ? paths : []) {
+    const upstream = spawnSync("git", ["show", `${base}:${rel}`], { cwd: REPO, encoding: "utf8" });
+    if (upstream.status !== 0) continue; // not tracked at the merge-base yet (pre-#305)
+    compared += 1;
+    for (const marker of markers) {
+      assert.ok(
+        !upstream.stdout.includes(marker),
+        `marker ${JSON.stringify(marker)} is ALSO in the upstream ${rel} — it can never go missing, so it can never detect a revert`
+      );
+    }
+  }
+
+  // Weaker tier, but a real assertion rather than an absent one: a marker must
+  // be specific enough that upstream could not plausibly contain it. Runs
+  // ALWAYS, so this check can never report success without checking something.
+  for (const marker of markers) {
+    assert.ok(marker.length >= 8, `marker ${JSON.stringify(marker)} is too short to prove a revert`);
+    assert.ok(
+      /[-_]|[a-z][A-Z]/.test(marker),
+      `marker ${JSON.stringify(marker)} is a single generic word — upstream could contain it, so it cannot prove a revert`
+    );
+  }
+  if (compared === 0) {
+    process.stdout.write(
+      "       (tier: specificity only — no declared path is tracked at the merge-base yet;\n" +
+        "        the upstream-diff tier arms itself once #305 lands and the gate is tracked)\n"
+    );
+  }
+});
+
 // ── teardown ─────────────────────────────────────────────────────────────
 if (scratchDir) fs.rmSync(scratchDir, { recursive: true, force: true });
 

--- a/scripts/check-review-convergence-hardening.test.js
+++ b/scripts/check-review-convergence-hardening.test.js
@@ -539,8 +539,17 @@ check("F4 CONTROL: every required key present and well-formed still passes", () 
 // I verified all three by hand when drafting the entry. Doing it by hand is the
 // wrong shape for precisely the reason this whole task keeps re-teaching, so it
 // is mechanical now.
-const PATCH_REF = "backlog #98";
-const INTENDED_MARKERS = ["review-gate-hardening", "legacy_skip_authorized", "--allow-legacy"];
+// The ref MUST match scripts/review-bundle.manifest.json exactly. It did not,
+// once: the constant said "backlog #98" while the landed entry said
+// "#98 — convergence gate fails closed", so the lookup missed, the
+// not-yet-landed fallback fired, and all three checks below silently graded the
+// INTENDED list instead of the DECLARED one. Adding a marker that upstream also
+// contains changed nothing — the declaration was not being read at all. Hence
+// `#98 patch is DECLARED` below, which fails if this constant ever drifts again.
+const PATCH_REF = "#98 — convergence gate fails closed";
+const PATCH_PATH = "scripts/check-review-convergence.js";
+// A marker of the applied patch, used to decide whether a declaration is OWED.
+const APPLIED_SENTINEL = "evaluateHardening";
 
 function readManifest() {
   const file = path.join(REPO, "scripts", "review-bundle.manifest.json");
@@ -548,21 +557,36 @@ function readManifest() {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
 
-// Markers as declared, or as intended if the entry has not landed yet. The
-// not-yet-landed branch is NOT a skip: it asserts the declaration will be true
-// at the moment it is made, which is the whole point of landing the entry
-// atomically with the wiring.
-function markersUnderTest() {
+function declaredPatch() {
   const manifest = readManifest();
-  const declared = manifest && Array.isArray(manifest.local_patches)
-    ? manifest.local_patches.find((p) => p && p.ref === PATCH_REF)
-    : null;
-  if (!declared) return { markers: INTENDED_MARKERS, paths: ["scripts/check-review-convergence.js"], declared: false };
-  const markers = Array.isArray(declared.markers)
-    ? declared.markers
-    : Object.values(declared.markers || {}).flat();
-  return { markers, paths: declared.paths, declared: true };
+  if (!manifest || !Array.isArray(manifest.local_patches)) return null;
+  return manifest.local_patches.find((p) => p && p.ref === PATCH_REF) || null;
 }
+
+function markersUnderTest() {
+  const declared = declaredPatch();
+  assert.ok(declared, `no local_patches[] entry with ref ${JSON.stringify(PATCH_REF)} — nothing to verify`);
+  const markers = Array.isArray(declared.markers) ? declared.markers : Object.values(declared.markers || {}).flat();
+  return { markers, paths: declared.paths || [] };
+}
+
+// The bidirectional consistency the fallback used to hide. An applied patch owes
+// a declaration; the two may not disagree in either direction.
+check("#98 patch is DECLARED whenever it is applied", () => {
+  const gate = fs.readFileSync(path.join(REPO, PATCH_PATH), "utf8");
+  const applied = gate.includes(APPLIED_SENTINEL);
+  const declared = declaredPatch();
+  if (applied) {
+    assert.ok(
+      declared,
+      `${PATCH_PATH} carries the #98 hardening but no local_patches[] entry with ref ${JSON.stringify(PATCH_REF)} declares it — undeclared drift is exactly what the manifest exists to prevent`
+    );
+    assert.ok(declared.reapply_on_upgrade === true, "#98 must declare reapply_on_upgrade: an upgrade overwrites the gate");
+    assert.ok((declared.paths || []).includes(PATCH_PATH), `#98 paths must include ${PATCH_PATH}`);
+  } else {
+    assert.ok(!declared, `local_patches[] declares #98 but ${PATCH_PATH} does not carry it — the declaration is false`);
+  }
+});
 
 check("local-patch markers are non-empty (an empty needle matches everything)", () => {
   const { markers } = markersUnderTest();

--- a/scripts/check-review-convergence-hardening.test.js
+++ b/scripts/check-review-convergence-hardening.test.js
@@ -354,7 +354,7 @@ check("G8 rejects the gate REPORT's mode enum copied into the verdict", () => {
 check("G9 rejects an absent task on a non-legacy round", () => {
   const verdict = base();
   delete verdict.task;
-  rejects(verdict, /field task is undefined, not a valid slug/);
+  rejects(verdict, /has no `task` key/);
 });
 
 check("G9 rejects a path-traversing task slug", () => {
@@ -376,11 +376,12 @@ check("G10 rejects a stringly-typed cycle (it silently became null)", () => {
 check("G11 rejects a verdict that never went through review-normalize.js", () => {
   const verdict = base();
   delete verdict.normalized_by;
-  rejects(verdict, /normalized_by is absent or empty/);
+  const r = rejects(verdict, /has no `normalized_by` key/);
+  assert.match(r.stderr, /`novel finding` is uncomputable/, "the message must say why, not just which key");
 });
 
 check("G11 rejects an empty normalized_by", () => {
-  rejects(base({ normalized_by: "   " }), /normalized_by is absent or empty/);
+  rejects(base({ normalized_by: "   " }), /field normalized_by is "   ", not a non-empty string/);
 });
 
 // ── G12 / D9 — cross_runtime key asymmetry and status enum ───────────────
@@ -410,6 +411,109 @@ check("G13 rejects a non-array rounds_audit (it was silently read as [])", () =>
 
 check("G13 rejects a non-object cross_runtime (it was silently ignored)", () => {
   rejects(base({ cross_runtime: [] }), /cross_runtime is present but not an object/);
+});
+
+// ── G14/G15 (review finding F4) — absence-blindness in the hardening itself ─
+//
+// The first version of this module guarded `mode` and `status` with
+// `has(review, key) && !VALID.has(value)`: it closed the malformed half and
+// left the omission half open, three lines under a comment describing these as
+// keys "whose omission used to remove an obligation rather than fail one".
+// Measured at the time:
+//
+//   mode: "Full"      -> exit 2, "not one of express | fast | full (D5)"
+//   mode key OMITTED  -> exit 0, violations: []
+//
+// Every case below is paired: the malformed form was ALREADY rejected, so the
+// omitted form is the one that proves the hole is shut. Three of the five keys
+// (`cycle`, `task`, `normalized_by`) did check absence, which is exactly why
+// hand-written guards looked complete — hence the table in the module.
+
+check("F4 rejects an OMITTED mode, not just a misspelled one", () => {
+  // The dropped obligation is real: review-trace-rules.js requires the
+  // scope-gate trace line only when mode === "full".
+  rejects(base({ mode: "Full" }), /field mode is "Full"/); // was already caught
+  const verdict = base();
+  delete verdict.mode;
+  const r = rejects(verdict, /has no `mode` key/); // was exit 0
+  assert.match(r.stderr, /DROPS that obligation rather than failing it/);
+});
+
+check("F4 rejects an OMITTED status, which disarmed the GO-consistency check", () => {
+  // With status present, an unmirrored HIGH yields BOTH violations.
+  const withStatus = reports(base({ status: "GO", cross_runtime_findings: [finding()] }));
+  assert.deepStrictEqual(
+    withStatus.report.violations.map((v) => v.type).sort(),
+    ["go-with-design-violation", "unmirrored-cross-runtime-finding"]
+  );
+  // Deleting the key used to silently drop go-with-design-violation.
+  const verdict = base({ cross_runtime_findings: [finding()] });
+  delete verdict.status;
+  rejects(verdict, /has no `status` key/);
+});
+
+check("F4 rejects an OMITTED cross_runtime_findings, not just a non-array one", () => {
+  rejects(base({ cross_runtime_findings: {} }), /not an array/); // was already caught
+  const verdict = base();
+  delete verdict.cross_runtime_findings;
+  rejects(verdict, /has no `cross_runtime_findings` key/); // was exit 0
+});
+
+check("F4 rejects cross_runtime: null — the carve-out its own message condemned", () => {
+  // checkContainerTypes had an explicit `!== null` exemption, granting null
+  // precisely the "silently ignored" treatment the message warns about.
+  const r = rejects(base({ cross_runtime: null }), /field cross_runtime is null/);
+  assert.match(r.stderr, /drops every cross-runtime corroboration check/);
+});
+
+check("F4 rejects an OMITTED rounds_audit and an OMITTED cross_runtime", () => {
+  const noAudit = base();
+  delete noAudit.rounds_audit;
+  rejects(noAudit, /has no `rounds_audit` key/);
+
+  const noXruntime = base();
+  delete noXruntime.cross_runtime;
+  rejects(noXruntime, /has no `cross_runtime` key/);
+});
+
+check("F4 rejects an OMITTED findings array", () => {
+  const verdict = base();
+  delete verdict.findings;
+  rejects(verdict, /has no `findings` key/);
+});
+
+check("F4 rejects a cross_runtime entry with NO status", () => {
+  // computeCrossRuntimeCorroboration only attests healthy|degraded|skipped-human,
+  // so a statusless entry is never corroborated — the omission bought the same
+  // silence an unrecognised value would have.
+  rejects(base({ cross_runtime: { codex: { config_digest: "abc", round: 1 } } }), /status is absent/);
+});
+
+check("G14 rejects a null / non-object rounds_audit ELEMENT", () => {
+  // The container type was checked; the element types were not. Every consumer
+  // opens with `if (!e || typeof e !== "object") continue`.
+  const audit = (extra) => base({ round: 3, rounds_audit: [auditEntry(1, { strike: false }), extra, auditEntry(3)] });
+  rejects(audit(null), /rounds_audit\[1\] is not an object/);
+  rejects(audit("x"), /rounds_audit\[1\] is not an object/);
+});
+
+check("G14 rejects a rounds_audit element with no numeric round", () => {
+  rejects(
+    base({ round: 3, rounds_audit: [auditEntry(1, { strike: false }), { reviewed_sha: "a", strike: true }, auditEntry(3)] }),
+    /rounds_audit\[1\] has no numeric `round`/
+  );
+});
+
+check("G14 rejects a null element in findings and in cross_runtime_findings", () => {
+  rejects(base({ findings: [null] }), /findings\[0\] is not an object/);
+  rejects(base({ cross_runtime_findings: [finding(), "x"] }), /cross_runtime_findings\[1\] is not an object/);
+});
+
+check("F4 CONTROL: every required key present and well-formed still passes", () => {
+  // The base fixture carries all nine table keys. If this ever goes red, the
+  // table has grown a requirement the assembler does not emit.
+  const { status } = reports(base());
+  assert.strictEqual(status, 0);
 });
 
 // ── teardown ─────────────────────────────────────────────────────────────

--- a/scripts/check-review-convergence.js
+++ b/scripts/check-review-convergence.js
@@ -15,7 +15,7 @@
 // are keyed by (check, fid) with a fingerprint fallback (E-3).
 //
 // Usage: node scripts/check-review-convergence.js <review.json path>
-//   [--static] [--max-rounds N] [--timeout S] [--strikes N]
+//   [--static] [--max-rounds N] [--timeout S] [--strikes N] [--allow-legacy]
 //
 // Exit contract:
 //   0 = pass (no violations, no degraded input)
@@ -40,10 +40,16 @@
 // executed here (see roster-review.md §5.5) — out of mechanical-verification
 // scope, not a violation.
 //
-// Legacy handling (B-8): when review.json lacks the `round` key (the
-// physical per-cycle counter), strike classification and the rounds_audit
-// completeness check are SKIPPED with a warning — the 17 pre-existing
-// fixtures (keyed on `no_go_round` only) pass unmodified.
+// Legacy handling (B-8, HARDENED): when review.json lacks the `round` key
+// (the physical per-cycle counter), strike classification and the rounds_audit
+// completeness check cannot run. That used to be a WARNING on an exit-0 run —
+// i.e. a gate that could not fail, whose green was byte-identical to a real
+// one. It is now exit 2 unless the caller passes --allow-legacy, which is
+// RECORDED in the report as `legacy_skip_authorized: true` and refused by
+// review-verdict-assemble.js --write-strike. The 17 pre-existing fixtures
+// (keyed on `no_go_round` only) pass with that flag, and only with it.
+// Same treatment for an absent `no_go_round` (D10), under which the round cap
+// could never fire.
 //
 // Config-echo contract (B-4, FIX-6): the JSON report ALWAYS includes
 // `config: {max_rounds, strikes, static}` on every exit code — this is how a
@@ -80,18 +86,37 @@ const {
 } = require("./lib/review/review-convergence-rules");
 const { isFullSha, verifyFinding } = require("./lib/review/redgreen-scratch");
 const { evaluateTrace } = require("./lib/review/review-trace-dispatch");
+// Repo-local (NOT bundle-owned — see scripts/lib/review-gate-hardening.js's
+// header). Turns the eleven recorded prose/enforcer discrepancies
+// (schema/review-json-schema.md §"Prose/enforcer discrepancies", D1..D11) plus
+// three undocumented vacuity paths from warnings-on-an-exit-0-run into
+// fail-closed refusals.
+const { HARDENING_VERSION, evaluateHardening, computeGoConsistencyViolation } = require("./lib/review-gate-hardening");
 
-const KNOWN_FLAGS = new Set(["--static", "--max-rounds", "--timeout", "--strikes"]);
+const KNOWN_FLAGS = new Set(["--static", "--max-rounds", "--timeout", "--strikes", "--allow-legacy"]);
 const DEFAULT_STRIKES = 2;
 
 // B-4: unknown flags are rejected (exit 2) so a stale/mismatched invocation
 // fails loudly instead of silently ignoring a new flag.
 function parseArgs(argv) {
-  const out = { reviewPath: null, static: false, maxRounds: 5, timeout: 120, strikes: DEFAULT_STRIKES, unknownFlag: null };
+  const out = {
+    reviewPath: null,
+    static: false,
+    maxRounds: 5,
+    timeout: 120,
+    strikes: DEFAULT_STRIKES,
+    allowLegacy: false,
+    unknownFlag: null,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--static") {
       out.static = true;
+    } else if (a === "--allow-legacy") {
+      // A RECORDED skip, not a silent one: it is echoed into the report as
+      // `legacy_skip_authorized`, and review-verdict-assemble.js --write-strike
+      // refuses a report carrying it.
+      out.allowLegacy = true;
     } else if (a === "--max-rounds") {
       out.maxRounds = parseInt(argv[++i], 10);
     } else if (a === "--timeout") {
@@ -350,7 +375,13 @@ function buildReport({ args, noGoRound, legacyNoGoRound, round, legacyRound, cur
     round,
     legacy_round: legacyRound,
     current_round_strike: currentRoundStrike,
+    // The recorded-skip field. True means the caller explicitly authorized the
+    // gate to skip checks it could not perform; the run is NOT evidence that
+    // those checks passed, and --write-strike refuses to journal a strike from
+    // a report carrying it.
+    legacy_skip_authorized: args.allowLegacy && (legacyRound || legacyNoGoRound),
     config: { max_rounds: args.maxRounds, strikes: args.strikes, static: args.static },
+    hardening: { version: HARDENING_VERSION },
     cause: selectCause(violations),
     warnings,
     violations,
@@ -382,6 +413,13 @@ function main() {
 
   const violations = [];
 
+  // Fail-closed hardening FIRST: every rule below assumes the envelope is
+  // populated well enough for its answer to mean something. Running it first
+  // is what makes the message name the root cause rather than a symptom.
+  const hardening = evaluateHardening({ review, round, legacyRound, legacyNoGoRound, allowLegacy: args.allowLegacy, findings });
+  if (hardening.fatal) fail(2, hardening.fatal);
+  violations.push(...hardening.violations);
+
   // FR-026: cap violation.
   if (noGoRound >= args.maxRounds) {
     violations.push({
@@ -392,6 +430,10 @@ function main() {
   }
 
   violations.push(...computeFindingViolations(findings));
+  // D1: cross_runtime_findings entries are canonical findings with GO
+  // authority. They were exempt from the ratchet, the provenance check and the
+  // unencodable-finding check purely because nothing ever opened the array.
+  violations.push(...computeFindingViolations(Array.isArray(review.cross_runtime_findings) ? review.cross_runtime_findings : []));
 
   const strikeAudit = evaluateStrikesAndAudit(review, round, legacyRound, findings, args.strikes);
   violations.push(...strikeAudit.violations);
@@ -405,6 +447,11 @@ function main() {
   if (trace.fail) fail(trace.fail.code, trace.fail.message);
   violations.push(...trace.violations);
   warnings.push(...trace.warnings);
+
+  // Evaluated last, over the fully accumulated list: a verdict may not assert
+  // GO while the gate is reporting a design violation (D2).
+  const goConsistency = computeGoConsistencyViolation(review, violations);
+  if (goConsistency) violations.push(goConsistency);
 
   const report = buildReport({
     args,

--- a/scripts/lib/mandated-steps-rules.js
+++ b/scripts/lib/mandated-steps-rules.js
@@ -1,0 +1,205 @@
+// scripts/lib/mandated-steps-rules.js — CommonJS, repo-local, pure rules.
+//
+// THE DEFECT THIS CLOSES
+//
+// A mandated pipeline step that is skipped without leaving a record is
+// indistinguishable from one that ran and passed. Nothing in the artifacts
+// separates the two, so the skip reads as a pass forever after. Three real
+// instances, all from the same friction log:
+//
+//   - roster-run Step 4 mandates `/roster-doctor preflight` before any phase
+//     that builds or tests. It was not run across an entire day of
+//     implementation work, and the environment had three real problems it
+//     would have surfaced (stale main, wedged Docker daemon, half-upgraded
+//     opam switch). Nothing recorded that it had not run.
+//   - the roster-ship human gate was skipped under a standing autonomy
+//     delegation. Legitimate — but it went into the record as though a human
+//     had answered, which is exactly the distinction the gate exists to keep.
+//   - the cross-runtime pass, mandatory on every Fast/Full PR, was disabled by
+//     its own circuit breaker on a caller-side fault; the round then looked
+//     like a round on which cross-runtime simply had nothing to say.
+//
+// This is the same defect as the review gate's silent degradation, one level
+// up: a green that means "not checked", not "checked out".
+//
+// THE RULE
+//
+// Every mandated step emits exactly one record. `skipped` is a legal outcome —
+// the point is not to forbid skipping, it is to make a skip *say so*, in
+// writing, with a reason and an actor. The absence of a required record is
+// then a failure, because absence is the only thing that can no longer be
+// confused with success.
+//
+// Deliberately NOT enforced: whether a `reason` is a *good* reason. That is a
+// human judgement. What is enforced is that one exists, that it is attributable,
+// and that an agent's decision is never recorded as a human's.
+"use strict";
+
+const OUTCOMES = new Set(["ran", "skipped"]);
+const ACTORS = new Set(["human", "agent"]);
+// `ran` steps additionally report what they found. NOT-READY is a legitimate,
+// recordable result — a preflight that ran and found the environment broken is
+// evidence, and must not be indistinguishable from one that found it healthy.
+const RESULTS = new Set(["READY", "NOT-READY", "PASS", "FAIL", "N/A"]);
+
+// The mandated-step catalogue. A step id absent from here is rejected rather
+// than accepted, so a typo can never stand in for the step it resembles —
+// `prefligt` recorded, `preflight` still missing, is a failure, not a pass.
+const STEPS = {
+  preflight: {
+    description: "/roster-doctor preflight — required before any phase that builds or tests (roster-run Step 4)",
+  },
+  "human-gate": {
+    description: "the human validation quiz (rules/human-validation.md)",
+    // A gate whose whole purpose is human judgement cannot be recorded as
+    // having *run* by an agent. Under a standing delegation the honest record
+    // is outcome: skipped, actor: agent, reason: <the delegation>.
+    humanOnly: true,
+  },
+  xruntime: {
+    description: "the cross-runtime review pass (mandatory on Fast/Full PRs)",
+  },
+  "scope-gate": {
+    description: "check-scope-diff.sh — the out-of-scope-change gate",
+  },
+  "degraded-specialist": {
+    description: "a conditional specialist that was selected but could not run",
+    repeatable: true,
+  },
+};
+
+// Which steps each phase mandates. `--require` overrides this; an unknown
+// phase is rejected, never defaulted to "nothing required" (that default would
+// itself be a gate that cannot fail — a typo'd phase would demand nothing).
+const PHASE_REQUIREMENTS = {
+  intake: [],
+  question: [],
+  research: [],
+  spec: [],
+  plan: ["human-gate"],
+  implement: ["preflight"],
+  review: ["preflight", "scope-gate", "xruntime"],
+  qa: ["preflight"],
+  ship: ["preflight", "human-gate"],
+};
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+// Validates one record in isolation. Returns an error string or null.
+function validateRecord(record, index) {
+  const where = `record ${index + 1}`;
+  if (!record || typeof record !== "object" || Array.isArray(record)) return `${where} is not a JSON object`;
+  if (!isNonEmptyString(record.step)) return `${where} has no \`step\``;
+  if (!Object.prototype.hasOwnProperty.call(STEPS, record.step)) {
+    return `${where} names an unknown step ${JSON.stringify(record.step)} — known steps: ${Object.keys(STEPS).join(", ")}. An unrecognised id cannot satisfy a requirement, so a typo here leaves the real step unrecorded.`;
+  }
+  if (!OUTCOMES.has(record.outcome)) {
+    return `${where} (${record.step}) has outcome ${JSON.stringify(record.outcome)}, not one of ${[...OUTCOMES].join(" | ")}`;
+  }
+  if (!ACTORS.has(record.actor)) {
+    return `${where} (${record.step}) has actor ${JSON.stringify(record.actor)}, not one of ${[...ACTORS].join(" | ")} — a skip must be attributable`;
+  }
+  if (!isNonEmptyString(record.ts)) return `${where} (${record.step}) has no \`ts\` timestamp`;
+
+  if (record.outcome === "skipped") {
+    if (!isNonEmptyString(record.reason)) {
+      return `${where} (${record.step}) is outcome "skipped" with no \`reason\` — an unreasoned skip is the thing this check exists to stop`;
+    }
+    return null;
+  }
+
+  // outcome === "ran"
+  if (!RESULTS.has(record.result)) {
+    return `${where} (${record.step}) is outcome "ran" with result ${JSON.stringify(record.result)}, not one of ${[...RESULTS].join(" | ")} — a step that ran must say what it found`;
+  }
+  if ((record.result === "NOT-READY" || record.result === "FAIL") && !isNonEmptyString(record.reason)) {
+    return `${where} (${record.step}) reports ${record.result} with no \`reason\``;
+  }
+  if (STEPS[record.step].humanOnly && record.actor !== "human") {
+    return `${where} (${record.step}) is recorded as outcome "ran" by actor ${JSON.stringify(record.actor)} — this step is human-only. An agent proceeding under a standing delegation must record outcome "skipped" with the delegation as its reason, so an agent's decision is never journaled as a human's.`;
+  }
+  return null;
+}
+
+// Cross-record rules: one record per step (except explicitly repeatable ones),
+// and every record belongs to the task under check.
+function validateRecordSet(records, task) {
+  const errors = [];
+  const seen = new Map();
+  records.forEach((record, index) => {
+    const error = validateRecord(record, index);
+    if (error) {
+      errors.push(error);
+      return;
+    }
+    if (task && record.task !== undefined && record.task !== task) {
+      errors.push(`record ${index + 1} (${record.step}) is stamped task ${JSON.stringify(record.task)}, not ${JSON.stringify(task)}`);
+      return;
+    }
+    if (STEPS[record.step].repeatable) return;
+    if (seen.has(record.step)) {
+      errors.push(
+        `step ${JSON.stringify(record.step)} is recorded twice (records ${seen.get(record.step) + 1} and ${index + 1}) — two records for one step means one of them is not evidence about this run`
+      );
+      return;
+    }
+    seen.set(record.step, index);
+  });
+  return errors;
+}
+
+function resolveRequirements({ phase, require: explicit }) {
+  if (Array.isArray(explicit) && explicit.length > 0) {
+    const unknown = explicit.filter((step) => !Object.prototype.hasOwnProperty.call(STEPS, step));
+    if (unknown.length > 0) return { error: `--require names unknown step(s): ${unknown.join(", ")}` };
+    return { required: explicit };
+  }
+  if (!Object.prototype.hasOwnProperty.call(PHASE_REQUIREMENTS, phase)) {
+    return {
+      error: `unknown phase ${JSON.stringify(phase)} — known phases: ${Object.keys(PHASE_REQUIREMENTS).join(", ")}. Refusing to default an unrecognised phase to "nothing required".`,
+    };
+  }
+  return { required: PHASE_REQUIREMENTS[phase] };
+}
+
+// THE load-bearing rule: a required step with no record is a failure. Not a
+// warning, not an empty list — a failure with the step named.
+function computeMissingRequirements(records, required) {
+  const recorded = new Set(records.filter((r) => r && typeof r.step === "string").map((r) => r.step));
+  return required
+    .filter((step) => !recorded.has(step))
+    .map(
+      (step) =>
+        `no record for mandated step ${JSON.stringify(step)} (${STEPS[step].description}). An unrecorded step is indistinguishable from one that ran and passed; if it was skipped, record it as skipped with a reason.`
+    );
+}
+
+function evaluate({ records, phase, require: explicit, task }) {
+  const resolved = resolveRequirements({ phase, require: explicit });
+  if (resolved.error) return { usageError: resolved.error };
+
+  const invalid = validateRecordSet(records, task);
+  const missing = computeMissingRequirements(records, resolved.required);
+  return {
+    usageError: null,
+    required: resolved.required,
+    invalid,
+    missing,
+    ok: invalid.length === 0 && missing.length === 0,
+  };
+}
+
+module.exports = {
+  OUTCOMES,
+  ACTORS,
+  RESULTS,
+  STEPS,
+  PHASE_REQUIREMENTS,
+  validateRecord,
+  validateRecordSet,
+  resolveRequirements,
+  computeMissingRequirements,
+  evaluate,
+};

--- a/scripts/lib/mandated-steps-rules.js
+++ b/scripts/lib/mandated-steps-rules.js
@@ -178,7 +178,15 @@ function validateRecordSet(records, task) {
 }
 
 function resolveRequirements({ phase, require: explicit }) {
-  if (Array.isArray(explicit) && explicit.length > 0) {
+  if (Array.isArray(explicit)) {
+    // An empty explicit list must NOT silently fall through to the phase
+    // defaults: the caller asked for a specific requirement set, and answering
+    // with a different one (possibly the empty one) is how an explicit demand
+    // gets discharged by nothing. `null` means "not given"; `[]` means "given
+    // and empty", which is a usage error.
+    if (explicit.length === 0) {
+      return { error: "--require was given but names no steps — refusing to fall back to the phase defaults" };
+    }
     const unknown = explicit.filter((step) => !Object.prototype.hasOwnProperty.call(STEPS, step));
     if (unknown.length > 0) return { error: `--require names unknown step(s): ${unknown.join(", ")}` };
     return { required: explicit };

--- a/scripts/lib/mandated-steps-rules.js
+++ b/scripts/lib/mandated-steps-rules.js
@@ -71,6 +71,33 @@ const STEPS = {
 // Which steps each phase mandates. `--require` overrides this; an unknown
 // phase is rejected, never defaulted to "nothing required" (that default would
 // itself be a gate that cannot fail — a typo'd phase would demand nothing).
+//
+// MEASURED BEFORE SHIPPING, not assumed. The first draft of this table also
+// mandated `scope-gate` and `xruntime` on `review`. Measuring against the real
+// artifacts in briefs/ killed that:
+//
+//   36 verdicts, 30 journaled rounds, 16 review traces
+//   scope-gate trace events ..........  9
+//   cross-runtime trace events .......  1
+//   verdicts recording cross_runtime ..  3   (0 with status "healthy")
+//
+// So the requirement would have fired on nearly every round. Under this ledger
+// a `skipped` record discharges it, so it would never have been *unsatisfiable*
+// — but a requirement discharged by boilerplate on 9 rounds out of 10 is an
+// alarm people learn to paste past, which is the same failure as an alarm they
+// learn to ignore.
+//
+// The decisive reason is the second one: both obligations are ALREADY enforced,
+// better, by the trace mechanism — review-trace-rules.js requires a `scope-gate`
+// line whenever mode === "full" (computeRequiredCoverage) and corroborates every
+// claimed probe against the xruntime journal (computeCrossRuntimeCorroboration,
+// exit 1 `unattested-invocation`). Mandating them here too would be a second,
+// weaker record of a fact that already has an authoritative one, and two records
+// of the same fact drift apart.
+//
+// They remain *recordable* — `--require scope-gate,xruntime` opts in — and
+// `degraded-specialist` is recordable but never required, because a step that
+// may legitimately never occur cannot have its absence read as a skip.
 const PHASE_REQUIREMENTS = {
   intake: [],
   question: [],
@@ -78,7 +105,7 @@ const PHASE_REQUIREMENTS = {
   spec: [],
   plan: ["human-gate"],
   implement: ["preflight"],
-  review: ["preflight", "scope-gate", "xruntime"],
+  review: [], // scope-gate + cross-runtime: owned by the trace mechanism (above)
   qa: ["preflight"],
   ship: ["preflight", "human-gate"],
 };

--- a/scripts/lib/review-gate-hardening.js
+++ b/scripts/lib/review-gate-hardening.js
@@ -1,0 +1,404 @@
+// scripts/lib/review-gate-hardening.js — CommonJS, repo-local tool (NOT part
+// of the upstream review-tool bundle; deliberately absent from
+// scripts/review-bundle.manifest.json, and it sits directly in scripts/lib/
+// rather than the bundle-owned scripts/lib/review/, exactly like its sibling
+// scripts/lib/review-verdict-rules.js).
+//
+// WHY THIS EXISTS
+//
+// scripts/check-review-convergence.js is the review pipeline's anti-vacuity
+// gate, and it was itself vacuous. A verdict that under-populates the keys the
+// gate reads does not fail the gate — it removes the gate's ability to check
+// anything, and the resulting run is byte-identical to a genuine pass at every
+// point a caller looks (exit 0, `violations: []`, `cause: null`). That is the
+// "a gate that cannot fail" defect: a green that means "nothing was checked",
+// not "everything checked out".
+//
+// schema/review-json-schema.md §"Prose/enforcer discrepancies" recorded eleven
+// of these (D1..D11) as *known and unresolved*. This module resolves them. Each
+// rule below is labelled with its D-number where it has one, plus the three
+// undocumented holes found while auditing the same file (G3/G5/G13).
+//
+// THE TWO SHAPES OF FAILURE, and why the split matters
+//
+//   fatal      → exit 2, degraded input. Used when the verdict has removed the
+//                gate's ability to decide. There is no honest verdict to give,
+//                so the gate refuses to give one. `fatal` is a string message;
+//                the caller performs the exit.
+//   violation  → exit 1 or 3 via the existing precedence. Used when the gate
+//                CAN decide and the answer is "no".
+//
+// The distinction is the whole point: previously every one of these landed in
+// `warnings[]` on an exit-0 run, i.e. in the one channel that a passing gate
+// lets a caller ignore.
+//
+// RECORDED SKIPS (the --allow-legacy contract)
+//
+// Two rules (G3 `round`, G4 `no_go_round`) guard genuinely pre-schema fixtures
+// that must keep passing. They are NOT silently tolerated: the caller must pass
+// --allow-legacy, and the gate then stamps `legacy_skip_authorized: true` into
+// its report. An authorized skip is a *recorded* skip — visible in the
+// artifact, and refused downstream by review-verdict-assemble.js --write-strike,
+// because a strike computed by a gate that skipped its own checks must never be
+// journaled as if it had been computed. An unrecorded skip is indistinguishable
+// from a pass; a recorded one is not.
+"use strict";
+
+const { validSlug } = require("./xruntime/xruntime-journal");
+
+// Bumped whenever a gate is added or its verdict changes. Echoed into the gate
+// report as `hardening.version` so a consumer can detect a check-review-
+// convergence.js that predates this module, exactly as it detects a stale
+// script via `config.strikes` and `trace`.
+const HARDENING_VERSION = "1.0.0";
+
+const HIGH_PLUS = new Set(["CRITICAL", "HIGH"]);
+// schema/review-finding.schema.json §properties.status. The gate only ever
+// tested `=== "RESOLVED"` / `=== "ACCEPTED"`, so any other string silently
+// took the neither-branch (D7).
+const FINDING_STATUSES = new Set(["OPEN", "RESOLVED", "ACCEPTED"]);
+// schema/review-json-schema.md §`mode`. Verdict mode — NOT the gate report's
+// own `mode`, whose enum is static|full (D5).
+const VERDICT_MODES = new Set(["express", "fast", "full"]);
+const VERDICT_STATUSES = new Set(["GO", "NO-GO"]);
+const NO_GO_TYPES = new Set([
+  "out-of-scope-change",
+  "spec-ac-failure",
+  "cross-runtime-finding",
+  "design-not-converging",
+  "review-integrity-failure",
+]);
+const NO_GO_CAUSES = new Set(["unencodable-finding", "unattested-invocation", "novel-finding-streak", "round-cap"]);
+// schema/review-json-schema.md §`cross_runtime`. Prose lists five statuses and
+// the gate validated none of them, so an unrecognised status fell out of the
+// corroboration set and was never attested (D9's neighbour).
+const CROSS_RUNTIME_STATUSES = new Set(["healthy", "degraded", "skipped-degraded", "skipped-human", "blocked"]);
+
+function has(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function fingerprintOf(finding) {
+  if (!finding || typeof finding !== "object") return "?";
+  return typeof finding.fingerprint === "string"
+    ? finding.fingerprint
+    : `${finding.path || "?"}:${finding.line ?? 0}:${finding.category || "?"}`;
+}
+
+function isOpen(finding) {
+  return finding.status !== "RESOLVED" && finding.status !== "ACCEPTED";
+}
+
+// ── G3 (P3 core) + G4 (D10): the two absent-key vacuity paths ────────────
+// `round` absent removed strike classification, rounds_audit completeness AND
+// every trace check. `no_go_round` absent defaulted to 0, so the round cap
+// could never fire. Both used to be warnings on an exit-0 run.
+function checkLegacyAuthorization({ legacyRound, legacyNoGoRound, allowLegacy }) {
+  if (allowLegacy) return null;
+  if (legacyRound) {
+    return (
+      "review.json has no `round` key — the gate would skip strike classification, the rounds_audit " +
+      "completeness check and every trace check, then exit 0 with violations: [] (B-8 vacuity, " +
+      "schema/review-json-schema.md §round). Assemble the verdict with scripts/review-verdict-assemble.js, " +
+      "or pass --allow-legacy to authorize the skip — it is then RECORDED as legacy_skip_authorized in " +
+      "the report and --write-strike refuses that report."
+    );
+  }
+  if (legacyNoGoRound) {
+    return (
+      "review.json has no `no_go_round` key — it defaults to 0, so the round-cap violation can never " +
+      "fire (D10, schema/review-json-schema.md §no_go_round). Assemble the verdict with " +
+      "scripts/review-verdict-assemble.js, or pass --allow-legacy to authorize the skip."
+    );
+  }
+  return null;
+}
+
+// ── G13: blind coercions ─────────────────────────────────────────────────
+// `rounds_audit` and `cross_runtime` were both read as
+// `Array.isArray(x) ? x : []` / `typeof x === "object" || return`. A wrong type
+// therefore silently emptied the check rather than failing it — the same shape
+// as the `findings` hole already closed by FIX-A/CGF-1.
+function checkContainerTypes(review) {
+  if (has(review, "rounds_audit") && !Array.isArray(review.rounds_audit)) {
+    return "review.json field rounds_audit is present but not an array (degraded input) — it was silently read as [], which empties the past-strike map and the loop-back completeness check";
+  }
+  if (
+    has(review, "cross_runtime") &&
+    review.cross_runtime !== null &&
+    (typeof review.cross_runtime !== "object" || Array.isArray(review.cross_runtime))
+  ) {
+    return "review.json field cross_runtime is present but not an object (degraded input) — it was silently ignored, which drops every cross-runtime corroboration check";
+  }
+  if (has(review, "cross_runtime_findings") && !Array.isArray(review.cross_runtime_findings)) {
+    return "review.json field cross_runtime_findings is present but not an array (degraded input)";
+  }
+  return null;
+}
+
+// ── G8 (D5) / G7 (D2) / G9 (D4) / G10 (D11) / G11 (D6): envelope keys ────
+// Each of these is a key whose malformed value used to read to the gate
+// exactly like an omission, and whose omission used to remove an obligation
+// rather than fail one.
+function checkEnvelopeKeys(review, { legacyRound }) {
+  // G8/D5: `mode: "Full"` (or the gate report's own `mode: "static"` copied in
+  // by mistake) reads to the gate as "no scope-gate trace line required".
+  if (has(review, "mode") && !VERDICT_MODES.has(review.mode)) {
+    return (
+      `review.json field mode is ${JSON.stringify(review.mode)}, not one of ${[...VERDICT_MODES].join(" | ")} (D5). ` +
+      "Any other value silently drops the scope-gate trace obligation. Note the name collision: the gate " +
+      "REPORT's `mode` is static|full and is a different field — do not copy one into the other."
+    );
+  }
+  // G7/D2: the routing key the gate never read. A typo routes nowhere.
+  if (has(review, "status") && !VERDICT_STATUSES.has(review.status)) {
+    return `review.json field status is ${JSON.stringify(review.status)}, not one of ${[...VERDICT_STATUSES].join(" | ")}`;
+  }
+  const noGoReasonFatal = checkNoGoReason(review);
+  if (noGoReasonFatal) return noGoReasonFatal;
+
+  if (legacyRound) return null; // pre-schema fixtures: already authorized above
+
+  // G9/D4: `task` was load-bearing only once the round was trace-obligated;
+  // on any other round an absent/invalid slug fell through to the B-8 skip.
+  if (typeof review.task !== "string" || !validSlug(review.task)) {
+    return `review.json field task is ${JSON.stringify(review.task)}, not a valid slug — it derives the trace and journal sibling paths (D4)`;
+  }
+  // G10/D11: absent or non-numeric `cycle` silently became null, which filters
+  // every numerically-stamped trace line out as prior-cycle.
+  if (!has(review, "cycle")) {
+    return "review.json has no `cycle` key — every numerically-stamped trace line then classifies as prior-cycle, so a trace-obligated round reports missing-trace even with the lines on disk (D11)";
+  }
+  if (typeof review.cycle !== "number" || !Number.isFinite(review.cycle) || review.cycle < 1) {
+    return `review.json field cycle is ${JSON.stringify(review.cycle)} — must be a finite number >= 1 (D11)`;
+  }
+  // G11/D6: without normalization, fingerprints are not stable, so "novel
+  // finding" is uncomputable and strike classification is meaningless. That
+  // used to be a conditional warning.
+  if (typeof review.normalized_by !== "string" || review.normalized_by.trim() === "") {
+    return (
+      "review.json field normalized_by is absent or empty — the findings were never run through " +
+      "scripts/review-normalize.js, so fingerprints are not stable and `novel finding` is uncomputable. " +
+      "Strike classification on an unnormalized verdict is not a result (D6)."
+    );
+  }
+  return null;
+}
+
+function checkNoGoReason(review) {
+  const reason = review.no_go_reason;
+  if (review.status === "NO-GO" && (reason === null || reason === undefined)) {
+    return "review.json has status NO-GO with no no_go_reason — no_go_reason.type is the routing key, and roster-run falls through to `none` without it (D2)";
+  }
+  if (reason === null || reason === undefined) return null;
+  if (typeof reason !== "object" || Array.isArray(reason)) {
+    return `review.json field no_go_reason is ${Array.isArray(reason) ? "an array" : typeof reason}, not an object or null (D2)`;
+  }
+  if (!NO_GO_TYPES.has(reason.type)) {
+    return `review.json field no_go_reason.type is ${JSON.stringify(reason.type)}, not one of ${[...NO_GO_TYPES].join(" | ")} — an unrecognised type routes nowhere (D2)`;
+  }
+  if (has(reason, "cause") && reason.cause !== null && !NO_GO_CAUSES.has(reason.cause)) {
+    return `review.json field no_go_reason.cause is ${JSON.stringify(reason.cause)}, not one of ${[...NO_GO_CAUSES].join(" | ")} (D2)`;
+  }
+  return null;
+}
+
+// ── G6 (D7): finding status enum ─────────────────────────────────────────
+// The gate tested `=== "RESOLVED"` and `=== "ACCEPTED"` and nothing else, so
+// `status: "OPEN-FOR-HUMAN"` (live in this repo) took neither branch. The
+// dangerous direction is a near-miss of "ACCEPTED", which reads as un-waived —
+// but a near-miss of "RESOLVED" skips the ratchet entirely.
+function checkFindingStatuses(findings, label) {
+  for (const finding of findings) {
+    if (!finding || typeof finding !== "object") continue;
+    if (!has(finding, "status")) continue;
+    if (!FINDING_STATUSES.has(finding.status)) {
+      return (
+        `${label} entry ${fingerprintOf(finding)} has status ${JSON.stringify(finding.status)}, not one of ` +
+        `${[...FINDING_STATUSES].join(" | ")} (schema/review-finding.schema.json, D7) — the gate only ever ` +
+        "compares against RESOLVED and ACCEPTED, so any other value silently escapes both the ratchet and the waiver"
+      );
+    }
+  }
+  return null;
+}
+
+// ── G1 (D3, named): rounds_audit[].strike must be a boolean ──────────────
+// computeStrikeMap() only records `typeof entry.strike === "boolean"`, so a
+// null never lands in the map, Map.get() returns undefined, and
+// computeStreakViolation()'s `!== true` test resets the streak. A verdict with
+// `strike: null` on every round escapes novel-finding escalation completely
+// while the report prints current_round_strike: true next to violations: [].
+// This was a warning, and only for PAST rounds — a null on the current round
+// produced no signal at all.
+function checkStrikeBooleans(review, currentRound) {
+  if (currentRound === null) return null;
+  const roundsAudit = Array.isArray(review.rounds_audit) ? review.rounds_audit : [];
+  for (const entry of roundsAudit) {
+    if (!entry || typeof entry.round !== "number") continue;
+    if (entry.round < 2) continue; // round 1 never strikes
+    const isCurrent = entry.round === currentRound;
+    if (isCurrent && !has(entry, "strike")) continue; // absent on the draft is correct — the gate writes it
+    if (typeof entry.strike === "boolean") continue;
+    return (
+      `rounds_audit entry for round ${entry.round} has strike ${JSON.stringify(entry.strike)} — it must be a ` +
+      "boolean (D3). A non-boolean never enters the strike map, so computeStreakViolation() reads it as " +
+      "not-a-strike and the novel-finding streak silently resets. Re-gate that round and journal its strike " +
+      "with `review-verdict-assemble.js --write-strike`; on the round being gated now, leave `strike` ABSENT."
+    );
+  }
+  return null;
+}
+
+// ── G12 (D9): cross_runtime entry shape ──────────────────────────────────
+// The verdict persists `config_digest`; the journal persists the same value
+// under `digest`. Writing the journal's key into the verdict yields a silent
+// corroboration miss. Nothing validated `status` either, so an unrecognised
+// value simply fell out of the corroborated set.
+function checkCrossRuntime(review) {
+  const crossRuntime = review.cross_runtime;
+  if (!crossRuntime || typeof crossRuntime !== "object" || Array.isArray(crossRuntime)) return null;
+  for (const [name, entry] of Object.entries(crossRuntime)) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return `cross_runtime.${name} is not an object (degraded input)`;
+    }
+    if (has(entry, "digest") && !has(entry, "config_digest")) {
+      return (
+        `cross_runtime.${name} carries \`digest\` but not \`config_digest\` (D9). The key asymmetry is ` +
+        "deliberate and load-bearing: the VERDICT writes config_digest, the JOURNAL writes digest, and the " +
+        "gate matches cross_runtime[rt].config_digest against journalEntry.digest. As written, corroboration " +
+        "silently finds nothing."
+      );
+    }
+    if (has(entry, "status") && !CROSS_RUNTIME_STATUSES.has(entry.status)) {
+      return (
+        `cross_runtime.${name}.status is ${JSON.stringify(entry.status)}, not one of ` +
+        `${[...CROSS_RUNTIME_STATUSES].join(" | ")} — an unrecognised status is never corroborated and never ` +
+        "warned about, so a runtime that did not run reads exactly like one that did"
+      );
+    }
+  }
+  return null;
+}
+
+// ── G5: rounds_audit gaps erase the streak ───────────────────────────────
+// Undocumented, found auditing §round: computeStrikeMap() only knows rounds
+// that HAVE an entry and computeStreakViolation() stops at the first round that
+// is not `true`, so jumping round 3 → round 7 erases the streak with no
+// warning at all (computeMissingStrikeWarnings only inspects entries that
+// exist). Repairable by journaling the missing round, hence process-incomplete.
+function computeAuditGapViolations(review, currentRound) {
+  if (currentRound === null || currentRound < 3) return [];
+  const roundsAudit = Array.isArray(review.rounds_audit) ? review.rounds_audit : [];
+  const seen = new Set(roundsAudit.filter((e) => e && typeof e.round === "number").map((e) => e.round));
+  const violations = [];
+  for (let r = 2; r < currentRound; r++) {
+    if (seen.has(r)) continue;
+    violations.push({
+      type: "missing-past-audit",
+      cause: "process-incomplete",
+      detail:
+        `no rounds_audit entry for round ${r} (rounds 2..${currentRound - 1} must all be journaled). ` +
+        "A gap is invisible to computeStrikeMap() and resets the novel-finding streak silently.",
+    });
+  }
+  return violations;
+}
+
+// ── G2 (D1, named): cross_runtime_findings has GO authority and was unread ─
+// roster-review: "any cross_runtime_findings entry that is CRITICAL or HIGH
+// (OPEN) sets status: NO-GO". The gate never opened the array. The prose escape
+// hatch is to mirror the entry into `findings` so it enters the ratchet — and
+// forgetting the mirror was unenforced, on the array that carries the findings
+// the primary reviewer missed.
+function computeCrossRuntimeFindingViolations(review, findings) {
+  const crossRuntimeFindings = Array.isArray(review.cross_runtime_findings) ? review.cross_runtime_findings : [];
+  if (crossRuntimeFindings.length === 0) return [];
+
+  const mirrored = new Set();
+  for (const finding of findings) {
+    if (!finding || typeof finding !== "object") continue;
+    mirrored.add(fingerprintOf(finding));
+    if (typeof finding.fingerprint_v2 === "string") mirrored.add(finding.fingerprint_v2);
+  }
+
+  const violations = [];
+  for (const finding of crossRuntimeFindings) {
+    if (!finding || typeof finding !== "object") continue;
+    if (!HIGH_PLUS.has(finding.severity)) continue;
+    if (!isOpen(finding)) continue;
+    const fingerprint = fingerprintOf(finding);
+    if (mirrored.has(fingerprint)) continue;
+    violations.push({
+      type: "unmirrored-cross-runtime-finding",
+      cause: "unencodable-finding",
+      fingerprint,
+      detail:
+        `${finding.severity} OPEN cross_runtime_findings entry is not mirrored into findings[] (D1). ` +
+        "roster-review gives it GO authority, but only the findings[] mirror puts it under the ratchet, " +
+        "the red/green obligation and strike classification.",
+    });
+  }
+  return violations;
+}
+
+// ── G7 (D2, second half): a GO verdict that the gate is failing ──────────
+// The gate never read `status`, so a verdict could assert GO while the gate
+// simultaneously reported a design violation, and the two artifacts disagreed
+// with nothing to reconcile them. Evaluated last, over the fully accumulated
+// violation list.
+function computeGoConsistencyViolation(review, violations) {
+  if (review.status !== "GO") return null;
+  const design = violations.filter((v) => v.cause && v.cause !== "process-incomplete");
+  if (design.length === 0) return null;
+  return {
+    type: "go-with-design-violation",
+    cause: design[0].cause,
+    detail:
+      `verdict claims status GO while the gate reports ${design.length} design violation(s) ` +
+      `(${[...new Set(design.map((v) => v.type))].join(", ")}) — the gate's answer is authoritative (D2)`,
+  };
+}
+
+// ── entry point ──────────────────────────────────────────────────────────
+// Returns { fatal, violations } — `fatal` is a message the caller must turn
+// into exit 2, `violations` join the existing precedence machinery. Ordered
+// most-fundamental first so the message a caller sees names the root cause and
+// not a downstream symptom of it.
+function evaluateHardening({ review, round, legacyRound, legacyNoGoRound, allowLegacy, findings }) {
+  const fatal =
+    checkContainerTypes(review) ||
+    checkLegacyAuthorization({ legacyRound, legacyNoGoRound, allowLegacy }) ||
+    checkEnvelopeKeys(review, { legacyRound }) ||
+    checkFindingStatuses(findings, "findings") ||
+    checkFindingStatuses(Array.isArray(review.cross_runtime_findings) ? review.cross_runtime_findings : [], "cross_runtime_findings") ||
+    checkStrikeBooleans(review, round) ||
+    checkCrossRuntime(review);
+  if (fatal) return { fatal, violations: [] };
+
+  return {
+    fatal: null,
+    violations: computeAuditGapViolations(review, round).concat(computeCrossRuntimeFindingViolations(review, findings)),
+  };
+}
+
+module.exports = {
+  HARDENING_VERSION,
+  FINDING_STATUSES,
+  VERDICT_MODES,
+  VERDICT_STATUSES,
+  NO_GO_TYPES,
+  NO_GO_CAUSES,
+  CROSS_RUNTIME_STATUSES,
+  checkLegacyAuthorization,
+  checkContainerTypes,
+  checkEnvelopeKeys,
+  checkNoGoReason,
+  checkFindingStatuses,
+  checkStrikeBooleans,
+  checkCrossRuntime,
+  computeAuditGapViolations,
+  computeCrossRuntimeFindingViolations,
+  computeGoConsistencyViolation,
+  evaluateHardening,
+};

--- a/scripts/lib/review-gate-hardening.js
+++ b/scripts/lib/review-gate-hardening.js
@@ -19,6 +19,17 @@
 // rule below is labelled with its D-number where it has one, plus the three
 // undocumented holes found while auditing the same file (G3/G5/G13).
 //
+// AND THEN IT HAD THE DEFECT ITSELF (G14/G15, review finding F4). The first
+// version guarded `mode` and `status` with `has(review, key) && !VALID(value)`
+// — closing the malformed half and leaving the absent half open, which is the
+// precise defect this module was written to close. Two of five keys, under a
+// comment naming omission as the problem. The structural cause was that every
+// guard was hand-written, so "required" and "well-formed" were two independent
+// decisions per key and getting three of five right looked complete; the fix is
+// the REQUIRED_ENVELOPE_KEYS table, which makes them one decision. Worth
+// keeping in mind when reading the rest of this file: the failure mode is not
+// exotic, it is what writing these checks by hand does by default.
+//
 // THE TWO SHAPES OF FAILURE, and why the split matters
 //
 //   fatal      → exit 2, degraded input. Used when the verdict has removed the
@@ -50,7 +61,8 @@ const { validSlug } = require("./xruntime/xruntime-journal");
 // report as `hardening.version` so a consumer can detect a check-review-
 // convergence.js that predates this module, exactly as it detects a stale
 // script via `config.strikes` and `trace`.
-const HARDENING_VERSION = "1.0.0";
+// 1.1.0 — G14/G15 (review finding F4): absence-blindness inside this module.
+const HARDENING_VERSION = "1.1.0";
 
 const HIGH_PLUS = new Set(["CRITICAL", "HIGH"]);
 // schema/review-finding.schema.json §properties.status. The gate only ever
@@ -119,30 +131,124 @@ function checkLegacyAuthorization({ legacyRound, legacyNoGoRound, allowLegacy })
 // `Array.isArray(x) ? x : []` / `typeof x === "object" || return`. A wrong type
 // therefore silently emptied the check rather than failing it — the same shape
 // as the `findings` hole already closed by FIX-A/CGF-1.
+//
+// G14 (F4): the ELEMENT types matter as much as the container's. Every consumer
+// of these arrays opens with `if (!e || typeof e !== "object") continue;` or
+// `typeof e.round !== "number"`, so a `null` or `"x"` element is skipped in
+// silence — the round it should have represented simply does not exist as far
+// as the strike map is concerned. It happened to surface as a `missing-past-audit`
+// gap only because G5 independently noticed the hole it left behind; on a round
+// with no gap to notice, it was exit 0.
 function checkContainerTypes(review) {
   if (has(review, "rounds_audit") && !Array.isArray(review.rounds_audit)) {
     return "review.json field rounds_audit is present but not an array (degraded input) — it was silently read as [], which empties the past-strike map and the loop-back completeness check";
   }
-  if (
-    has(review, "cross_runtime") &&
-    review.cross_runtime !== null &&
-    (typeof review.cross_runtime !== "object" || Array.isArray(review.cross_runtime))
-  ) {
-    return "review.json field cross_runtime is present but not an object (degraded input) — it was silently ignored, which drops every cross-runtime corroboration check";
+  // No `!== null` carve-out. `cross_runtime: null` is not an object, and
+  // granting it a pass would hand it exactly the "silently ignored, drops every
+  // cross-runtime corroboration check" treatment this message condemns (F4).
+  if (has(review, "cross_runtime") && (typeof review.cross_runtime !== "object" || review.cross_runtime === null || Array.isArray(review.cross_runtime))) {
+    return `review.json field cross_runtime is ${review.cross_runtime === null ? "null" : "present but not an object"} (degraded input) — it was silently ignored, which drops every cross-runtime corroboration check`;
   }
   if (has(review, "cross_runtime_findings") && !Array.isArray(review.cross_runtime_findings)) {
     return "review.json field cross_runtime_findings is present but not an array (degraded input)";
+  }
+  return (
+    checkArrayElements(review, "findings", (e) => (!e || typeof e !== "object" || Array.isArray(e) ? "is not an object" : null)) ||
+    checkArrayElements(review, "cross_runtime_findings", (e) => (!e || typeof e !== "object" || Array.isArray(e) ? "is not an object" : null)) ||
+    checkArrayElements(review, "rounds_audit", (e) => {
+      if (!e || typeof e !== "object" || Array.isArray(e)) return "is not an object";
+      if (typeof e.round !== "number" || !Number.isFinite(e.round)) return "has no numeric `round` — it can never be matched to a round, so it is invisible to the strike map";
+      return null;
+    })
+  );
+}
+
+function checkArrayElements(review, key, validate) {
+  const array = review[key];
+  if (!Array.isArray(array)) return null;
+  for (let i = 0; i < array.length; i++) {
+    const problem = validate(array[i]);
+    if (problem) {
+      return `review.json ${key}[${i}] ${problem} (degraded input) — every consumer skips a malformed element in silence, so it is not a missing entry, it is an entry that cannot be seen`;
+    }
   }
   return null;
 }
 
 // ── G8 (D5) / G7 (D2) / G9 (D4) / G10 (D11) / G11 (D6): envelope keys ────
-// Each of these is a key whose malformed value used to read to the gate
-// exactly like an omission, and whose omission used to remove an obligation
-// rather than fail one.
+//
+// TABLE-DRIVEN ON PURPOSE (G15, review finding F4). The first version of this
+// function hand-wrote one `if` per key, and guarded two of the five with
+// `has(review, key) && !VALID.has(value)` — which checks the malformed half and
+// skips the absent half. That is the exact defect this whole module exists to
+// catch, reproduced inside it, three lines under a comment describing the keys
+// as ones "whose omission used to remove an obligation rather than fail one":
+//
+//   mode: "Full"      -> exit 2, "not one of express | fast | full"
+//   mode key OMITTED  -> exit 0, violations: []      <- the obligation is gone
+//
+// The dropped obligation was real: review-trace-rules.js gates the scope-gate
+// trace line on `mode === "full"`, so omitting the key removed the requirement
+// instead of failing it. `status` omitted likewise disarmed the whole
+// GO-consistency check, whose first line is `if (review.status !== "GO")`.
+//
+// Hand-writing the guards made "is it required" and "is it well-formed" two
+// independent decisions per key, so getting three of five right looked complete.
+// The table makes them ONE decision, and a key cannot be added with half a guard.
+const REQUIRED_ENVELOPE_KEYS = [
+  {
+    key: "task",
+    why: "it derives the trace and journal sibling paths (D4)",
+    check: (v) => (typeof v === "string" && validSlug(v) ? null : `is ${JSON.stringify(v)}, not a valid slug`),
+  },
+  {
+    key: "cycle",
+    why: "without it every numerically-stamped trace line classifies as prior-cycle, so a trace-obligated round reports missing-trace even with the lines on disk (D11)",
+    check: (v) => (typeof v === "number" && Number.isFinite(v) && v >= 1 ? null : `is ${JSON.stringify(v)}, not a finite number >= 1`),
+  },
+  {
+    key: "normalized_by",
+    why: "the findings were never run through scripts/review-normalize.js, so fingerprints are not stable, `novel finding` is uncomputable, and strike classification is not a result (D6)",
+    check: (v) => (typeof v === "string" && v.trim() !== "" ? null : `is ${JSON.stringify(v)}, not a non-empty string`),
+  },
+  {
+    key: "mode",
+    why: "review-trace-rules.js requires a scope-gate trace line only when mode === \"full\", so an absent or misspelled mode DROPS that obligation rather than failing it (D5/F4)",
+    check: (v) =>
+      VERDICT_MODES.has(v)
+        ? null
+        : `is ${JSON.stringify(v)}, not one of ${[...VERDICT_MODES].join(" | ")}. Note the name collision: the gate REPORT's \`mode\` is static|full and is a different field — do not copy one into the other`,
+  },
+  {
+    key: "status",
+    why: "the GO-consistency check opens with `if (review.status !== \"GO\")`, so an absent status disarms it entirely and a NO-GO with no no_go_reason routes nowhere (D2/F4)",
+    check: (v) => (VERDICT_STATUSES.has(v) ? null : `is ${JSON.stringify(v)}, not one of ${[...VERDICT_STATUSES].join(" | ")}`),
+  },
+  {
+    key: "findings",
+    why: "an absent findings array is nothing to ratchet, nothing to strike-classify and nothing to red/green — indistinguishable from a round that found nothing",
+    check: (v) => (Array.isArray(v) ? null : `is ${JSON.stringify(v)}, not an array`),
+  },
+  {
+    key: "cross_runtime_findings",
+    why: "it carries GO authority; omitting the key is how a HIGH cross-runtime finding goes unmirrored without anything to notice (D1/F4)",
+    check: (v) => (Array.isArray(v) ? null : `is ${JSON.stringify(v)}, not an array`),
+  },
+  {
+    key: "rounds_audit",
+    why: "it is the entire past-strike map and the loop-back completeness record; absent, both are empty and every streak check passes vacuously",
+    check: (v) => (Array.isArray(v) ? null : `is ${JSON.stringify(v)}, not an array`),
+  },
+  {
+    key: "cross_runtime",
+    why: "it is what the journal is corroborated against; absent, no probe can ever be found unattested (D9)",
+    check: (v) => (v && typeof v === "object" && !Array.isArray(v) ? null : `is ${JSON.stringify(v)}, not an object`),
+  },
+];
+
 function checkEnvelopeKeys(review, { legacyRound }) {
-  // G8/D5: `mode: "Full"` (or the gate report's own `mode: "static"` copied in
-  // by mistake) reads to the gate as "no scope-gate trace line required".
+  // Malformed-value checks apply to EVERY verdict, including pre-schema ones:
+  // a legacy fixture may omit these keys, but it may not carry a wrong value.
   if (has(review, "mode") && !VERDICT_MODES.has(review.mode)) {
     return (
       `review.json field mode is ${JSON.stringify(review.mode)}, not one of ${[...VERDICT_MODES].join(" | ")} (D5). ` +
@@ -150,37 +256,18 @@ function checkEnvelopeKeys(review, { legacyRound }) {
       "REPORT's `mode` is static|full and is a different field — do not copy one into the other."
     );
   }
-  // G7/D2: the routing key the gate never read. A typo routes nowhere.
   if (has(review, "status") && !VERDICT_STATUSES.has(review.status)) {
     return `review.json field status is ${JSON.stringify(review.status)}, not one of ${[...VERDICT_STATUSES].join(" | ")}`;
   }
   const noGoReasonFatal = checkNoGoReason(review);
   if (noGoReasonFatal) return noGoReasonFatal;
 
-  if (legacyRound) return null; // pre-schema fixtures: already authorized above
+  if (legacyRound) return null; // pre-schema fixtures: the skip is authorized and recorded
 
-  // G9/D4: `task` was load-bearing only once the round was trace-obligated;
-  // on any other round an absent/invalid slug fell through to the B-8 skip.
-  if (typeof review.task !== "string" || !validSlug(review.task)) {
-    return `review.json field task is ${JSON.stringify(review.task)}, not a valid slug — it derives the trace and journal sibling paths (D4)`;
-  }
-  // G10/D11: absent or non-numeric `cycle` silently became null, which filters
-  // every numerically-stamped trace line out as prior-cycle.
-  if (!has(review, "cycle")) {
-    return "review.json has no `cycle` key — every numerically-stamped trace line then classifies as prior-cycle, so a trace-obligated round reports missing-trace even with the lines on disk (D11)";
-  }
-  if (typeof review.cycle !== "number" || !Number.isFinite(review.cycle) || review.cycle < 1) {
-    return `review.json field cycle is ${JSON.stringify(review.cycle)} — must be a finite number >= 1 (D11)`;
-  }
-  // G11/D6: without normalization, fingerprints are not stable, so "novel
-  // finding" is uncomputable and strike classification is meaningless. That
-  // used to be a conditional warning.
-  if (typeof review.normalized_by !== "string" || review.normalized_by.trim() === "") {
-    return (
-      "review.json field normalized_by is absent or empty — the findings were never run through " +
-      "scripts/review-normalize.js, so fingerprints are not stable and `novel finding` is uncomputable. " +
-      "Strike classification on an unnormalized verdict is not a result (D6)."
-    );
+  for (const { key, why, check } of REQUIRED_ENVELOPE_KEYS) {
+    if (!has(review, key)) return `review.json has no \`${key}\` key — ${why}`;
+    const problem = check(review[key]);
+    if (problem) return `review.json field ${key} ${problem} — ${why}`;
   }
   return null;
 }
@@ -270,10 +357,15 @@ function checkCrossRuntime(review) {
         "silently finds nothing."
       );
     }
-    if (has(entry, "status") && !CROSS_RUNTIME_STATUSES.has(entry.status)) {
+    // F4 family, found auditing this function against its own lesson: the
+    // check was `has(entry, "status") && !VALID`, so an entry with NO status
+    // passed. computeCrossRuntimeCorroboration() only corroborates
+    // healthy|degraded|skipped-human, so a statusless entry is never attested —
+    // the omission bought silence exactly as an unrecognised value would have.
+    if (!has(entry, "status") || !CROSS_RUNTIME_STATUSES.has(entry.status)) {
       return (
-        `cross_runtime.${name}.status is ${JSON.stringify(entry.status)}, not one of ` +
-        `${[...CROSS_RUNTIME_STATUSES].join(" | ")} — an unrecognised status is never corroborated and never ` +
+        `cross_runtime.${name}.status is ${has(entry, "status") ? JSON.stringify(entry.status) : "absent"}, not one of ` +
+        `${[...CROSS_RUNTIME_STATUSES].join(" | ")} — an unrecognised or absent status is never corroborated and never ` +
         "warned about, so a runtime that did not run reads exactly like one that did"
       );
     }

--- a/scripts/lib/review-verdict-rules.js
+++ b/scripts/lib/review-verdict-rules.js
@@ -146,6 +146,22 @@ function assertGateReportIsCurrent(report) {
     stale("no numeric config.strikes");
   }
   if (!report.trace || typeof report.trace !== "object") stale("no `trace` block (FR-176)");
+  if (!report.hardening || typeof report.hardening.version !== "string") {
+    stale("no `hardening.version` (scripts/lib/review-gate-hardening.js)");
+  }
+  // A gate run that was authorized to SKIP its own checks is not evidence that
+  // those checks passed. `legacy_skip_authorized` is the recorded-skip marker
+  // the gate stamps when --allow-legacy suppressed the round / no_go_round
+  // fail-closed refusal; journaling a strike from such a report would convert
+  // a recorded skip back into an indistinguishable pass, which is precisely
+  // the defect the flag exists to avoid.
+  if (report.legacy_skip_authorized === true) {
+    fail(
+      "gate report has legacy_skip_authorized: true — that run was authorized (via --allow-legacy) to SKIP " +
+        "strike classification and/or the round cap, so its strike is not a computed result. Refusing to journal " +
+        "it. Assemble the verdict properly (scripts/review-verdict-assemble.js) and re-gate without --allow-legacy."
+    );
+  }
 }
 
 // ── rounds_audit carry-forward (append-only) ─────────────────────────────

--- a/scripts/review-bundle.manifest.json
+++ b/scripts/review-bundle.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "bundle_version": "1.6.0+spoc.2",
+  "bundle_version": "1.6.0+spoc.3",
   "channel": "local-patched",
   "source_ref": "main",
   "files": [
@@ -14,7 +14,7 @@
     },
     {
       "path": "scripts/check-review-convergence.js",
-      "sha256": "fafbf46ba7e0e0baacc88537060fef94d3a4373bde27c17cea8f5ddc4d25ee9a"
+      "sha256": "3517b40534bf78d47df46c28a4a39c2a6ec52429640397b413a7460424389b69"
     },
     {
       "path": "scripts/check-scope-diff.sh",
@@ -150,6 +150,21 @@
         ]
       },
       "tests": "scripts/xruntime-caller-fault.test.js",
+      "reapply_on_upgrade": true
+    },
+    {
+      "ref": "#98 — convergence gate fails closed",
+      "summary": "An under-populated verdict removed the gate’s ability to check anything and exited 0 with violations: [], byte-identical to a real pass. Wires the gate to scripts/lib/review-gate-hardening.js (repo-local, deliberately NOT bundle-owned so an upgrade cannot silently restore the holes), adds --allow-legacy as a RECORDED skip, and reads cross_runtime_findings. Closes D1-D11 plus G3/G5/G13/G14/G15.",
+      "paths": [
+        "scripts/check-review-convergence.js"
+      ],
+      "markers": [
+        "review-gate-hardening",
+        "evaluateHardening",
+        "legacy_skip_authorized",
+        "--allow-legacy"
+      ],
+      "tests": "scripts/check-review-convergence-hardening.test.js",
       "reapply_on_upgrade": true
     }
   ]

--- a/scripts/review-verdict-assemble.test.js
+++ b/scripts/review-verdict-assemble.test.js
@@ -104,11 +104,20 @@ function appendTraces(dir, round) {
   }
 }
 
-function gate(verdictPath, args = []) {
+// Runs the gate WITHOUT parsing its stdout. Required for the fail-closed
+// cases: an input-rejection exit 2 deliberately emits no report at all, so
+// JSON.parse()ing it would mask the refusal as a parse error.
+function gateRaw(verdictPath, args = []) {
   const r = spawnSync(process.execPath, [GATE, verdictPath, "--max-rounds", "5", "--strikes", "2", "--static", ...args], {
     cwd: REPO,
     encoding: "utf8",
   });
+  return { status: r.status, stdout: r.stdout || "", stderr: r.stderr || "" };
+}
+
+function gate(verdictPath, args = []) {
+  const r = gateRaw(verdictPath, args);
+  assert.notStrictEqual(r.stdout, "", `gate emitted no report (exit ${r.status}): ${r.stderr}`);
   return { status: r.status, report: JSON.parse(r.stdout), raw: r.stdout };
 }
 
@@ -208,21 +217,26 @@ check("five novel rounds: round-cap AND streak both fire; streak wins on precede
   assert.deepStrictEqual(audit.map((e) => e.strike), [false, true, true, true, true]);
 });
 
-check("MUTATION: strike:null on a past round silently resets the streak (round-cap only)", () => {
+// The three cases below used to assert the DEFECT — they are the executable
+// record of what "a gate that cannot fail" looked like here, and each now
+// asserts the refusal that replaced it. Read the old expectations in git
+// history alongside these: same mutation, opposite verdict.
+check("MUTATION: strike:null on a past round is now refused, not warned about", () => {
   const dir = scratch();
   const { final } = driveRounds(dir, 5);
   const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
   verdict.rounds_audit.find((e) => e.round === 4).strike = null;
   fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
 
-  const mutated = gate(final);
-  assert.strictEqual(mutated.report.cause, "round-cap", "the streak must have been reset by the null");
-  assert.deepStrictEqual(mutated.report.violations.map((v) => v.type), ["round-cap"]);
-  assert.match(mutated.report.warnings.join("\n"), /round 4 lacks a boolean strike field/);
-  assert.strictEqual(mutated.status, 1);
+  // WAS: exit 1, cause "round-cap", the streak silently reset by the null, and
+  // the only signal a warning inside a report nobody reads.
+  const mutated = gateRaw(final);
+  assert.strictEqual(mutated.status, 2, "a non-boolean strike is degraded input, not a warning");
+  assert.match(mutated.stderr, /rounds_audit entry for round 4 has strike null/);
+  assert.match(mutated.stderr, /silently resets/);
 });
 
-check("MUTATION: all-null strikes below the cap escape the gate entirely (exit 0)", () => {
+check("MUTATION: all-null strikes below the cap are refused (was: total escape, exit 0)", () => {
   const dir = scratch();
   const { final } = driveRounds(dir, 5);
   const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
@@ -230,34 +244,38 @@ check("MUTATION: all-null strikes below the cap escape the gate entirely (exit 0
   verdict.no_go_round = 2; // below --max-rounds, as in the real five-round PR
   fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
 
-  const escaped = gate(final);
-  // Documented defect (schema/review-json-schema.md §strike): five striking
-  // rounds, `current_round_strike: true`, and the gate still reports no
-  // violation. Warnings only. This is why `strike` must be a boolean.
-  assert.strictEqual(escaped.report.current_round_strike, true);
-  assert.deepStrictEqual(escaped.report.violations, []);
-  assert.strictEqual(escaped.report.cause, null);
-  assert.strictEqual(escaped.status, 0);
-  assert.strictEqual(escaped.report.warnings.length, 3);
+  // WAS the headline defect (schema/review-json-schema.md §strike): five
+  // striking rounds, `current_round_strike: true`, `violations: []`, exit 0.
+  const escaped = gateRaw(final);
+  assert.strictEqual(escaped.status, 2);
+  assert.strictEqual(escaped.stdout, "", "an input-rejection exit 2 emits no report to mistake for a pass");
+  assert.match(escaped.stderr, /must be a\s+boolean/);
 });
 
-// NOTE the exit code: dropping `round` removes the strike/rounds_audit/trace
-// checks, but `no_go_round` (5) still trips the round cap on its own, so the
-// gate exits 1 here for a reason that has nothing to do with the skipped
-// checks. That is what makes the skip dangerous — below the cap (see the
-// preceding case, which sets no_go_round: 2) the same mutation exits 0.
-check("MUTATION: dropping `round` skips strike/audit/trace checks; only round-cap survives (exit 1)", () => {
+check("MUTATION: dropping `round` is refused unless the skip is explicitly authorized", () => {
   const dir = scratch();
   const { final } = driveRounds(dir, 5);
   const verdict = JSON.parse(fs.readFileSync(final, "utf8"));
   delete verdict.round;
   fs.writeFileSync(final, JSON.stringify(verdict, null, 2));
 
-  const skipped = gate(final);
-  assert.strictEqual(skipped.report.legacy_round, true);
-  assert.strictEqual(skipped.report.current_round_strike, null);
-  assert.match(skipped.report.warnings.join("\n"), /round key absent — skipping strike and rounds_audit checks/);
-  assert.strictEqual(skipped.status, 1, "only round-cap survives, via no_go_round");
+  // WAS: exit 1 via the round cap alone — the skipped strike/audit/trace checks
+  // contributed nothing, and below the cap the same mutation exited 0.
+  const skipped = gateRaw(final);
+  assert.strictEqual(skipped.status, 2);
+  assert.match(skipped.stderr, /no `round` key/);
+  assert.match(skipped.stderr, /--allow-legacy/);
+
+  // The escape hatch exists, but it leaves a mark: authorized, recorded, and
+  // refused downstream.
+  const authorized = gate(final, ["--allow-legacy"]);
+  assert.strictEqual(authorized.report.legacy_skip_authorized, true);
+  assert.strictEqual(authorized.report.current_round_strike, null);
+
+  const dirReport = path.join(dir, "briefs", `${TASK}-authorized-report.json`);
+  fs.writeFileSync(dirReport, authorized.raw);
+  const w = run(ASSEMBLE, ["--write-strike", "--verdict", final, "--gate-report", dirReport], dir);
+  assert.strictEqual(w.status, 2, "a strike from a legacy-skipped gate must never be journaled");
 });
 
 // ── carry-forward + delegation contracts ─────────────────────────────────


### PR DESCRIPTION
Backlog **#98 (P3)** and **#104 (P10)** — two "gate that cannot fail" defects in the review machinery itself.

Both have the same shape: a green that means *nothing was checked*, not *everything checked out*. The review pipeline is where every other change is judged, so a gate that cannot fail there is a false green on everything downstream of it.

## #98 — the convergence gate could not fail

`check-review-convergence.js` didn't reject an under-populated verdict; it lost the ability to check anything, and the resulting run was **byte-identical to a genuine pass** at every point a caller looks — exit `0`, `violations: []`, `cause: null`. The reproduction that opens `schema/review-json-schema.md` is a real verdict from this repo. Five review rounds ran on a real PR without the gate ever routing back.

`schema/review-json-schema.md` recorded eleven of these as *known and unresolved* (D1–D11). All eleven are now enforced, plus three undocumented vacuity paths found auditing the same file:

| # | Hole | Now |
|---|---|---|
| D1 | `cross_runtime_findings` never read, despite carrying GO authority | ratchet-checked; an unmirrored `CRITICAL`/`HIGH` `OPEN` entry violates (exit 1) |
| D2 | `status` / `no_go_reason` routing keys unread — a typo routed nowhere | enums validated (exit 2); `GO` asserted over a design violation is itself a violation |
| D3 | `strike: null` silently reset the novel-finding streak | non-boolean on a gated round → exit 2 |
| D4 | `task` load-bearing only on a trace-obligated round | required + slug-checked on every non-legacy round |
| D5 | `mode` typo read exactly like an omission | enum-checked, with the gate-report `mode` collision named in the message |
| D6 | absent `normalized_by` was a warning — fingerprints unstable, "novel" uncomputable | exit 2 |
| D7 | finding `status` accepted any string (`"OPEN-FOR-HUMAN"` is live here) | enum-checked in **both** finding arrays |
| D8 | — | **not a hole** (the enforcer is stricter than the prose); resolved by documentation |
| D9 | verdict `config_digest` vs journal `digest` — silent corroboration miss; statuses unvalidated | both → exit 2, asymmetry explained |
| D10 | absent `no_go_round` → the cap could never fire | exit 2 unless the skip is recorded |
| D11 | absent/non-numeric `cycle` filtered every trace line out as prior-cycle | exit 2 |
| G3 | absent `round` — the vacuity core | exit 2 unless the skip is recorded |
| G5 | a `rounds_audit` **gap** erased the streak with no warning at all | `missing-past-audit`, exit 3 |
| G13 | `rounds_audit` / `cross_runtime` blind-coerced — a wrong type emptied the check instead of failing it | exit 2 |

The legacy escape hatch survives, as a **recorded** skip: `--allow-legacy` stamps `legacy_skip_authorized: true` into the report, and `--write-strike` refuses to journal a strike from it — a strike computed by a run that skipped strike classification is not a result.

## #104 — every mandated-step skip is now recorded

Preflight, human gates and degraded specialists could all be skipped without a trace, and **an unrecorded skip is indistinguishable from a pass**. Three real instances, all in the friction log: preflight unrun across a full day of implementation work (with three real environment problems it would have surfaced); the ship human gate skipped under a standing delegation but journaled as though a human answered; the mandatory cross-runtime pass breaker-disabled on a caller-side fault.

New `scripts/check-mandated-steps.js` + the `briefs/<task>-steps.jsonl` ledger:

- every mandated step emits one record — outcome, actor, and on a skip a **reason**
- **absence of a required record is a failure**; an absent ledger fails listing every requirement
- an **unknown step id is rejected**, so a typo can never stand in for the step it resembles
- an **unknown phase is rejected**, never defaulted to "nothing required"
- `human-gate` is human-only: an agent may not record it as `ran`, so a standing delegation is journaled as the skip it is

Skipping is allowed. Skipping silently is not.

## Proof, not assertion

Every gate here was watched failing before being trusted:

- **60 new cases**, each constructing the input that *should* be rejected and asserting the exit code, the empty report, and a message that names the hole.
- **Negative control:** disabling the hardening wiring turns **28 of 35** hardening cases red. The 7 survivors are the deliberate controls (the base fixture, `strike` absent on the round being gated, a mirrored cross-runtime finding, a MEDIUM one, the five documented `cross_runtime` statuses) — they must pass in both states, and do.
- The three cases in `review-verdict-assemble.test.js` that **used to assert the defect** now assert the refusal. Same mutation, opposite verdict; the old expectations are in git history next to them.
- `make test-review-tools` was verified to exit **2** with the bundle absent before being trusted green — a target that swallows failures would be the same bug again.

```
node scripts/review-verdict-assemble.test.js              30 passed, 0 failed
node scripts/check-review-convergence-hardening.test.js   35 passed, 0 failed
node scripts/check-mandated-steps.test.js                 25 passed, 0 failed
node scripts/review-bundle-verify.js                      OK — 22 file(s) sha-matched
```

Kept out of `test-all` deliberately: that target runs the GPU suites, and these contracts must stay checkable on a machine with no GPU.

## Note on file placement (task #108)

`scripts/check-review-convergence.js` and `scripts/lib/review/*` are **untracked** in this repo — excluded via `.git/info/exclude`. Not fixed here; that is task #108.

Consequence for this PR: the new rules live in a repo-local, **tracked** module `scripts/lib/review-gate-hardening.js`, which the gate `require`s. The gate itself takes a ~20-line wiring diff that lands in the working tree only, and its manifest entry is annotated `local_patch` (re-apply after any bundle upgrade). This is not purely a workaround — keeping the rules outside the bundle means a bundle upgrade cannot silently restore any of the eleven holes.

`briefs/` and `skills-meta/` are local-only and are not part of this PR; the emitting skill prose (`roster-run` Step 4, `roster-ship` §4, `roster-review` §5.5, all three mirrors each) was updated in the working tree, where those files live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mandated-step recording and verification for pipeline checks.
  * Added stricter review validation that fails closed on missing, malformed, or inconsistent data.
  * Added explicit handling and reporting for authorized legacy skips.
  * Added a dedicated review-tool verification gate.

* **Documentation**
  * Documented mandated-step ledger requirements and hardened review validation behavior.

* **Tests**
  * Expanded coverage for review convergence, mandated steps, legacy handling, and integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->