### PR TITLE
f16 slice 2b (GLSL/Vulkan): RADV fuses too, and worse — refused by measurement

### DIFF
--- a/docs/design/f16-dsl-element-type.md
+++ b/docs/design/f16-dsl-element-type.md
@@ -960,6 +960,71 @@ conversions.
 > 2. *Port the property, not the patch.* The HIP work delivered a barrier; what
 >    was actually reusable was the exhaustive-sweep harness and the bit-identity
 >    property. The barrier itself did not survive a change of front end.
+
+> ### CORRECTION — and for GLSL/Vulkan too, worse than for OpenCL
+>
+> **VERIFIED BY EXECUTION** (#57 slice 2b, 2026-07-26). Rule 1 above told slice
+> 2b to *assume* RADV carries the defect and to *measure* rather than infer it.
+> Measured: it does. Exhaustive sweep of all 63488 finite binary16 inputs, on
+> both local devices (RX 7900 XTX / **RADV NAVI31** and the Raphael iGPU / **RADV
+> RAPHAEL_MENDOCINO**, Mesa 26.1.4-arch3.1, Vulkan 1.4.354), against a
+> host implementation of §6.2's discipline. Both devices report identical
+> counts. The oracle was calibrated first: the same host code reproduces the
+> **620** figure on the HIP/OpenCL kernel shape, and a barriered kernel agrees
+> bit-exactly on all 63488, so the harness is shown able to go both ways before
+> either verdict is read.
+>
+> | kernel shape / source-level defence | disagreements with the discipline |
+> |---|---|
+> | `f16(x*1.1)`, plain | **2912/63488** |
+> | `f16(x*1.1)`, `precise` on the f32 local | **2912/63488** |
+> | `f16(f16(x*1.1) + 1000)`, plain | **5075/63488** |
+> | `f16(f16(x*1.1) + 1000)`, `precise` (what the backend already emits) | **4776/63488** |
+> | … with an f16 bitcast round-trip | 5075/63488 |
+> | … with a volatile SSBO round-trip on the f32 intermediates | 4774/63488 |
+> | … volatile SSBO round-trip **including the f16 bit pattern** | **0/63488** |
+>
+> **Three things this changes, none of which were predictable from the OpenCL
+> result.**
+>
+> *Same locus, different severity.* Rule 1 was right that ACO is the locus, and
+> wrong to imply the count would follow. Through OpenCL C the combine swallows
+> the multiply only. Through SPIR-V it also swallows the f32 **add**: the plain
+> two-narrowing kernel compiles to a *single* `v_fma_mixlo_f16 1.1, x, 1000.0f`
+> — one rounding for an expression the DSL says has three. "One bug seen three
+> times" is right about the compiler and wrong about the blast radius; a third
+> front end is still worth measuring even once the locus is known.
+>
+> *`precise` works, and does not help.* This is the load-bearing result and it
+> resolves a contradiction §6 of `fp-contraction-policy.md` had left open. With
+> `precise` on the f32 local, ACO emits `v_fma_mix_f32 1.1, x, -0` — the
+> multiply survives as its own correctly-rounded f32 operation — and without it,
+> the multiply vanishes into the narrowing. So RADV demonstrably **does** honour
+> SPIR-V `NoContraction`. It simply does not reach: absorbing a *conversion* is
+> a different combine from contracting `a*b+c`, and only the latter is what
+> `NoContraction` forbids. The tempting inference from #106/#126 — "we already
+> emit `precise`, and RADV was measured not to contract 7 f32 shapes, so f16 is
+> safe" — is therefore false, and is now guarded by a named test case.
+>
+> *No affordable barrier, again, and for a new reason.* On OpenCL the working
+> barriers cost memory traffic. Here even that is not enough at the
+> two-narrowing shape: barriering the f32 intermediates makes ACO drop the
+> intermediate narrowing **entirely** rather than materialise a binary16 value
+> (4774/63488, matching a "narrowing elided" model exactly). Only forcing the
+> f16 *bit pattern* through memory restores the discipline.
+>
+> **Outcome: GLSL/Vulkan f16 stays rejected**, with the same shape of
+> justification as OpenCL — a measured refusal plus a tripwire
+> (`sarek-vulkan/test/test_vulkan_f16_tripwire.ml`) that goes red the day the
+> fusion disappears.
+>
+> **A fourth rule, from the shape of this slice.** *A defence that is verified
+> at one layer is not verified at the layer above it.* `precise` →
+> `NoContraction` was verified as far as the SPIR-V (§6, compiler-output tier)
+> and has now been verified as far as the ISA — and it is still the wrong
+> instrument for this hazard. Verifying that a mechanism is *present* is not
+> verifying that it is *sufficient*; those are separate measurements and this
+> project has now conflated them twice.
 - **PTX** — carved out here because of the string-prefix register-class sniffing
   risk (§4). Treat as its own reviewable unit: new `%h` register class, `is_f16`
   guards in `emit_cast`/`emit_bitwise`, `cvt.*.f16.*` conversions, `mov.f16` const.

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -34,6 +34,13 @@ actually had:
   Intel UHD Graphics 630). Attributed to a `fma` that is not correctly rounded,
   *not* to contraction — but the two failure modes look identical from the
   outside, and telling them apart took a separate measurement.
+- **Vulkan/RADV, f16.** RADV's ACO backend absorbs an f32→f16 narrowing into
+  whatever arithmetic feeds it, and `precise`/`NoContraction` does not stop it —
+  the decoration is emitted, and the emitted ISA is byte-identical with and
+  without it. **2912 of 63488** finite binary16 inputs disagree with the
+  interpreter on a single narrowing, **5075** on a two-narrowing expression.
+  Third front end onto the same ACO backend as HIP and rusticl, and a wider
+  combine than either. f16 stays refused on this backend (§2, §6).
 
 This document states, per backend, what the compiler is permitted to contract,
 what mechanism (if any) actually prevents it, whether that mechanism is
