### PR TITLE
fix(opencl): bound residual recursion (#127) + OpenCL validation gate (#128)

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -62,6 +62,29 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 #                       false — but it cannot actually be removed without
 #                       losing glslangValidator.
 #
+#   clang               NOT installed here - already provided by the base
+#                       toolchain layer at the top of this file, so the OpenCL
+#                       validation gate (#128) adds 0 MB. Recorded in this list
+#                       anyway because that install now has a SECOND consumer
+#                       and nothing else would say so: `clang` there is no
+#                       longer only a C toolchain, it is the OpenCL C front-end
+#                       the gate and ci/assert-toolchain.sh's probe depend on.
+#                       If it is ever trimmed as unused, assert-toolchain.sh
+#                       fails loudly rather than letting the sweep return to
+#                       self-skipping.
+#
+#                       Deliberately NOT an OpenCL ICD: the gate must be able
+#                       to REPORT a rejection, and on the reference hardware
+#                       (RX 7900 XTX, rusticl/radeonsi) illegal generated
+#                       OpenCL crashed the host process instead of returning a
+#                       build log (#53/#127). clang needs no device, so this
+#                       does not change device enumeration. `clang -x cl` plus
+#                       `-Xclang -finclude-default-header` supplies the builtin
+#                       declarations an ICD would inject; the assert-toolchain
+#                       probe fails if that header is missing, because without
+#                       it every kernel would fail on get_global_id rather than
+#                       on its own defects.
+#
 # NOT installed, and why:
 #
 #   pocl-opencl-icd

--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -14,6 +14,8 @@
 #     wgsl_validation_sweep                       -> naga
 #   sarek/tests/unit/test_shader_recursion_vector.ml -> glslangValidator + naga
 #   sarek-cuda/test/test_cuda_nvrtc_gate.ml       -> libnvrtc
+#     opencl_validation_sweep                     -> clang (OpenCL C)
+#   sarek/tests/unit/test_opencl_gate.ml          -> clang (OpenCL C)
 #
 # That skip is correct behaviour for a developer machine, which legitimately has
 # none of these installed. It is a disaster in CI: the previous image carried
@@ -40,7 +42,7 @@ set -uo pipefail
 # is tautological by construction and can never report a gap on its own.
 #
 # The Rocq section below is deliberately NOT counted; see its comment.
-EXPECTED_CHECKS=8
+EXPECTED_CHECKS=10
 
 failures=0
 checks=0
@@ -215,6 +217,40 @@ WGSL
     ok "naga validated a probe shader — $out"
   else
     fail "naga is on PATH but cannot validate a trivial compute shader:
+$out"
+  fi
+  rm -rf "$tmpdir"
+fi
+
+# --------------------------------------------------------------------------
+section "clang (OpenCL C validation)"
+# The OpenCL gate (#128) compiles generated OpenCL C with `clang -x cl` rather
+# than through a vendor ICD, and that choice is the point: on the reference
+# machine (RX 7900 XTX, rusticl/radeonsi) illegal generated OpenCL did not
+# produce a build log, it took the host process down with SIGSEGV. A gate has to
+# fail where we can read the failure.
+if ! command -v clang >/dev/null 2>&1; then
+  checks=$((checks + 1))
+  fail "clang is not on PATH. OpenCL C is then the ONLY backend with committed \
+goldens and no executable validation at all, so opencl_validation_sweep would \
+silently validate nothing."
+else
+  run_check "clang --version" clang --version
+  tmpdir=$(mktemp -d)
+  cat >"$tmpdir/probe.cl" <<'CL'
+__kernel void probe(__global int *o) { o[get_global_id(0)] = 1; }
+CL
+  checks=$((checks + 1))
+  # Positive control, not `command -v`: a clang built without OpenCL support, or
+  # without the default builtin header, is on PATH and useless. This probe needs
+  # BOTH -x cl and -finclude-default-header to succeed, which is exactly the
+  # invocation the gate uses (opencl_clang.ml). A clang that cannot resolve
+  # get_global_id would fail every kernel on builtins rather than on defects.
+  if out=$(clang -x cl -cl-std=CL1.2 -Xclang -finclude-default-header \
+             -fsyntax-only "$tmpdir/probe.cl" 2>&1); then
+    ok "clang compiled a probe OpenCL kernel"
+  else
+    fail "clang is on PATH but cannot compile a trivial OpenCL kernel:
 $out"
   fi
   rm -rf "$tmpdir"

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -642,8 +642,9 @@ let gen_local buf indent = function
 
 (** {1 Helper Function Generation} *)
 
-(** Generate a helper function (OpenCL device function) *)
-let gen_helper_func buf (hf : helper_func) =
+(** Emit [ret name(params)] — shared by the prototype and the definition so the
+    two can never drift apart. *)
+let gen_helper_signature buf (hf : helper_func) =
   (* In OpenCL, helper functions don't need any special decoration *)
   Buffer.add_string buf (opencl_type_of_elttype hf.hf_ret_type) ;
   Buffer.add_char buf ' ' ;
@@ -656,11 +657,37 @@ let gen_helper_func buf (hf : helper_func) =
       Buffer.add_string buf (opencl_param_type v.var_type) ;
       Buffer.add_char buf ' ' ;
       Buffer.add_string buf v.var_name)
-    hf.hf_params ;
+    hf.hf_params
+
+(** Forward declaration for a helper.
+
+    Emitted for every helper BEFORE any definition, because [kern_funcs] carries
+    no ordering guarantee: a caller listed before its callee produced [error: use
+    of undeclared identifier 'g'] — invalid OpenCL C that depended purely on list
+    order. Found by the #128 sweep once the recursion classifier stopped refusing
+    helper-to-helper calls; no golden kernel has helpers, which is why the corpus
+    never showed it. Declaring all of them up front makes the order irrelevant
+    rather than relying on the IR producer to topologically sort. *)
+let gen_helper_proto buf (hf : helper_func) =
+  gen_helper_signature buf hf ;
+  Buffer.add_string buf ");\n"
+
+(** Generate a helper function (OpenCL device function) *)
+let gen_helper_func buf (hf : helper_func) =
+  gen_helper_signature buf hf ;
   Buffer.add_string buf ") {\n" ;
   (* Body *)
   gen_stmt buf "  " hf.hf_body ;
   Buffer.add_string buf "}\n\n"
+
+(** Prototypes for every helper, then the definitions. A no-op when the kernel
+    has no helpers, so kernels without them are byte-identical to before. *)
+let gen_helpers buf (funcs : helper_func list) =
+  if funcs <> [] then begin
+    List.iter (gen_helper_proto buf) funcs ;
+    Buffer.add_char buf '\n'
+  end ;
+  List.iter (gen_helper_func buf) funcs
 
 (** {1 Kernel Generation} *)
 
@@ -678,13 +705,286 @@ let reject_float16_kernel =
     ~hint:"needs cl_khr_fp16 enablement"
     Sarek_ir_analysis.Float16
 
+(** {1 Recursion Resolution}
+
+    OpenCL C forbids recursion outright (OpenCL C 1.2 §6.9.e, 3.0 §6.9.5: "the
+    OpenCL C programming language does not support recursion"). Unlike an
+    undeclared identifier, no compiler in this project's reach diagnoses it:
+    [clang -x cl -cl-std=CL1.2 -fsyntax-only] accepts a recursive device
+    function silently, and rusticl/radeonsi (Mesa) does not diagnose it either —
+    it overflows its own compiler stack inside [libRusticlOpenCL] and takes the
+    host process down with SIGSEGV (~30 800 recursive frames on a [clctxworker]
+    thread, zero OCaml frames in the backtrace). That crash is backlog #53, and
+    its cause is this: [pragma ["sarek.inline N"]] bounds the UNROLLING, not the
+    recursion, so the PPX leaves a residual self-call in the IR and this backend
+    used to print it verbatim.
+
+    Emitting a self-call and hoping the vendor rejects it is therefore not an
+    option, and neither is a blanket refusal: [pragma ["sarek.inline N"]] is an
+    advertised feature that the PTX backend already lowers correctly. So this
+    pass takes the same two-part policy as PTX
+    ({!Sarek_ir_ptx_expr.emit_app_recursive}), which keeps one semantics for one
+    pragma across backends:
+
+    - A self-recursive helper carrying [pragma ["sarek.inline N"]] has its
+      residual self-calls replaced by a typed zero. The pragma is the author's
+      contract that N levels cover every runtime input, so the residual call
+      site is dynamically unreachable: it only has to be well-formed OpenCL C,
+      never correct. Dropping the arguments is sound because IR expressions are
+      pure by construction (see {!Sarek_ir_types.expr}), so there are no
+      argument side effects to lose — PTX has to evaluate them only because its
+      lowering emits into a register file.
+    - Any other cycle — a recursive helper with no pragma, or mutual recursion
+      between helpers, which the PPX's self-call-only inliner cannot bound
+      anyway — is REFUSED with a located error, the way
+      {!Sarek_ir_inline_vec.splice_call} refuses recursion for GLSL/WGSL.
+
+    A partial unroll that silently leaves a self-call is the one outcome ruled
+    out: it is neither bounded nor refused. *)
+
+(** Typed zero for the result of a residual (dynamically unreachable) recursive
+    call. Aggregates are zeroed field-by-field / through the first constructor,
+    so the emitted expression is a real value of the helper's return type. *)
+let rec zero_expr (t : elttype) : expr =
+  match t with
+  | TInt32 -> EConst (CInt32 0l)
+  | TInt64 -> EConst (CInt64 0L)
+  | TFloat32 -> EConst (CFloat32 0.0)
+  | TFloat64 -> EConst (CFloat64 0.0)
+  | TBool -> EConst (CBool false)
+  | TUnit -> EConst CUnit
+  | TRecord (name, fields) ->
+      ERecord (name, List.map (fun (f, ft) -> (f, zero_expr ft)) fields)
+  | TVariant (name, (cname, payload) :: _) ->
+      EVariant (name, cname, List.map zero_expr payload)
+  | TVariant (name, []) ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "recursion"
+           (Printf.sprintf
+              "OpenCL: recursive helper returns the uninhabited variant '%s', \
+               so its residual call has no value to elide to"
+              name))
+  | TFloat16 | TArray _ | TVec _ ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "recursion"
+           "OpenCL: a recursive helper returning an array, vector or f16 \
+            cannot have its residual call elided; rewrite it without recursion")
+
+(** Inline budget declared by [hf], parsed from an [SPragma] at its body root.
+
+    Deliberately a copy of {!Sarek_ir_ptx_expr.helper_inline_budget} rather than
+    a shared symbol: both are minimal re-implementations of the option parsing
+    in [Sarek_tailrec_pragma.parse_sarek_inline_pragma] (the source of truth for
+    the "sarek.inline N" string format), which lives in the PPX — a separate
+    library not linkable from codegen. Factoring the two copies together belongs
+    with moving the parser into the IR, not with this fix. *)
+let helper_inline_budget (hf : helper_func) : int option =
+  let checked n_str =
+    match int_of_string_opt n_str with
+    | Some n when n < 0 ->
+        Codegen_error.raise_error
+          (Codegen_error.unsupported_construct
+             "pragma"
+             ("pragma [\"sarek.inline " ^ n_str
+            ^ "\"]: the inline depth must be >= 0"))
+    | v -> v
+  in
+  let parse = function
+    | [opt] -> (
+        match String.split_on_char ' ' opt with
+        | ["sarek.inline"; n] -> checked n
+        | _ -> None)
+    | ["sarek.inline"; n] -> checked n
+    | _ -> None
+  in
+  let rec root = function SBlock s -> root s | s -> s in
+  match root hf.hf_body with SPragma (opts, _) -> parse opts | _ -> None
+
+(** Bottom-up rewrite of every expression node reachable from a statement. One
+    traversal serves both the call-graph scan (with [f] the identity plus a side
+    effect) and the residual-call elision. *)
+let rec map_expr (f : expr -> expr) (e : expr) : expr =
+  let r = map_expr f in
+  let e' =
+    match e with
+    | EConst _ | EVar _ | EArrayLen _ -> e
+    | EBinop (op, a, b) -> EBinop (op, r a, r b)
+    | EUnop (op, a) -> EUnop (op, r a)
+    | EArrayRead (arr, i) -> EArrayRead (arr, r i)
+    | EArrayReadExpr (b, i) -> EArrayReadExpr (r b, r i)
+    | ERecordField (a, fld) -> ERecordField (r a, fld)
+    | EIntrinsic (path, name, args) -> EIntrinsic (path, name, List.map r args)
+    | ECast (t, a) -> ECast (t, r a)
+    | ETuple es -> ETuple (List.map r es)
+    | EApp (fn, args) -> EApp (r fn, List.map r args)
+    | ERecord (n, fields) ->
+        ERecord (n, List.map (fun (fl, a) -> (fl, r a)) fields)
+    | EVariant (n, c, args) -> EVariant (n, c, List.map r args)
+    | EArrayCreate (t, sz, ms) -> EArrayCreate (t, r sz, ms)
+    | EIf (c, a, b) -> EIf (r c, r a, r b)
+    | EMatch (s, cases) -> EMatch (r s, List.map (fun (p, a) -> (p, r a)) cases)
+  in
+  f e'
+
+let rec map_lvalue f (lv : lvalue) : lvalue =
+  match lv with
+  | LVar _ -> lv
+  | LArrayElem (a, i) -> LArrayElem (a, map_expr f i)
+  | LArrayElemExpr (b, i) -> LArrayElemExpr (map_expr f b, map_expr f i)
+  | LRecordField (b, fld) -> LRecordField (map_lvalue f b, fld)
+
+let rec map_stmt (f : expr -> expr) (s : stmt) : stmt =
+  let e = map_expr f and r = map_stmt f in
+  match s with
+  | SBarrier | SWarpBarrier | SEmpty | SMemFence | SNative _ -> s
+  | SAssign (lv, x) -> SAssign (map_lvalue f lv, e x)
+  | SSeq ss -> SSeq (List.map r ss)
+  | SIf (c, t, el) -> SIf (e c, r t, Option.map r el)
+  | SWhile (c, b) -> SWhile (e c, r b)
+  | SFor (v, lo, hi, d, b) -> SFor (v, e lo, e hi, d, r b)
+  | SMatch (sc, cases) -> SMatch (e sc, List.map (fun (p, b) -> (p, r b)) cases)
+  | SReturn x -> SReturn (e x)
+  | SExpr x -> SExpr (e x)
+  | SLet (v, x, b) -> SLet (v, e x, r b)
+  | SLetMut (v, x, b) -> SLetMut (v, e x, r b)
+  | SPragma (h, b) -> SPragma (h, r b)
+  | SBlock b -> SBlock (r b)
+
+(** Names of helper functions called (directly) from [s]. *)
+let called_helpers (helpers : string list) (s : stmt) : string list =
+  let acc = ref [] in
+  ignore
+    (map_stmt
+       (fun x ->
+         (match x with
+         | EApp (EVar v, _) when List.mem v.var_name helpers ->
+             if not (List.mem v.var_name !acc) then acc := v.var_name :: !acc
+         | _ -> ()) ;
+         x)
+       s) ;
+  !acc
+
+(** Every helper name reachable from [start] through the call graph [edges]. *)
+let reachable (edges : (string * string list) list) (start : string) :
+    string list =
+  let seen = ref [] in
+  let rec go n =
+    if not (List.mem n !seen) then begin
+      seen := n :: !seen ;
+      List.iter go (try List.assoc n edges with Not_found -> [])
+    end
+  in
+  List.iter go (try List.assoc start edges with Not_found -> []) ;
+  !seen
+
+let refuse_recursion name detail =
+  Codegen_error.raise_error
+    (Codegen_error.unsupported_construct
+       "recursion"
+       (Printf.sprintf
+          "OpenCL: helper '%s' is %s. OpenCL C forbids recursion (OpenCL C 1.2 \
+           §6.9.e), and no vendor compiler on this path diagnoses it — \
+           rusticl/radeonsi crashes on it instead of rejecting it (#53/#127). \
+           Annotate the helper body with pragma [\"sarek.inline N\"] for a \
+           depth-bounded self-recursion, or rewrite it without recursion."
+          name
+          detail))
+
+(** Replace residual self-calls in budgeted self-recursive helpers by a typed
+    zero, and refuse every other cycle. Post-condition (asserted below): the
+    returned kernel's helper call graph is acyclic, so no [EApp] this backend
+    emits can ever be a recursive call. *)
+let resolve_recursive_helpers (k : kernel) : kernel =
+  let names = List.map (fun hf -> hf.hf_name) k.kern_funcs in
+  let edges =
+    List.map
+      (fun hf -> (hf.hf_name, called_helpers names hf.hf_body))
+      k.kern_funcs
+  in
+  let on_cycle n = List.mem n (reachable edges n) in
+  let funcs =
+    List.map
+      (fun hf ->
+        if not (on_cycle hf.hf_name) then hf
+        else
+          (* Mutual recursion: the PPX inliner only rewrites SELF-calls
+             (Sarek_tailrec_analysis.is_self_call), so no pragma can bound this
+             — refuse before looking at the budget.
+
+             "Mutually recursive with [hf]" means SAME SCC: reachable from [hf]
+             AND able to reach [hf] back. Testing only [on_cycle n] would be an
+             over-approximation — it holds for any callee sitting on a cycle of
+             its own — and that is not a cosmetic difference here. This
+             backend's whole policy turns on the self-vs-other distinction:
+             budgeted self-recursion is elided to a typed zero, everything else
+             is refused. So a budgeted self-recursive [f] that merely calls an
+             independently self-recursive [g] would have been REFUSED as
+             "mutually recursive with 'g'" even though the two cycles never
+             touch — a false refusal on a case the inliner can bound, i.e. a
+             regression for anyone using the pragma. Each of [f] and [g] is
+             resolved by its own iteration of this map. *)
+          let direct = try List.assoc hf.hf_name edges with Not_found -> [] in
+          let through =
+            List.filter (fun n -> n <> hf.hf_name) (reachable edges hf.hf_name)
+          in
+          let mutual =
+            List.filter
+              (fun n -> List.mem hf.hf_name (reachable edges n))
+              through
+          in
+          if mutual <> [] then
+            refuse_recursion
+              hf.hf_name
+              (Printf.sprintf
+                 "mutually recursive with %s"
+                 (String.concat ", " (List.map (fun n -> "'" ^ n ^ "'") mutual)))
+          else if not (List.mem hf.hf_name direct) then
+            refuse_recursion hf.hf_name "recursive"
+          else
+            match helper_inline_budget hf with
+            | None ->
+                refuse_recursion
+                  hf.hf_name
+                  "self-recursive with no inline bound"
+            | Some _ ->
+                let zero = zero_expr hf.hf_ret_type in
+                let body =
+                  map_stmt
+                    (function
+                      | EApp (EVar v, _) when v.var_name = hf.hf_name -> zero
+                      | x -> x)
+                    hf.hf_body
+                in
+                {hf with hf_body = body})
+      k.kern_funcs
+  in
+  let k = {k with kern_funcs = funcs} in
+  (* Post-condition. Cheap, and it is the only thing standing between a future
+     change to the elision above and another silent SIGSEGV inside the vendor
+     compiler. *)
+  let edges' =
+    List.map (fun hf -> (hf.hf_name, called_helpers names hf.hf_body)) funcs
+  in
+  List.iter
+    (fun hf ->
+      if List.mem hf.hf_name (reachable edges' hf.hf_name) then
+        refuse_recursion
+          hf.hf_name
+          "still recursive after residual-call elision (internal invariant \
+           violated)")
+    funcs ;
+  k
+
 (** Generate complete OpenCL source for a kernel *)
 let generate (k : kernel) : string =
   reject_float16_kernel k ;
+  let k = resolve_recursive_helpers k in
   let buf = Buffer.create large_buffer_size in
 
   (* Generate helper functions before kernel *)
-  List.iter (gen_helper_func buf) k.kern_funcs ;
+  gen_helpers buf k.kern_funcs ;
 
   (* Kernel signature *)
   Buffer.add_string buf "__kernel void " ;
@@ -723,6 +1023,7 @@ let gen_variant_def buf v =
 let generate_with_types ~(types : (string * (string * elttype) list) list)
     (k : kernel) : string =
   reject_float16_kernel k ;
+  let k = resolve_recursive_helpers k in
   (* Set current_variants for SMatch binding extraction *)
   current_variants := k.kern_variants ;
   let buf = Buffer.create large_buffer_size in
@@ -737,7 +1038,7 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
     types ;
 
   (* Generate helper functions before kernel *)
-  List.iter (gen_helper_func buf) k.kern_funcs ;
+  gen_helpers buf k.kern_funcs ;
 
   (* Kernel signature *)
   Buffer.add_string buf "__kernel void " ;

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -32,7 +32,7 @@
 (test
  (name test_codegen_golden)
  (modules test_codegen_golden)
- (libraries codegen_golden_backends sarek_ir alcotest unix)
+ (libraries codegen_golden_backends opencl_gate sarek_ir alcotest unix)
  (instrumentation
   (backend bisect_ppx)))
 

--- a/sarek/tests/codegen_golden/opencl_gate/dune
+++ b/sarek/tests/codegen_golden/opencl_gate/dune
@@ -1,0 +1,11 @@
+; OpenCL validation gate (#128) — see opencl_clang.ml / opencl_recursion.ml /
+; ir_uniquify.ml for what each layer catches and what it provably cannot.
+;
+; Its own library rather than modules of test_codegen_golden so the negative
+; controls in ../../unit/test_opencl_gate.ml can drive the same code the sweep
+; drives — a gate whose red path is never executed is not a gate.
+
+(library
+ (name opencl_gate)
+ (modules ir_uniquify opencl_clang opencl_recursion)
+ (libraries sarek_ir unix))

--- a/sarek/tests/codegen_golden/opencl_gate/ir_uniquify.ml
+++ b/sarek/tests/codegen_golden/opencl_gate/ir_uniquify.ml
@@ -1,0 +1,252 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Capture-avoiding uniquification of every binder in a kernel IR — the "binder
+    canary" half of the OpenCL validation gate (#128).
+
+    {1 Why}
+
+    A compile gate on generated OpenCL C catches the shape where a dropped
+    binder leaves an identifier with no declaration:
+
+    {v input.cl:30:52: error: use of undeclared identifier 'q' v}
+
+    It provably cannot catch the shape where the dropped binder's name happens
+    to match something else in scope. Binder names come from user source, so any
+    colliding in-scope name — a parameter, a [let], a loop index — turns that
+    build error into VALID OpenCL C that computes the wrong answer with no
+    diagnostic at any layer. Measured on an RX 7900 XTX (rusticl/radeonsi): a
+    dropped [EMatch] payload binder [r] resolved to an enclosing local [r], the
+    program built clean, and every one of 1024 elements was wrong.
+
+    {1 What this does}
+
+    Rename every BINDING occurrence in the kernel to a globally unique name
+    ([sk<n>_<original>]) and rewrite each reference to its innermost binder.
+    This is a semantics-preserving α-conversion — the generated source must
+    still compile and behave identically. But collisions are now impossible by
+    construction: two binders that used to share the name [r] become [sk3_r] and
+    [sk7_r]. A binder the emitter drops therefore always leaves an identifier
+    that nothing declares, converting the whole class into the one shape the
+    compile gate does catch.
+
+    So: generate once from the kernel as written (checks what we ship), and once
+    from its uniquified twin (checks that no binder was silently dropped). Both
+    go through the same compiler. *)
+
+open Sarek_ir_types
+module SMap = Map.Make (String)
+
+type env = string SMap.t
+
+let counter = ref 0
+
+let reset () = counter := 0
+
+(** Fresh name for a binding occurrence. The [sk<n>_] prefix is unique across
+    the whole kernel and is a valid C identifier, so a dropped binder surfaces
+    as [use of undeclared identifier 'sk7_r'] — unmistakable in the compiler
+    diagnostic and impossible to satisfy by accident. *)
+let fresh (base : string) : string =
+  incr counter ;
+  Printf.sprintf "sk%d_%s" !counter base
+
+(** References to names this pass never bound (kernel-external arrays, if any)
+    are left alone: renaming them would create a false positive, and leaving
+    them cannot create one — they were already resolving to whatever they
+    resolved to before. *)
+let look (env : env) (n : string) : string =
+  match SMap.find_opt n env with Some m -> m | None -> n
+
+let rename_var env (v : var) : var = {v with var_name = look env v.var_name}
+
+let bind env (v : var) : env * var =
+  let n = fresh v.var_name in
+  (SMap.add v.var_name n env, {v with var_name = n})
+
+let rec uexpr (env : env) (e : expr) : expr =
+  let r = uexpr env in
+  match e with
+  | EConst _ -> e
+  | EVar v -> EVar (rename_var env v)
+  | EBinop (op, a, b) -> EBinop (op, r a, r b)
+  | EUnop (op, a) -> EUnop (op, r a)
+  | EArrayRead (arr, i) -> EArrayRead (look env arr, r i)
+  | EArrayReadExpr (b, i) -> EArrayReadExpr (r b, r i)
+  | ERecordField (a, f) -> ERecordField (r a, f)
+  | EIntrinsic (p, n, args) -> EIntrinsic (p, n, List.map r args)
+  | ECast (t, a) -> ECast (t, r a)
+  | ETuple es -> ETuple (List.map r es)
+  (* An [EApp] head names a helper function, not a local binder: helpers are
+     renamed as a group by [uniquify_kernel] so call and definition stay in
+     step. *)
+  | EApp (fn, args) -> EApp (uexpr env fn, List.map r args)
+  | ERecord (n, fs) -> ERecord (n, List.map (fun (f, a) -> (f, r a)) fs)
+  | EVariant (n, c, args) -> EVariant (n, c, List.map r args)
+  | EArrayLen a -> EArrayLen (look env a)
+  | EArrayCreate (t, sz, ms) -> EArrayCreate (t, r sz, ms)
+  | EIf (c, a, b) -> EIf (r c, r a, r b)
+  | EMatch (s, cases) ->
+      EMatch (r s, List.map (fun (p, a) -> ucase_expr env p a) cases)
+
+(** A [PConstr] payload binds its variables in the arm only. This is exactly the
+    binder class the #75 defect dropped, so it is the one that most needs a name
+    no enclosing scope can supply. *)
+and ucase_expr env p a =
+  match p with
+  | PWild -> (PWild, uexpr env a)
+  | PConstr (c, vars) ->
+      let env, vars =
+        List.fold_left
+          (fun (env, acc) v ->
+            let n = fresh v in
+            (SMap.add v n env, n :: acc))
+          (env, [])
+          vars
+      in
+      (PConstr (c, List.rev vars), uexpr env a)
+
+let rec ulvalue env (lv : lvalue) : lvalue =
+  match lv with
+  | LVar v -> LVar (rename_var env v)
+  | LArrayElem (a, i) -> LArrayElem (look env a, uexpr env i)
+  | LArrayElemExpr (b, i) -> LArrayElemExpr (uexpr env b, uexpr env i)
+  | LRecordField (b, f) -> LRecordField (ulvalue env b, f)
+
+let rec ustmt (env : env) (s : stmt) : stmt =
+  let e = uexpr env and r = ustmt env in
+  match s with
+  | SBarrier | SWarpBarrier | SEmpty | SMemFence -> s
+  (* [SNative] carries an opaque source-generating closure whose identifiers
+     this pass cannot see, so renaming around it would be unsound. Kernels
+     containing one are refused by [uniquify_kernel] instead. *)
+  | SNative _ -> s
+  | SAssign (lv, x) -> SAssign (ulvalue env lv, e x)
+  | SSeq ss -> SSeq (List.map r ss)
+  | SIf (c, t, el) -> SIf (e c, r t, Option.map r el)
+  | SWhile (c, b) -> SWhile (e c, r b)
+  | SFor (v, lo, hi, d, b) ->
+      (* Bounds are evaluated in the enclosing scope; the index binds the body. *)
+      let lo = e lo and hi = e hi in
+      let env', v' = bind env v in
+      SFor (v', lo, hi, d, ustmt env' b)
+  | SMatch (sc, cases) ->
+      SMatch (e sc, List.map (fun (p, b) -> ucase_stmt env p b) cases)
+  | SReturn x -> SReturn (e x)
+  | SExpr x -> SExpr (e x)
+  | SLet (v, x, b) ->
+      let x = e x in
+      let env', v' = bind env v in
+      SLet (v', x, ustmt env' b)
+  | SLetMut (v, x, b) ->
+      let x = e x in
+      let env', v' = bind env v in
+      SLetMut (v', x, ustmt env' b)
+  | SPragma (h, b) -> SPragma (h, r b)
+  | SBlock b -> SBlock (r b)
+
+and ucase_stmt env p b =
+  match p with
+  | PWild -> (PWild, ustmt env b)
+  | PConstr (c, vars) ->
+      let env, vars =
+        List.fold_left
+          (fun (env, acc) v ->
+            let n = fresh v in
+            (SMap.add v n env, n :: acc))
+          (env, [])
+          vars
+      in
+      (PConstr (c, List.rev vars), ustmt env b)
+
+let bind_decl (env : env) (d : decl) : env * decl =
+  match d with
+  | DParam (v, ai) ->
+      let env, v = bind env v in
+      (env, DParam (v, ai))
+  | DLocal (v, init) ->
+      (* The initialiser is in the enclosing scope, so rename it BEFORE binding. *)
+      let init = Option.map (uexpr env) init in
+      let env, v = bind env v in
+      (env, DLocal (v, init))
+  | DShared (n, t, sz) ->
+      let sz = Option.map (uexpr env) sz in
+      let n' = fresh n in
+      (SMap.add n n' env, DShared (n', t, sz))
+
+exception Unsupported of string
+
+let rec stmt_has_native = function
+  | SNative _ -> true
+  | SSeq ss -> List.exists stmt_has_native ss
+  | SIf (_, t, el) -> (
+      stmt_has_native t
+      || match el with Some e -> stmt_has_native e | None -> false)
+  | SWhile (_, b) | SFor (_, _, _, _, b) | SPragma (_, b) | SBlock b ->
+      stmt_has_native b
+  | SMatch (_, cases) -> List.exists (fun (_, b) -> stmt_has_native b) cases
+  | SLet (_, _, b) | SLetMut (_, _, b) -> stmt_has_native b
+  | _ -> false
+
+(** α-convert every binder in [k]. Raises {!Unsupported} for kernels this pass
+    cannot rename soundly, so the caller reports a SKIP with a reason rather
+    than validating a kernel it silently left alone. *)
+let uniquify_kernel (k : kernel) : kernel =
+  if
+    stmt_has_native k.kern_body
+    || List.exists (fun hf -> stmt_has_native hf.hf_body) k.kern_funcs
+  then raise (Unsupported "kernel contains SNative (opaque generated source)") ;
+  reset () ;
+  (* Helpers are renamed as a group so definitions and call sites agree. Their
+     parameters bind only inside their own bodies — helpers are module-level and
+     capture nothing, so each starts from the helper-name environment alone. *)
+  let henv =
+    List.fold_left
+      (fun env hf -> SMap.add hf.hf_name (fresh hf.hf_name) env)
+      SMap.empty
+      k.kern_funcs
+  in
+  let funcs =
+    List.map
+      (fun hf ->
+        let env, params =
+          List.fold_left
+            (fun (env, acc) v ->
+              let env, v = bind env v in
+              (env, v :: acc))
+            (henv, [])
+            hf.hf_params
+        in
+        {
+          hf with
+          hf_name = look henv hf.hf_name;
+          hf_params = List.rev params;
+          hf_body = ustmt env hf.hf_body;
+        })
+      k.kern_funcs
+  in
+  let env, params =
+    List.fold_left
+      (fun (env, acc) d ->
+        let env, d = bind_decl env d in
+        (env, d :: acc))
+      (henv, [])
+      k.kern_params
+  in
+  let env, locals =
+    List.fold_left
+      (fun (env, acc) d ->
+        let env, d = bind_decl env d in
+        (env, d :: acc))
+      (env, [])
+      k.kern_locals
+  in
+  {
+    k with
+    kern_params = List.rev params;
+    kern_locals = List.rev locals;
+    kern_funcs = funcs;
+    kern_body = ustmt env k.kern_body;
+  }

--- a/sarek/tests/codegen_golden/opencl_gate/opencl_clang.ml
+++ b/sarek/tests/codegen_golden/opencl_gate/opencl_clang.ml
@@ -1,0 +1,74 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** OpenCL C compile gate — the OpenCL counterpart of the [ptxas], [nvrtc],
+    [glslangValidator] and [naga] gates (#84/#51, extended by #128).
+
+    Uses [clang -x cl] rather than a vendor ICD on purpose. A gate must fail
+    where WE can read the failure, and a real ICD is exactly what this project
+    cannot rely on: on the reference machine (RX 7900 XTX, rusticl/radeonsi,
+    Mesa) illegal generated OpenCL took the host process down with SIGSEGV
+    instead of returning a build log (#53/#127). [clang] is hermetic, needs no
+    device, runs in CI, and reports a diagnostic. Its blind spots are documented
+    in {!Opencl_recursion}, which covers them. *)
+
+let read_file f =
+  try
+    let ic = open_in f in
+    let n = in_channel_length ic in
+    let s = really_input_string ic n in
+    close_in ic ;
+    s
+  with _ -> ""
+
+let write_file f s =
+  let oc = open_out f in
+  output_string oc s ;
+  close_out oc
+
+(** The invocation. [-cl-std=CL1.2] is the language level Sarek's OpenCL backend
+    targets; [-finclude-default-header] supplies the OpenCL builtin declarations
+    ([get_global_id], [sqrt], ...) that a real ICD injects, without which every
+    kernel would fail on builtins rather than on its own defects. *)
+let cmd_for src err =
+  Printf.sprintf
+    "clang -x cl -cl-std=CL1.2 -Xclang -finclude-default-header -fsyntax-only \
+     %s >%s 2>&1"
+    (Filename.quote src)
+    (Filename.quote err)
+
+let run_clang (source : string) : (unit, string) result =
+  let base = Filename.temp_file "sarek_gate_ocl_" "" in
+  let src = base ^ ".cl" in
+  let err = base ^ ".err" in
+  write_file src source ;
+  let rc = Unix.system (cmd_for src err) in
+  let out = read_file err in
+  List.iter (fun f -> try Sys.remove f with _ -> ()) [src; err; base] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+(** Availability is a POSITIVE CONTROL, not [command -v]: a clang build without
+    OpenCL support, or without the default header, is on PATH and useless. The
+    probe below is the smallest kernel that exercises both the [cl] language
+    mode and the builtin header, so "available" means "has just compiled
+    something". Mirrors the probe discipline in [ci/assert-toolchain.sh]. *)
+let probe =
+  "__kernel void probe(__global int *o) { o[get_global_id(0)] = 1; }\n"
+
+let unavailable_reason : string option Lazy.t =
+  lazy
+    (match Unix.system "command -v clang >/dev/null 2>&1" with
+    | Unix.WEXITED 0 -> (
+        match run_clang probe with
+        | Ok () -> None
+        | Error e ->
+            Some ("clang is on PATH but rejected the OpenCL probe kernel: " ^ e)
+        )
+    | _ -> Some "clang not on PATH")
+
+let available () = Lazy.force unavailable_reason = None
+
+let why_unavailable () =
+  match Lazy.force unavailable_reason with Some r -> r | None -> ""

--- a/sarek/tests/codegen_golden/opencl_gate/opencl_recursion.ml
+++ b/sarek/tests/codegen_golden/opencl_gate/opencl_recursion.ml
@@ -1,0 +1,197 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Recursion detector for generated OpenCL C — the check no compiler makes.
+
+    OpenCL C forbids recursion (OpenCL C 1.2 §6.9.e, 3.0 §6.9.5). Nothing on
+    this project's path enforces it:
+
+    - [clang -x cl -cl-std=CL1.2 -Xclang -finclude-default-header -fsyntax-only]
+      accepts a recursive device function and exits 0. Verified with clang
+      22.1.6 for the default host target and for [--target=spirv64],
+      [--target=spirv32] and [--target=amdgcn-amd-amdhsa -mcpu=gfx1100].
+    - rusticl/radeonsi (Mesa, RX 7900 XTX) does not diagnose it either. It
+      recurses through its own compiler on a [clctxworker] thread until the
+      stack is gone and takes the host process down with SIGSEGV — backlog #53,
+      root-caused in #127.
+
+    So the compile gate is structurally blind here, and this check exists
+    precisely to cover that blind spot. It reads the EMITTED source rather than
+    the IR on purpose: the IR-level guarantee lives in the backend
+    ([Sarek_ir_opencl.resolve_recursive_helpers]), and a gate that re-ran the
+    backend's own reasoning would go green on any bug that made the backend emit
+    something other than what it reasoned about.
+
+    The parser is deliberately small — it only has to understand the shape this
+    project's own emitter produces (top-level function definitions, one brace
+    nesting, no strings, no function pointers). It is not a C parser and does
+    not try to be. *)
+
+(** Blank out [//] and [/* */] comments, preserving length and newlines so
+    nothing downstream has to care. *)
+let strip_comments (s : string) : string =
+  let n = String.length s in
+  let b = Bytes.of_string s in
+  let i = ref 0 in
+  while !i < n do
+    if !i + 1 < n && s.[!i] = '/' && s.[!i + 1] = '/' then begin
+      while !i < n && s.[!i] <> '\n' do
+        Bytes.set b !i ' ' ;
+        incr i
+      done
+    end
+    else if !i + 1 < n && s.[!i] = '/' && s.[!i + 1] = '*' then begin
+      let stop = ref false in
+      while (not !stop) && !i < n do
+        if !i + 1 < n && s.[!i] = '*' && s.[!i + 1] = '/' then begin
+          Bytes.set b !i ' ' ;
+          Bytes.set b (!i + 1) ' ' ;
+          i := !i + 2 ;
+          stop := true
+        end
+        else begin
+          if s.[!i] <> '\n' then Bytes.set b !i ' ' ;
+          incr i
+        end
+      done
+    end
+    else incr i
+  done ;
+  Bytes.to_string b
+
+let is_ident_char c =
+  (c >= 'a' && c <= 'z')
+  || (c >= 'A' && c <= 'Z')
+  || (c >= '0' && c <= '9')
+  || c = '_'
+
+(** The identifier immediately preceding position [i] (skipping whitespace), or
+    [None]. *)
+let ident_before (s : string) (i : int) : (string * int) option =
+  let j = ref (i - 1) in
+  while !j >= 0 && (s.[!j] = ' ' || s.[!j] = '\n' || s.[!j] = '\t') do
+    decr j
+  done ;
+  if !j < 0 || not (is_ident_char s.[!j]) then None
+  else begin
+    let e = !j in
+    while !j >= 0 && is_ident_char s.[!j] do
+      decr j
+    done ;
+    Some (String.sub s (!j + 1) (e - !j), !j + 1)
+  end
+
+(** Top-level function definitions as [(name, body)]. A definition is a [{] at
+    brace depth 0 whose matching [(] is preceded by an identifier — which
+    excludes struct/union initialisers and typedef bodies. *)
+let definitions (src : string) : (string * string) list =
+  let s = strip_comments src in
+  let n = String.length s in
+  let depth = ref 0 in
+  let out = ref [] in
+  let i = ref 0 in
+  while !i < n do
+    (match s.[!i] with
+    | '{' ->
+        if !depth = 0 then begin
+          (* Walk back over the parameter list to the opening paren. *)
+          let j = ref (!i - 1) in
+          while !j >= 0 && s.[!j] <> ')' && s.[!j] <> ';' && s.[!j] <> '}' do
+            decr j
+          done ;
+          if !j >= 0 && s.[!j] = ')' then begin
+            let pd = ref 0 in
+            let k = ref !j in
+            let stop = ref false in
+            while (not !stop) && !k >= 0 do
+              if s.[!k] = ')' then incr pd
+              else if s.[!k] = '(' then begin
+                decr pd ;
+                if !pd = 0 then stop := true
+              end ;
+              if not !stop then decr k
+            done ;
+            if !stop then
+              match ident_before s !k with
+              | Some (name, _) ->
+                  (* Body span: from this brace to its match. *)
+                  let d = ref 0 in
+                  let e = ref !i in
+                  let fin = ref (-1) in
+                  while !fin < 0 && !e < n do
+                    if s.[!e] = '{' then incr d
+                    else if s.[!e] = '}' then begin
+                      decr d ;
+                      if !d = 0 then fin := !e
+                    end ;
+                    incr e
+                  done ;
+                  let fin = if !fin < 0 then n - 1 else !fin in
+                  out := (name, String.sub s !i (fin - !i + 1)) :: !out
+              | None -> ()
+          end
+        end ;
+        incr depth
+    | '}' -> decr depth
+    | _ -> ()) ;
+    incr i
+  done ;
+  List.rev !out
+
+(** Identifiers applied to an argument list inside [body]. *)
+let calls_in (body : string) : string list =
+  let n = String.length body in
+  let out = ref [] in
+  for i = 0 to n - 1 do
+    if body.[i] = '(' then
+      match ident_before body i with
+      | Some (name, _) when not (List.mem name !out) -> out := name :: !out
+      | _ -> ()
+  done ;
+  !out
+
+type cycle = string list
+
+(** Every call cycle among the function definitions in [src]. An empty result is
+    the OpenCL C requirement satisfied. *)
+let cycles (src : string) : cycle list =
+  let defs = definitions src in
+  let names = List.map fst defs in
+  let edges =
+    List.map
+      (fun (n, body) ->
+        (n, List.filter (fun c -> List.mem c names) (calls_in body)))
+      defs
+  in
+  let succ n = try List.assoc n edges with Not_found -> [] in
+  let found = ref [] in
+  let rec walk path n =
+    if List.mem n path then begin
+      (* Normalise to the cycle itself so the same loop is not reported once
+         per entry point. *)
+      let rec suffix = function
+        | x :: tl -> if x = n then x :: tl else suffix tl
+        | [] -> []
+      in
+      (* [suffix] returns the loop with its entry node repeated at the end
+         ([f; g; f]); drop the repeat so a self-call is [f], not [f; f]. *)
+      let cyc =
+        match List.rev (suffix (List.rev (n :: path))) with
+        | _ :: _ as l -> List.filteri (fun i _ -> i < List.length l - 1) l
+        | [] -> []
+      in
+      let key = List.sort compare cyc in
+      if not (List.exists (fun c -> List.sort compare c = key) !found) then
+        found := cyc :: !found
+    end
+    else List.iter (walk (n :: path)) (succ n)
+  in
+  List.iter (fun n -> walk [] n) names ;
+  !found
+
+let describe (c : cycle) : string =
+  match c with
+  | [x] -> Printf.sprintf "'%s' calls itself" x
+  | _ -> String.concat " -> " (List.map (fun n -> "'" ^ n ^ "'") c)

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -2210,7 +2210,58 @@ let validation_exclusions : ((string * string) * string) list =
      GLSL backend now lowers every Float64 transcendental through the software
      helper family (Sarek_ir_softmath), so both goldens emit valid GLSL and are
      validated by the sweep below like every other case. *)
-  []
+  (* FINDING (#128 sweep, first run): Float64.abs_float and Float64.copysign are
+     declared in sarek/Sarek_float64/Float64.ml — user-callable — but are absent
+     from Sarek_pure_registry.float64_list, which is what every non-GLSL backend
+     dispatches through. GLSL survives only because it special-cases both in a
+     hardcoded arm. On OpenCL they die at codegen:
+
+       [OpenCL Codegen] Unknown intrinsic: Float64.abs_float
+       [OpenCL Codegen] Unknown intrinsic: Float64.copysign
+
+     Two exclusions rather than a fix, deliberately. Naively adding the names to
+     float64_list was tried and makes it worse, not better: the float64 template
+     emits the Sarek name verbatim (the float32 table carries an explicit
+     ("abs_float","fabsf","fabs") mapping; the float64 table is a bare name
+     list), so codegen then emits [abs_float(a[idx])] — clang: "use of
+     undeclared identifier 'abs_float'". And the module-level comment on
+     Sarek_pure_registry states the boundary directly: registering float64 names
+     the interpreter cannot evaluate converts an honest lookup failure into a
+     silent miscompile. A real fix needs a name mapping AND interpreter support,
+     across every backend — a separate change, not a rider on the gate that
+     found it. *)
+  [
+    ( ("opencl", "float64_abs_float_path"),
+      "Float64.abs_float is user-callable but unmapped on every non-GLSL \
+       backend (Sarek_pure_registry.float64_list) — codegen raises Unknown \
+       intrinsic. Found by this sweep; see the note above for why the one-line \
+       fix is wrong." );
+    ( ("opencl", "float64_copysign_path"),
+      "Float64.copysign — same gap as float64_abs_float_path above." );
+    (* RESOLVED (#128 sweep, first run -> fixed by #75): the binder canary
+       reproduced the #75 EMatch-payload defect on OpenCL, in the shape a
+       compile gate provably cannot see. It emitted:
+
+         out[idx] = ((s.tag == Circle) ? (r * 2.0f) : (r + 7.0f));
+
+       — accepted by clang and by rusticl, and wrong, because the dropped
+       payload binder [r] silently resolved to the enclosing local [r]. Under
+       unique binder names the same emission was:
+
+         sk2_out[sk3_idx] = ((sk5_s.tag == Circle) ? (sk6_r * 2.0f) : (sk7_r + 7.0f));
+         error: use of undeclared identifier 'sk6_r'; did you mean 'sk4_r'?
+
+       That exclusion is GONE, and it was removed the way its own removal
+       condition demanded: not because a PR merged, but because the check
+       passes. Re-verified after the EMatch payload fix landed —
+       opencl-validate/ematch_payload_shadowed now reports [OK] ("clang OK:
+       ematch_payload_shadowed (+ binder canary)"), not [SKIP]. So the fix
+       covers the colliding-binder shape, not just the undeclared-identifier
+       one, which is the part a compile gate alone could never have confirmed.
+
+       [ematch_payload_shadowed] stays in the sweep corpus permanently as the
+       live regression check for that shape. *)
+  ]
 
 let excluded backend name = List.assoc_opt (backend, name) validation_exclusions
 
@@ -2287,6 +2338,188 @@ let wgsl_validation_tests () =
                       wgsl)))
     (test_kernels () @ wgsl_only_kernels ())
 
+(** {1 OpenCL validation sweep (#128)}
+
+    OpenCL was the one backend with goldens but no validator, and it is the one
+    where the vendor compiler is least able to act as a safety net: on the
+    reference machine (RX 7900 XTX, rusticl/radeonsi) illegal generated OpenCL
+    crashed the host process instead of producing a build log, and valid-but-
+    wrong generated OpenCL produced no diagnostic at all.
+
+    Three layers per kernel, each with a different blind spot:
+
+    + {b recursion} ({!Opencl_recursion}) — reads the emitted text. No compiler
+      in reach diagnoses OpenCL recursion (measured: clang 22.1.6 accepts it on
+      four targets; rusticl SIGSEGVs on it), so this layer is not redundant with
+      the compile gate, it is the only cover for that class.
+    + {b compile} ({!Opencl_clang}) — [clang -x cl], the same language level and
+      builtin header a real ICD provides. Catches ill-typed and undeclared-
+      identifier defects.
+    + {b binder canary} ({!Ir_uniquify}) — regenerates from an α-converted twin
+      of the kernel and compiles that too. See ir_uniquify.ml: the compile layer
+      alone is structurally unable to see a dropped binder whose name collides
+      with something in scope, because such code IS valid OpenCL C. Under unique
+      binder names a collision cannot happen, so the class collapses into
+      "undeclared identifier", which layer 2 does catch.
+
+    What this sweep still cannot catch, stated plainly so a green run is not
+    mistaken for "our OpenCL is correct": anything that is well-formed OpenCL C
+    with all binders present but the wrong semantics — a wrong operator, a wrong
+    intrinsic mapping, a wrong index. That is what the goldens above and the e2e
+    runtime tests are for. *)
+
+(** Kernels that exist only to be run through the OpenCL validator, and carry no
+    golden: their point is what the gate says about the emitted source, not
+    which bytes it is. Keeping them out of [test_kernels ()] avoids minting five
+    backends' worth of goldens for a case that is about validation. *)
+let opencl_validation_only_kernels () =
+  (* Colliding-binder reproduction (#75 / PR #306). An enclosing local [r] and
+     an EMatch payload binder also called [r]. If the emitter drops the payload
+     binding, the arm's [r] resolves to the enclosing [r]: the source is VALID
+     OpenCL C, no compiler anywhere says a word, and the kernel returns a wrong
+     answer. Measured on an RX 7900 XTX (rusticl/radeonsi): 1024/1024 elements
+     wrong, first at index 0 — got 2000.0, expected 1.0. Layer 2 cannot see
+     this; layer 3 (binder canary) exists for it. *)
+  let shape_constrs = [("Circle", [TFloat32]); ("Square", [TFloat32])] in
+  let shape_ty = TVariant ("Shape", shape_constrs) in
+  let shapes = make_var "shapes" (TVec shape_ty) in
+  let out = make_var "out" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let r = make_var "r" TFloat32 in
+  let s = make_var "s" shape_ty in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( r,
+            EConst (CFloat32 1000.0),
+            SLet
+              ( s,
+                EArrayRead ("shapes", EVar idx),
+                SAssign
+                  ( LArrayElem ("out", EVar idx),
+                    EMatch
+                      ( EVar s,
+                        [
+                          ( PConstr ("Circle", ["r"]),
+                            EBinop (Mul, EVar r, EConst (CFloat32 2.0)) );
+                          ( PConstr ("Square", ["r"]),
+                            EBinop (Add, EVar r, EConst (CFloat32 7.0)) );
+                        ] ) ) ) ) )
+  in
+  let k =
+    empty_kernel
+      "ematch_payload_shadowed"
+      [
+        DParam (shapes, None);
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ]
+      []
+      body
+  in
+  [
+    ( "ematch_payload_shadowed",
+      {k with kern_variants = [("Shape", shape_constrs)]} );
+  ]
+
+module Opencl_recursion = Opencl_gate.Opencl_recursion
+module Opencl_clang = Opencl_gate.Opencl_clang
+module Ir_uniquify = Opencl_gate.Ir_uniquify
+
+(** Mirror of the production path in [Opencl_plugin.generate_source]: the
+    generator plus the fp64 preamble the plugin prepends. Validating anything
+    else would validate a string we never ship. *)
+let opencl_production_source k =
+  Gen_opencl.reset_state () ;
+  let src = Gen_opencl.generate_with_types ~types:k.kern_types k in
+  if Sarek_ir_analysis.kernel_uses_float64 k then
+    "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\n" ^ src
+  else src
+
+let opencl_validation_tests () =
+  List.map
+    (fun (kernel_name, k) ->
+      Alcotest.test_case
+        (Printf.sprintf "opencl-validate/%s" kernel_name)
+        `Quick
+        (fun () ->
+          match excluded "opencl" kernel_name with
+          | Some reason ->
+              Printf.printf
+                "  SKIP (excluded): opencl/%s — %s\n%!"
+                kernel_name
+                reason ;
+              Alcotest.skip ()
+          | None ->
+              let src = opencl_production_source k in
+              (* Layer 1 — always runs, needs no external tool. *)
+              (match Opencl_recursion.cycles src with
+              | [] -> ()
+              | cs ->
+                  Alcotest.failf
+                    "generated OpenCL for %s contains recursion, which OpenCL \
+                     C forbids (§6.9.e) and no vendor compiler here diagnoses:\n\
+                     %s\n\
+                     --- source ---\n\
+                     %s"
+                    kernel_name
+                    (String.concat "\n" (List.map Opencl_recursion.describe cs))
+                    src) ;
+              if not (Opencl_clang.available ()) then begin
+                Printf.printf
+                  "  SKIP: %s — %s (recursion layer ran; compile and binder \
+                   layers did not)\n\
+                   %!"
+                  kernel_name
+                  (Opencl_clang.why_unavailable ()) ;
+                Alcotest.skip ()
+              end
+              else begin
+                (* Layer 2 — the kernel as we ship it. *)
+                (match Opencl_clang.run_clang src with
+                | Ok () -> ()
+                | Error e ->
+                    Alcotest.failf
+                      "clang rejected generated opencl/%s:\n\
+                       %s\n\
+                       --- source ---\n\
+                       %s"
+                      kernel_name
+                      e
+                      src) ;
+                (* Layer 3 — the same kernel with every binder made unique. *)
+                match Ir_uniquify.uniquify_kernel k with
+                | exception Ir_uniquify.Unsupported r ->
+                    Printf.printf
+                      "  clang OK: %s (binder canary skipped: %s)\n%!"
+                      kernel_name
+                      r
+                | ku -> (
+                    let usrc = opencl_production_source ku in
+                    match Opencl_clang.run_clang usrc with
+                    | Ok () ->
+                        Printf.printf
+                          "  clang OK: %s (+ binder canary)\n%!"
+                          kernel_name
+                    | Error e ->
+                        Alcotest.failf
+                          "binder canary FAILED for opencl/%s.\n\
+                           The kernel compiles as written but not after \
+                           α-renaming every binder to a unique name, so a \
+                           binder the emitter drops is currently being \
+                           resolved by an unrelated same-named identifier in \
+                           scope — valid OpenCL C computing the wrong answer, \
+                           with no diagnostic on the shipped source.\n\
+                           %s\n\
+                           --- α-renamed source ---\n\
+                           %s"
+                          kernel_name
+                          e
+                          usrc)
+              end))
+    (test_kernels () @ glsl_only_kernels () @ opencl_validation_only_kernels ())
+
 let () =
   Alcotest.run
     "codegen_golden"
@@ -2297,4 +2530,5 @@ let () =
         ("metal_only", metal_only_tests ());
         ("glsl_validation_sweep", glsl_validation_tests ());
         ("wgsl_validation_sweep", wgsl_validation_tests ());
+        ("opencl_validation_sweep", opencl_validation_tests ());
       ])

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -376,36 +376,39 @@
  (action
   (run %{dep:test_domain_pool_stress.exe})))
 
-; compile-only alias: the assertion IS successful compilation (PPX
-; convergence-analysis positive cases, or a smoke test with no runtime
-; check). Build-only - not executed - since there is nothing to run that
-; would add verification beyond "it compiled".
+; test_inline_pragma EXECUTES again (#127) - it is no longer parked.
 ;
-; test_inline_pragma is also parked here (build-only): it is otherwise
-; self-verifying and CPU-safe, but it segfaults DETERMINISTICALLY (not
-; flakily) whenever an OpenCL device is present. Diagnosed 2026-07-25:
+; It was build-only because it segfaulted DETERMINISTICALLY (not flakily)
+; whenever an OpenCL device was present. Never a test bug:
 ;
 ;   `pragma ["sarek.inline N"]` bounds the UNROLLING of a non-tail-recursive
-;   function but leaves a residual self-call, so the OpenCL backend emits a
+;   function but leaves a residual self-call, so the OpenCL backend emitted a
 ;   genuinely recursive device function:
 ;
 ;     int pow2(int n) { ... return (2 * (... (2 * pow2(n-1-1-1-1-1-1-1))))); }
 ;
-;   OpenCL C forbids recursion. rusticl (Mesa 26.1.4) does not diagnose it;
-;   it tries to inline and overflows its own compiler stack - the crash is a
+;   OpenCL C forbids recursion (1.2 6.9.e). rusticl (Mesa 26.1.4) does not
+;   diagnose it; it tries to inline and overflows its own compiler stack - a
 ;   ~30800-frame recursion inside libRusticlOpenCL on a `clctxworker` thread,
 ;   with zero SPOC/OCaml frames on the stack.
 ;
-; So the fix belongs in the OpenCL backend: either fully bound the recursion
-; (emit a depth-limited base case) or refuse with an explicit "Unsupported
-; construct" error the way the GLSL backend already does. Until then this
-; stays build-only.
+; Fixed in the backend: Sarek_ir_opencl.resolve_recursive_helpers elides the
+; residual call in a budgeted self-recursive helper (typed zero, matching what
+; PTX already does for the same pragma) and REFUSES every other cycle. Verified
+; on an AMD RX 7900 XTX (rusticl/radeonsi): exit 139 before, exit 0 with correct
+; results after. The generated OpenCL is now checked for recursion on every
+; codegen_golden run - see opencl_validation_sweep (#128), layer 1, which exists
+; because no compiler on this path reports this class.
 ;
-; NOTE: this is NOT the ctypes-rooting use-after-free that was fixed in
-; sarek-vulkan (PR #303). That one also presented as a SIGSEGV, which is why
-; the two were once filed as one class. They are unrelated: this crash is
-; unchanged by that fix, is OpenCL-only, and disappears when the OpenCL ICD
-; is hidden.
+; HISTORICAL NOTE, kept because the two were once filed as one class: this was
+; NOT the ctypes-rooting use-after-free fixed in sarek-vulkan (PR #303). Both
+; presented as SIGSEGV; they are unrelated. This one was OpenCL-only and
+; disappeared when the OpenCL ICD was hidden.
+
+; compile-only alias: the assertion IS successful compilation (PPX
+; convergence-analysis positive cases, or a smoke test with no runtime
+; check). Build-only - not executed - since there is nothing to run that
+; would add verification beyond "it compiled".
 
 (alias
  (name compile-only)
@@ -413,7 +416,6 @@
   test_pragma.exe
   test_barrier_converged.exe
   test_superstep.exe
-  test_inline_pragma.exe
   test_ppx_scan_failure_warning.exe))
 
 ; Build-gate the compile-only tests under default `runtest` too, so a
@@ -422,7 +424,7 @@
 ; deliberately distinct from the `(rule (alias runtest) (action (run ...)))`
 ; pattern used above for tests that must actually execute). See the
 ; comment block above and briefs/make-tests-actually-run-impl-notes.md for
-; why these four are build-only rather than run.
+; why these are build-only rather than run.
 
 (alias
  (name runtest)
@@ -430,8 +432,15 @@
   test_pragma.exe
   test_barrier_converged.exe
   test_superstep.exe
-  test_inline_pragma.exe
   test_ppx_scan_failure_warning.exe))
+
+; #127: executed, not build-only. Self-verifying (exit 1 on mismatch) and
+; self-skipping when Device.all () is empty.
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_inline_pragma.exe})))
 
 ; Regression tests wired to executing runtest rules (found unwired by
 ; scripts/check-test-alias-coverage.sh - the guard added after the 2026-07

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -120,3 +120,13 @@
 (test
  (name test_soa)
  (libraries spoc_core spoc.ir ctypes alcotest))
+
+; Negative controls for the OpenCL validation gate (#127/#128). Proves each
+; layer of the gate can go red: recursion detection, the clang compile gate
+; under a removed declaration, and the α-renaming binder canary. Also pins the
+; #127 backend policy (budgeted self-recursion bounded, every other cycle
+; refused). CPU-only, no device; clang-dependent cases self-skip.
+
+(test
+ (name test_opencl_gate)
+ (libraries sarek.codegen spoc.ir opencl_gate alcotest str))

--- a/sarek/tests/unit/test_opencl_gate.ml
+++ b/sarek/tests/unit/test_opencl_gate.ml
@@ -1,0 +1,517 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Negative controls for the OpenCL validation gate (#127/#128).
+
+    The sweep in test_codegen_golden.ml is the gate; this file is the proof that
+    the gate can go red. Every case here mutates an input and requires the
+    corresponding layer to fail with the right diagnostic, because a check that
+    has never been observed failing is not evidence of anything.
+
+    Also pins the #127 backend policy: budgeted self-recursion is bounded, every
+    other cycle is refused, and neither outcome is "emit a self-call and hope".
+*)
+
+open Sarek_ir_types
+module Ocl = Sarek_codegen.Sarek_ir_opencl
+module Recursion = Opencl_gate.Opencl_recursion
+module Clang = Opencl_gate.Opencl_clang
+module Uniquify = Opencl_gate.Ir_uniquify
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let empty_kernel name params locals body =
+  {
+    kern_name = name;
+    kern_params = params;
+    kern_locals = locals;
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(** A kernel calling helper [pow2], whose body is [hf_body]. *)
+let recursive_helper_kernel ~budgeted =
+  let n = make_var "n" TInt32 in
+  let self =
+    EApp
+      (EVar (make_var "pow2" TInt32), [EBinop (Sub, EVar n, EConst (CInt32 1l))])
+  in
+  let core =
+    SReturn
+      (EIf
+         ( EBinop (Le, EVar n, EConst (CInt32 0l)),
+           EConst (CInt32 1l),
+           EBinop (Mul, EConst (CInt32 2l), self) ))
+  in
+  let hf =
+    {
+      hf_name = "pow2";
+      hf_params = [n];
+      hf_ret_type = TInt32;
+      hf_body = (if budgeted then SPragma (["sarek.inline 0"], core) else core);
+    }
+  in
+  let out = make_var "out" (TVec TInt32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar idx),
+            EApp (EVar (make_var "pow2" TInt32), [EConst (CInt32 5l)]) ) )
+  in
+  let k =
+    empty_kernel
+      "rec_kernel"
+      [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+      []
+      body
+  in
+  {k with kern_funcs = [hf]}
+
+(** Two INDEPENDENTLY self-recursive helpers, both budgeted, where [f] also
+    calls [g]. Their cycles never touch, so this is not mutual recursion and
+    both are bounded by their own pragma.
+
+    The distinction is load-bearing: this backend elides budgeted self-recursion
+    but REFUSES everything else, so an over-approximating "is the callee on some
+    cycle?" test turns this into a false refusal — a regression for anyone using
+    the pragma. *)
+let nested_selfrec_kernel () =
+  let n = make_var "n" TInt32 in
+  let dec v = EBinop (Sub, EVar v, EConst (CInt32 1l)) in
+  let selfrec name extra =
+    let self = EApp (EVar (make_var name TInt32), [dec n]) in
+    let rhs =
+      match extra with
+      | None -> self
+      | Some other ->
+          EBinop (Add, self, EApp (EVar (make_var other TInt32), [dec n]))
+    in
+    {
+      hf_name = name;
+      hf_params = [n];
+      hf_ret_type = TInt32;
+      hf_body =
+        SPragma
+          ( ["sarek.inline 0"],
+            SReturn
+              (EIf
+                 ( EBinop (Le, EVar n, EConst (CInt32 0l)),
+                   EConst (CInt32 1l),
+                   rhs )) );
+    }
+  in
+  (* g is self-recursive only; f is self-recursive AND calls g. *)
+  let g = selfrec "g" None in
+  let f = selfrec "f" (Some "g") in
+  let out = make_var "out" (TVec TInt32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar idx),
+            EApp (EVar (make_var "f" TInt32), [EConst (CInt32 4l)]) ) )
+  in
+  let k =
+    empty_kernel
+      "nested_selfrec"
+      [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+      []
+      body
+  in
+  {k with kern_funcs = [f; g]}
+
+(** Two helpers that call each other — no pragma can bound this, because the PPX
+    inliner only ever rewrites SELF-calls. *)
+let mutual_kernel () =
+  let x = make_var "x" TInt32 in
+  let call name = EApp (EVar (make_var name TInt32), [EVar x]) in
+  let f =
+    {
+      hf_name = "f";
+      hf_params = [x];
+      hf_ret_type = TInt32;
+      hf_body = SPragma (["sarek.inline 0"], SReturn (call "g"));
+    }
+  in
+  let g =
+    {
+      hf_name = "g";
+      hf_params = [x];
+      hf_ret_type = TInt32;
+      hf_body = SPragma (["sarek.inline 0"], SReturn (call "f"));
+    }
+  in
+  let out = make_var "out" (TVec TInt32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar idx),
+            EApp (EVar (make_var "f" TInt32), [EConst (CInt32 3l)]) ) )
+  in
+  let k =
+    empty_kernel
+      "mutual_kernel"
+      [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})]
+      []
+      body
+  in
+  {k with kern_funcs = [f; g]}
+
+let plain_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let b = make_var "b" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("b", EVar idx),
+            EBinop (Mul, EArrayRead ("a", EVar idx), EConst (CFloat32 2.0)) ) )
+  in
+  empty_kernel
+    "plain"
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+    []
+    body
+
+let contains hay needle =
+  let n = String.length needle and h = String.length hay in
+  let rec go i = i + n <= h && (String.sub hay i n = needle || go (i + 1)) in
+  n = 0 || go 0
+
+(* ------------------------------------------------------------------ *)
+(* Layer 1 — recursion detector                                        *)
+(* ------------------------------------------------------------------ *)
+
+(** RED: a self-recursive device function must be reported. This is the case no
+    compiler on this path reports — see the header of opencl_recursion.ml. *)
+let test_recursion_self () =
+  let src =
+    "int pow2(int n) { if (n <= 0) return 1; return 2 * pow2(n - 1); }\n\
+     __kernel void k(__global int* o) { o[get_global_id(0)] = pow2(3); }\n"
+  in
+  match Recursion.cycles src with
+  | [c] ->
+      Alcotest.(check string)
+        "cycle names the function"
+        "'pow2' calls itself"
+        (Recursion.describe c)
+  | cs -> Alcotest.failf "expected exactly one cycle, got %d" (List.length cs)
+
+(** RED: mutual recursion too — a self-call check alone would miss it. *)
+let test_recursion_mutual () =
+  let src =
+    "int g(int n);\n\
+     int f(int n) { return g(n - 1); }\n\
+     int g(int n) { return f(n - 1); }\n\
+     __kernel void k(__global int* o) { o[get_global_id(0)] = f(3); }\n"
+  in
+  match Recursion.cycles src with
+  | [] -> Alcotest.fail "mutual recursion not detected"
+  | c :: _ ->
+      let d = Recursion.describe c in
+      Alcotest.(check bool)
+        (Printf.sprintf "cycle mentions both helpers (%s)" d)
+        true
+        (contains d "'f'" && contains d "'g'")
+
+(** GREEN control: real generator output must be reported clean, so the layer is
+    not simply always-red. *)
+let test_recursion_clean () =
+  Ocl.current_variants := [] ;
+  let src = Ocl.generate_with_types ~types:[] (plain_kernel ()) in
+  Alcotest.(check int)
+    "no cycles in real output"
+    0
+    (List.length (Recursion.cycles src)) ;
+  (* And a struct initialiser / typedef must not be mistaken for a definition. *)
+  let src2 =
+    "typedef struct { int tag; } Opt;\n\
+     static inline Opt make_Opt(int v) { Opt r; r.tag = v; return r; }\n\
+     __kernel void k(__global int* o) { o[0] = make_Opt(1).tag; }\n"
+  in
+  Alcotest.(check int)
+    "no false positive on constructors"
+    0
+    (List.length (Recursion.cycles src2))
+
+(* ------------------------------------------------------------------ *)
+(* Layer 2 — clang compile gate                                        *)
+(* ------------------------------------------------------------------ *)
+
+let skip_without_clang () =
+  if not (Clang.available ()) then begin
+    Printf.printf "  SKIP: %s\n%!" (Clang.why_unavailable ()) ;
+    Alcotest.skip ()
+  end
+
+(** RED-ON-MUTATION: delete the declaration of [idx] from real generator output
+    and require clang to name it. This is the exact diagnostic the gate relies
+    on for the whole dropped-binder class. *)
+let test_clang_red_on_mutation () =
+  skip_without_clang () ;
+  Ocl.current_variants := [] ;
+  let src = Ocl.generate_with_types ~types:[] (plain_kernel ()) in
+  (match Clang.run_clang src with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "unmutated source must compile:\n%s\n%s" e src) ;
+  let lines = String.split_on_char '\n' src in
+  let mutated =
+    String.concat
+      "\n"
+      (List.filter (fun l -> not (contains l "int idx = ")) lines)
+  in
+  Alcotest.(check bool)
+    "mutation actually changed the source"
+    true
+    (mutated <> src) ;
+  match Clang.run_clang mutated with
+  | Ok () ->
+      Alcotest.failf
+        "clang accepted a source with the declaration of 'idx' removed — the \
+         compile layer is not checking anything:\n\
+         %s"
+        mutated
+  | Error e ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "diagnostic names the undeclared binder (%s)"
+           (String.trim e))
+        true
+        (contains e "undeclared identifier" && contains e "idx")
+
+(* ------------------------------------------------------------------ *)
+(* Layer 3 — binder canary                                             *)
+(* ------------------------------------------------------------------ *)
+
+(** The canary's whole premise: after α-conversion, two binders that shared a
+    name no longer can. Checked on the IR AND on the emitted source, because it
+    is the emitted source the compiler sees. *)
+let test_canary_makes_names_unique () =
+  let outer = make_var "r" TFloat32 in
+  let inner = make_var "r" TFloat32 in
+  let out = make_var "out" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( outer,
+            EConst (CFloat32 1.0),
+            SBlock
+              (SLet
+                 ( inner,
+                   EConst (CFloat32 2.0),
+                   SAssign (LArrayElem ("out", EVar idx), EVar inner) )) ) )
+  in
+  let k =
+    empty_kernel
+      "shadow"
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})]
+      []
+      body
+  in
+  Ocl.current_variants := [] ;
+  let plain = Ocl.generate_with_types ~types:[] k in
+  (* Pre-condition: as written, the same name really is declared twice — this is
+     what makes a dropped binder invisible. *)
+  let count_decl s =
+    List.length
+      (List.filter
+         (fun l -> contains l "float r = ")
+         (String.split_on_char '\n' s))
+  in
+  Alcotest.(check int) "as written, 'r' is declared twice" 2 (count_decl plain) ;
+  let ku = Uniquify.uniquify_kernel k in
+  let canary = Ocl.generate_with_types ~types:[] ku in
+  Alcotest.(check int)
+    "after α-conversion, no bare 'r' declaration remains"
+    0
+    (count_decl canary) ;
+  Alcotest.(check bool)
+    "α-converted source still compiles (renaming is sound)"
+    true
+    (if Clang.available () then Clang.run_clang canary = Ok () else true)
+
+(** α-conversion must not change what the kernel computes; if it did, a canary
+    failure would be uninformative. Structural proxy: the two sources are
+    identical once binder names are erased to a canonical token. *)
+let test_canary_is_semantics_preserving () =
+  Ocl.current_variants := [] ;
+  let k = plain_kernel () in
+  let plain = Ocl.generate_with_types ~types:[] k in
+  let canary = Ocl.generate_with_types ~types:[] (Uniquify.uniquify_kernel k) in
+  Alcotest.(check bool) "α-conversion changed the text" true (plain <> canary) ;
+  let erase s = Str.global_replace (Str.regexp "sk[0-9]+_") "" s in
+  Alcotest.(check string)
+    "identical modulo the sk<n>_ prefix"
+    plain
+    (erase canary)
+
+(* ------------------------------------------------------------------ *)
+(* #127 — backend recursion policy                                     *)
+(* ------------------------------------------------------------------ *)
+
+(** A budgeted self-recursive helper must generate, and the generated source
+    must contain no self-call at all. Emitting a residual call is the outcome
+    that crashed rusticl; a blanket refusal would have regressed the pragma. *)
+let test_budgeted_recursion_is_bounded () =
+  Ocl.current_variants := [] ;
+  let src =
+    Ocl.generate_with_types ~types:[] (recursive_helper_kernel ~budgeted:true)
+  in
+  Alcotest.(check int)
+    "generated source has no call cycle"
+    0
+    (List.length (Recursion.cycles src)) ;
+  Alcotest.(check bool)
+    "residual call replaced by a typed zero"
+    true
+    (contains src "2 * 0" || contains src "(2 * 0)") ;
+  if Clang.available () then
+    match Clang.run_clang src with
+    | Ok () -> ()
+    | Error e -> Alcotest.failf "clang rejected the bounded form:\n%s\n%s" e src
+
+(** RED: no pragma, no bound — refuse loudly rather than emit recursion. *)
+let test_unbudgeted_recursion_refused () =
+  Ocl.current_variants := [] ;
+  match
+    Ocl.generate_with_types ~types:[] (recursive_helper_kernel ~budgeted:false)
+  with
+  | src ->
+      Alcotest.failf
+        "expected a refusal for an unbounded recursive helper, got:\n%s"
+        src
+  | exception e ->
+      let m = Printexc.to_string e in
+      Alcotest.(check bool)
+        (Printf.sprintf "error names recursion and the helper (%s)" m)
+        true
+        (contains m "recursion" && contains m "pow2")
+
+(** A self-recursive callee must NOT make its caller "mutually recursive".
+
+    Pins the classifier against over-approximation: [f] and [g] are each
+    budgeted and self-recursive, and [f] calls [g], but the two cycles are
+    independent. Both must be bounded, not refused. An "is the callee on some
+    cycle?" test refuses [f] here with "mutually recursive with 'g'", which is
+    false and costs a pragma user a working kernel — the failure direction that
+    matters, since a compiler refusing valid input is a regression. *)
+let test_independent_selfrec_not_mutual () =
+  Ocl.current_variants := [] ;
+  match Ocl.generate_with_types ~types:[] (nested_selfrec_kernel ()) with
+  | exception e ->
+      Alcotest.failf
+        "independently self-recursive helpers must both be bounded, not \
+         refused — got: %s"
+        (Printexc.to_string e)
+  | src -> (
+      Alcotest.(check int)
+        "no call cycle survives"
+        0
+        (List.length (Recursion.cycles src)) ;
+      (* f must still really call g: the elision may only remove SELF-calls, and
+         a pass that "fixed" this by deleting the cross-call would also pass the
+         cycle check above while silently changing what the kernel computes. *)
+      Alcotest.(check bool)
+        "f still calls g (only self-calls were elided)"
+        true
+        (contains src "g(") ;
+      (* [kern_funcs] has no ordering guarantee, and here the caller [f] comes
+         first. Without a forward declaration that is `error: use of undeclared
+         identifier 'g'` — invalid OpenCL C decided purely by list order. Pins
+         the prototype block emitted by Sarek_ir_opencl.gen_helpers. *)
+      Alcotest.(check bool)
+        "helpers are forward-declared, so emission order cannot matter"
+        true
+        (contains src "int g(int n);" && contains src "int f(int n);") ;
+      if Clang.available () then
+        match Clang.run_clang src with
+        | Ok () -> ()
+        | Error e -> Alcotest.failf "clang rejected:\n%s\n%s" e src)
+
+(** RED: mutual recursion is refused even though both helpers carry a pragma —
+    the pragma cannot bound a cycle the inliner never rewrites. *)
+let test_mutual_recursion_refused () =
+  Ocl.current_variants := [] ;
+  match Ocl.generate_with_types ~types:[] (mutual_kernel ()) with
+  | src ->
+      Alcotest.failf "expected a refusal for mutual recursion, got:\n%s" src
+  | exception e ->
+      let m = Printexc.to_string e in
+      Alcotest.(check bool)
+        (Printf.sprintf "error says mutually recursive (%s)" m)
+        true
+        (contains m "mutually recursive")
+
+let () =
+  Alcotest.run
+    "opencl_gate"
+    [
+      ( "layer1_recursion",
+        [
+          Alcotest.test_case "self-recursion detected" `Quick test_recursion_self;
+          Alcotest.test_case
+            "mutual recursion detected"
+            `Quick
+            test_recursion_mutual;
+          Alcotest.test_case "no false positives" `Quick test_recursion_clean;
+        ] );
+      ( "layer2_clang",
+        [
+          Alcotest.test_case
+            "red on a removed declaration"
+            `Quick
+            test_clang_red_on_mutation;
+        ] );
+      ( "layer3_binder_canary",
+        [
+          Alcotest.test_case
+            "α-conversion removes name collisions"
+            `Quick
+            test_canary_makes_names_unique;
+          Alcotest.test_case
+            "α-conversion is semantics-preserving"
+            `Quick
+            test_canary_is_semantics_preserving;
+        ] );
+      ( "backend_recursion_policy",
+        [
+          Alcotest.test_case
+            "budgeted self-recursion is fully bounded"
+            `Quick
+            test_budgeted_recursion_is_bounded;
+          Alcotest.test_case
+            "unbounded recursion is refused"
+            `Quick
+            test_unbudgeted_recursion_refused;
+          Alcotest.test_case
+            "mutual recursion is refused"
+            `Quick
+            test_mutual_recursion_refused;
+          Alcotest.test_case
+            "an independently self-recursive callee is not mutual recursion"
+            `Quick
+            test_independent_selfrec_not_mutual;
+        ] );
+    ]


### PR DESCRIPTION
Closes #127. Closes #53. Addresses #128.

Two halves of one arc: a concrete bug where Sarek emitted illegal OpenCL C, and the gate that would have caught it.

Rebased onto `2075ee1b` (post-#306). Hardware for every empirical claim below: **AMD Radeon RX 7900 XTX, rusticl/radeonsi (Mesa, navi31, ACO, DRM 3.64)**, plus **clang 22.1.6** as the hermetic OpenCL C front-end. No NVIDIA, no Apple.

---

## Why three layers and not one

Two measurements drive the whole design. Stating them up front because without them a three-layer gate looks over-engineered.

**1. The vendor compiler is blind in *both* directions.** It is not "mostly reliable with one gap":

| | vendor compiler behaviour |
|---|---|
| **#127** — invalid OpenCL (recursion) | rusticl does not diagnose it; it **crashes** (SIGSEGV inside `libRusticlOpenCL`). And **clang 22.1.6 accepts recursive OpenCL C and exits 0** — measured on the default host target, `--target=spirv64`, `--target=spirv32`, and `--target=amdgcn-amd-amdhsa -mcpu=gfx1100`. |
| **#75 colliding-binder form** — *valid* OpenCL | **nothing objects at all** — clean build, wrong answer, no diagnostic at any layer |

So a compile gate alone cannot cover #127. Layer 1 is not redundant with layer 2; it is the only cover for a class no compiler on this path reports.

**2. The binder canary converts the invisible class into the visible one.** α-converting every binder to a globally unique name (`sk<n>_<original>`) is semantics-preserving, so the result must still compile — but collisions become **impossible by construction**. A binder the emitter drops therefore *always* degrades to "undeclared identifier", which layer 2 does catch. This does not merely document that the failure class exists; it makes the existing compile gate able to see it.

---

## #127 — the OpenCL backend emitted a recursive device function

`pragma ["sarek.inline N"]` bounds the *unrolling*, not the recursion. The PPX unrolls N times, leaves a residual self-call in the IR, marks it `sarek.inline 0`, and warns only under `SAREK_DEBUG`. `Sarek_ir_opencl` then printed that call verbatim:

```c
int pow2(int n) { ... return (2 * ( ... (2 * pow2((((((((n-1)-1)-1)-1)-1)-1)-1))) ... )); }
```

OpenCL C forbids recursion (OpenCL C 1.2 §6.9.e). rusticl recurses through its own compiler on a `clctxworker` thread (~30 800 frames, zero OCaml frames on the stack) until the stack is gone and takes the host process down. That is backlog #53, parked as "segfaults on a real GPU" without a diagnosis. Reproduced before the fix: **exit 139**.

### The choice: bound it, don't refuse

Not a blanket refusal, and not a silent partial unroll. `Sarek_ir_opencl` resolves the helper call graph before emission and takes **the same two-part policy the PTX backend already applies to the same pragma** (`Sarek_ir_ptx_expr.emit_app_recursive`), so one pragma keeps one meaning across backends:

- **Budgeted self-recursion → residual self-calls become a typed zero.** The pragma is the author's contract that N levels cover every runtime input, so the residual site is dynamically unreachable: it only has to be well-formed OpenCL C, never correct. Dropping the arguments is sound because IR expressions are pure by construction (`Sarek_ir_types.expr`) — PTX evaluates them only because its lowering emits into a register file.
- **Every other cycle → refused with a located error.** No pragma, or mutual recursion — which no pragma can bound, since the PPX inliner only rewrites *self*-calls. Mirrors how `Sarek_ir_inline_vec.splice_call` refuses recursion for GLSL/WGSL.

A blanket refusal would have regressed an advertised feature PTX supports. A partial unroll that leaves a self-call is the one outcome ruled out: neither bounded nor refused. A post-condition re-checks the call graph after elision, so a later change cannot quietly restore a self-call.

### `test_inline_pragma` un-parked

Removed from the build-only alias, given a real `(rule (alias runtest) (action (run ...)))`. The parking comment is rewritten to record the diagnosis, and keeps `d6099c76`'s note that this was **not** the ctypes-rooting use-after-free fixed in #303 — the two were once filed as one class and the distinction is worth preserving.

```
runtime: Testing pow2 on: AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, ...)
  PASS: pow2(5) = 32 (expected 32)
  PASS: fib(0) = 0 / fib(1) = 1 / fib(5) = 5 / fib(7) = 13
=== All pragma inline tests PASSED ===        EXIT=0
```

---

## #128 — the gate

New `opencl_validation_sweep` in `test_codegen_golden.ml`, three layers per kernel:

1. **Recursion, read off the emitted text** (`opencl_recursion.ml`). No external tool, always runs. Reads the emitted source rather than the IR on purpose: the IR-level guarantee lives in the backend, and a gate re-running the backend's own reasoning goes green on any bug that made the backend emit something other than what it reasoned about.
2. **`clang -x cl` compile gate** (`opencl_clang.ml`), mirroring the production path exactly (`generate_with_types` + the fp64 preamble `Opencl_plugin.generate_source` prepends). `clang` rather than a vendor ICD deliberately: a gate must fail where *we* can read the failure, and on this hardware illegal OpenCL produced a SIGSEGV instead of a build log. Availability is a **positive control**, not `command -v` — a clang without OpenCL support or without the default builtin header is on PATH and useless.
3. **Binder canary** (`ir_uniquify.ml`) — as described above.

### What this gate provably cannot catch

Anything that is well-formed OpenCL C with every binder present but the wrong semantics — a wrong operator, a wrong intrinsic mapping, a wrong index. That is what the goldens and the e2e runtime tests are for. **A green `opencl_validation_sweep` does not mean "our OpenCL is correct."** Stated in the module docs so nobody later reads it that way.

### Proving red

`sarek/tests/unit/test_opencl_gate.ml`, 9 controls, each mutating an input and requiring the right diagnostic:

- layer 1: self-recursion detected, mutual recursion detected, no false positive on struct constructors/typedefs
- layer 2: delete the `int idx = ...;` declaration from real generator output → clang must fail naming `idx`; the unmutated source must compile
- layer 3: α-conversion removes the collision (`r` declared twice → zero bare `r`), and is semantics-preserving (identical modulo the `sk<n>_` prefix)
- #127 policy: budgeted self-recursion produces a cycle-free source clang accepts; unbudgeted recursion refused naming the helper; mutual recursion refused even with a pragma on both helpers; and an independently self-recursive callee is **not** treated as mutual recursion (findings 3/4 below)

Every `validation_exclusions` entry was proven load-bearing by deleting it (working tree verified actually changed, `diff` exit 1) and confirming the case turns **red**. That is also how the `ematch_payload_shadowed` entry came to be removed for good — see finding 1.

---

## What the sweep found

Four defects, on a corpus that was previously green because nobody was looking. One is now fixed and verified by the gate; two are fixed here; one remains, recorded as a `validation_exclusions` entry phrased as a **defect, not a plan** — no PR number is load-bearing and it cannot be read as "someone else handled it".

### 1. #75 reproduced on OpenCL in the invisible form — now fixed and verified

Added `ematch_payload_shadowed` — an enclosing local `r` and an `EMatch` payload binder also called `r`. The OpenCL `EMatch`→ternary path drops payload bindings entirely (`Sarek_ir_opencl.gen_expr`). As shipped:

```c
out[idx] = ((s.tag == Circle) ? (r * 2.0f) : (r + 7.0f));
```

Accepted by clang. Accepted by rusticl. Wrong — `r` silently resolved to the enclosing local. Under the canary:

```
sk2_out[sk3_idx] = ((sk5_s.tag == Circle) ? (sk6_r * 2.0f) : (sk7_r + 7.0f));
error: use of undeclared identifier 'sk6_r'; did you mean 'sk4_r'?
note: 'sk4_r' declared here    float sk4_r = 1000.0f;
```

**Now RESOLVED, and the exclusion is gone.** It was removed exactly the way its own removal condition demanded — not because #75's fix merged, but because the check passes. Re-run after rebasing onto `2075ee1b`:

```
[OK]  opencl_validation_sweep  22  opencl-validate/ematch_payload_shadowed
      clang OK: ematch_payload_shadowed (+ binder canary)
```

`[OK]`, not `[SKIP]` — so the merged fix covers the **colliding-binder** shape, not just the undeclared-identifier one. That is the part a compile gate alone could never have confirmed, and it is the independent check worth having: the canary reaches a case the fix's own tests could not distinguish from a pass. `ematch_payload_shadowed` stays in the corpus permanently as the live regression check for that shape.

### 2. `Float64.abs_float` and `Float64.copysign` do not compile on any non-GLSL backend — filed as #133

```
[OpenCL Codegen] Unknown intrinsic: Float64.abs_float
[OpenCL Codegen] Unknown intrinsic: Float64.copysign
```

Both are declared in `sarek/Sarek_float64/Float64.ml` — user-callable — but absent from `Sarek_pure_registry.float64_list`, which every non-GLSL backend dispatches through. GLSL survives only via a hardcoded arm. So a user kernel calling `Float64.abs_float` type-checks as OCaml and dies at codegen on OpenCL/CUDA/Metal/PTX.

**Deliberately not fixed here, and the obvious one-line fix makes it worse.** I tried adding the names to `float64_list`; the float64 template emits the Sarek name verbatim (the float32 table carries an explicit `("abs_float","fabsf","fabs")` mapping, the float64 table is a bare name list), so codegen then emits `abs_float(a[idx])` → `error: use of undeclared identifier 'abs_float'`. And `Sarek_pure_registry`'s own module comment fences this off: registering float64 names the interpreter cannot evaluate converts an honest lookup failure into a silent miscompile. A real fix needs a name mapping *and* interpreter support across every backend.

### 3. False refusal: an independently self-recursive callee was classified as mutual recursion

Caught in review by CodeRabbit, and a genuine correctness bug rather than a style point, because this backend's whole policy turns on the self-vs-other distinction. The classifier asked "is the callee on *some* cycle?" instead of "is it in the *same* cycle?", so a budgeted self-recursive `f` that merely calls an independently budgeted self-recursive `g` was **refused** with `helper 'f' is mutually recursive with 'g'` — even though the two cycles never touch. A compiler refusing valid input is the failure direction that costs a user a working kernel, so this is now a same-SCC test (reachable from `hf` **and** able to reach `hf` back) with a negative control pinning it.

### 4. Helpers were emitted with no forward declarations, so emission order decided validity

Surfaced immediately once the classifier stopped refusing helper-to-helper calls. `kern_funcs` carries no ordering guarantee, and a caller listed before its callee emitted:

```
error: use of undeclared identifier 'g'
   3 |   return ((n <= 0) ? 1 : (0 + g((n - 1))));
```

Invalid OpenCL C decided purely by list order. Fixed by emitting a prototype block for every helper before any definition, so order cannot matter — rather than relying on the IR producer to topologically sort. No golden kernel has helpers, which is exactly why the corpus never showed this; kernels without helpers remain byte-identical.

---

## CI

`ci/assert-toolchain.sh` gains a clang section following the established pattern — `command -v`, `--version`, and a **positive control** that compiles a probe kernel requiring both `-x cl` and `-finclude-default-header` (without the header every kernel would fail on `get_global_id` rather than on its own defects). `EXPECTED_CHECKS` 8 → 10.

`ci/Dockerfile` installs **no new package**: `clang` was already in the base toolchain layer, so my second install was a no-op (flagged in review). I removed mine rather than the pre-existing one — both resolve the same jammy `clang` metapackage, so there is no version difference, but the base-layer install predates this PR and intermediate build steps may rely on it. The rationale comment stays, rewritten to record that this install now has a **second consumer**: `clang` there is no longer just a C toolchain, it is the OpenCL C front-end the gate depends on. If it is ever trimmed as unused, `assert-toolchain.sh` fails loudly instead of letting the sweep return to self-skipping.

```
== clang (OpenCL C validation)
  OK  clang --version — clang version 22.1.6
  OK  clang compiled a probe OpenCL kernel
```

---

## Test results (all re-run after the rebase)

| suite | result |
|---|---|
| `sarek/tests/unit/test_opencl_gate.exe` | **10/10 pass** |
| `sarek/tests/codegen_golden` | 96 run, **Test Successful** (2 remaining exclusions, proven load-bearing; goldens byte-identical) |
| `@sarek/tests/unit/runtest`, `@sarek/tests/codegen_golden/runtest`, `@sarek-opencl/runtest`, `@spoc/ir/runtest` | **all pass** |
| `sarek/tests/e2e/test_inline_pragma.exe` on RX 7900 XTX | **exit 0** (was exit 139) |
| `@sarek/tests/e2e/runtest` | **fully green, exit 0** |

The e2e alias is now clean end to end. An earlier run of mine showed `test_static_tag_erasure` SIGSEGVing on RADV — that was the ctypes-rooting use-after-free fixed in #303 (`a8b5a193`), which this branch predated. Post-rebase it passes on both RADV devices; that caveat is withdrawn.

`ocamlformat` applied to every file touched. `scripts/check-test-alias-coverage.sh`: OK, all 77 e2e executables wired.

---

## One process note worth recording

I hit the stale-executable trap and it produced a **false red**, not the false green others hit: after editing `test_codegen_golden.ml` I ran the previously-built `test_codegen_golden.exe` and saw the `ematch_payload_shadowed` case fail *as if my exclusion entry had not been applied*. The entry was fine; the binary was stale. The failure mode is symmetric — a stale executable will happily report a result that contradicts your source in either direction — so "it went red, so my change didn't take" is exactly as unreliable as "it went green, so it works". Every result above was re-verified after an explicit successful build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
