### PR TITLE
chore: restore @fmt cleanliness on main

### DIFF
--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -662,12 +662,13 @@ let gen_helper_signature buf (hf : helper_func) =
 (** Forward declaration for a helper.
 
     Emitted for every helper BEFORE any definition, because [kern_funcs] carries
-    no ordering guarantee: a caller listed before its callee produced [error: use
-    of undeclared identifier 'g'] — invalid OpenCL C that depended purely on list
-    order. Found by the #128 sweep once the recursion classifier stopped refusing
-    helper-to-helper calls; no golden kernel has helpers, which is why the corpus
-    never showed it. Declaring all of them up front makes the order irrelevant
-    rather than relying on the IR producer to topologically sort. *)
+    no ordering guarantee: a caller listed before its callee produced
+    [error: use of undeclared identifier 'g'] — invalid OpenCL C that depended
+    purely on list order. Found by the #128 sweep once the recursion classifier
+    stopped refusing helper-to-helper calls; no golden kernel has helpers, which
+    is why the corpus never showed it. Declaring all of them up front makes the
+    order irrelevant rather than relying on the IR producer to topologically
+    sort. *)
 let gen_helper_proto buf (hf : helper_func) =
   gen_helper_signature buf hf ;
   Buffer.add_string buf ");\n"

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1277,6 +1277,7 @@
  (alias runtest)
  (action
   (run %{dep:test_ematch_payload_e2e.exe})))
+
 (rule
  (alias runtest)
  (action


### PR DESCRIPTION
`dune build @fmt` fails on current `main`, which red-lights every open PR now that #310 has landed the fmt gate.

Two files, both merged **before** the gate existed:

| File | Origin |
|---|---|
| `sarek/tests/e2e/dune` | missing blank line between two `rule` stanzas — introduced by my hand resolution of the #302 conflict after #306 moved the file |
| `sarek/codegen/Sarek_ir_opencl.ml` | helper-prototype block from #309 |

This is not a hole in the gate. #310 added `@fmt` enforcement, but #302 and #309 merged ahead of it, so their drift was never checked. The gate is correctly reporting a backlog it inherited on its first day.

Fixed with `dune build @fmt --auto-promote`. `dune build @fmt` now exits 0 repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)