@@ -99,8 +106,9 @@ Legend for the evidence column:
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C | **no flag** — Sarek passes an empty build-option string. Same `mul_rn`-by-construction defence as CUDA | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
 | **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, same ACO backend | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c` |
+| **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as HIP and rusticl, reached through a third front end, but a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on ACO and does not fuse here, so the locus is *the ACO backend*, not *OpenCL*. That in turn is the second independent reason to read rusticl and HIP/AMDGPU as one bug seen through two front ends rather than two bugs. Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any non-ACO implementation is found to fuse |
-| **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing: the driver does not contract these shapes even without the decoration | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV not measured — no Intel GPU on this machine.** Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound |
+| **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV not measured — no Intel GPU on this machine.** Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound |
 | **Metal** | Metal's default compile options enable fast math | **nothing.** `Metal_api` passes a null `MTLCompileOptions`, and `Metal_bindings.mtl_device_new_library_with_source` *ignores its `_options` argument entirely* | unverified — no Apple hardware in this project's CI or on the machine this policy was written on. Treat Metal float results as outside the guarantee |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
@@ -171,6 +179,24 @@ Legend for the evidence column:
   gets assertions deleted. On a runner with no ACO device the tripwire is
   therefore a no-op, and the C probe is the only artifact CI exercises; the
   tripwire is in practice a developer-workstation gate.
+- **f16 on Vulkan/GLSL, on Mesa RADV.** Measured, not assumed, and *worse* than
+  the OpenCL case: **2912 of 63488** finite binary16 inputs disagree with the
+  interpreter on a single narrowing, and **5075** on the two-narrowing shape,
+  on both the RX 7900 XTX (RADV NAVI31) and the Raphael iGPU (RADV
+  RAPHAEL_MENDOCINO). `Sarek_ir_glsl` therefore rejects f16 at codegen — a
+  *deliberate* refusal backed by a measurement, not an unimplemented feature.
+  **Do not reason from `precise`.** This backend already emits `precise` on
+  every float local, and #106/#126 measured RADV not to contract 7 f32 shapes;
+  neither is evidence about this combine, and the `precise` variant still
+  disagrees on 2912 inputs. Re-test before enabling: the blocker is a Mesa
+  optimiser behaviour and could change with a Mesa release. That re-test is
+  automated — `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` fails when the
+  fusion stops, and separately fails if `precise` starts working, so neither
+  half of the refusal can quietly outlive its reason. It asserts **only on RADV
+  devices** (it keys on `"RADV"` in the Vulkan device name — driver identity,
+  not device model, because the Raphael iGPU's name reads like a CPU and
+  reproduces the defect identically) and **skips visibly** elsewhere, naming
+  the devices it rejected.
 - **A product you compute yourself staying unfused across a `Sarek_df64`
   boundary.** `[@sarek.module]` bodies are inlined into your kernel, so
   `df64_add_f32 acc (x *. y)` re-creates the exact fusable pattern the library
@@ -437,12 +463,47 @@ exactly the explicitly-requested `fma()` calls.
   not supported: with `precise` stripped, RADV still did not contract, and the
   ISA is unchanged.
 
-What is *not* established is that RADV would honour `NoContraction` if it ever
-did want to contract. This is an **absence of the hazard on this driver and this
-version**, not a demonstration of obedience. The honest status of `precise` on
-RADV is therefore: **inert, and free** — it costs nothing (identical ISA) and it
-is the correct thing to emit for portability, but on RADV today it is not what
-is holding anything up. Keep it; do not credit it.
+What is *not* established by the experiment above is that RADV would honour
+`NoContraction` if it ever did want to contract. That was left open here, and
+**#57 slice 2b closed it — negatively.**
+
+### RADV *does* want to contract somewhere, and there it ignores `NoContraction`
+
+Measured 2026-07-26, RX 7900 XTX (RADV NAVI31) and the Raphael iGPU (RADV
+RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1. The shape is `float16_t(x * 1.1)` — a
+combine the twelve shapes above do not probe, because it is not `a*b+c`: it is a
+multiply absorbed by the **conversion** that consumes it.
+
+| | no `precise` | `precise` |
+|---|---|---|
+| `NoContraction` decorations in the SPIR-V (`glslangValidator` → `spirv-dis`, reproduced by `tools/probes/vulkan_f16_narrowing_probe.sh`) | **0** | **1**, on the `OpFMul` |
+| emitted RDNA ISA | `v_fma_mixlo_f16 0xcccd, v1, neg(0)` | **byte-identical** |
+| disagreements with the interpreter, all 63488 finite binary16 inputs | 2912 | **2912** |
+| matches a single-rounding model | exactly, 0/63488 | exactly, 0/63488 |
+
+The decoration is emitted, by the same `glslangValidator` the Vulkan runtime
+path actually uses; the driver produces opcode-for-opcode identical machine code
+either way; and that machine code performs one rounding where the SPIR-V asks
+for two. **That is a `NoContraction` violation, observed.**
+
+So the honest status of `precise` on RADV is *not* "inert, and free". It is:
+
+- **inert** for the seven f32 `a*b+c`-family shapes above — RADV does not
+  contract them with or without it, so nothing is being held up;
+- **ignored** for the multiply-into-narrowing combine, where RADV *does*
+  contract and the decoration does not stop it.
+
+Keep emitting it — it is correct for portability and costs nothing. Do not
+credit it with a guarantee on RADV, in either direction: it is not what makes
+f32 safe here, and it is not enough to make f16 safe here. The consequence for
+f16 is the `Vulkan / RADV (f16 narrowing)` row in §2 and the refusal in
+`Sarek_ir_glsl`; the consequence for f32 is that the phrase "contraction-safe by
+front-end declaration" describes what Sarek *emits*, never what RADV *obeys*.
+
+**Generalisable, and the reason this was missed for a whole slice:** the twelve
+shapes were chosen to probe *contraction* as the term is normally used —
+`a*b+c`. A conversion is also an operation that can absorb its operand, and it
+is not in that family. A null result is only as broad as its shape catalogue.
 
 **Not run: Mesa ANV.** There is no Intel GPU on this machine. The ANV half of
 the original disagreement is a **hardware gap**, not a null result — recorded in
@@ -567,6 +628,25 @@ this is where they are collected):
   same device, tracked as #136. The **Vulkan** residual (1.68e-14 on NVIDIA,
   while Intel UHD 630 passes at 1.17e-14) has no established cause — that one is
   still "do not promote a hypothesis to a cause".
+- **f16 on Vulkan/GLSL: what slice 2b did NOT close.** The refusal is measured
+  and gated, but three things remain unmeasured and must not be read into it.
+  (a) **Only RADV.** No non-RADV Vulkan implementation has been measured for
+  this combine — not ANV, not AMDVLK, not NVIDIA, not lavapipe — so "Vulkan
+  fuses" is not a claim this repository makes; "RADV fuses" is. The tripwire
+  deliberately carries no "non-RADV does not fuse" cross-check for that reason,
+  unlike its OpenCL sibling, which has pocl data behind it.
+  (b) **The `shaderFloat16` device feature is not enabled.** Vulkan requires it
+  before a shader may use the SPIR-V `Float16` capability;
+  `Vulkan_api_device` chains no feature structs beyond core
+  `VkPhysicalDeviceFeatures`, and RADV accepts the shaders anyway. The
+  measurement stands — the defect is visible in the ISA, and the barriered
+  control returns bit-exact results on the same un-enabled path — but that
+  plumbing is real work that enabling f16 here would have to do first, and it
+  is not done.
+  (c) **No Sarek-generated shader was involved.** The tripwire compiles raw
+  GLSL, because `Sarek_ir_glsl` refuses f16; it measures the driver, not the
+  codegen. If the refusal is ever lifted, the codegen's own output needs its own
+  exhaustive interpreter-agreement gate — this one does not substitute.
 - **Metal is entirely unverified** (no Apple hardware), and it is the one
   backend currently compiled with fast math on.
 
@@ -580,7 +660,9 @@ this is where they are collected):
 | `sarek/codegen/Sarek_ir_cuda.ml` | `sarek_f32_barrier` — load-bearing on HIP, a documented identity on NVIDIA |
 | `sarek-cuda/Cuda_nvrtc.ml` | `check_fp_conformance` — rejects subnormal-flushing / approximate-div options |
 | `sarek/Sarek_df64/Sarek_df64.ml` | the `mul_rn` contraction barrier, its per-backend precision table, and the caller-side hazard |
-| `sarek/codegen/Sarek_ir_glsl.ml` | `precise` on float locals → SPIR-V `NoContraction` |
+| `sarek/codegen/Sarek_ir_glsl.ml` | `precise` on float locals → SPIR-V `NoContraction`; and the measured f16 refusal |
+| `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` | the RADV f16-fusion tripwire, its calibration and its green control |
+| `tools/probes/vulkan_f16_narrowing_probe.sh` | standalone reproducer for the emitted-but-ignored `NoContraction`; needs no device |
 | `sarek-cuda/test/test_cuda_f16_sass.ml` | the f16 SASS gate (with positive control) |
 | `sarek-cuda/test/test_cuda_fp_conformance.ml` | the nvrtc FP-option guard and its hazard control |
 | `sarek-hip/test/test_hip_rtc_options.ml` | proves `-ffp-contract=off` stays last whatever the caller passes |

--- a/sarek-vulkan/test/dune
+++ b/sarek-vulkan/test/dune
@@ -23,3 +23,7 @@
 (test
  (name test_vulkan_error_observability)
  (libraries sarek_vulkan sarek_ir sarek_backend_error alcotest))
+
+(test
+ (name test_vulkan_f16_tripwire)
+ (libraries sarek_vulkan spoc_framework alcotest))

--- a/sarek-vulkan/test/test_vulkan_f16_tripwire.ml
+++ b/sarek-vulkan/test/test_vulkan_f16_tripwire.ml
@@ -1,0 +1,549 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * #57 slice 2b — GLSL/Vulkan f16 refusal TRIPWIRE.
+ *
+ * WHAT THIS TEST IS FOR, because it is not what it looks like.
+ *
+ * [Sarek_ir_glsl] refuses float16. That refusal is not "unimplemented" — the
+ * codegen is a small change and the GLSL extension compiles and runs here. It
+ * is a REFUSAL BY MEASUREMENT: RADV's ACO backend absorbs the f32->f16
+ * narrowing into the arithmetic that feeds it (v_fma_mixlo_f16), rounding once
+ * where slice 1's f16 discipline mandates twice, so 2912 of the 63488 finite
+ * binary16 inputs disagree with the interpreter on the single-narrowing shape
+ * this file measures. See docs/fp-contraction-policy.md, row
+ * "Vulkan / RADV (f16 narrowing)".
+ *
+ * A refusal backed by a measurement can quietly outlive its own justification.
+ * If Mesa stops fusing, the refusal becomes wrong, and nothing would tell us —
+ * the codegen would keep raising, the golden test would keep passing, and the
+ * documentation would keep citing a defect that no longer exists. So this test
+ * asserts the REASON, not the behaviour. It does not check that Sarek refuses
+ * f16 (test_cuda_f16_golden pins that). It checks that refusing is still
+ * WARRANTED. It goes red when the fusion STOPS.
+ *
+ * WHY THIS ONE USES A HOST REFERENCE, WHERE THE OPENCL TRIPWIRE COMPARES TWO
+ * KERNELS.
+ *
+ * test_opencl_f16_tripwire.ml avoids host binary16 arithmetic entirely by
+ * diffing a naive kernel against a barriered one. That trick is not available
+ * in full here: on RADV, putting a barrier around the f32 intermediates of the
+ * two-narrowing shape does NOT restore the discipline — ACO responds by
+ * dropping the intermediate narrowing altogether rather than materialising a
+ * binary16 value (4774/63488, measured; see the table in
+ * docs/fp-contraction-policy.md). A barriered kernel is therefore not a
+ * trustworthy oracle on this backend at that shape.
+ *
+ * So the oracle is a host implementation of the discipline, and it is
+ * CALIBRATED before it is believed, three ways:
+ *
+ *   1. [host_rounding_round_trips] — [f16_bits] re-encodes every one of the
+ *      63488 finite binary16 values to its own bit pattern. Catches an encoder
+ *      that is wrong about subnormals, the binade edges or the carry case.
+ *   2. [host_models_reproduce_the_620] — the SAME host code, applied to the
+ *      HIP/OpenCL kernel shape, must separate the two-roundings model from the
+ *      one-rounding model on exactly 620 inputs. 620 is the figure independently
+ *      measured on hiprtc/gfx1100 and on rusticl/radeonsi. Reproducing a
+ *      known positive with an independent implementation is what makes the
+ *      rest of the file's zeros and nonzeros worth reading.
+ *   3. [barrier_variant_matches_the_discipline] — a kernel whose f32
+ *      intermediate is forced through a volatile SSBO round-trip agrees with
+ *      the host model on all 63488 inputs. This is the green control: it proves
+ *      the harness CAN report agreement, so "disagrees" below is a statement
+ *      about ACO and not about a broken buffer layout, a broken pack/unpack, or
+ *      the Float16 caveat in the next paragraph.
+ *
+ * ONE HONEST CAVEAT ABOUT HOW THESE SHADERS RUN.
+ *
+ * Vulkan requires the [shaderFloat16] feature to be enabled at device creation
+ * before a shader may use the SPIR-V Float16 capability. Sarek's Vulkan device
+ * creation chains no feature structs beyond core VkPhysicalDeviceFeatures, so
+ * that feature is NOT enabled; RADV accepts these shaders anyway. That plumbing
+ * is part of what enabling f16 on this backend would have to build, and it is
+ * listed as still-open in docs/fp-contraction-policy.md. It does not weaken the
+ * finding: the defect is visible in the emitted ISA (run this executable under
+ * RADV_DEBUG=asm to see v_fma_mixlo_f16 for the plain variant and a separate
+ * conversion for the barriered one), and control 3 above shows the same
+ * un-enabled path producing bit-exact agreement when the fusion is defeated.
+ ******************************************************************************)
+
+open Sarek_vulkan
+module Device = Vulkan_api_device
+module Memory = Vulkan_api_memory
+module Kernel = Vulkan_api_kernel
+
+let n_local = 256
+
+(* Buffers are `uint` holding one binary16 bit pattern in the low 16 bits,
+   rather than 16-bit storage: it keeps VK_KHR_16bit_storage out of the picture
+   so the only 16-bit thing in play is the arithmetic under test. The
+   pack/unpack framing is not itself a barrier — the plain variant below still
+   fuses with it in place, and the barriered variant still agrees with it in
+   place. *)
+let shader body =
+  Printf.sprintf
+    {|#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = %d) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+%s
+}
+|}
+    n_local
+    body
+
+(* The narrowing shape that fuses: an f32 multiply consumed by an f32->f16
+   narrowing. Sarek's discipline rounds twice here (once to binary32 at the
+   multiply, once to binary16 at the narrowing). *)
+let src_plain = shader "  outb[i] = pack(float16_t(x * 1.1));"
+
+(* Identical, except the f32 local carries `precise` — which is what
+   Sarek_ir_glsl.gen_var_decl already emits on every float local, and which
+   glslang lowers to SPIR-V NoContraction. Present as its own variant because
+   "we already emit precise, so we are fine" is the inference this measurement
+   exists to refute. *)
+let src_precise =
+  shader "  precise float p = x * 1.1;\n  outb[i] = pack(float16_t(p));"
+
+(* Identical, except the f32 product is forced through a volatile SSBO
+   round-trip before being narrowed — measured to be the one defence that works.
+   Not shippable as codegen (a global-memory round-trip per narrowing, into a
+   scratch buffer this backend does not control) but a perfectly good control. *)
+let src_barriered =
+  shader
+    "  outb[i] = floatBitsToUint(x * 1.1);\n\
+    \  outb[i] = pack(float16_t(uintBitsToFloat(outb[i])));"
+
+(* ---------------------------------------------------------------------- *)
+(* HOST REFERENCE                                                           *)
+(* ---------------------------------------------------------------------- *)
+
+(* Round a binary64 to binary32. Every intermediate below is exactly
+   representable in binary64 before this is applied (a binary16 operand times a
+   binary32 constant needs at most 35 significand bits), so this is a single
+   correct rounding and not a double rounding. *)
+let f32 x = Int32.float_of_bits (Int32.bits_of_float x)
+
+(* Exact value of a binary16 bit pattern; None for NaN/Inf. Decoding needs no
+   rounding, so it cannot itself be a source of mismatch. *)
+let f16_decode b =
+  let sign = if b land 0x8000 <> 0 then -1.0 else 1.0 in
+  let e = (b lsr 10) land 0x1f and m = b land 0x3ff in
+  if e = 31 then None
+  else if e = 0 then Some (sign *. float_of_int m *. ldexp 1.0 (-24))
+  else Some (sign *. float_of_int (1024 + m) *. ldexp 1.0 (e - 25))
+
+let dec b =
+  match f16_decode b with
+  | Some v -> v
+  | None ->
+      if b land 0x3ff <> 0 then Float.nan
+      else if b land 0x8000 <> 0 then Float.neg_infinity
+      else Float.infinity
+
+let round_even v =
+  let f = Float.floor v in
+  let r = v -. f in
+  if r > 0.5 then f +. 1.0
+  else if r < 0.5 then f
+  else if Float.rem f 2.0 = 0.0 then f
+  else f +. 1.0
+
+(* Round-to-nearest-even of an exactly-represented real to a binary16 bit
+   pattern. [round_even] is exact because [a /. ldexp 1.0 k] is a power-of-two
+   rescale, and the rescaled value is below 2048. *)
+let f16_bits d =
+  if Float.is_nan d then 0x7E00
+  else
+    let s = if d < 0.0 || (d = 0.0 && 1.0 /. d < 0.0) then 0x8000 else 0 in
+    let a = Float.abs d in
+    if a = Float.infinity then s lor 0x7C00
+    else if a = 0.0 then s
+    else
+      (* [frexp] is exact by construction: it returns [(m, k)] with
+         [0.5 <= |m| < 1] and [a = m * 2^k], so the unbiased exponent is
+         [k - 1]. Deriving it from [log2] instead would need a correction step
+         for the binade edges, and that correction cannot be exercised by any
+         input in this domain — an unfalsifiable branch is worse than none. *)
+      let e = snd (Float.frexp a) - 1 in
+      if e < -14 then
+        (* subnormal; a carry out of the 10-bit field lands exactly on the
+           smallest normal, which the bit layout already spells correctly *)
+        s lor int_of_float (round_even (a /. ldexp 1.0 (-24)))
+      else
+        let q = round_even (a /. ldexp 1.0 (e - 10)) in
+        let e, q = if q >= 2048.0 then (e + 1, 1024.0) else (e, q) in
+        if e + 15 >= 31 then s lor 0x7C00
+        else s lor ((e + 15) lsl 10) lor (int_of_float q - 1024)
+
+(* All finite binary16 bit patterns. 63488 of them — small enough that the
+   exhaustive statement is affordable, which is why the f16 gates in this
+   project are exhaustive rather than sampled. Also exactly 248 * 256, so the
+   kernels need no bounds check and no scalar argument. *)
+let finite_bits =
+  let acc = ref [] in
+  for b = 0xFFFF downto 0 do
+    if f16_decode b <> None then acc := b :: !acc
+  done ;
+  Array.of_list !acc
+
+let c11 = f32 1.1
+
+(* Sarek's discipline for [f16(x * 1.1)]: two roundings. *)
+let ref_discipline b = f16_bits (f32 (dec b *. c11))
+
+(* The multiply absorbed into the narrowing: one rounding. *)
+let ref_fused b = f16_bits (dec b *. c11)
+
+(* The HIP/OpenCL kernel shape, [f16(f16(x*1.1) + 1000)], under each model.
+   Used only by the 620 calibration — no kernel here computes it. *)
+let ref_hipshape_discipline b =
+  let m = f16_bits (f32 (dec b *. c11)) in
+  f16_bits (f32 (dec m +. 1000.0))
+
+let ref_hipshape_fused b =
+  let m = f16_bits (dec b *. c11) in
+  f16_bits (f32 (dec m +. 1000.0))
+
+(* ---------------------------------------------------------------------- *)
+
+let run device ~source ~inputs =
+  let n = Array.length inputs in
+  let host_in = Bigarray.(Array1.create int32 c_layout n) in
+  Array.iteri (fun i b -> host_in.{i} <- Int32.of_int b) inputs ;
+  let din = Memory.alloc device n Bigarray.int32 in
+  let dout = Memory.alloc device n Bigarray.int32 in
+  Memory.host_to_device ~src:host_in ~dst:din ;
+  let compiled = Kernel.compile device ~name:"main" ~source in
+  let args = Kernel.create_args () in
+  Kernel.set_arg_buffer args 0 dout ;
+  Kernel.set_arg_buffer args 1 din ;
+  let block = Spoc_framework.Framework_sig.dims_1d n_local in
+  let grid = Spoc_framework.Framework_sig.dims_1d (n / n_local) in
+  Kernel.launch compiled ~args ~grid ~block ~shared_mem:0 ~stream:None ;
+  Device.synchronize device ;
+  let host_out = Bigarray.(Array1.create int32 c_layout n) in
+  Memory.device_to_host ~src:dout ~dst:host_out ;
+  Memory.free din ;
+  Memory.free dout ;
+  Array.init n (fun i -> Int32.to_int host_out.{i} land 0xFFFF)
+
+(* count of disagreements, and the index of the first *)
+let compare_bits got want =
+  let c = ref 0 and first = ref (-1) in
+  Array.iteri
+    (fun i x ->
+      if x <> want.(i) then begin
+        incr c ;
+        if !first < 0 then first := i
+      end)
+    got ;
+  (!c, !first)
+
+(* ---------------------------------------------------------------------- *)
+(* SCOPE                                                                    *)
+(*                                                                          *)
+(* The refusal this test defends is about ONE compiler: the ACO shader      *)
+(* backend in Mesa, reached here through Mesa's Vulkan driver (RADV). It is *)
+(* NOT a claim about Vulkan or GLSL in general, and asserting it against    *)
+(* whatever device happens to be first is how a gate fires for the wrong    *)
+(* reason.                                                                  *)
+(*                                                                          *)
+(* Keyed on DRIVER identity: the device name must contain "RADV". Mesa puts *)
+(* its Vulkan driver name in VkPhysicalDeviceProperties::deviceName, e.g.   *)
+(* "AMD Radeon RX 7900 XTX (RADV NAVI31)". RADV compiles shaders with ACO,  *)
+(* which is the component that performs the fusion, so this is driver       *)
+(* identity rather than a device model.                                     *)
+(*                                                                          *)
+(* Deliberately NOT keyed on a device-model substring ("NAVI31") or on a    *)
+(* CPU/GPU distinction. The second local device is named "AMD Ryzen 9 7950X *)
+(* 16-Core Processor (RADV RAPHAEL_MENDOCINO)" — an integrated GPU whose    *)
+(* NAME reads like a CPU, and it reproduces the defect identically, with    *)
+(* identical counts. Any heuristic keyed on the model, or on "looks like a  *)
+(* CPU", would silently drop it from scope. The same trap was found on the  *)
+(* OpenCL side in slice 2a.                                                 *)
+(*                                                                          *)
+(* IF THE VENDOR RENAMES: this test SKIPS, it does not silently pass. Mesa  *)
+(* renaming RADV, or switching it away from ACO, makes [in_scope] empty,    *)
+(* which produces a visible skip naming what it looked for. That is the     *)
+(* intended failure direction — an unmeasured platform must never be read   *)
+(* as evidence that the refusal still holds — but it does mean a rename     *)
+(* converts this gate into a no-op until someone updates the key. The skip  *)
+(* message says so, so the silence is at least loud.                        *)
+(*                                                                          *)
+(* There is deliberately NO "non-RADV Vulkan does not fuse" cross-check     *)
+(* here, unlike the OpenCL tripwire's pocl one: no non-RADV Vulkan          *)
+(* implementation has been measured for this project, so such a check would *)
+(* assert a claim nobody has evidence for.                                  *)
+(* ---------------------------------------------------------------------- *)
+
+let contains ~needle haystack =
+  let n = String.length needle and h = String.length haystack in
+  let lower = String.lowercase_ascii in
+  let needle = lower needle and haystack = lower haystack in
+  let rec go i =
+    i + n <= h && (String.sub haystack i n = needle || go (i + 1))
+  in
+  n = 0 || go 0
+
+let describe device = device.Device.name
+
+let is_in_scope device = contains ~needle:"radv" (describe device)
+
+let all_devices () =
+  if not (Vulkan_api.is_available ()) then [||]
+  else begin
+    Device.init () ;
+    Array.init (Device.count ()) Device.get
+  end
+
+(* Partition, report what was seen, and skip visibly when nothing is in scope.
+   The listing matters: a skip that does not say which devices it rejected is
+   indistinguishable from a skip caused by a broken scope predicate. *)
+let with_in_scope_devices f =
+  let devices = all_devices () in
+  let in_scope, out_of_scope =
+    Array.to_list devices |> List.partition is_in_scope
+  in
+  List.iter
+    (fun d -> Printf.printf "    out of scope: %s\n%!" (describe d))
+    out_of_scope ;
+  match in_scope with
+  | [] ->
+      let seen =
+        match out_of_scope with
+        | [] -> "no Vulkan devices at all"
+        | l -> String.concat "; " (List.map describe l)
+      in
+      Printf.printf
+        "[SKIP] No in-scope Vulkan device. This tripwire defends a refusal \
+         measured on Mesa's ACO backend reached through RADV, so it only \
+         asserts on a device whose name contains \"RADV\" (e.g. \"AMD Radeon \
+         RX 7900 XTX (RADV NAVI31)\"). Saw: %s. Not asserting: a different \
+         Vulkan implementation agreeing here would say nothing about whether \
+         ACO still fuses.\n\
+         %!"
+        seen ;
+      Alcotest.skip ()
+  | ds -> List.iter f ds
+
+(* ---------------------------------------------------------------------- *)
+(* CALIBRATION                                                              *)
+(* ---------------------------------------------------------------------- *)
+
+let host_rounding_round_trips () =
+  Array.iter
+    (fun b ->
+      if f16_bits (dec b) <> b then
+        Alcotest.failf
+          "host binary16 rounding is wrong: re-encoding the exact value of \
+           0x%04X gives 0x%04X. Every device verdict in this file is measured \
+           against this function, so nothing below means anything until it is \
+           fixed."
+          b
+          (f16_bits (dec b)))
+    finite_bits ;
+  Alcotest.(check int)
+    "the exhaustive finite binary16 domain"
+    63488
+    (Array.length finite_bits)
+
+let host_models_reproduce_the_620 () =
+  let disc = Array.map ref_hipshape_discipline finite_bits in
+  let fused = Array.map ref_hipshape_fused finite_bits in
+  let diffs, _ = compare_bits disc fused in
+  if diffs <> 620 then
+    Alcotest.failf
+      "CALIBRATION FAILED — do not read any other result in this file.\n\n\
+       On the HIP/OpenCL kernel shape f16(f16(x*1.1) + 1000), this file's own \
+       host models separate the two-roundings discipline from the \
+       fused-first-narrowing behaviour on %d of %d inputs. It must be 620: \
+       that is the figure measured independently on hiprtc/gfx1100 \
+       (sarek-hip/test/test_hip_f16.ml) and on rusticl/radeonsi \
+       (docs/fp-contraction-policy.md).\n\n\
+       Reproducing a known positive is what licenses believing this file's \
+       other counts. If this number moved, [f16_bits], [f32] or [dec] is wrong \
+       — fix the host reference, do not adjust this expectation."
+      diffs
+      (Array.length finite_bits)
+
+(* The GREEN control. A tripwire that can only ever report disagreement proves
+   nothing when it reports disagreement. *)
+let barrier_variant_matches_the_discipline () =
+  with_in_scope_devices (fun device ->
+      let want = Array.map ref_discipline finite_bits in
+      let got = run device ~source:src_barriered ~inputs:finite_bits in
+      let diffs, first = compare_bits got want in
+      if diffs <> 0 then
+        Alcotest.failf
+          "CONTROL BROKEN on %s: the barriered kernel — whose f32 product is \
+           forced through a volatile SSBO round-trip — disagrees with the host \
+           model on %d/%d inputs (first at x=%.9g: device 0x%04X, model \
+           0x%04X).\n\n\
+           This is the control that shows the harness can report AGREEMENT. \
+           Until it does, a disagreement reported by the other cases cannot be \
+           attributed to ACO: it could equally be a wrong buffer layout, a \
+           wrong pack/unpack, or a wrong host reference. Fix this before \
+           reading anything else."
+          (describe device)
+          diffs
+          (Array.length finite_bits)
+          (dec finite_bits.(first))
+          got.(first)
+          want.(first))
+
+(* ---------------------------------------------------------------------- *)
+(* THE TRIPWIRE                                                             *)
+(* ---------------------------------------------------------------------- *)
+
+let obsolete_refusal_message device n =
+  Printf.sprintf
+    "OBSOLETE REFUSAL, NOT A REGRESSION — READ BEFORE \"FIXING\".\n\n\
+     On %s, the naive f32->f16 narrowing now agrees with Sarek's f16 \
+     discipline on all %d finite binary16 inputs. The multiply is no longer \
+     being absorbed into the narrowing.\n\n\
+     This test exists to detect exactly that. Sarek_ir_glsl refuses float16 \
+     *because* of that fusion (2912/63488 disagreements when this was \
+     measured, 2026-07-26, RADV NAVI31 and RADV RAPHAEL_MENDOCINO, Mesa \
+     26.1.4-arch3.1). If the fusion is gone, the refusal has lost its \
+     justification and #57 slice 2b should be REVISITED.\n\n\
+     Do NOT make this pass by deleting or weakening the assertion. The correct \
+     responses are, in order: (1) re-run this executable under RADV_DEBUG=asm \
+     and confirm v_fma_mixlo_f16 is gone from the plain variant, (2) \
+     re-measure the two-narrowing shapes too — this case covers only the \
+     single narrowing, and the two-narrowing shape failed WORSE (5075/63488), \
+     (3) record the new measurement in docs/fp-contraction-policy.md, (4) \
+     build the shaderFloat16 device-feature plumbing, which Sarek's Vulkan \
+     device creation still lacks, (5) enable f16 in Sarek_ir_glsl behind the \
+     usual exhaustive interpreter-agreement gate, and (6) delete this test as \
+     part of THAT change, not before it."
+    device
+    n
+
+let refusal_is_still_warranted () =
+  with_in_scope_devices (fun device ->
+      let want = Array.map ref_discipline finite_bits in
+      let got = run device ~source:src_plain ~inputs:finite_bits in
+      let n = Array.length finite_bits in
+      let diffs, first = compare_bits got want in
+      if diffs > 0 then
+        Printf.printf
+          "    [%s] fusion still present: %d/%d differ; first at x=%.9g \
+           (device 0x%04X, discipline 0x%04X)\n\
+           %!"
+          (describe device)
+          diffs
+          n
+          (dec finite_bits.(first))
+          got.(first)
+          want.(first) ;
+      if diffs = 0 then
+        Alcotest.failf "%s" (obsolete_refusal_message (describe device) n) ;
+      (* Not asserted as an exact count: it is a Mesa-version-dependent number.
+         Asserted as a range, because "everything differs" would mean the kernel
+         is no longer computing the intended expression at all. *)
+      if diffs = n then
+        Alcotest.failf
+          "all %d inputs differ on %s — that is not a fusion signature, it \
+           means the kernel and the host model are no longer computing the \
+           same expression. Fix the tripwire, do not read this as evidence \
+           about Mesa."
+          n
+          (describe device))
+
+(* Separate case, deliberately. The one above is the CI-blocking essential
+   ("is fusion still happening at all"). This one pins the MECHANISM, and is
+   the specific inference that would otherwise get made from #106/#126: that
+   backend already emits `precise` on every float local, #106 measured 0 of 7
+   f32 contraction shapes on RADV, so surely f16 is safe. It is not — `precise`
+   stops a*b+c from contracting, which is a different combine from a conversion
+   absorbing its operand. *)
+let precise_does_not_prevent_it () =
+  with_in_scope_devices (fun device ->
+      let want = Array.map ref_discipline finite_bits in
+      let fused = Array.map ref_fused finite_bits in
+      let got = run device ~source:src_precise ~inputs:finite_bits in
+      let n = Array.length finite_bits in
+      let diffs, _ = compare_bits got want in
+      let vs_fused, _ = compare_bits got fused in
+      Printf.printf
+        "    [%s] precise: %d/%d differ from the discipline, %d/%d from the \
+         single-rounding model\n\
+         %!"
+        (describe device)
+        diffs
+        n
+        vs_fused
+        n ;
+      if diffs = 0 then
+        Alcotest.failf
+          "`precise` now DOES prevent the f16 narrowing fusion on %s: the \
+           precise variant agrees with Sarek's discipline on all %d inputs, \
+           where it disagreed on 2912 when this was measured.\n\n\
+           That would be a real change and a genuinely good one — \
+           Sarek_ir_glsl already emits `precise` on every float local, so it \
+           would mean the codegen's existing defence now covers f16 too. It is \
+           NOT licence to enable f16 on its own: re-measure the two-narrowing \
+           shape as well (it failed worse, 4776/63488 even with `precise`) \
+           before touching the refusal. Update docs/fp-contraction-policy.md \
+           either way."
+          (describe device)
+          n ;
+      if vs_fused <> 0 then
+        Alcotest.failf
+          "MECHANISM CHANGED on %s. The precise variant still disagrees with \
+           Sarek's discipline (%d/%d), so the refusal stands — but it no \
+           longer matches the single-rounding model either (%d/%d), which it \
+           did exactly when this was measured.\n\n\
+           This is not a regression and not a reason to weaken the assertion. \
+           It means RADV is now getting the answer wrong in a way this file \
+           does not describe. Re-run under RADV_DEBUG=asm, work out the new \
+           combine, and update both this model and \
+           docs/fp-contraction-policy.md."
+          (describe device)
+          diffs
+          n
+          vs_fused
+          n)
+
+let () =
+  Alcotest.run
+    "Vulkan_f16_tripwire"
+    [
+      ( "calibration",
+        [
+          Alcotest.test_case
+            "host binary16 rounding round-trips on the whole domain"
+            `Quick
+            host_rounding_round_trips;
+          Alcotest.test_case
+            "host models reproduce the independently measured 620"
+            `Quick
+            host_models_reproduce_the_620;
+          Alcotest.test_case
+            "the barriered kernel agrees with the discipline (green control)"
+            `Quick
+            barrier_variant_matches_the_discipline;
+        ] );
+      ( "refusal_still_warranted",
+        [
+          Alcotest.test_case
+            "the f32 multiply is still absorbed into the f16 narrowing"
+            `Quick
+            refusal_is_still_warranted;
+          Alcotest.test_case
+            "`precise` does not prevent it"
+            `Quick
+            precise_does_not_prevent_it;
+        ] );
+    ]

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -227,14 +227,66 @@ let rec glsl_type_of_elttype = function
   | TInt32 -> "int"
   | TInt64 -> "int64_t" (* Requires GL_ARB_gpu_shader_int64 *)
   | TFloat16 ->
