### PR TITLE
test(fp): settle #126 on RADV (precise is inert, not ignored) and audit every f16 shape for AMDGPU demotion (#106)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,29 @@
   `sarek-cuda/test/test_cuda_fp_conformance.ml` reproduces the hazard
   host-side (`-ftz=true` turns `FMUL`/`FADD` into `FMUL.FTZ`/`FADD.FTZ` at
   sm_90, CUDA 13.3) and each of its four cases was proved red by mutation.
+- `sarek/tests/e2e/test_vulkan_no_contraction.ml` (on the `e2e-gpu` alias, so
+  it executes rather than merely building) — settles whether a Vulkan driver
+  honours SPIR-V `NoContraction` (#126). Same shader compiled twice,
+  differing only by `precise`, run on the same device/driver/process; the
+  contracted target is taken from the device's own `fma()` rather than an IEEE
+  model, because RADV's `fma` is not correctly rounded and a modelled target
+  can make a genuinely contracted result read as clean. **Measured on RX 7900
+  XTX (RADV NAVI31) and the Raphael iGPU, Mesa 26.1.4-arch3.1: 0 of 7
+  contraction shapes contracted with or without `precise`, and the emitted RDNA
+  ISA is opcode-identical between the two builds.** Both in-tree claims are
+  refuted: RADV neither ignores the decoration nor needs it. Mesa ANV remains
+  unmeasured — no Intel GPU on this machine.
+- `sarek-hip/test/test_hip_f16_shapes.ml` + `scripts/f16_shape_isa_audit.sh` —
+  exhaustive f16 expression-shape audit for AMDGPU fusion demotion (#106). All
+  20 shapes the DSL can emit, each swept over all 63488 finite binary16 inputs,
+  on gfx1100 and gfx1036: **0 disagreements as shipped**. Removing the opacity
+  barrier breaks 9 of 20 and reproduces the original 620 exactly — the harness
+  was calibrated against that known positive before its nulls were trusted, and
+  it fails closed if the barrier-removed control stops going red. Disassembly
+  additionally shows *four* demotion opcodes, not two (`v_mul_f16` and
+  `v_sub_f16` are new), and three shapes that are demoted in machine code yet
+  numerically clean — which a numeric-only audit would have mis-reported as
+  unaffected. See `docs/optimization/amdgpu-f16-fusion-shape-audit.md`.
 - ZLUDA/AMD support for the CUDA/PTX backend (PTX launch ABI fix)
 - T3-SEMANTIC milestone lock for both formal projects; conformance +
   mutation tests wired into `dune runtest`

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -3,8 +3,8 @@
 _Cross-backend policy for what a Sarek DSL author may rely on when a device
 compiler is free to fuse, reassociate or flush floating-point operations._
 
-**Status:** normative for this repository. **Issue:** #116 (absorbs #110, #111).
-**Date:** 2026-07-25.
+**Status:** normative for this repository. **Issue:** #116 (absorbs #110, #111);
+§6 answers #126 and the HIP row answers #106. **Date:** 2026-07-26.
 
 Three separate defects in this project came from the same place — the gap
 between the floating-point semantics we assumed a backend had and the ones it
@@ -93,12 +93,12 @@ Legend for the evidence column:
 | backend | what the compiler may contract | what actually prevents it | evidence |
 |---|---|---|---|
 | **Interpreter** | nothing — it is the oracle | it evaluates the IR directly | executed (any host) |
-| **HIP / AMDGPU** | `a*b+c`; **and**, below the FP flags, an f32 multiply into an f32→f16 narrowing, plus f32 add demotion to binary16 | two mechanisms, both required: `-ffp-contract=off` forced **last** in the hiprtc option array (`Hip_rtc.base_options` / `hiprtc_options`), *and* the `asm volatile("" : "+v"(x))` opacity barrier on every narrowing's argument (`Sarek_ir_cuda.sarek_f32_barrier_decl`) | executed (quoted), RX 7900 XTX / gfx1100, ROCm hiprtc: exhaustive sweep of all 63488 finite binary16 inputs — 620 device/interpreter disagreements before the barrier, 0 after. See the caveat in the opening section about the separate, inconsistent "373" |
+| **HIP / AMDGPU** | `a*b+c`; **and**, below the FP flags, an f32 multiply or fma fused into an f32→f16 narrowing (`v_fma_mixlo_f16`), plus f32 add/sub/mul/negate demotion to binary16 (`v_add_f16`, `v_sub_f16`, `v_mul_f16`) | two mechanisms, both required: `-ffp-contract=off` forced **last** in the hiprtc option array (`Hip_rtc.base_options` / `hiprtc_options`), *and* the `asm volatile("" : "+v"(x))` opacity barrier on every narrowing's argument (`Sarek_ir_cuda.sarek_f32_barrier_decl`). One barrier covers every affected shape; none needs a different one | **executed + machine-code**, RX 7900 XTX / gfx1100 **and** Raphael iGPU / gfx1036, ROCm hiprtc: all 20 Sarek-emittable f16 expression shapes swept over all 63488 finite binary16 inputs, **0 disagreements as shipped**; removing the barrier breaks 9 of 20 (reproducing the original 620 exactly on the `f16_midround` shape), and disassembly shows demotion opcodes in 3 further shapes that are demoted yet numerically clean — see [`docs/optimization/amdgpu-f16-fusion-shape-audit.md`](optimization/amdgpu-f16-fusion-shape-audit.md) |
 | **CUDA / nvrtc (f16 narrowing)** | in principle the same fusion — but NVIDIA has no fused multiply-and-convert-to-f16 instruction to fuse *into* | **nothing Sarek emits.** `ptxas` simply declines to absorb `cvt.rn.f16.f32` | **executed**, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: exhaustive sweep of all 63488 finite binary16 inputs, 0 device/interpreter disagreements, with a liveness control proving the sweep can go red (§7). Also machine-code, CUDA 13.3 host tools, sm_75…sm_121 — see §4. Machine-checked by `test_cuda_f16_sass`, which until this change **self-skipped in CI** for want of `nvdisasm` (§7) |
 | **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C | **no flag** — Sarek passes an empty build-option string. Same `mul_rn`-by-construction defence as CUDA | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
-| **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` | compiler-output (measured, §6): glslc 2026.2 / SPIRV-Tools 1.4.350.1 emits 2 `NoContraction` decorations for the generated matmul shader, 0 with `precise` stripped. **Whether a given driver honours `NoContraction` is NOT established here** — see §6. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, measured on RX 7900 XTX, Mesa 26.1.4-arch3.1 |
+| **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing: the driver does not contract these shapes even without the decoration | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV not measured — no Intel GPU on this machine.** Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound |
 | **Metal** | Metal's default compile options enable fast math | **nothing.** `Metal_api` passes a null `MTLCompileOptions`, and `Metal_bindings.mtl_device_new_library_with_source` *ignores its `_options` argument entirely* | unverified — no Apple hardware in this project's CI or on the machine this policy was written on. Treat Metal float results as outside the guarantee |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
@@ -110,7 +110,10 @@ Legend for the evidence column:
 **You may rely on, today:**
 
 - **f32 arithmetic agreeing with the interpreter on HIP/AMDGPU**, including f16
-  round-trips.
+  round-trips — confirmed across **every f16 expression shape the DSL can
+  emit**, each swept over the whole finite binary16 domain
+  ([`docs/optimization/amdgpu-f16-fusion-shape-audit.md`](optimization/amdgpu-f16-fusion-shape-audit.md)),
+  on gfx1100 and gfx1036.
 - **The f16 discipline agreeing with the interpreter on NVIDIA**, via the
   CUDA/C (nvrtc) path — executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver
   580.119.02, exhaustive over all 63488 finite binary16 inputs, **0**
@@ -137,7 +140,14 @@ Legend for the evidence column:
   fast math on, unopposed.
 - **Vulkan `fma` being correctly rounded.** On Mesa RADV it is not, and
   `Sarek_df64` mul/div is ~5.8e-08 there — a *documented*, unfixed deviation,
-  not a bug to rediscover.
+  not a bug to rediscover. Note this is a distinct failure from contraction:
+  RADV does **not** contract (§6).
+- **`precise` protecting you on a driver other than RADV.** On RADV it is inert,
+  because the driver does not contract in the first place; that is a measured
+  property of Mesa 26.1.4-arch3.1 on two devices, not a bound and not a
+  guarantee, and it says nothing about ANV, AMDVLK, proprietary drivers, or a
+  future Mesa. The decoration is emitted and correct — it has simply never been
+  observed to change a result.
 - **f16 on NVIDIA through the PTX backend.** The CUDA/C path is now confirmed
   by execution (above), but `Sarek_ir_ptx` still refuses kernel-level f16
   outright, so "f16 works on CUDA" is true only of CUDA/C.
@@ -313,64 +323,131 @@ kernel.
 
 ---
 
-## 6. Vulkan/GLSL: `precise` is emitted, and honouring it is the driver's job
+## 6. Vulkan/GLSL: `precise` is emitted; RADV has nothing to honour
 
 `Sarek_ir_glsl.gen_var_decl` prefixes every `float`/`double` local with
 `precise`. The front end does lower it:
 
-**Measured** (glslc 2026.2, SPIRV-Tools 1.4.350.1, on the Sarek-generated
-`matrix_mul` compute shader taken verbatim from
-`benchmarks/descriptions/generated/matrix_mul_generated.md`): the SPIR-V carries
-**2 `NoContraction` decorations** on the accumulation `OpFMul`/`OpFAdd`, and
-**0** when `precise` is stripped from the same source.
+**Measured** (glslc 2026.2 and glslangValidator, SPIRV-Tools 1.4.350.1). On the
+Sarek-generated `matrix_mul` compute shader, the SPIR-V carries **2
+`NoContraction` decorations** on the accumulation `OpFMul`/`OpFAdd` and **0**
+when `precise` is stripped. On the 12-shape probe shader described below, **18**
+and **0** respectively — both toolchains agree, which matters because the
+runtime path compiles through `glslangValidator`, not `glslc`.
 
-That is a **compiler-output** claim and it stops there. `NoContraction` is a
-requirement placed on the SPIR-V consumer, i.e. the driver. Whether a given
-driver honours it is a separate question that this measurement does not touch.
+### The question this section used to leave open
 
-**This is an open question in this repository, and the two things written down
-about it disagree.** `Sarek_ir_glsl.ml` says `precise` was added *because* RADV
-was observed simplifying error-free transformations without it — which implies
-RADV honours it. Campaign notes state the opposite, that Mesa ANV and RADV
-ignore it. Neither is backed by a recorded, reproducible measurement in-tree.
-**Do not restate either as fact.**
+Whether a driver *obeys* `NoContraction` is a separate question from whether the
+decoration is emitted, and the two things written down in this repository
+disagreed about the answer. `Sarek_ir_glsl.ml` said `precise` was added
+*because* RADV was observed simplifying error-free transformations without it —
+which implies RADV honours it. Campaign notes said the opposite, that Mesa ANV
+and RADV ignore it. Neither was backed by a recorded measurement.
 
-What *is* measured, and what it does and does not tell us: **re-measured for
-this document on RX 7900 XTX under RADV, Mesa 26.1.4-arch3.1** (`test_df64`,
-2026-07-25) — mul 5.84e-08, div 5.86e-08, against add 5.33e-15, sub 6.51e-15,
-sqrt 1.08e-14, and the interpreter's mul 9.07e-15 / div 5.08e-15 on the same
-run. The same shape appears on the Raphael iGPU under RADV. `Sarek_df64` mul/div
-sat at ~5.8e-08 both **before and after** the
-`mul_rn` contraction barrier. Since that barrier works by removing the fusable
-multiply, a contraction-shaped failure would have been fixed by it. It was not.
-So RADV's deviation has a different cause, consistent with the recorded one —
-RADV's GLSL `fma` is not correctly rounded, which is independently supported by
-the measurement that extending `mul_rn` into `two_sum`/`quick_two_sum`
-*regressed* RADV (add 5.33e-15 → 1.15e-07). That argues RADV is not silently
-contracting; it does **not** establish that RADV honours `NoContraction`.
+**It is now measured, and neither claim survives on RADV.**
 
-**The experiment that would settle it** (not run): a kernel computing
-`precise float p = a*b; out = p + c;` and, separately, `out = fma(a,b,c)`,
-executed on RADV and on ANV. If the two kernels agree, the driver contracted
-despite `NoContraction`.
+### The experiment
 
-Two things it must get right, or it will return a false "they agree":
+`sarek/tests/e2e/test_vulkan_no_contraction.ml`. The same shader is compiled
+twice, differing **only** by the expansion of a `#define` that adds or omits
+`precise` on the float locals, and both are run on the same device, same
+driver, same process.
 
-- **Choose the inputs against the device's MEASURED `fma`, not the correctly
-  rounded one.** This same document establishes that RADV's `fma` is not
-  correctly rounded, so inputs picked so that
-  `fl(fl(a*b)+c) ≠ fma_correct(a,b,c)` may still collide with what RADV's `fma`
-  actually returns. Read the device's `fma` result first, then select inputs on
-  which it differs from the separately-rounded form.
-- **ANV is not available here.** There is no Intel GPU on the machine this
-  policy was written on (AMD RX 7900 XTX and a Raphael iGPU only), so the ANV
-  half cannot be run without different hardware — the same class of gap as
-  everything in §7.
+The discriminator is chosen so a contracted evaluation is not a one-ulp wobble.
+With `a = b = 1 + 2^-12` and `c = -(1 + 2^-11)`, all exactly representable in
+binary32:
 
-Until that is run, treat Vulkan float32 as *contraction-safe by front-end
-declaration only*.
+```
+exact a*b          = 1 + 2^-11 + 2^-24
+fl32(a*b)          = 1 + 2^-11          (2^-24 is exactly half an ulp at 1.0;
+                                         ties-to-even drops it)
+fl32(fl32(a*b)+c)  = 0                  <- multiply then add
+fl32(fma(a,b,c))   = 2^-24 = 5.96e-08   <- contracted
+```
 
----
+Exactly zero against 5.96e-08. There is no tolerance to choose and no way to
+read the result ambiguously.
+
+**The contracted target is measured, not modelled.** This document establishes
+in the same table that RADV's `fma` is not correctly rounded, so predicting
+"what a fused evaluation would return" from an exact-fma model can be wrong on
+precisely this driver — and wrong in the dangerous direction, because a
+mispredicted target makes a genuinely contracted result match neither candidate
+and the shape reads as clean. Every contraction shape is therefore compared
+against a **sibling shape that asks the device for the fused value of the same
+operands** via an explicit `fma()`, never against an IEEE model. Those sibling
+shapes are themselves integrity-checked: an explicit `fma()` that fails to fuse
+means the harness is not being handed a fused value at all, and the test fails
+rather than reporting. (At these particular operands the device's `fma` does
+agree with IEEE — the harness prints that comparison — but nothing depends on
+it doing so.)
+
+Twelve shapes are probed, because "honoured" need not be one yes/no: a driver
+may contract a mul-add but not a mul-sub, and `precise` forbids reassociation as
+well as contraction. The seven contraction-sensitive shapes cover multiply into
+add, into subtract from either side, the same expression with and without a
+named intermediate, the TwoProd error term, and — the shape `precise` was
+actually put in the codegen for — a **loop-carried `acc += a*b` accumulation**
+with a non-constant trip count, i.e. the `matrix_mul` inner loop. Two further
+shapes probe reassociation.
+
+### The result
+
+**Measured on RX 7900 XTX (RADV NAVI31) and on the Raphael iGPU (RADV
+RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1, 2026-07-26:**
+
+| | no `precise` | `precise` |
+|---|---|---|
+| contraction shapes contracted | **0 of 7** | **0 of 7** |
+| reassociation shapes reassociated | 0 of 2 | 0 of 2 |
+| explicit `fma()` controls fused | 4 of 4 | 4 of 4 |
+
+Identical on both devices. Confirmed at machine-code level: with `RADV_DEBUG=asm`
+the emitted RDNA ISA is **opcode-for-opcode identical** between the `precise` and
+non-`precise` builds on both devices, and in the *non*-`precise` build — where
+the driver is completely free to fuse — the multiply and the add are separate
+`v_mul_f32` / `v_add_f32` instructions. The `v_fma_f32` instructions present are
+exactly the explicitly-requested `fma()` calls.
+
+**So: RADV does not contract these shapes even when nothing forbids it.**
+
+- The claim that **RADV ignores `NoContraction`** is not supported: the driver
+  never produced a contracted result, decoration or no decoration.
+- The claim that **`precise` was needed because RADV was contracting** is also
+  not supported: with `precise` stripped, RADV still did not contract, and the
+  ISA is unchanged.
+
+What is *not* established is that RADV would honour `NoContraction` if it ever
+did want to contract. This is an **absence of the hazard on this driver and this
+version**, not a demonstration of obedience. The honest status of `precise` on
+RADV is therefore: **inert, and free** — it costs nothing (identical ISA) and it
+is the correct thing to emit for portability, but on RADV today it is not what
+is holding anything up. Keep it; do not credit it.
+
+**Not run: Mesa ANV.** There is no Intel GPU on this machine. The ANV half of
+the original disagreement is a **hardware gap**, not a null result — recorded in
+§7's still-open list.
+
+### This does not explain the df64 deviation, and never could
+
+`Sarek_df64` mul/div sit at ~5.8e-08 on RADV (re-measured for this document on
+RX 7900 XTX, Mesa 26.1.4-arch3.1, `test_df64`, 2026-07-25: mul 5.84e-08, div
+5.86e-08, against add 5.33e-15, sub 6.51e-15, sqrt 1.08e-14, and the
+interpreter's mul 9.07e-15 / div 5.08e-15 on the same run). Every figure here is
+the **measured worst-case relative error over that test's own input set**, on the
+named device and driver — a maximum observed, not a bound proved, and agreement
+between two such maxima is agreement between summary statistics rather than a
+demonstration of element-wise identity. The same shape appears on the Raphael
+iGPU.
+
+That deviation was already known to have a different cause, and this measurement
+independently confirms it. `Sarek_df64` mul/div sat at ~5.8e-08 both **before and
+after** the `mul_rn` contraction barrier; since that barrier works by removing
+the fusable multiply, a contraction-shaped failure would have been fixed by it,
+and it was not. The recorded cause — RADV's GLSL `fma` is not correctly rounded
+— is further supported by extending `mul_rn` into `two_sum`/`quick_two_sum`
+*regressing* RADV (add 5.33e-15 → 1.15e-07). The present result closes the loop:
+RADV is not contracting at all, so contraction cannot be the explanation.
 
 ## 7. What NVIDIA hardware settled, and what is still open
 
@@ -419,8 +496,19 @@ barrier still existed, neutralising it left the sm_61 SASS **byte-identical**
 F2F.F16.F32`, every mandated rounding its own instruction). Two methods, two
 architectures ranges, same answer.
 
-**Still open:**
+**Still open** (the first is not an NVIDIA gap, but it is a hardware gap and
+this is where they are collected):
 
+- **No Intel GPU: the ANV half of §6 is unrun.** The `precise` /
+  `NoContraction` question was originally disputed for **both** Mesa RADV and
+  Mesa ANV. §6 settles RADV by measurement. ANV is **not** measured and cannot
+  be measured here — the experiment requires executing on the driver in
+  question. Nothing in §6 licenses any statement about ANV in either direction,
+  and the campaign note claiming ANV ignores `NoContraction` remains unverified.
+  One run closes it on any Intel box:
+  `dune build @e2e-gpu` enumerates every Vulkan device present and needs no
+  configuration. AMDVLK and the proprietary AMD Vulkan driver are unmeasured for
+  the same reason — different SPIR-V consumers on the very same GPU.
 - **f16 on the PTX backend.** `Sarek_ir_ptx` refuses kernel-level f16 (`#57`
   slice 2). Everything above is the **CUDA/C** path.
 - **One GPU, one architecture.** sm_61 has no tensor cores, no bf16 and no FP8,
@@ -477,3 +565,6 @@ architectures ranges, same answer.
 | `sarek-cuda/test/test_cuda_fp_conformance.ml` | the nvrtc FP-option guard and its hazard control |
 | `sarek-hip/test/test_hip_rtc_options.ml` | proves `-ffp-contract=off` stays last whatever the caller passes |
 | `sarek/tests/e2e/test_df64.ml` | the per-backend precision measurement this policy quotes |
+| `sarek/tests/e2e/test_vulkan_no_contraction.ml` | the §6 experiment: `precise` vs not, same device/driver/run, contracted targets taken from the device's own `fma` (`e2e-gpu` alias) |
+| `sarek-hip/test/test_hip_f16_shapes.ml` | every f16 expression shape swept over all 63488 finite binary16 inputs, with a barrier-removed control that must go red (`e2e-hip` alias) |
+| `scripts/f16_shape_isa_audit.sh` | the ISA half of that audit — catches shapes demoted in machine code but numerically clean |

--- a/docs/optimization/amdgpu-f16-fusion-shape-audit.md
+++ b/docs/optimization/amdgpu-f16-fusion-shape-audit.md
@@ -1,0 +1,191 @@
+# AMDGPU f16 fusion/demotion: exhaustive shape audit
+
+_Issue #106. Measured 2026-07-25/26 on **AMD Radeon RX 7900 XTX (gfx1100)** and
+**AMD Ryzen 9 7950X iGPU (gfx1036)**, ROCm hiprtc, `-ffp-contract=off` forced
+last per `Hip_rtc.base_options`. Disassembly via `hipcc`/ROCm LLVM for gfx1100._
+
+## What was already known
+
+An AMDGPU ISel combine fuses an f32 multiply into the f32→f16 narrowing that
+consumes it (`v_fma_mixlo_f16`), and demotes a neighbouring f32 add to binary16
+(`v_add_f16`). It sits **below** the C-level FP controls, so `-ffp-contract=off`
+does not prevent it. `Sarek_ir_cuda.sarek_f32_barrier` — `asm volatile("" :
+"+v"(x))` on the narrowing's argument — does.
+
+That was established on **one** expression shape (`f16_midround`, 620 of 63488
+finite binary16 inputs disagreeing with the interpreter). The `v_add_f16`
+observation showed the class was broader than multiply-then-narrow, but nobody
+had enumerated it.
+
+## Why the enumeration is small, and closed
+
+f16 in Sarek is a **storage-only element type**. The typer rejects f16 operands
+for every arithmetic, comparison, bitwise and unary operator; there is no f16
+literal; there is no f16 math intrinsic; f16 struct fields are rejected at
+layout; an f16 scalar kernel parameter is rejected at lowering. The entire f16
+surface is two core primitives, `float16_of_float32` and `float32_of_float16`.
+
+So the only f16 value producer is `ECast (TFloat16, e)` for an f32-typed `e`,
+and "audit every f16 expression shape" reduces to: **audit the shapes of `e`
+that can reach a narrowing**, plus the two paths with no narrowing at all (a
+straight f16→f16 copy, and a widening whose result never narrows). That is a
+closed enumeration, not a sample.
+
+## Method
+
+Two independent instruments, because neither alone is sufficient.
+
+**Numeric** — `sarek-hip/test/test_hip_f16_shapes.ml` sweeps each shape over
+**all 63488 finite binary16 values** (the whole domain, including both zeros and
+the entire subnormal range) and compares bit-exactly against the interpreter.
+Three columns:
+
+| column | what it runs |
+|---|---|
+| `shipping` | the ordinary Sarek path (`Execute.run_vectors`) |
+| `src+barrier` | the generated HIP source, verbatim, through `run_source` |
+| `src-barrier` | the same source with the barrier's `asm volatile` body deleted |
+
+`src+barrier` exists so that `src-barrier` differs from it by exactly one
+textual substitution and nothing else, and so that `shipping` vs `src+barrier`
+checks the `run_source` path is faithful.
+
+**ISA** — `scripts/f16_shape_isa_audit.sh` disassembles every shape for gfx1100
+with and without the barrier.
+
+The second instrument is not redundant. **A numeric null cannot distinguish "not
+demoted" from "demoted, but exact on this domain"**, and the second is a latent
+hazard: the demotion is present in the machine code and will bite on the next
+expression shape that is not so lucky. Three shapes below are exactly that case.
+
+### Calibration before trust
+
+The harness reproduces the known result — shape B1 returns **620** mismatches
+with the barrier removed, matching the originally reported 620 of 63488. The
+harness was therefore shown to detect this defect class *before* its null
+results were relied on. The test enforces this permanently: if removing the
+barrier breaks **no** shape, it exits non-zero on the grounds that it has not
+been shown to detect demotion at all and its zeros are uninformative.
+
+This matters because the original 620 hid behind a *sampled* f16 test that was
+green for months.
+
+## Results
+
+`ship` / `+bar` / `-bar` are mismatch counts out of 63488. Identical on gfx1100
+and gfx1036.
+
+| id | shape (`x` = `float32_of_float16 inp.(i)`) | ship | +bar | −bar | ISA with barrier | ISA without barrier | verdict |
+|---|---|---|---|---|---|---|---|
+| A1 | `narrow x` | 0 | 0 | 0 | `cvt` | *(collapses to a 16-bit load/store)* | unaffected |
+| A2 | `narrow (x *. 1.1)` | 0 | 0 | **2913** | `cvt` | `v_fma_mixlo_f16` | **affected** |
+| A3 | `narrow (x +. 1000.)` | 0 | 0 | 0 | `cvt` | `v_add_f16` | **demoted, unobservable** |
+| A4 | `narrow (x -. 1000.)` | 0 | 0 | 0 | `cvt` | `v_add_f16` | **demoted, unobservable** |
+| A5 | `narrow (x /. 3.)` | 0 | 0 | 0 | `cvt` | `cvt` + `v_fma_mix_f32`×2 | unaffected |
+| A6 | `narrow (x *. 1.1 +. 1000.)` | 0 | 0 | 0 | `cvt` | `cvt` | unaffected |
+| A7 | `narrow ((x +. 1000.) *. 1.1)` | 0 | 0 | **374** | `cvt` | `v_fma_mixlo_f16` | **affected** |
+| A8 | `narrow (fma x 1.1 1000.)` | 0 | 0 | **484** | `cvt` + `v_fma_mix_f32` | `v_fma_mixlo_f16` | **affected** |
+| A9 | `narrow (sqrt (x *. x))` | 0 | 0 | 0 | `cvt` | `cvt` | unaffected |
+| A10 | `narrow (0. -. x)` | 0 | 0 | 0 | `cvt` | `v_sub_f16` | **demoted, unobservable** |
+| A11 | `narrow (floor (x *. 1.1))` | 0 | 0 | 0 | `cvt` | `cvt` | unaffected |
+| A12 | `narrow (if x>0. then x*.1.1 else x*.0.9)` | 0 | 0 | **2864** | `cvt` | `v_fma_mixlo_f16` | **affected** |
+| A13 | `narrow (x *. x)` | 0 | 0 | 0 | `cvt` | `v_mul_f16` | **demoted, unobservable** |
+| A14 | `narrow (x *. 1.1 *. 1.1)` | 0 | 0 | **309** | `cvt` | `v_fma_mixlo_f16` | **affected** |
+| A15 | `narrow (x *. 1.1 +. x /. 3.)` | 0 | 0 | 0 | `cvt` | `cvt` | unaffected |
+| B1 | mid-narrow then `+. 1000.` | 0 | 0 | **620** | `cvt`×2 | `v_add_f16` + `v_fma_mixlo_f16` | **affected** *(the original)* |
+| B2 | mid-narrow then `*. 1.1` | 0 | 0 | **5369** | `cvt`×2 | `v_fma_mixlo_f16`×2 | **affected** |
+| B3 | mid-narrow of add then `*. 1.1` | 0 | 0 | **963** | `cvt`×2 | `v_add_f16` + `v_fma_mixlo_f16` | **affected** |
+| B4 | two mid-narrows then `*. 1.1` | 0 | 0 | **1518** | `cvt`×3 | `v_add_f16` + `v_fma_mixlo_f16`×2 | **affected** |
+| C1 | `out.(i) <- inp.(i)` (no cast) | 0 | 0 | 0 | *(load/store only)* | *(load/store only)* | unaffected |
+
+`cvt` = `v_cvt_f16_f32`, a standalone narrowing — the correct shape.
+`v_fma_mix_f32` is **not** a demotion: it keeps an f32 result and is how an
+explicitly requested `fma()` is meant to be emitted.
+
+### Every shape is correct as shipped
+
+**All 20 shapes, both devices: 0 mismatches out of 63488 on the shipping path.**
+No currently-emittable f16 expression shape disagrees with the interpreter.
+
+### The barrier is load-bearing, and one barrier covers everything
+
+9 of 20 shapes break when the barrier is removed; the *same single* mechanism —
+`sarek_f32_barrier`'s `asm volatile("" : "+v"(x))` — fixes every one. There is no
+shape needing a different or additional barrier. With the barrier present, every
+narrowing in every shape is a standalone `v_cvt_f16_f32`.
+
+### Four demotion opcodes, not one
+
+The combine family is wider than the two opcodes previously recorded:
+
+| opcode | what it does | first seen here |
+|---|---|---|
+| `v_fma_mixlo_f16` | f32 multiply/fma fused **into** the narrowing | already known |
+| `v_add_f16` | f32 add/sub demoted to a binary16 add | already known |
+| `v_mul_f16` | f32 multiply demoted to a binary16 multiply | **new** (A13) |
+| `v_sub_f16` | f32 negate/subtract demoted to binary16 | **new** (A10) |
+
+### The rule
+
+A shape is demoted iff **the operation immediately feeding the narrowing** is an
+f32 arithmetic op whose operands the compiler can prove are binary16-representable.
+Whether that demotion is *observable* is a separate question:
+
+- **multiply or fma feeding the narrowing** → `v_fma_mixlo_f16`, and always
+  observable in these tests (A2, A7, A8, A12, A14, B1–B4). Double rounding
+  (round to binary32, then to binary16) genuinely differs from the single
+  rounding the fused form performs.
+- **add/sub feeding the narrowing** (A3, A4) → `v_add_f16`, **zero** observable
+  disagreements across the entire domain.
+- **`x *. x`** (A13) → `v_mul_f16`, and provably harmless: a product of two
+  binary16 values needs at most 22 significant bits, so it is *exact* in
+  binary32 and the demoted binary16 multiply rounds identically. Not luck — a
+  theorem about the operand widths.
+- **negation** (A10) → `v_sub_f16`, harmless because negation is exact in every
+  format.
+- **an op that is not the last before the narrowing** is not fused (A6, A15:
+  the multiply feeds an add, and the add is what reaches the narrowing).
+
+A3, A4, A10 and A13 are the important rows. They are **demoted in the machine
+code and clean in the numbers**. Had this audit been numeric-only it would have
+reported them as unaffected, and the conclusion "only multiplies are at risk"
+would have been drawn from a measurement that does not support it.
+
+## Reproduction
+
+```
+dune exec sarek-hip/test/test_hip_f16_shapes.exe   # numeric, all 63488 inputs
+scripts/f16_shape_isa_audit.sh                     # ISA, gfx1100
+```
+
+## What this does not settle
+
+- **gfx1100 and gfx1036 only.** Both are RDNA3/RDNA2-era. CDNA (MI200/MI300) and
+  older GCN are untested; the combine is an LLVM AMDGPU ISel pattern, so it
+  plausibly applies to all AMDGPU subtargets, but plausibly is not measured.
+- **One ROCm version**, the one installed on this machine.
+- **Sarek-emittable shapes only.** The audit is closed over what the Sarek DSL
+  can currently produce. If f16 ever stops being storage-only — an f16 literal,
+  an f16 arithmetic operator, an f16 intrinsic — the enumeration reopens and
+  this table is no longer complete.
+- **Transcendentals are excluded on purpose** (`sin`, `exp`, `log`, `pow`). Per
+  `docs/fp-contraction-policy.md` §1 their rounding is the oracle's own and a
+  device is not required to match bit-for-bit, so a disagreement there would not
+  be evidence of demotion.
+
+## Incidental defect found
+
+`Sarek_stdlib.Float32.abs_float` cannot be used in a kernel at all. Its native
+fallback lowers to `Sarek_cpu_runtime.Float32.abs_float`, which does not exist —
+the runtime function is named `abs`:
+
+```
+Error: Unbound value Sarek.Sarek_cpu_runtime.Float32.abs_float
+Hint:   Did you mean Sarek.Sarek_cpu_runtime.Float32.of_float?
+```
+
+The same name mismatch affects `expm1`, `log1p`, `hypot`, `copysign`, `fmod` and
+`minus`, all declared in `sarek/Sarek_stdlib/Float32.ml` with no counterpart in
+`sarek/interp/Sarek_float32.ml`. Not fixed here — out of scope for #106, and it
+wants its own test — but it is why this audit uses `0. -. x` for negation and
+`sqrt (x *. x)` rather than `sqrt (abs_float x)`.

--- a/sarek-hip/test/dune
+++ b/sarek-hip/test/dune
@@ -102,3 +102,30 @@
  (alias e2e-hip)
  (action
   (run %{dep:test_hip_f16_argcheck.exe})))
+
+; Exhaustive f16 expression-shape audit for AMDGPU fusion demotion (#106).
+; Sweeps every shape Sarek can emit over all 63488 finite binary16 inputs,
+; three ways: shipping path, generated source verbatim, generated source with
+; the sarek_f32_barrier body deleted. The third column is the harness's own
+; red-on-mutation control.
+
+(executable
+ (name test_hip_f16_shapes)
+ (modules test_hip_f16_shapes)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek.interp
+  sarek_codegen
+  sarek_ir
+  spoc_core
+  sarek_hip)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias e2e-hip)
+ (action
+  (run %{dep:test_hip_f16_shapes.exe})))

--- a/sarek-hip/test/test_hip_f16_shapes.ml
+++ b/sarek-hip/test/test_hip_f16_shapes.ml
@@ -1,0 +1,713 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Exhaustive f16 expression-shape audit for AMDGPU fusion demotion (issue #106)
+ *
+ * WHAT IS KNOWN
+ *
+ * An AMDGPU ISel combine fuses an f32 multiply into the f32->f16 narrowing that
+ * consumes it ([v_fma_mixlo_f16]) and demotes a neighbouring f32 add to
+ * binary16 ([v_add_f16]). It sits BELOW the C-level FP controls, so
+ * [-ffp-contract=off] does not prevent it. [Sarek_ir_cuda.sarek_f32_barrier]
+ * -- [asm volatile("" : "+v"(x))] on the narrowing's argument -- does.
+ * That was established on ONE expression shape (the [f16_midround] kernel,
+ * 620 of 63488 finite binary16 inputs disagreeing with the interpreter). The
+ * [v_add_f16] demotion shows the class is broader than multiply-then-narrow.
+ *
+ * WHAT THIS TEST DOES
+ *
+ * It enumerates the f16 expression shapes Sarek can actually emit and sweeps
+ * each one over the WHOLE finite binary16 domain -- all 63488 values, not a
+ * sample. That matters: a sampled f16 test was green for months while the
+ * 620-input defect was live.
+ *
+ * The enumeration is small, and closed, for a reason that is a property of the
+ * language rather than of this test. f16 in Sarek is a STORAGE-ONLY element
+ * type: [Sarek_typer] rejects f16 operands for every arithmetic, comparison,
+ * bitwise and unary operator; there is no [CFloat16] literal; there is no f16
+ * math intrinsic; f16 record/struct fields are rejected at layout; an f16
+ * scalar kernel parameter is rejected at lowering. The entire f16 surface is
+ * two core primitives, [float16_of_float32] and [float32_of_float16]. So the
+ * only value producer is [ECast (TFloat16, e)] for an f32-typed [e], and
+ * auditing "every f16 expression shape" reduces to auditing the shapes of [e]
+ * that can reach a narrowing, plus the two paths with no narrowing at all
+ * (a straight f16->f16 copy, and a widening whose result never narrows).
+ * That is what the shape table below covers.
+ *
+ * THREE COLUMNS, AND WHY
+ *
+ *   shipping     the ordinary Sarek path ([Execute.run_vectors]) -- the answer
+ *                to "is this shape correct today?"
+ *   src+barrier  the generated HIP source, run verbatim through [run_source]
+ *   src-barrier  the same source with the barrier's [asm volatile] body
+ *                deleted -- the answer to "is the barrier what is holding this
+ *                shape up?"
+ *
+ * [src+barrier] exists so that [src-barrier] differs from it in exactly one
+ * textual substitution and nothing else; comparing [shipping] against
+ * [src+barrier] checks that the [run_source] path is faithful. A shape whose
+ * [src-barrier] column is non-zero while [src+barrier] is zero is a shape the
+ * barrier is load-bearing for -- and that difference is this harness's own
+ * red-on-mutation control: if NO shape goes red when the barrier is removed,
+ * the harness is not sensitive to demotion at all and its zeros mean nothing.
+ * [main] fails on exactly that condition.
+ *
+ * ORACLE
+ *
+ * The interpreter. Its f16 narrowing is [Sarek_interp.Sarek_float16.to_float16]
+ * (a [Bigarray.Float16] store), and its f32 rounding is an [Int32] bit
+ * round-trip; the reference for each shape below composes those two the way the
+ * IR says the expression evaluates. Comparison is bit-exact -- there is no
+ * tolerance, because the claim is agreement, not closeness.
+ *
+ * Transcendentals ([sin], [exp], [log], [pow]) are deliberately NOT in the
+ * table. Per docs/fp-contraction-policy.md §1 their rounding is the oracle's
+ * own and a device is not required to match it bit-for-bit, so a disagreement
+ * there would not be evidence of demotion.
+ *
+ * Run:  dune exec sarek-hip/test/test_hip_f16_shapes.exe
+ ******************************************************************************)
+
+open Sarek
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+(* [Gpu] must be in scope at the top level: the PPX's native fallback names
+   core primitives as [Gpu.<prim>]. *)
+module Gpu = Sarek_stdlib.Gpu
+module Float32 = Sarek_stdlib.Float32
+
+let () = Sarek_hip.Hip_plugin.register ()
+
+(* ------------------------------------------------------------------ *)
+(* Oracle arithmetic                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(* The interpreter's binary16 narrowing. *)
+let round16 = Sarek_interp.Sarek_float16.to_float16
+
+(* Plain IEEE round-to-nearest-even binary32, as [test_hip_f16] uses: NOT
+   [Sarek_float32.to_float32], which additionally flushes subnormals and clamps
+   overflow (interpreter policy, not hardware behaviour). *)
+let f32 x = Int32.float_of_bits (Int32.bits_of_float x)
+
+let fma32 a b c = f32 (Float.fma a b c)
+
+(* Constants as the device sees them: the PPX emits float32 literals, so the
+   reference must use the binary32 value of each constant, not its binary64
+   one. [1.1] is the whole point -- [f32 1.1 <> 1.1]. *)
+let c11 = f32 1.1
+
+let c09 = f32 0.9
+
+let c1000 = 1000.0 (* exact in binary32 *)
+
+let c3 = 3.0 (* exact *)
+
+(* ------------------------------------------------------------------ *)
+(* The shapes                                                          *)
+(* ------------------------------------------------------------------ *)
+
+(* Every kernel has the same signature -- (out : float16 vector) (inp :
+   float16 vector) (n : int32) -- so one runner serves them all. [x] below is
+   always [float32_of_float16 inp.(tid)], the only way to get an f32 out of an
+   f16. *)
+
+let k_a1_roundtrip =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <- float16_of_float32 (float32_of_float16 inp.(tid))]
+
+let k_a2_mul =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <- float16_of_float32 (float32_of_float16 inp.(tid) *. 1.1)]
+
+let k_a3_add =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <- float16_of_float32 (float32_of_float16 inp.(tid) +. 1000.0)]
+
+let k_a4_sub =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <- float16_of_float32 (float32_of_float16 inp.(tid) -. 1000.0)]
+
+let k_a5_div =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <- float16_of_float32 (float32_of_float16 inp.(tid) /. 3.0)]
+
+let k_a6_mul_add =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32 ((float32_of_float16 inp.(tid) *. 1.1) +. 1000.0)]
+
+let k_a7_add_mul =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32 ((float32_of_float16 inp.(tid) +. 1000.0) *. 1.1)]
+
+let k_a8_fma =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32
+            (Float32.fma (float32_of_float16 inp.(tid)) 1.1 1000.0)]
+
+let k_a9_sqrt =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        let x = float32_of_float16 inp.(tid) in
+        out.(tid) <- float16_of_float32 (Float32.sqrt (x *. x))]
+
+let k_a10_neg =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <- float16_of_float32 (0.0 -. float32_of_float16 inp.(tid))]
+
+let k_a11_floor =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32
+            (Float32.floor (float32_of_float16 inp.(tid) *. 1.1))]
+
+let k_a12_cond =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        let x = float32_of_float16 inp.(tid) in
+        out.(tid) <- float16_of_float32 (if x > 0.0 then x *. 1.1 else x *. 0.9)]
+
+let k_a13_square =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        let x = float32_of_float16 inp.(tid) in
+        out.(tid) <- float16_of_float32 (x *. x)]
+
+let k_a14_mul_mul =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32 (float32_of_float16 inp.(tid) *. 1.1 *. 1.1)]
+
+let k_a15_mul_div_add =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        let x = float32_of_float16 inp.(tid) in
+        out.(tid) <- float16_of_float32 ((x *. 1.1) +. (x /. 3.0))]
+
+(* B family: the narrowing is MID-expression, so an unrounded intermediate can
+   survive into the result instead of being masked by the f16 store. B1 is the
+   shape that produced the original 620. *)
+
+let k_b1_midround =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32
+            (float32_of_float16
+               (float16_of_float32 (float32_of_float16 inp.(tid) *. 1.1))
+            +. 1000.0)]
+
+let k_b2_midround_mul =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32
+            (float32_of_float16
+               (float16_of_float32 (float32_of_float16 inp.(tid) *. 1.1))
+            *. 1.1)]
+
+let k_b3_midround_add_mul =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32
+            (float32_of_float16
+               (float16_of_float32 (float32_of_float16 inp.(tid) +. 1000.0))
+            *. 1.1)]
+
+let k_b4_double_mid =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then
+        out.(tid) <-
+          float16_of_float32
+            (float32_of_float16
+               (float16_of_float32
+                  (float32_of_float16
+                     (float16_of_float32 (float32_of_float16 inp.(tid) *. 1.1))
+                  +. 1000.0))
+            *. 1.1)]
+
+(* C family: no [ECast (TFloat16, _)] at all -- the two f16 paths where no
+   barrier is emitted, and none should be needed. *)
+
+let k_c1_copy =
+  [%kernel
+    fun (out : float16 vector) (inp : float16 vector) (n : int32) ->
+      let open Sarek_stdlib.Std in
+      let tid = global_thread_id in
+      if tid < n then out.(tid) <- inp.(tid)]
+
+(* ------------------------------------------------------------------ *)
+(* Shape table: kernel + its reference semantics                       *)
+(* ------------------------------------------------------------------ *)
+
+let ir_of (_, kirc) =
+  match kirc.Kirc_types.body_ir with Some ir -> ir | None -> failwith "no IR"
+
+type shape = {
+  id : string;
+  descr : string;
+  ir : Sarek_ir_types.kernel;
+  (* [x] is the exact binary16 input value, already representable. *)
+  reference : float -> float;
+}
+
+let shapes =
+  [
+    {
+      id = "A1";
+      descr = "narrow(widen x)              round trip";
+      ir = ir_of k_a1_roundtrip;
+      reference = (fun x -> round16 x);
+    };
+    {
+      id = "A2";
+      descr = "narrow(x *. 1.1)             mul -> narrow";
+      ir = ir_of k_a2_mul;
+      reference = (fun x -> round16 (f32 (x *. c11)));
+    };
+    {
+      id = "A3";
+      descr = "narrow(x +. 1000.)           add -> narrow";
+      ir = ir_of k_a3_add;
+      reference = (fun x -> round16 (f32 (x +. c1000)));
+    };
+    {
+      id = "A4";
+      descr = "narrow(x -. 1000.)           sub -> narrow";
+      ir = ir_of k_a4_sub;
+      reference = (fun x -> round16 (f32 (x -. c1000)));
+    };
+    {
+      id = "A5";
+      descr = "narrow(x /. 3.)              div -> narrow";
+      ir = ir_of k_a5_div;
+      reference = (fun x -> round16 (f32 (x /. c3)));
+    };
+    {
+      id = "A6";
+      descr = "narrow(x *. 1.1 +. 1000.)    mul,add -> narrow";
+      ir = ir_of k_a6_mul_add;
+      reference = (fun x -> round16 (f32 (f32 (x *. c11) +. c1000)));
+    };
+    {
+      id = "A7";
+      descr = "narrow((x +. 1000.) *. 1.1)  add,mul -> narrow";
+      ir = ir_of k_a7_add_mul;
+      reference = (fun x -> round16 (f32 (f32 (x +. c1000) *. c11)));
+    };
+    {
+      id = "A8";
+      descr = "narrow(fma x 1.1 1000.)      fma -> narrow";
+      ir = ir_of k_a8_fma;
+      reference = (fun x -> round16 (fma32 x c11 c1000));
+    };
+    {
+      id = "A9";
+      descr = "narrow(sqrt (x *. x))         mul,sqrt -> narrow";
+      ir = ir_of k_a9_sqrt;
+      reference = (fun x -> round16 (f32 (sqrt (f32 (x *. x)))));
+    };
+    {
+      id = "A10";
+      descr = "narrow(0. -. x)               negation -> narrow";
+      ir = ir_of k_a10_neg;
+      reference = (fun x -> round16 (f32 (0.0 -. x)));
+    };
+    {
+      id = "A11";
+      descr = "narrow(floor (x *. 1.1))     mul,floor -> narrow";
+      ir = ir_of k_a11_floor;
+      reference = (fun x -> round16 (f32 (Float.floor (f32 (x *. c11)))));
+    };
+    {
+      id = "A12";
+      descr = "narrow(if x>0 then .. else)  conditional -> narrow";
+      ir = ir_of k_a12_cond;
+      reference =
+        (fun x -> round16 (f32 (if x > 0.0 then x *. c11 else x *. c09)));
+    };
+    {
+      id = "A13";
+      descr = "narrow(x *. x)               square -> narrow";
+      ir = ir_of k_a13_square;
+      reference = (fun x -> round16 (f32 (x *. x)));
+    };
+    {
+      id = "A14";
+      descr = "narrow(x *. 1.1 *. 1.1)      chained mul -> narrow";
+      ir = ir_of k_a14_mul_mul;
+      reference = (fun x -> round16 (f32 (f32 (x *. c11) *. c11)));
+    };
+    {
+      id = "A15";
+      descr = "narrow(x*.1.1 +. x/.3.)      two products -> narrow";
+      ir = ir_of k_a15_mul_div_add;
+      reference = (fun x -> round16 (f32 (f32 (x *. c11) +. f32 (x /. c3))));
+    };
+    {
+      id = "B1";
+      descr = "mid-narrow then +. 1000.     [the original 620]";
+      ir = ir_of k_b1_midround;
+      reference = (fun x -> round16 (f32 (round16 (f32 (x *. c11)) +. c1000)));
+    };
+    {
+      id = "B2";
+      descr = "mid-narrow then *. 1.1";
+      ir = ir_of k_b2_midround_mul;
+      reference = (fun x -> round16 (f32 (round16 (f32 (x *. c11)) *. c11)));
+    };
+    {
+      id = "B3";
+      descr = "mid-narrow of add then *. 1.1";
+      ir = ir_of k_b3_midround_add_mul;
+      reference = (fun x -> round16 (f32 (round16 (f32 (x +. c1000)) *. c11)));
+    };
+    {
+      id = "B4";
+      descr = "two mid-narrows then *. 1.1";
+      ir = ir_of k_b4_double_mid;
+      reference =
+        (fun x ->
+          let m1 = round16 (f32 (x *. c11)) in
+          let m2 = round16 (f32 (m1 +. c1000)) in
+          round16 (f32 (m2 *. c11)));
+    };
+    {
+      id = "C1";
+      descr = "out.(i) <- inp.(i)           f16->f16 copy, NO cast";
+      ir = ir_of k_c1_copy;
+      reference = (fun x -> x);
+    };
+  ]
+
+(* ------------------------------------------------------------------ *)
+(* The exhaustive binary16 domain                                      *)
+(* ------------------------------------------------------------------ *)
+
+(* Exact value of a binary16 bit pattern; None for NaN/Inf. Both zeros and the
+   whole subnormal range are included. *)
+let f16_value_of_bits b =
+  let sign = if b land 0x8000 <> 0 then -1.0 else 1.0 in
+  let exp = (b lsr 10) land 0x1f and man = b land 0x3ff in
+  if exp = 31 then None
+  else if exp = 0 then Some (sign *. float_of_int man *. ldexp 1.0 (-24))
+  else Some (sign *. float_of_int (1024 + man) *. ldexp 1.0 (exp - 25))
+
+let sweep_inputs =
+  List.init 0x10000 (fun i -> i)
+  |> List.filter_map f16_value_of_bits
+  |> Array.of_list
+
+let m = Array.length sweep_inputs
+
+(* ------------------------------------------------------------------ *)
+(* Barrier neutralisation                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* The HIP arm of [Sarek_ir_cuda.sarek_f32_barrier_decl]. Deleting exactly this
+   statement turns the barrier into an identity function while leaving every
+   call site, and the rest of the generated source, byte-identical. *)
+let barrier_stmt = {|asm volatile("" : "+v"(x));|}
+
+let replace_once ~needle ~repl hay =
+  let nl = String.length needle and hl = String.length hay in
+  let rec go i =
+    if i + nl > hl then None
+    else if String.sub hay i nl = needle then Some i
+    else go (i + 1)
+  in
+  match go 0 with
+  | None -> None
+  | Some i ->
+      Some (String.sub hay 0 i ^ repl ^ String.sub hay (i + nl) (hl - i - nl))
+
+let count_sub needle hay =
+  let nl = String.length needle and hl = String.length hay in
+  let rec go i acc =
+    if i + nl > hl then acc
+    else if String.sub hay i nl = needle then go (i + 1) (acc + 1)
+    else go (i + 1) acc
+  in
+  go 0 0
+
+(* ------------------------------------------------------------------ *)
+(* Runners                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let block = 256
+
+let grid = (m + block - 1) / block
+
+let fresh_io () =
+  let inp = Vector.create Vector.float16 m in
+  Array.iteri (fun i x -> Vector.set inp i x) sweep_inputs ;
+  let out = Vector.create Vector.float16 m in
+  for i = 0 to m - 1 do
+    Vector.set out i (-999.0)
+  done ;
+  (inp, out)
+
+let run_shipping dev sh =
+  let inp, out = fresh_io () in
+  Execute.run_vectors
+    ~device:dev
+    ~ir:sh.ir
+    ~args:[Execute.Vec out; Execute.Vec inp; Execute.Int m]
+    ~block:(Execute.dims1d block)
+    ~grid:(Execute.dims1d grid)
+    () ;
+  Transfer.flush dev ;
+  Vector.to_array out
+
+let run_from_source dev sh ~source =
+  let inp, out = fresh_io () in
+  Execute.run_source
+    ~device:dev
+    ~source
+    ~lang:Execute.CUDA_Source
+    ~kernel_name:sh.ir.Sarek_ir_types.kern_name
+    ~block:(Execute.dims1d block)
+    ~grid:(Execute.dims1d grid)
+    [Execute.Vec out; Execute.Vec inp; Execute.Int32 (Int32.of_int m)] ;
+  Transfer.flush dev ;
+  Vector.to_array out
+
+(* Bit equality: OCaml [=] conflates -0.0 and 0.0, and both occur in the sweep
+   domain. *)
+let same_bits g e = Int64.bits_of_float g = Int64.bits_of_float e
+
+type result = {mismatches : int; first : (float * float * float) option}
+
+let compare_against_reference sh got =
+  let bad = ref 0 and first = ref None in
+  for i = 0 to m - 1 do
+    let g = got.(i) and e = sh.reference sweep_inputs.(i) in
+    if not (same_bits g e || (g <> g && e <> e)) then begin
+      incr bad ;
+      if !first = None then first := Some (sweep_inputs.(i), g, e)
+    end
+  done ;
+  {mismatches = !bad; first = !first}
+
+(* ------------------------------------------------------------------ *)
+(* Main                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let audit_device (dev : Device.t) =
+  Printf.printf
+    "\n=== %s (framework %s) ===\n"
+    dev.Device.name
+    dev.Device.framework ;
+  Printf.printf "exhaustive sweep over all %d finite binary16 inputs\n\n" m ;
+  Printf.printf
+    "  %-4s %-45s %10s %12s %12s\n"
+    "id"
+    "shape"
+    "shipping"
+    "src+barrier"
+    "src-barrier" ;
+  Printf.printf "  %s\n" (String.make 87 '-') ;
+  let any_barrier_sensitive = ref false in
+  let shipping_failures = ref [] in
+  let details = ref [] in
+  List.iter
+    (fun sh ->
+      let source =
+        Sarek_codegen.Sarek_ir_cuda.generate_with_types
+          ~types:sh.ir.Sarek_ir_types.kern_types
+          sh.ir
+      in
+      let has_barrier = count_sub barrier_stmt source in
+      (match Sys.getenv_opt "SAREK_F16_DUMP" with
+      | None -> ()
+      | Some dir -> (
+          let w suffix txt =
+            let oc = open_out (Filename.concat dir (sh.id ^ suffix ^ ".hip")) in
+            output_string oc txt ;
+            close_out oc
+          in
+          w "_barrier" source ;
+          match replace_once ~needle:barrier_stmt ~repl:"" source with
+          | Some patched -> w "_nobarrier" patched
+          | None -> ())) ;
+      let r_ship = compare_against_reference sh (run_shipping dev sh) in
+      let r_src =
+        compare_against_reference sh (run_from_source dev sh ~source)
+      in
+      let r_nobar, nobar_label =
+        if has_barrier = 0 then
+          (* No barrier in this shape's generated code at all: there is nothing
+             to neutralise, and that is itself a reportable fact. *)
+          ({mismatches = 0; first = None}, "n/a")
+        else
+          match replace_once ~needle:barrier_stmt ~repl:"" source with
+          | None -> assert false
+          | Some patched ->
+              (* Guard against a vacuous control. *)
+              assert (count_sub barrier_stmt patched = has_barrier - 1) ;
+              assert (String.length patched < String.length source) ;
+              ( compare_against_reference
+                  sh
+                  (run_from_source dev sh ~source:patched),
+                "" )
+      in
+      let show r lbl =
+        if lbl <> "" then lbl
+        else if r.mismatches = 0 then "0"
+        else string_of_int r.mismatches
+      in
+      Printf.printf
+        "  %-4s %-45s %10s %12s %12s\n"
+        sh.id
+        sh.descr
+        (show r_ship "")
+        (show r_src "")
+        (show r_nobar nobar_label) ;
+      if r_nobar.mismatches > 0 then any_barrier_sensitive := true ;
+      if r_ship.mismatches > 0 || r_src.mismatches > 0 then
+        shipping_failures := sh.id :: !shipping_failures ;
+      details := (sh, has_barrier, r_ship, r_src, r_nobar) :: !details)
+    shapes ;
+  Printf.printf "\n  witnesses (first disagreeing input per non-zero cell):\n" ;
+  List.iter
+    (fun (sh, has_barrier, r_ship, r_src, r_nobar) ->
+      let w lbl r =
+        match r.first with
+        | None -> ()
+        | Some (x, g, e) ->
+            Printf.printf
+              "    %-4s %-12s x=%.9g  device=%.9g  interpreter=%.9g  (%d/%d)\n"
+              sh.id
+              lbl
+              x
+              g
+              e
+              r.mismatches
+              m
+      in
+      w "shipping" r_ship ;
+      w "src+barrier" r_src ;
+      w "src-barrier" r_nobar ;
+      if has_barrier = 0 then
+        Printf.printf
+          "    %-4s no sarek_f32_barrier in generated code (no f16 narrowing \
+           to protect)\n"
+          sh.id)
+    (List.rev !details) ;
+  (!shipping_failures, !any_barrier_sensitive)
+
+let () =
+  let devs = Device.init () in
+  let hip =
+    Array.to_list devs |> List.filter (fun d -> d.Device.framework = "HIP")
+  in
+  if hip = [] then begin
+    print_endline "[SKIP] no HIP device available" ;
+    exit 0
+  end ;
+  print_endline
+    "=== f16 expression-shape audit for AMDGPU fusion demotion (issue #106) ===" ;
+  let results = List.map audit_device hip in
+  let failures = List.concat_map fst results in
+  let sensitive = List.exists snd results in
+  print_endline "" ;
+  if not sensitive then begin
+    (* Red-on-mutation control. Removing the barrier MUST break at least one
+       shape; if it does not, this harness cannot see demotion and every zero
+       above is uninformative. *)
+    print_endline
+      "[FAIL] control broken: neutralising sarek_f32_barrier changed nothing \
+       on any shape." ;
+    print_endline
+      "       This harness has not been shown to detect demotion, so its zeros \
+       mean nothing." ;
+    exit 1
+  end ;
+  if failures <> [] then begin
+    Printf.printf
+      "[FAIL] %d shape(s) disagree with the interpreter as shipped: %s\n"
+      (List.length failures)
+      (String.concat ", " (List.sort_uniq compare failures)) ;
+    exit 1
+  end ;
+  print_endline
+    "[PASS] every shape agrees with the interpreter as shipped, and the \
+     barrier is demonstrably load-bearing (removing it breaks at least one \
+     shape)."

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1307,3 +1307,30 @@
  (alias runtest)
  (action
   (run %{dep:test_vulkan_cache_device_scope.exe})))
+
+; Measurement (issue #126): does a Vulkan driver HONOUR the SPIR-V
+; NoContraction decoration that Sarek's `precise` float locals lower to?
+; Runs the same shader twice, differing only by `precise`, on every Vulkan
+; device present, and compares each contraction shape against a fused value
+; the DEVICE produced rather than an IEEE model.
+;
+; Classified e2e-gpu, deliberately: there is no Native/Interpreter fallback
+; (the whole point is what a specific driver does), so on a machine with no
+; Vulkan device it can only print [SKIP], and a [SKIP] sitting on the default
+; runtest alias is indistinguishable from a pass. It is NOT e2e-manual either -
+; it has a real failure mode and exits 1 on it: if an explicit fma() fails to
+; fuse, or a result matches neither candidate, the harness is not measuring
+; what it claims and says so. What it deliberately does NOT do is fail because
+; a driver's answer changed - that is a finding to record in
+; docs/fp-contraction-policy.md, not a build to break.
+
+(executable
+ (name test_vulkan_no_contraction)
+ (modules test_vulkan_no_contraction)
+ (optional)
+ (libraries sarek sarek_vulkan spoc_core))
+
+(rule
+ (alias e2e-gpu)
+ (action
+  (run %{dep:test_vulkan_no_contraction.exe})))

--- a/sarek/tests/e2e/test_vulkan_no_contraction.ml
+++ b/sarek/tests/e2e/test_vulkan_no_contraction.ml
@@ -1,0 +1,600 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E measurement: does the Vulkan driver HONOUR SPIR-V [NoContraction]?
+ *
+ * Issue #126. [Sarek_ir_glsl.gen_var_decl] prefixes every float local with
+ * GLSL [precise], which glslang lowers to a SPIR-V [NoContraction] decoration
+ * on each contributing arithmetic instruction. That the decoration is *emitted*
+ * is settled (compiler-output tier, glslc 2026.2 / SPIRV-Tools 1.4.350.1).
+ * Whether a driver *obeys* it is a separate question, and the two things
+ * written down in this repository disagreed about the answer for Mesa RADV:
+ * [Sarek_ir_glsl.ml] said [precise] was added because RADV needed it, campaign
+ * notes said RADV ignores it. Neither was backed by a measurement.
+ *
+ * THE DISCRIMINATOR
+ *
+ * With a = b = 1 + 2^-12 and c = -(1 + 2^-11), all three exactly representable
+ * in binary32:
+ *
+ *   exact a*b        = 1 + 2^-11 + 2^-24
+ *   fl32(a*b)        = 1 + 2^-11        (2^-24 is exactly half an ulp at 1.0;
+ *                                        ties-to-even rounds the trailing 1
+ *                                        away)
+ *   fl32(fl32(a*b)+c) = 0                <- separate  multiply then add
+ *   fl32(fma(a,b,c))  = 2^-24 = 5.96e-08 <- contracted multiply-add
+ *
+ * So a contracted evaluation is not a one-ulp wobble here: it is the difference
+ * between exactly zero and 5.96e-08. There is no way to read the result
+ * ambiguously, and no tolerance to choose.
+ *
+ * THE EXPERIMENT
+ *
+ * The same shader source is compiled twice, differing ONLY by the [precise]
+ * qualifier on the float locals (a [#define], so the two strings are otherwise
+ * character-identical), and both are run on the same device, same driver, same
+ * process. Reading the two columns together is what makes the result
+ * conclusive:
+ *
+ *   plain contracts, precise does not  -> NoContraction is HONOURED
+ *   both contract                      -> NoContraction is IGNORED
+ *   neither contracts                  -> the driver does not contract this
+ *                                         shape anyway; [precise] is untested
+ *                                         on it (no hazard, no evidence)
+ *
+ * Eight expression shapes are probed, because "honoured" is not necessarily a
+ * single yes/no: a driver may contract a mul-add but not a mul-sub, and
+ * [precise] forbids reassociation as well as contraction. Shape S4 is an
+ * explicit [fma()] call, which is a positive control in the other direction:
+ * it MUST come back fused, on both columns, or the harness is not measuring
+ * what it thinks it is.
+ *
+ * This test is deliberately NOT part of [runtest]: it is a measurement of a
+ * third-party driver, not a property of this repository, and a driver that
+ * starts contracting is a finding to record rather than a build to break. It
+ * exits 0 on any outcome except a broken harness (see [main]).
+ *
+ * Run:
+ *   dune exec sarek/tests/e2e/test_vulkan_no_contraction.exe
+ * Dump the exact two shader strings for offline glslc/spirv-dis inspection:
+ *   SAREK_NOCONTRACT_DUMP=/tmp/x dune exec \
+ *     sarek/tests/e2e/test_vulkan_no_contraction.exe
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Sarek_vulkan.Vulkan_plugin.init ()
+
+(* ------------------------------------------------------------------ *)
+(* binary32 reference arithmetic                                       *)
+(* ------------------------------------------------------------------ *)
+
+(* Round an OCaml binary64 to binary32, the same Int32 bit round-trip the
+   interpreter's oracle uses (Sarek_float32.to_float32). *)
+let f32 x = Int32.float_of_bits (Int32.bits_of_float x)
+
+(* Correctly-rounded fused multiply-add on binary32 operands. [Float.fma]
+   correctly rounds the exact a*b+c to binary64; rounding that on to binary32 is
+   benign double rounding, because binary64 carries 53 >= 2*24+2 bits of a
+   binary32 operand. *)
+let fma32 a b c = f32 (Float.fma a b c)
+
+(* ------------------------------------------------------------------ *)
+(* The shader                                                          *)
+(* ------------------------------------------------------------------ *)
+
+(* Buffer/push-constant layout matches Sarek's own GLSL calling convention
+   (vector lengths first, then user scalars) so this goes through the ordinary
+   [run_source] path with no special casing. *)
+let shader_body =
+  {|#version 450
+@PRECISE@
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(std430, set=0, binding = 0) readonly  buffer BufA { float a[]; };
+layout(std430, set=0, binding = 1) readonly  buffer BufB { float b[]; };
+layout(std430, set=0, binding = 2) readonly  buffer BufC { float c[]; };
+layout(std430, set=0, binding = 3) writeonly buffer BufO { float o[]; };
+
+layout(push_constant) uniform PushConstants {
+    int a_len; int b_len; int c_len; int o_len; int n;
+} pc;
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i < uint(pc.n)) {
+        P float av = a[i];
+        P float bv = b[i];
+        P float cv = c[i];
+
+        /* S0: multiply into a named local, then add */
+        P float q0 = av * bv;
+        P float r0 = q0 + cv;
+
+        /* S1: multiply then subtract, product on the LEFT  (q - c) */
+        P float q1 = av * bv;
+        P float r1 = q1 - cv;
+
+        /* S2: multiply then subtract, product on the RIGHT (c - q) */
+        P float q2 = av * bv;
+        P float r2 = cv - q2;
+
+        /* S3: multiply and add in ONE expression, no named product */
+        P float r3 = (av * bv) + cv;
+
+        /* S4: explicit fma() - positive control, MUST be fused */
+        P float r4 = fma(av, bv, cv);
+
+        /* S5: TwoProd error term - the df64 pattern that contraction kills */
+        P float q5 = av * bv;
+        P float r5 = fma(av, bv, -q5);
+
+        /* S6: left-associated sum  ((a+b)+c) */
+        P float s6 = av + bv;
+        P float r6 = s6 + cv;
+
+        /* S7: right-associated sum (a+(b+c)) */
+        P float s7 = bv + cv;
+        P float r7 = av + s7;
+
+        /* S8: loop-carried accumulation `acc += a*b` - the matrix_mul inner
+           loop, i.e. the shape `precise` was actually put in the codegen for.
+           The trip count is a push constant, so the loop cannot be unrolled
+           into a compile-time-constant straight line. */
+        P float acc = cv;
+        for (int k = 0; k < pc.n; ++k) {
+            acc = acc + av * bv;
+        }
+        P float r8 = acc;
+
+        /* S9, S10, S11: the MEASURED contracted value for S1, S2 and S8.
+           docs/fp-contraction-policy.md establishes that RADV's fma is not
+           correctly rounded, so predicting "what a contracted evaluation would
+           return" from an exact-fma model can be wrong on exactly this driver
+           -- and wrong in the dangerous direction, because a mispredicted
+           target makes a genuinely contracted result fail to match and the
+           shape reads as clean. Every contraction shape is therefore compared
+           against a sibling shape that asks the DEVICE for the fused value of
+           the same operands, not against an IEEE model. S4 plays that role for
+           S0 and S3. */
+        P float r9  = fma(av, bv, -cv);
+        P float r10 = fma(-av, bv, cv);
+
+        P float facc = cv;
+        for (int k = 0; k < pc.n; ++k) {
+            facc = fma(av, bv, facc);
+        }
+        P float r11 = facc;
+
+        o[i * 12u +  0u] = r0;
+        o[i * 12u +  1u] = r1;
+        o[i * 12u +  2u] = r2;
+        o[i * 12u +  3u] = r3;
+        o[i * 12u +  4u] = r4;
+        o[i * 12u +  5u] = r5;
+        o[i * 12u +  6u] = r6;
+        o[i * 12u +  7u] = r7;
+        o[i * 12u +  8u] = r8;
+        o[i * 12u +  9u] = r9;
+        o[i * 12u + 10u] = r10;
+        o[i * 12u + 11u] = r11;
+    }
+}
+|}
+
+(* The ONLY difference between the two compiled shaders: the expansion of [P].
+   [#version] must be the first token in a GLSL translation unit, so the
+   [#define] is substituted into the line after it rather than prepended. *)
+let source ~precise =
+  let marker = "@PRECISE@" in
+  let def = if precise then "#define P precise" else "#define P" in
+  let i =
+    let n = String.length marker and h = String.length shader_body in
+    let rec go k =
+      if k + n > h then failwith "shader marker missing"
+      else if String.sub shader_body k n = marker then k
+      else go (k + 1)
+    in
+    go 0
+  in
+  String.sub shader_body 0 i ^ def
+  ^ String.sub
+      shader_body
+      (i + String.length marker)
+      (String.length shader_body - i - String.length marker)
+
+(* ------------------------------------------------------------------ *)
+(* Inputs                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let p2 k = ldexp 1.0 k
+
+(* Each triple is exactly representable in binary32. *)
+let triples =
+  [|
+    (* T0: contraction probe. fl(fl(a*b)+c) = 0, fma(a,b,c) = 2^-24. *)
+    ( "T0 contraction",
+      f32 (1.0 +. p2 (-12)),
+      f32 (1.0 +. p2 (-12)),
+      f32 (-.(1.0 +. p2 (-11))) );
+    (* T1: reassociation probe. ((a+b)+c) = 1, (a+(b+c)) = 1+2^-23. *)
+    ("T1 reassociation", 1.0, p2 (-24), p2 (-24));
+    (* T2: contraction probe, opposite sign of c, so the mul-sub shapes S1/S2
+       are discriminating too. *)
+    ( "T2 contraction'",
+      f32 (1.0 +. p2 (-12)),
+      f32 (1.0 +. p2 (-12)),
+      f32 (1.0 +. p2 (-11)) );
+  |]
+
+let n_triples = Array.length triples
+
+let n_shapes = 12
+
+(* ------------------------------------------------------------------ *)
+(* Per-shape reference values                                          *)
+(* ------------------------------------------------------------------ *)
+
+(* [sep] is what the interpreter/IEEE-as-written semantics give: every
+   operation rounded. [alt] is what the shape degrades to if the compiler takes
+   the liberty [precise] is supposed to forbid - contraction for S0..S5,
+   reassociation for S6/S7. *)
+type shape = {
+  name : string;
+  liberty : string;
+  (* The value every operation-rounded-as-written evaluation must produce. *)
+  sep : float -> float -> float -> float;
+  (* What the shape degrades to if the compiler takes the liberty [precise]
+     forbids, computed from an IEEE model. Used for PRINTING and as the
+     fallback when no measured control exists. *)
+  alt : float -> float -> float -> float;
+  (* Index of the sibling shape that asks the DEVICE for the fused value of the
+     same operands. When present this, not [alt], is the target a contracted
+     result is recognised by -- see the S9/S10/S11 comment in the shader. *)
+  control : int option;
+}
+
+let shapes =
+  [|
+    {
+      name = "S0 q=a*b; q+c";
+      control = Some 4;
+      liberty = "contract";
+      sep = (fun a b c -> f32 (f32 (a *. b) +. c));
+      alt = (fun a b c -> fma32 a b c);
+    };
+    {
+      name = "S1 q=a*b; q-c";
+      control = Some 9;
+      liberty = "contract";
+      sep = (fun a b c -> f32 (f32 (a *. b) -. c));
+      alt = (fun a b c -> fma32 a b (-.c));
+    };
+    {
+      name = "S2 q=a*b; c-q";
+      control = Some 10;
+      liberty = "contract";
+      sep = (fun a b c -> f32 (c -. f32 (a *. b)));
+      alt = (fun a b c -> fma32 (-.a) b c);
+    };
+    {
+      name = "S3 (a*b)+c inline";
+      control = Some 4;
+      liberty = "contract";
+      sep = (fun a b c -> f32 (f32 (a *. b) +. c));
+      alt = (fun a b c -> fma32 a b c);
+    };
+    (* Positive control, stated the other way round: [sep] here is the FUSED
+       value, because an explicit fma() must fuse. If the device reports [alt]
+       the harness is broken (or the driver's fma is not an fma at all). *)
+    {
+      name = "S4 fma(a,b,c) CTL";
+      control = None;
+      liberty = "must fuse";
+      sep = (fun a b c -> fma32 a b c);
+      alt = (fun a b c -> f32 (f32 (a *. b) +. c));
+    };
+    {
+      name = "S5 fma(a,b,-a*b)";
+      control = None;
+      liberty = "contract";
+      sep = (fun a b _ -> fma32 a b (-.f32 (a *. b)));
+      alt = (fun _ _ _ -> 0.0);
+    };
+    {
+      name = "S6 s=a+b; s+c";
+      control = None;
+      liberty = "reassoc";
+      sep = (fun a b c -> f32 (f32 (a +. b) +. c));
+      alt = (fun a b c -> f32 (a +. f32 (b +. c)));
+    };
+    {
+      name = "S7 s=b+c; a+s";
+      control = None;
+      liberty = "reassoc";
+      sep = (fun a b c -> f32 (a +. f32 (b +. c)));
+      alt = (fun a b c -> f32 (f32 (a +. b) +. c));
+    };
+    (* The loop runs [n_triples] times, matching the shader's `k < pc.n`. *)
+    {
+      name = "S8 loop acc+=a*b";
+      control = Some 11;
+      liberty = "contract";
+      sep =
+        (fun a b c ->
+          let acc = ref c in
+          for _ = 1 to n_triples do
+            acc := f32 (!acc +. f32 (a *. b))
+          done ;
+          !acc);
+      alt =
+        (fun a b c ->
+          let acc = ref c in
+          for _ = 1 to n_triples do
+            acc := fma32 a b !acc
+          done ;
+          !acc);
+    };
+    (* S9/S10/S11 are the measured contracted targets for S1/S2/S8. Like S4
+       they are explicit fma() calls, so [sep] is the FUSED value and they are
+       integrity-checked: an explicit fma that does not fuse means the device
+       is not giving us a fused value to compare against at all. *)
+    {
+      name = "S9 fma(a,b,-c) CTL";
+      control = None;
+      liberty = "must fuse";
+      sep = (fun a b c -> fma32 a b (-.c));
+      alt = (fun a b c -> f32 (f32 (a *. b) -. c));
+    };
+    {
+      name = "S10 fma(-a,b,c) CTL";
+      control = None;
+      liberty = "must fuse";
+      sep = (fun a b c -> fma32 (-.a) b c);
+      alt = (fun a b c -> f32 (c -. f32 (a *. b)));
+    };
+    {
+      name = "S11 loop fma CTL";
+      control = None;
+      liberty = "must fuse";
+      sep =
+        (fun a b c ->
+          let acc = ref c in
+          for _ = 1 to n_triples do
+            acc := fma32 a b !acc
+          done ;
+          !acc);
+      alt =
+        (fun a b c ->
+          let acc = ref c in
+          for _ = 1 to n_triples do
+            acc := f32 (!acc +. f32 (a *. b))
+          done ;
+          !acc);
+    };
+  |]
+
+(* ------------------------------------------------------------------ *)
+(* Execution                                                           *)
+(* ------------------------------------------------------------------ *)
+
+let run_on (dev : Device.t) ~precise =
+  let a = Vector.create Vector.float32 n_triples in
+  let b = Vector.create Vector.float32 n_triples in
+  let c = Vector.create Vector.float32 n_triples in
+  let o = Vector.create Vector.float32 (n_triples * n_shapes) in
+  Array.iteri
+    (fun i (_, av, bv, cv) ->
+      Vector.set a i av ;
+      Vector.set b i bv ;
+      Vector.set c i cv)
+    triples ;
+  for i = 0 to (n_triples * n_shapes) - 1 do
+    Vector.set o i nan
+  done ;
+  Sarek.Execute.run_source
+    ~device:dev
+    ~source:(source ~precise)
+    ~lang:Sarek.Execute.GLSL_Source
+    ~kernel_name:"main"
+    ~block:(Sarek.Execute.dims1d 64)
+    ~grid:(Sarek.Execute.dims1d 1)
+    [
+      Sarek.Execute.Vec a;
+      Sarek.Execute.Vec b;
+      Sarek.Execute.Vec c;
+      Sarek.Execute.Vec o;
+      Sarek.Execute.Int32 (Int32.of_int n_triples);
+    ] ;
+  Transfer.flush dev ;
+  Vector.to_array o
+
+(* ------------------------------------------------------------------ *)
+(* Reporting                                                           *)
+(* ------------------------------------------------------------------ *)
+
+(* Position of a shape in [shapes], which is also its slot in the output
+   buffer -- the shader writes r0..r11 to o[i*12 + 0..11] in this order. *)
+let index_of sh =
+  let r = ref (-1) in
+  Array.iteri (fun i s -> if s.name = sh.name then r := i) shapes ;
+  if !r < 0 then failwith ("unknown shape " ^ sh.name) ;
+  !r
+
+let () =
+  if Array.length shapes <> n_shapes then
+    failwith "shapes array and n_shapes disagree with the shader layout"
+
+type verdict = Sep | Alt | Other | Undiscriminating
+
+let eq_bits x y = Int32.bits_of_float x = Int32.bits_of_float y
+
+(* The value a contracted (or reassociated) evaluation is recognised by. For
+   every contraction shape this is a value the DEVICE produced for the same
+   operands via an explicit fma(), never an IEEE model -- see the S9/S10/S11
+   comment in the shader. Only the reassociation shapes, which involve no
+   multiply and so no fma, fall back to the model. *)
+let target_of sh (_, a, b, c) col ti =
+  match sh.control with
+  | Some ci -> col.((ti * n_shapes) + ci)
+  | None -> sh.alt a b c
+
+let classify sh tr col ti =
+  let _, ta, tb, tc = tr in
+  let v = col.((ti * n_shapes) + index_of sh) in
+  let s = sh.sep ta tb tc in
+  let t = target_of sh tr col ti in
+  if eq_bits s t then Undiscriminating
+  else if eq_bits v s then Sep
+  else if eq_bits v t then Alt
+  else Other
+
+let verdict_str sh = function
+  | Sep -> if sh.liberty = "must fuse" then "fused(ok)" else "as-written"
+  | Alt -> (
+      match sh.liberty with
+      | "contract" -> "CONTRACTED"
+      | "reassoc" -> "REASSOCIATED"
+      | _ -> "NOT-FUSED")
+  | Other -> "other"
+  | Undiscriminating -> "-"
+
+let broken = ref false
+
+let report_device (dev : Device.t) =
+  let name = dev.Device.name in
+  Printf.printf "\n=== %s (framework %s) ===\n%!" name dev.Device.framework ;
+  let plain = run_on dev ~precise:false in
+  let prec = run_on dev ~precise:true in
+  (* Anchor check. The classification never uses the IEEE fma model for a
+     contraction shape, but whether the device AGREES with that model at these
+     operands is worth stating, because it is the assumption the original
+     design of this experiment would have rested on. *)
+  Array.iteri
+    (fun ti (tname, a, b, c) ->
+      let dev_fma = plain.((ti * n_shapes) + 4) in
+      let ieee_fma = fma32 a b c in
+      Printf.printf
+        "  fma anchor %-16s device %.17g  IEEE %.17g  %s\n"
+        tname
+        dev_fma
+        ieee_fma
+        (if eq_bits dev_fma ieee_fma then "agree"
+         else "DISAGREE - model-based targets would be wrong here"))
+    triples ;
+  Printf.printf "\n" ;
+  Printf.printf
+    "  %-20s %-16s | %-12s %-12s | %-24s %s\n"
+    "shape"
+    "triple"
+    "no-precise"
+    "precise"
+    "value(no-precise)"
+    "value(precise)" ;
+  Printf.printf "  %s\n" (String.make 108 '-') ;
+  let plain_contracted = ref 0 and prec_contracted = ref 0 and total = ref 0 in
+  Array.iter
+    (fun sh ->
+      Array.iteri
+        (fun ti tr ->
+          let tname, _, _, _ = tr in
+          let idx = (ti * n_shapes) + index_of sh in
+          let vp = plain.(idx) and vq = prec.(idx) in
+          let cp = classify sh tr plain ti and cq = classify sh tr prec ti in
+          if cp <> Undiscriminating || cq <> Undiscriminating then begin
+            Printf.printf
+              "  %-20s %-16s | %-12s %-12s | %-24.17g %.17g\n"
+              sh.name
+              tname
+              (verdict_str sh cp)
+              (verdict_str sh cq)
+              vp
+              vq ;
+            if sh.liberty = "contract" then begin
+              incr total ;
+              if cp = Alt then incr plain_contracted ;
+              if cq = Alt then incr prec_contracted
+            end ;
+            (* Harness integrity: an explicit fma() must fuse in both columns.
+               If it does not, it is not supplying a fused value and every
+               shape it is the control for is being compared to nothing. *)
+            if sh.liberty = "must fuse" && (cp <> Sep || cq <> Sep) then begin
+              Printf.printf
+                "    !! CONTROL BROKEN: %s did not fuse on this device; the \
+                 shapes it controls are not being measured\n"
+                sh.name ;
+              broken := true
+            end ;
+            if cp = Other || cq = Other then begin
+              let _, a, b, c = tr in
+              Printf.printf
+                "    !! neither candidate matched (as-written %.17g, \
+                 liberty-taken %.17g)\n"
+                (sh.sep a b c)
+                (target_of sh tr plain ti) ;
+              broken := true
+            end
+          end)
+        triples)
+    shapes ;
+  Printf.printf
+    "\n\
+    \  contraction summary on %s: no-precise %d/%d contracted, precise %d/%d \
+     contracted\n"
+    name
+    !plain_contracted
+    !total
+    !prec_contracted
+    !total ;
+  Printf.printf
+    "  -> %s\n%!"
+    (match (!plain_contracted > 0, !prec_contracted > 0) with
+    | true, false ->
+        "NoContraction is HONOURED (precise suppressed a real, observed \
+         contraction)"
+    | true, true ->
+        "NoContraction is IGNORED (the driver contracted despite the \
+         decoration)"
+    | false, false ->
+        "INCONCLUSIVE for contraction: this driver did not contract these \
+         shapes even when free to, so `precise` had nothing to suppress"
+    | false, true ->
+        "ANOMALY: `precise` introduced contraction that was absent without it")
+
+let () =
+  (match Sys.getenv_opt "SAREK_NOCONTRACT_DUMP" with
+  | None -> ()
+  | Some prefix ->
+      List.iter
+        (fun (suffix, precise) ->
+          let path = prefix ^ suffix ^ ".comp" in
+          let oc = open_out path in
+          output_string oc (source ~precise) ;
+          close_out oc ;
+          Printf.printf "wrote %s\n%!" path)
+        [("_plain", false); ("_precise", true)]) ;
+  let devs = Device.by_framework "Vulkan" in
+  if Array.length devs = 0 then
+    print_endline "[SKIP] no Vulkan device available"
+  else begin
+    print_endline
+      "=== SPIR-V NoContraction: is it honoured at execution? (issue #126) ===" ;
+    Printf.printf
+      "discriminator: a=b=1+2^-12, c=-(1+2^-11) -> as-written 0, contracted \
+       2^-24 = %.17g\n\
+       %!"
+      (ldexp 1.0 (-24)) ;
+    Array.iter report_device devs ;
+    if !broken then begin
+      print_endline
+        "\n[FAIL] harness integrity check failed - see the !! lines above" ;
+      exit 1
+    end ;
+    print_endline "\n[DONE] measurement complete"
+  end

--- a/scripts/f16_shape_isa_audit.sh
+++ b/scripts/f16_shape_isa_audit.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+#
+# ISA half of the f16 expression-shape audit (issue #106).
+#
+# test_hip_f16_shapes.exe answers "does this shape DISAGREE with the
+# interpreter". That is necessary but not sufficient: a shape can be demoted by
+# the AMDGPU ISel combine and still agree on every input, because the demoted
+# computation happens to be exact on the whole binary16 domain (A13 `x *. x` is
+# the clean example -- a product of two binary16 values needs at most 22
+# significant bits, so it is exact in binary32 and the demoted binary16
+# multiply rounds identically). A numeric null therefore cannot distinguish
+# "not demoted" from "demoted, harmless here" -- and the second is a latent
+# hazard, because the next expression shape may not be so lucky.
+#
+# This script settles that by disassembling each shape for gfx1100 with and
+# without the barrier and reporting which demotion opcodes appear.
+#
+# Usage:  scripts/f16_shape_isa_audit.sh [outdir]
+
+set -euo pipefail
+
+OUT="${1:-${TMPDIR:-/tmp}/sarek-f16-isa}"
+ARCH="${SAREK_F16_ARCH:-gfx1100}"
+ROCM="${ROCM_PATH:-/opt/rocm}"
+HIPCC="$ROCM/bin/hipcc"
+
+if [ ! -x "$HIPCC" ]; then
+  echo "hipcc not found at $HIPCC (set ROCM_PATH); skipping" >&2
+  exit 0
+fi
+
+mkdir -p "$OUT"
+
+# 1. Dump the generated HIP source for every shape, with and without the
+#    barrier. The test itself does the substitution, so what is compiled below
+#    is byte-for-byte what the runtime compiles.
+echo "==> dumping generated sources to $OUT"
+SAREK_F16_DUMP="$OUT" dune exec sarek-hip/test/test_hip_f16_shapes.exe >/dev/null
+
+# 2. Disassemble each. hiprtc implicitly includes the HIP runtime and fp16
+#    headers; hipcc does not, hence the two -include flags. -ffp-contract=off
+#    mirrors Hip_rtc.base_options -- the point of the exercise is that it does
+#    NOT prevent these combines.
+echo "==> compiling for $ARCH"
+for f in "$OUT"/*.hip; do
+  b="${f%.hip}"
+  "$HIPCC" -x hip -I"$ROCM/include" \
+    -include hip/hip_runtime.h -include hip/hip_fp16.h \
+    --offload-arch="$ARCH" -O3 -ffp-contract=off \
+    -S -o "$b.s" "$f" 2>/dev/null || echo "  ! failed: $(basename "$f")" >&2
+done
+
+# 3. Report. Any of these opcodes means an f32 operation was folded into, or
+#    demoted to, binary16:
+#      v_fma_mixlo_f16  an f32 multiply/fma fused into the f32->f16 narrowing
+#      v_add_f16        an f32 add/sub demoted to a binary16 add
+#      v_sub_f16        an f32 subtract/negate demoted to binary16
+#      v_mul_f16        an f32 multiply demoted to a binary16 multiply
+#    v_fma_mix_f32 is NOT in the list: it keeps an f32 result and is how an
+#    explicitly requested fma() is meant to be emitted.
+DEMOTE='v_fma_mixlo_f16|v_mad_mixlo_f16|v_add_f16|v_sub_f16|v_mul_f16'
+
+printf '\n%-6s %-34s %s\n' "shape" "with barrier" "barrier removed"
+printf '%-6s %-34s %s\n' "-----" "----------------------------------" \
+  "----------------------------------"
+for f in "$OUT"/*_barrier.s; do
+  case "$f" in *_nobarrier.s) continue ;; esac
+  id="$(basename "$f" _barrier.s)"
+  nb="$OUT/${id}_nobarrier.s"
+  [ -f "$nb" ] || continue
+  # `grep` exits 1 when a shape has no demotion at all -- which is the
+  # RESULT, not an error. Without the `|| true` the pipeline fails under
+  # `set -o pipefail` and the whole report silently comes out empty.
+  fmt() {
+    { grep -oE "$DEMOTE" "$1" || true; } | sort | uniq -c \
+      | awk '{printf "%sx%s ", $1, $2}'
+  }
+  a="$(fmt "$f")"; b="$(fmt "$nb")"
+  printf '%-6s %-34s %s\n' "$id" "${a:-(none)}" "${b:-(none)}"
+done
+
+echo
+echo "A non-empty 'with barrier' cell is a REGRESSION: the barrier is supposed"
+echo "to leave every narrowing as a standalone v_cvt_f16_f32."


### PR DESCRIPTION
Closes #126. Closes #106.

Two measurement questions, both answerable on the AMD hardware on this machine, neither needing NVIDIA.

> **Rebased onto `main` now that #304 and #298 have landed.** Single commit, 8 files, no stacking. Cherry-picked explicitly rather than rebased — `git rebase` dropped the commit as "already applied" when it demonstrably was not, so the five new files were verified present on disk and in `git show --stat` afterwards rather than trusting an exit code.

---

## #126 — does a Vulkan driver *honour* SPIR-V `NoContraction`?

That the decoration is **emitted** was already settled. Whether a driver **obeys** it was not, and the two things written down in this repository disagreed:

- `Sarek_ir_glsl.ml` said `precise` was added *because* RADV was observed simplifying error-free transformations — implying RADV honours it.
- Campaign notes said the opposite, that Mesa ANV and RADV ignore it.

Neither was backed by a recorded measurement. §6 of the new policy doc recorded this as an open dispute.

### The experiment

`sarek/tests/e2e/test_vulkan_no_contraction.ml`. The same shader is compiled twice, differing **only** by the expansion of a `#define` that adds or omits `precise` on the float locals, and both run on the same device, same driver, same process.

With `a = b = 1 + 2^-12` and `c = -(1 + 2^-11)`, all exactly representable in binary32:

```
fl32(fl32(a*b) + c) = 0                  <- multiply then add
fl32(fma(a, b, c))  = 2^-24 = 5.96e-08   <- contracted
```

Exactly zero against 5.96e-08 — no tolerance to choose, no ambiguous reading.

**The contracted target is measured, not modelled.** The policy doc establishes in the same table that RADV's `fma` is not correctly rounded, so predicting the fused value from an exact-fma model can be wrong on precisely this driver — and wrong in the dangerous direction, because a mispredicted target makes a genuinely contracted result match *neither* candidate and the shape reads as clean. Every contraction shape is therefore compared against a sibling shape that asks **the device** for the fused value of the same operands (`S4`, `S9`, `S10`, `S11`), and those siblings are themselves integrity-checked: an explicit `fma()` that fails to fuse fails the run rather than reporting.

Twelve shapes, because "honoured" need not be one yes/no — multiply into add, into subtract from either side, with and without a named intermediate, the TwoProd error term, two reassociation probes, and a **loop-carried `acc += a*b` with a non-constant trip count**, i.e. the `matrix_mul` inner loop that `precise` was actually put in the codegen for.

### The result

**RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1:**

| | no `precise` | `precise` |
|---|---|---|
| contraction shapes contracted | **0 of 7** | **0 of 7** |
| reassociation shapes reassociated | 0 of 2 | 0 of 2 |
| explicit `fma()` controls fused | 4 of 4 | 4 of 4 |

Identical on both devices. Confirmed at machine-code level with `RADV_DEBUG=asm`: the RDNA ISA is **opcode-for-opcode identical** between the two builds, and in the *non*-`precise` build — where the driver is completely free to fuse — the multiply and the add are separate `v_mul_f32` / `v_add_f32`. The `v_fma_f32` instructions present are exactly the explicitly-requested `fma()` calls.

Decoration emission re-checked on both toolchains, since the runtime path uses `glslangValidator` and not `glslc`: 18 `NoContraction` with `precise`, 0 without, from both.

### So, plainly

**Both in-tree claims are refuted.** RADV does not ignore `NoContraction` — it never produced a contracted result at all. And `precise` was not needed to stop RADV contracting — with it stripped, RADV still does not contract, and the ISA does not change.

What is **not** established is that RADV would honour `NoContraction` if it ever did want to contract. This is an absence of the hazard on this driver and version, not a demonstration of obedience. The honest status of `precise` on RADV: **inert, and free**. Keep emitting it for portability; do not credit it with holding anything up.

This also keeps the two questions separate, as it should: RADV's df64 mul/div deviation (~5.8e-08) has a different, already-recorded cause — `fma` is not correctly rounded — and this result *confirms* that by elimination, since RADV is not contracting at all.

### Hardware gap, stated explicitly

**Mesa ANV is not measured. There is no Intel GPU on this machine**, and the experiment requires executing on the driver in question. Recorded as §7a of the policy doc rather than left implicit — nothing here licenses any statement about ANV in either direction, and the campaign note about ANV remains unverified. Anyone with Intel hardware closes it in one run; the test enumerates every Vulkan device present and needs no configuration. AMDVLK and the proprietary AMD driver are unmeasured for the same reason.

---

## #106 — audit ALL f16 expression shapes for AMDGPU fusion demotion

### The enumeration is closed, not sampled

f16 is a **storage-only** element type in Sarek: the typer rejects f16 operands for every arithmetic, comparison, bitwise and unary operator; there is no f16 literal, no f16 math intrinsic, no f16 struct field, no f16 scalar parameter. The whole f16 surface is two core primitives. So the only value producer is `ECast (TFloat16, e)`, and "audit every f16 shape" reduces to auditing the shapes of `e` that can reach a narrowing, plus the two paths with no narrowing at all. That is a closed enumeration.

### Calibrated against a known positive before its nulls were trusted

Shape **B1 returns exactly 620** with the barrier removed, matching the originally reported 620 of 63488. The harness was shown to detect this defect class before any of its zeros were relied on — which is the whole point, since the original 620 hid behind a *sampled* f16 test that was green for months. The test now enforces this permanently: if removing the barrier breaks **no** shape, it exits non-zero on the grounds that its zeros are uninformative.

### Results — all 63488 finite binary16 inputs, gfx1100 and gfx1036

| id | shape (`x` = `float32_of_float16 inp.(i)`) | ship | +bar | −bar | ISA without barrier | verdict |
|---|---|---|---|---|---|---|
| A1 | `narrow x` | 0 | 0 | 0 | *(collapses to 16-bit load/store)* | unaffected |
| A2 | `narrow (x *. 1.1)` | 0 | 0 | **2913** | `v_fma_mixlo_f16` | **affected** |
| A3 | `narrow (x +. 1000.)` | 0 | 0 | 0 | `v_add_f16` | **demoted, unobservable** |
| A4 | `narrow (x -. 1000.)` | 0 | 0 | 0 | `v_add_f16` | **demoted, unobservable** |
| A5 | `narrow (x /. 3.)` | 0 | 0 | 0 | `cvt` + `v_fma_mix_f32`×2 | unaffected |
| A6 | `narrow (x *. 1.1 +. 1000.)` | 0 | 0 | 0 | `cvt` | unaffected |
| A7 | `narrow ((x +. 1000.) *. 1.1)` | 0 | 0 | **374** | `v_fma_mixlo_f16` | **affected** |
| A8 | `narrow (fma x 1.1 1000.)` | 0 | 0 | **484** | `v_fma_mixlo_f16` | **affected** |
| A9 | `narrow (sqrt (x *. x))` | 0 | 0 | 0 | `cvt` | unaffected |
| A10 | `narrow (0. -. x)` | 0 | 0 | 0 | `v_sub_f16` | **demoted, unobservable** |
| A11 | `narrow (floor (x *. 1.1))` | 0 | 0 | 0 | `cvt` | unaffected |
| A12 | `narrow (if x>0. then x*.1.1 else x*.0.9)` | 0 | 0 | **2864** | `v_fma_mixlo_f16` | **affected** |
| A13 | `narrow (x *. x)` | 0 | 0 | 0 | `v_mul_f16` | **demoted, unobservable** |
| A14 | `narrow (x *. 1.1 *. 1.1)` | 0 | 0 | **309** | `v_fma_mixlo_f16` | **affected** |
| A15 | `narrow (x *. 1.1 +. x /. 3.)` | 0 | 0 | 0 | `cvt` | unaffected |
| B1 | mid-narrow then `+. 1000.` | 0 | 0 | **620** | `v_add_f16` + `v_fma_mixlo_f16` | **affected** *(the original)* |
| B2 | mid-narrow then `*. 1.1` | 0 | 0 | **5369** | `v_fma_mixlo_f16`×2 | **affected** |
| B3 | mid-narrow of add then `*. 1.1` | 0 | 0 | **963** | `v_add_f16` + `v_fma_mixlo_f16` | **affected** |
| B4 | two mid-narrows then `*. 1.1` | 0 | 0 | **1518** | `v_add_f16` + `v_fma_mixlo_f16`×2 | **affected** |
| C1 | `out.(i) <- inp.(i)` (no cast) | 0 | 0 | 0 | *(load/store only)* | unaffected |

**With the barrier, every shape's narrowing is a standalone `v_cvt_f16_f32`** — the ISA column for the shipping configuration is empty of demotion opcodes for all 20.

### Every shape is correct as shipped

**0 mismatches out of 63488, all 20 shapes, both devices.** No currently-emittable f16 expression shape disagrees with the interpreter.

### Which barrier fixes each: one barrier, all of them

9 of 20 shapes break when the barrier is removed, and the *same single* mechanism — `sarek_f32_barrier`'s `asm volatile("" : "+v"(x))` — fixes every one. No shape needs a different or additional barrier.

### Why the ISA half was necessary

A numeric null **cannot distinguish "not demoted" from "demoted but exact on this domain"**, and the second is a latent hazard. Four rows are exactly that: **A3, A4, A10 and A13 are demoted in the machine code and clean in the numbers.** A numeric-only audit would have reported them unaffected and supported the conclusion "only multiplies are at risk" — which the measurement does not support.

A13 is provably harmless (a product of two binary16 values needs at most 22 significant bits, so it is exact in binary32 and the demoted binary16 multiply rounds identically) and A10 likewise (negation is exact in every format). A3/A4 are not provably anything — just currently quiet.

### Four demotion opcodes, not two

| opcode | what it does | status |
|---|---|---|
| `v_fma_mixlo_f16` | f32 multiply/fma fused **into** the narrowing | already known |
| `v_add_f16` | f32 add/sub demoted to binary16 | already known |
| `v_mul_f16` | f32 multiply demoted to binary16 | **new** (A13) |
| `v_sub_f16` | f32 negate/subtract demoted to binary16 | **new** (A10) |

### The rule

A shape is demoted iff **the operation immediately feeding the narrowing** is an f32 arithmetic op whose operands the compiler can prove are binary16-representable. An op that is *not* last before the narrowing is not fused — A6 and A15 are clean because the multiply feeds an add and the add is what reaches the narrowing.

---

## Merging with #298's NVIDIA measurements

The rebase conflicted in five hunks of `docs/fp-contraction-policy.md`, all of them rows carrying **measured figures** — mine from RADV, `main`'s now from #298 on GTX 1070 / sm_61 / CUDA 12.9. I resolved by **ownership rather than by picking a side**: RADV rows from here, NVIDIA rows from #298, kept verbatim. Concretely:

- **Two claims my branch carried are retired, not merged.** #298 executed f16 on NVIDIA (0/63488 on sm_61 via CUDA/C, liveness control 63085/63488), so "HIP/AMDGPU is the only backend where the f16 discipline has been confirmed by execution" and §7's "no f16 kernel has ever been executed on an NVIDIA GPU" are both **false now** and are gone. My contribution to that bullet is narrowed to what it actually shows: that the AMDGPU confirmation covers *every emittable shape*, not that it is the only one.
- **§7 stays #298's.** It is now NVIDIA-scoped and well-structured, so rather than retitle it I added the Intel/ANV gap as the first entry in its "still open" list, flagged as a hardware gap that is not an NVIDIA one. §6 points there.
- **My RADV figures now use #298's register.** `df64 mul 5.84e-08 / div 5.86e-08` is stated as *the measured worst-case relative error over `test_df64`'s own input set, on the named device and driver* — a maximum observed, not a bound proved, and agreement between two such maxima is agreement between summary statistics, not element-wise identity.
- The §6 result itself is unchanged and needed no reconciliation: it concerns a different vendor's driver entirely.

Both measurements were re-run from the rebased tree and reproduce identically — 0/7 contraction shapes on both RADV devices; 0 mismatches shipped across all 20 f16 shapes, B1 still exactly 620 with the barrier removed.

## Wiring — and the gate that caught me

The first push of this PR had `test_vulkan_no_contraction` declared as an `(executable)` **attached to no alias**. `scripts/check-test-alias-coverage.sh` refused it:

```
UNWIRED: test_vulkan_no_contraction is declared in sarek/tests/e2e/dune
         but referenced by no alias or run rule
```

That is the last entry in the very taxonomy this PR is about — a declaration wired to nothing, a test that exists and compiles and never runs, whose absence is indistinguishable from success. I wrote the experiment that settles #126 and left it unreachable. The gate did its job.

It is now on **`e2e-gpu`**, chosen deliberately against the taxonomy in `sarek/tests/e2e/dune`:

- **not plain `runtest`** — there is no Native/Interpreter fallback (the whole point is what a *specific driver* does), so on a machine with no Vulkan device it can only print `[SKIP]`, and a `[SKIP]` sitting on `runtest` is indistinguishable from a pass. That is the same failure mode one rung down.
- **not `e2e-manual`** — it has a real failure mode and exits 1 on it: an explicit `fma()` that fails to fuse, or a result matching neither candidate, means the harness is not measuring what it claims.
- **`e2e-gpu`** — "GPU-required, no Native/Interpreter fallback exists". Correct classification.

What it deliberately does *not* do is fail because a driver's answer changed; that is a finding to record in the policy doc, not a build to break.

And rather than trust the declaration a second time, I confirmed the wiring **executes** and is **fail-closed**:

| check | result |
|---|---|
| `dune build @e2e-gpu` | runs the test — measurement output present, exit 0 |
| `dune build @e2e-hip` | runs the f16 audit — `A2 … 2913`, `B1 … 620` present, exit 0 |
| `@e2e-gpu` with S0's reference corrupted | `!! neither candidate matched`, **exit 1** |
| `scripts/check-test-alias-coverage.sh` | `OK: all 81 e2e test executables are wired to an alias` |

`ci/assert-toolchain.sh` is untouched by this PR and keeps upstream's `EXPECTED_CHECKS=12`. `dune build @fmt` exits 0 (my two new files needed promoting after #312's drift fix).

**One thing I backed out, and why.** I had added a missing SPDX header to `scripts/check-test-alias-coverage.sh`. On checking, `check-license-headers.sh` is **not** run by `.github/workflows/ci.yml` (only `check-test-alias-coverage.sh` is), and **8 further scripts on `main`** fail it identically — `agent-worktree-bootstrap.sh`, `check-review-bundle-tracked.sh`, `check-scope-diff.sh`, `roster-implement-posthook.sh`, `xruntime-exec.sh` and their tests. Fixing exactly one of nine in a measurement PR is arbitrary, so I reverted it. Flagging it instead: the shell-script half of the license gate is failing on `main` and nothing is enforcing it.

## Both harnesses proved red before being trusted

| harness | mutation | result |
|---|---|---|
| `test_hip_f16_shapes` | drop the binary16 narrowing from A2's reference | 57720/63488 mismatches, exit 1 |
| `test_vulkan_no_contraction` | corrupt S0's as-written reference | `!! neither candidate matched`, exit 1 |

Also fixed while writing the ISA script: a `set -o pipefail` interaction where `grep`'s "no match" exit status aborted the report, so it printed an **empty table that read as clean**.

## Not settled

- **Mesa ANV** — no Intel GPU on this machine (above). Likewise AMDVLK and the proprietary AMD Vulkan driver.
- **Whether RADV would honour `NoContraction` if it wanted to contract.** Unfalsifiable while the driver does not contract; this measures the absence of the hazard, not obedience.
- **CDNA and older GCN** for #106. gfx1100 and gfx1036 only. The combine is an LLVM AMDGPU ISel pattern so it plausibly generalises — plausibly is not measured.
- **One Mesa version and one ROCm version**, the ones installed here.
- **Transcendentals** (`sin`, `exp`, `log`, `pow`) excluded from the f16 audit on purpose — per policy §1 their rounding is the oracle's own and a device need not match bit-for-bit, so a disagreement would not be evidence of demotion.

## Incidental defect found, not fixed

`Sarek_stdlib.Float32.abs_float` cannot be used in a kernel at all — its native fallback lowers to `Sarek_cpu_runtime.Float32.abs_float`, which does not exist (the runtime function is named `abs`). Same mismatch for `expm1`, `log1p`, `hypot`, `copysign`, `fmod` and `minus`. Out of scope for #106 and it wants its own test; recorded in the audit doc, and it is why the audit uses `0. -. x` and `sqrt (x *. x)`.

## Files

| file | |
|---|---|
| `sarek/tests/e2e/test_vulkan_no_contraction.ml` | new — the #126 experiment |
| `sarek-hip/test/test_hip_f16_shapes.ml` | new — the #106 numeric audit |
| `scripts/f16_shape_isa_audit.sh` | new — the #106 ISA audit |
| `docs/optimization/amdgpu-f16-fusion-shape-audit.md` | new — full #106 write-up |
| `docs/fp-contraction-policy.md` | §6 rewritten with the measured answer; Vulkan and HIP rows re-tiered to executed + machine-code; §7a records the ANV hardware gap |
| `sarek/tests/e2e/dune`, `sarek-hip/test/dune` | wiring — `e2e-gpu` and `e2e-hip` rules that actually execute |
| `CHANGES.md` | entries |

Neither test is on plain `runtest` — both measure third-party compilers and drivers, and both need a device — but both are on an executing alias (`e2e-gpu` / `e2e-hip`), not merely declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded floating-point contraction guidance with measured Vulkan and AMDGPU behavior, backend limitations, and supported guarantees.
  * Added detailed AMDGPU f16 fusion and demotion audit documentation.

* **Tests**
  * Added a Vulkan GPU test covering `precise` and `NoContraction` behavior.
  * Added exhaustive HIP/AMDGPU f16 expression-shape validation across finite binary16 values.
  * Added an ISA audit helper for reviewing generated GPU instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->