### PR TITLE
fix(sarek): close the wrong-width family at the source-type mappers (#85, #96, #97)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_shared_tuple.cma > "$$out" 2>&1; if grep -q "Tuple-typed shared-memory arrays are not supported" "$$out"; then echo "  PASS: tuple shared array rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing recursive-call vector-swap rejection (tail-recursion + vector)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_tailrec_vec_swap.cma > "$$out" 2>&1; if grep -q "must pass its own vector parameter" "$$out"; then echo "  PASS: recursive vector-swap rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing char element-type rejection (1-byte host vs 4-byte device stride)..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_char_vector.cma > "$$out" 2>&1; if grep -q "is not a supported Sarek element type" "$$out"; then echo "  PASS: char element type rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing polymorphic-helper instantiation diagnostic (names the callee)..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_poly_helper_f64.cma > "$$out" 2>&1; if grep -q "'norm' cannot be used at this call site" "$$out"; then echo "  PASS: polymorphic helper instantiation named the callee"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "All negative tests checked (see KNOWN-ISSUE line above for the one non-blocking gap, if any)"
 
 

--- a/sarek/ppx/README.md
+++ b/sarek/ppx/README.md
@@ -349,7 +349,7 @@ type 'a local   = Local of 'a        (* Thread-local / register *)
 
 ### IR Generation & Code Generation
 - **[Sarek_lower_ir](Sarek_lower_ir.ml)** - Generate Sarek IR
-- **[Sarek_ctype_gen](Sarek_ctype_gen.ml)** - C struct/union/builder strings for `[%%sarek.type]`
+- **[Sarek_ctype_gen](Sarek_ctype_gen.ml)** - C struct/union/builder strings for the `[%%sarek.type]` extension (currently unwired — see the module header; the live path is the `[@@sarek.type]` attribute, whose device definitions come from `Sarek_ir_codegen`)
 - **[Sarek_quote](Sarek_quote.ml)** - Quote kernels as OCaml expressions
 - **[Sarek_quote_ir](Sarek_quote_ir.ml)** - Quote IR constructors
 - **[Sarek_native_gen](Sarek_native_gen.ml)** - Native OCaml code generation

--- a/sarek/ppx/Sarek_ast.ml
+++ b/sarek/ppx/Sarek_ast.ml
@@ -10,13 +10,28 @@
  * It replaces the camlp4-coupled AST from the old implementation.
  ******************************************************************************)
 
-(** Source locations *)
+(** Source locations.
+
+    [loc_bol]/[loc_end_bol] are the ABSOLUTE byte offsets of the start of
+    [loc_line]/[loc_end_line]. They exist because a [Lexing.position] is not
+    (line, column): its [pos_cnum] is an absolute byte offset from the start of
+    the file, and the column is [pos_cnum - pos_bol]. The OCaml driver seeks to
+    [pos_bol] to echo the offending source line under a diagnostic, so a
+    location that keeps only line+column and rebuilds the position with
+    [pos_bol = 0; pos_cnum = column] makes every Sarek diagnostic quote bytes
+    taken from the TOP OF THE FILE instead of the line it names — an accurate
+    message rendered against unrelated source (issue #97).
+
+    Keeping the line-start offset makes {!loc_to_ppxlib} a true inverse of
+    {!loc_of_ppxlib}, which is what {!Sarek_ast} locations are for. *)
 type loc = {
   loc_file : string;
   loc_line : int;
   loc_col : int;
   loc_end_line : int;
   loc_end_col : int;
+  loc_bol : int;  (** absolute byte offset of the start of [loc_line] *)
+  loc_end_bol : int;  (** absolute byte offset of the start of [loc_end_line] *)
 }
 
 let dummy_loc =
@@ -26,6 +41,8 @@ let dummy_loc =
     loc_col = 0;
     loc_end_line = 1;
     loc_end_col = 0;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 let loc_of_ppxlib (loc : Ppxlib.Location.t) : loc =
@@ -35,6 +52,8 @@ let loc_of_ppxlib (loc : Ppxlib.Location.t) : loc =
     loc_col = loc.loc_start.pos_cnum - loc.loc_start.pos_bol;
     loc_end_line = loc.loc_end.pos_lnum;
     loc_end_col = loc.loc_end.pos_cnum - loc.loc_end.pos_bol;
+    loc_bol = loc.loc_start.pos_bol;
+    loc_end_bol = loc.loc_end.pos_bol;
   }
 
 let loc_to_ppxlib (loc : loc) : Ppxlib.Location.t =
@@ -43,16 +62,16 @@ let loc_to_ppxlib (loc : loc) : Ppxlib.Location.t =
     {
       pos_fname = loc.loc_file;
       pos_lnum = loc.loc_line;
-      pos_bol = 0;
-      pos_cnum = loc.loc_col;
+      pos_bol = loc.loc_bol;
+      pos_cnum = loc.loc_bol + loc.loc_col;
     }
   in
   let pos_end =
     {
       pos_fname = loc.loc_file;
       pos_lnum = loc.loc_end_line;
-      pos_bol = 0;
-      pos_cnum = loc.loc_end_col;
+      pos_bol = loc.loc_end_bol;
+      pos_cnum = loc.loc_end_bol + loc.loc_end_col;
     }
   in
   {loc_start = pos_start; loc_end = pos_end; loc_ghost = false}

--- a/sarek/ppx/Sarek_ctype_gen.ml
+++ b/sarek/ppx/Sarek_ctype_gen.ml
@@ -8,8 +8,30 @@
  *
  * C-type / struct-string generation for [%%sarek.type] top-level type
  * registrations. Maps Sarek types (and ppxlib core_types) to the C struct,
- * union and builder-function source strings that the GPU backends splice into
- * generated kernels.
+ * union and builder-function source strings.
+ *
+ * REACHABILITY, stated because it is not obvious: the only caller is
+ * [Sarek_ppx.expand_sarek_type], and the [%%sarek.type] EXTENSION it
+ * implements is NOT registered in the driver's rule list
+ * ([Sarek_ppx.sarek_type_extension] is bound to [()], and the rules are
+ * [sarek_type_rule; sarek_type_private_rule; kernel; kernel.real64;
+ * sarek_include]). Writing [%%sarek.type type t = ...] therefore fails with
+ * ppxlib's "Uninterpreted extension" — loudly, so no user code depends on it.
+ * The live registration path is the [@@sarek.type] ATTRIBUTE, which goes
+ * through [Sarek_ppx.register_sarek_type_decl] and the typed AST; the emitted
+ * device definitions for records and variants come from
+ * [Sarek_ir_codegen.gen_variant_def] and its record counterpart, not from
+ * here. Note also that this module's naming convention (`build_X_sarek`,
+ * `X_sarek_tag`, `union X_sarek_union`) has diverged from what those emitters
+ * produce (`make_<mangled>_<ctor>`, `int tag`, `union {...} data`), so wiring
+ * the extension up would need that reconciled first.
+ *
+ * It is kept and CORRECTED rather than deleted because it is the reference
+ * implementation behind a documented (if presently unwired) entry point, and
+ * because both of its defects — a variant payload type computed and then
+ * discarded, and a wildcard mapping every unknown type to C `int` — are
+ * members of the wrong-width family and would be re-introduced verbatim by
+ * anyone reviving it. sarek/tests/unit/test_ctype_gen.ml pins both.
  ******************************************************************************)
 
 open Ppxlib
@@ -17,11 +39,18 @@ open Sarek_types
 
 let mangle_type_name name = String.map (function '.' -> '_' | c -> c) name
 
+(** C type name for a Sarek type.
+
+    TOTAL — deliberately no [| _ -> "int"] arm. That wildcard answered "int" (4
+    bytes, integer) for every type it did not enumerate, including 2-byte
+    [float16], 1-byte [char] and registered aggregates of arbitrary size, and it
+    did so silently. A type this function cannot name must raise. *)
 let rec c_type_of_typ ty : string =
   match repr ty with
   | TPrim TInt32 -> "int"
   | TPrim TBool -> "int"
   | TPrim TUnit -> "void"
+  | TReg Int -> "int"
   | TReg Int64 -> "long"
   | TReg Float32 -> "float"
   | TReg Float64 -> "double"
@@ -29,7 +58,37 @@ let rec c_type_of_typ ty : string =
   | TVariant (name, _) -> "struct " ^ mangle_type_name name ^ "_sarek"
   | TVec t -> c_type_of_typ t ^ " *"
   | TArr (t, _) -> c_type_of_typ t ^ " *"
-  | _ -> "int"
+  | TReg Float16 ->
+      Location.raise_errorf
+        ~loc:Location.none
+        "float16 has no C type in a generated struct/builder: it is a 2-byte \
+         storage-only element type and the previous wildcard declared it as a \
+         4-byte `int`. Use float32 in aggregate fields."
+  | TReg Char ->
+      Location.raise_errorf
+        ~loc:Location.none
+        "`char` is not a supported Sarek element type: it is 1 byte on the \
+         host and has no 1-byte device counterpart. Use int32."
+  | TReg (Custom name) ->
+      Location.raise_errorf
+        ~loc:Location.none
+        "Type %S is not a registered Sarek type, so its C representation is \
+         unknown. Declare it with [@@sarek.type]."
+        name
+  | TVar _ ->
+      Location.raise_errorf
+        ~loc:Location.none
+        "A type variable has no C representation; annotate with a concrete \
+         type."
+  | TFun _ ->
+      Location.raise_errorf
+        ~loc:Location.none
+        "A function type has no C representation."
+  | TTuple _ ->
+      Location.raise_errorf
+        ~loc:Location.none
+        "A tuple type has no C representation; declare a record type with \
+         [@@sarek.type] instead."
 
 let record_constructor_strings name (fields : (string * typ * bool) list) =
   let name = mangle_type_name name in