-      (* Deferred to #57 slice 2: GLSL spells this `float16_t` and needs both
-         GL_EXT_shader_explicit_arithmetic_types_float16 and (for buffer I/O)
-         GL_EXT_shader_16bit_storage declared in the header. *)
+      (* Still rejected after #57 slice 2b, and — as with OpenCL in slice 2a —
+         NOT for the reason originally recorded here. The old comment said the
+         arm was "deferred" and named
+         GL_EXT_shader_explicit_arithmetic_types_float16 as what was missing.
+         Measured false: that extension compiles through this backend's own
+         glslang/shaderc path and runs on both local RADV devices. The codegen
+         is small ("float16_t" here, a narrowing arm, and two #extension lines).
+
+         What blocks it is that RADV cannot hold Sarek's f16 contract. Slice 1
+         defines f16 as "store f16, compute f32, round on every narrowing", and
+         gates it on BIT-EXACT agreement with the interpreter. RADV's ACO
+         backend absorbs the f32->f16 narrowing into whatever arithmetic feeds
+         it, via v_fma_mixlo_f16 — one rounding where the DSL mandates two.
+
+         This is the SAME backend compiler as the HIP and rusticl defects
+         (ACO), reached through a third front end, but it is NOT the same
+         severity. On HIP/OpenCL the fusion swallows the multiply only. Here it
+         also swallows the f32 add, and — when an f32 barrier is placed around
+         the multiply — it drops the intermediate narrowing altogether rather
+         than materialising a binary16 value. Measured, both local devices,
+         exhaustive over all 63488 finite binary16 inputs:
+
+           kernel shape / source-level defence   disagreements with interpreter
+           f16(x*1.1), plain                                     2912/63488
+           f16(x*1.1), `precise` on the f32 local                2912/63488
+           f16(f16(x*1.1) + 1000), plain                         5075/63488
+           f16(f16(x*1.1) + 1000), `precise` (what this
+             backend already emits on every float local)         4776/63488
+           ... with an f16 bitcast round-trip                    5075/63488
+           ... with a volatile SSBO round-trip on the f32s       4774/63488
+           ... volatile SSBO round-trip incl. the f16 bits          0/63488
+
+         The `precise` row is the load-bearing one. This backend already
+         prefixes every float local with `precise`, which glslang lowers to
+         SPIR-V NoContraction — and that IS honoured: the f32 multiply survives
+         as its own rounding. It simply does not reach the narrowing, because
+         absorbing a conversion is a different combine from contracting a*b+c.
+         So "we already emit precise" is not an argument for enabling f16, and
+         the #106/#126 f32 result (0 of 7 contraction shapes on RADV) does not
+         transfer either — it measured the combine that `precise` does stop.
+
+         The only defence measured to work costs a global-memory round-trip per
+         narrowing, of the f16 bit pattern itself, which this backend cannot
+         emit without a scratch buffer it does not control.
+
+         Measured 2026-07-26 on RX 7900 XTX (RADV NAVI31) AND the integrated
+         Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1, Vulkan
+         1.4.354; both devices report identical counts. Gate:
+         sarek-vulkan/test/test_vulkan_f16_tripwire.ml. Full table, ISA and
+         method: docs/fp-contraction-policy.md, "Vulkan / RADV (f16
+         narrowing)". *)
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct
            "f16"
-           "GLSL: float16 not yet supported (#57 slice 2 — needs \
-            GL_EXT_shader_explicit_arithmetic_types_float16)")
+           "GLSL: float16 is refused by measurement, not pending \
+            implementation — RADV's ACO backend absorbs the f32->f16 narrowing \
+            into the arithmetic that feeds it, so 2912/63488 binary16 inputs \
+            disagree with the interpreter on a single narrowing, and `precise` \
+            does not prevent it. See docs/fp-contraction-policy.md (#57 slice \
+            2b).")
   | TFloat32 -> "float"
   | TFloat64 -> "double" (* Requires GL_ARB_gpu_shader_fp64 *)
   | TBool -> "bool"
