### PR TITLE
chore: four backlog cleanups — CI token scope, fmt gate, SASS classifier refusal, PTX intrinsic registry (#120, #122, #115, #92)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,17 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
+    # Least privilege, same precedent as `formal-proofs` (#294): without an
+    # explicit block this job inherits the repository default token scope
+    # (zizmor: excessive-permissions). Every step here only reads the checkout
+    # and runs builds/tests in a container — no `git push`, no `gh`, no
+    # `secrets.*`, no `GITHUB_TOKEN`, and build-push-action runs with
+    # `load: true`, never `push: true`. The `actions/cache`, buildx `type=gha`
+    # cache and `actions/upload-artifact` steps authenticate with the runner's
+    # own job-scoped ACTIONS_RUNTIME_TOKEN, not with GITHUB_TOKEN, so they are
+    # unaffected by this block.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -119,8 +130,29 @@ jobs:
               eval $(opam env --switch=${{ matrix.ocaml-compiler }}) && \
               opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git --set-default || true && \
               opam update && \
-              opam install -y ctypes ctypes-foreign ppxlib alcotest qcheck-core js_of_ocaml js_of_ocaml-ppx js_of_ocaml-compiler && \
+              opam install -y ctypes ctypes-foreign ppxlib alcotest qcheck-core js_of_ocaml js_of_ocaml-ppx js_of_ocaml-compiler ocamlformat.0.28.1 && \
               dune build @install'
+
+      # #122: nothing enforced `.ocamlformat`, so formatting drift accumulated
+      # on main unnoticed (Device.ml, Sarek_float32.ml, test_ir_layout.ml).
+      #
+      # `ocamlformat` is pinned to 0.28.1 to match `version=0.28.1` in
+      # `.ocamlformat`; ocamlformat refuses to run on a version mismatch, so the
+      # pin cannot silently drift from the config. And when ocamlformat is
+      # absent entirely dune fails with "Program ocamlformat not found in the
+      # tree or in PATH" rather than skipping the alias — verified locally — so
+      # unlike the codegen gates this one cannot self-skip into a vacuous green.
+      - name: Formatting gate
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -w /work \
+            spoc-ci:latest \
+            bash -lc 'git config --global --add safe.directory /work && \
+              export OPAMROOT=/work/.opam-ci && \
+              eval $(opam env --switch=${{ matrix.ocaml-compiler }}) && \
+              dune build @fmt'
+
       - name: jsoo-compat gate
         run: |
           docker run --rm \
@@ -261,7 +293,14 @@ jobs:
   check-generated-code:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    
+    # Least privilege, same precedent as `formal-proofs` (#294). This job
+    # regenerates the backend code and asserts the working tree is unchanged;
+    # it only ever *reads* git state (`git diff --quiet` / `--stat`). The
+    # `git commit` on the failure path is text inside an `echo`, telling a
+    # human what to run locally — nothing here writes to the repository.
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/sarek-cuda/test/test_cuda_f16_sass.ml
+++ b/sarek-cuda/test/test_cuda_f16_sass.ml
@@ -34,7 +34,10 @@
  * form appears" would pass for a detector that can see nothing at all.
  *
  * Skips cleanly with no CUDA toolkit, no nvrtc, or no CUDA headers; and skips
- * individual architectures the local ptxas does not know.
+ * individual architectures the local ptxas does not know. It does NOT skip an
+ * architecture whose SASS the classifier cannot read — see [classifier_min_sm]:
+ * that is a hard failure, because a classifier applied to an instruction shape
+ * it does not model returns a wrong verdict, not no verdict.
  ******************************************************************************)
 
 open Sarek_ir_types
@@ -154,7 +157,11 @@ let ready () =
    (see docs/optimization/cuda-f16-fusion-sass-audit.md) to give SASS byte-identical
    to assembling arch-native PTX on every target here. Any name the local ptxas
    does not know is skipped rather than failed, so an older toolkit still runs
-   the targets it does support. *)
+   the targets it does support.
+
+   This list is bounded below by [classifier_min_sm]: adding a pre-Turing target
+   here (sm_61, say) makes the test fail rather than classify a SASS shape the
+   classifier was never written for. *)
 let architectures =
   ["sm_75"; "sm_80"; "sm_86"; "sm_89"; "sm_90"; "sm_100"; "sm_120"]
 
@@ -170,16 +177,26 @@ let write_file path contents =
   output_string oc contents ;
   close_out oc
 
-(** Why the toolchain produced no SASS for an architecture. The distinction is
+(** Why this test produced no verdict for an architecture. The distinction is
     load-bearing: [Unknown_arch] is an environment gap and a legitimate skip,
     while [Tool_error] means ptxas or nvdisasm rejected work this test generated
     — a real failure that must not be folded into the skip bucket. Before this
     split every nonzero exit read as "arch not supported", so a ptxas that
     rejected the generated PTX outright made the gate report a green pass having
-    checked nothing. *)
-type tool_failure = Unknown_arch of string | Tool_error of string
+    checked nothing.
 
-let failure_message = function Unknown_arch m | Tool_error m -> m
+    [Unclassifiable_arch] is the third case and belongs to US, not to the
+    toolchain: the local ptxas may assemble the target perfectly well while the
+    classifier below has no idea what the resulting instruction stream means. It
+    is a hard failure for the same reason [Tool_error] is — a classifier that
+    guesses is worse than one that declines. *)
+type tool_failure =
+  | Unknown_arch of string
+  | Unclassifiable_arch of string
+  | Tool_error of string
+
+let failure_message = function
+  | Unknown_arch m | Unclassifiable_arch m | Tool_error m -> m
 
 (* ptxas reports an unrecognised target as
    [ptxas fatal : Value 'sm_XXX' is not defined for option 'gpu-name'],
@@ -211,53 +228,125 @@ let classify_nvdisasm_error msg =
   then Unknown_arch msg
   else Tool_error msg
 
+(* ------------------------------------------------------------------ *)
+(* What the classifier is allowed to look at                          *)
+(* ------------------------------------------------------------------ *)
+
+(** The lowest SM the SASS classifier below is written for.
+
+    Every idiom it matches is Turing-and-later shaped: the
+    [HADD2 Rd, -RZ, Rs.H0_H0] widening idiom, the
+    [HFMA2.MMA ..., -RZ, RZ, imm, imm] immediate materialisation, and the
+    [F2F.F16.F32] / [F2FP.PACK_AB] narrowing family. Pascal (sm_5x/sm_6x) does
+    not emit that stream — it converts with [F2F.F32.F16] in BOTH directions and
+    has no [HADD2]-based widening idiom at all — so on Pascal {!is_widening}
+    would recognise nothing, {!narrowings} would count widenings as narrowings,
+    and {!binary16_arithmetic} would flag conversions as the defect. That is
+    MISCLASSIFICATION, not detection: the gate would report a defect that is not
+    there, or (worse, under a different instruction selection) miss one that is.
+
+    So the classifier declines instead. Adding an architecture below this floor
+    to {!architectures} makes the test FAIL with {!Unclassifiable_arch} until
+    someone teaches the classifier that architecture's idioms and verifies them
+    against real SASS for it. *)
+let classifier_min_sm = 75
+
+(* [sm_90a] / [sm_100f] and friends: take the leading digit run after "sm_". *)
+let sm_version arch =
+  let prefix = "sm_" in
+  let pl = String.length prefix and al = String.length arch in
+  if al <= pl || String.sub arch 0 pl <> prefix then None
+  else
+    let i = ref pl in
+    while !i < al && arch.[!i] >= '0' && arch.[!i] <= '9' do
+      incr i
+    done ;
+    if !i = pl then None else int_of_string_opt (String.sub arch pl (!i - pl))
+
+(** [Ok ()] only for architectures whose SASS the classifier actually models. An
+    unparsable name is refused too: guessing at [gfx1100] or [compute_75] here
+    would be the same mistake. *)
+let classifier_supports arch =
+  match sm_version arch with
+  | Some v when v >= classifier_min_sm -> Ok ()
+  | Some v ->
+      Error
+        (Unclassifiable_arch
+           (Printf.sprintf
+              "the SASS classifier in this test is written for sm_%d and later \
+               (Turing/Ampere/Hopper/Blackwell instruction shapes: HADD2 \
+               widening idiom, F2F/F2FP narrowing family). sm_%d predates that \
+               shape, so classifying its disassembly would produce a wrong \
+               verdict rather than no verdict. Refusing. Teach the classifier \
+               this architecture's idioms (is_widening, narrowings, \
+               binary16_arithmetic) and verify them against real sm_%d SASS \
+               before adding it to `architectures`."
+              classifier_min_sm
+              v
+              v))
+  | None ->
+      Error
+        (Unclassifiable_arch
+           (Printf.sprintf
+              "cannot tell which SASS instruction shape %S has; the classifier \
+               only models sm_NN targets with NN >= %d. Refusing rather than \
+               guessing."
+              arch
+              classifier_min_sm))
+
 (** [sass_of_ptx ~arch ptx] assembles [ptx] for [arch] and disassembles the
-    result. See {!tool_failure} for the two error kinds. *)
+    result. See {!tool_failure} for the three error kinds. The classifier's own
+    competence is checked FIRST: an architecture it cannot read is refused
+    before any tool runs, so the refusal does not depend on which CUDA release
+    happens to be installed. *)
 let sass_of_ptx ~arch ptx =