@@ -148,8 +207,16 @@ let constructor_strings_of_core_type_decl ~loc (tdecl : type_declaration) =
             match cd.pcd_args with
             | Pcstr_tuple [] -> (cd.pcd_name.txt, None)
             | Pcstr_tuple [ct] ->
-                let _ = typ_of_core_type ~loc ct in
-                (cd.pcd_name.txt, None)
+                (* WRONG-WIDTH #4. This arm used to read
+                     let _ = typ_of_core_type ~loc ct in (cd.pcd_name.txt, None)
+                   — the payload's type was computed (so an unsupported payload
+                   type was still rejected) and then DISCARDED. [None] means
+                   "nullary constructor" to [variant_constructor_strings], so
+                   `Shade of float32` emitted a union member declared
+                   `int col_sarek_Shade_t;` and a builder
+                   `build_col_Shade()` with no parameter at all: the payload
+                   was given the wrong C type AND no way to be set. *)
+                (cd.pcd_name.txt, Some (typ_of_core_type ~loc ct))
             | Pcstr_tuple _ | Pcstr_record _ ->
                 Location.raise_errorf
                   ~loc

--- a/sarek/ppx/Sarek_error.ml
+++ b/sarek/ppx/Sarek_error.ml
@@ -49,6 +49,13 @@ type error =
   | Expression_needs_statement_context of string * loc
   | Invalid_lvalue of loc
   | Function_value_escapes of string * typ * loc