@@ -1520,19 +1572,41 @@ let rename_pc_shadowing_locals ~pc_names ~len_names body =
       Printf.sprintf "sarek_pc_shadow_%s_%d" (escape_glsl_name orig) n)
     body
 
-(* Slice-2 deferral for this backend. The explanation of WHY a whole-kernel gate
-   is needed (and not just the per-element-type arms) lives once, at
-   {!Sarek_ir_codegen.reject_feature}. Named [_kernel] to distinguish it from
-   [Sarek_typer.reject_float16], which rejects an f16 OPERAND — a different
-   concept at a different layer. *)
-let reject_float16_kernel =
-  Sarek_ir_codegen.reject_feature
-    ~raise_:(fun reason ->
-      Codegen_error.raise_error
-        (Codegen_error.unsupported_construct "f16" reason))
-    ~backend:"GLSL"
-    ~hint:"needs GL_EXT_shader_explicit_arithmetic_types_float16"
-    Sarek_ir_analysis.Float16
+(* GLSL f16 refusal. Like OpenCL's (#57 slice 2a) and unlike Metal's and
+   WGSL's, this deliberately does NOT go through
+   {!Sarek_ir_codegen.reject_feature}, and the divergence is the point.
+
+   [reject_feature] composes "<backend>: float16 not yet supported (#57 slice
+   2 — <hint>)". Both halves were false here, and #57 slice 2b measured them
+   false rather than inferring it:
+
+   - "not YET supported" describes a queue position. GLSL is not in the queue.
+   - the old hint, "needs GL_EXT_shader_explicit_arithmetic_types_float16",
+     named the wrong blocker: that extension compiles and runs on both local
+     RADV devices, and enabling it changes nothing about why f16 is refused.
+
+   The actual blocker, and the reason `precise` does not rescue it, is
+   documented at length on the [TFloat16] arm of {!glsl_type_of_elttype}. The
+   whole-kernel rationale for gating here as well (rather than relying on the
+   per-element-type arm) lives once, at {!Sarek_ir_codegen.reject_feature}.
+
+   Metal and WGSL keep the shared composer precisely so THEY still reword
+   together: those two are genuinely unimplemented, and filing a measured,
+   possibly-permanent refusal under the same heading would lose that
+   distinction.
+
+   Named [_kernel] to distinguish it from [Sarek_typer.reject_float16], which
+   rejects an f16 OPERAND — a different concept at a different layer. *)
+let reject_float16_kernel (k : kernel) : unit =
+  if Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Float16 k then
+    Codegen_error.raise_error
+      (Codegen_error.unsupported_construct
+         "f16"
+         "GLSL: float16 is refused by measurement, not pending implementation \
+          — RADV's ACO backend absorbs the f32->f16 narrowing into the \
+          arithmetic that feeds it, so 2912/63488 binary16 inputs disagree \
+          with the interpreter on a single narrowing, and `precise` does not \
+          prevent it. See docs/fp-contraction-policy.md (#57 slice 2b).")
 
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -362,9 +362,20 @@ let reason_opencl =
    barrier exists on this path. See docs/fp-contraction-policy.md (#57 slice \
    2a)."
 