-  let base = Filename.temp_file "sarek_f16_sass_" "" in
-  let src = base ^ ".ptx" and obj = base ^ ".cubin" in
-  let err = base ^ ".err" and out = base ^ ".sass" in
-  let cleanup () =
-    List.iter
-      (fun f -> try Sys.remove f with _ -> ())
-      [base; src; obj; err; out]
-  in
-  Fun.protect ~finally:cleanup (fun () ->
-      write_file src ptx ;
-      let rc =
-        Unix.system
-          (Printf.sprintf
-             "ptxas -arch=%s -o %s %s 2>%s"
-             (Filename.quote arch)
-             (Filename.quote obj)
-             (Filename.quote src)
-             (Filename.quote err))
+  match classifier_supports arch with
+  | Error _ as e -> e
+  | Ok () ->
+      let base = Filename.temp_file "sarek_f16_sass_" "" in
+      let src = base ^ ".ptx" and obj = base ^ ".cubin" in
+      let err = base ^ ".err" and out = base ^ ".sass" in
+      let cleanup () =
+        List.iter
+          (fun f -> try Sys.remove f with _ -> ())
+          [base; src; obj; err; out]
       in
-      match rc with
-      | Unix.WEXITED 0 -> (
+      Fun.protect ~finally:cleanup (fun () ->
+          write_file src ptx ;
           let rc =
             Unix.system
               (Printf.sprintf
-                 "nvdisasm -c %s >%s 2>%s"
+                 "ptxas -arch=%s -o %s %s 2>%s"
+                 (Filename.quote arch)
                  (Filename.quote obj)
-                 (Filename.quote out)
+                 (Filename.quote src)
                  (Filename.quote err))
           in
           match rc with
-          | Unix.WEXITED 0 -> Ok (read_file out)
-          | _ ->
-              (* ptxas accepted the target but nvdisasm did not. ptxas and
+          | Unix.WEXITED 0 -> (
+              let rc =
+                Unix.system
+                  (Printf.sprintf
+                     "nvdisasm -c %s >%s 2>%s"
+                     (Filename.quote obj)
+                     (Filename.quote out)
+                     (Filename.quote err))
+              in
+              match rc with
+              | Unix.WEXITED 0 -> Ok (read_file out)
+              | _ ->
+                  (* ptxas accepted the target but nvdisasm did not. ptxas and
                  nvdisasm are located independently by [on_path], so they can
                  come from different CUDA installs: a newer ptxas assembling
                  sm_100 whose cubin an older nvdisasm cannot read is an
                  environment gap, not a defect. Classify it the same way. *)
+                  Error
+                    (classify_nvdisasm_error
+                       ("nvdisasm failed: " ^ try read_file err with _ -> "")))
+          | _ ->
               Error
-                (classify_nvdisasm_error
-                   ("nvdisasm failed: " ^ try read_file err with _ -> "")))
-      | _ ->
-          Error
-            (classify_ptxas_error
-               ("ptxas failed: " ^ try read_file err with _ -> "")))
+                (classify_ptxas_error
+                   ("ptxas failed: " ^ try read_file err with _ -> "")))
 
 (* ------------------------------------------------------------------ *)
 (* SASS classification                                                *)
@@ -401,6 +490,15 @@ let test_midround_sass_unfused () =
                    %s"
                   arch
                   (String.trim e)
+            | Error (Unclassifiable_arch e) ->
+                (* Not an environment gap: this architecture is in the list
+                   above and the classifier cannot read its SASS. Skipping it
+                   would let the gate report green having classified a stream
+                   it does not understand. *)
+                Alcotest.failf
+                  "%s: refusing to classify this architecture's SASS: %s"
+                  arch
+                  (String.trim e)
             | Error (Unknown_arch e) ->
                 (* ptxas does not know this architecture. Legitimate per-arch
                    skip; recorded so the zero-architecture case can report
@@ -498,6 +596,11 @@ let test_classifier_detects_fusion () =
               match sass_of_ptx ~arch:a ptx with
               | Ok _ -> true
               | Error (Unknown_arch _) -> false
+              | Error (Unclassifiable_arch e) ->
+                  Alcotest.failf
+                    "%s: refusing to classify this architecture's SASS: %s"
+                    a
+                    (String.trim e)
               | Error (Tool_error e) ->
                   (* Same rule as the gate: a target the toolchain knows but
                      could not process is a failure, not "no usable arch". *)

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -419,122 +419,60 @@ let intr_no_f64 intr =
     (intr ^ ": no native f64 " ^ intr
    ^ " in PTX; compute in float32 or on the CPU")
 
-(** {1 Intrinsic name tables}
+(** {1 Intrinsic dispatch registry}
 
-    The name set OWNED by each per-category intrinsic emitter below. These are
-    the dispatch table consulted by {!emit_intrinsic_native} — not
-    documentation: a name absent from every list is [unsupported], and a name
-    present in two lists is an internal error (the emitters must partition the
-    intrinsic surface, see {!intrinsic_emitter_table}). They also give the ptxas
-    sweep gate a drift-proof enumeration of the whole PTX intrinsic surface
-    (sarek/tests/unit/test_ptx_intrinsic_sweep.ml): an intrinsic added here
-    without an assembling kernel recipe fails that test. *)
+    Every PTX intrinsic is one entry in a per-category handler registry
+    ([index_intrinsic_handlers], [transcendental_intrinsic_handlers], …): the
+    names it answers to, paired with the closure that lowers it. Dispatch
+    ({!emit_intrinsic_native}) looks a name up in those registries, and the
+    exported name tables ({!intrinsic_names} and friends, at the bottom of this
+    file) are computed from the same values by {!names_of_category} — literally
+    [List.filter_map] over these entries, not a second list written out beside
+    them. There is therefore no way to add a handler the tables do not know
+    about, or to declare a name no handler answers: the two are one data
+    structure, not two texts that have to be kept in step.
 
-let index_intrinsic_names =
-  [
-    "thread_id_x";
-    "thread_idx_x";
-    "thread_id_y";
-    "thread_idx_y";
-    "thread_id_z";
-    "thread_idx_z";
-    "block_id_x";
-    "block_idx_x";
-    "block_id_y";
-    "block_idx_y";
-    "block_id_z";
-    "block_idx_z";
-    "block_dim_x";
-    "block_dim_y";
-    "block_dim_z";
-    "grid_dim_x";
-    "grid_dim_y";
-    "grid_dim_z";
-    "global_thread_id";
-    "global_idx";
-    "global_idx_x";
-    "global_idx_y";
-    "global_size";
-    "block_barrier";
-  ]
+    The one property this does NOT give for free is that the registries
+    partition the surface. A name claimed by two handlers is possible to write,
+    and is an internal error raised at dispatch; a name claimed by none is
+    [unsupported].
 
-let transcendental_intrinsic_names =
-  [
-    "sin";
-    "cos";
-    "tan";
-    "sqrt";
-    "exp";
-    "log";
-    "log10";
-    "pow";
-    "sinh";
-    "cosh";
-    "tanh";
-    "asin";
-    "acos";
-    "atan";
-    "atan2";
-    "expm1";
-    "log1p";
-    "rsqrt";
-  ]
+    The tables give the ptxas sweep gate a drift-proof enumeration of the whole
+    PTX intrinsic surface (sarek/tests/unit/test_ptx_intrinsic_sweep.ml): an
+    intrinsic added here without an assembling kernel recipe fails that test. *)
 
-let float_ops_intrinsic_names =
-  [
-    "fabs";
-    "abs_float";
-    "copysign";
-    "fmod";
-    "hypot";
-    "fma";
-    "min";
-    "max";
-    "floor";
-    "ceil";
-  ]
+(** What one registry entry does: emit the PTX for [name] applied to [args] and
+    return the register holding the result. [path] disambiguates
+    module-qualified names ("of_int" is Float32's or Float64's depending on it).
+    [None] means the handler declines the call, which dispatch reports as
+    [unsupported] — a handler owning a name it will not lower is a bug, and the
+    sweep gate generates a kernel per registered name to catch it. *)
+type intrinsic_handler =
+  Buffer.t ->
+  reg_alloc ->
+  env ->
+  string list ->
+  string ->
+  expr list ->
+  string option
 
-let bitcast_intrinsic_names = ["f64_bits"; "bits_f64"]
+(** The per-category registries, in dispatch order. *)
+type intrinsic_category =
+  | Index
+  | Transcendental
+  | Float_ops
+  | Bitcast
+  | Convert
+  | Atomic
 
-let convert_intrinsic_names =
-  [
-    "float";
-    "float_of_int";
-    "float64";
-    "float64_of_int";
-    "int_of_float";
-    "int_of_float64";
-    "of_int";
-    "to_int";
-  ]
-
-let atomic_intrinsic_names =
-  [
-    "atomic_add_int32";
-    "atomic_add_global_int32";
-    "atomic_sub_int32";
-    "atomic_min_int32";
-    "atomic_max_int32";
-    "atomic_and_int32";
-    "atomic_or_int32";
-    "atomic_xor_int32";
-    "atomic_exch_int32";
-    "atomic_exch_int64";
-    "atomic_add_int64";
-    "atomic_add_float32";
-    "atomic_add_float64";
-    "atomic_cas_int32";
-    "atomic_cas_int64";
-    "atomic_inc_int32";
-    "atomic_inc_global_int32";
-    "atomic_dec_int32";
-  ]
-
-(** Every intrinsic name the PTX backend lowers natively, in dispatch order. *)
-let intrinsic_names =
-  index_intrinsic_names @ transcendental_intrinsic_names
-  @ float_ops_intrinsic_names @ bitcast_intrinsic_names
-  @ convert_intrinsic_names @ atomic_intrinsic_names
+(* Flattened registry, built once on first use. The per-category registries are
+   thunks because their handlers close over [emit_expr], so they live inside the
+   recursive chain below and cannot be plain values; this cell is what keeps
+   dispatch from rebuilding ~80 tuples and their closures for every intrinsic
+   node. It is written once and never invalidated — the registry is constant. *)
+let intrinsic_entries_memo :
+    (string * intrinsic_category * intrinsic_handler) list option ref =
+  ref None
 
 (** {1 Expression emitter}
 
@@ -1726,214 +1664,243 @@ and intr_atomic_incdec buf alloc env intr ~global_only ~op args =
 
 (* Thread/block/grid indices, derived global indices, and the block
    barrier. All are pure special-register moves plus arithmetic. *)
-and emit_intrinsic_index buf alloc name : string option =
-  match name with
-  | "thread_id_x" | "thread_idx_x" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%tid.x;" r ;
-      Some r
-  | "thread_id_y" | "thread_idx_y" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%tid.y;" r ;
-      Some r
-  | "thread_id_z" | "thread_idx_z" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%tid.z;" r ;
-      Some r
-  | "block_id_x" | "block_idx_x" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ctaid.x;" r ;
-      Some r
-  | "block_id_y" | "block_idx_y" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ctaid.y;" r ;
-      Some r
-  | "block_id_z" | "block_idx_z" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ctaid.z;" r ;
-      Some r
-  | "block_dim_x" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ntid.x;" r ;
-      Some r
-  | "block_dim_y" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ntid.y;" r ;
-      Some r
-  | "block_dim_z" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ntid.z;" r ;
-      Some r
-  | "grid_dim_x" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%nctaid.x;" r ;
-      Some r
-  | "grid_dim_y" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%nctaid.y;" r ;
-      Some r
-  | "grid_dim_z" ->
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, %%nctaid.z;" r ;
-      Some r
-  | "global_thread_id" | "global_idx" | "global_idx_x" ->
-      let r_tid = new_u32 alloc in
-      emit buf "mov.u32 %s, %%tid.x;" r_tid ;
-      let r_bid = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ctaid.x;" r_bid ;
-      let r_bdim = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ntid.x;" r_bdim ;
-      let r_off = new_u32 alloc in
-      emit buf "mul.lo.u32 %s, %s, %s;" r_off r_bid r_bdim ;
-      let r_gid = new_u32 alloc in
-      emit buf "add.u32 %s, %s, %s;" r_gid r_tid r_off ;
-      Some r_gid
-  | "global_idx_y" ->
-      let r_tid = new_u32 alloc in
-      emit buf "mov.u32 %s, %%tid.y;" r_tid ;
-      let r_bid = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ctaid.y;" r_bid ;
-      let r_bdim = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ntid.y;" r_bdim ;
-      let r_off = new_u32 alloc in
-      emit buf "mul.lo.u32 %s, %s, %s;" r_off r_bid r_bdim ;
-      let r_gid = new_u32 alloc in
-      emit buf "add.u32 %s, %s, %s;" r_gid r_tid r_off ;
-      Some r_gid
-  | "global_size" ->
-      let r_bdim = new_u32 alloc in
-      emit buf "mov.u32 %s, %%ntid.x;" r_bdim ;
-      let r_gdim = new_u32 alloc in
-      emit buf "mov.u32 %s, %%nctaid.x;" r_gdim ;
-      let r = new_u32 alloc in
-      emit buf "mul.lo.u32 %s, %s, %s;" r r_bdim r_gdim ;
-      Some r
-  | "block_barrier" ->
-      emit buf "bar.sync 0;" ;
-      let r = new_u32 alloc in
-      emit buf "mov.u32 %s, 0;" r ;
-      Some r
-  | _ -> None
+and index_intrinsic_handlers () : (string list * intrinsic_handler) list =
+  [
+    ( ["thread_id_x"; "thread_idx_x"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%tid.x;" r ;
+        Some r );
+    ( ["thread_id_y"; "thread_idx_y"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%tid.y;" r ;
+        Some r );
+    ( ["thread_id_z"; "thread_idx_z"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%tid.z;" r ;
+        Some r );
+    ( ["block_id_x"; "block_idx_x"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ctaid.x;" r ;
+        Some r );
+    ( ["block_id_y"; "block_idx_y"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ctaid.y;" r ;
+        Some r );
+    ( ["block_id_z"; "block_idx_z"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ctaid.z;" r ;
+        Some r );
+    ( ["block_dim_x"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ntid.x;" r ;
+        Some r );
+    ( ["block_dim_y"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ntid.y;" r ;
+        Some r );
+    ( ["block_dim_z"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ntid.z;" r ;
+        Some r );
+    ( ["grid_dim_x"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%nctaid.x;" r ;
+        Some r );
+    ( ["grid_dim_y"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%nctaid.y;" r ;
+        Some r );
+    ( ["grid_dim_z"],
+      fun buf alloc _env _path _name _args ->
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, %%nctaid.z;" r ;
+        Some r );
+    ( ["global_thread_id"; "global_idx"; "global_idx_x"],
+      fun buf alloc _env _path _name _args ->
+        let r_tid = new_u32 alloc in
+        emit buf "mov.u32 %s, %%tid.x;" r_tid ;
+        let r_bid = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ctaid.x;" r_bid ;
+        let r_bdim = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ntid.x;" r_bdim ;
+        let r_off = new_u32 alloc in
+        emit buf "mul.lo.u32 %s, %s, %s;" r_off r_bid r_bdim ;
+        let r_gid = new_u32 alloc in
+        emit buf "add.u32 %s, %s, %s;" r_gid r_tid r_off ;
+        Some r_gid );
+    ( ["global_idx_y"],
+      fun buf alloc _env _path _name _args ->
+        let r_tid = new_u32 alloc in
+        emit buf "mov.u32 %s, %%tid.y;" r_tid ;
+        let r_bid = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ctaid.y;" r_bid ;
+        let r_bdim = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ntid.y;" r_bdim ;
+        let r_off = new_u32 alloc in
+        emit buf "mul.lo.u32 %s, %s, %s;" r_off r_bid r_bdim ;
+        let r_gid = new_u32 alloc in
+        emit buf "add.u32 %s, %s, %s;" r_gid r_tid r_off ;
+        Some r_gid );
+    ( ["global_size"],
+      fun buf alloc _env _path _name _args ->
+        let r_bdim = new_u32 alloc in
+        emit buf "mov.u32 %s, %%ntid.x;" r_bdim ;
+        let r_gdim = new_u32 alloc in
+        emit buf "mov.u32 %s, %%nctaid.x;" r_gdim ;
+        let r = new_u32 alloc in
+        emit buf "mul.lo.u32 %s, %s, %s;" r r_bdim r_gdim ;
+        Some r );
+    ( ["block_barrier"],
+      fun buf alloc _env _path _name _args ->
+        emit buf "bar.sync 0;" ;
+        let r = new_u32 alloc in
+        emit buf "mov.u32 %s, 0;" r ;
+        Some r );
+  ]
 
 (* Transcendental and trigonometric functions. Most are f32-only .approx
    compositions; the arc/expm1/log1p family widens to the f64 softmath
    helper and rounds back. *)
-and emit_intrinsic_transcendental buf alloc env name args : string option =
-  match name with
-  | "sin" ->
-      Some
-        (intr_f32_op1
-           buf
-           alloc
-           "sin.approx.f32"
-           (intr_unary_f32_arg buf alloc env "sin" args))
-  | "cos" ->
-      Some
-        (intr_f32_op1
-           buf
-           alloc
-           "cos.approx.f32"
-           (intr_unary_f32_arg buf alloc env "cos" args))
-  | "tan" ->
-      (* tan = sin/cos, all .approx: f32 precision only. *)
-      let r_arg = intr_unary_f32_arg buf alloc env "tan" args in
-      let r_sin = intr_f32_op1 buf alloc "sin.approx.f32" r_arg in
-      let r_cos = intr_f32_op1 buf alloc "cos.approx.f32" r_arg in
-      Some (intr_f32_op2 buf alloc "div.approx.f32" r_sin r_cos)
-  | "sqrt" ->
-      Some
-        (intr_unary_native
-           buf
-           alloc
-           env
-           "sqrt"
-           ~f32_op:(Some "sqrt.approx.f32")
-           ~f64_op:(Some "sqrt.rn.f64")
-           args)
-  | "exp" ->
-      (* exp(x) = 2^(x·log2 e); PTX only has base-2 ex2 (.approx, f32). *)
-      let r_arg = intr_unary_f32_arg buf alloc env "exp" args in
-      Some
-        (intr_f32_op1
-           buf
-           alloc
-           "ex2.approx.f32"
-           (intr_f32_mul_const buf alloc r_arg f32_log2_e_bits))
-  | "log" ->
-      (* log(x) = log2(x)·ln 2; PTX only has base-2 lg2 (.approx, f32). *)
-      let r_arg = intr_unary_f32_arg buf alloc env "log" args in
-      Some
-        (intr_f32_mul_const
-           buf
-           alloc
-           (intr_f32_op1 buf alloc "lg2.approx.f32" r_arg)
-           f32_ln_2_bits)
-  | "log10" ->
-      (* log10(x) = log2(x)·log10 2; .approx, f32 precision only. *)
-      let r_arg = intr_unary_f32_arg buf alloc env "log10" args in
-      Some
-        (intr_f32_mul_const
-           buf
-           alloc
-           (intr_f32_op1 buf alloc "lg2.approx.f32" r_arg)
-           f32_log10_2_bits)
-  | "pow" ->
-      (* pow(x,y) = 2^(y·log2 x) via lg2/ex2 (.approx, f32). Domain caveat:
+
+and transcendental_intrinsic_handlers () :
+    (string list * intrinsic_handler) list =
+  [
+    ( ["sin"],
+      fun buf alloc env _path _name args ->
+        Some
+          (intr_f32_op1
+             buf
+             alloc
+             "sin.approx.f32"
+             (intr_unary_f32_arg buf alloc env "sin" args)) );
+    ( ["cos"],
+      fun buf alloc env _path _name args ->
+        Some
+          (intr_f32_op1
+             buf
+             alloc
+             "cos.approx.f32"
+             (intr_unary_f32_arg buf alloc env "cos" args)) );
+    ( ["tan"],
+      fun buf alloc env _path _name args ->
+        (* tan = sin/cos, all .approx: f32 precision only. *)
+        let r_arg = intr_unary_f32_arg buf alloc env "tan" args in
+        let r_sin = intr_f32_op1 buf alloc "sin.approx.f32" r_arg in
+        let r_cos = intr_f32_op1 buf alloc "cos.approx.f32" r_arg in
+        Some (intr_f32_op2 buf alloc "div.approx.f32" r_sin r_cos) );
+    ( ["sqrt"],
+      fun buf alloc env _path _name args ->
+        Some
+          (intr_unary_native
+             buf
+             alloc
+             env
+             "sqrt"
+             ~f32_op:(Some "sqrt.approx.f32")
+             ~f64_op:(Some "sqrt.rn.f64")
+             args) );
+    ( ["exp"],
+      fun buf alloc env _path _name args ->
+        (* exp(x) = 2^(x·log2 e); PTX only has base-2 ex2 (.approx, f32). *)
+        let r_arg = intr_unary_f32_arg buf alloc env "exp" args in
+        Some
+          (intr_f32_op1
+             buf
+             alloc
+             "ex2.approx.f32"
+             (intr_f32_mul_const buf alloc r_arg f32_log2_e_bits)) );
+    ( ["log"],
+      fun buf alloc env _path _name args ->
+        (* log(x) = log2(x)·ln 2; PTX only has base-2 lg2 (.approx, f32). *)
+        let r_arg = intr_unary_f32_arg buf alloc env "log" args in
+        Some
+          (intr_f32_mul_const
+             buf
+             alloc
+             (intr_f32_op1 buf alloc "lg2.approx.f32" r_arg)
+             f32_ln_2_bits) );
+    ( ["log10"],
+      fun buf alloc env _path _name args ->
+        (* log10(x) = log2(x)·log10 2; .approx, f32 precision only. *)
+        let r_arg = intr_unary_f32_arg buf alloc env "log10" args in
+        Some
+          (intr_f32_mul_const
+             buf
+             alloc
+             (intr_f32_op1 buf alloc "lg2.approx.f32" r_arg)
+             f32_log10_2_bits) );
+    ( ["pow"],
+      fun buf alloc env _path _name args ->
+        (* pow(x,y) = 2^(y·log2 x) via lg2/ex2 (.approx, f32). Domain caveat:
          valid for x > 0 only — lg2 of a negative is NaN, so integer-exponent
          negative bases are not handled. *)
-      let ra, rb = intr_binary_f32_args buf alloc env "pow" args in
-      let r_lg = intr_f32_op1 buf alloc "lg2.approx.f32" ra in
-      Some
-        (intr_f32_op1
-           buf
-           alloc
-           "ex2.approx.f32"
-           (intr_f32_op2 buf alloc "mul.f32" rb r_lg))
-  | "sinh" | "cosh" ->
-      (* sinh/cosh x = (e^x ∓ e^-x)/2 via ex2(±x·log2 e); .approx, f32. *)
-      let r_arg = intr_unary_f32_arg buf alloc env name args in
-      let r_t = intr_f32_mul_const buf alloc r_arg f32_log2_e_bits in
-      let r_pos = intr_f32_op1 buf alloc "ex2.approx.f32" r_t in
-      let r_neg =
-        intr_f32_op1
-          buf
-          alloc
-          "ex2.approx.f32"
-          (intr_f32_op1 buf alloc "neg.f32" r_t)
-      in
-      let comb = if name = "sinh" then "sub.f32" else "add.f32" in
-      Some
-        (intr_f32_mul_const
-           buf
-           alloc
-           (intr_f32_op2 buf alloc comb r_pos r_neg)
-           f32_half_bits)
-  | "tanh" ->
-      (* tanh x = copysign(1 − 2/(e^(2|x|) + 1), x) via ex2(2|x|·log2 e).
+        let ra, rb = intr_binary_f32_args buf alloc env "pow" args in
+        let r_lg = intr_f32_op1 buf alloc "lg2.approx.f32" ra in
+        Some
+          (intr_f32_op1
+             buf
+             alloc
+             "ex2.approx.f32"
+             (intr_f32_op2 buf alloc "mul.f32" rb r_lg)) );
+    ( ["sinh"; "cosh"],
+      fun buf alloc env _path name args ->
+        (* sinh/cosh x = (e^x ∓ e^-x)/2 via ex2(±x·log2 e); .approx, f32. *)
+        let r_arg = intr_unary_f32_arg buf alloc env name args in
+        let r_t = intr_f32_mul_const buf alloc r_arg f32_log2_e_bits in
+        let r_pos = intr_f32_op1 buf alloc "ex2.approx.f32" r_t in
+        let r_neg =
+          intr_f32_op1
+            buf
+            alloc
+            "ex2.approx.f32"
+            (intr_f32_op1 buf alloc "neg.f32" r_t)
+        in
+        let comb = if name = "sinh" then "sub.f32" else "add.f32" in
+        Some
+          (intr_f32_mul_const
+             buf
+             alloc
+             (intr_f32_op2 buf alloc comb r_pos r_neg)
+             f32_half_bits) );
+    ( ["tanh"],
+      fun buf alloc env _path _name args ->
+        (* tanh x = copysign(1 − 2/(e^(2|x|) + 1), x) via ex2(2|x|·log2 e).
          Using |x| keeps the exponential finite-or-+inf only: at overflow
          e^(2|x|) = +inf, 2/(inf+1) = 0 and the result saturates to ±1
          instead of the NaN the naive (e^2x−1)/(e^2x+1) form produces. *)
-      let r_arg = intr_unary_f32_arg buf alloc env "tanh" args in
-      let r_abs = intr_f32_op1 buf alloc "abs.f32" r_arg in
-      let r_e2x =
-        intr_f32_op1
-          buf
-          alloc
-          "ex2.approx.f32"
-          (intr_f32_mul_const buf alloc r_abs f32_two_log2_e_bits)
-      in
-      let r_den = new_f32 alloc in
-      emit buf "add.f32 %s, %s, 0F%08lX;" r_den r_e2x f32_one_bits ;
-      let r_two = new_f32 alloc in
-      emit buf "mov.f32 %s, 0F%08lX;" r_two (Int32.bits_of_float 2.0) ;
-      let r_frac = intr_f32_op2 buf alloc "div.approx.f32" r_two r_den in
-      let r_mag = new_f32 alloc in
-      emit buf "sub.f32 %s, 0F%08lX, %s;" r_mag f32_one_bits r_frac ;
-      let r = new_f32 alloc in
-      emit buf "copysign.f32 %s, %s, %s;" r r_arg r_mag ;
-      Some r
-  | "asin" | "acos" | "atan" | "atan2" | "expm1" | "log1p" -> (
-      (* f32 path: no native PTX instruction and no accurate ex2/lg2
+        let r_arg = intr_unary_f32_arg buf alloc env "tanh" args in
+        let r_abs = intr_f32_op1 buf alloc "abs.f32" r_arg in
+        let r_e2x =
+          intr_f32_op1
+            buf
+            alloc
+            "ex2.approx.f32"
+            (intr_f32_mul_const buf alloc r_abs f32_two_log2_e_bits)
+        in
+        let r_den = new_f32 alloc in
+        emit buf "add.f32 %s, %s, 0F%08lX;" r_den r_e2x f32_one_bits ;
+        let r_two = new_f32 alloc in
+        emit buf "mov.f32 %s, 0F%08lX;" r_two (Int32.bits_of_float 2.0) ;
+        let r_frac = intr_f32_op2 buf alloc "div.approx.f32" r_two r_den in
+        let r_mag = new_f32 alloc in
+        emit buf "sub.f32 %s, 0F%08lX, %s;" r_mag f32_one_bits r_frac ;
+        let r = new_f32 alloc in
+        emit buf "copysign.f32 %s, %s, %s;" r r_arg r_mag ;
+        Some r );
+    ( ["asin"; "acos"; "atan"; "atan2"; "expm1"; "log1p"],
+      fun buf alloc env _path name args ->
+        (* f32 path: no native PTX instruction and no accurate ex2/lg2
          composition (and for expm1/log1p an exp/log composition would lose
          the near-zero precision they exist for). Widen to f64
          (cvt.f64.f32 — exact, hence no rounding modifier), run the softmath f64
@@ -1943,445 +1910,503 @@ and emit_intrinsic_transcendental buf alloc env name args : string option =
          GPUs); acceptable for these rare functions — a native-f32
          composition can come later if profiling demands. f64 callers reach
          the softmath helper directly via the ["Float64"] path. *)
-      let hname =
-        match Sarek_ir_softmath.helper_name name with
-        | Some h -> h
-        | None ->
-            fail ("PTX codegen: internal error: no softmath helper for " ^ name)
-      in
-      Sarek_ir_softmath.register alloc.funcs ;
-      let f =
-        {
-          var_name = hname;
-          var_id = -1;
-          var_type = TFloat64;
-          var_mutable = false;
-        }
-      in
-      let args64 = List.map (fun a -> ECast (TFloat64, a)) args in
-      match emit_app buf alloc env f args64 with
-      | Scalar r -> Some (emit_cast buf alloc r TFloat32)
-      | Agg _ ->
-          fail
-            "PTX codegen: internal error: softmath helper returned an aggregate"
-      )
-  | "rsqrt" ->
-      (* f64: rcp.rn∘sqrt.rn — rsqrt.approx.f64 exists but is low-precision
+        let hname =
+          match Sarek_ir_softmath.helper_name name with
+          | Some h -> h
+          | None ->
+              fail
+                ("PTX codegen: internal error: no softmath helper for " ^ name)
+        in
+        Sarek_ir_softmath.register alloc.funcs ;
+        let f =
+          {
+            var_name = hname;
+            var_id = -1;
+            var_type = TFloat64;
+            var_mutable = false;
+          }
+        in
+        let args64 = List.map (fun a -> ECast (TFloat64, a)) args in
+        match emit_app buf alloc env f args64 with
+        | Scalar r -> Some (emit_cast buf alloc r TFloat32)
+        | Agg _ ->
+            fail
+              "PTX codegen: internal error: softmath helper returned an \
+               aggregate" );
+    ( ["rsqrt"],
+      fun buf alloc env _path _name args ->
+        (* f64: rcp.rn∘sqrt.rn — rsqrt.approx.f64 exists but is low-precision
          (~1e-4); the two correctly-rounded ops give ~1-ulp-per-op accuracy.
          f32 keeps the fast rsqrt.approx.f32. *)
-      let r = intr_unary_arg buf alloc env "rsqrt" args in
-      if is_f64_reg r then (
-        let r_sqrt = new_f64 alloc in
-        emit buf "sqrt.rn.f64 %s, %s;" r_sqrt r ;
-        let d = new_f64 alloc in
-        emit buf "rcp.rn.f64 %s, %s;" d r_sqrt ;
-        Some d)
-      else if is_f32_reg r then (
-        let d = new_f32 alloc in
-        emit buf "rsqrt.approx.f32 %s, %s;" d r ;
-        Some d)
-      else unsupported "rsqrt: float operand required"
-  | _ -> None
+        let r = intr_unary_arg buf alloc env "rsqrt" args in
+        if is_f64_reg r then (
+          let r_sqrt = new_f64 alloc in
+          emit buf "sqrt.rn.f64 %s, %s;" r_sqrt r ;
+          let d = new_f64 alloc in
+          emit buf "rcp.rn.f64 %s, %s;" d r_sqrt ;
+          Some d)
+        else if is_f32_reg r then (
+          let d = new_f32 alloc in
+          emit buf "rsqrt.approx.f32 %s, %s;" d r ;
+          Some d)
+        else unsupported "rsqrt: float operand required" );
+  ]
 
 (* Elementary float operations with direct (or short) native lowerings:
    abs, copysign, fmod, hypot, fma, min/max, floor/ceil. *)
-and emit_intrinsic_float_ops buf alloc env name args : string option =
-  match name with
-  | "fabs" | "abs_float" ->
-      Some
-        (intr_unary_native
-           buf
-           alloc
-           env
-           name
-           ~f32_op:(Some "abs.f32")
-           ~f64_op:(Some "abs.f64")
-           args)
-  | "copysign" ->
-      (* PTX: copysign d, a, b = |b| with a's sign. OCaml copysign x y = |x|
+
+and float_ops_intrinsic_handlers () : (string list * intrinsic_handler) list =
+  [
+    ( ["fabs"; "abs_float"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_unary_native
+             buf
+             alloc
+             env
+             name
+             ~f32_op:(Some "abs.f32")
+             ~f64_op:(Some "abs.f64")
+             args) );
+    ( ["copysign"],
+      fun buf alloc env _path _name args ->
+        (* PTX: copysign d, a, b = |b| with a's sign. OCaml copysign x y = |x|
          with y's sign — the sign source (second Sarek argument) therefore
          goes in the FIRST PTX operand slot. *)
-      let ra, rb = intr_binary_args buf alloc env "copysign" args in
-      if is_f64_reg ra && is_f64_reg rb then (
-        let d = new_f64 alloc in
-        emit buf "copysign.f64 %s, %s, %s;" d rb ra ;
-        Some d)
-      else if is_f32_reg ra && is_f32_reg rb then (
-        let d = new_f32 alloc in
-        emit buf "copysign.f32 %s, %s, %s;" d rb ra ;
-        Some d)
-      else
-        unsupported
-          ("copysign: operands " ^ ra ^ ", " ^ rb
-         ^ " must both be f32 or both f64; cast one operand first")
-  | "fmod" ->
-      (* C fmod (Float32.fmod / Float64.fmod): exact iterative reduction shared
+        let ra, rb = intr_binary_args buf alloc env "copysign" args in
+        if is_f64_reg ra && is_f64_reg rb then (
+          let d = new_f64 alloc in
+          emit buf "copysign.f64 %s, %s, %s;" d rb ra ;
+          Some d)
+        else if is_f32_reg ra && is_f32_reg rb then (
+          let d = new_f32 alloc in
+          emit buf "copysign.f32 %s, %s, %s;" d rb ra ;
+          Some d)
+        else
+          unsupported
+            ("copysign: operands " ^ ra ^ ", " ^ rb
+           ^ " must both be f32 or both f64; cast one operand first") );
+    ( ["fmod"],
+      fun buf alloc env _path _name args ->
+        (* C fmod (Float32.fmod / Float64.fmod): exact iterative reduction shared
          with the float [Mod] binop lowering (see emit_float_fmod). Both operands
          must share a width — a mixed-width op would be invalid PTX. *)
-      let ra, rb = intr_binary_args buf alloc env "fmod" args in
-      if is_f64_reg ra && is_f64_reg rb then
-        Some (emit_float_fmod buf alloc ~is64:true ra rb)
-      else if is_f32_reg ra && is_f32_reg rb then
-        Some (emit_float_fmod buf alloc ~is64:false ra rb)
-      else
-        unsupported
-          ("fmod: operands " ^ ra ^ ", " ^ rb
-         ^ " must both be f32 or both f64; cast one operand first")
-  | "hypot" ->
-      (* hypot = sqrt(x² + y²) via mul + fma + sqrt. No overflow/underflow
+        let ra, rb = intr_binary_args buf alloc env "fmod" args in
+        if is_f64_reg ra && is_f64_reg rb then
+          Some (emit_float_fmod buf alloc ~is64:true ra rb)
+        else if is_f32_reg ra && is_f32_reg rb then
+          Some (emit_float_fmod buf alloc ~is64:false ra rb)
+        else
+          unsupported
+            ("fmod: operands " ^ ra ^ ", " ^ rb
+           ^ " must both be f32 or both f64; cast one operand first") );
+    ( ["hypot"],
+      fun buf alloc env _path _name args ->
+        (* hypot = sqrt(x² + y²) via mul + fma + sqrt. No overflow/underflow
          rescaling: exact enough for moderate magnitudes (f64 uses only
          correctly-rounded ops), wrong near FLT/DBL_MAX. *)
-      let ra, rb = intr_binary_args buf alloc env "hypot" args in
-      if is_f64_reg ra && is_f64_reg rb then (
-        let r_xx = new_f64 alloc in
-        emit buf "mul.f64 %s, %s, %s;" r_xx ra ra ;
-        let r_sum = new_f64 alloc in
-        emit buf "fma.rn.f64 %s, %s, %s, %s;" r_sum rb rb r_xx ;
-        let d = new_f64 alloc in
-        emit buf "sqrt.rn.f64 %s, %s;" d r_sum ;
-        Some d)
-      else if is_f32_reg ra && is_f32_reg rb then (
-        let r_xx = intr_f32_op2 buf alloc "mul.f32" ra ra in
-        let r_sum = new_f32 alloc in
-        emit buf "fma.rn.f32 %s, %s, %s, %s;" r_sum rb rb r_xx ;
-        Some (intr_f32_op1 buf alloc "sqrt.rn.f32" r_sum))
-      else
-        unsupported
-          ("hypot: operands " ^ ra ^ ", " ^ rb
-         ^ " must both be f32 or both f64; cast one operand first")
-  | "fma" -> (
-      match args with
-      | [a; b; c] ->
-          let ra = emit_expr buf alloc env a in
-          let rb = emit_expr buf alloc env b in
-          let rc = emit_expr buf alloc env c in
-          if is_f64_reg ra && is_f64_reg rb && is_f64_reg rc then (
-            let r = new_f64 alloc in
-            emit buf "fma.rn.f64 %s, %s, %s, %s;" r ra rb rc ;
-            Some r)
-          else if is_f32_reg ra && is_f32_reg rb && is_f32_reg rc then (
-            let r = new_f32 alloc in
-            emit buf "fma.rn.f32 %s, %s, %s, %s;" r ra rb rc ;
-            Some r)
-          else
-            unsupported
-              ("fma: operands " ^ ra ^ ", " ^ rb ^ ", " ^ rc
-             ^ " must all be f32 or all f64; cast the mismatched operand")
-      | _ -> unsupported "fma arity != 3")
-  | "min" -> Some (intr_binary_minmax buf alloc env name "min" args)
-  | "max" -> Some (intr_binary_minmax buf alloc env name "max" args)
-  | "floor" -> Some (intr_unary_round buf alloc env name "cvt.rmi" args)
-  | "ceil" -> Some (intr_unary_round buf alloc env name "cvt.rpi" args)
-  | _ -> None
+        let ra, rb = intr_binary_args buf alloc env "hypot" args in
+        if is_f64_reg ra && is_f64_reg rb then (
+          let r_xx = new_f64 alloc in
+          emit buf "mul.f64 %s, %s, %s;" r_xx ra ra ;
+          let r_sum = new_f64 alloc in
+          emit buf "fma.rn.f64 %s, %s, %s, %s;" r_sum rb rb r_xx ;
+          let d = new_f64 alloc in
+          emit buf "sqrt.rn.f64 %s, %s;" d r_sum ;
+          Some d)
+        else if is_f32_reg ra && is_f32_reg rb then (
+          let r_xx = intr_f32_op2 buf alloc "mul.f32" ra ra in
+          let r_sum = new_f32 alloc in
+          emit buf "fma.rn.f32 %s, %s, %s, %s;" r_sum rb rb r_xx ;
+          Some (intr_f32_op1 buf alloc "sqrt.rn.f32" r_sum))
+        else
+          unsupported
+            ("hypot: operands " ^ ra ^ ", " ^ rb
+           ^ " must both be f32 or both f64; cast one operand first") );
+    ( ["fma"],
+      fun buf alloc env _path _name args ->
+        match args with
+        | [a; b; c] ->
+            let ra = emit_expr buf alloc env a in
+            let rb = emit_expr buf alloc env b in
+            let rc = emit_expr buf alloc env c in
+            if is_f64_reg ra && is_f64_reg rb && is_f64_reg rc then (
+              let r = new_f64 alloc in
+              emit buf "fma.rn.f64 %s, %s, %s, %s;" r ra rb rc ;
+              Some r)
+            else if is_f32_reg ra && is_f32_reg rb && is_f32_reg rc then (
+              let r = new_f32 alloc in
+              emit buf "fma.rn.f32 %s, %s, %s, %s;" r ra rb rc ;
+              Some r)
+            else
+              unsupported
+                ("fma: operands " ^ ra ^ ", " ^ rb ^ ", " ^ rc
+               ^ " must all be f32 or all f64; cast the mismatched operand")
+        | _ -> unsupported "fma arity != 3" );
+    ( ["min"],
+      fun buf alloc env _path name args ->
+        Some (intr_binary_minmax buf alloc env name "min" args) );
+    ( ["max"],
+      fun buf alloc env _path name args ->
+        Some (intr_binary_minmax buf alloc env name "max" args) );
+    ( ["floor"],
+      fun buf alloc env _path name args ->
+        Some (intr_unary_round buf alloc env name "cvt.rmi" args) );
+    ( ["ceil"],
+      fun buf alloc env _path name args ->
+        Some (intr_unary_round buf alloc env name "cvt.rpi" args) );
+  ]
 
 (* Bitcasts between f64 and int64 (mov.b64) — the exponent-field plumbing
    the softmath f64 transcendentals are built on. *)
-and emit_intrinsic_bitcast buf alloc env name args : string option =
-  match name with
-  | "f64_bits" ->
-      let r = intr_unary_arg buf alloc env "f64_bits" args in
-      if is_f64_reg r then (
-        let d = new_u64 alloc in
-        emit buf "mov.b64 %s, %s;" d r ;
-        Some d)
-      else unsupported "f64_bits: f64 operand required"
-  | "bits_f64" ->
-      let r = intr_unary_arg buf alloc env "bits_f64" args in
-      if String.length r >= 3 && r.[1] = 'r' && r.[2] = 'd' then (
-        let d = new_f64 alloc in
-        emit buf "mov.b64 %s, %s;" d r ;
-        Some d)
-      else unsupported "bits_f64: int64 operand required"
-  | _ -> None
+
+and bitcast_intrinsic_handlers () : (string list * intrinsic_handler) list =
+  [
+    ( ["f64_bits"],
+      fun buf alloc env _path _name args ->
+        let r = intr_unary_arg buf alloc env "f64_bits" args in
+        if is_f64_reg r then (
+          let d = new_u64 alloc in
+          emit buf "mov.b64 %s, %s;" d r ;
+          Some d)
+        else unsupported "f64_bits: f64 operand required" );
+    ( ["bits_f64"],
+      fun buf alloc env _path _name args ->
+        let r = intr_unary_arg buf alloc env "bits_f64" args in
+        if String.length r >= 3 && r.[1] = 'r' && r.[2] = 'd' then (
+          let d = new_f64 alloc in
+          emit buf "mov.b64 %s, %s;" d r ;
+          Some d)
+        else unsupported "bits_f64: int64 operand required" );
+  ]
 
 (* Type conversions (Gpu.float / Float32.of_int / …). "of_int"/"to_int"
    are path-dependent: they exist in both the Float32 and Float64 stdlib
    modules. *)
-and emit_intrinsic_convert buf alloc env path name args : string option =
-  match name with
-  | "float" | "float_of_int" ->
-      Some (intr_unary_cast buf alloc env name TFloat32 args)
-  | "float64" | "float64_of_int" ->
-      Some (intr_unary_cast buf alloc env name TFloat64 args)
-  | "int_of_float" | "int_of_float64" ->
-      Some (intr_unary_cast buf alloc env name TInt32 args)
-  | "of_int" ->
-      if List.exists (fun p -> p = "Float64") path then
-        Some (intr_unary_cast buf alloc env name TFloat64 args)
-      else Some (intr_unary_cast buf alloc env name TFloat32 args)
-  | "to_int" -> Some (intr_unary_cast buf alloc env name TInt32 args)
-  | _ -> None
+
+and convert_intrinsic_handlers () : (string list * intrinsic_handler) list =
+  [
+    ( ["float"; "float_of_int"],
+      fun buf alloc env _path name args ->
+        Some (intr_unary_cast buf alloc env name TFloat32 args) );
+    ( ["float64"; "float64_of_int"],
+      fun buf alloc env _path name args ->
+        Some (intr_unary_cast buf alloc env name TFloat64 args) );
+    ( ["int_of_float"; "int_of_float64"],
+      fun buf alloc env _path name args ->
+        Some (intr_unary_cast buf alloc env name TInt32 args) );
+    ( ["of_int"],
+      fun buf alloc env path name args ->
+        if List.exists (fun p -> p = "Float64") path then
+          Some (intr_unary_cast buf alloc env name TFloat64 args)
+        else Some (intr_unary_cast buf alloc env name TFloat32 args) );
+    ( ["to_int"],
+      fun buf alloc env _path name args ->
+        Some (intr_unary_cast buf alloc env name TInt32 args) );
+  ]
 
 (* Atomics (old value returned). Shared vs global is auto-detected from the
    array's memory space; the *_global_* names force the global path. *)
-and emit_intrinsic_atomic buf alloc env name args : string option =
-  match name with
-  | "atomic_add_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"add"
-           ~ty:".s32"
-           ~result:`U32
-           args)
-  | "atomic_add_global_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:true
-           ~elt_shift:2
-           ~op:"add"
-           ~ty:".s32"
-           ~result:`U32
-           args)
-  | "atomic_sub_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"sub"
-           ~ty:".s32"
-           ~result:`U32
-           args)
-  | "atomic_min_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"min"
-           ~ty:".s32"
-           ~result:`U32
-           args)
-  | "atomic_max_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"max"
-           ~ty:".s32"
-           ~result:`U32
-           args)
-  | "atomic_and_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"and"
-           ~ty:".b32"
-           ~result:`U32
-           args)
-  | "atomic_or_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"or"
-           ~ty:".b32"
-           ~result:`U32
-           args)
-  | "atomic_xor_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"xor"
-           ~ty:".b32"
-           ~result:`U32
-           args)
-  | "atomic_exch_int32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"exch"
-           ~ty:".b32"
-           ~result:`U32
-           args)
-  (* exch generalized to 64-bit elements. No stdlib/ppx int64-exch name
-     exists yet; the emitter accepts the conventional name ahead of it
-     (snapshot-only coverage). *)
-  | "atomic_exch_int64" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:3
-           ~op:"exch"
-           ~ty:".b64"
-           ~result:`U64
-           args)
-  (* atom.add.u64: PTX add has no .s64 form; u64 add is two's-complement,
-     identical to signed int64 add. *)
-  | "atomic_add_int64" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:3
-           ~op:"add"
-           ~ty:".u64"
-           ~result:`U64
-           args)
-  | "atomic_add_float32" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:2
-           ~op:"add"
-           ~ty:".f32"
-           ~result:`F32
-           args)
-  (* atom.add.f64 requires sm_60+; the default target is sm_86. ZLUDA
-     support for f64 atomics is unverified — snapshot coverage only. *)
-  | "atomic_add_float64" ->
-      Some
-        (intr_atomic_rmw
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~elt_shift:3
-           ~op:"add"
-           ~ty:".f64"
-           ~result:`F64
-           args)
-  | "atomic_cas_int32" ->
-      Some
-        (intr_atomic_cas
-           buf
-           alloc
-           env
-           name
-           ~elt_shift:2
-           ~ty:".b32"
-           ~result:`U32
-           args)
-  (* No stdlib/ppx int64-CAS name exists yet; the emitter accepts the
-     conventional name ahead of it (snapshot-only coverage). *)
-  | "atomic_cas_int64" ->
-      Some
-        (intr_atomic_cas
-           buf
-           alloc
-           env
-           name
-           ~elt_shift:3
-           ~ty:".b64"
-           ~result:`U64
-           args)
-  | "atomic_inc_int32" ->
-      Some
-        (intr_atomic_incdec
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~op:"inc"
-           args)
-  | "atomic_inc_global_int32" ->
-      Some
-        (intr_atomic_incdec buf alloc env name ~global_only:true ~op:"inc" args)
-  | "atomic_dec_int32" ->
-      Some
-        (intr_atomic_incdec
-           buf
-           alloc
-           env
-           name
-           ~global_only:false
-           ~op:"dec"
-           args)
-  | _ -> None
 
-(* Which emitter owns which names. Ownership is by NAME, not by "first emitter
-   that returns [Some]": a name claimed by two emitters would otherwise be
-   silently won by whichever comes first in the list (no warning, no test
-   failure, wrong lowering) — the single [match] this dispatcher replaced would
-   at least have warned about a redundant arm. Here the overlap is an explicit
-   internal error, and test_ptx_intrinsic_sweep.ml asserts the six name sets are
-   pairwise disjoint up front. A thunk because the closures reference the
-   emitters defined in this same [let rec] chain. *)
-and intrinsic_emitter_table () =
+and atomic_intrinsic_handlers () : (string list * intrinsic_handler) list =
   [
-    ( index_intrinsic_names,
-      fun buf alloc _env _path name _args -> emit_intrinsic_index buf alloc name
-    );
-    ( transcendental_intrinsic_names,
+    ( ["atomic_add_int32"],
       fun buf alloc env _path name args ->
-        emit_intrinsic_transcendental buf alloc env name args );
-    ( float_ops_intrinsic_names,
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"add"
+             ~ty:".s32"
+             ~result:`U32
+             args) );
+    ( ["atomic_add_global_int32"],
       fun buf alloc env _path name args ->
-        emit_intrinsic_float_ops buf alloc env name args );
-    ( bitcast_intrinsic_names,
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:true
+             ~elt_shift:2
+             ~op:"add"
+             ~ty:".s32"
+             ~result:`U32
+             args) );
+    ( ["atomic_sub_int32"],
       fun buf alloc env _path name args ->
-        emit_intrinsic_bitcast buf alloc env name args );
-    ( convert_intrinsic_names,
-      fun buf alloc env path name args ->
-        emit_intrinsic_convert buf alloc env path name args );
-    ( atomic_intrinsic_names,
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"sub"
+             ~ty:".s32"
+             ~result:`U32
+             args) );
+    ( ["atomic_min_int32"],
       fun buf alloc env _path name args ->
-        emit_intrinsic_atomic buf alloc env name args );
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"min"
+             ~ty:".s32"
+             ~result:`U32
+             args) );
+    ( ["atomic_max_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"max"
+             ~ty:".s32"
+             ~result:`U32
+             args) );
+    ( ["atomic_and_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"and"
+             ~ty:".b32"
+             ~result:`U32
+             args) );
+    ( ["atomic_or_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"or"
+             ~ty:".b32"
+             ~result:`U32
+             args) );
+    ( ["atomic_xor_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"xor"
+             ~ty:".b32"
+             ~result:`U32
+             args) );
+    ( ["atomic_exch_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"exch"
+             ~ty:".b32"
+             ~result:`U32
+             args) );
+    (* exch generalized to 64-bit elements. No stdlib/ppx int64-exch name
+       exists yet; the emitter accepts the conventional name ahead of it
+       (snapshot-only coverage). *)
+    ( ["atomic_exch_int64"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:3
+             ~op:"exch"
+             ~ty:".b64"
+             ~result:`U64
+             args) );
+    (* atom.add.u64: PTX add has no .s64 form; u64 add is two's-complement,
+       identical to signed int64 add. *)
+    ( ["atomic_add_int64"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:3
+             ~op:"add"
+             ~ty:".u64"
+             ~result:`U64
+             args) );
+    ( ["atomic_add_float32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:2
+             ~op:"add"
+             ~ty:".f32"
+             ~result:`F32
+             args) );
+    (* atom.add.f64 requires sm_60+; the default target is sm_86. ZLUDA
+       support for f64 atomics is unverified — snapshot coverage only. *)
+    ( ["atomic_add_float64"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_rmw
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~elt_shift:3
+             ~op:"add"
+             ~ty:".f64"
+             ~result:`F64
+             args) );
+    ( ["atomic_cas_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_cas
+             buf
+             alloc
+             env
+             name
+             ~elt_shift:2
+             ~ty:".b32"
+             ~result:`U32
+             args) );
+    (* No stdlib/ppx int64-CAS name exists yet; the emitter accepts the
+       conventional name ahead of it (snapshot-only coverage). *)
+    ( ["atomic_cas_int64"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_cas
+             buf
+             alloc
+             env
+             name
+             ~elt_shift:3
+             ~ty:".b64"
+             ~result:`U64
+             args) );
+    ( ["atomic_inc_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_incdec
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~op:"inc"
+             args) );
+    ( ["atomic_inc_global_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_incdec
+             buf
+             alloc
+             env
+             name
+             ~global_only:true
+             ~op:"inc"
+             args) );
+    ( ["atomic_dec_int32"],
+      fun buf alloc env _path name args ->
+        Some
+          (intr_atomic_incdec
+             buf
+             alloc
+             env
+             name
+             ~global_only:false
+             ~op:"dec"
+             args) );
   ]
 
-(* PTX-assembly intrinsic emitter. Looks [name] up in {!intrinsic_emitter_table}
-   and runs its owning per-category emitter; an unowned (or declined) name is
-   [unsupported]. *)
+(* Which handler registry owns which names, in dispatch order. Ownership is by
+   NAME, not by "first emitter that returns [Some]": a name claimed twice would
+   otherwise be silently won by whichever comes first (no warning, no test
+   failure, wrong lowering). Here the overlap is an explicit internal error, and
+   test_ptx_intrinsic_sweep.ml asserts the registries are pairwise disjoint up
+   front. Thunks because the closures reference the emitters defined in this
+   same [let rec] chain. *)
+and intrinsic_emitter_table () :
+    (intrinsic_category * (string list * intrinsic_handler) list) list =
+  [
+    (Index, index_intrinsic_handlers ());
+    (Transcendental, transcendental_intrinsic_handlers ());
+    (Float_ops, float_ops_intrinsic_handlers ());
+    (Bitcast, bitcast_intrinsic_handlers ());
+    (Convert, convert_intrinsic_handlers ());
+    (Atomic, atomic_intrinsic_handlers ());
+  ]
+
+(* Every (name, handler) pair the PTX backend lowers natively, flattened out of
+   {!intrinsic_emitter_table} in dispatch order. Both dispatch below and the
+   exported name tables at the bottom of this file are computed from THIS list —
+   that is what makes "the dispatch arms and the name tables agree" true by
+   construction rather than by a check. Memoized: see {!intrinsic_entries_memo}. *)
+and intrinsic_handler_entries () :
+    (string * intrinsic_category * intrinsic_handler) list =
+  match !intrinsic_entries_memo with
+  | Some entries -> entries
+  | None ->
+      let entries =
+        List.concat_map
+          (fun (cat, handlers) ->
+            List.concat_map
+              (fun (names, h) -> List.map (fun n -> (n, cat, h)) names)
+              handlers)
+          (intrinsic_emitter_table ())
+      in
+      intrinsic_entries_memo := Some entries ;
+      entries
+
+(* PTX-assembly intrinsic emitter. Looks [name] up in the handler registry and
+   runs its owning handler; an unowned (or declined) name is [unsupported]. *)
 and emit_intrinsic_native buf alloc (env : env) path name args : string =
   match
-    List.filter
-      (fun (names, _) -> List.mem name names)
-      (intrinsic_emitter_table ())
+    List.filter (fun (n, _, _) -> n = name) (intrinsic_handler_entries ())
   with
-  | [(_, emitter)] -> (
-      match emitter buf alloc env path name args with
+  | [(_, _, handler)] -> (
+      match handler buf alloc env path name args with
       | Some r -> r
       | None -> unsupported ("intrinsic: " ^ name))
   | [] -> unsupported ("intrinsic: " ^ name)
@@ -2389,3 +2414,47 @@ and emit_intrinsic_native buf alloc (env : env) path name args : string =
       fail
         ("PTX codegen: internal error: intrinsic " ^ name
        ^ " is claimed by more than one emitter")
+
+(** {1 Intrinsic name tables}
+
+    Derived from the handler registry above, not written out beside it. Each
+    table is the names of the handlers in one category, in dispatch order, so
+    the tables cannot disagree with what dispatch does: there is no way to
+    declare a name no handler answers, or to add a handler the tables do not
+    know about. That is a property of the definitions, not of a test — the
+    correspondence has no opportunity to drift, so nothing has to check it.
+
+    These are what the ptxas sweep gate enumerates
+    (sarek/tests/unit/test_ptx_intrinsic_sweep.ml): every registered name gets a
+    generated kernel, so an intrinsic added to a registry without an assembling
+    recipe fails there. *)
+
+let names_of_category cat =
+  List.filter_map
+    (fun (n, c, _) -> if c = cat then Some n else None)
+    (intrinsic_handler_entries ())
+
+let index_intrinsic_names = names_of_category Index
+
+let transcendental_intrinsic_names = names_of_category Transcendental
+
+let float_ops_intrinsic_names = names_of_category Float_ops
+
+let bitcast_intrinsic_names = names_of_category Bitcast
+
+let convert_intrinsic_names = names_of_category Convert
+
+let atomic_intrinsic_names = names_of_category Atomic
+
+(** Every intrinsic name the PTX backend lowers natively, in dispatch order. *)
+let intrinsic_names =
+  index_intrinsic_names @ transcendental_intrinsic_names
+  @ float_ops_intrinsic_names @ bitcast_intrinsic_names
+  @ convert_intrinsic_names @ atomic_intrinsic_names
+
+(** Every intrinsic name the dispatch registry holds a handler for, with the
+    registry that owns it, in dispatch order. Like the tables above, this is the
+    handler values themselves projected — it is the same list, retaining the
+    category. *)
+let intrinsic_registry : (string * intrinsic_category) list =
+  List.map (fun (n, cat, _) -> (n, cat)) (intrinsic_handler_entries ())

--- a/sarek/codegen/Sarek_ir_ptx_expr.mli
+++ b/sarek/codegen/Sarek_ir_ptx_expr.mli
@@ -61,14 +61,32 @@ val emit_cast : Buffer.t -> reg_alloc -> string -> elttype -> string
 val emit_intrinsic :
   Buffer.t -> reg_alloc -> env -> string list -> string -> expr list -> string
 
-(** {1 Intrinsic name tables}
+(** {1 Intrinsic dispatch registry}
 
-    The intrinsic names each per-category emitter owns. This is the dispatch
-    table {!emit_intrinsic} consults, so it cannot drift from what the backend
-    actually lowers: a name absent from every list raises
-    {!Sarek_ir_ptx_types.Ptx_codegen_error}, and a name in two lists is an
-    internal error. Exposed so the ptxas sweep gate can assemble one kernel per
-    intrinsic name and so a new intrinsic is covered automatically. *)
+    Each intrinsic is one entry in a per-category handler registry: the names it
+    answers to paired with the closure that lowers them. {!emit_intrinsic}
+    dispatches by looking a name up there, so {!intrinsic_registry} is what the
+    backend actually lowers; the tables below are pinned to it entry for entry
+    by a value-level test. A name absent from the registry raises
+    {!Sarek_ir_ptx_types.Ptx_codegen_error}; a name claimed by two handlers is
+    an internal error. Exposed so the ptxas sweep gate can assemble one kernel
+    per intrinsic name and so a new intrinsic is covered automatically. *)
+
+(** The per-category handler registries, in dispatch order. *)
+type intrinsic_category =
+  | Index
+  | Transcendental
+  | Float_ops
+  | Bitcast
+  | Convert
+  | Atomic
+
+(** Every intrinsic name the PTX backend lowers, with the registry that owns it,
+    in dispatch order. Derived from the handler values themselves: an entry here
+    is a handler that exists, and every handler has its entries here. The name
+    tables below are checked against it — over these values, not over source
+    text — by sarek/tests/unit/test_ptx_intrinsic_sweep.ml. *)
+val intrinsic_registry : (string * intrinsic_category) list
 
 val index_intrinsic_names : string list
 
@@ -82,5 +100,6 @@ val convert_intrinsic_names : string list
 
 val atomic_intrinsic_names : string list
 
-(** All of the above concatenated, in dispatch order. *)
+(** All of the above concatenated, in dispatch order — i.e. the names of
+    {!intrinsic_registry}. *)
 val intrinsic_names : string list

--- a/sarek/core/Device.ml
+++ b/sarek/core/Device.ml
@@ -40,7 +40,8 @@ let resolve_framework fw_name =
 (** Initialize all available backends and enumerate devices *)
 let init
     ?(frameworks =
-      ["CUDA"; "HIP"; "OpenCL"; "Vulkan"; "Metal"; "Native"; "Interpreter"]) () =
+      ["CUDA"; "HIP"; "OpenCL"; "Vulkan"; "Metal"; "Native"; "Interpreter"]) ()
+    =
   if !initialized then !devices
   else begin
     let all_devices = ref [] in

--- a/sarek/interp/Sarek_float32.ml
+++ b/sarek/interp/Sarek_float32.ml
@@ -157,10 +157,11 @@ let ceil x = to_float32 (Stdlib.ceil x)
 
 let abs x = to_float32 (Stdlib.abs_float x)
 
-(** FMA (fused multiply-add) - important for GPU accuracy *)
 (* A single fused rounding (Float.fma), then one float32 rounding — not
    [(x *. y) +. z], whose intermediate product rounds independently and breaks
    exact TwoProd error extraction for the df64 (float-float) library. *)
+
+(** FMA (fused multiply-add) - important for GPU accuracy *)
 let fma x y z = to_float32 (Float.fma x y z) |> check_overflow "fma"
 
 (** Min/max that handle NaN correctly (GPU semantics) *)

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -64,14 +64,11 @@
  (libraries sarek.codegen alcotest unix str))
 
 ; ptxas sweep over the WHOLE PTX intrinsic surface: one kernel per intrinsic
-; name, enumerated from Sarek_ir_ptx_expr's own dispatch tables so a new
+; name, enumerated from Sarek_ir_ptx_expr's own dispatch registry so a new
 ; intrinsic is assembled automatically. Skips cleanly without ptxas.
 
 (test
  (name test_ptx_intrinsic_sweep)
- ; The emitter source is a dep: one test scans its intrinsic match arms and
- ; requires them to agree with the exported name tables.
- (deps ../../codegen/Sarek_ir_ptx_expr.ml)
  (libraries sarek.codegen alcotest unix str))
 
 ; WGSL identifier escaping: injectivity + legality of escape_wgsl_name, and

--- a/sarek/tests/unit/test_ir_layout.ml
+++ b/sarek/tests/unit/test_ir_layout.ml
@@ -154,8 +154,9 @@ let test_mixed_align_record () =
     rl.rl_fields ;
   Alcotest.(check int) "mixed_align size" 16 rl.rl_size
 
-(** L8: [{b:f64; a:i32}] reordered largest-first packs tighter: b@0, a@8, size 16
-    (a fits in the trailing 8 bytes; still 16 due to 8-byte struct alignment). *)
+(** L8: [{b:f64; a:i32}] reordered largest-first packs tighter: b@0, a@8, size
+    16 (a fits in the trailing 8 bytes; still 16 due to 8-byte struct
+    alignment). *)
 let test_mixed_align_record_reordered () =
   let rl =
     get_ok

--- a/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
+++ b/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
@@ -12,8 +12,8 @@
     generated fine, passed a substring snapshot test that asserted the invalid
     opcode, and died at [cuModuleLoadData].
 
-    So this gate is driven by the emitter's own dispatch tables
-    ({!Sarek_ir_ptx_expr.intrinsic_names}) rather than a hand-picked list: it
+    So this gate is driven by the emitter's own dispatch registry
+    ({!Sarek_ir_ptx_expr.intrinsic_registry}) rather than a hand-picked list: it
     builds and assembles at least one kernel per intrinsic NAME, and an
     intrinsic added to the emitter with no kernel recipe here FAILS the recipe
     test. Kernel GENERATION always runs; only the [ptxas] assembly step
@@ -334,128 +334,27 @@ let test_name_sets_disjoint () =
                (String.concat "; " ds)))
     named_sets
 
-(* ---- registry vs. emitter arms ------------------------------------------- *)
+(* ---- why there is no "tables match the registry" test --------------------
 
-(* The name tables and the emitters' [match] arms are two sources for one fact,
-   hundreds of lines apart: a name declared in a table but with no arm, or an
-   arm added without its table entry, is drift. The unregistered direction is
-   fail-loud at runtime (the name reaches no emitter and becomes [unsupported])
-   but nothing FAILS A TEST — the arm is simply absent from dispatch, from
-   [intrinsic_names] and from this sweep, all at once. Until the categories
-   become single name -> handler registries (which would make this structural),
-   scan the emitter source and require the two to agree exactly. *)
+   There used to be one, and before that a worse one: the exported name tables
+   and the dispatch arms were two sources for one fact, hundreds of lines apart,
+   compared by SCANNING THE EMITTER SOURCE for [match] arms — a textual check
+   that passes whenever the text moves, and fails when it moves harmlessly.
 
-let emitter_source_path () =
-  List.find_opt
-    Sys.file_exists
-    ((match Sys.getenv_opt "SAREK_PTX_EXPR_SRC" with
-       | Some p -> [p]
-       | None -> [])
-    @ [
-        (* cwd is the test's build dir under dune runtest; the file is a
-           declared dep of this test in sarek/tests/unit/dune. *)
-        Filename.concat
-          ".."
-          (Filename.concat ".." "codegen/Sarek_ir_ptx_expr.ml");
-        "sarek/codegen/Sarek_ir_ptx_expr.ml";
-      ])
+   Replacing the scan with a value-level comparison against the handler registry
+   fixed the textual coupling but kept two lists. The tables are now COMPUTED
+   from the handlers ([Sarek_ir_ptx_expr.names_of_category]), so "the tables
+   agree with dispatch" is true by construction and there is nothing left to
+   compare: such a test would assert [x = x] and could never fail. A test that
+   cannot fail is worse than no test, so it is gone rather than kept for
+   appearances.
 
-let read_lines path =
-  let ic = open_in path in
-  let rec go acc =
-    match input_line ic with
-    | l -> go (l :: acc)
-    | exception End_of_file ->
-        close_in ic ;
-        List.rev acc
-  in
-  go []
-
-(* The quoted names of a top-level [match] arm: everything before the [->], so
-   string arguments in the arm's BODY (e.g. ~f32_op:(Some "sqrt.rn.f32")) are
-   not mistaken for patterns. *)
-let pattern_names line =
-  let head =
-    match Str.bounded_split_delim (Str.regexp_string "->") line 2 with
-    | h :: _ -> h
-    | [] -> line
-  in
-  let re = Str.regexp "\"\\([a-z0-9_]+\\)\"" in
-  let rec go i acc =
-    match Str.search_forward re head i with
-    | exception Not_found -> List.rev acc
-    | _ -> go (Str.match_end ()) (Str.matched_group 1 head :: acc)
-  in
-  go 0 []
-
-(** [category, arm names] scraped from the emitter source, in file order. *)
-let arms_by_category lines =
-  let categories =
-    ["index"; "transcendental"; "float_ops"; "bitcast"; "convert"; "atomic"]
-  in
-  let acc = Hashtbl.create 8 in
-  let current = ref None in
-  List.iter
-    (fun line ->
-      (match
-         List.find_opt
-           (fun c -> starts_with ("and emit_intrinsic_" ^ c ^ " ") line)
-           categories
-       with
-      | Some c -> current := Some c
-      | None -> if starts_with "and " line then current := None) ;
-      match !current with
-      | None -> ()
-      | Some c ->
-          let t = String.trim line in
-          if starts_with "| \"" t then
-            let previous = Option.value (Hashtbl.find_opt acc c) ~default:[] in
-            Hashtbl.replace acc c (previous @ pattern_names t))
-    lines ;
-  List.map
-    (fun c -> (c, Option.value (Hashtbl.find_opt acc c) ~default:[]))
-    categories
-
-(** The exported name tables and the emitters' own [match] arms must agree, name
-    for name, in both directions. *)
-let test_arms_match_registry () =
-  match emitter_source_path () with
-  | None ->
-      Alcotest.fail
-        "cannot locate Sarek_ir_ptx_expr.ml to scan its intrinsic match arms \
-         (declare it as a dep of this test, or set SAREK_PTX_EXPR_SRC)"
-  | Some path ->
-      let scraped = arms_by_category (read_lines path) in
-      let registered = named_sets in
-      List.iter
-        (fun (cat, arms) ->
-          let declared =
-            Option.value (List.assoc_opt cat registered) ~default:[]
-          in
-          let arms = List.sort_uniq compare arms in
-          let declared = List.sort_uniq compare declared in
-          let missing = List.filter (fun n -> not (List.mem n declared)) arms in
-          let extra = List.filter (fun n -> not (List.mem n arms)) declared in
-          if missing <> [] then
-            Alcotest.fail
-              (Printf.sprintf
-                 "emit_intrinsic_%s has match arm(s) [%s] that are NOT in \
-                  %s_intrinsic_names — the arm is unreachable: dispatch is by \
-                  name, so the intrinsic is [unsupported] and absent from the \
-                  sweep"
-                 cat
-                 (String.concat "; " missing)
-                 cat) ;
-          if extra <> [] then
-            Alcotest.fail
-              (Printf.sprintf
-                 "%s_intrinsic_names declares [%s] with no matching arm in \
-                  emit_intrinsic_%s — dispatch would route the name to an \
-                  emitter that declines it"
-                 cat
-                 (String.concat "; " extra)
-                 cat))
-        scraped
+   What derivation does NOT give is that the registries PARTITION the surface —
+   two handlers, in the same category or different ones, can still claim the
+   same name, and dispatch raises an internal error on it. That property has
+   real content and is checked by [test_name_sets_disjoint] above. The sweep
+   below, which lowers a kernel per registered name, is what proves each entry's
+   handler actually claims and emits it. *)
 
 (** Every dispatched intrinsic name has an assembling kernel recipe above. This
     is the anti-drift check: add an intrinsic to the emitter and this fails
@@ -581,10 +480,6 @@ let () =
             "emitter name sets partition the intrinsic surface"
             `Quick
             test_name_sets_disjoint;
-          Alcotest.test_case
-            "emitter match arms and the exported name tables agree"
-            `Quick
-            test_arms_match_registry;
           Alcotest.test_case
             "every dispatched intrinsic has a sweep kernel"
             `Quick


### PR DESCRIPTION
Four independent backlog cleanups (#120, #122, #115, #92), batched into one PR because none is big enough to justify its own review cycle. They touch disjoint files; the commits are separated per issue.

**Three of the four turned out to be broken gates rather than the cosmetic fixes they were filed as.**

## A declared gate needs evidence that it *executes*, not evidence that it exists

#122 is the most valuable thing in this PR, and the formatting fix is the least interesting part of it. The finding is that **`ci.yml` has never contained the string `fmt` — in any of its 30 commits.** The three drifted files did not slip past a check; there was no check. The project's mental model contained a gate that was never wired.

That is the third instance of the same failure discovered in this codebase in a single day:

| Believed | Actual |
|---|---|
| CUDA SASS gate validates f16 codegen in CI | `nvdisasm` was absent from the CI image, so the gate self-skipped (fixed on `docs/fp-contraction-policy`) |
| The review bundle supplies gates to any clone | The bundle was untracked, so a fresh clone got no gates at all |
| `@fmt` enforcement was added to CI | It never existed (this PR) |

In all three the gate was *declared* and never *ran*, and in all three the symptom was indistinguishable from success. Existence is not execution: a gate is only evidence if you have seen it go red. The generalisable rule this suggests — and the one I applied to all three items below — is that adding a gate is not done until you have (a) made it fail on purpose and read the message, and (b) checked what it does when its *tooling* is missing, because "tool absent" is the failure mode that silently converts a gate into a no-op.

The other two items are the same disease in different tissue:

- **#115 — the latent misclassification would have surfaced as a vacuous green, not a wrong answer.** With the guard weakened and `sm_61` listed, the suite exits **0**, because CUDA 13.3 rejects `sm_61` as `Unknown_arch` and folds it into the silent skip bucket. The bug was invisible *by the same mechanism* as the `nvdisasm` one.
- **#92 — the old check was wrong in both directions**, passing an unreachable dispatch arm and failing on a pure reformat. It ran, but what it measured was the source text, not the property.

Accordingly, every gate touched here ships with a recorded red: an injected drift probe for #122, two mutations for #115 (one of which demonstrates the vacuous green), and four for #92 (plus two run against the *old* check to show what it missed).

---

## #120 — restrict `permissions:` on `build` and `check-generated-code`

Both jobs had no `permissions:` block and inherited the repository default token scope. Follows the precedent PR #294 set for `formal-proofs`: `permissions: contents: read`. The `ci.yml` diff is confined to the two `permissions:` blocks plus the #122 gate step.

### No-write-operations verification (published so it can be checked without re-deriving it)

I enumerated every step and every `uses:` in both jobs. Reproducible against this branch:

```
grep -n 'push: true\|GITHUB_TOKEN\|secrets\.\|gh api\|gh pr\|gh release\|git push\|actions/github-script' .github/workflows/ci.yml
# → no matches (rc=1)
```

- **No credentialed operations at all.** Neither job references `secrets.*` or `GITHUB_TOKEN`, invokes `gh`, or runs `git push`/`git tag`.
- **`actions/checkout@v4`** is already `persist-credentials: false` in all three jobs, so no token is left in the work tree.
- **`docker/build-push-action@v5`** runs with `load: true` and never `push: true` — it builds the CI image into the local daemon, it does not publish it. Image publication lives in a separate workflow (`ghcr-image.yml`), untouched here.
- **The only `git commit` in the file is a string inside an `echo`** (`check-generated-code`, failure path) telling a human what to run locally. The job's actual git usage is read-only: `git diff --quiet` and `git diff --stat`. The `git config --global --add safe.directory` calls write container-local git config, not the repository.
- **`upload-artifact` / `actions/cache` / buildx `cache-to: type=gha`** are the ones that genuinely write. They authenticate with the runner's job-scoped `ACTIONS_RUNTIME_TOKEN`, **not** `GITHUB_TOKEN`, so they are not governed by `permissions:` and `contents: read` does not affect them.

`contents: read` is therefore the narrowest scope that works for both; neither job needed anything broader.

---

## #122 — formatting drift, and the gate that was never there

**The drift.** `dune build @fmt` reported three files on an unmodified `origin/main`: `sarek/core/Device.ml`, `sarek/interp/Sarek_float32.ml`, `sarek/tests/unit/test_ir_layout.ml`. Fixed with the pinned `ocamlformat` 0.28.1: 7 insertions / 4 deletions, all pure formatting.

### Why they survived

Neither hypothesis in the issue. **There is no `@fmt` gate in CI, and there never has been.** `ci.yml` has never contained the string `fmt`:

```
for c in $(git log --format=%h -30 -- .github/workflows/ci.yml); do
  echo "$c $(git show $c:.github/workflows/ci.yml | grep -ci fmt)"
done
# → every commit: 0
```

`grep -rn fmt .github/` matches nothing (rc=1); neither the `Makefile` nor any script runs `dune build @fmt`. PR #294 added the Rocq `formal-proofs` job and the codegen-toolchain assertion — it did not add format enforcement.

The drift is the symptom; the gap between "we have a fmt gate" and "no commit has ever contained one" is the actual defect. Note that no amount of *reading* `.ocamlformat` would have revealed it — the config file is present, correct, and pinned. Only asking "what executes it?" does. Same question that would have caught the missing `nvdisasm`.

### Fixing the gate

Added a `Formatting gate` step to `build` running `dune build @fmt`, with `ocamlformat.0.28.1` pinned into the job's `opam install` list. Two properties make it non-vacuous, which matters given this repo's history with self-skipping gates (#84/#51/#79 — and now `nvdisasm`):

1. **It cannot self-skip on a missing tool.** The codegen gates print SKIP when their tool is absent; `dune build @fmt` hard-fails instead. Verified by running the build against a shimmed `PATH` containing every opam binary *except* `ocamlformat`:
   ```
   Error: Program ocamlformat not found in the tree or in PATH
   DUNE_FMT_RC=1
   ```
2. **It cannot drift from the config.** `ocamlformat` refuses to run when its version disagrees with `version=0.28.1` in `.ocamlformat`, so the pin and the config cannot silently diverge.

### Red-before-green proof

Baseline after the fix: `Device.ml` clean. Then injected drift:

```
sed -i '1i let _drift_probe_122   =    (   1,2   )' sarek/core/Device.ml
dune build @fmt
```
```
DUNE_FMT_RC=1
File "sarek/core/Device.ml", line 1, characters 0-0:
-let _drift_probe_122   =    (   1,2   )
```

Probe reverted, back to clean. Post-rebase, `dune build @fmt` over the whole repo exits **0** with zero diffs, so the new gate lands green on current `main`.

---

## #115 — SASS classifier and `sm_61`

Chose **explicit refusal** over teaching the classifier Pascal.

Why: validating a Pascal classifier requires real sm_61 SASS, and **`ptxas` 13.3 cannot target `sm_61` at all** — minimum `sm_75`. Verified here:
```
ptxas fatal : Value 'sm_61' is not defined for option 'gpu-name'
```
Writing Pascal idioms from memory and shipping them unverified would be exactly the failure this issue is about.

Staying with the PR #300 design, the existing `tool_failure` variant gains a third constructor rather than a parallel mechanism:

```ocaml
type tool_failure =
  | Unknown_arch of string        (* environment gap             -> legitimate skip *)
  | Unclassifiable_arch of string (* OUR gap                     -> hard failure    *)
  | Tool_error of string          (* toolchain rejected our work -> hard failure    *)
```

`classifier_min_sm = 75`; `classifier_supports` refuses anything below it *and* any name it cannot parse (`gfx1100`, `compute_75`), while still accepting suffixed targets like `sm_90a`/`sm_100f`. The check runs **before any tool is invoked**, so the refusal is a property of the classifier, not of whichever CUDA release happens to be installed.

### Red proof, and the vacuous-green it closes

`sm_61` added to `architectures` with the guard intact — build exit 0, test exit 1:
```
[FAIL] sass_fusion_gate 0  midround SASS keeps the f32 dis...
FAIL sm_61: refusing to classify this architecture's SASS: the SASS classifier in
this test is written for sm_75 and later ... Refusing.
2 failures! in 0.110s.
```

The second mutation is the important one. With `sm_61` listed **and** the refusal weakened (`classifier_min_sm = 0`), the suite reports `Test Successful`, **exit 0** — CUDA 13.3's `ptxas` rejects `sm_61` as `Unknown_arch`, which is a silent per-arch skip. On a modern toolkit the latent bug would never have appeared as a misclassification; it would have appeared as a green run that checked nothing.

### Verified vs reasoned

**Executed here** (RX 7900 XTX, no NVIDIA GPU; host-side CUDA 13.3 tools):
- the `ptxas -arch=sm_61` rejection, verbatim;
- guard fires with the intended message (mutation 1);
- weakened guard + `sm_61` → green pass (mutation 2), so the silent-skip hazard is executed evidence, not conjecture;
- `sm_90a` temporarily listed → accepted and actually classified, so the suffix parse does not over-refuse;
- unmutated suite green; every dune exit code checked explicitly before trusting a test result.

**Reasoned, not verified** — no pre-Turing-capable toolkit exists on this machine:
- the claim that Pascal emits `F2F.F32.F16` in both directions and lacks a `HADD2` widening idiom is documented-ISA knowledge, not disassembly produced here. The refusal's correctness does not depend on it: declining is right as long as the classifier has not been validated against sm_61 SASS, which it demonstrably has not.
- that an older toolkit (CUDA 11.x, which does support sm_61) would, with the guard removed, produce a *misclassification* rather than a skip. Only the CUDA-13.3 silent-skip half is executed evidence.
- `classifier_min_sm = 75` is a lower bound only; nothing here verifies that architectures above 75 keep the same SASS shape. That risk predates this change and still surfaces loudly, as a count mismatch.

---

## #92 — PTX intrinsic dispatch registry

The arms-vs-registry correspondence was checked by reading `Sarek_ir_ptx_expr.ml` as text and regexing out its match arms.

Each per-category emitter is now a value-level registry of `(names, intrinsic_handler)` pairs instead of a `match name with`, and the exported name tables are **computed** from those handlers by `names_of_category` — `List.filter_map` over the flattened registry — rather than written out beside them. So "the tables agree with dispatch" holds by construction: you cannot add a handler the tables don't know about, nor declare a name no handler answers.

The sweep test no longer reads source at all, which also drops the `(deps ../../codegen/Sarek_ir_ptx_expr.ml)` in `sarek/tests/unit/dune` that existed only to feed the scan.

### On CodeRabbit's finding — the doc was stronger than the code

The first version of this PR documented the tables as *projections* of the handlers when they were still hand-written literals, guaranteed only by a test. That is the same assumed-versus-actual gap the rest of this PR is about, in my own prose, so it deserved fixing at the source rather than by softening the wording. **The tables are now genuinely derived**, which makes the claim true.

Proof the derivation is behaviour-preserving: I dumped all six tables, `intrinsic_names` and `intrinsic_registry` at runtime before and after the change — **240 entries, byte-identical, same order** (`diff` exit 0).

**This retires the table-vs-registry test rather than keeping it.** With both sides computed from one list, that test would assert `x = x` and could never fail — and a test that cannot fail is precisely what this PR argues against, so it is deleted, not left in place for appearances. The file now carries a comment explaining why it is absent.

What derivation does *not* give is that the registries **partition** the surface: two handlers, in the same or different categories, can still claim one name. That property has real content and keeps a real check.

### Red proofs after the rework

| Mutation | Result |
|---|---|
| `"sqrt"` added to the `index` registry (already owned by `transcendental`) | build 0, test **1** — *"intrinsic name(s) [sqrt] are claimed by both the index and the transcendental emitter — dispatch would be ambiguous"* |
| new handler name `"frobnicate"` added to `transcendental` | build 0, test **1** — *"no ptxas-sweep kernel recipe for intrinsic(s) [frobnicate]"* |

The second doubles as evidence the derivation works: the new name reached the exported tables, and hence the sweep's enumeration, **with no table edit**.

One nuance found while proving this, worth recording: adding a fresh name to the `index` category does *not* trip the drift alarm, because `cases_for` gives index intrinsics a generic recipe by category (they are all nullary, so one recipe shape genuinely covers them). That is by design and the generated kernel does assemble — not a hole, but it means the drift alarm's teeth are in the per-name-recipe categories.

Also addressed from the same review: the flattened registry was being rebuilt for every intrinsic node and is now memoized, and four explanatory comments in the atomics registry had landed inside the preceding entry's tuple rather than above the entry they describe.

**Behaviour identity:** handler bodies are unchanged, and the PTX emitted for all 114 sweep kernels is byte-identical to the pre-#92 emitter — **re-confirmed against the new base `2075ee1b`** by building a dump program in both trees, not carried over from the earlier run (`diff` exit 0 over 9309 lines, 114 kernels, zero codegen exceptions).

**Why this is worth the churn**, executed against the **old** code:
- adding a dispatch arm spelled `| n when n = "frobnicate" -> …` — an unreachable arm, exactly the defect the old check claimed to catch — left the old scan **green, exit 0**;
- wrapping `and emit_intrinsic_float_ops` onto two lines, a pure reformat with zero semantic change, made the old scan **fail** with a bogus *"declares […] with no matching arm"*.

Text-coupled in both directions. The new check reads values and is fooled by neither.

---

## Verification on the rebased branch

Rebased onto `2075ee1b` (after #306 merged), no conflicts.

- `dune build @install` → **0**
- `dune runtest sarek --force` → **0**; zero `[FAIL]` markers. The `Error` strings in the log are df64 `KNOWN-DEVIATION` warnings and the negative suite's expected compiler output.
- `dune runtest sarek-cuda` → **0**
- `dune build @fmt` → **0**, zero diffs repo-wide
- PTX byte-identity re-run against `2075ee1b` → **0** (9309 lines, 114 kernels)
- Intrinsic table dump before/after derivation → **0** (240 entries, same order)
- `test_local_tuple` → **0/10 failures** at `OCAMLRUNPARAM=s=262143`; earlier also 0/10 at `s=262145`, `s=65536`, `s=16384` and the default. I had seen intermittent segfaults here on an older base; #303 (`a8b5a193`, rooting ctypes allocations across FFI calls) fixed them, and there is no residual caveat to carry.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