+  | Instantiation_mismatch of {callee : string; t1 : typ; t2 : typ; loc : loc}
+      (** A call site could not be typed against the callee's type. Reported
+          instead of a bare [Cannot_unify] when the callee is NAMED, because the
+          bare form ("Cannot unify types: float32 and float64") gives the user
+          two type names and no indication of which function they came from —
+          the reported failure mode of a polymorphic [@sarek.module] helper
+          instantiated at a non-default element type (#97). *)
   | Float16_operand of string * loc
       (** An f16 value reached an operator. f16 is a storage-only type, so this
           is always a user error with a specific remedy; reporting it as
@@ -91,6 +98,7 @@ let error_loc = function
   | Expression_needs_statement_context (_, loc) -> loc
   | Invalid_lvalue loc -> loc
   | Function_value_escapes (_, _, loc) -> loc
+  | Instantiation_mismatch {loc; _} -> loc
   | Float16_operand (_, loc) -> loc
 
 (** Pretty print an error *)
@@ -215,6 +223,21 @@ let pp_error fmt = function
         msg
         pp_typ
         t
+  | Instantiation_mismatch {callee; t1; t2; _} ->
+      Format.fprintf
+        fmt
+        "'%s' cannot be used at this call site: %a and %a do not match.@ A \
+         [@sarek.module] helper is monomorphised per call site, so a \
+         polymorphic helper can only be instantiated at the element types its \
+         BODY admits — a body using a float32-only operation (the \
+         Sarek_stdlib.Std math intrinsics are float32) cannot be instantiated \
+         at float64. Give the helper a concrete type, or use the \
+         element-type-specific module (e.g. Sarek_float64)."
+        callee
+        pp_typ
+        t1
+        pp_typ
+        t2
   | Float16_operand (what, _) ->
       Format.fprintf
         fmt

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -29,8 +29,47 @@ let rec elttype_of_typ (ty : typ) : Ir.elttype =
   | TReg Float16 -> Ir.TFloat16
   | TReg Float32 -> Ir.TFloat32
   | TReg Float64 -> Ir.TFloat64
-  | TReg Char -> Ir.TInt32 (* char represented as int32 *)
-  | TReg (Custom _) -> Ir.TInt32 (* Custom types handled separately *)
+  | TReg Char ->
+      (* WRONG-WIDTH #5. `char` used to lower to [Ir.TInt32] "represented as
+         int32". It is not: [Spoc_core.Vector.char] is a Bigarray of OCaml
+         chars — ONE byte per element — while the device declaration produced
+         from [Ir.TInt32] is `int*`, four. A `char vector` kernel therefore
+         compiled clean and strode the buffer at 4x the host's element size,
+         with no diagnostic anywhere in the pipeline.
+
+         There is no 1-byte element type in the IR to map it to, so the honest
+         answer is to refuse rather than to guess a width. Nothing is lost by
+         refusing: [Execute.check_launch_args] already rejects a [Vector.Char]
+         argument against a [TInt32] parameter on physical width (see
+         test_float16.test_argcheck_width_fallback_for_unmappable_kinds), on
+         BOTH the device and the interpreter entry points — so a `char vector`
+         kernel could never launch on any backend. All this arm changes is WHEN
+         the user is told, and by a message that names the cause.
+
+         Same shape and same remedy as the float16 rejections
+         ([lower_param]'s scalar-parameter arm, Sarek_ir_layout, Soa). *)
+      Ppxlib.Location.raise_errorf
+        ~loc:Ppxlib.Location.none
+        "`char` is not a supported Sarek element type: a host `char` is 1 byte \
+         (Spoc_core.Vector.char) but the device IR has no 1-byte element type, \
+         so it would be accessed through a 4-byte `int`. Use `int32` (and \
+         convert on the host) instead."
+  | TReg (Custom name) ->
+      (* Same class as the [Char] arm above: a registered custom type is a
+         user-declared aggregate whose size comes from its registered layout,
+         so collapsing it to [Ir.TInt32] ("Custom types handled separately")
+         claims a 4-byte scalar for something that is generally neither 4 bytes
+         nor a scalar. Record and variant types reach lowering as
+         [TRecord]/[TVariant] with their fields, which are handled above; a
+         bare [TReg (Custom _)] is a type name that was never registered as a
+         Sarek type (it comes from [%sarek_intrinsic]'s fallback for unknown
+         type names), and its layout is genuinely unknown here. *)
+      Ppxlib.Location.raise_errorf
+        ~loc:Ppxlib.Location.none
+        "Type %S is not a registered Sarek type, so its device size is \
+         unknown. Declare it with [@@sarek.type] (records and variants), or \
+         use a built-in scalar type."
+        name
   | TVec elem_ty -> Ir.TVec (elttype_of_typ elem_ty)
   | TArr (elem_ty, mem) ->
       let ir_mem =
@@ -196,105 +235,26 @@ let memspace_of_memspace (mem : Sarek_types.memspace) : Ir.memspace =
   | Sarek_types.Shared -> Ir.Shared
   | Sarek_types.Local -> Ir.Local
 
-(** Get C type string for a typ *)
-let rec c_type_of_typ ty =
-  match repr ty with
-  | TPrim TInt32 -> "int"
-  | TPrim TBool -> "int"
-  | TPrim TUnit -> "void"
-  | TReg Int -> "int"
-  | TReg Int64 -> "long"
-  | TReg Float32 -> "float"
-  | TReg Float64 -> "double"
-  | TReg Char -> "char"
-  | TReg (Custom name) -> mangle_type_name name
-  | TRecord (name, _) -> "struct " ^ mangle_type_name name ^ "_sarek"
-  | TVariant (name, _) -> "struct " ^ mangle_type_name name ^ "_sarek"
-  | TVec t -> c_type_of_typ t ^ " *"
-  | TArr (t, _) -> c_type_of_typ t ^ " *"
-  | _ -> "int"
+(* REMOVED: [c_type_of_typ] / [record_constructor_strings] /
+   [variant_constructor_strings].
 
-(** Generate C struct definition and builder for record types *)
-let record_constructor_strings name (fields : (string * typ) list) =
-  let name = mangle_type_name name in
-  let struct_name = name ^ "_sarek" in
-  let struct_fields =
-    List.map
-      (fun (fname, fty) -> "  " ^ c_type_of_typ fty ^ " " ^ fname ^ ";")
-      fields
-  in
-  let struct_def =
-    "struct " ^ struct_name ^ " {\n" ^ String.concat "\n" struct_fields ^ "\n};"
-  in
-  let params =
-    String.concat
-      ", "
-      (List.map (fun (fname, fty) -> c_type_of_typ fty ^ " " ^ fname) fields)
-  in
-  let assigns =
-    String.concat
-      "\n"
-      (List.map
-         (fun (fname, _) -> "  res." ^ fname ^ " = " ^ fname ^ ";")
-         fields)
-  in
-  let builder =
-    "struct " ^ struct_name ^ " build_" ^ struct_name ^ "(" ^ params ^ ") {\n"
-    ^ "  struct " ^ struct_name ^ " res;\n" ^ assigns ^ "\n  return res;\n}"
-  in
-  [struct_def; builder]
+   These emitted C struct/union/builder source strings for registered record
+   and variant types, which [lower_kernel] returned and [Sarek_quote] passed
+   to [Sarek.Kirc_types.register_constructor_string]. That function appends to
+   [Kirc_types.constructors], a list that NOTHING in the tree ever reads: the
+   C-family backends build variant/record definitions themselves from
+   [kern_types]/[kern_variants] via [Sarek_ir_codegen.gen_variant_def], and
+   have done so since the Sarek_ir cutover. The strings were write-only.
 
-(** Generate C struct definitions and builders for variant types *)
-let variant_constructor_strings name constrs =
-  let name = mangle_type_name name in
-  let struct_name = name ^ "_sarek" in
-  let constr_structs =
-    List.map
-      (fun (cname, carg) ->
-        let field =
-          match carg with
-          | None -> "  int " ^ name ^ "_sarek_" ^ cname ^ "_t;"
-          | Some ty ->
-              "  " ^ c_type_of_typ ty ^ " " ^ name ^ "_sarek_" ^ cname ^ "_t;"
-        in
-        "struct " ^ name ^ "_sarek_" ^ cname ^ " {\n" ^ field ^ "\n};")
-      constrs
-  in
-  let union_fields =
-    List.map
-      (fun (cname, _) ->
-        "  struct " ^ name ^ "_sarek_" ^ cname ^ " " ^ name ^ "_sarek_" ^ cname
-        ^ ";")
-      constrs
-  in
-  let union_def =
-    "union " ^ name ^ "_sarek_union {\n"
-    ^ String.concat "\n" union_fields
-    ^ "\n};"
-  in
-  let main_struct =
-    "struct " ^ struct_name ^ " {\n" ^ "  int " ^ name ^ "_sarek_tag;\n"
-    ^ "  union " ^ name ^ "_sarek_union " ^ name ^ "_sarek_union;\n" ^ "};"
-  in
-  let builders =
-    List.mapi
-      (fun idx (cname, carg) ->
-        let params, assign =
-          match carg with
-          | None -> ("", "  /* no payload */")
-          | Some ty ->
-              let pname = "v" in
-              ( c_type_of_typ ty ^ " " ^ pname,
-                "  res." ^ name ^ "_sarek_union." ^ name ^ "_sarek_" ^ cname
-                ^ "." ^ name ^ "_sarek_" ^ cname ^ "_t = " ^ pname ^ ";" )
-        in
-        "struct " ^ struct_name ^ " build_" ^ name ^ "_" ^ cname ^ "(" ^ params
-        ^ ") {\n" ^ "  struct " ^ struct_name ^ " res;\n" ^ "  res." ^ name
-        ^ "_sarek_tag = " ^ string_of_int idx ^ ";\n" ^ assign ^ "\n"
-        ^ "  return res;\n}")
-      constrs
-  in
-  constr_structs @ (union_def :: main_struct :: builders)
+   They are removed rather than repaired because they could not be repaired.
+   [c_type_of_typ] ended in the wildcard [| _ -> "int"] — the
+   silently-succeeding shape of the wrong-width family, which declared 2-byte
+   float16 members as 4-byte `int`. Replacing that wildcard with the explicit
+   rejection the class demands immediately broke a real kernel
+   (sarek/tests/e2e/test_static_tag_erasure.ml), because this path is handed
+   types it has no C name for and depended on the placeholder to keep going.
+   A generator that only works while it is silently wrong, and whose output no
+   one reads, is dead weight with a live hazard attached. *)
 
 (* Debug counters for IR lowering *)
 let ir_lower_expr_count = ref 0
@@ -1168,19 +1128,12 @@ let lower_kernel (kernel : tkernel) : Ir.kernel * string list =
       Ir.SEmpty
   in
 
-  (* Generate type constructors *)
-  let constructors =
-    List.concat
-      (List.map
-         (function
-           | TTypeRecord {tdecl_name; tdecl_fields; _} ->
-               (* Strip mutability flag from fields *)
-               let fields = List.map (fun (n, ty, _) -> (n, ty)) tdecl_fields in
-               record_constructor_strings tdecl_name fields
-           | TTypeVariant {tdecl_name; tdecl_constructors; _} ->
-               variant_constructor_strings tdecl_name tdecl_constructors)
-         kernel.tkern_type_decls)
-  in
+  (* No C constructor strings are produced any more: the backends emit record
+     and variant definitions themselves from [kern_types]/[kern_variants], and
+     the strings this used to build were only ever appended to a list nobody
+     read. See the REMOVED note near the top of this file. The return type is
+     kept so callers are unchanged. *)
+  let constructors = [] in
 
   (* Lower body *)
   let body_ir = lower_stmt state kernel.tkern_body in

--- a/sarek/ppx/Sarek_native_helpers.ml
+++ b/sarek/ppx/Sarek_native_helpers.ml
@@ -25,25 +25,14 @@ open Sarek_types
 
 (** {1 Location Conversion} *)
 
-(** Convert Sarek_ast.loc to Ppxlib.location *)
+(** Convert Sarek_ast.loc to Ppxlib.location.
+
+    Must agree with {!Sarek_ast.loc_to_ppxlib}: [pos_cnum] is an ABSOLUTE byte
+    offset and [pos_bol] the offset of the line's first byte, so both have to be
+    carried through. Dropping [pos_bol] makes the compiler echo bytes from the
+    top of the file under a diagnostic that names a different line (#97). *)
 let ppxlib_loc_of_sarek (l : Sarek_ast.loc) : location =
-  let pos_start =
-    {
-      Lexing.pos_fname = l.loc_file;
-      pos_lnum = l.loc_line;
-      pos_bol = 0;
-      pos_cnum = l.loc_col;
-    }
-  in
-  let pos_end =
-    {
-      Lexing.pos_fname = l.loc_file;
-      pos_lnum = l.loc_end_line;
-      pos_bol = 0;
-      pos_cnum = l.loc_end_col;
-    }
-  in
-  {loc_start = pos_start; loc_end = pos_end; loc_ghost = false}
+  Sarek_ast.loc_to_ppxlib l
 
 (** {1 Expression Helpers} *)
 

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -2197,7 +2197,15 @@ let kernel_real64_extension =
     Ast_pattern.(single_expr_payload __)
     expand_kernel_real64
 
-(* Register top-level Sarek type declarations *)
+(* Register top-level Sarek type declarations via the [%%sarek.type] EXTENSION.
+
+   NOT WIRED UP: [sarek_type_extension] below is [()], and this function is
+   absent from the driver's rule list, so [%%sarek.type] is rejected by ppxlib
+   as an uninterpreted extension. The live path is the [@@sarek.type]
+   ATTRIBUTE ([sarek_type_rule]). Left in place, with its emitter corrected
+   (see the header of Sarek_ctype_gen), rather than removed — but a caller
+   reviving it must first reconcile that emitter's naming convention with
+   Sarek_ir_codegen's, which is what the backends actually emit. *)
 let expand_sarek_type ~ctxt payload =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   match payload with

--- a/sarek/ppx/Sarek_quote.ml
+++ b/sarek/ppx/Sarek_quote.ml
@@ -460,6 +460,8 @@ let quote_sarek_loc ~loc (l : Sarek_ast.loc) : expression =
       loc_col = [%e quote_int ~loc l.loc_col];
       loc_end_line = [%e quote_int ~loc l.loc_end_line];
       loc_end_col = [%e quote_int ~loc l.loc_end_col];
+      loc_bol = [%e quote_int ~loc l.loc_bol];
+      loc_end_bol = [%e quote_int ~loc l.loc_end_bol];
     }]
 
 (** Quote a Sarek_ast.memspace *)

--- a/sarek/ppx/Sarek_typer.ml
+++ b/sarek/ppx/Sarek_typer.ml
@@ -860,7 +860,26 @@ let rec infer (env : t) (expr : expr) : (texpr * t) result =
           (* Regular function application *)
           let ret_ty = fresh_tvar () in
           let expected_fn_ty = TFun (List.map (fun t -> t.ty) targs, ret_ty) in
-          let* () = unify_or_error tfn.ty expected_fn_ty fn.expr_loc in
+          let* () =
+            (* When the callee is NAMED, say so. A bare [Cannot_unify] here
+               reads "Cannot unify types: float32 and float64" and names
+               neither the helper nor why it is constrained, which is the
+               reported failure mode for a polymorphic [@sarek.module] helper
+               instantiated at a non-default element type (#97). *)
+            match unify_or_error tfn.ty expected_fn_ty fn.expr_loc with
+            | Ok () -> Ok ()
+            | Error errs -> (
+                match fn.e with
+                | EVar callee ->
+                    Error
+                      (List.map
+                         (function
+                           | Cannot_unify (t1, t2, l) ->
+                               Instantiation_mismatch {callee; t1; t2; loc = l}
+                           | e -> e)
+                         errs)
+                | _ -> Error errs)
+          in
           Ok (mk_texpr (TEApp (tfn, targs)) (repr ret_ty) loc, env))
   (* Let bindings *)
   | EAssign _ | ELet _ | ELetMut _ | ELetRec _ ->

--- a/sarek/ppx/test/test_sarek_error.ml
+++ b/sarek/ppx/test/test_sarek_error.ml
@@ -18,6 +18,8 @@ let dummy_loc =
     loc_col = 0;
     loc_end_line = 1;
     loc_end_col = 0;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 (** Test error location extraction *)

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -31,6 +31,8 @@
 ; - test_f16_compare:  "float16 is a storage-only type and has no arithmetic"
 ; - test_f16_scalar_param: "cannot be a scalar kernel parameter"
 ; - test_f16_poly_helper: "a polymorphic helper instantiated at float16"
+; - test_char_vector: "`char` is not a supported Sarek element type"
+; - test_poly_helper_f64: "'norm' cannot be used at this call site"
 
 (library
  (name neg_test_unregistered_field)
@@ -322,6 +324,36 @@
 (library
  (name neg_test_f16_poly_helper)
  (modules test_f16_poly_helper)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+; `char` element type: 1 byte on the host (Bigarray char), lowered to a 4-byte
+; int on the device — a silent stride mismatch on every backend (#96).
+
+(library
+ (name neg_test_char_vector)
+ (modules test_char_vector)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))
+
+; A polymorphic [@sarek.module] helper whose body uses a float32-only stdlib
+; intrinsic, instantiated at float64 (#97). The rejection is correct; what was
+; wrong was the rendering (unrelated source bytes, from a location that had
+; lost pos_bol) and the message (no callee named).
+
+(library
+ (name neg_test_poly_helper_f64)
+ (modules test_poly_helper_f64)
  (libraries sarek sarek.stdlib sarek.ppx.lib)
  (preprocess
   (pps sarek_ppx))

--- a/sarek/tests/negative/test_char_vector.ml
+++ b/sarek/tests/negative/test_char_vector.ml
@@ -1,0 +1,28 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Negative test: `char` as a Sarek element type (wrong-width family, #96).
+
+   `Spoc_core.Vector.char` is a Bigarray of OCaml chars — ONE byte per element.
+   Source `char` lowered to [Ir.TInt32] ("char represented as int32"), so the
+   emitted device signature was `int*`:
+
+     __global__ void sarek_kern(int* __restrict__ o, ..., int* __restrict__ a, ...)
+
+   i.e. the buffer was strode at four times the host's element size, with no
+   diagnostic at any stage. Nothing could ever run: [Execute.check_launch_args]
+   already refuses a [Vector.Char] argument against a [TInt32] parameter on
+   physical width, on both the device and interpreter entry points. All that
+   was missing was telling the user at compile time, and why.
+
+   Expected error:
+     "`char` is not a supported Sarek element type" *)
+
+let k =
+  [%kernel
+    fun (o : char vector) (a : char vector) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      o.(tid) <- a.(tid)]

--- a/sarek/tests/negative/test_poly_helper_f64.ml
+++ b/sarek/tests/negative/test_poly_helper_f64.ml
@@ -1,0 +1,38 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Negative test: a polymorphic [@sarek.module] helper instantiated at a
+   non-default element type (#97).
+
+   [norm]'s body calls [sqrt], which the Sarek stdlib types at float32, so the
+   helper's type variable is pinned to float32 and it cannot be monomorphised
+   at float64. That IS a legitimate compile error — the defect was how it was
+   reported. Before the fix, on this tree:
+
+     File "p64.ml", line 10, characters 15-31:
+     10 | ...............float
+        |
+     10 | let[@sare.......................................................
+     Error: Cannot unify types: float32 and float64
+
+   The caret region and the echoed source line are unrelated bytes taken from
+   the TOP of the file, because [Sarek_ast.loc] dropped [pos_bol] and rebuilt
+   the position with [pos_bol = 0; pos_cnum = column] — so the driver, which
+   seeks to [pos_bol] to echo the line, read from byte `column` of the file.
+   The message also named neither the helper nor why float32 was required.
+
+   Expected error:
+     "'norm' cannot be used at this call site" *)
+
+type float64 = float
+
+let[@sarek.module] norm (x : 'a) (y : 'a) : 'a = sqrt ((x *. x) +. (y *. y))
+
+let k =
+  [%kernel
+    fun (o : float64 vector) (a : float64 vector) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      o.(tid) <- norm a.(tid) a.(tid)]

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -24,7 +24,10 @@
   test_ir_interp
   test_execute
   test_kirc_kernel
-  test_float16)
+  test_float16
+  test_type_width_totality
+  test_diagnostic_locations
+  test_ctype_gen)
  ; Link sarek_stdlib to trigger auto-registration of intrinsics
  ; ctypes is listed explicitly (not relied on transitively via sarek): the
  ; GC-root canary in test_float16 asserts the managed-vs-unmanaged asymmetry

--- a/sarek/tests/unit/test_convergence.ml
+++ b/sarek/tests/unit/test_convergence.ml
@@ -22,6 +22,8 @@ let dummy_loc =
       loc_col = 0;
       loc_end_line = 1;
       loc_end_col = 10;
+      loc_bol = 0;
+      loc_end_bol = 0;
     }
 
 (* Helper to create texpr with type *)

--- a/sarek/tests/unit/test_ctype_gen.ml
+++ b/sarek/tests/unit/test_ctype_gen.ml
@@ -1,0 +1,177 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * [Sarek_ctype_gen] turns a registered record/variant declaration into the C
+ * struct / union / builder source the backends splice into generated kernels.
+ *
+ * Two members of the "wrong-width / silently-wrong-type" family live here:
+ *
+ *  1. VARIANT PAYLOAD TYPE COMPUTED AND THEN DISCARDED.
+ *     [constructor_strings_of_core_type_decl] evaluated the payload's Sarek
+ *     type and dropped it on the floor:
+ *
+ *         | Pcstr_tuple [ct] ->
+ *             let _ = typ_of_core_type ~loc ct in     (* computed... *)
+ *             (cd.pcd_name.txt, None)                 (* ...and discarded *)
+ *
+ *     [None] then means "no payload" downstream, so [Shade of float32] emitted
+ *     a union member declared `int Shade_t;` and a builder taking no argument
+ *     at all. A 4-byte integer slot holding an f32's bits, and no way to set
+ *     it — wrong type, wrong builder, no diagnostic.
+ *
+ *  2. SILENT `int` WILDCARD in [c_type_of_typ] (`| _ -> "int"`), which answers
+ *     "int" for every type it does not enumerate — including 2-byte float16
+ *     and 8-byte int64-carrying registered types.
+ *
+ * These tests pin both against the emitted C source.
+ ******************************************************************************)
+
+open Ppxlib
+
+let loc = Location.none
+
+let contains hay needle =
+  let nh = String.length needle and h = String.length hay in
+  let rec go i =
+    if i + nh > h then false
+    else if String.sub hay i nh = needle then true
+    else go (i + 1)
+  in
+  nh = 0 || go 0
+
+(* [type col = Red | Shade of float32] as a ppxlib type declaration. *)
+let variant_decl =
+  let ctor name args =
+    {
+      pcd_name = {txt = name; loc};
+      pcd_vars = [];
+      pcd_args = Pcstr_tuple args;
+      pcd_res = None;
+      pcd_loc = loc;
+      pcd_attributes = [];
+    }
+  in
+  let f32 = [%type: float32] in
+  {
+    ptype_name = {txt = "col"; loc};
+    ptype_params = [];
+    ptype_cstrs = [];
+    ptype_kind = Ptype_variant [ctor "Red" []; ctor "Shade" [f32]];
+    ptype_private = Public;
+    ptype_manifest = None;
+    ptype_attributes = [];
+    ptype_loc = loc;
+  }
+
+(* [constructor_strings_of_core_type_decl] returns an OCaml list expression of
+   string literals; collect them back into the C source they denote. *)
+let emitted_variant_source () =
+  let strings = ref [] in
+  let it =
+    object
+      inherit Ast_traverse.iter as super
+
+      method! expression e =
+        (match e.pexp_desc with
+        | Pexp_constant (Pconst_string (s, _, _)) -> strings := s :: !strings
+        | _ -> ()) ;
+        super#expression e
+    end
+  in
+  it#expression
+    (Sarek_ctype_gen.constructor_strings_of_core_type_decl ~loc variant_decl) ;
+  let src = String.concat "\n" (List.rev !strings) in
+  if String.equal src "" then
+    Alcotest.fail "no C source strings were emitted — the test would be vacuous" ;
+  src
+
+(** The payload's type must reach the emitted C. A [float32] payload must be
+    declared `float`, never `int`. *)
+let test_variant_payload_keeps_its_type () =
+  let src = emitted_variant_source () in
+  Alcotest.(check bool)
+    ("the float32 payload member must be declared `float`, not `int`.\n\
+      Emitted source was:\n" ^ src)
+    true
+    (contains src "float col_sarek_Shade_t;") ;
+  Alcotest.(check bool)
+    ("the payload member must NOT be declared `int` (the discarded-type defect).\n\
+      Emitted source was:\n" ^ src)
+    false
+    (contains src "int col_sarek_Shade_t;")
+
+(** The builder for a constructor WITH a payload must take that payload as a
+    parameter and assign it. A dropped payload type also drops the parameter, so
+    the generated `build_col_Shade()` could not set the union member at all. *)
+let test_variant_builder_takes_the_payload () =
+  let src = emitted_variant_source () in
+  Alcotest.(check bool)
+    ("build_col_Shade must take the float payload.\nEmitted source was:\n" ^ src)
+    true
+    (contains src "build_col_Shade(float v)") ;
+  Alcotest.(check bool)
+    ("build_col_Shade must not be a no-payload builder.\nEmitted source was:\n"
+   ^ src)
+    false
+    (contains src "build_col_Shade()")
+
+(** The nullary constructor keeps its placeholder integer member — this is the
+    control showing the assertions above are about the payload, not about the
+    shape of the emitted struct. *)
+let test_nullary_constructor_unchanged () =
+  let src = emitted_variant_source () in
+  Alcotest.(check bool)
+    "nullary constructor keeps its placeholder member"
+    true
+    (contains src "int col_sarek_Red_t;") ;
+  Alcotest.(check bool)
+    "nullary builder takes no argument"
+    true
+    (contains src "build_col_Red()")
+
+(** No silent `int` for a type the mapper does not enumerate. float16 is 2
+    bytes; answering "int" declares a 4-byte member for it. *)
+let test_c_type_has_no_silent_int_wildcard () =
+  let check_not_int label t =
+    match Sarek_ctype_gen.c_type_of_typ t with
+    | exception Location.Error _ -> () (* explicit rejection is fine *)
+    | "int" ->
+        Alcotest.failf
+          "%s was mapped to C `int` by the wildcard arm — it is not a 4-byte \
+           integer type"
+          label
+    | _ -> ()
+  in
+  check_not_int "float16" (Sarek_types.TReg Sarek_types.Float16) ;
+  check_not_int "char" (Sarek_types.TReg Sarek_types.Char) ;
+  check_not_int
+    "a registered custom type"
+    (Sarek_types.TReg (Sarek_types.Custom "df64"))
+
+let () =
+  Alcotest.run
+    "ctype_gen"
+    [
+      ( "variant payload types reach the emitted C",
+        [
+          Alcotest.test_case
+            "payload member keeps its type"
+            `Quick
+            test_variant_payload_keeps_its_type;
+          Alcotest.test_case
+            "builder takes the payload"
+            `Quick
+            test_variant_builder_takes_the_payload;
+          Alcotest.test_case
+            "nullary constructor unchanged (control)"
+            `Quick
+            test_nullary_constructor_unchanged;
+          Alcotest.test_case
+            "c_type_of_typ has no silent int wildcard"
+            `Quick
+            test_c_type_has_no_silent_int_wildcard;
+        ] );
+    ]

--- a/sarek/tests/unit/test_diagnostic_locations.ml
+++ b/sarek/tests/unit/test_diagnostic_locations.ml
@@ -1,0 +1,128 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Locations carried by Sarek's own AST must survive the round trip back to
+ * ppxlib, because that location is what the OCaml driver uses to SLICE THE
+ * SOURCE FILE when it renders a Sarek diagnostic.
+ *
+ * [Lexing.position] is not (line, column): [pos_cnum] is the ABSOLUTE byte
+ * offset from the start of the file and [pos_bol] is the absolute offset of
+ * the start of the current line, so the column is [pos_cnum - pos_bol]. A
+ * conversion that keeps only line+column and then rebuilds a position with
+ * [pos_bol = 0; pos_cnum = column] produces a position whose column is right
+ * but whose absolute offset points at byte `column` of the FILE.
+ *
+ * The user-visible consequence is the #97 report: a real, correct Sarek type
+ * error is rendered against unrelated bytes taken from the top of the file.
+ * Observed on this tree before the fix, for a polymorphic [@sarek.module]
+ * helper instantiated at float64:
+ *
+ *   File "p64.ml", line 10, characters 15-31:
+ *   10 | ...............float
+ *      |
+ *   10 | let[@sare..................................................
+ *   Error: Cannot unify types: float32 and float64
+ *
+ * — the caret region and the echoed line are nonsense, so the diagnostic
+ * cannot be acted on even though the message itself is accurate. The kernel is
+ * on line 10 but the bytes shown come from line 1.
+ *
+ * These tests pin the round trip itself, which is where the loss happens.
+ ******************************************************************************)
+
+let pos ~fname ~lnum ~bol ~cnum =
+  {Lexing.pos_fname = fname; pos_lnum = lnum; pos_bol = bol; pos_cnum = cnum}
+
+(* A location on a line that does NOT start at byte 0 — i.e. every line of
+   every real source file except the first. Line 10 starts at byte 300; the
+   span covers bytes 315..331, which is columns 15..31 of that line. *)
+let sample : Ppxlib.Location.t =
+  {
+    loc_start = pos ~fname:"p64.ml" ~lnum:10 ~bol:300 ~cnum:315;
+    loc_end = pos ~fname:"p64.ml" ~lnum:10 ~bol:300 ~cnum:331;
+    loc_ghost = false;
+  }
+
+let check_position label (expected : Lexing.position) (got : Lexing.position) =
+  Alcotest.(check string) (label ^ ": file") expected.pos_fname got.pos_fname ;
+  Alcotest.(check int) (label ^ ": line") expected.pos_lnum got.pos_lnum ;
+  Alcotest.(check int)
+    (label
+   ^ ": absolute byte offset (pos_cnum) — this is what the compiler uses to \
+      slice the source line")
+    expected.pos_cnum
+    got.pos_cnum ;
+  Alcotest.(check int)
+    (label ^ ": line-start byte offset (pos_bol)")
+    expected.pos_bol
+    got.pos_bol ;
+  Alcotest.(check int)
+    (label ^ ": column (pos_cnum - pos_bol)")
+    (expected.pos_cnum - expected.pos_bol)
+    (got.pos_cnum - got.pos_bol)
+
+(** [loc_to_ppxlib (loc_of_ppxlib l)] must be [l]. Anything less means every
+    Sarek diagnostic that passes through the Sarek AST is rendered against the
+    wrong bytes. *)
+let test_ast_loc_round_trip () =
+  let got = Sarek_ast.loc_to_ppxlib (Sarek_ast.loc_of_ppxlib sample) in
+  check_position "start" sample.loc_start got.loc_start ;
+  check_position "end" sample.loc_end got.loc_end
+
+(** The native-generation copy of the same conversion must agree. It is used for
+    the locations attached to generated OCaml, so a bogus offset there sends the
+    OCaml type-checker's own errors to the wrong place. *)
+let test_native_helpers_loc_round_trip () =
+  let got =
+    Sarek_native_helpers.ppxlib_loc_of_sarek (Sarek_ast.loc_of_ppxlib sample)
+  in
+  check_position "start" sample.loc_start got.loc_start ;
+  check_position "end" sample.loc_end got.loc_end
+
+(** The column must still be derivable, so nothing downstream that reads
+    [loc_col] changes meaning. *)
+let test_column_is_preserved () =
+  let l = Sarek_ast.loc_of_ppxlib sample in
+  Alcotest.(check int) "loc_line" 10 l.Sarek_ast.loc_line ;
+  Alcotest.(check int) "loc_col" 15 l.Sarek_ast.loc_col ;
+  Alcotest.(check int) "loc_end_col" 31 l.Sarek_ast.loc_end_col
+
+(** A location built by hand from line/column only (the dummy and the
+    parser-synthesised cases) must still round-trip to something the compiler
+    renders sanely: line 1 columns are absolute offsets, so this degenerate case
+    is consistent by construction. *)
+let test_dummy_loc_is_consistent () =
+  let got = Sarek_ast.loc_to_ppxlib Sarek_ast.dummy_loc in
+  Alcotest.(check int) "dummy line" 1 got.loc_start.pos_lnum ;
+  Alcotest.(check int)
+    "dummy column"
+    0
+    (got.loc_start.pos_cnum - got.loc_start.pos_bol)
+
+let () =
+  Alcotest.run
+    "diagnostic_locations"
+    [
+      ( "source locations survive the Sarek AST round trip",
+        [
+          Alcotest.test_case
+            "Sarek_ast round trip is the identity"
+            `Quick
+            test_ast_loc_round_trip;
+          Alcotest.test_case
+            "Sarek_native_helpers round trip is the identity"
+            `Quick
+            test_native_helpers_loc_round_trip;
+          Alcotest.test_case
+            "line and column are preserved"
+            `Quick
+            test_column_is_preserved;
+          Alcotest.test_case
+            "dummy location stays consistent"
+            `Quick
+            test_dummy_loc_is_consistent;
+        ] );
+    ]

--- a/sarek/tests/unit/test_error.ml
+++ b/sarek/tests/unit/test_error.ml
@@ -16,6 +16,8 @@ let dummy_loc =
       loc_col = 5;
       loc_end_line = 10;
       loc_end_col = 10;
+      loc_bol = 0;
+      loc_end_bol = 0;
     }
 
 (* Helper to check if string contains substring *)

--- a/sarek/tests/unit/test_lower_ir.ml
+++ b/sarek/tests/unit/test_lower_ir.ml
@@ -121,85 +121,14 @@ let test_memspace_of_memspace_local () =
   let result = Sarek_lower_ir.memspace_of_memspace Sarek_types.Local in
   Alcotest.(check bool) "is Local" true (result = Ir.Local)
 
-(* Test: c_type_of_typ generates C type strings *)
-let test_c_type_of_typ_int () =
-  let ty = Sarek_types.(TPrim TInt32) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "int" result
-
-let test_c_type_of_typ_bool () =
-  let ty = Sarek_types.(TPrim TBool) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "int" result
-
-let test_c_type_of_typ_unit () =
-  let ty = Sarek_types.(TPrim TUnit) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "void" result
-
-let test_c_type_of_typ_float () =
-  let ty = Sarek_types.(TReg Float32) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "float" result
-
-let test_c_type_of_typ_double () =
-  let ty = Sarek_types.(TReg Float64) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "double" result
-
-let test_c_type_of_typ_long () =
-  let ty = Sarek_types.(TReg Int64) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "long" result
-
-let test_c_type_of_typ_char () =
-  let ty = Sarek_types.(TReg Char) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "char" result
-
-let test_c_type_of_typ_custom () =
-  let ty = Sarek_types.(TReg (Custom "MyType")) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "MyType" result
-
-let test_c_type_of_typ_vec_pointer () =
-  let ty = Sarek_types.(TVec (TReg Float32)) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "float *" result
-
-let test_c_type_of_typ_array_pointer () =
-  let ty = Sarek_types.(TArr (TReg Int, Local)) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "int *" result
-
-let test_c_type_of_typ_record_struct () =
-  let ty = Sarek_types.(TRecord ("Point", [("x", TReg Int)])) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type" "struct Point_sarek" result
-
-let test_c_type_of_typ_record_with_dots () =
-  let ty = Sarek_types.(TRecord ("Mod.Point", [("x", TReg Int)])) in
-  let result = Sarek_lower_ir.c_type_of_typ ty in
-  Alcotest.(check string) "C type mangled" "struct Mod_Point_sarek" result
-
-(* Test: record_constructor_strings generates C code *)
-let test_record_constructor_strings () =
-  let fields = [("x", Sarek_types.(TReg Int)); ("y", Sarek_types.(TReg Int))] in
-  let result = Sarek_lower_ir.record_constructor_strings "Point" fields in
-  (* Returns [struct_def; builder] *)
-  Alcotest.(check int) "two strings" 2 (List.length result) ;
-  let struct_def = List.hd result in
-  Alcotest.(check bool)
-    "struct has fields"
-    true
-    (String.length struct_def > 0 && String.contains struct_def '{')
-
-(* Test: variant_constructor_strings generates C code *)
-let test_variant_constructor_strings () =
-  let constrs = [("None", None); ("Some", Some Sarek_types.(TReg Int))] in
-  let result = Sarek_lower_ir.variant_constructor_strings "Option" constrs in
-  (* Returns list of constructor structs, union, main struct, and builders *)
-  Alcotest.(check bool) "has multiple parts" true (List.length result > 2)
+(* REMOVED: the [c_type_of_typ] and [record_/variant_constructor_strings]
+   cases. Those functions are gone (see the REMOVED note in
+   sarek/ppx/Sarek_lower_ir.ml): they emitted C source strings that were only
+   ever appended to [Kirc_types.constructors], a list nothing reads, and their
+   type mapper ended in a silent [| _ -> "int"] wildcard that could not be made
+   total without breaking real kernels. The type-mapping invariant those tests
+   were nominally about is now enforced, for the LIVE mappers and against the
+   HOST element widths, by sarek/tests/unit/test_type_width_totality.ml. *)
 
 (* Test: ir_binop converts binary operators *)
 let test_ir_binop_add () =
@@ -546,41 +475,6 @@ let () =
           Alcotest.test_case "global" `Quick test_memspace_of_memspace_global;
           Alcotest.test_case "shared" `Quick test_memspace_of_memspace_shared;
           Alcotest.test_case "local" `Quick test_memspace_of_memspace_local;
-        ] );
-      ( "c_type_generation",
-        [
-          Alcotest.test_case "int" `Quick test_c_type_of_typ_int;
-          Alcotest.test_case "bool" `Quick test_c_type_of_typ_bool;
-          Alcotest.test_case "unit" `Quick test_c_type_of_typ_unit;
-          Alcotest.test_case "float" `Quick test_c_type_of_typ_float;
-          Alcotest.test_case "double" `Quick test_c_type_of_typ_double;
-          Alcotest.test_case "long" `Quick test_c_type_of_typ_long;
-          Alcotest.test_case "char" `Quick test_c_type_of_typ_char;
-          Alcotest.test_case "custom" `Quick test_c_type_of_typ_custom;
-          Alcotest.test_case "vec pointer" `Quick test_c_type_of_typ_vec_pointer;
-          Alcotest.test_case
-            "array pointer"
-            `Quick
-            test_c_type_of_typ_array_pointer;
-          Alcotest.test_case
-            "record struct"
-            `Quick
-            test_c_type_of_typ_record_struct;
-          Alcotest.test_case
-            "record with dots"
-            `Quick
-            test_c_type_of_typ_record_with_dots;
-        ] );
-      ( "constructor_generation",
-        [
-          Alcotest.test_case
-            "record constructor"
-            `Quick
-            test_record_constructor_strings;
-          Alcotest.test_case
-            "variant constructor"
-            `Quick
-            test_variant_constructor_strings;
         ] );
       ( "operator_conversion",
         [

--- a/sarek/tests/unit/test_native_helpers.ml
+++ b/sarek/tests/unit/test_native_helpers.ml
@@ -23,6 +23,8 @@ let dummy_sarek_loc : Sarek_ast.loc =
     loc_col = 10;
     loc_end_line = 42;
     loc_end_col = 20;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 let dummy_loc = Location.none

--- a/sarek/tests/unit/test_ppx_registry.ml
+++ b/sarek/tests/unit/test_ppx_registry.ml
@@ -22,6 +22,8 @@ let dummy_loc =
       loc_col = 0;
       loc_end_line = 1;
       loc_end_col = 10;
+      loc_bol = 0;
+      loc_end_bol = 0;
     }
 
 (* Test: register and find type *)

--- a/sarek/tests/unit/test_quote.ml
+++ b/sarek/tests/unit/test_quote.ml
@@ -25,6 +25,8 @@ let dummy_sarek_loc : Sarek_ast.loc =
     loc_col = 10;
     loc_end_line = 42;
     loc_end_col = 20;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 (* Helper to check expression structure - handles extension nodes and nested expressions *)

--- a/sarek/tests/unit/test_reserved.ml
+++ b/sarek/tests/unit/test_reserved.ml
@@ -22,6 +22,8 @@ let dummy_loc =
       loc_col = 0;
       loc_end_line = 1;
       loc_end_col = 10;
+      loc_bol = 0;
+      loc_end_bol = 0;
     }
 
 (* Test: is_reserved recognizes C keywords *)

--- a/sarek/tests/unit/test_tailrec.ml
+++ b/sarek/tests/unit/test_tailrec.ml
@@ -26,6 +26,8 @@ let dummy_loc =
     loc_col = 0;
     loc_end_line = 1;
     loc_end_col = 0;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 (* Helper to create typed expressions *)

--- a/sarek/tests/unit/test_tailrec_analysis.ml
+++ b/sarek/tests/unit/test_tailrec_analysis.ml
@@ -29,6 +29,8 @@ let dummy_loc =
     loc_col = 0;
     loc_end_line = 1;
     loc_end_col = 0;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 (* Helper to create typed expressions *)

--- a/sarek/tests/unit/test_tailrec_bounded.ml
+++ b/sarek/tests/unit/test_tailrec_bounded.ml
@@ -20,6 +20,8 @@ let dummy_loc =
       loc_col = 0;
       loc_end_line = 1;
       loc_end_col = 10;
+      loc_bol = 0;
+      loc_end_bol = 0;
     }
 
 (* Helper to create typed expression *)

--- a/sarek/tests/unit/test_tailrec_elim.ml
+++ b/sarek/tests/unit/test_tailrec_elim.ml
@@ -24,6 +24,8 @@ let dummy_loc =
     loc_col = 0;
     loc_end_line = 1;
     loc_end_col = 0;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 (* Helper to create typed expressions *)

--- a/sarek/tests/unit/test_tailrec_pragma.ml
+++ b/sarek/tests/unit/test_tailrec_pragma.ml
@@ -22,6 +22,8 @@ let dummy_loc =
       loc_col = 0;
       loc_end_line = 1;
       loc_end_col = 10;
+      loc_bol = 0;
+      loc_end_bol = 0;
     }
 
 (* Helper: create a simple typed expression *)

--- a/sarek/tests/unit/test_type_width_totality.ml
+++ b/sarek/tests/unit/test_type_width_totality.ml
@@ -1,0 +1,302 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * CLASS VALIDATOR for the "wrong-width / silently-wrong-type" family.
+ *
+ * Every member of that family so far (kernel-local tuple, vector-of-tuple,
+ * helper return type, variant payload, `char` stride) has the same shape: a
+ * SOURCE type is mapped to a DEVICE type by a function that has a placeholder
+ * or wildcard arm collapsing the unknown case to `int` / [Ir.TInt32]. The
+ * result compiles, runs, and produces wrong bytes with no diagnostic.
+ *
+ * The invariant this test enforces is the one those arms break:
+ *
+ *   for every scalar source type T,
+ *     either [elttype_of_typ T] raises a located PPX error,
+ *     or     byte_width (elttype_of_typ T) = host_byte_width T.
+ *
+ * A silent width change is never admissible; a REJECTION always is. That is
+ * what makes this a validator for the class rather than three point checks —
+ * a new element type added to [Sarek_types.registered_type] must either be
+ * mapped at the right width or explicitly rejected, and it cannot reach the
+ * backends through a wildcard.
+ *
+ * WHY THIS GATE CANNOT SILENTLY PASS (see the "gates that cannot fail" list):
+ *
+ *  - the source enumeration is not a hand-written list that can go stale: it
+ *    is generated from a total successor chain ([next_reg] / [next_prim])
+ *    whose match has no wildcard, so adding a constructor to
+ *    [Sarek_types.registered_type] or [prim_type] fails to compile here;
+ *  - the IR width function [ir_width] is likewise a total match on
+ *    [Sarek_ir_ppx.elttype] with no wildcard, so a new IR element type fails
+ *    to compile here too;
+ *  - the host width table [host_width] is a total match on the source type;
+ *  - the enumeration is asserted non-empty and of the expected size, so a
+ *    chain accidentally cut short cannot make the sweep vacuous.
+ ******************************************************************************)
+
+module T = Sarek_types
+module Ir = Sarek_ir_ppx
+
+(* ------------------------------------------------------------------ *)
+(* Compiler-enforced enumeration of the source scalar types.           *)
+(*                                                                     *)
+(* [next_reg] is a total match: it has one arm per constructor and NO   *)
+(* wildcard, so a new [registered_type] constructor is a compile error  *)
+(* here (warning 8 is an error in this test's flags). The list is then  *)
+(* UNFOLDED from the chain, so it cannot drift from the type.          *)
+(* ------------------------------------------------------------------ *)
+
+let next_reg : T.registered_type -> T.registered_type option = function
+  | T.Int -> Some T.Int64
+  | T.Int64 -> Some T.Float16
+  | T.Float16 -> Some T.Float32
+  | T.Float32 -> Some T.Float64
+  | T.Float64 -> Some T.Char
+  | T.Char -> Some (T.Custom "some_registered_type")
+  | T.Custom _ -> None
+
+let next_prim : T.prim_type -> T.prim_type option = function
+  | T.TInt32 -> Some T.TBool
+  | T.TBool -> Some T.TUnit
+  | T.TUnit -> None
+
+let unfold next first =
+  let rec go acc x =
+    match next x with Some y -> go (y :: acc) y | None -> List.rev (x :: acc)
+  in
+  go [] first
+
+let all_reg = unfold next_reg T.Int
+
+let all_prim = unfold next_prim T.TInt32
+
+let all_scalar_typs : T.typ list =
+  List.map (fun r -> T.TReg r) all_reg @ List.map (fun p -> T.TPrim p) all_prim
+
+(* ------------------------------------------------------------------ *)
+(* Widths                                                              *)
+(* ------------------------------------------------------------------ *)
+
+(** Byte width the HOST uses for a value of this source type. This is the width
+    the runtime actually moves: it is [Spoc_core.Vector.elem_size] of the
+    corresponding vector kind, restated here on the source type so the test does
+    not need a device or a vector.
+
+    [Custom] is a user-registered aggregate whose width is only known from its
+    registered layout, so it has no scalar width — a mapper is required to
+    reject it, not to guess. *)
+let host_width : T.typ -> int option = function
+  | T.TReg T.Int -> Some 4 (* OCaml int, carried in a 32-bit slot *)
+  | T.TReg T.Int64 -> Some 8
+  | T.TReg T.Float16 -> Some 2 (* Vector.float16: IEEE binary16 *)
+  | T.TReg T.Float32 -> Some 4
+  | T.TReg T.Float64 -> Some 8
+  | T.TReg T.Char -> Some 1 (* Vector.char: Bigarray char, ONE byte *)
+  | T.TReg (T.Custom _) -> None
+  | T.TPrim T.TInt32 -> Some 4
+  | T.TPrim T.TBool -> Some 4
+  | T.TPrim T.TUnit -> Some 4
+  | T.TVar _ | T.TVec _ | T.TArr _ | T.TFun _ | T.TRecord _ | T.TVariant _
+  | T.TTuple _ ->
+      None
+
+(** Byte width of an IR element type. Total match, no wildcard: a new IR element
+    type is a compile error here. *)
+let ir_width : Ir.elttype -> int option = function
+  | Ir.TInt32 -> Some 4
+  | Ir.TInt64 -> Some 8
+  | Ir.TFloat16 -> Some 2
+  | Ir.TFloat32 -> Some 4
+  | Ir.TFloat64 -> Some 8
+  | Ir.TBool -> Some 4
+  | Ir.TUnit -> Some 4
+  | Ir.TRecord _ | Ir.TVariant _ | Ir.TArray _ | Ir.TVec _ -> None
+
+let string_of_typ t = Format.asprintf "%a" T.pp_typ t
+
+(* ------------------------------------------------------------------ *)
+(* The sweep                                                           *)
+(* ------------------------------------------------------------------ *)
+
+(** The enumeration must not be vacuous or truncated. If the successor chain is
+    ever cut short, the sweep below would pass by testing nothing — this is the
+    check that makes that impossible. *)
+let test_enumeration_is_complete () =
+  Alcotest.(check int) "registered_type constructors" 7 (List.length all_reg) ;
+  Alcotest.(check int) "prim_type constructors" 3 (List.length all_prim) ;
+  Alcotest.(check int)
+    "scalar source types swept"
+    10
+    (List.length all_scalar_typs)
+
+(** THE INVARIANT. For every scalar source type, [elttype_of_typ] must either
+    reject it or preserve its byte width. *)
+let test_elttype_of_typ_preserves_width () =
+  List.iter
+    (fun t ->
+      let label = string_of_typ t in
+      match Sarek_lower_ir.elttype_of_typ t with
+      | exception Ppxlib.Location.Error _ ->
+          (* Explicit rejection is always admissible: it is loud. *)
+          ()
+      | ir -> (
+          match (host_width t, ir_width ir) with
+          | Some hw, Some iw ->
+              Alcotest.(check int)
+                (Printf.sprintf
+                   "%s: device element width must equal the host's %d byte(s)"
+                   label
+                   hw)
+                hw
+                iw
+          | None, _ ->
+              (* No scalar host width (Custom aggregate): the mapper must not
+                 have produced a scalar element type silently. *)
+              Alcotest.failf
+                "%s has no known scalar host width, so mapping it to a scalar \
+                 device element type is a guess: it must be rejected with a \
+                 diagnostic instead"
+                label
+          | Some hw, None ->
+              Alcotest.failf
+                "%s is a %d-byte scalar on the host but lowered to a \
+                 non-scalar device element type"
+                label
+                hw))
+    all_scalar_typs
+
+(** The same invariant for the data-slot mapper (vector elements and
+    kernel-local bindings). It delegates to [elttype_of_typ] for non-tuples
+    today; this pins that it cannot start diverging on widths. *)
+let test_slot_elttype_of_typ_preserves_width () =
+  List.iter
+    (fun t ->
+      let label = string_of_typ t in
+      match Sarek_lower_ir.slot_elttype_of_typ t with
+      | exception Ppxlib.Location.Error _ -> ()
+      | ir -> (
+          match (host_width t, ir_width ir) with
+          | Some hw, Some iw ->
+              Alcotest.(check int)
+                (Printf.sprintf "%s (data slot): width" label)
+                hw
+                iw
+          | None, _ ->
+              Alcotest.failf
+                "%s (data slot) has no known scalar host width but was mapped \
+                 to a scalar device element type"
+                label
+          | Some hw, None ->
+              Alcotest.failf
+                "%s (data slot) is a %d-byte scalar but lowered to a \
+                 non-scalar element type"
+                label
+                hw))
+    all_scalar_typs
+
+(** A vector of a scalar must carry that scalar's width through to the element
+    type recorded on the parameter — this is the exact path a `char vector` took
+    to reach the backends as `int*`. *)
+let test_vector_element_width () =
+  List.iter
+    (fun t ->
+      let label = string_of_typ t ^ " vector" in
+      match Sarek_lower_ir.elttype_of_typ (T.TVec t) with
+      | exception Ppxlib.Location.Error _ -> ()
+      | Ir.TVec elem -> (
+          match (host_width t, ir_width elem) with
+          | Some hw, Some iw ->
+              Alcotest.(check int)
+                (Printf.sprintf
+                   "%s: buffer stride must be the host's %d byte(s)"
+                   label
+                   hw)
+                hw
+                iw
+          | None, _ ->
+              Alcotest.failf
+                "%s: element type has no known scalar host width but was \
+                 mapped to a scalar device element type"
+                label
+          | Some hw, None ->
+              Alcotest.failf
+                "%s: %d-byte host element lowered to a non-scalar element type"
+                label
+                hw)
+      | other ->
+          Alcotest.failf
+            "%s did not lower to a vector element type (%s)"
+            label
+            (match other with
+            | Ir.TInt32 -> "TInt32"
+            | Ir.TInt64 -> "TInt64"
+            | Ir.TFloat16 -> "TFloat16"
+            | Ir.TFloat32 -> "TFloat32"
+            | Ir.TFloat64 -> "TFloat64"
+            | Ir.TBool -> "TBool"
+            | Ir.TUnit -> "TUnit"
+            | Ir.TRecord _ -> "TRecord"
+            | Ir.TVariant _ -> "TVariant"
+            | Ir.TArray _ -> "TArray"
+            | Ir.TVec _ -> "TVec"))
+    all_scalar_typs
+
+(** The C type-name mapper feeding generated struct/builder source is held to
+    the same standard: no arm may silently answer "int" for a type it does not
+    know. A type it cannot name must raise.
+
+    [Sarek_ctype_gen] is the surviving emitter of that kind (the
+    [Sarek_lower_ir] copy was write-only and has been removed). *)
+let test_c_type_of_typ_has_no_silent_int () =
+  List.iter
+    (fun t ->
+      let label = string_of_typ t in
+      match Sarek_ctype_gen.c_type_of_typ t with
+      | exception Ppxlib.Location.Error _ -> ()
+      | c ->
+          (* "int" is only correct for the 4-byte integer-ish source types. Any
+             other type answering "int" is the wildcard defect. *)
+          if String.equal c "int" then
+            Alcotest.(check bool)
+              (Printf.sprintf
+                 "%s emitted C type \"int\": only 4-byte integer source types \
+                  may do so"
+                 label)
+              true
+              (match t with
+              | T.TReg T.Int | T.TPrim T.TInt32 | T.TPrim T.TBool -> true
+              | _ -> false))
+    all_scalar_typs
+
+let () =
+  Alcotest.run
+    "type_width_totality"
+    [
+      ( "wrong-width class validator",
+        [
+          Alcotest.test_case
+            "enumeration is complete (gate is not vacuous)"
+            `Quick
+            test_enumeration_is_complete;
+          Alcotest.test_case
+            "elttype_of_typ preserves byte width or rejects"
+            `Quick
+            test_elttype_of_typ_preserves_width;
+          Alcotest.test_case
+            "slot_elttype_of_typ preserves byte width or rejects"
+            `Quick
+            test_slot_elttype_of_typ_preserves_width;
+          Alcotest.test_case
+            "vector element stride matches the host element width"
+            `Quick
+            test_vector_element_width;
+          Alcotest.test_case
+            "c_type_of_typ has no silent int wildcard"
+            `Quick
+            test_c_type_of_typ_has_no_silent_int;
+        ] );
+    ]

--- a/sarek/tests/unit/test_typer.ml
+++ b/sarek/tests/unit/test_typer.ml
@@ -25,6 +25,8 @@ let dummy_loc =
     loc_col = 0;
     loc_end_line = 1;
     loc_end_col = 0;
+    loc_bol = 0;
+    loc_end_bol = 0;
   }
 
 (* Helper to create expressions *)

--- a/sarek/transpile/Sarek_transpile.ml
+++ b/sarek/transpile/Sarek_transpile.ml
@@ -209,6 +209,8 @@ let dummy_loc =
       loc_col = 0;
       loc_end_line = 1;
       loc_end_col = 0;
+      loc_bol = 0;
+      loc_end_bol = 0;
     }
 
 open Sarek_codegen
@@ -250,6 +252,8 @@ let loc_of_lexing (p : Lexing.position) : Sarek_ast.loc =
       loc_col = p.pos_cnum - p.pos_bol;
       loc_end_line = p.pos_lnum;
       loc_end_col = p.pos_cnum - p.pos_bol;
+      loc_bol = p.pos_bol;
+      loc_end_bol = p.pos_bol;
     }
 
 (** Run the shared parse→native-check→type→convergence→mono→tailrec→lower


### PR DESCRIPTION
Closes the "wrong-width / silently-wrong-type" family at the source-type mappers: the three reported members (#85, #96, #97), two more the added validator found, and the rendering defect that made #97 unreadable.

## The validator (the main deliverable)

`sarek/tests/unit/test_type_width_totality.ml` sweeps **every** scalar source type through the width-critical mappers (`elttype_of_typ`, `slot_elttype_of_typ`, the vector-element path, `c_type_of_typ`) and requires, for each:

> either an explicit located rejection, or `byte_width(device element) = byte_width(host element)`

A silent width change is never admissible; a rejection always is. That is the invariant every member of this family has broken.

**It cannot go vacuous.** The source enumeration is unfolded from a total successor chain with no wildcard; the IR width function is a total match on `Sarek_ir_ppx.elttype`; the host width table is a total match on the source type; and the enumeration size is asserted. A new constructor on either side is a *compile error in the test*, not a silently-skipped case.

Run against `main` it fails on `char` (expected 1, received 4) on all three element mappers, and on `float16` through `c_type_of_typ`. That is how #96 and the two new instances below were found.

## Fixes

| | |
|---|---|
| **#96** — `char` read at 4-byte stride (family #5) | `elttype_of_typ` mapped `TReg Char -> Ir.TInt32` ("char represented as int32"). `Vector.char` is a Bigarray of chars, **one** byte. A `char vector` kernel emitted `int* o, int* a` and strode the buffer at 4×, silently. Now rejected at lowering with a diagnostic naming the cause. **Nothing is lost**: `Execute.check_launch_args` already refused a `Char` vector against a `TInt32` parameter on physical width, on both the device and interpreter entry points, so such a kernel could never launch. Only the timing and the message change. |
| **NEW** — `TReg (Custom _)` claimed a 4-byte scalar | Same arm, same shape: an unregistered type name (from `%sarek_intrinsic`'s fallback) got `Ir.TInt32` under the comment "Custom types handled separately". Now rejected, with a message saying how to register it. |
| **NEW** — `float16` declared as C `int` | Both copies of `c_type_of_typ` ended in `\| _ -> "int"`, so a 2-byte f16 became a 4-byte `int` member. Made total in `Sarek_ctype_gen`. |
| **#85** — variant payload computed then discarded (family #4) | `Sarek_ctype_gen` ran `let _ = typ_of_core_type ~loc ct in ... None`, so `Shade of float32` emitted `int col_sarek_Shade_t;` and a builder `build_col_Shade()` taking no argument at all — wrong type **and** no way to set it. The payload type is now threaded through. |
| **#97** — polymorphic `[@sarek.module]` helper at a non-default element type | Two defects, one rendering and one message — see below. |

## #97: the deliverable is the diagnostic, and here is why

A helper whose body calls a float32-only stdlib intrinsic genuinely *cannot* be monomorphised at float64. Making that instantiation work means overloading the stdlib's math intrinsics over element types — a language change, not a bug fix. The rejection was already correct; what was broken was how it reached the user.

**1. The location was garbage.** `Sarek_ast.loc` kept only line+column and rebuilt the `Lexing.position` with `pos_bol = 0; pos_cnum = column`. `pos_cnum` is an **absolute file offset**, and the driver seeks to `pos_bol` to echo the offending line — so it quoted bytes from the top of the file under a diagnostic naming line 10:

```
File "p64.ml", line 10, characters 15-31:
10 | ...............float
   |
10 | let[@sare..................................................
Error: Cannot unify types: float32 and float64
```

`loc` now carries `loc_bol`/`loc_end_bol` so `loc_to_ppxlib` is a true inverse of `loc_of_ppxlib`. **This fixes the rendering of every Sarek diagnostic**, not just this one — the existing negative tests now point at the right source too.

**2. The message named no callee.** A new `Instantiation_mismatch` replaces a bare `Cannot_unify` when the callee is an `EVar`. After both fixes:

```
File "p64.ml", line 10, characters 17-37:
10 |       o.(tid) <- norm a.(tid) a.(tid)]
                      ^^^^^^^^^^^^^^^^^^^^
Error: 'norm' cannot be used at this call site: float32 and float64 do not match.
       A [@sarek.module] helper is monomorphised per call site, so a polymorphic
       helper can only be instantiated at the element types its BODY admits — a
       body using a float32-only operation (the Sarek_stdlib.Std math intrinsics
       are float32) cannot be instantiated at float64. Give the helper a concrete
       type, or use the element-type-specific module (e.g. Sarek_float64).
```

## Removed: the write-only constructor-string emitters in `Sarek_lower_ir`

`c_type_of_typ` / `record_constructor_strings` / `variant_constructor_strings` fed `Kirc_types.register_constructor_string`, which appends to a list **nothing in the tree reads** — the backends build record and variant definitions themselves from `kern_types`/`kern_variants` via `Sarek_ir_codegen.gen_variant_def`.

They are removed rather than repaired **because they could not be repaired**: replacing their `\| _ -> "int"` wildcard with the rejection the class demands immediately broke a real kernel (`e2e/test_static_tag_erasure`), since this path is handed types it has no C name for and depended on the placeholder to keep going. A generator that works only while it is silently wrong, and whose output no one reads, is dead weight with a live hazard attached.

The `test_lower_ir` `c_type_generation` and `constructor_generation` groups go with them; the invariant they were nominally about is now enforced for the **live** mappers, against **host** widths, by the new validator.

## Reported, not changed: `[%%sarek.type]` is not wired up

`Sarek_ctype_gen` is reachable only from `Sarek_ppx.expand_sarek_type`, and the `[%%sarek.type]` **extension** is absent from the driver's rule list (`sarek_type_extension` is bound to `()`), so writing it fails with ppxlib's "Uninterpreted extension" — loudly, so nothing depends on it. The live registration path is the `[@@sarek.type]` **attribute**. Its emitter's naming convention (`build_X_sarek`, `X_sarek_tag`) has also drifted from what the backends emit (`make_<mangled>_<ctor>`, `int tag`, `union {...} data`). I fixed the defect and documented the situation in both module headers rather than leave a corrected-but-unreachable trap or wire up an emitter whose output would not match — reconciling the two conventions is an owner decision.

## Tests

Each was written first and **observed RED on this tree**, with a message naming the real defect, before the corresponding fix.

- `test_type_width_totality` — 5 cases, the class validator
- `test_diagnostic_locations` — 4 cases, the loc round trip
- `test_ctype_gen` — 4 cases, variant payload + the `int` wildcard
- `negative/test_char_vector`, `negative/test_poly_helper_f64` + Makefile stanzas

## Verification

Hardware: AMD RX 7900 XTX + Ryzen 7950X iGPU — radeonsi OpenCL, RADV Vulkan, CPU Native. **No NVIDIA GPU present, so CUDA/PTX is compile-only here.** No Metal hardware.

- `dune build` (default target) — clean
- `dune runtest` over `unit`, `codegen_golden`, `new_runtime`, `sarek/core/test`, `spoc`, `sarek/ppx/test` — all pass
- `make test_negative` — every stanza PASS, including the two new ones
- e2e on hardware: `test_static_tag_erasure`, `test_ktype_record`, `test_klet_variant`, `test_helper_tuple_ret`, `test_module_poly`, `test_transpose` — all PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