+(* GLSL left the shared composer for the same reason OpenCL did (#57 slice 2b),
+   and is pinned verbatim here for the same reason: the shared wording said "not
+   YET supported" and blamed
+   GL_EXT_shader_explicit_arithmetic_types_float16. Both were measured false —
+   the extension compiles and runs on both local RADV devices, and the real
+   blocker is that ACO absorbs the f32->f16 narrowing into the arithmetic
+   feeding it. Re-folding GLSL back into the composer breaks this assertion,
+   which is the intent. *)
 let reason_glsl =
-  "GLSL: float16 not yet supported (#57 slice 2 — needs \
-   GL_EXT_shader_explicit_arithmetic_types_float16)"
+  "GLSL: float16 is refused by measurement, not pending implementation — \
+   RADV's ACO backend absorbs the f32->f16 narrowing into the arithmetic that \
+   feeds it, so 2912/63488 binary16 inputs disagree with the interpreter on a \
+   single narrowing, and `precise` does not prevent it. See \
+   docs/fp-contraction-policy.md (#57 slice 2b)."
 
 let reason_metal = "Metal: float16 not yet supported (#57 slice 2)"
 

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -42,10 +42,20 @@
           ~raise_:(fun reason ->
             Codegen_error.raise_error
               (Codegen_error.unsupported_construct "f16" reason))
-          ~backend:"OpenCL"
-          ~hint:"needs cl_khr_fp16 enablement"
+          ~backend:"WGSL"
+          ~hint:"needs a module-top `enable f16;` directive"
           Sarek_ir_analysis.Float16
-    ]} *)
+    ]}
+
+    {b Only for backends that are genuinely unimplemented.} The composed
+    sentence says "not YET supported", which is a claim about a queue position,
+    and the hint names what is missing. Two backends have left this composer
+    because both halves became false for them — OpenCL in #57 slice 2a and GLSL
+    in slice 2b — and each now raises its own diagnostic naming a {e measured}
+    blocker (see [Sarek_ir_opencl.reject_float16_kernel] and
+    [Sarek_ir_glsl.reject_float16_kernel]). The example above deliberately uses
+    WGSL rather than OpenCL for that reason. If you are about to add a backend
+    here, check that "not yet supported" is true of it. *)
 let reject_feature ~raise_ ~backend ?hint (feature : Sarek_ir_analysis.feature)
     (k : Sarek_ir_types.kernel) : unit =
   if Sarek_ir_analysis.kernel_uses feature k then

--- a/tools/probes/vulkan_f16_narrowing_probe.sh
+++ b/tools/probes/vulkan_f16_narrowing_probe.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+#
+# #57 slice 2b — standalone reproducer for the RADV f16-narrowing fusion.
+#
+# WHAT THIS IS FOR, and how it differs from the test next to it.
+#
+#   sarek-vulkan/test/test_vulkan_f16_tripwire.ml
+#       is the GATE. It runs the shaders on a device and fails when the fusion
+#       stops, so the refusal in Sarek_ir_glsl cannot outlive its reason.
+#
+#   this script
+#       is the DOCUMENTED REPRODUCER, and it exists because the gate cannot
+#       cover one half of the claim in docs/fp-contraction-policy.md §6. That
+#       claim is "the decoration is emitted AND the driver ignores it". The gate
+#       measures the ignoring. Nothing measures the emitting for THIS shape — if
+#       glslang ever stopped decorating, "ignored" would quietly become "never
+#       asked", the gate would still pass, and §6 would be wrong in a way no
+#       test could see.
+#
+# It needs no Vulkan device and no OCaml toolchain: glslangValidator and
+# spirv-dis only. With a RADV device present, pass --asm to also dump the ISA.
+#
+# Measured 2026-07-26, glslangValidator + SPIRV-Tools from the Vulkan SDK on
+# Mesa 26.1.4-arch3.1:
+#
+#   plain   : 0 NoContraction
+#   precise : 1 NoContraction, on the OpFMul
+#
+# and the RADV ISA is byte-identical between the two, both fusing via
+# v_fma_mixlo_f16 — see docs/fp-contraction-policy.md §6.
+set -euo pipefail
+
+need() { command -v "$1" >/dev/null || { echo "missing: $1"; exit 2; }; }
+need glslangValidator
+need spirv-dis
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+emit() { # $1 = "" | "precise "
+  cat <<EOF
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  ${1}float p = x * 1.1;
+  outb[i] = pack(float16_t(p));
+}
+EOF
+}
+
+status=0
+for variant in plain precise; do
+  qual=""
+  [ "$variant" = precise ] && qual="precise "
+  emit "$qual" > "$work/$variant.comp"
+  glslangValidator -V -S comp "$work/$variant.comp" -o "$work/$variant.spv" \
+    >/dev/null
+  n=$(spirv-dis "$work/$variant.spv" | grep -c NoContraction || true)
+  echo "$variant: $n NoContraction decoration(s)"
+
+  # The expectations are asserted, not printed: an unasserted probe that drifts
+  # is how a documented reproducer stops reproducing anything.
+  case "$variant" in
+    plain)
+      [ "$n" -eq 0 ] || {
+        echo "  UNEXPECTED: the undecorated variant should carry none"
+        status=1
+      } ;;
+    precise)
+      [ "$n" -eq 1 ] || {
+        echo "  UNEXPECTED: glslang no longer decorates the OpFMul for this"
+        echo "  shape. docs/fp-contraction-policy.md §6 says RADV IGNORES a"
+        echo "  decoration that IS emitted. If it is no longer emitted, that"
+        echo "  sentence is wrong and must be rewritten — do not just adjust"
+        echo "  this number."
+        status=1
+      } ;;
+  esac
+done
+
+spirv-dis "$work/precise.spv" | grep -E "NoContraction|OpFMul|OpFConvert" || true
+
+if [ "${1:-}" = "--asm" ]; then
+  echo
+  echo "ISA (needs a RADV device; both variants are expected to be identical,"
+  echo "and both to contain v_fma_mixlo_f16):"
+  echo "  RADV_DEBUG=asm dune exec sarek-vulkan/test/test_vulkan_f16_tripwire.exe"
+fi
+
+exit "$status"


### PR DESCRIPTION
## The answer

**RADV fuses.** Slice 2a's prediction — that GLSL/Vulkan on RADV is a third
front end onto the same ACO backend and should be *assumed* to carry the defect
*until measured* — holds. It was measured, not inferred, and the f32 null from
#106/#126 was correctly not treated as evidence: that measured `a*b+c`
contraction, and this is a multiply absorbed by a **conversion**, a different
combine that no RADV path had ever exercised because GLSL f16 is refused.

It is also **worse than OpenCL**, which does not follow from the locus being
shared.

## What was measured

Exhaustive over all 63488 finite binary16 values, on both local devices — RX
7900 XTX (**RADV NAVI31**) and the Raphael iGPU (**RADV RAPHAEL_MENDOCINO**),
Mesa 26.1.4-arch3.1, Vulkan 1.4.354 — against a host implementation of slice 1's
discipline. **Identical counts on both devices.**

| kernel shape / source-level defence | disagreements |
|---|---|
| `f16(x*1.1)`, plain | **2912/63488** |
| `f16(x*1.1)`, `precise` on the f32 local | **2912/63488** |
| `f16(f16(x*1.1) + 1000)`, plain | **5075/63488** |
| `f16(f16(x*1.1) + 1000)`, `precise` (what the backend already emits) | **4776/63488** |
| … with an f16 bitcast round-trip | 5075/63488 |
| … with a volatile SSBO round-trip on the f32 intermediates | 4774/63488 |
| … volatile SSBO round-trip **including the f16 bit pattern** | **0/63488** |

Every row matches a model of the emitted ISA **exactly** (0/63488), so these are
mechanisms rather than discrepancies.

**Same locus, wider combine.** Through OpenCL C, ACO swallows the multiply.
Through SPIR-V it also swallows the f32 **add**: the plain two-narrowing kernel
compiles to a *single* `v_fma_mixlo_f16 0xcccd, v1, 1000.0f` — one rounding for
an expression the DSL says has three.

**No affordable barrier, for a new reason.** Barriering the f32 intermediates
makes ACO drop the intermediate narrowing *entirely* rather than materialise a
binary16 value. Only forcing the f16 bit pattern through global memory works.

## The result that reaches beyond f16

`precise` **is honoured, and is the wrong instrument** — and this closes an open
question in `fp-contraction-policy.md` §6, negatively.

On the single-narrowing shape, `glslangValidator` emits `OpDecorate …
NoContraction` on the `OpFMul` (0 decorations without `precise`, 1 with), and
RADV's ISA is **byte-identical** between the two — *both fusing*, both
2912/63488, both matching the single-rounding model exactly.

The decoration is emitted, by the compiler the runtime path actually uses, and
ignored. §6 previously concluded "the claim that RADV ignores `NoContraction` is
not supported" and "`precise` is **inert, and free**". Both were true only of the
seven `a*b+c` shapes it probed. A null result is only as broad as its shape
catalogue.

So the inference this PR most exists to block — *we already emit `precise`, and
#106/#126 measured RADV not to contract 7 f32 shapes, therefore f16 is safe* —
is **false**, and is now a named test case that fails if it ever becomes true.

## Calibration, before any of the above is believed

A count nobody can falsify is not a measurement. Three controls, all asserted:

1. the host oracle re-encodes all 63488 finite binary16 values to themselves;
2. the **same host code reproduces the independently measured 620** on the
   HIP/OpenCL kernel shape — the known positive, reproduced by an independent
   implementation;
3. the barriered kernel agrees **bit-exactly, 0/63488** — the green control,
   proving the harness can report agreement, so "disagrees" is a statement about
   ACO and not about buffer layout, pack/unpack, or the `shaderFloat16` caveat.

All five assertions were **proved red by mutation** before being banked:
mis-scaled subnormal branch; the 620 models collapsed into one; the barrier
removed from the green control; comparison against the fused model in each of the
two device cases. One mutation's build failed and would have reported the
*previous* binary's result as the mutant's — caught, and the mutation harness
fixed to refuse a stale run. One defensive branch (`log2` binade correction) was
found to be **unfalsifiable by any input in the domain** and was replaced with an
exact `frexp` formulation rather than kept as an untestable branch.

## What this PR does

- **Does not enable f16 on GLSL.** The refusal stands.
- Fixes the **false diagnostic**: the shared composer said "not YET supported"
  and blamed `GL_EXT_shader_explicit_arithmetic_types_float16`. That extension
  compiles through this backend's own glslang path and runs on both devices;
  enabling it changes nothing. GLSL now raises its own diagnostic naming the
  measured blocker and leaves the composer — Metal and WGSL, which genuinely are
  unimplemented, keep sharing it.
- Adds `sarek-vulkan/test/test_vulkan_f16_tripwire.ml`, scoped on **driver
  identity** (`"RADV"` in the device name), not device model: the Raphael iGPU's
  name reads like a CPU and reproduces the defect identically — the same trap
  slice 2a found on the OpenCL side. Skips **visibly** elsewhere, naming what it
  rejected. Carries **no** "non-RADV does not fuse" cross-check, unlike its
  OpenCL sibling, because there is no data behind such a claim here.
- Adds `tools/probes/vulkan_f16_narrowing_probe.sh` for the half the gate cannot
  cover: if glslang ever stopped decorating, "ignored" would quietly become
  "never asked" with every test still green.
- Fixes `Sarek_ir_codegen.reject_feature`'s docstring, whose example still
  advertised OpenCL after OpenCL left the composer in slice 2a.

## What it does NOT close

- **Only RADV.** Not ANV, AMDVLK, NVIDIA or lavapipe. "RADV fuses" is the claim;
  "Vulkan fuses" is not.
- **`shaderFloat16` is not enabled.** `Vulkan_api_device` chains no feature
  structs beyond core `VkPhysicalDeviceFeatures`; RADV accepts these shaders
  anyway. The finding stands (the defect is in the ISA, and the barriered control
  returns bit-exact results on the same un-enabled path), but that plumbing is
  real work enabling f16 here would have to do first.
- **No Sarek-generated shader was involved.** The tripwire compiles raw GLSL,
  because the codegen refuses f16. It measures the driver, not the codegen; if
  the refusal is ever lifted, the codegen needs its own exhaustive gate.

## Verification

`dune build` clean; `dune build @fmt` exits 0; `dune runtest sarek-vulkan`,
`sarek/tests/codegen_golden`, `spoc` all green; `check-test-alias-coverage.sh`
OK (81 wired); `check-alcotest-registration.js` OK (558 files, 71 suites). The
new test is a `(test)` stanza, hence attached to `runtest` by construction.

Pre-existing and unchanged by this branch: `ci/assert-toolchain.sh` fails 3 of 10
on this workstation (no CUDA dev headers), identically before and after;
`check-license-headers.sh` lists the same 9 shell scripts before and after, none
of them mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of f16 operations on Vulkan/RADV by rejecting unsupported kernels with clearer diagnostics.
  - Clarified that `precise` does not reliably prevent f16 narrowing fusion.

- **Tests**
  - Added exhaustive Vulkan f16 tripwire coverage across finite binary16 inputs.
  - Added checks for plain, precise, and barriered shader behavior.

- **Documentation**
  - Updated floating-point contraction policies with measured Vulkan/RADV behavior and limitations.
  - Added a standalone probe for validating f16 narrowing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->