### PR TITLE
fix(backends): choose the FP build options instead of inheriting or discarding them (#136, #125)

### DIFF
--- a/benchmarks/descriptions/generated/dot_product_generated.md
+++ b/benchmarks/descriptions/generated/dot_product_generated.md
@@ -245,6 +245,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* output [[buffer(4)]], constant int &sarek_output_length [[buffer(5)]], constant int &n [[buffer(6)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/gather_generated.md
+++ b/benchmarks/descriptions/generated/gather_generated.md
@@ -72,6 +72,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device int* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device int* indices [[buffer(2)]], constant int &sarek_indices_length [[buffer(3)]], device int* output [[buffer(4)]], constant int &sarek_output_length [[buffer(5)]], constant int &n [[buffer(6)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/mandelbrot_generated.md
+++ b/benchmarks/descriptions/generated/mandelbrot_generated.md
@@ -99,6 +99,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device int* output [[buffer(0)]], constant int &sarek_output_length [[buffer(1)]], constant int &width [[buffer(2)]], constant int &height [[buffer(3)]], constant int &max_iter [[buffer(4)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/matrix_mul_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_generated.md
@@ -93,6 +93,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &m [[buffer(6)]], constant int &n [[buffer(7)]], constant int &k [[buffer(8)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
@@ -177,6 +177,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &m [[buffer(6)]], constant int &n [[buffer(7)]], constant int &k [[buffer(8)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/radix_sort_histogram_generated.md
+++ b/benchmarks/descriptions/generated/radix_sort_histogram_generated.md
@@ -130,6 +130,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device int* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device atomic_int* histogram [[buffer(2)]], constant int &sarek_histogram_length [[buffer(3)]], constant int &n [[buffer(4)]], constant int &shift [[buffer(5)]], constant int &mask [[buffer(6)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/radix_sort_scatter_generated.md
+++ b/benchmarks/descriptions/generated/radix_sort_scatter_generated.md
@@ -82,6 +82,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device int* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device int* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], device atomic_int* counters [[buffer(4)]], constant int &sarek_counters_length [[buffer(5)]], constant int &n [[buffer(6)]], constant int &shift [[buffer(7)]], constant int &mask [[buffer(8)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/reduction_generated.md
+++ b/benchmarks/descriptions/generated/reduction_generated.md
@@ -249,6 +249,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &n [[buffer(4)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/reduction_max_generated.md
+++ b/benchmarks/descriptions/generated/reduction_max_generated.md
@@ -345,6 +345,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &n [[buffer(4)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/scatter_generated.md
+++ b/benchmarks/descriptions/generated/scatter_generated.md
@@ -72,6 +72,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device int* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device int* indices [[buffer(2)]], constant int &sarek_indices_length [[buffer(3)]], device int* output [[buffer(4)]], constant int &sarek_output_length [[buffer(5)]], constant int &n [[buffer(6)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/stream_triad_generated.md
+++ b/benchmarks/descriptions/generated/stream_triad_generated.md
@@ -71,6 +71,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant float &scalar [[buffer(6)]], constant int &n [[buffer(7)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/transpose_naive_generated.md
+++ b/benchmarks/descriptions/generated/transpose_naive_generated.md
@@ -83,6 +83,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &width [[buffer(4)]], constant int &height [[buffer(5)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/transpose_tiled_generated.md
+++ b/benchmarks/descriptions/generated/transpose_tiled_generated.md
@@ -134,6 +134,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* input [[buffer(0)]], constant int &sarek_input_length [[buffer(1)]], device float* output [[buffer(2)]], constant int &sarek_output_length [[buffer(3)]], constant int &width [[buffer(4)]], constant int &height [[buffer(5)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/vector_add_generated.md
+++ b/benchmarks/descriptions/generated/vector_add_generated.md
@@ -69,6 +69,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], constant int &sarek_c_length [[buffer(5)]], constant int &n [[buffer(6)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/benchmarks/descriptions/generated/vector_copy_generated.md
+++ b/benchmarks/descriptions/generated/vector_copy_generated.md
@@ -64,6 +64,7 @@ void main() {
 ```metal
 #include <metal_stdlib>
 using namespace metal;
+#pragma METAL fp contract(off)
 
 kernel void sarek_kern(device float* a [[buffer(0)]], constant int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant int &sarek_b_length [[buffer(3)]], constant int &n [[buffer(4)]],
 uint3 __metal_gid [[thread_position_in_grid]],

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -104,12 +104,12 @@ Legend for the evidence column:
 | **CUDA / nvrtc (f16 narrowing)** | in principle the same fusion — but NVIDIA has no fused multiply-and-convert-to-f16 instruction to fuse *into* | **nothing Sarek emits.** `ptxas` simply declines to absorb `cvt.rn.f16.f32` | **executed**, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: exhaustive sweep of all 63488 finite binary16 inputs, 0 device/interpreter disagreements, with a liveness control proving the sweep can go red (§7). Also machine-code, CUDA 13.3 host tools, sm_75…sm_121 — see §4. Machine-checked by `test_cuda_f16_sass`, which until this change **self-skipped in CI** for want of `nvdisasm` (§7) |
 | **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
-| **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C | **no flag** — Sarek passes an empty build-option string. Same `mul_rn`-by-construction defence as CUDA | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
+| **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C, and no build option turns it off | for contraction, **no flag** — same `mul_rn`-by-construction defence as CUDA. For div/sqrt, `Opencl_fp.conformance_options` requests `-cl-fp32-correctly-rounded-divide-sqrt`, **gated** on `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT` in the device's `CL_DEVICE_SINGLE_FP_CONFIG`; `Opencl_fp.check_fp_conformance` **rejects** the relaxing `-cl-*` options at `Opencl_api.Program.build`, the single point an option string reaches `clBuildProgram` (§9) | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
 | **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, same ACO backend | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c` |
 | **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as HIP and rusticl, reached through a third front end, but a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on ACO and does not fuse here, so the locus is *the ACO backend*, not *OpenCL*. That in turn is the second independent reason to read rusticl and HIP/AMDGPU as one bug seen through two front ends rather than two bugs. Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any non-ACO implementation is found to fuse |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV not measured — no Intel GPU on this machine.** Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound |
-| **Metal** | Metal's default compile options enable fast math | **nothing.** `Metal_api` passes a null `MTLCompileOptions`, and `Metal_bindings.mtl_device_new_library_with_source` *ignores its `_options` argument entirely* | unverified — no Apple hardware in this project's CI or on the machine this policy was written on. Treat Metal float results as outside the guarantee |
+| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Still unverified: agreement with the interpreter** — `test_df64`/`test_real64` have not been run on a Mac (§11) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
 
@@ -625,7 +625,10 @@ this is where they are collected):
   bug class in a different backend** — `clBuildProgram` is called with no
   options and OpenCL's default permits a 3-ulp `sqrt`; adding
   `-cl-fp32-correctly-rounded-divide-sqrt` moves it to 8.87e-15, measured on the
-  same device, tracked as #136. The **Vulkan** residual (1.68e-14 on NVIDIA,
+  same device. **Fixed in backlog #136 (§9)** — but the fix could not be
+  re-measured here: the red does not reproduce on this machine's OpenCL devices
+  (rusticl/radeonsi reports `sqrt` 9.68e-15, a PASS) and rusticl ignores FP
+  build options outright. The **Vulkan** residual (1.68e-14 on NVIDIA,
   while Intel UHD 630 passes at 1.17e-14) has no established cause — that one is
   still "do not promote a hypothesis to a cause".
 - **f16 on Vulkan/GLSL: what slice 2b did NOT close.** The refusal is measured
@@ -647,8 +650,14 @@ this is where they are collected):
   GLSL, because `Sarek_ir_glsl` refuses f16; it measures the driver, not the
   codegen. If the refusal is ever lifted, the codegen's own output needs its own
   exhaustive interpreter-agreement gate — this one does not substitute.
-- **Metal is entirely unverified** (no Apple hardware), and it is the one
-  backend currently compiled with fast math on.
+- **Metal: no longer unverified, and the measurement changed the fix.** An
+  Apple M4 became available on 2026-07-26. Measured there (macOS 15.6.1, Apple
+  clang 17.0.0): both of Metal's math defaults are the fast one, the compile
+  options ARE honoured — and **none of them stops contraction**, which needs a
+  source pragma instead. Full account and the three things still open in §10.
+  What remains unverified is the part that matters most: **`test_df64` and
+  `test_real64` have not been run on a Mac**, so agreement with the interpreter
+  is still not established and Metal stays in the §3 "may NOT rely on" list.
 
 ---
 
@@ -656,7 +665,14 @@ this is where they are collected):
 
 | file | what it carries |
 |---|---|
-| `sarek-hip/Hip_rtc.ml` | `-ffp-contract=off` forced last; warning for caller-supplied fast-math options |
+| `sarek-hip/Hip_rtc.ml` | `-ffp-contract=off` forced last; `-fhip-fp32-correctly-rounded-divide-sqrt` and `-fno-gpu-flush-denormals-to-zero` set explicitly (§9); warning for caller-supplied fast-math options |
+| `sarek-opencl/Opencl_fp.ml` | the OpenCL build-option string: the capability-gated correctly-rounded-div/sqrt request, and `check_fp_conformance` rejecting the relaxing `-cl-*` options |
+| `sarek-opencl/test/test_opencl_fp_conformance.ml` | that guard and its two anti-vacuity controls (§9.5) |
+| `sarek/codegen/Sarek_ir_metal.ml` | `metal_fp_contract_pragma` — the ONLY measured Metal contraction defence (§10.5) |
+| `sarek-metal/Metal_bindings.ml` | `mtl_compile_options_conformant` — `mathMode=Safe` + `fpFunctions=Precise`, with the pre-macOS-15 fallback (§10.6) |
+| `tools/probes/opencl_build_options_probe.c` | which OpenCL build options a stack accepts, and whether they do anything — with plumbing and FP liveness controls |
+| `tools/probes/metal_math_mode_probe.m` | Metal's real defaults, and whether its options change results (M4) |
+| `tools/probes/metal_contraction_barrier_probe.m` | the Metal contraction barrier sweep, and the deprecated/modern API equivalence |
 | `sarek/codegen/Sarek_ir_cuda.ml` | `sarek_f32_barrier` — load-bearing on HIP, a documented identity on NVIDIA |
 | `sarek-cuda/Cuda_nvrtc.ml` | `check_fp_conformance` — rejects subnormal-flushing / approximate-div options |
 | `sarek/Sarek_df64/Sarek_df64.ml` | the `mul_rn` contraction barrier, its per-backend precision table, and the caller-side hazard |
@@ -665,8 +681,325 @@ this is where they are collected):
 | `tools/probes/vulkan_f16_narrowing_probe.sh` | standalone reproducer for the emitted-but-ignored `NoContraction`; needs no device |
 | `sarek-cuda/test/test_cuda_f16_sass.ml` | the f16 SASS gate (with positive control) |
 | `sarek-cuda/test/test_cuda_fp_conformance.ml` | the nvrtc FP-option guard and its hazard control |
-| `sarek-hip/test/test_hip_rtc_options.ml` | proves `-ffp-contract=off` stays last whatever the caller passes |
+| `sarek-hip/test/test_hip_rtc_options.ml` | proves `-ffp-contract=off` stays last whatever the caller passes, that the two §9 conformance defaults are set explicitly, and that the relaxing-option warning list covers what was measured to matter (with an anti-vacuity control) |
 | `sarek/tests/e2e/test_df64.ml` | the per-backend precision measurement this policy quotes |
 | `sarek/tests/e2e/test_vulkan_no_contraction.ml` | the §6 experiment: `precise` vs not, same device/driver/run, contracted targets taken from the device's own `fma` (`e2e-gpu` alias) |
 | `sarek-hip/test/test_hip_f16_shapes.ml` | every f16 expression shape swept over all 63488 finite binary16 inputs, with a barrier-removed control that must go red (`e2e-hip` alias) |
 | `scripts/f16_shape_isa_audit.sh` | the ISA half of that audit — catches shapes demoted in machine code but numerically clean |
+
+---
+
+## 9. OpenCL and HIP: what an unset option was choosing (backlog #136)
+
+`Opencl_api.Program.build` called `clBuildProgram` with an **empty option
+string**, and every caller in the tree passed nothing. An empty option string
+is not "no policy". It is a policy chosen by omission — whatever each vendor
+decided its default should be — and OpenCL's default permits a `sqrt` of up to
+3 ulp and a divide of up to 2.5 ulp, against §1's requirement that both are
+correctly rounded.
+
+That is the same shape as the PTX `sqrt.approx.f32` defect (§7): a faster, less
+accurate default selected by passing nothing.
+
+### 9.1 The red, and where it lives
+
+**The red is real and it is quoted, not re-measured.** On a GTX 1070 Max-Q
+(sm_61, CUDA 12.9, driver 580.119.02), `test_real64`'s df64 fallback measured
+OpenCL `sqrt` at **1.81e-14** against a 1.42e-14 tolerance — a FAIL — and
+building with `-cl-fp32-correctly-rounded-divide-sqrt` moved it to **8.87e-15**,
+a PASS coinciding with the interpreter's figure for the same input set.
+Measured during #298 on that device.
+
+**That device is not on this machine, and the red does not reproduce here.**
+Measured 2026-07-26, `test_real64` on rusticl/radeonsi 26.1.4-arch3.1: OpenCL
+`sqrt` 9.68e-15 on both the RX 7900 XTX and the Raphael iGPU — already passing.
+Say so plainly rather than implying the fix was observed to move anything
+locally: it was not, and it could not have been.
+
+### 9.2 The instrument, and why its cost figures are worthless here
+
+`tools/probes/opencl_build_options_probe.c`, 2^20 inputs per device, carries two
+controls and they disagree:
+
+| variant | sqrt vs correctly-rounded | bit-differs from baseline |
+|---|---|---|
+| baseline (empty option string) | ≤1 ulp | — |
+| `-cl-fp32-correctly-rounded-divide-sqrt` (the fix) | ≤1 ulp | **0 / 1048576** |
+| `-cl-fast-relaxed-math` (**FP liveness control**) | ≤1 ulp | **0 / 1048576** |
+| `-DSAREK_PROBE_SCALE=…` (**plumbing control**) | 3 ulp | 1048576 / 1048576 |
+
+The plumbing control **passes**: the option string really does reach rusticl's
+compiler and the comparison can go non-zero. The FP liveness control **fails**:
+even `-cl-fast-relaxed-math` changes nothing.
+
+**So on this stack "the flag changed nothing" is indistinguishable from "the
+flag was discarded", and no accuracy or cost conclusion may be drawn from these
+devices.** The probe prints −3.0% and +0.2% for the two devices; those are
+run-to-run noise around an unchanged kernel and **must not be reported as a
+measured cost**. The honest statement of cost on this machine is: *not
+measurable here*. The CUDA analogue (~12% on `bench_nbody` at sm_61 for
+`sqrt.rn.f32`) is a different backend on a different device and does not
+transfer.
+
+### 9.3 Why the flag is capability-gated
+
+The OpenCL spec permits `-cl-fp32-correctly-rounded-divide-sqrt` only when the
+device's `CL_DEVICE_SINGLE_FP_CONFIG` contains
+`CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT`; otherwise `clBuildProgram` returns
+`CL_INVALID_BUILD_OPTIONS`. An unconditional flag would therefore fail **every
+kernel build** on every device lacking the capability — a total failure, worse
+than the numerical one it fixes.
+
+**This machine would not have caught that.** Measured: both local devices report
+`CL_DEVICE_SINGLE_FP_CONFIG = 0x6` (`INF_NAN | ROUND_TO_NEAREST`, with neither
+`CL_FP_DENORM` nor `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT`) and **both accept the
+flag with `CL_SUCCESS` anyway** — rusticl departing from the spec in the
+permissive direction. The gate exists because the local stack cannot be trusted
+to reveal its absence. (Control: the deliberately invalid
+`-cl-this-option-does-not-exist` *is* refused, so "ACCEPTED" is not the probe's
+answer to everything.)
+
+### 9.4 The full audit — every default now chosen rather than inherited
+
+| option | decision | why |
+|---|---|---|
+| `-cl-fp32-correctly-rounded-divide-sqrt` | **set**, gated on the device bit | default off ⇒ 3-ulp `sqrt`, 2.5-ulp divide; `Sarek_df64`'s Newton/Karp step squares its seed error and has no margin for it |
+| `-cl-denorms-are-zero` | **never passed; refused from callers** | asks the device to flush binary32 subnormals, which §1 forbids. Its default (absent) is already conformant |
+| `-cl-fast-relaxed-math` | **never passed; refused** | implies unsafe-math + finite-math, and permits `native_*` substitution |
+| `-cl-unsafe-math-optimizations` | **never passed; refused** | permits reassociation, which destroys an error-free transformation outright (§1 corollary 1) |
+| `-cl-finite-math-only` | **never passed; refused** | assumes no NaN/Inf; the oracle assumes no such thing |
+| `-cl-no-signed-zeros` | **never passed; refused** | discards the sign of zero, which `Sarek_df64` renormalisation relies on |
+| `-cl-mad-enable` | **never passed; refused** | the contraction hazard by name |
+| `-cl-single-precision-constant` | **never passed; refused** | silently demotes double literals |
+| `-cl-opt-disable` | **allowed** from callers | conservative; cannot relax FP semantics |
+| `FP_CONTRACT` | **not addressable** | on by default in OpenCL C and **no build option turns it off**. `#pragma OPENCL FP_CONTRACT OFF` was measured on this stack and does not work (`Sarek_ir_opencl`'s `TFloat16` rejection: 620/63488 survive it). Contraction remains defeated **by construction** via `mul_rn`, as on CUDA |
+
+**Subnormals are flushed here regardless.** Both local devices lack
+`CL_FP_DENORM`, so f32 subnormals do not survive on this hardware whatever the
+build options say. That is a device property Sarek cannot correct; it is
+recorded, not fixed.
+
+Options are **refused** rather than countered because — unlike HIP, where
+appending `-ffp-contract=off` last neutralises whatever the caller passed —
+OpenCL has no build option that undoes `-cl-fast-relaxed-math`. Same reasoning
+as §5.
+
+### 9.5 The guard has been seen to fire
+
+`sarek-opencl/test/test_opencl_fp_conformance.ml`. Every case was proved red by
+mutating the thing under test:
+
+| mutation | test that went red |
+|---|---|
+| drop `-cl-fast-relaxed-math` from the reject list | rejection, token matching, assembly, **and** the real-device refusal |
+| ignore the capability gate (pass the flag unconditionally) | "off when the device does not advertise" |
+| make `conformance_options` always empty | "on when it does", assembled-string, caller-options |
+| remove `check_fp_conformance` from `build_options` | "raises instead of assembling", real-device refusal |
+| prefix-match instead of whole-token match | token matching (`-cl-mad-enable-that-is-not-a-real-option` wrongly refused) |
+| drop the caller's options while assembling | caller-options-survive |
+| make the `CL_DEVICE_SINGLE_FP_CONFIG` query return 0 | **fp-config-query-is-live** |
+
+The last is the one that matters most. The capability gate is *off* whenever the
+device lacks the bit — which is the case on every device here — so a silently
+broken query would disable the gate everywhere and make every "correctly gated
+off" assertion vacuous. Asserting the query returns non-zero on a real device is
+the only thing separating "the device says no" from "we never asked".
+
+### 9.6 HIP does NOT share the omission — but it had a neighbouring one
+
+The same question was put to the HIP path, since it is the same family and
+likely the same oversight. It is not: **HIP's inherited defaults are already
+conformant.**
+
+Measured on this machine 2026-07-26, ROCm 7.2.4 / AMD clang 22.0.0git, gfx1100,
+on `out = sqrtf(a) + a/b` via `clang++ -x hip --cuda-device-only -O3 -S`:
+
+| build | divide / sqrt shape | `.amdhsa_float_denorm_mode_32` |
+|---|---|---|
+| what Sarek passed (`-ffp-contract=off`) | refined: `v_div_scale_f32`, `v_div_fmas_f32`, `v_div_fixup_f32`; `v_sqrt_f32` + `v_fma_f32` Newton residuals (13 fp instructions) | **3** (subnormals preserved) |
+| `-fno-hip-fp32-correctly-rounded-divide-sqrt` (**liveness control**) | bare `v_rcp_f32` / `v_sqrt_f32` with `v_frexp`/`v_ldexp` scaling, **no `v_div_fixup_f32`** (10) | 3 |
+| `-fgpu-flush-denormals-to-zero` (**liveness control**) | refined | **0** (flushed) |
+| **with the two flags now set explicitly** | **identical** to row 1, all 13 instructions | 3 |
+
+So setting them costs nothing, and both controls confirm the comparison can go
+non-identical. What it buys, since `hiprtc_options` appends `base_options`
+**last**: a caller passing `-fgpu-flush-denormals-to-zero` or
+`-fno-hip-fp32-correctly-rounded-divide-sqrt` is now neutralised by last
+occurrence — verified, denorm mode returns to 3 and `v_div_fixup_f32` returns to
+the output. And a future clang default change becomes a no-op instead of a
+silent regression, which is the entire lesson of the OpenCL case.
+
+**The limit of the append-last defence, measured:** `-ffast-math` from a caller
+removes `v_div_fixup_f32` and is **not** rescued by appending
+`-fhip-fp32-correctly-rounded-divide-sqrt`, because it sets the per-instruction
+`afn` fast-math flag rather than changing the lowering default. No trailing
+clang option was found that undoes the `-cl-*` spellings at all.
+
+**HIP's actual gap was silence.** `fp_relaxing_option_prefixes` warned on four
+prefixes and passed these through unwarned, each measured to change gfx1100
+codegen: `-Ofast`, `-cl-fast-relaxed-math`, `-cl-unsafe-math-optimizations`,
+`-fapprox-func` (all degrade divide/sqrt exactly like `-ffast-math`),
+`-fgpu-flush-denormals-to-zero`, `-fno-hip-fp32-correctly-rounded-divide-sqrt`,
+and `-munsafe-fp-atomics` (swaps the `global_atomic_cmpswap_b32` CAS loop for a
+hardware `global_atomic_add_f32`). All are now in the list.
+
+**Still open, deliberately.** The first four are *not neutralisable by anything*,
+which is precisely the condition under which §5 says to **reject** rather than
+warn. That is a caller-visible behaviour change and is not made here. It is the
+recommended follow-up, and until it lands a caller can still relax HIP float
+semantics by passing `-ffast-math` and reading a warning.
+
+---
+
+---
+
+## 10. Metal: measured on an M4 — and the compile options were the wrong lever (backlog #125)
+
+This section was written as "a statement about code, not behaviour", because
+there was no Apple hardware. An Apple M4 became available on 2026-07-26, and the
+measurement **contradicted the fix it was defending**.
+
+**Device and toolchain, named as §1 corollary 3 requires:** Apple M4, macOS
+15.6.1 (24G90), arm64, Apple clang 17.0.0 (clang-1700.0.13.5), Metal.framework
+from the Command Line Tools SDK. No Xcode, therefore no offline `metal`
+compiler — and it does not matter, because `newLibraryWithSource:options:error:`
+compiles through the driver at runtime, which is exactly the call under test.
+
+### 10.1 What was wrong before
+
+`Metal_bindings.mtl_device_new_library_with_source` took an `_options` parameter
+and ignored it; `Metal_api` passed null regardless. So every Sarek Metal kernel
+took Metal's defaults and there was **no route to change them** — not "no
+policy", but an *unsettable* wrong default.
+
+### 10.2 Metal's defaults are fast on TWO knobs, not one
+
+Read from a freshly constructed `MTLCompileOptions`:
+
+| property | default | meaning |
+|---|---|---|
+| `mathMode` | `2` = `MTLMathModeFast` | aggressive unsafe FP optimisation |
+| `mathFloatingPointFunctions` | `0` = `...Fast` | single-precision math functions resolve to `metal::fast` |
+
+"Metal defaults to fast math" was previously quoted from Apple's documentation.
+It is now measured — and it is **two** independent knobs. Setting `mathMode`
+alone leaves math functions on the fast path.
+
+The enum values are **read from the SDK** (`MTLLibrary.h:241-246`, `258-262`),
+not guessed. The previous revision of `Metal_bindings.ml` deliberately avoided
+`setMathMode:` because these values could not be checked; that objection is
+retired by reading them.
+
+### 10.3 The options ARE honoured — liveness, not plumbing
+
+A compile that succeeds proves plumbing, not semantics. That distinction is what
+made the OpenCL FP liveness control valuable (§9.2), so the same question was put
+to Metal. Over 65536 inputs on `sqrt(a) + 1/a`, against the default:
+
+| setting | results changed |
+|---|---|
+| `mathMode = Safe` | **16017 / 65536** |
+| `mathMode = Safe` + `fpFunctions = Precise` | **22135 / 65536** |
+| `fastMathEnabled = NO` | **22135 / 65536** |
+| `mathMode = Fast`, `fastMathEnabled = YES` | 0 (confirming the default) |
+
+**Metal is therefore NOT in rusticl's class.** It does not accept these options
+and discard them. And the two-knob point is quantified: 16017 against 22135.
+
+### 10.4 But the options do NOT touch contraction — and that broke the fix
+
+The kernel under test is `o = a*b + c`. The separately-rounded reference is
+computed in **two kernel passes** with the product round-tripped through device
+memory, so it cannot itself be fused; the device's **own** `fma` is read from the
+device rather than modelled (§6 records why an IEEE model risks a false "they
+agree"); and elements are restricted to the **8773 of 65536** where those two
+differ, since contraction is unobservable anywhere else.
+
+| build | contracted |
+|---|---|
+| default options | 8773 / 8773 |
+| `mathMode = MTLMathModeSafe` | **8773 / 8773** |
+| `mathMode=Safe` + `fpFunctions=Precise` | **8773 / 8773** |
+| `fastMathEnabled = NO` | **8773 / 8773** |
+| **`#pragma METAL fp contract(off)`** | **0 / 8773** |
+
+`a*b+c` is bit-identical across every compile-option setting (0/65536 differ).
+
+**This is §1 corollary 2 for the third time in this document** — a flag that
+names the hazard is not a mechanism that prevents it. `-ffp-contract=off` did
+nothing for the AMDGPU combine; `precise`/`NoContraction` does nothing for the
+RADV f16 narrowing (§6); `mathMode = Safe` does nothing for Metal contraction.
+Had the M4 not become available, this change would have shipped `mathMode = Safe`
+believing it was a contraction defence. It is not one, and it is no longer
+described as one.
+
+### 10.5 What actually prevents it
+
+A full barrier sweep, every variant built with `mathMode=Safe` +
+`fpFunctions=Precise` (`tools/probes/metal_contraction_barrier_probe.m`):
+
+| candidate | contracted |
+|---|---|
+| plain `a*b+c` | 8773 / 8773 |
+| **`#pragma METAL fp contract(off)`** | **0 / 8773** — adopted |
+| `#pragma METAL fp math_mode(safe)` | 8773 / 8773 |
+| `#pragma clang fp contract(off)` | 0 / 8773 |
+| `volatile thread` local | 0 / 8773 |
+| `threadgroup volatile` round-trip | 0 / 8773 |
+| device round-trip | 0 / 8773 |
+| `as_type` bitcast round-trip | 0 / 8773 |
+| `precise::` namespace | does not compile — no such namespace in MSL |
+
+Note `#pragma METAL fp math_mode(safe)` fails exactly as the `mathMode`
+*property* does: on Metal, math mode and contraction are orthogonal.
+
+`Sarek_ir_metal` emits `#pragma METAL fp contract(off)` in every generated
+kernel. It is chosen over the working alternatives because it is file-scoped,
+costs no register or memory traffic, and needs no per-expression codegen change —
+the same reasoning that put `precise` on GLSL locals (§6). All nine byte-exact
+generated Metal goldens were compiled on the M4 to confirm the pragma is accepted
+in the position Sarek emits it. Gated by `test_codegen_golden`'s
+`metal_contraction_pragma` group, which carries an anti-vacuity control that
+fails if the kernel list is empty.
+
+### 10.6 Which API spelling, settled by measurement
+
+`fastMathEnabled` is deprecated since macOS 15.0 in favour of `mathMode`, but
+`mathMode` does not exist before macOS 15.0 / iOS 18.0, so both are needed: the
+modern pair when present, the deprecated boolean as fallback, selected by
+`respondsToSelector:`.
+
+**They are equivalent, measured.** `fastMathEnabled = NO` and
+`mathMode=Safe + fpFunctions=Precise` are **bit-identical over 65536 elements**
+of `sqrt + reciprocal + sin + log + exp` (0 differ). The pre-macOS-15 fallback is
+exact, not degraded — measured rather than assumed.
+
+### 10.7 What is STILL not established
+
+- **Agreement with the interpreter.** `test_df64` and `test_real64` have not been
+  run on a Mac. Everything above is a probe measuring Metal against *itself* —
+  its own `fma`, its own separately-rounded reference. That Sarek's Metal backend
+  end-to-end agrees with the oracle remains **unverified**, and Metal stays in
+  the §3 "you may NOT rely on" list until it is. Closing it needs the e2e suite
+  on Apple hardware plus a control showing it can go red there.
+- **One device, one OS.** M4 / macOS 15.6.1 only. Nothing here constrains older
+  Metal versions, Intel Macs, or the `fastMathEnabled` fallback path — which was
+  measured for *equivalence* on macOS 15 but has never run on the pre-15 OS that
+  is its only reason to exist.
+- **Subnormals.** Not probed at all on Metal.
+
+### 10.8 A separate defect this uncovered
+
+Compiling the nine byte-exact generated Metal goldens on the M4: **seven compile,
+two do not.** `record_kernel` and `variant_kernel` emit `constant Point2* &pts` /
+`constant Opt* &out`, and Metal rejects the pointee address space: *"invalid
+address space qualification for buffer pointee type ... valid address space
+qualifications are device and constant"*.
+
+**Pre-existing and unrelated to the FP work** — a control run with the pragma
+stripped from those same two sources fails identically. It is a codegen
+correctness bug that had never been observable, because nothing in this project
+had ever compiled Metal on Apple hardware. **Not fixed here**: choosing between
+`device` and `constant` for record and variant buffers is a design decision, not
+a typo. Recorded because it is the clearest illustration of what "unverified
+backend" was actually costing.

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -109,7 +109,7 @@ Legend for the evidence column:
 | **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as HIP and rusticl, reached through a third front end, but a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on ACO and does not fuse here, so the locus is *the ACO backend*, not *OpenCL*. That in turn is the second independent reason to read rusticl and HIP/AMDGPU as one bug seen through two front ends rather than two bugs. Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any non-ACO implementation is found to fuse |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV not measured — no Intel GPU on this machine.** Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound |
-| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Still unverified: agreement with the interpreter** — `test_df64`/`test_real64` have not been run on a Mac (§11) |
+| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. f16 and subnormals unprobed; two record/variant kernels do not compile at all (§10.11) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
 
@@ -137,6 +137,13 @@ Legend for the evidence column:
   sampled maxima on named devices, not bounds — see the caveat at the top of
   `Sarek_df64`'s PRECISION CONTRACT. The OpenCL and Vulkan `sqrt` residuals
   recorded in that header are still open.
+- **`Sarek_df64` meeting its precision contract on Metal, for f32 scalar
+  kernels** — executed on an Apple M4 / macOS 15.6.1 (24G90) / Apple clang
+  17.0.0: `test_df64` and `test_real64` PASS on every op and reproduce the
+  interpreter's worst-case figures exactly (§10.7). Read the scope narrowly:
+  one device, one OS, summary maxima rather than element-wise identity, no f16,
+  no subnormals, and **not** kernels using records or variants — those do not
+  compile on Metal at all (§10.11).
 - **No `-use_fast_math` / `-ftz=true` reaching nvrtc**, enforced rather than
   documented (§5) — in **both** the inline (`--ftz=true`) and the separated
   (`--ftz true`) spelling, and fail-closed on a bare `--ftz` whose value cannot
@@ -146,8 +153,16 @@ Legend for the evidence column:
 
 **You may NOT rely on:**
 
-- **Metal or WGSL float semantics at all.** Metal in particular compiles with
-  fast math on, unopposed.
+- **WGSL float semantics at all.**
+- **Metal f16, Metal subnormals, and Metal record/variant kernels.** Metal
+  **f32 arithmetic** has moved OFF this list: `test_df64` and `test_real64`
+  agree with the interpreter on every op on an Apple M4 / macOS 15.6.1 / Apple
+  clang 17.0.0 (§10.7), with contraction defeated by
+  `#pragma METAL fp contract(off)` in every generated kernel (§10.5). What is
+  still NOT covered: f16 (never probed on Metal), subnormals (never probed),
+  element-wise identity (the agreement is between summary maxima), any device
+  or OS other than that one, and kernels using **records or variants**, which
+  do not compile on Metal at all (§10.11).
 - **Vulkan `fma` being correctly rounded.** On Mesa RADV it is not, and
   `Sarek_df64` mul/div is ~5.8e-08 there — a *documented*, unfixed deviation,
   not a bug to rediscover. Note this is a distinct failure from contraction:
@@ -655,9 +670,11 @@ this is where they are collected):
   clang 17.0.0): both of Metal's math defaults are the fast one, the compile
   options ARE honoured — and **none of them stops contraction**, which needs a
   source pragma instead. Full account and the three things still open in §10.
-  What remains unverified is the part that matters most: **`test_df64` and
-  `test_real64` have not been run on a Mac**, so agreement with the interpreter
-  is still not established and Metal stays in the §3 "may NOT rely on" list.
+  Interpreter agreement has since been executed on that M4: `test_df64` and
+  `test_real64` PASS on every op and reproduce the interpreter's figures
+  exactly (§10.7), so Metal **f32** has left the §3 "may NOT rely on" list.
+  Metal f16, subnormals, and record/variant kernels have not — the last of
+  those because they do not compile (§10.11).
 
 ---
 
@@ -974,21 +991,90 @@ modern pair when present, the deprecated boolean as fallback, selected by
 of `sqrt + reciprocal + sin + log + exp` (0 differ). The pre-macOS-15 fallback is
 exact, not degraded — measured rather than assumed.
 
-### 10.7 What is STILL not established
+### 10.7 Interpreter agreement: measured, and it holds
 
-- **Agreement with the interpreter.** `test_df64` and `test_real64` have not been
-  run on a Mac. Everything above is a probe measuring Metal against *itself* —
-  its own `fma`, its own separately-rounded reference. That Sarek's Metal backend
-  end-to-end agrees with the oracle remains **unverified**, and Metal stays in
-  the §3 "you may NOT rely on" list until it is. Closing it needs the e2e suite
-  on Apple hardware plus a control showing it can go red there.
+`test_df64` and `test_real64` have now been run on the M4. **Metal agrees with
+the interpreter oracle on every operation**, worst-case relative error over each
+test's own input set:
+
+| op | Metal | Interpreter | tol | |
+|---|---|---|---|---|
+| `mul` | 9.07e-15 | 9.07e-15 | 1.42e-14 | PASS |
+| `add` | 5.33e-15 | 5.33e-15 | 7.11e-15 | PASS |
+| `sub` | 6.51e-15 | 6.51e-15 | 7.11e-15 | PASS |
+| `div` | 5.08e-15 | 5.08e-15 | 1.42e-14 | PASS |
+| `sqrt` | 8.53e-15 | 8.53e-15 | 1.42e-14 | PASS |
+| `of_i32` | 0 | 0 | 0 | PASS |
+
+`test_real64`'s df64 fallback on the same device: add 5.31e-15, sub 6.94e-15,
+mul 8.73e-15, div 5.26e-15, sqrt 8.87e-15 — all PASS. `dot(2^20)` 2.89e-13,
+identical to the interpreter's.
+
+These are **sampled maxima on one device over one input set, not bounds**, and
+Metal reproducing the interpreter's figure is agreement between two summary
+statistics — no element-wise comparison was run. Same caveat as the CUDA
+figures in §7.
+
+### 10.8 The pragma does NOT move df64 — and that is the expected answer
+
+Rebuilt with `metal_fp_contract_pragma` emptied and re-run on the same device:
+**every df64 and real64 figure above is unchanged, to the digit.**
+
+That is not a failure of the pragma. It is `Sarek_df64` working as designed.
+The library defeats contraction **by construction** — `mul_rn` routes products
+through `fma` so there is no fusable multiply left for any compiler to fuse —
+which is exactly why §2 records "no flag" as the CUDA and OpenCL mechanism too.
+**`Sarek_df64` is immune to contraction by design, so it cannot be an instrument
+for detecting it.** Expecting it to move the way `sqrt.rn.f32` did on NVIDIA
+conflates two different mechanisms: that was an approximate *seed inside the
+algorithm*, which `mul_rn` does not protect against; this is contraction, which
+it does.
+
+So the pragma's value is precisely for the code `Sarek_df64` cannot protect —
+**caller-written kernels**. That is the §3 hazard that "lives in *caller* code,
+and no gate in this repository can see": a user writing `a*b + c`, or
+`df64_add_f32 acc (x *. y)`, re-creates the fusable pattern the library removed
+from its own code. On the M4 that pattern is contracted 8773/8773 without the
+pragma and 0/8773 with it (§10.4). The synthetic probe is the right instrument
+and the only one; df64 passing either way is consistent with both.
+
+### 10.9 What is STILL not established
+
+- **Element-wise identity.** The agreement above is between summary statistics.
 - **One device, one OS.** M4 / macOS 15.6.1 only. Nothing here constrains older
   Metal versions, Intel Macs, or the `fastMathEnabled` fallback path — which was
   measured for *equivalence* on macOS 15 but has never run on the pre-15 OS that
   is its only reason to exist.
 - **Subnormals.** Not probed at all on Metal.
+- **f16 on Metal.** Not probed. The three other backends that reach an ACO or
+  NVIDIA compiler each needed a separate exhaustive f16 sweep before anything
+  could be said; Metal has had none.
+- **The two kernels that do not compile** (§10.11) are excluded from every
+  figure above, because they never ran.
 
-### 10.8 A separate defect this uncovered
+### 10.10 Running the full suite on the M4: one more environmental finding
+
+`dune runtest` on the M4 is green except for **six `opencl_validation_sweep`
+cases, all `float64`**. Apple's clang rejects them outright:
+
+```
+warning: unsupported OpenCL extension 'cl_khr_fp64' - ignoring
+error: use of type 'double' requires cl_khr_fp64 support
+```
+
+**Environmental, not a regression.** Apple Silicon's OpenCL has no `cl_khr_fp64`
+at all, so the host-clang validation of any generated f64 OpenCL kernel cannot
+pass there. This branch touches no OpenCL codegen (its OpenCL changes are all in
+`sarek-opencl/` runtime bindings) and no f64 path, so it cannot be the cause.
+Worth noting nonetheless: cases 7-8 of the same sweep **SKIP** on f64 while
+16-20 **FAIL**, so the sweep's own capability gating is inconsistent — some f64
+cases detect the missing extension and some do not. That is a test-scoping bug
+in the sweep, pre-existing, and a good candidate for the "a skip is not a pass"
+treatment the CUDA gates got.
+
+All six `metal_contraction_pragma` cases pass on the M4.
+
+### 10.11 A separate defect this uncovered
 
 Compiling the nine byte-exact generated Metal goldens on the M4: **seven compile,
 two do not.** `record_kernel` and `variant_kernel` emit `constant Point2* &pts` /

--- a/sarek-hip/Hip_rtc.ml
+++ b/sarek-hip/Hip_rtc.ml
@@ -215,17 +215,112 @@ let check ctx result =
     — so the defect is specifically the FUSION, not the arithmetic or the
     conversion.
 
-    An exhaustive sweep of all finite binary16 inputs found 373 values on which
-    contraction changed the result; with contraction off, zero. *)
-let base_options = ["-ffp-contract=off"]
+    An exhaustive sweep of all finite binary16 inputs found values on which
+    contraction changed the result; with contraction off, zero. (The count that
+    used to be quoted here was 373. Do not restore it:
+    docs/fp-contraction-policy.md §2 records that 373 appears in-tree for two
+    DIFFERENT populations whose uses contradict each other, and that 620 is the
+    barrier/ISel-combine figure. Neither is the number for THIS sentence, and
+    the right count for it has not been established, so it is not asserted.)
+
+    {2 The other two options, and why they are here (#136)}
+
+    [-fhip-fp32-correctly-rounded-divide-sqrt] and
+    [-fno-gpu-flush-denormals-to-zero] are already clang's HIP defaults. They
+    are set anyway, and the reason is the whole subject of #136: an inherited
+    default is a choice nobody made. The OpenCL backend inherited a 3-ulp [sqrt]
+    this way for years, silently, because it passed no build options at all.
+
+    MEASURED on this machine, 2026-07-26, ROCm 7.2.4 / AMD clang 22.0.0git,
+    gfx1100, on [out = sqrtf(a) + a/b] compiled with
+    [clang++ -x hip --offload-arch=gfx1100 --cuda-device-only -O3 -S]:
+
+    - Adding both flags to today's option list is a NO-OP: the emitted assembly
+      is IDENTICAL over all 13 floating-point instructions. So this costs
+      nothing.
+    - The liveness control confirms the comparison can go non-identical:
+      [-fno-hip-fp32-correctly-rounded-divide-sqrt] drops the emitted code from
+      the refined form ([v_div_scale_f32] / [v_div_fmas_f32] /
+      [v_div_fixup_f32], and [v_sqrt_f32] with [v_fma_f32] Newton residuals) to
+      a bare [v_rcp_f32] / [v_sqrt_f32] with [v_frexp]/[v_ldexp] scaling — 10
+      instructions, no [v_div_fixup_f32].
+    - [-fgpu-flush-denormals-to-zero] moves [.amdhsa_float_denorm_mode_32] from
+      3 (IEEE, subnormals preserved) to 0 (flushed).
+
+    What that buys, given {!hiprtc_options} appends these LAST: a caller passing
+    [-fgpu-flush-denormals-to-zero] or
+    [-fno-hip-fp32-correctly-rounded-divide-sqrt] is now neutralised by
+    last-occurrence, exactly as [-ffp-contract=off] neutralises
+    [-ffp-contract=fast]. Both verified: denorm mode returns to 3, and
+    [v_div_fixup_f32] returns to the output.
+
+    What it does NOT buy, and this is the limit of the whole append-last
+    defence: [-ffast-math] from a caller still removes [v_div_fixup_f32] and is
+    NOT rescued by appending [-fhip-fp32-correctly-rounded-divide-sqrt], because
+    it sets the per-instruction [afn] fast-math flag rather than changing the
+    divide/sqrt lowering default. That class is warned about below and is a
+    candidate for outright rejection — see {!fp_relaxing_option_prefixes}. *)
+let base_options =
+  [
+    "-fhip-fp32-correctly-rounded-divide-sqrt";
+    "-fno-gpu-flush-denormals-to-zero";
+    (* MUST STAY LAST: see {!hiprtc_options}. The two above are order-
+       insensitive against each other; this one is not, against a caller's. *)
+    "-ffp-contract=off";
+  ]
 
 (** Floating-point option classes a caller can pass that would re-enable
     contraction, or otherwise relax the f32 evaluation discipline, if they took
     effect. Matched by prefix so [-ffp-contract=fast] and [-ffp-model=fast] are
-    both caught. *)
+    both caught.
+
+    EXTENDED FOR #136. The first four entries were the original list. Each of
+    the rest was MEASURED to change the emitted gfx1100 code through this exact
+    option ordering (ROCm 7.2.4 / AMD clang 22.0.0git, 2026-07-26) while passing
+    this warning silently:
+
+    - [-Ofast], [-cl-fast-relaxed-math], [-cl-unsafe-math-optimizations],
+      [-fapprox-func] — all degrade divide and [sqrt] to the approximate form,
+      the same result as [-ffast-math], under names the original four prefixes
+      could not see. Note [-Ofast] in particular: a prefix list is the wrong
+      shape for it in general (a [-O] prefix would wrongly catch [-O3]), which
+      is why the full token is listed.
+    - [-fgpu-flush-denormals-to-zero] — moves [.amdhsa_float_denorm_mode_32]
+      from 3 to 0, flushing binary32 subnormals, which
+      docs/fp-contraction-policy.md §1 forbids.
+    - [-fno-hip-fp32-correctly-rounded-divide-sqrt] — removes [v_div_fixup_f32].
+    - [-munsafe-fp-atomics] — swaps the [global_atomic_cmpswap_b32] CAS loop for
+      a hardware [global_atomic_add_f32] whose rounding and denormal behaviour
+      is not the IEEE path.
+
+    THE LAST THREE ARE NOW NEUTRALISED by {!base_options} (verified: denorm mode
+    returns to 3, [v_div_fixup_f32] returns), so for those the warning says
+    "your flag was overridden", not "your flag took effect". THE FIRST FOUR ARE
+    NOT NEUTRALISED BY ANYTHING — measured: appending
+    [-fhip-fp32-correctly-rounded-divide-sqrt] does not restore
+    [v_div_fixup_f32] after [-ffast-math], and no trailing clang option was
+    found that undoes the [-cl-*] spellings at all.
+
+    That asymmetry is the argument for eventually REJECTING the first group
+    rather than warning, as [Cuda_nvrtc.check_fp_conformance] and
+    [Opencl_fp.check_fp_conformance] both do for their unneutralisable options.
+    That is a caller-visible behaviour change and is deliberately NOT made here;
+    this change only stops the options being invisible. *)
 let fp_relaxing_option_prefixes =
   [
-    "-ffp-contract="; "-ffp-model="; "-ffast-math"; "-funsafe-math-optimizations";
+    (* Not neutralisable — reject candidates. *)
+    "-ffp-contract=";
+    "-ffp-model=";
+    "-ffast-math";
+    "-funsafe-math-optimizations";
+    "-Ofast";
+    "-cl-fast-relaxed-math";
+    "-cl-unsafe-math-optimizations";
+    "-fapprox-func";
+    (* Neutralised by [base_options], but the caller should still be told. *)
+    "-fgpu-flush-denormals-to-zero";
+    "-fno-hip-fp32-correctly-rounded-divide-sqrt";
+    "-munsafe-fp-atomics";
   ]
 
 let has_prefix ~prefix s =
@@ -240,9 +335,10 @@ let has_prefix ~prefix s =
     and [-ffp-model]. With the conformance flag placed first (as it was), a
     caller passing [-ffp-contract=fast], [-ffast-math] or [-ffp-model=fast]
     would silently reinstate the very contraction {!base_options} exists to
-    forbid, and the f16 device/interpreter agreement would break on the 373
-    inputs measured above. Putting it last makes that unreachable by
-    construction rather than by convention.
+    forbid, and the f16 device/interpreter agreement would break on the inputs
+    measured above. Putting it last makes that unreachable by construction
+    rather than by convention. (No count is quoted: see {!base_options} on why
+    "373" must not be restored.)
 
     Contraction is then guaranteed off regardless of the caller. The other
     effects of a fast-math-class flag (reassociation, finite-math-only) are NOT

--- a/sarek-hip/Hip_rtc.ml
+++ b/sarek-hip/Hip_rtc.ml
@@ -223,13 +223,14 @@ let check ctx result =
     barrier/ISel-combine figure. Neither is the number for THIS sentence, and
     the right count for it has not been established, so it is not asserted.)
 
-    {2 The other two options, and why they are here (#136)}
+    {2 The other two options, and why they are here (backlog #136)}
 
     [-fhip-fp32-correctly-rounded-divide-sqrt] and
     [-fno-gpu-flush-denormals-to-zero] are already clang's HIP defaults. They
-    are set anyway, and the reason is the whole subject of #136: an inherited
-    default is a choice nobody made. The OpenCL backend inherited a 3-ulp [sqrt]
-    this way for years, silently, because it passed no build options at all.
+    are set anyway, and the reason is the whole subject of backlog #136: an
+    inherited default is a choice nobody made. The OpenCL backend inherited a
+    3-ulp [sqrt] this way for years, silently, because it passed no build
+    options at all.
 
     MEASURED on this machine, 2026-07-26, ROCm 7.2.4 / AMD clang 22.0.0git,
     gfx1100, on [out = sqrtf(a) + a/b] compiled with
@@ -274,10 +275,10 @@ let base_options =
     effect. Matched by prefix so [-ffp-contract=fast] and [-ffp-model=fast] are
     both caught.
 
-    EXTENDED FOR #136. The first four entries were the original list. Each of
-    the rest was MEASURED to change the emitted gfx1100 code through this exact
-    option ordering (ROCm 7.2.4 / AMD clang 22.0.0git, 2026-07-26) while passing
-    this warning silently:
+    EXTENDED FOR backlog #136. The first four entries were the original list.
+    Each of the rest was MEASURED to change the emitted gfx1100 code through
+    this exact option ordering (ROCm 7.2.4 / AMD clang 22.0.0git, 2026-07-26)
+    while passing this warning silently:
 
     - [-Ofast], [-cl-fast-relaxed-math], [-cl-unsafe-math-optimizations],
       [-fapprox-func] — all degrade divide and [sqrt] to the approximate form,

--- a/sarek-hip/test/test_hip_rtc_options.ml
+++ b/sarek-hip/test/test_hip_rtc_options.ml
@@ -117,7 +117,7 @@ let () =
     (if mutation_detected then ""
      else Printf.sprintf " — %s did not trip the check" (show bad)) ;
   (* ---------------------------------------------------------------- *)
-  (* 3. #136: the two conformance defaults are set EXPLICITLY, and     *)
+  (* 3. backlog #136: the two conformance defaults are set EXPLICITLY, and     *)
   (*    -ffp-contract=off is still last.                               *)
   (*                                                                   *)
   (*    These two flags are already clang's HIP defaults - MEASURED     *)
@@ -172,8 +172,8 @@ let () =
       "-fno-hip-fp32-correctly-rounded-divide-sqrt";
     ] ;
   (* ---------------------------------------------------------------- *)
-  (* 4. #136: the relaxing-option WARNING list must actually cover the *)
-  (*    options measured to degrade gfx1100 codegen. Before #136 each  *)
+  (* 4. backlog #136: the relaxing-option WARNING list must actually cover the *)
+  (*    options measured to degrade gfx1100 codegen. Before backlog #136 each  *)
   (*    of these passed silently.                                      *)
   (* ---------------------------------------------------------------- *)
   let relaxing s =

--- a/sarek-hip/test/test_hip_rtc_options.ml
+++ b/sarek-hip/test/test_hip_rtc_options.ml
@@ -8,8 +8,12 @@
  *
  * [Sarek_hip.Hip_rtc.base_options] carries "-ffp-contract=off", which is a CONFORMANCE
  * requirement: with contraction on, RDNA3 fuses the f32 multiply into the
- * f32->f16 narrowing and the device stops matching the interpreter on 373 of
- * the 63488 finite binary16 inputs.
+ * f32->f16 narrowing and the device stops matching the interpreter on some of
+ * the 63488 finite binary16 inputs. (No count: docs/fp-contraction-policy.md
+ * §2 records that the "373" this line used to carry is one of two mutually
+ * inconsistent in-tree uses of that figure, and that 620 is the barrier/ISel
+ * count for a DIFFERENT population. The right count for this sentence has not
+ * been established.)
  *
  * hiprtc hands its option array straight to clang, and clang resolves
  * conflicting floating-point options by LAST OCCURRENCE. So the conformance
@@ -112,6 +116,107 @@ let () =
     mutation_detected
     (if mutation_detected then ""
      else Printf.sprintf " — %s did not trip the check" (show bad)) ;
+  (* ---------------------------------------------------------------- *)
+  (* 3. #136: the two conformance defaults are set EXPLICITLY, and     *)
+  (*    -ffp-contract=off is still last.                               *)
+  (*                                                                   *)
+  (*    These two flags are already clang's HIP defaults - MEASURED     *)
+  (*    ISA-identical on gfx1100, ROCm 7.2.4 / clang 22.0.0git. They    *)
+  (*    are set anyway so a caller's -fgpu-flush-denormals-to-zero or   *)
+  (*    -fno-hip-fp32-correctly-rounded-divide-sqrt is neutralised by   *)
+  (*    last occurrence (both verified: denorm mode returns to 3,       *)
+  (*    v_div_fixup_f32 returns), and so a future clang default change  *)
+  (*    is a no-op rather than a silent regression.                     *)
+  (* ---------------------------------------------------------------- *)
+  let base = Sarek_hip.Hip_rtc.base_options in
+  List.iter
+    (fun flag ->
+      let present = List.exists (String.equal flag) base in
+      report
+        (Printf.sprintf "base_options sets %s explicitly" flag)
+        present
+        (if present then ""
+         else Printf.sprintf " — base_options = %s" (show base)))
+    [
+      "-fhip-fp32-correctly-rounded-divide-sqrt";
+      "-fno-gpu-flush-denormals-to-zero";
+    ] ;
+  (* The two new flags must NOT displace -ffp-contract=off from last. *)
+  let contract_last =
+    match List.rev base with "-ffp-contract=off" :: _ -> true | _ -> false
+  in
+  report
+    "-ffp-contract=off is still the LAST base option"
+    contract_last
+    (if contract_last then ""
+     else Printf.sprintf " — base_options = %s" (show base)) ;
+  (* And a caller passing the negated forms must still lose to them. *)
+  List.iter
+    (fun opt ->
+      let got = Sarek_hip.Hip_rtc.hiprtc_options [opt] in
+      let neg = last_index_of (String.equal opt) got in
+      let pos =
+        last_index_of
+          (fun s ->
+            s = "-fhip-fp32-correctly-rounded-divide-sqrt"
+            || s = "-fno-gpu-flush-denormals-to-zero")
+          got
+      in
+      let ok = neg >= 0 && pos > neg in
+      report
+        (Printf.sprintf "%s is overridden by a later conformance flag" opt)
+        ok
+        (if ok then "" else Printf.sprintf " — result = %s" (show got)))
+    [
+      "-fgpu-flush-denormals-to-zero";
+      "-fno-hip-fp32-correctly-rounded-divide-sqrt";
+    ] ;
+  (* ---------------------------------------------------------------- *)
+  (* 4. #136: the relaxing-option WARNING list must actually cover the *)
+  (*    options measured to degrade gfx1100 codegen. Before #136 each  *)
+  (*    of these passed silently.                                      *)
+  (* ---------------------------------------------------------------- *)
+  let relaxing s =
+    List.exists
+      (fun prefix -> has_prefix ~prefix s)
+      Sarek_hip.Hip_rtc.fp_relaxing_option_prefixes
+  in
+  List.iter
+    (fun opt ->
+      let ok = relaxing opt in
+      report
+        (Printf.sprintf "%s is recognised as fp-relaxing" opt)
+        ok
+        (if ok then ""
+         else
+           " — measured to change gfx1100 codegen (approximate divide/sqrt, \
+            flushed subnormals, or an unsafe fp atomic) yet passes unwarned"))
+    [
+      "-ffast-math";
+      "-funsafe-math-optimizations";
+      "-ffp-model=fast";
+      "-Ofast";
+      "-cl-fast-relaxed-math";
+      "-cl-unsafe-math-optimizations";
+      "-fapprox-func";
+      "-fgpu-flush-denormals-to-zero";
+      "-fno-hip-fp32-correctly-rounded-divide-sqrt";
+      "-munsafe-fp-atomics";
+    ] ;
+  (* ANTI-VACUITY CONTROL for section 4: the list must not match          *)
+  (* everything. -O3 in particular must NOT be caught by -Ofast, and the  *)
+  (* rocWMMA include/define path must stay warning-free.                  *)
+  List.iter
+    (fun opt ->
+      let ok = not (relaxing opt) in
+      report
+        (Printf.sprintf "%s is NOT flagged (anti-vacuity control)" opt)
+        ok
+        (if ok then ""
+         else
+           " — a benign option is being reported as fp-relaxing, so section 4 \
+            proves nothing"))
+    ["-O3"; "-O2"; "-I/opt/rocm/include"; "-DSAREK=1"; "--offload-arch=gfx1100"] ;
   if !failures = 0 then (
     print_endline "  hiprtc option assembly: PASS" ;
     exit 0)

--- a/sarek-metal/Metal_api.ml
+++ b/sarek-metal/Metal_api.ml
@@ -248,28 +248,38 @@ module Library = struct
       regardless, so every Sarek Metal kernel compiled under Metal's fast-math
       default with no way to turn it off.
 
-      NOT EXECUTED ON HARDWARE — there is no Apple device on the machine this
-      was written on. If [mtl_compile_options_conformant] returns [None] (older
-      OS, missing selector, allocation failure) this falls back to null options,
-      i.e. exactly the behaviour before backlog #125, and says so in the log rather
-      than silently. Either way, Metal float results remain outside the
-      guarantee until somebody runs [test_df64] on a Mac; see
-      docs/fp-contraction-policy.md §11. *)
+      These options are NOT a contraction defence — measured on an Apple M4,
+      [a*b+c] is contracted under every setting of them, and only
+      [Sarek_ir_metal.metal_fp_contract_pragma] in the generated source stops
+      it. What they buy is math-function accuracy, and that much is measured
+      (22135 of 65536 results change on [sqrt(a) + 1/a]).
+
+      If [mtl_compile_options_conformant] returns [None] (older OS, missing
+      selector, allocation failure) this falls back to null options, i.e.
+      exactly the behaviour before backlog #125, and says so in the log rather
+      than silently.
+
+      Metal float results are STILL outside the guarantee: [test_df64] and
+      [test_real64] have never been run on a Mac, so agreement with the
+      interpreter is not established. See docs/fp-contraction-policy.md §10. *)
   let create_from_source device source =
     let options = mtl_compile_options_conformant () in
     (match options with
     | Some _ ->
         Spoc_core.Log.debugf
           Spoc_core.Log.Kernel
-          "Metal: compiling with fastMathEnabled=NO (requested, UNVERIFIED on \
-           hardware - see docs/fp-contraction-policy.md §11)"
+          "Metal: compiling with safe math mode (mathMode=Safe + \
+           mathFloatingPointFunctions=Precise, or fastMathEnabled=NO on macOS \
+           < 15). Contraction is handled separately, by the #pragma METAL fp \
+           contract(off) in the generated source."
     | None ->
         Spoc_core.Log.warnf
           Spoc_core.Log.Kernel
           "Metal: could not build MTLCompileOptions, falling back to Metal's \
-           DEFAULT compile options, which enable FAST MATH. Kernel results may \
-           disagree with the Sarek interpreter on contraction- or \
-           subnormal-sensitive code. See docs/fp-contraction-policy.md §11.") ;
+           DEFAULT compile options, whose math mode is FAST on both knobs \
+           (measured on Apple M4). Single-precision math functions will \
+           resolve to metal::fast and may disagree with the Sarek interpreter. \
+           See docs/fp-contraction-policy.md §10.") ;
     let result =
       mtl_device_new_library_with_source device.Device.handle source options
     in

--- a/sarek-metal/Metal_api.ml
+++ b/sarek-metal/Metal_api.ml
@@ -243,17 +243,17 @@ module Library = struct
 
   (** Compile MSL source.
 
-      Requests Metal's non-fast-math mode (#125). Until this change the options
-      argument was hardcoded [None] AND the binding ignored it regardless, so
-      every Sarek Metal kernel compiled under Metal's fast-math default with no
-      way to turn it off.
+      Requests Metal's non-fast-math mode (backlog #125). Until this change the
+      options argument was hardcoded [None] AND the binding ignored it
+      regardless, so every Sarek Metal kernel compiled under Metal's fast-math
+      default with no way to turn it off.
 
       NOT EXECUTED ON HARDWARE — there is no Apple device on the machine this
       was written on. If [mtl_compile_options_conformant] returns [None] (older
       OS, missing selector, allocation failure) this falls back to null options,
-      i.e. exactly the pre-#125 behaviour, and says so in the log rather than
-      silently. Either way, Metal float results remain outside the guarantee
-      until somebody runs [test_df64] on a Mac; see
+      i.e. exactly the pre-backlog #125 behaviour, and says so in the log rather
+      than silently. Either way, Metal float results remain outside the
+      guarantee until somebody runs [test_df64] on a Mac; see
       docs/fp-contraction-policy.md §11. *)
   let create_from_source device source =
     let options = mtl_compile_options_conformant () in

--- a/sarek-metal/Metal_api.ml
+++ b/sarek-metal/Metal_api.ml
@@ -241,10 +241,40 @@ end
 module Library = struct
   type t = {handle : mtl_library; device : Device.t}
 
+  (** Compile MSL source.
+
+      Requests Metal's non-fast-math mode (#125). Until this change the options
+      argument was hardcoded [None] AND the binding ignored it regardless, so
+      every Sarek Metal kernel compiled under Metal's fast-math default with no
+      way to turn it off.
+
+      NOT EXECUTED ON HARDWARE — there is no Apple device on the machine this
+      was written on. If [mtl_compile_options_conformant] returns [None] (older
+      OS, missing selector, allocation failure) this falls back to null options,
+      i.e. exactly the pre-#125 behaviour, and says so in the log rather than
+      silently. Either way, Metal float results remain outside the guarantee
+      until somebody runs [test_df64] on a Mac; see
+      docs/fp-contraction-policy.md §11. *)
   let create_from_source device source =
-    match
-      mtl_device_new_library_with_source device.Device.handle source None
-    with
+    let options = mtl_compile_options_conformant () in
+    (match options with
+    | Some _ ->
+        Spoc_core.Log.debugf
+          Spoc_core.Log.Kernel
+          "Metal: compiling with fastMathEnabled=NO (requested, UNVERIFIED on \
+           hardware - see docs/fp-contraction-policy.md §11)"
+    | None ->
+        Spoc_core.Log.warnf
+          Spoc_core.Log.Kernel
+          "Metal: could not build MTLCompileOptions, falling back to Metal's \
+           DEFAULT compile options, which enable FAST MATH. Kernel results may \
+           disagree with the Sarek interpreter on contraction- or \
+           subnormal-sensitive code. See docs/fp-contraction-policy.md §11.") ;
+    let result =
+      mtl_device_new_library_with_source device.Device.handle source options
+    in
+    (match options with Some o -> release o | None -> ()) ;
+    match result with
     | Ok lib -> {handle = lib; device}
     | Error msg ->
         Metal_error.raise_error (Metal_error.compilation_failed source msg)

--- a/sarek-metal/Metal_api.ml
+++ b/sarek-metal/Metal_api.ml
@@ -251,7 +251,7 @@ module Library = struct
       NOT EXECUTED ON HARDWARE — there is no Apple device on the machine this
       was written on. If [mtl_compile_options_conformant] returns [None] (older
       OS, missing selector, allocation failure) this falls back to null options,
-      i.e. exactly the pre-backlog #125 behaviour, and says so in the log rather
+      i.e. exactly the behaviour before backlog #125, and says so in the log rather
       than silently. Either way, Metal float results remain outside the
       guarantee until somebody runs [test_df64] on a Mac; see
       docs/fp-contraction-policy.md §11. *)

--- a/sarek-metal/Metal_bindings.ml
+++ b/sarek-metal/Metal_bindings.ml
@@ -260,7 +260,86 @@ let mtl_buffer_length buf =
 
 (** {1 Library API} *)
 
-let mtl_device_new_library_with_source dev source _options =
+(** Build an [MTLCompileOptions] with Metal's fast-math default turned OFF, or
+    [None] if that cannot be done on this host.
+
+    WHY (#125). Metal's default compile options enable fast math, and until this
+    change {!mtl_device_new_library_with_source} took an [_options] argument and
+    IGNORED it while [Metal_api] passed null anyway. So every Sarek Metal kernel
+    compiled with fast math and there was no route to turn it off — not "no
+    policy", but an UNSETTABLE wrong default, which will diverge from the
+    interpreter (the cross-backend oracle, docs/fp-contraction-policy.md §1) on
+    any contraction- or subnormal-sensitive kernel.
+
+    NOT EXECUTED. There is no Apple hardware on the machine this was written on,
+    so not one line of this function has ever run. It typechecks and it is
+    structurally identical to {!nsstring_from_cstring} above (same
+    [objc_getClass] / [alloc] / [init] / typed [objc_msgSend] idiom, which does
+    work in production on Apple hardware) — and that is the entire basis for it.
+    Do not record this as verified anywhere. See docs/fp-contraction-policy.md
+    §11.
+
+    FAIL-SOFT BY CONSTRUCTION. Every failure path returns [None], and [None]
+    makes the caller pass null, which is EXACTLY the behaviour that shipped
+    before this change. So the worst case of this unverified code is the status
+    quo, not a crash: a missing libobjc, a missing class, an OS that does not
+    respond to the selector, or a null allocation all degrade to the old
+    behaviour rather than propagating.
+
+    WHY [setFastMathEnabled:] AND NOT [setMathMode:]. [setMathMode:] with
+    [MTLMathModeSafe] is the modern spelling and [fastMathEnabled] is deprecated
+    in its favour. It is deliberately not used here: [MTLMathMode]'s integer
+    encoding could not be verified on this machine, and passing the wrong
+    constant would silently select FAST math while looking like a fix —
+    precisely the failure this change exists to remove. [setFastMathEnabled:]
+    has one unambiguous meaning and a boolean argument. If someone with a Mac
+    confirms the enum values, switching is a small change; guessing them is not.
+*)
+let mtl_compile_options_conformant () : mtl_compile_options option =
+  try
+    let cls = objc_getClass "MTLCompileOptions" in
+    if is_null cls then None
+    else
+      let obj = objc_msgSend cls (sel_registerName "alloc") in
+      if is_null obj then None
+      else
+        let obj = objc_msgSend obj (sel_registerName "init") in
+        if is_null obj then None
+        else
+          let sel_set = sel_registerName "setFastMathEnabled:" in
+          (* BOOL is [signed char] on x86_64 macOS and [_Bool] on arm64; both
+             are one byte and passed in the low byte of the argument register,
+             so [uchar] is correct on both and ctypes' [bool] would not be. *)
+          let responds =
+            foreign
+              ~from:(get_objc_lib ())
+              "objc_msgSend"
+              (ptr void @-> ptr void @-> ptr void @-> returning uchar)
+          in
+          if
+            Unsigned.UChar.to_int
+              (responds obj (sel_registerName "respondsToSelector:") sel_set)
+            = 0
+          then None
+          else begin
+            let set_bool =
+              foreign
+                ~from:(get_objc_lib ())
+                "objc_msgSend"
+                (ptr void @-> ptr void @-> uchar @-> returning void)
+            in
+            set_bool obj sel_set (Unsigned.UChar.of_int 0) ;
+            Some obj
+          end
+  with _ -> None
+
+(** Compile MSL source into an [MTLLibrary].
+
+    [options] is now HONOURED. Before #125 this function's parameter was named
+    [_options] and dropped on the floor, so the only thing it could ever pass
+    was null — see {!mtl_compile_options_conformant} for what that meant. *)
+let mtl_device_new_library_with_source dev source
+    (options : mtl_compile_options option) =
   let sel = sel_registerName "newLibraryWithSource:options:error:" in
   let source_ns = nsstring_from_cstring source in
   let error_ptr = allocate (ptr void) null in
@@ -268,11 +347,12 @@ let mtl_device_new_library_with_source dev source _options =
     foreign
       ~from:(get_objc_lib ())
       "objc_msgSend"
-      (ptr void @-> ptr void @-> ns_string @-> ptr void
+      (ptr void @-> ptr void @-> ns_string @-> mtl_compile_options
       @-> ptr (ptr void)
       @-> returning mtl_library)
   in
-  let lib = fn dev sel source_ns null error_ptr in
+  let opts = match options with Some o -> o | None -> null in
+  let lib = fn dev sel source_ns opts error_ptr in
   if is_null lib then begin
     let err = !@error_ptr in
     Error (nserror_description err)

--- a/sarek-metal/Metal_bindings.ml
+++ b/sarek-metal/Metal_bindings.ml
@@ -260,84 +260,149 @@ let mtl_buffer_length buf =
 
 (** {1 Library API} *)
 
-(** Build an [MTLCompileOptions] with Metal's fast-math default turned OFF, or
+(** {2 MTLMathMode / MTLMathFloatingPointFunctions}
+
+    READ FROM THE SDK, not guessed: [MTLLibrary.h:241-246] and [258-262] on
+    macOS 15.6.1 (Command Line Tools SDK). The previous revision of this file
+    declined to use [setMathMode:] precisely because these values could not be
+    checked; they can now. *)
+
+let mtl_math_mode_safe = 0L
+
+let mtl_math_floating_point_functions_precise = 1L
+
+(** Build an [MTLCompileOptions] configured for Sarek's float semantics, or
     [None] if that cannot be done on this host.
 
-    WHY (#125). Metal's default compile options enable fast math, and until this
-    change {!mtl_device_new_library_with_source} took an [_options] argument and
-    IGNORED it while [Metal_api] passed null anyway. So every Sarek Metal kernel
-    compiled with fast math and there was no route to turn it off — not "no
-    policy", but an UNSETTABLE wrong default, which will diverge from the
-    interpreter (the cross-backend oracle, docs/fp-contraction-policy.md §1) on
-    any contraction- or subnormal-sensitive kernel.
+    WHY (backlog #125). Metal's defaults trade accuracy for speed, and until
+    this change {!mtl_device_new_library_with_source} took an [_options]
+    argument and IGNORED it while [Metal_api] passed null anyway. So every Sarek
+    Metal kernel took those defaults and there was no route to change them — not
+    "no policy", but an UNSETTABLE wrong default.
 
-    NOT EXECUTED. There is no Apple hardware on the machine this was written on,
-    so not one line of this function has ever run. It typechecks and it is
-    structurally identical to {!nsstring_from_cstring} above (same
-    [objc_getClass] / [alloc] / [init] / typed [objc_msgSend] idiom, which does
-    work in production on Apple hardware) — and that is the entire basis for it.
-    Do not record this as verified anywhere. See docs/fp-contraction-policy.md
-    §11.
+    MEASURED on Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0. A freshly
+    constructed [MTLCompileOptions] reports [mathMode = 2] ([MTLMathModeFast])
+    and [mathFloatingPointFunctions = 0] ([...Fast]). BOTH defaults are the fast
+    one, which is why both are set here — setting [mathMode] alone still leaves
+    single-precision math functions resolving to [metal::fast].
+
+    THE OPTIONS ARE HONOURED, and that had to be established rather than
+    assumed: a compile that succeeds proves plumbing, not semantics. Over 65536
+    inputs on [sqrt(a) + 1/a], against the default:
+
+    - [mathMode=Safe] alone changes 16017 results;
+    - [mathMode=Safe] + [fpFunctions=Precise] changes 22135.
+
+    So Metal is NOT in the class of rusticl's OpenCL FP options, which are
+    accepted and discarded (docs/fp-contraction-policy.md §10.2).
+
+    WHAT THESE OPTIONS DO NOT BUY: CONTRACTION. Measured on the same device,
+    [a*b+c] is contracted into an fma on all 8773 observable elements under
+    EVERY setting tried, including [mathMode=Safe]. Contraction is defeated in
+    the generated source instead, by [#pragma METAL fp contract(off)]
+    ([Sarek_ir_metal.metal_fp_contract_pragma], measured 0/8773). Do not read
+    this function as a contraction defence; it is not one.
+
+    WHY BOTH SPELLINGS. [fastMathEnabled] is deprecated since macOS 15.0 in
+    favour of [mathMode], but [mathMode] does not exist before macOS 15.0 / iOS
+    18.0, so the deprecated property is the only route on older systems. The
+    modern pair is preferred when present and the boolean is the fallback. They
+    are EQUIVALENT, measured: [fastMathEnabled = NO] and
+    [mathMode=Safe + fpFunctions=Precise] are BIT-IDENTICAL over 65536 elements
+    of [sqrt + reciprocal + sin + log + exp]. The fallback is therefore not a
+    degraded path, and that is measured rather than believed.
 
     FAIL-SOFT BY CONSTRUCTION. Every failure path returns [None], and [None]
     makes the caller pass null, which is EXACTLY the behaviour that shipped
-    before this change. So the worst case of this unverified code is the status
-    quo, not a crash: a missing libobjc, a missing class, an OS that does not
-    respond to the selector, or a null allocation all degrade to the old
-    behaviour rather than propagating.
-
-    WHY [setFastMathEnabled:] AND NOT [setMathMode:]. [setMathMode:] with
-    [MTLMathModeSafe] is the modern spelling and [fastMathEnabled] is deprecated
-    in its favour. It is deliberately not used here: [MTLMathMode]'s integer
-    encoding could not be verified on this machine, and passing the wrong
-    constant would silently select FAST math while looking like a fix —
-    precisely the failure this change exists to remove. [setFastMathEnabled:]
-    has one unambiguous meaning and a boolean argument. If someone with a Mac
-    confirms the enum values, switching is a small change; guessing them is not.
-*)
+    before this change: a missing libobjc, a missing class, an OS responding to
+    neither selector, or a null allocation all degrade to the old behaviour
+    rather than propagating. *)
 let mtl_compile_options_conformant () : mtl_compile_options option =
   try
     let cls = objc_getClass "MTLCompileOptions" in
     if is_null cls then None
     else
-      let obj = objc_msgSend cls (sel_registerName "alloc") in
-      if is_null obj then None
+      let allocated = objc_msgSend cls (sel_registerName "alloc") in
+      if is_null allocated then None
       else
-        let obj = objc_msgSend obj (sel_registerName "init") in
+        let obj = objc_msgSend allocated (sel_registerName "init") in
         if is_null obj then None
-        else
-          let sel_set = sel_registerName "setFastMathEnabled:" in
-          (* BOOL is [signed char] on x86_64 macOS and [_Bool] on arm64; both
-             are one byte and passed in the low byte of the argument register,
-             so [uchar] is correct on both and ctypes' [bool] would not be. *)
-          let responds =
-            foreign
-              ~from:(get_objc_lib ())
-              "objc_msgSend"
-              (ptr void @-> ptr void @-> ptr void @-> returning uchar)
-          in
-          if
+        else begin
+          (* From here on [obj] is owned by us (+1 from [alloc]), so every exit
+             that does not hand it to the caller must release it. *)
+          let responds_to sel =
+            let f =
+              foreign
+                ~from:(get_objc_lib ())
+                "objc_msgSend"
+                (ptr void @-> ptr void @-> ptr void @-> returning uchar)
+            in
             Unsigned.UChar.to_int
-              (responds obj (sel_registerName "respondsToSelector:") sel_set)
-            = 0
-          then None
-          else begin
+              (f obj (sel_registerName "respondsToSelector:") sel)
+            <> 0
+          in
+          (* [MTLMathMode] and [MTLMathFloatingPointFunctions] are [NS_ENUM(
+             NSInteger, ...)], i.e. [long] on every Apple 64-bit platform. *)
+          let set_long sel v =
+            let f =
+              foreign
+                ~from:(get_objc_lib ())
+                "objc_msgSend"
+                (ptr void @-> ptr void @-> long @-> returning void)
+            in
+            f obj sel (Signed.Long.of_int64 v)
+          in
+          let sel_math_mode = sel_registerName "setMathMode:" in
+          let sel_fp_funcs =
+            sel_registerName "setMathFloatingPointFunctions:"
+          in
+          let sel_fast_math = sel_registerName "setFastMathEnabled:" in
+          if responds_to sel_math_mode then begin
+            set_long sel_math_mode mtl_math_mode_safe ;
+            (* Independent of mathMode: without it, single-precision math
+               functions still resolve to [metal::fast]. Measured: 16017 vs
+               22135 changed results out of 65536. *)
+            if responds_to sel_fp_funcs then
+              set_long sel_fp_funcs mtl_math_floating_point_functions_precise ;
+            Some obj
+          end
+          else if responds_to sel_fast_math then begin
+            (* Pre-macOS-15 fallback. BOOL is [signed char] on x86_64 macOS and
+               [_Bool] on arm64; both are one byte passed in the low byte of the
+               argument register, so [uchar] is correct on both and ctypes'
+               [bool] would not be. *)
             let set_bool =
               foreign
                 ~from:(get_objc_lib ())
                 "objc_msgSend"
                 (ptr void @-> ptr void @-> uchar @-> returning void)
             in
-            set_bool obj sel_set (Unsigned.UChar.of_int 0) ;
+            set_bool obj sel_fast_math (Unsigned.UChar.of_int 0) ;
             Some obj
           end
+          else begin
+            (* Neither spelling available: release rather than leak, and fall
+               back to null options (the pre-change behaviour). Spelled out
+               rather than calling {!release}, which is defined further down
+               this file. *)
+            let f =
+              foreign
+                ~from:(get_objc_lib ())
+                "objc_msgSend"
+                (ptr void @-> ptr void @-> returning void)
+            in
+            f obj (sel_registerName "release") ;
+            None
+          end
+        end
   with _ -> None
 
 (** Compile MSL source into an [MTLLibrary].
 
-    [options] is now HONOURED. Before #125 this function's parameter was named
-    [_options] and dropped on the floor, so the only thing it could ever pass
-    was null — see {!mtl_compile_options_conformant} for what that meant. *)
+    [options] is now HONOURED. Before backlog #125 this function's parameter was
+    named [_options] and dropped on the floor, so the only thing it could ever
+    pass was null — see {!mtl_compile_options_conformant} for what that meant.
+*)
 let mtl_device_new_library_with_source dev source
     (options : mtl_compile_options option) =
   let sel = sel_registerName "newLibraryWithSource:options:error:" in

--- a/sarek-metal/Metal_bindings.ml
+++ b/sarek-metal/Metal_bindings.ml
@@ -294,7 +294,7 @@ let mtl_math_floating_point_functions_precise = 1L
     - [mathMode=Safe] + [fpFunctions=Precise] changes 22135.
 
     So Metal is NOT in the class of rusticl's OpenCL FP options, which are
-    accepted and discarded (docs/fp-contraction-policy.md §10.2).
+    accepted and discarded (docs/fp-contraction-policy.md §9.2).
 
     WHAT THESE OPTIONS DO NOT BUY: CONTRACTION. Measured on the same device,
     [a*b+c] is contracted into an fma on all 8773 observable elements under

--- a/sarek-metal/Metal_types.ml
+++ b/sarek-metal/Metal_types.ml
@@ -61,7 +61,7 @@ let mtl_library : mtl_library typ = ptr void
 
     Carries the floating-point math mode among other things. Metal's DEFAULT is
     fast math ON, which is why this type exists at all: see [Metal_bindings]
-    ([mtl_compile_options_conformant]) and docs/fp-contraction-policy.md §11. *)
+    ([mtl_compile_options_conformant]) and docs/fp-contraction-policy.md §10. *)
 type mtl_compile_options = unit ptr
 
 let mtl_compile_options : mtl_compile_options typ = ptr void

--- a/sarek-metal/Metal_types.ml
+++ b/sarek-metal/Metal_types.ml
@@ -57,6 +57,15 @@ type mtl_library = unit ptr
 
 let mtl_library : mtl_library typ = ptr void
 
+(** Compile options - MTLCompileOptions class.
+
+    Carries the floating-point math mode among other things. Metal's DEFAULT is
+    fast math ON, which is why this type exists at all: see [Metal_bindings]
+    ([mtl_compile_options_conformant]) and docs/fp-contraction-policy.md §11. *)
+type mtl_compile_options = unit ptr
+
+let mtl_compile_options : mtl_compile_options typ = ptr void
+
 (** Function - MTLFunction protocol *)
 type mtl_function = unit ptr
 

--- a/sarek-metal/test/dune
+++ b/sarek-metal/test/dune
@@ -7,3 +7,7 @@
 (test
  (name test_sarek_ir_metal)
  (libraries sarek_metal sarek_ir alcotest str))
+
+(test
+ (name test_metal_compile_options)
+ (libraries sarek_metal alcotest))

--- a/sarek-metal/test/test_metal_compile_options.ml
+++ b/sarek-metal/test/test_metal_compile_options.ml
@@ -10,7 +10,7 @@
  * macOS 15.6.1 (24G90), Apple clang 17.0.0 — by
  * tools/probes/metal_math_mode_probe.m and
  * tools/probes/metal_contraction_barrier_probe.m, written up in
- * docs/fp-contraction-policy.md §11. Those probes, not this file, are what
+ * docs/fp-contraction-policy.md §10. Those probes, not this file, are what
  * establish that Metal's defaults are fast on both knobs, that the options are
  * honoured, and that contraction needs a source pragma instead.
  *

--- a/sarek-metal/test/test_metal_compile_options.ml
+++ b/sarek-metal/test/test_metal_compile_options.ml
@@ -4,29 +4,26 @@
 (******************************************************************************)
 
 (******************************************************************************
- * MTLCompileOptions fail-soft contract (#125).
+ * MTLCompileOptions fail-soft contract (backlog #125).
  *
- * READ THIS BEFORE TREATING A GREEN RUN AS EVIDENCE OF ANYTHING.
+ * SCOPE. The Metal FP behaviour itself is now MEASURED on hardware — Apple M4,
+ * macOS 15.6.1 (24G90), Apple clang 17.0.0 — by
+ * tools/probes/metal_math_mode_probe.m and
+ * tools/probes/metal_contraction_barrier_probe.m, written up in
+ * docs/fp-contraction-policy.md §11. Those probes, not this file, are what
+ * establish that Metal's defaults are fast on both knobs, that the options are
+ * honoured, and that contraction needs a source pragma instead.
  *
- * #125 makes the Metal backend ask for fastMathEnabled=NO, because Metal's
- * default is fast math ON and the binding previously ignored its options
- * argument outright. NONE of that has been executed on Apple hardware — there
- * is no Apple device on the machine it was written on, and this test does NOT
- * verify it. Whether Metal actually honours the request, and whether Metal
- * float results then agree with the interpreter, are both OPEN. See
- * docs/fp-contraction-policy.md §11.
- *
- * What this file DOES verify, and it is the only claim it makes: the
- * FAIL-SOFT mechanism that is the entire safety argument for landing
- * unverified Objective-C. [mtl_compile_options_conformant] must return [None]
- * — never raise — when the Objective-C runtime is unavailable, because [None]
- * makes the caller pass null options, which is exactly the behaviour that
- * shipped before #125. A host with no libobjc (this Linux box, and CI) is a
- * perfectly good instrument for that one question, and it is the strongest
+ * This file verifies the one thing those probes cannot: the FAIL-SOFT
+ * mechanism, on a host where the Objective-C runtime is ABSENT.
+ * [mtl_compile_options_conformant] must return [None] — never raise — because
+ * [None] makes the caller pass null options, which is exactly the behaviour
+ * that shipped before backlog #125. A machine with no libobjc (this Linux box,
+ * and CI) is the right instrument for that question, and it is the strongest
  * failure the mechanism has to survive: nothing resolves at all.
  *
- * On a Mac this test asserts nothing beyond "it returned without raising",
- * and says so.
+ * On a Mac this test cannot reach that path and skips, rather than passing
+ * while checking nothing.
  ******************************************************************************)
 
 open Sarek_metal
@@ -57,9 +54,10 @@ let test_returns_none_without_objc () =
         Alcotest.failf
           "mtl_compile_options_conformant raised %s instead of returning None. \
            The safety argument for landing this unverified Objective-C is that \
-           every failure degrades to the pre-#125 behaviour (null options); an \
-           escaping exception breaks Metal kernel compilation outright on any \
-           host where the runtime, the class or the selector is missing."
+           every failure degrades to the pre-backlog #125 behaviour (null \
+           options); an escaping exception breaks Metal kernel compilation \
+           outright on any host where the runtime, the class or the selector \
+           is missing."
           (Printexc.to_string e)
 
 (* Called twice: a first call that succeeded in caching something bad, or a

--- a/sarek-metal/test/test_metal_compile_options.ml
+++ b/sarek-metal/test/test_metal_compile_options.ml
@@ -1,0 +1,93 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * MTLCompileOptions fail-soft contract (#125).
+ *
+ * READ THIS BEFORE TREATING A GREEN RUN AS EVIDENCE OF ANYTHING.
+ *
+ * #125 makes the Metal backend ask for fastMathEnabled=NO, because Metal's
+ * default is fast math ON and the binding previously ignored its options
+ * argument outright. NONE of that has been executed on Apple hardware — there
+ * is no Apple device on the machine it was written on, and this test does NOT
+ * verify it. Whether Metal actually honours the request, and whether Metal
+ * float results then agree with the interpreter, are both OPEN. See
+ * docs/fp-contraction-policy.md §11.
+ *
+ * What this file DOES verify, and it is the only claim it makes: the
+ * FAIL-SOFT mechanism that is the entire safety argument for landing
+ * unverified Objective-C. [mtl_compile_options_conformant] must return [None]
+ * — never raise — when the Objective-C runtime is unavailable, because [None]
+ * makes the caller pass null options, which is exactly the behaviour that
+ * shipped before #125. A host with no libobjc (this Linux box, and CI) is a
+ * perfectly good instrument for that one question, and it is the strongest
+ * failure the mechanism has to survive: nothing resolves at all.
+ *
+ * On a Mac this test asserts nothing beyond "it returned without raising",
+ * and says so.
+ ******************************************************************************)
+
+open Sarek_metal
+
+(* The fail-soft path is only exercised where the Objective-C runtime is
+   ABSENT. On a Mac this test cannot reach it, and rather than pretend
+   otherwise it skips — a skip is not a pass, and this one is honest about
+   which machine can answer the question. *)
+let objc_runtime_absent () = not (Metal_bindings.is_available ())
+
+let test_returns_none_without_objc () =
+  if not (objc_runtime_absent ()) then begin
+    Printf.printf
+      "[SKIP] Metal is available on this host, so the no-Objective-C fail-soft \
+       path cannot be reached here\n\
+       %!" ;
+    Alcotest.skip ()
+  end
+  else
+    match Metal_bindings.mtl_compile_options_conformant () with
+    | None -> ()
+    | Some _ ->
+        Alcotest.fail
+          "mtl_compile_options_conformant returned Some on a host with no \
+           Objective-C runtime; it cannot have built a real MTLCompileOptions, \
+           so this is a bogus pointer heading for newLibraryWithSource:"
+    | exception e ->
+        Alcotest.failf
+          "mtl_compile_options_conformant raised %s instead of returning None. \
+           The safety argument for landing this unverified Objective-C is that \
+           every failure degrades to the pre-#125 behaviour (null options); an \
+           escaping exception breaks Metal kernel compilation outright on any \
+           host where the runtime, the class or the selector is missing."
+          (Printexc.to_string e)
+
+(* Called twice: a first call that succeeded in caching something bad, or a
+   lazy that raised once and is now poisoned, must not change the answer. *)
+let test_is_repeatable () =
+  if not (objc_runtime_absent ()) then Alcotest.skip ()
+  else
+    let attempt n =
+      match Metal_bindings.mtl_compile_options_conformant () with
+      | None -> ()
+      | Some _ -> Alcotest.failf "call %d returned Some without a runtime" n
+      | exception e ->
+          Alcotest.failf "call %d raised %s" n (Printexc.to_string e)
+    in
+    attempt 1 ;
+    attempt 2 ;
+    attempt 3
+
+let () =
+  Alcotest.run
+    "Metal_compile_options"
+    [
+      ( "fail-soft without an Objective-C runtime",
+        [
+          Alcotest.test_case
+            "returns None rather than raising"
+            `Quick
+            test_returns_none_without_objc;
+          Alcotest.test_case "is repeatable" `Quick test_is_repeatable;
+        ] );
+    ]

--- a/sarek-metal/test/test_metal_compile_options.ml
+++ b/sarek-metal/test/test_metal_compile_options.ml
@@ -54,7 +54,7 @@ let test_returns_none_without_objc () =
         Alcotest.failf
           "mtl_compile_options_conformant raised %s instead of returning None. \
            The safety argument for landing this unverified Objective-C is that \
-           every failure degrades to the pre-backlog #125 behaviour (null \
+           every failure degrades to the behaviour before backlog #125 (null \
            options); an escaping exception breaks Metal kernel compilation \
            outright on any host where the runtime, the class or the selector \
            is missing."

--- a/sarek-opencl/Opencl_api.ml
+++ b/sarek-opencl/Opencl_api.ml
@@ -583,9 +583,9 @@ module Program = struct
       caller's. Same placement argument as [Cuda_nvrtc.compile_with_string_opts]
       (docs/fp-contraction-policy.md §5).
 
-      Until #136 this function passed [options] straight through, and every
-      caller in the tree passed nothing — so the effective option string was
-      empty and Sarek silently accepted each vendor's default, including a
+      Until backlog #136 this function passed [options] straight through, and
+      every caller in the tree passed nothing — so the effective option string
+      was empty and Sarek silently accepted each vendor's default, including a
       [sqrt] of up to 3 ulp. *)
   let build program ?(options = "") () =
     let devices = CArray.make cl_device_id 1 in

--- a/sarek-opencl/Opencl_api.ml
+++ b/sarek-opencl/Opencl_api.ml
@@ -108,6 +108,16 @@ module Device = struct
     max_clock_freq : int;
     supports_fp64 : bool;
     is_cpu : bool; (* True for CPU OpenCL devices - enables zero-copy *)
+    single_fp_config : int64;
+        (* CL_DEVICE_SINGLE_FP_CONFIG, verbatim. Read once at device
+           construction because [Program.build] needs it on every compile to
+           decide whether -cl-fp32-correctly-rounded-divide-sqrt is LEGAL on
+           this device: the OpenCL spec makes passing that option an error
+           (CL_INVALID_BUILD_OPTIONS) unless CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT
+           is set here. Kept as the raw bitfield rather than a decoded bool so
+           the other bits (notably CL_FP_DENORM, clear on both devices on this
+           machine) stay available without a second query. See
+           [Opencl_fp] for the full audit. *)
   }
 
   let get_devices platform device_type =
@@ -244,6 +254,10 @@ module Device = struct
     let is_cpu = Int64.logand device_type 2L <> 0L in
     (* CL_DEVICE_TYPE_CPU = 2 *)
 
+    (* cl_device_fp_config is a cl_bitfield, i.e. cl_ulong — the same width
+       [get_info_long] already reads for CL_DEVICE_TYPE just above. *)
+    let single_fp_config = get_info_long handle CL_DEVICE_SINGLE_FP_CONFIG in
+
     {
       id = idx;
       handle;
@@ -259,6 +273,7 @@ module Device = struct
       max_clock_freq;
       supports_fp64;
       is_cpu;
+      single_fp_config;
     }
 
   let init () = () (* OpenCL doesn't require explicit init *)
@@ -553,15 +568,44 @@ module Program = struct
     (* Store bigarray in record to prevent GC until after build *)
     {handle = prog; context; _source = ba}
 
+  (** Build a program.
+
+      [options] is what the CALLER wants; it is not what [clBuildProgram]
+      receives. {!Opencl_fp.build_options} screens it — raising
+      {!Opencl_fp.Fp_conformance_violation} on anything that would relax float
+      semantics below docs/fp-contraction-policy.md §1 — and appends the options
+      this backend requires on its own behalf, gated on the device's
+      [CL_DEVICE_SINGLE_FP_CONFIG].
+
+      This is the ONLY place an option string reaches [clBuildProgram], and that
+      is deliberately where the guard sits rather than at the caller: it screens
+      flags a FUTURE maintainer of this module adds itself, not merely a
+      caller's. Same placement argument as [Cuda_nvrtc.compile_with_string_opts]
+      (docs/fp-contraction-policy.md §5).
+
+      Until #136 this function passed [options] straight through, and every
+      caller in the tree passed nothing — so the effective option string was
+      empty and Sarek silently accepted each vendor's default, including a
+      [sqrt] of up to 3 ulp. *)
   let build program ?(options = "") () =
     let devices = CArray.make cl_device_id 1 in
     CArray.set devices 0 program.context.device.Device.handle ;
+    let effective_options =
+      Opencl_fp.build_options
+        ~single_fp_config:program.context.device.Device.single_fp_config
+        ~caller:options
+    in
+    Spoc_core.Log.debugf
+      Spoc_core.Log.Kernel
+      "OpenCL clBuildProgram options: %S (device fp_config 0x%Lx)"
+      effective_options
+      program.context.device.Device.single_fp_config ;
     let result =
       clBuildProgram
         program.handle
         Unsigned.UInt32.one
         (CArray.start devices)
-        options
+        effective_options
         (from_voidp void null)
         (from_voidp void null)
     in

--- a/sarek-opencl/Opencl_fp.ml
+++ b/sarek-opencl/Opencl_fp.ml
@@ -1,0 +1,264 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * OpenCL floating-point conformance: the build-option string this backend
+ * hands to [clBuildProgram], and the screen applied to anything a caller adds.
+ *
+ * WHY THIS EXISTS (#136)
+ *
+ * Until this module, [Opencl_api.Program.build] called [clBuildProgram] with
+ * an EMPTY option string. An empty option string is not "no policy": it is a
+ * policy, chosen by omission, and it is whatever each vendor decided its
+ * default should be. OpenCL's default permits a [sqrt] of up to 3 ulp and a
+ * divide of up to 2.5 ulp (OpenCL C spec, "Relative error as ULPs"), and
+ * Sarek's rule (docs/fp-contraction-policy.md §1) is that division and square
+ * root are CORRECTLY ROUNDED.
+ *
+ * That gap was not hypothetical. On a GTX 1070 Max-Q (sm_61, CUDA 12.9,
+ * driver 580.119.02), [test_real64]'s df64 fallback measured an OpenCL [sqrt]
+ * worst-case relative error of 1.81e-14 against a 1.42e-14 tolerance — a
+ * FAILURE — and building the same kernel with
+ * [-cl-fp32-correctly-rounded-divide-sqrt] moved it to 8.87e-15, a PASS,
+ * coinciding with the interpreter's figure for the same input set. Measured
+ * during #298; quoted here rather than re-measured, because there is no NVIDIA
+ * device on the machine this module was written on.
+ *
+ * This is the same shape as the PTX [sqrt.approx.f32] defect (#298) and the
+ * OpenCL sibling of [Cuda_nvrtc.check_fp_conformance] and
+ * [Hip_rtc.hiprtc_options]: a faster, less accurate default selected by
+ * passing nothing.
+ *
+ * WHY THE CORRECTLY-ROUNDED FLAG IS CAPABILITY-GATED AND NOT UNCONDITIONAL
+ *
+ * The OpenCL spec makes [-cl-fp32-correctly-rounded-divide-sqrt] conditional:
+ * it may only be specified if [CL_DEVICE_SINGLE_FP_CONFIG] contains
+ * [CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT]; otherwise [clBuildProgram] "will
+ * return CL_INVALID_BUILD_OPTIONS". Passing it unconditionally would therefore
+ * break EVERY kernel build on every device that does not advertise the
+ * capability — which is a strictly worse failure than the accuracy defect it
+ * fixes, because it is total rather than numerical.
+ *
+ * This machine would not have caught that. MEASURED here, 2026-07-26, with
+ * tools/probes/opencl_build_options_probe.c on rusticl/radeonsi 26.1.4-arch3.1
+ * (RX 7900 XTX navi31, and the Raphael iGPU): both devices report
+ * [CL_DEVICE_SINGLE_FP_CONFIG = 0x6] — [INF_NAN | ROUND_TO_NEAREST], with
+ * neither [CL_FP_DENORM] nor [CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT] — and BOTH
+ * accept [-cl-fp32-correctly-rounded-divide-sqrt] with [CL_SUCCESS] anyway.
+ * That is rusticl departing from the spec in the permissive direction. An
+ * unconditional flag would have looked perfectly healthy on this box and
+ * failed on a conformant implementation elsewhere. The gate exists because the
+ * local stack cannot be trusted to reveal its absence.
+ *
+ * WHAT THIS BUYS ON THE LOCAL DEVICES: NOTHING, MEASURABLY
+ *
+ * Also measured 2026-07-26 (tools/probes/opencl_build_options_probe.c, the
+ * [effect] mode), 2^20 inputs per device: rusticl's [sqrt] is already within
+ * 1 ulp and its divide within 2 ulp of the host's correctly-rounded result,
+ * and the results are BIT-IDENTICAL (0 of 1048576 differ) with and without the
+ * flag. So on this box the flag changes nothing and costs nothing.
+ *
+ * That "costs nothing" must be read with its control attached. The probe
+ * carries two:
+ *   - a PLUMBING control ([-DSAREK_PROBE_SCALE=1.0000001f]) which DOES change
+ *     the result on 1048576/1048576 inputs, proving the option string really
+ *     reaches rusticl's compiler and the comparison can go non-zero;
+ *   - an FP LIVENESS control ([-cl-fast-relaxed-math]) which does NOT — it is
+ *     bit-identical to the baseline too.
+ * The second control FAILING is the finding: rusticl delivers the option
+ * string but ignores the FP-relaxing options in it. So on this stack, "the
+ * flag changed nothing" cannot be distinguished from "the flag was discarded",
+ * and no accuracy or cost claim for this change may be founded on these
+ * devices. The measurement that matters is the sm_61 one quoted above.
+ *
+ * WHAT IS *NOT* FIXED HERE
+ *
+ * [FP_CONTRACT] is ON by default in OpenCL C and NO build option turns it off.
+ * The source-level [#pragma OPENCL FP_CONTRACT OFF] was measured on this stack
+ * and does not work (see [Sarek_ir_opencl], the [TFloat16] rejection comment:
+ * 620/63488 f16 disagreements survive it). Contraction on OpenCL is therefore
+ * still defeated BY CONSTRUCTION, via [Sarek_df64]'s [mul_rn], exactly as on
+ * CUDA — not by any flag this module sets.
+ ******************************************************************************)
+
+(** Raised when a build-option string would relax float semantics below what
+    docs/fp-contraction-policy.md §1 promises. *)
+exception Fp_conformance_violation of string
+
+(** {1 CL_DEVICE_SINGLE_FP_CONFIG bits}
+
+    The vendored [dependencies/CL/cl.h] is OpenCL 1.0-era and defines neither of
+    the two bits this module needs, so they are spelled out. Values from the
+    OpenCL 1.2+ headers. *)
+
+let cl_fp_denorm = 1L
+
+let cl_fp_correctly_rounded_divide_sqrt = 128L
+
+let has_bit (config : int64) (bit : int64) = Int64.logand config bit <> 0L
+
+(** {1 The options this backend sets explicitly} *)
+
+(** [conformance_options ~single_fp_config] is the option list Sarek chooses on
+    its own behalf, given a device's [CL_DEVICE_SINGLE_FP_CONFIG].
+
+    The full audit of what an empty option string was silently accepting, and
+    what is now decided explicitly. Every entry is a DEFAULT that was being
+    inherited rather than chosen:
+
+    - [-cl-fp32-correctly-rounded-divide-sqrt] — ADDED, gated on
+      [CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT]. Default off means [sqrt] up to 3
+      ulp and divide up to 2.5 ulp; §1 requires both correctly rounded, and
+      [Sarek_df64]'s Newton/Karp step squares its seed's error and has no margin
+      for a 3-ulp seed. Gated because the spec makes it an error to pass it
+      otherwise (see the header).
+    - [-cl-denorms-are-zero] — NEVER PASSED. It is a HINT that the device may
+      flush binary32 subnormals; §1 says subnormals are not flushed. Its default
+      (absent) is the conformant one, so the fix is to keep not passing it — but
+      note this is a request, not a guarantee in either direction: whether
+      subnormals actually survive is [CL_FP_DENORM] in the device's config, and
+      on BOTH local devices that bit is CLEAR, so f32 subnormals are flushed
+      here regardless of any build option. That is a device property Sarek
+      cannot correct, and it is recorded rather than fixed.
+    - [-cl-fast-relaxed-math] — NEVER PASSED, and REFUSED from callers. It
+      implies [-cl-unsafe-math-optimizations] and [-cl-finite-math-only], and
+      additionally lets the implementation substitute [native_*] builtins.
+    - [-cl-unsafe-math-optimizations] — NEVER PASSED, REFUSED. Permits
+      reassociation, which destroys an error-free transformation outright (§1
+      corollary 1); implies [-cl-no-signed-zeros] and [-cl-mad-enable].
+    - [-cl-finite-math-only] — NEVER PASSED, REFUSED. Assumes no NaN/Inf
+      operand; the interpreter oracle assumes no such thing.
+    - [-cl-no-signed-zeros] — NEVER PASSED, REFUSED. Discards the sign of zero,
+      which [Sarek_df64]'s renormalisation steps rely on.
+    - [-cl-mad-enable] — NEVER PASSED, REFUSED. This is the contraction hazard
+      by name: it permits [a*b+c] to become a [mad] of reduced accuracy.
+    - [-cl-single-precision-constant] — NEVER PASSED, REFUSED. Silently demotes
+      double literals to single, changing the meaning of a written constant.
+    - [-cl-opt-disable] — not passed, and ALLOWED from a caller: it is
+      conservative, it cannot relax FP semantics, and it is useful for debugging
+      codegen.
+
+    Deliberately NOT here: anything that would need to be undone later. Unlike
+    HIP — where appending [-ffp-contract=off] LAST neutralises whatever the
+    caller passed, because clang resolves conflicting FP options by last
+    occurrence — OpenCL has no build option that undoes [-cl-fast-relaxed-math].
+    So the relaxing options are REFUSED rather than countered, for the same
+    reason [Cuda_nvrtc] refuses [-use_fast_math] (docs/fp-contraction-policy.md
+    §5). *)
+let conformance_options ~(single_fp_config : int64) : string list =
+  if has_bit single_fp_config cl_fp_correctly_rounded_divide_sqrt then
+    ["-cl-fp32-correctly-rounded-divide-sqrt"]
+  else []
+
+(** {1 Screening what a caller adds} *)
+
+type fp_verdict = Fp_reject of string | Fp_warn of string
+
+(** [(token, verdict, why)].
+
+    Every OpenCL FP option is a BARE SWITCH — none takes a value, inline or
+    separated. That is why this screen can match on whole tokens and does not
+    need [Cuda_nvrtc]'s value-resolution machinery, which exists because nvrtc
+    accepts [--ftz true] as two array elements and a spelling-shaped matcher let
+    the separated form straight through (§5). The hazard has no OpenCL analogue;
+    if a future OpenCL option ever takes a value, this comment is the warning
+    that this matcher is then the wrong shape. *)
+let fp_option_classes : (string * [`Reject | `Warn] * string) list =
+  [
+    ( "-cl-fast-relaxed-math",
+      `Reject,
+      "implies -cl-unsafe-math-optimizations and -cl-finite-math-only, and \
+       lets the implementation substitute native_* builtins; no later OpenCL \
+       build option undoes it" );
+    ( "-cl-unsafe-math-optimizations",
+      `Reject,
+      "permits reassociation, which destroys an error-free transformation \
+       (Dekker/Knuth TwoSum, TwoProd) outright rather than by one ulp; implies \
+       -cl-no-signed-zeros and -cl-mad-enable" );
+    ( "-cl-finite-math-only",
+      `Reject,
+      "assumes no argument or result is NaN or Inf; the interpreter oracle \
+       assumes no such thing, so device and oracle diverge on the inputs the \
+       flag excluded" );
+    ( "-cl-no-signed-zeros",
+      `Reject,
+      "discards the sign of zero, which Sarek_df64's renormalisation relies on"
+    );
+    ( "-cl-mad-enable",
+      `Reject,
+      "permits a*b+c to become a mad of reduced accuracy — contraction by \
+       name; Sarek_df64 defeats contraction by construction (mul_rn) and a \
+       reduced-accuracy mad is below what that defence assumes" );
+    ( "-cl-denorms-are-zero",
+      `Reject,
+      "asks the device to flush binary32 subnormals; \
+       docs/fp-contraction-policy.md §1 says subnormals are not flushed, and \
+       unlike contraction there is no later option that restores them" );
+    ( "-cl-single-precision-constant",
+      `Reject,
+      "silently treats double-precision literals as single, changing the value \
+       of a written constant" );
+    ( "-cl-fp32-correctly-rounded-divide-sqrt",
+      `Warn,
+      "is set by this backend already when the device advertises \
+       CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT; passing it by hand on a device \
+       that does NOT advertise it makes clBuildProgram return \
+       CL_INVALID_BUILD_OPTIONS on a conformant implementation" );
+  ]
+
+(** Split an OpenCL build-option string on whitespace. OpenCL takes ONE string,
+    not an array, so this is the only tokenisation there is. *)
+let tokenise (opts : string) : string list =
+  String.split_on_char ' ' opts
+  |> List.concat_map (String.split_on_char '\t')
+  |> List.concat_map (String.split_on_char '\n')
+  |> List.filter (fun s -> s <> "")
+
+let fp_scan (opts : string) : fp_verdict list =
+  let toks = tokenise opts in
+  List.filter_map
+    (fun (name, verdict, why) ->
+      if List.exists (String.equal name) toks then
+        let msg =
+          Printf.sprintf
+            "OpenCL build option %s violates Sarek's floating-point contract: \
+             %s. See docs/fp-contraction-policy.md."
+            name
+            why
+        in
+        Some
+          (match verdict with `Reject -> Fp_reject msg | `Warn -> Fp_warn msg)
+      else None)
+    fp_option_classes
+
+(** Raise {!Fp_conformance_violation} on a caller option string that would relax
+    float semantics; warn on the merely redundant.
+
+    Pure: no device, no OpenCL ICD and no [libOpenCL] are needed to run it, so
+    it is reachable in a test suite on a host with no OpenCL at all — the same
+    property that makes [Cuda_nvrtc.check_fp_conformance] testable without CUDA.
+*)
+let check_fp_conformance (opts : string) : unit =
+  List.iter
+    (function
+      | Fp_reject msg -> raise (Fp_conformance_violation msg)
+      | Fp_warn msg -> Spoc_core.Log.warnf Spoc_core.Log.Kernel "%s" msg)
+    (fp_scan opts)
+
+(** {1 The exact string handed to clBuildProgram} *)
+
+(** [build_options ~single_fp_config ~caller] is the complete option string
+    [clBuildProgram] receives.
+
+    [caller] is screened first — so an offending option raises BEFORE any OpenCL
+    entry point is touched — and Sarek's own options are appended after it.
+    Ordering carries no meaning here (no OpenCL FP option overrides another,
+    unlike clang's last-occurrence rule that [Hip_rtc.base_options] depends on);
+    the options are appended last purely so the resulting string reads as "what
+    the caller asked for, then what this backend requires". *)
+let build_options ~(single_fp_config : int64) ~(caller : string) : string =
+  check_fp_conformance caller ;
+  let ours = conformance_options ~single_fp_config in
+  String.concat " " (List.filter (fun s -> s <> "") (tokenise caller @ ours))

--- a/sarek-opencl/Opencl_fp.ml
+++ b/sarek-opencl/Opencl_fp.ml
@@ -7,7 +7,7 @@
  * OpenCL floating-point conformance: the build-option string this backend
  * hands to [clBuildProgram], and the screen applied to anything a caller adds.
  *
- * WHY THIS EXISTS (#136)
+ * WHY THIS EXISTS (backlog #136)
  *
  * Until this module, [Opencl_api.Program.build] called [clBuildProgram] with
  * an EMPTY option string. An empty option string is not "no policy": it is a

--- a/sarek-opencl/dune
+++ b/sarek-opencl/dune
@@ -22,6 +22,7 @@
  (modules
   Opencl_error
   Opencl_types
+  Opencl_fp
   Opencl_bindings
   Opencl_api
   Opencl_plugin_base

--- a/sarek-opencl/test/dune
+++ b/sarek-opencl/test/dune
@@ -4,7 +4,8 @@
   test_sarek_ir_opencl
   test_opencl_cache_two_kernels
   test_opencl_ffi_check_funnel
-  test_opencl_f16_tripwire)
+  test_opencl_f16_tripwire
+  test_opencl_fp_conformance)
  (libraries sarek_opencl sarek_backend_error alcotest str)
  (instrumentation
   (backend bisect_ppx)))

--- a/sarek-opencl/test/test_opencl_fp_conformance.ml
+++ b/sarek-opencl/test/test_opencl_fp_conformance.ml
@@ -1,0 +1,313 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * The OpenCL build-option guard (#136).
+ *
+ * Sibling of sarek-cuda/test/test_cuda_fp_conformance.ml, and shaped the same
+ * way: the screening half is PURE, so it runs on a host with no OpenCL ICD and
+ * no device at all, and only the end-to-end half needs hardware.
+ *
+ * EVERY CHECK HERE WAS PROVED RED BY MUTATING THE THING IT CHECKS. The table
+ * of mutations and the message each produced is in
+ * docs/fp-contraction-policy.md §10; if you add a case, add its mutation there
+ * too. A guard test that has never been seen to fail is not evidence.
+ *
+ * The two anti-vacuity controls are the important part of this file:
+ *
+ *   - [assembled_string_contains_the_option_under_test] — the gate could
+ *     "pass" while Sarek assembled an option string that never reaches
+ *     clBuildProgram. This asserts the option is IN the string the build path
+ *     produces, so the accept/reject cases cannot be proving something about a
+ *     value nobody uses.
+ *   - [device_fp_config_query_is_live] — the capability gate is OFF whenever
+ *     CL_DEVICE_SINGLE_FP_CONFIG lacks the bit. If the query silently returned
+ *     0 (wrong ctypes width, wrong enum value, a driver returning nothing),
+ *     the gate would be permanently off and every "correctly gated off" case
+ *     in this file would pass while checking nothing. This asserts the query
+ *     returns a NON-ZERO config on a real device, which is the only thing that
+ *     distinguishes "the device says no" from "we never asked".
+ ******************************************************************************)
+
+open Sarek_opencl
+
+(* ------------------------------------------------------------------ *)
+(* Pure: screening a caller's option string                            *)
+(* ------------------------------------------------------------------ *)
+
+let refused opts =
+  match Opencl_fp.check_fp_conformance opts with
+  | () -> false
+  | exception Opencl_fp.Fp_conformance_violation _ -> true
+
+let must_refuse opts () =
+  if not (refused opts) then
+    Alcotest.failf
+      "%S relaxes float semantics and must be refused on the OpenCL path; the \
+       guard accepted it"
+      opts
+
+let must_accept opts () =
+  if refused opts then
+    Alcotest.failf
+      "%S is legitimate and must be accepted; the guard refused it"
+      opts
+
+(* The relaxing options, each named individually rather than in a loop, so a
+   failure names the option rather than an index. *)
+let rejection_cases =
+  [
+    "-cl-fast-relaxed-math";
+    "-cl-unsafe-math-optimizations";
+    "-cl-finite-math-only";
+    "-cl-no-signed-zeros";
+    "-cl-mad-enable";
+    "-cl-denorms-are-zero";
+    "-cl-single-precision-constant";
+  ]
+
+let acceptance_cases =
+  [
+    "";
+    "-cl-opt-disable";
+    "-I/usr/include";
+    "-D SAREK_TEST=1";
+    "-cl-std=CL1.2";
+    "-Werror";
+  ]
+
+(* Rejection must survive being embedded in a realistic option string, and must
+   match a WHOLE token: a longer option that merely starts with a refused name
+   is a different option and must not be caught by accident. *)
+let test_embedded_in_a_longer_string () =
+  must_refuse "-I/usr/include -cl-fast-relaxed-math -D N=4" () ;
+  must_refuse "-D N=4 -cl-mad-enable" () ;
+  must_accept "-cl-mad-enable-that-is-not-a-real-option" () ;
+  must_accept "-D FLAG=-cl-fast-relaxed-math-lookalike" ()
+
+(* ------------------------------------------------------------------ *)
+(* Pure: the capability gate                                           *)
+(* ------------------------------------------------------------------ *)
+
+(* CL_FP_INF_NAN | CL_FP_ROUND_TO_NEAREST — the value BOTH devices on the
+   machine this was written on actually report (0x6, measured 2026-07-26,
+   rusticl/radeonsi 26.1.4-arch3.1). No CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT. *)
+let fp_config_without_cr = 0x6L
+
+let fp_config_with_cr =
+  Int64.logor fp_config_without_cr Opencl_fp.cl_fp_correctly_rounded_divide_sqrt
+
+let has_cr_flag s =
+  let re = Str.regexp_string "-cl-fp32-correctly-rounded-divide-sqrt" in
+  try
+    ignore (Str.search_forward re s 0) ;
+    true
+  with Not_found -> false
+
+let test_gate_on_when_device_advertises () =
+  let opts =
+    Opencl_fp.build_options ~single_fp_config:fp_config_with_cr ~caller:""
+  in
+  if not (has_cr_flag opts) then
+    Alcotest.failf
+      "device advertises CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT, so \
+       -cl-fp32-correctly-rounded-divide-sqrt must be requested; got %S"
+      opts
+
+let test_gate_off_when_device_does_not_advertise () =
+  let opts =
+    Opencl_fp.build_options ~single_fp_config:fp_config_without_cr ~caller:""
+  in
+  if has_cr_flag opts then
+    Alcotest.failf
+      "device does NOT advertise CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT, so \
+       passing -cl-fp32-correctly-rounded-divide-sqrt is an error \
+       (CL_INVALID_BUILD_OPTIONS) on a conformant implementation and every \
+       kernel build would fail; got %S"
+      opts
+
+(* ANTI-VACUITY CONTROL. Without this, the two cases above could both hold of a
+   build_options that returns "" unconditionally. *)
+let test_assembled_string_contains_the_option_under_test () =
+  let opts =
+    Opencl_fp.build_options ~single_fp_config:fp_config_with_cr ~caller:""
+  in
+  if String.trim opts = "" then
+    Alcotest.fail
+      "the assembled option string is empty, so the accept/reject cases in \
+       this file prove nothing about what reaches clBuildProgram" ;
+  if not (has_cr_flag opts) then
+    Alcotest.failf
+      "the assembled option string no longer contains the option under test, \
+       so this check proves nothing; got %S"
+      opts
+
+let test_caller_options_are_preserved () =
+  let opts =
+    Opencl_fp.build_options
+      ~single_fp_config:fp_config_with_cr
+      ~caller:"-I/usr/include -D N=4"
+  in
+  let contains sub =
+    try
+      ignore (Str.search_forward (Str.regexp_string sub) opts 0) ;
+      true
+    with Not_found -> false
+  in
+  if not (contains "-I/usr/include" && contains "-D" && contains "N=4") then
+    Alcotest.failf
+      "a legitimate caller option was dropped while assembling the build \
+       string; got %S"
+      opts ;
+  if not (has_cr_flag opts) then
+    Alcotest.failf
+      "Sarek's own conformance option was dropped once a caller supplied \
+       options; got %S"
+      opts
+
+let test_violation_raises_before_any_assembly () =
+  match
+    Opencl_fp.build_options
+      ~single_fp_config:fp_config_with_cr
+      ~caller:"-cl-fast-relaxed-math"
+  with
+  | s ->
+      Alcotest.failf
+        "build_options assembled %S from a relaxing caller option; the guard \
+         must raise instead, on the path that actually reaches clBuildProgram"
+        s
+  | exception Opencl_fp.Fp_conformance_violation _ -> ()
+
+(* ------------------------------------------------------------------ *)
+(* Device-backed                                                       *)
+(* ------------------------------------------------------------------ *)
+
+let with_device name f () =
+  if not (Opencl_api.is_available ()) then begin
+    Printf.printf "[SKIP] no OpenCL device available - skipping %s\n%!" name ;
+    Alcotest.skip ()
+  end
+  else begin
+    Opencl_api.Device.init () ;
+    f (Opencl_api.Device.get 0)
+  end
+
+(* ANTI-VACUITY CONTROL — see the header. *)
+let test_device_fp_config_query_is_live device =
+  let cfg = device.Opencl_api.Device.single_fp_config in
+  if cfg = 0L then
+    Alcotest.failf
+      "CL_DEVICE_SINGLE_FP_CONFIG read as 0 on %s. Every conformant OpenCL \
+       device sets at least CL_FP_ROUND_TO_NEAREST and CL_FP_INF_NAN, so 0 \
+       means the query is broken, not that the device is austere - and a \
+       broken query silently disables the capability gate for every device, \
+       making the gating tests in this file vacuous."
+      device.Opencl_api.Device.name ;
+  Printf.printf
+    "[info] %s: CL_DEVICE_SINGLE_FP_CONFIG = 0x%Lx (correctly-rounded \
+     divide/sqrt: %s; denormals: %s)\n\
+     %!"
+    device.Opencl_api.Device.name
+    cfg
+    (if Opencl_fp.has_bit cfg Opencl_fp.cl_fp_correctly_rounded_divide_sqrt then
+       "yes"
+     else "NO")
+    (if Opencl_fp.has_bit cfg Opencl_fp.cl_fp_denorm then "yes" else "NO")
+
+let trivial_source =
+  {|
+__kernel void k(__global float *out, __global const float *in) {
+    int i = get_global_id(0);
+    out[i] = sqrt(in[i]) + in[i] / 3.0f;
+}
+|}
+
+(* The change must not break the thing it is protecting: whatever option string
+   the gate produces for the LOCAL device has to be one clBuildProgram accepts.
+   This is the regression that an ungated, unconditional
+   -cl-fp32-correctly-rounded-divide-sqrt would cause on a conformant driver. *)
+let test_real_build_still_succeeds device =
+  let context = Opencl_api.Context.create device in
+  let program = Opencl_api.Program.create_from_source context trivial_source in
+  Opencl_api.Program.build program () ;
+  let (_ : Opencl_api.Kernel.t) = Opencl_api.Kernel.create program "k" in
+  ()
+
+let test_real_build_refuses_relaxing_option device =
+  let context = Opencl_api.Context.create device in
+  let program = Opencl_api.Program.create_from_source context trivial_source in
+  match
+    Opencl_api.Program.build program ~options:"-cl-fast-relaxed-math" ()
+  with
+  | () ->
+      Alcotest.fail
+        "Program.build accepted -cl-fast-relaxed-math and compiled; the guard \
+         did not fire on the real entry point"
+  | exception Opencl_fp.Fp_conformance_violation _ -> ()
+
+let () =
+  Alcotest.run
+    "Opencl_fp_conformance"
+    [
+      ( "rejects relaxing options",
+        List.map
+          (fun o -> Alcotest.test_case o `Quick (must_refuse o))
+          rejection_cases );
+      ( "accepts legitimate options",
+        List.map
+          (fun o ->
+            Alcotest.test_case
+              (if o = "" then "(empty)" else o)
+              `Quick
+              (must_accept o))
+          acceptance_cases );
+      ( "token matching",
+        [
+          Alcotest.test_case
+            "refused options are matched as whole tokens"
+            `Quick
+            test_embedded_in_a_longer_string;
+        ] );
+      ( "capability gate",
+        [
+          Alcotest.test_case
+            "on when the device advertises the capability"
+            `Quick
+            test_gate_on_when_device_advertises;
+          Alcotest.test_case
+            "off when it does not"
+            `Quick
+            test_gate_off_when_device_does_not_advertise;
+          Alcotest.test_case
+            "assembled string contains the option under test (anti-vacuity)"
+            `Quick
+            test_assembled_string_contains_the_option_under_test;
+          Alcotest.test_case
+            "caller options survive assembly"
+            `Quick
+            test_caller_options_are_preserved;
+          Alcotest.test_case
+            "a relaxing caller option raises instead of assembling"
+            `Quick
+            test_violation_raises_before_any_assembly;
+        ] );
+      ( "device",
+        [
+          Alcotest.test_case
+            "CL_DEVICE_SINGLE_FP_CONFIG query is live (anti-vacuity)"
+            `Quick
+            (with_device "fp-config query" test_device_fp_config_query_is_live);
+          Alcotest.test_case
+            "a real build still succeeds under the new option string"
+            `Quick
+            (with_device "real build" test_real_build_still_succeeds);
+          Alcotest.test_case
+            "a real build refuses a relaxing option"
+            `Quick
+            (with_device
+               "real build refusal"
+               test_real_build_refuses_relaxing_option);
+        ] );
+    ]

--- a/sarek-opencl/test/test_opencl_fp_conformance.ml
+++ b/sarek-opencl/test/test_opencl_fp_conformance.ml
@@ -4,7 +4,7 @@
 (******************************************************************************)
 
 (******************************************************************************
- * The OpenCL build-option guard (#136).
+ * The OpenCL build-option guard (backlog #136).
  *
  * Sibling of sarek-cuda/test/test_cuda_fp_conformance.ml, and shaped the same
  * way: the screening half is PURE, so it runs on a host with no OpenCL ICD and

--- a/sarek-opencl/test/test_opencl_fp_conformance.ml
+++ b/sarek-opencl/test/test_opencl_fp_conformance.ml
@@ -12,7 +12,7 @@
  *
  * EVERY CHECK HERE WAS PROVED RED BY MUTATING THE THING IT CHECKS. The table
  * of mutations and the message each produced is in
- * docs/fp-contraction-policy.md §10; if you add a case, add its mutation there
+ * docs/fp-contraction-policy.md §9.5; if you add a case, add its mutation there
  * too. A guard test that has never been seen to fail is not evidence.
  *
  * The two anti-vacuity controls are the important part of this file:

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -921,6 +921,39 @@ let reject_float16_kernel =
     ~backend:"Metal"
     Sarek_ir_analysis.Float16
 
+(** The ONLY thing measured to stop Metal contracting [a*b+c].
+
+    Metal's compile options do NOT do it. Measured on Apple M4 / macOS 15.6.1
+    (24G90) / Apple clang 17.0.0, on [o = a*b + c] over 65536 inputs, restricted
+    to the 8773 elements where the DEVICE's own [fma] differs from the
+    separately-rounded value (so contraction is observable at all):
+
+    | build | contracted | |---|---| | default options | 8773 / 8773 | |
+    [mathMode = MTLMathModeSafe] | **8773 / 8773** | | [mathMode=Safe] +
+    [mathFloatingPointFunctions=Precise] | **8773 / 8773** | |
+    [fastMathEnabled = NO] | **8773 / 8773** | | **this pragma** | **0 / 8773**
+    |
+
+    That is §1 corollary 2 again — "a flag that names the hazard is not a
+    mechanism that prevents it" — and it is why the compile options set in
+    [Metal_bindings.mtl_compile_options_conformant] are NOT a contraction
+    defence and are not described as one. They buy math-function precision; this
+    pragma buys the rounding.
+
+    [#pragma clang fp contract(off)], a [volatile thread] local, a
+    [threadgroup volatile] round-trip and an [as_type] bitcast round-trip were
+    all measured to work too. The pragma is chosen because it is file-scoped,
+    costs no register or memory traffic, and needs no per-expression codegen
+    change — the same reasoning that put [precise] on GLSL locals (§6).
+    [#pragma METAL fp math_mode(safe)] does NOT work: like the [mathMode]
+    property it leaves contraction on. Sweep:
+    [tools/probes/metal_contraction_barrier_probe.m].
+
+    Sarek's rule is IEEE-754 with every operation rounded as written
+    (docs/fp-contraction-policy.md §1), so this is a conformance requirement,
+    not a tuning choice. *)
+let metal_fp_contract_pragma = "#pragma METAL fp contract(off)\n"
+
 (** Generate complete Metal source for a kernel *)
 let generate (k : kernel) : string =
   reject_float16_kernel k ;
@@ -931,7 +964,9 @@ let generate (k : kernel) : string =
 
   (* Metal header *)
   Buffer.add_string buf "#include <metal_stdlib>\n" ;
-  Buffer.add_string buf "using namespace metal;\n\n" ;
+  Buffer.add_string buf "using namespace metal;\n" ;
+  Buffer.add_string buf metal_fp_contract_pragma ;
+  Buffer.add_string buf "\n" ;
 
   (* Generate helper functions before kernel *)
   List.iter (gen_helper_func buf) k.kern_funcs ;
@@ -995,7 +1030,9 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
 
   (* Metal header *)
   Buffer.add_string buf "#include <metal_stdlib>\n" ;
-  Buffer.add_string buf "using namespace metal;\n\n" ;
+  Buffer.add_string buf "using namespace metal;\n" ;
+  Buffer.add_string buf metal_fp_contract_pragma ;
+  Buffer.add_string buf "\n" ;
 
   (* Variant type definitions first (may be needed by records).
      Previously omitted here, unlike the CUDA/OpenCL backends, so Metal kernels

--- a/sarek/tests/codegen_golden/gen_metal.real.ml
+++ b/sarek/tests/codegen_golden/gen_metal.real.ml
@@ -15,3 +15,9 @@ let reset_state () =
 
 let generate_with_types ~types (k : kernel) =
   Sarek_ir_metal.generate_with_types ~types k
+
+(* Exposed so the contraction-pragma gate can check BOTH preamble sites.
+   [Sarek_ir_metal] emits its header in two places - here and in
+   [generate_with_types] - and a gate that only exercised the latter would let
+   this one drift back to contracting silently. *)
+let generate (k : kernel) = Sarek_ir_metal.generate k

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -860,7 +860,8 @@ let () =
     "metal"
     "scalar_vec_add"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      kernel void scalar_vec_add(device float* a [[buffer(0)]], constant int \
      &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant \
      int &sarek_b_length [[buffer(3)]], device float* c [[buffer(4)]], \
@@ -878,7 +879,8 @@ let () =
     "metal"
     "record_kernel"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      typedef struct {\n\
     \  float x;\n\
     \  float y;\n\
@@ -899,7 +901,8 @@ let () =
     "metal"
     "variant_kernel"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      enum { OptNone = 0, OptSome = 1 };\n\
      typedef struct {\n\
     \  int tag;\n\
@@ -939,7 +942,8 @@ let () =
     "metal"
     "sin_kernel"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      kernel void sin_kernel(device float* a [[buffer(0)]], constant int \
      &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant \
      int &sarek_b_length [[buffer(3)]],\n\
@@ -1101,7 +1105,8 @@ let () =
     "metal"
     "float32_sin_path"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      kernel void float32_sin_path(device float* a [[buffer(0)]], constant int \
      &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant \
      int &sarek_b_length [[buffer(3)]],\n\
@@ -2046,7 +2051,8 @@ let () =
     "metal"
     "float32_cbrt_path"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      kernel void float32_cbrt_path(device float* a [[buffer(0)]], constant int \
      &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], constant \
      int &sarek_b_length [[buffer(3)]],\n\
@@ -2063,7 +2069,8 @@ let () =
     "metal"
     "float32_hypot_path"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      kernel void float32_hypot_path(device float* a [[buffer(0)]], constant \
      int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], \
      constant int &sarek_b_length [[buffer(3)]], device float* c \
@@ -2081,7 +2088,8 @@ let () =
     "metal"
     "float32_expm1_path"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      kernel void float32_expm1_path(device float* a [[buffer(0)]], constant \
      int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], \
      constant int &sarek_b_length [[buffer(3)]],\n\
@@ -2098,7 +2106,8 @@ let () =
     "metal"
     "float32_log1p_path"
     "#include <metal_stdlib>\n\
-     using namespace metal;\n\n\
+     using namespace metal;\n\
+     #pragma METAL fp contract(off)\n\n\
      kernel void float32_log1p_path(device float* a [[buffer(0)]], constant \
      int &sarek_a_length [[buffer(1)]], device float* b [[buffer(2)]], \
      constant int &sarek_b_length [[buffer(3)]],\n\
@@ -2520,6 +2529,65 @@ let opencl_validation_tests () =
               end))
     (test_kernels () @ glsl_only_kernels () @ opencl_validation_only_kernels ())
 
+(* The Metal contraction defence, pinned separately from the byte-exact goldens.
+
+   The goldens above would notice the pragma disappearing, but they would report
+   it as "some Metal source changed", which is the wrong diagnosis for a
+   conformance regression. This says what actually broke and why it matters.
+
+   MEASURED on Apple M4 / macOS 15.6.1 / Apple clang 17.0.0: without this
+   pragma, a*b+c is contracted into an fma on all 8773 observable elements of a
+   65536-input sweep; with it, 0. NO MTLCompileOptions setting achieves that —
+   not mathMode=Safe, not fastMathEnabled=NO. See
+   tools/probes/metal_contraction_barrier_probe.m and
+   docs/fp-contraction-policy.md §11. *)
+let metal_contraction_pragma_tests () =
+  let pragma = "#pragma METAL fp contract(off)" in
+  let contains hay needle =
+    let nh = String.length needle and h = String.length hay in
+    let rec go i =
+      i + nh <= h && (String.sub hay i nh = needle || go (i + 1))
+    in
+    go 0
+  in
+  List.filter_map
+    (fun (kernel_name, k) ->
+      Some
+        (Alcotest.test_case
+           (Printf.sprintf
+              "metal/%s carries the contraction pragma"
+              kernel_name)
+           `Quick
+           (fun () ->
+             metal_backend.reset () ;
+             let actual = metal_backend.generate ~types:[] k in
+             if not (contains actual pragma) then
+               Alcotest.failf
+                 "generated Metal for %s does not contain %S.\n\
+                  Metal contracts a*b+c into an fma by default and NO \
+                  MTLCompileOptions setting prevents it (measured on Apple M4 \
+                  / macOS 15.6.1: mathMode=Safe leaves 8773/8773 elements \
+                  contracted, this pragma leaves 0). Dropping it silently \
+                  removes a rounding docs/fp-contraction-policy.md §1 \
+                  promises, and breaks every error-free transformation in \
+                  Sarek_df64 on Metal."
+                 kernel_name
+                 pragma)))
+    (test_kernels ())
+
+(* ANTI-VACUITY CONTROL: the check above is worthless if it inspects an empty
+   list, which is exactly what happens if the golden fixture names change. *)
+let metal_contraction_pragma_coverage () =
+  Alcotest.test_case
+    "the pragma check inspects a non-empty set of kernels"
+    `Quick
+    (fun () ->
+      let n = List.length (metal_contraction_pragma_tests ()) in
+      if n = 0 then
+        Alcotest.fail
+          "no metal golden kernels were found, so the contraction-pragma check \
+           above asserted nothing")
+
 let () =
   Alcotest.run
     "codegen_golden"
@@ -2531,4 +2599,7 @@ let () =
         ("glsl_validation_sweep", glsl_validation_tests ());
         ("wgsl_validation_sweep", wgsl_validation_tests ());
         ("opencl_validation_sweep", opencl_validation_tests ());
+        ( "metal_contraction_pragma",
+          metal_contraction_pragma_coverage ()
+          :: metal_contraction_pragma_tests () );
       ])

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -2540,7 +2540,7 @@ let opencl_validation_tests () =
    65536-input sweep; with it, 0. NO MTLCompileOptions setting achieves that —
    not mathMode=Safe, not fastMathEnabled=NO. See
    tools/probes/metal_contraction_barrier_probe.m and
-   docs/fp-contraction-policy.md §11. *)
+   docs/fp-contraction-policy.md §10. *)
 let metal_contraction_pragma_tests () =
   let pragma = "#pragma METAL fp contract(off)" in
   let contains hay needle =

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -2559,20 +2559,31 @@ let metal_contraction_pragma_tests () =
               kernel_name)
            `Quick
            (fun () ->
+             (* BOTH entry points. Sarek_ir_metal has two preamble sites -
+                [generate] and [generate_with_types] - and the pragma was added
+                to each. Checking only the one the goldens happen to use would
+                leave the other free to drift back to contracting silently,
+                which is exactly the hole CodeRabbit found here. *)
              metal_backend.reset () ;
-             let actual = metal_backend.generate ~types:[] k in
-             if not (contains actual pragma) then
-               Alcotest.failf
-                 "generated Metal for %s does not contain %S.\n\
-                  Metal contracts a*b+c into an fma by default and NO \
-                  MTLCompileOptions setting prevents it (measured on Apple M4 \
-                  / macOS 15.6.1: mathMode=Safe leaves 8773/8773 elements \
-                  contracted, this pragma leaves 0). Dropping it silently \
-                  removes a rounding docs/fp-contraction-policy.md §1 \
-                  promises, and breaks every error-free transformation in \
-                  Sarek_df64 on Metal."
-                 kernel_name
-                 pragma)))
+             let via_types = metal_backend.generate ~types:[] k in
+             Gen_metal.reset_state () ;
+             let via_plain = Gen_metal.generate k in
+             List.iter
+               (fun (entry, actual) ->
+                 if not (contains actual pragma) then
+                   Alcotest.failf
+                     "generated Metal for %s via %s does not contain %S.\n\
+                      Metal contracts a*b+c into an fma by default and NO \
+                      MTLCompileOptions setting prevents it (measured on Apple \
+                      M4 / macOS 15.6.1: mathMode=Safe leaves 8773/8773 \
+                      elements contracted, this pragma leaves 0). Dropping it \
+                      silently removes a rounding \
+                      docs/fp-contraction-policy.md §1 promises, and breaks \
+                      every error-free transformation in Sarek_df64 on Metal."
+                     kernel_name
+                     entry
+                     pragma)
+               [("generate_with_types", via_types); ("generate", via_plain)])))
     (test_kernels ())
 
 (* ANTI-VACUITY CONTROL: the check above is worthless if it inspects an empty

--- a/tools/probes/metal_contraction_barrier_probe.m
+++ b/tools/probes/metal_contraction_barrier_probe.m
@@ -1,0 +1,207 @@
+/* metal_contraction_barrier_probe.m — backlog #125
+ *
+ * metal_math_mode_probe established that MTLCompileOptions' math settings ARE
+ * honoured by Metal, and that NONE of them stops Metal contracting `a*b+c`
+ * into an fma. This probe answers the follow-up: does anything?
+ *
+ * Same method as tools/probes/opencl_f16_contraction_probe.c — sweep every
+ * source-level barrier expressible on the platform and report which, if any,
+ * defeats the fusion. Plus the API-choice question: is the deprecated
+ * `fastMathEnabled = NO` equivalent to the two modern properties?
+ *
+ * The separately-rounded reference is computed in TWO KERNEL PASSES with the
+ * product round-tripped through device memory, so it cannot itself be fused;
+ * and elements are restricted to those where the DEVICE's own `fma` differs
+ * from it, since contraction is unobservable anywhere else. Both points matter
+ * — see docs/fp-contraction-policy.md §6 on why inputs must be chosen against
+ * a device's measured `fma` rather than an IEEE model.
+ *
+ * Build (Command Line Tools are enough; no Xcode, no offline `metal` compiler):
+ *   clang -fobjc-arc -O2 -framework Foundation -framework Metal \
+ *       metal_contraction_barrier_probe.m -o metal_contraction_barrier_probe
+ *
+ * ---------------------------------------------------------------------------
+ * MEASURED 2026-07-26, Apple M4, macOS 15.6.1 (24G90), Apple clang 17.0.0.
+ * 65536 inputs, 8773 of them observable. Every variant built with
+ * mathMode=Safe + mathFloatingPointFunctions=Precise:
+ *
+ *   plain a*b+c (no barrier)              CONTRACTED 8773 / 8773
+ *   #pragma METAL fp contract(off)        contracted    0 / 8773   <-- ADOPTED
+ *   #pragma METAL fp math_mode(safe)      CONTRACTED 8773 / 8773
+ *   #pragma clang fp contract(off)        contracted    0 / 8773
+ *   volatile thread local                 contracted    0 / 8773
+ *   volatile threadgroup local            contracted    0 / 8773
+ *   device round-trip                     contracted    0 / 8773
+ *   as_type bitcast round-trip            contracted    0 / 8773
+ *   precise:: namespace                   does not compile (no such namespace)
+ *
+ * Note `#pragma METAL fp math_mode(safe)` fails exactly as the `mathMode`
+ * PROPERTY does: math mode and contraction are orthogonal on Metal. That is
+ * docs/fp-contraction-policy.md §1 corollary 2 — a flag that names the hazard
+ * is not a mechanism that prevents it.
+ *
+ * `#pragma METAL fp contract(off)` is what Sarek_ir_metal now emits: file
+ * scoped, no register or memory traffic, no per-expression codegen change.
+ *
+ * Equivalence result: `fastMathEnabled = NO` and
+ * `mathMode=Safe + fpFunctions=Precise` are BIT-IDENTICAL over 65536 elements
+ * of sqrt + reciprocal + sin + log + exp (0 differ). So the pre-macOS-15
+ * fallback in Metal_bindings.mtl_compile_options_conformant is exact, not
+ * degraded.
+ * ---------------------------------------------------------------------------
+ */
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define N 65536
+
+static const char *PREAMBLE =
+"#include <metal_stdlib>\n"
+"using namespace metal;\n";
+
+/* Reference passes, compiled identically in every variant. */
+static const char *REFKERNELS =
+"kernel void mul_only(device float* p [[buffer(0)]], const device float* a [[buffer(1)]],\n"
+"                     const device float* b [[buffer(2)]], uint i [[thread_position_in_grid]]) {\n"
+"  p[i] = a[i] * b[i]; }\n"
+"kernel void add_only(device float* o [[buffer(0)]], const device float* p [[buffer(1)]],\n"
+"                     const device float* c [[buffer(2)]], uint i [[thread_position_in_grid]]) {\n"
+"  o[i] = p[i] + c[i]; }\n"
+"kernel void explicit_fma(device float* o [[buffer(0)]], const device float* a [[buffer(1)]],\n"
+"                         const device float* b [[buffer(2)]], const device float* c [[buffer(3)]],\n"
+"                         uint i [[thread_position_in_grid]]) {\n"
+"  o[i] = fma(a[i], b[i], c[i]); }\n";
+
+typedef struct { const char *label; const char *pragma; const char *body; } cand;
+
+static cand CANDS[] = {
+  { "plain a*b+c (no barrier)", "",
+    "  o[i] = a[i] * b[i] + c[i];\n" },
+  { "#pragma METAL fp contract(off)", "#pragma METAL fp contract(off)\n",
+    "  o[i] = a[i] * b[i] + c[i];\n" },
+  { "#pragma METAL fp math_mode(safe)", "#pragma METAL fp math_mode(safe)\n",
+    "  o[i] = a[i] * b[i] + c[i];\n" },
+  { "#pragma clang fp contract(off)", "#pragma clang fp contract(off)\n",
+    "  o[i] = a[i] * b[i] + c[i];\n" },
+  { "volatile thread local", "",
+    "  volatile thread float p = a[i] * b[i];\n  o[i] = p + c[i];\n" },
+  { "volatile threadgroup local", "",
+    "  threadgroup volatile float tg[64];\n  tg[i % 64] = a[i] * b[i];\n"
+    "  threadgroup_barrier(mem_flags::mem_threadgroup);\n  o[i] = tg[i % 64] + c[i];\n" },
+  { "device round-trip (write then read)", "",
+    "  o[i] = a[i] * b[i];\n  threadgroup_barrier(mem_flags::mem_device);\n  o[i] = o[i] + c[i];\n" },
+  { "as_type bitcast round-trip", "",
+    "  float p = as_type<float>(as_type<uint>(a[i] * b[i]));\n  o[i] = p + c[i];\n" },
+  { "separate precise:: namespace", "",
+    "  float p = precise::float(a[i]) * precise::float(b[i]);\n  o[i] = p + c[i];\n" },
+};
+static const int NC = sizeof(CANDS)/sizeof(CANDS[0]);
+
+static id<MTLBuffer> mkbuf(id<MTLDevice> d, const void *s, size_t n) {
+  return s ? [d newBufferWithBytes:s length:n options:MTLResourceStorageModeShared]
+           : [d newBufferWithLength:n options:MTLResourceStorageModeShared];
+}
+static int run1(id<MTLDevice> dev, id<MTLCommandQueue> q, id<MTLLibrary> lib,
+                const char *fn, NSArray<id<MTLBuffer>> *bufs) {
+  NSError *e=nil;
+  id<MTLFunction> f=[lib newFunctionWithName:[NSString stringWithUTF8String:fn]];
+  if(!f) return 0;
+  id<MTLComputePipelineState> ps=[dev newComputePipelineStateWithFunction:f error:&e];
+  if(!ps) return 0;
+  id<MTLCommandBuffer> cb=[q commandBuffer];
+  id<MTLComputeCommandEncoder> en=[cb computeCommandEncoder];
+  [en setComputePipelineState:ps];
+  for(NSUInteger i=0;i<bufs.count;i++)[en setBuffer:bufs[i] offset:0 atIndex:i];
+  [en dispatchThreads:MTLSizeMake(N,1,1) threadsPerThreadgroup:MTLSizeMake(64,1,1)];
+  [en endEncoding];[cb commit];[cb waitUntilCompleted];
+  return cb.error==nil;
+}
+
+int main(void){ @autoreleasepool {
+  id<MTLDevice> dev=MTLCreateSystemDefaultDevice();
+  printf("device = %s\n\n", dev.name.UTF8String);
+  id<MTLCommandQueue> q=[dev newCommandQueue];
+
+  float *A=malloc(N*4),*B=malloc(N*4),*C=malloc(N*4);
+  unsigned s=987654321u;
+  for(int i=0;i<N;i++){
+    s=s*1103515245u+12345u; A[i]=(float)((s>>8)&0xFFFFF)/8192.0f+0.5f;
+    s=s*1103515245u+12345u; B[i]=(float)((s>>8)&0xFFFFF)/8192.0f+0.5f;
+    s=s*1103515245u+12345u; C[i]=(float)((s>>8)&0xFFFFF)/4096.0f+0.5f;
+  }
+  id<MTLBuffer> bA=mkbuf(dev,A,N*4),bB=mkbuf(dev,B,N*4),bC=mkbuf(dev,C,N*4);
+
+  printf("=== barrier sweep, each built with mathMode=Safe + fpFunctions=Precise ===\n");
+  for(int c=0;c<NC;c++){
+    char src[8192];
+    snprintf(src,sizeof src,
+      "%s%s"
+      "kernel void test(device float* o [[buffer(0)]], const device float* a [[buffer(1)]],\n"
+      "                 const device float* b [[buffer(2)]], const device float* cc [[buffer(3)]],\n"
+      "                 uint i [[thread_position_in_grid]]) {\n"
+      "  const device float* c = cc;\n"
+      "%s"
+      "}\n%s", PREAMBLE, CANDS[c].pragma, CANDS[c].body, REFKERNELS);
+
+    MTLCompileOptions *o=[MTLCompileOptions new];
+    o.mathMode=MTLMathModeSafe;
+    o.mathFloatingPointFunctions=MTLMathFloatingPointFunctionsPrecise;
+    NSError *err=nil;
+    id<MTLLibrary> lib=[dev newLibraryWithSource:[NSString stringWithUTF8String:src] options:o error:&err];
+    if(!lib){ printf("  %-38s -> COMPILE FAILED (%s)\n", CANDS[c].label,
+                     err.localizedDescription.UTF8String); continue; }
+
+    id<MTLBuffer> bP=mkbuf(dev,NULL,N*4),bR=mkbuf(dev,NULL,N*4),bF=mkbuf(dev,NULL,N*4),bT=mkbuf(dev,NULL,N*4);
+    if(!run1(dev,q,lib,"mul_only",@[bP,bA,bB])||!run1(dev,q,lib,"add_only",@[bR,bP,bC])
+       ||!run1(dev,q,lib,"explicit_fma",@[bF,bA,bB,bC])||!run1(dev,q,lib,"test",@[bT,bA,bB,bC])){
+      printf("  %-38s -> EXEC FAILED\n", CANDS[c].label); continue; }
+
+    float *R=bR.contents,*F=bF.contents,*T=bT.contents;
+    int obs=0,mr=0,mf=0,mn=0;
+    for(int i=0;i<N;i++){
+      if(!memcmp(&R[i],&F[i],4)) continue;
+      obs++;
+      if(!memcmp(&T[i],&R[i],4)) mr++;
+      else if(!memcmp(&T[i],&F[i],4)) mf++;
+      else mn++;
+    }
+    printf("  %-38s -> observable %5d | separately-rounded %5d | CONTRACTED %5d | other %4d  %s\n",
+           CANDS[c].label, obs, mr, mf, mn,
+           obs==0?"(inconclusive)": mf==0?"<<< NOT CONTRACTED":"");
+  }
+
+  /* Equivalence: is deprecated fastMathEnabled=NO the same as the two modern
+     properties set safe/precise, bit for bit? */
+  printf("\n=== equivalence: fastMathEnabled=NO  vs  mathMode=Safe + fpFunctions=Precise ===\n");
+  const char *mathsrc =
+    "#include <metal_stdlib>\nusing namespace metal;\n"
+    "kernel void mfn(device float* o [[buffer(0)]], const device float* a [[buffer(1)]],\n"
+    "                uint i [[thread_position_in_grid]]) {\n"
+    "  o[i] = sqrt(a[i]) + 1.0f/a[i] + sin(a[i]) + log(a[i]) + exp(a[i]*0.01f); }\n";
+  float *out[2]={0,0};
+  for(int k=0;k<2;k++){
+    MTLCompileOptions *o=[MTLCompileOptions new];
+    if(k==0){
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      o.fastMathEnabled=NO;
+#pragma clang diagnostic pop
+    } else { o.mathMode=MTLMathModeSafe; o.mathFloatingPointFunctions=MTLMathFloatingPointFunctionsPrecise; }
+    NSError *err=nil;
+    id<MTLLibrary> lib=[dev newLibraryWithSource:[NSString stringWithUTF8String:mathsrc] options:o error:&err];
+    if(!lib){ printf("  variant %d compile failed\n",k); continue; }
+    id<MTLBuffer> bO=mkbuf(dev,NULL,N*4);
+    if(!run1(dev,q,lib,"mfn",@[bO,bA])){ printf("  variant %d exec failed\n",k); continue; }
+    out[k]=malloc(N*4); memcpy(out[k],bO.contents,N*4);
+  }
+  if(out[0]&&out[1]){
+    int d=0; for(int i=0;i<N;i++) if(memcmp(&out[0][i],&out[1][i],4)) d++;
+    printf("  differ on %d / %d elements -> %s\n", d, N,
+           d==0?"BIT-IDENTICAL (the deprecated boolean == both modern properties)"
+               :"NOT equivalent - the two spellings mean different things");
+  }
+  free(A);free(B);free(C);
+} return 0; }

--- a/tools/probes/metal_contraction_barrier_probe.m
+++ b/tools/probes/metal_contraction_barrier_probe.m
@@ -122,6 +122,7 @@ static int run1(id<MTLDevice> dev, id<MTLCommandQueue> q, id<MTLLibrary> lib,
 
 int main(void){ @autoreleasepool {
   id<MTLDevice> dev=MTLCreateSystemDefaultDevice();
+  if(!dev){ fprintf(stderr,"no Metal device available\n"); return 1; }
   printf("device = %s\n\n", dev.name.UTF8String);
   id<MTLCommandQueue> q=[dev newCommandQueue];
 

--- a/tools/probes/metal_math_mode_probe.m
+++ b/tools/probes/metal_math_mode_probe.m
@@ -1,0 +1,270 @@
+/* metal_math_mode_probe.m — backlog #125
+ *
+ * Does MTLCompileOptions' math setting actually CHANGE RESULTS on Metal, or is
+ * it accepted and ignored?
+ *
+ * That distinction is the whole point. A compile that succeeds proves plumbing,
+ * not semantics — the same trap that made the OpenCL FP liveness control
+ * valuable (docs/fp-contraction-policy.md §10.2: rusticl accepts every
+ * -cl-* FP option and honours none of them). Until this probe was run, Sarek
+ * asked Metal for non-fast math and had no evidence Metal was listening.
+ *
+ * Build (no Xcode needed; the Command Line Tools are enough, because
+ * newLibraryWithSource:options:error: compiles through the driver at runtime,
+ * which is exactly the call under test):
+ *
+ *   clang -fobjc-arc -O2 -framework Foundation -framework Metal \
+ *       metal_math_mode_probe.m -o metal_math_mode_probe
+ *
+ * METHOD
+ *
+ * The kernel under test is `out = a*b + c` — the shape a compiler is free to
+ * contract into a single fma, removing a rounding the Sarek DSL promises
+ * (§1 corollary 1).
+ *
+ * Three reference values are computed per element:
+ *
+ *   ref  = fl(fl(a*b) + c)   the separately-rounded value Sarek mandates.
+ *                            Computed in TWO KERNEL PASSES with the product
+ *                            round-tripped through device memory in between,
+ *                            so no compiler at any optimisation level can fuse
+ *                            it. An in-kernel "reference" would be contractible
+ *                            too and would silently agree with whatever the
+ *                            test expression did.
+ *   dfma = fma(a, b, c)      the DEVICE's own fma, read from the device, not
+ *                            modelled. The policy doc records why this matters
+ *                            (§6): RADV's fma is not correctly rounded, so
+ *                            inputs chosen against an IEEE model can collide
+ *                            with what the hardware actually returns and
+ *                            produce a false "they agree".
+ *   test = a*b + c           one expression, compiler's choice.
+ *
+ * Inputs are then SELECTED to the subset where ref != dfma bit-for-bit — the
+ * only elements on which contraction is observable at all. On that subset,
+ * `test` matching `ref` means not contracted; matching `dfma` means contracted.
+ *
+ * If `test` is bit-identical across every math setting, Metal accepts the
+ * option and ignores it, and Metal's FP options belong in the same class as
+ * rusticl's.
+ *
+ * ---------------------------------------------------------------------------
+ * MEASURED 2026-07-26 on Apple M4, macOS 15.6.1 (24G90), arm64, Apple clang
+ * 17.0.0 (clang-1700.0.13.5), Metal.framework via the Command Line Tools SDK.
+ * 65536 inputs, 8773 of them observable.
+ *
+ * Defaults, read from a freshly constructed MTLCompileOptions:
+ *   mathMode                   = 2  (MTLMathModeFast)
+ *   mathFloatingPointFunctions = 0  (MTLMathFloatingPointFunctionsFast)
+ * BOTH Metal defaults are the fast one. "Metal defaults to fast math" was
+ * previously quoted from Apple's documentation; it is now measured, and it is
+ * two knobs rather than one.
+ *
+ * THE OPTIONS ARE HONOURED (vs default, on sqrt(a) + 1/a, 65536 elements):
+ *   mathMode=Safe                              16017 results change
+ *   mathMode=Safe + fpFunctions=Precise        22135 results change
+ *   fastMathEnabled=NO                         22135 results change
+ *   mathMode=Fast / fastMathEnabled=YES            0 (confirms the default)
+ * So Metal is NOT in the class of rusticl's OpenCL FP options, which are
+ * accepted and discarded (§10.2). Setting mathMode alone is not enough:
+ * mathFloatingPointFunctions is a second, independent knob.
+ *
+ * BUT THEY DO NOT TOUCH CONTRACTION. `a*b+c` is CONTRACTED on all 8773
+ * observable elements under EVERY setting above, including mathMode=Safe, and
+ * `a*b+c` is bit-identical across all of them (0/65536 differ). The fix for
+ * that is source-level: see tools/probes/metal_contraction_barrier_probe.m and
+ * Sarek_ir_metal.metal_fp_contract_pragma.
+ *
+ * Full write-up: docs/fp-contraction-policy.md §11.
+ * ---------------------------------------------------------------------------
+ */
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define N 65536
+
+static const char *SRC =
+"#include <metal_stdlib>\n"
+"using namespace metal;\n"
+"kernel void mul_only(device float* p [[buffer(0)]],\n"
+"                     const device float* a [[buffer(1)]],\n"
+"                     const device float* b [[buffer(2)]],\n"
+"                     uint i [[thread_position_in_grid]]) {\n"
+"  p[i] = a[i] * b[i];\n"
+"}\n"
+"kernel void add_only(device float* o [[buffer(0)]],\n"
+"                     const device float* p [[buffer(1)]],\n"
+"                     const device float* c [[buffer(2)]],\n"
+"                     uint i [[thread_position_in_grid]]) {\n"
+"  o[i] = p[i] + c[i];\n"
+"}\n"
+"kernel void explicit_fma(device float* o [[buffer(0)]],\n"
+"                         const device float* a [[buffer(1)]],\n"
+"                         const device float* b [[buffer(2)]],\n"
+"                         const device float* c [[buffer(3)]],\n"
+"                         uint i [[thread_position_in_grid]]) {\n"
+"  o[i] = fma(a[i], b[i], c[i]);\n"
+"}\n"
+"kernel void mul_add(device float* o [[buffer(0)]],\n"
+"                    const device float* a [[buffer(1)]],\n"
+"                    const device float* b [[buffer(2)]],\n"
+"                    const device float* c [[buffer(3)]],\n"
+"                    uint i [[thread_position_in_grid]]) {\n"
+"  o[i] = a[i] * b[i] + c[i];\n"
+"}\n"
+/* A single-precision math function, to exercise mathFloatingPointFunctions,
+   which selects between metal::fast and metal::precise and defaults to fast. */
+"kernel void math_fn(device float* o [[buffer(0)]],\n"
+"                    const device float* a [[buffer(1)]],\n"
+"                    uint i [[thread_position_in_grid]]) {\n"
+"  o[i] = sqrt(a[i]) + 1.0f / a[i];\n"
+"}\n";
+
+typedef struct {
+    const char *label;
+    int set_math_mode;       /* -1 = leave default */
+    int set_fp_functions;    /* -1 = leave default */
+    int set_fast_math;       /* -1 = leave default (deprecated property) */
+} variant;
+
+static id<MTLBuffer> buf(id<MTLDevice> dev, const void *src, size_t bytes) {
+    return src ? [dev newBufferWithBytes:src length:bytes options:MTLResourceStorageModeShared]
+               : [dev newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+}
+
+static void run1(id<MTLDevice> dev, id<MTLCommandQueue> q, id<MTLLibrary> lib,
+                 const char *fn, NSArray<id<MTLBuffer>> *bufs) {
+    NSError *err = nil;
+    id<MTLFunction> f = [lib newFunctionWithName:[NSString stringWithUTF8String:fn]];
+    if (!f) { fprintf(stderr, "FATAL: no function %s\n", fn); exit(1); }
+    id<MTLComputePipelineState> ps = [dev newComputePipelineStateWithFunction:f error:&err];
+    if (!ps) { fprintf(stderr, "FATAL: pipeline %s: %s\n", fn, err.localizedDescription.UTF8String); exit(1); }
+    id<MTLCommandBuffer> cb = [q commandBuffer];
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    [e setComputePipelineState:ps];
+    for (NSUInteger i = 0; i < bufs.count; i++) [e setBuffer:bufs[i] offset:0 atIndex:i];
+    [e dispatchThreads:MTLSizeMake(N,1,1) threadsPerThreadgroup:MTLSizeMake(64,1,1)];
+    [e endEncoding];
+    [cb commit];
+    [cb waitUntilCompleted];
+    if (cb.error) { fprintf(stderr, "FATAL: exec %s: %s\n", fn, cb.error.localizedDescription.UTF8String); exit(1); }
+}
+
+int main(void) {
+  @autoreleasepool {
+    id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
+    if (!dev) { fprintf(stderr, "no Metal device\n"); return 1; }
+    printf("device = %s\n", dev.name.UTF8String);
+
+    /* ---- what the DEFAULTS actually are, read from a fresh options object -- */
+    MTLCompileOptions *probe = [MTLCompileOptions new];
+    printf("\n=== MTLCompileOptions defaults, as constructed ===\n");
+    if ([probe respondsToSelector:@selector(mathMode)])
+        printf("  mathMode                  = %ld   (Safe=0 Relaxed=1 Fast=2)\n", (long)probe.mathMode);
+    else
+        printf("  mathMode                  = SELECTOR ABSENT\n");
+    if ([probe respondsToSelector:@selector(mathFloatingPointFunctions)])
+        printf("  mathFloatingPointFunctions= %ld   (Fast=0 Precise=1)\n", (long)probe.mathFloatingPointFunctions);
+    else
+        printf("  mathFloatingPointFunctions= SELECTOR ABSENT\n");
+    printf("  respondsToSelector(setFastMathEnabled:) = %s\n",
+           [probe respondsToSelector:@selector(setFastMathEnabled:)] ? "YES" : "NO");
+    printf("  respondsToSelector(setMathMode:)        = %s\n",
+           [probe respondsToSelector:@selector(setMathMode:)] ? "YES" : "NO");
+
+    /* ---- inputs -------------------------------------------------------- */
+    float *A = malloc(N*4), *B = malloc(N*4), *C = malloc(N*4);
+    unsigned s = 987654321u;
+    for (int i = 0; i < N; i++) {
+        s = s*1103515245u + 12345u; A[i] = (float)((s>>8)&0xFFFFF) / 8192.0f + 0.5f;
+        s = s*1103515245u + 12345u; B[i] = (float)((s>>8)&0xFFFFF) / 8192.0f + 0.5f;
+        s = s*1103515245u + 12345u; C[i] = (float)((s>>8)&0xFFFFF) / 4096.0f + 0.5f;
+    }
+
+    id<MTLCommandQueue> q = [dev newCommandQueue];
+    id<MTLBuffer> bA = buf(dev,A,N*4), bB = buf(dev,B,N*4), bC = buf(dev,C,N*4);
+
+    variant variants[] = {
+      { "DEFAULT (nil options, what shipped before)", -1, -1, -1 },
+      { "mathMode = Safe",                             0, -1, -1 },
+      { "mathMode = Fast",                             2, -1, -1 },
+      { "mathMode=Safe + fpFunctions=Precise",         0,  1, -1 },
+      { "fastMathEnabled = NO  (deprecated)",         -1, -1,  0 },
+      { "fastMathEnabled = YES (deprecated)",         -1, -1,  1 },
+    };
+    int nv = sizeof(variants)/sizeof(variants[0]);
+
+    float *test[16], *dfma[16], *ref[16], *mfn[16];
+
+    for (int v = 0; v < nv; v++) {
+        MTLCompileOptions *o = [MTLCompileOptions new];
+        if (variants[v].set_math_mode >= 0)    o.mathMode = (MTLMathMode)variants[v].set_math_mode;
+        if (variants[v].set_fp_functions >= 0) o.mathFloatingPointFunctions = (MTLMathFloatingPointFunctions)variants[v].set_fp_functions;
+        if (variants[v].set_fast_math >= 0) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            o.fastMathEnabled = variants[v].set_fast_math ? YES : NO;
+#pragma clang diagnostic pop
+        }
+        NSError *err = nil;
+        id<MTLLibrary> lib = [dev newLibraryWithSource:[NSString stringWithUTF8String:SRC]
+                                               options:o error:&err];
+        if (!lib) { printf("  %-42s -> COMPILE FAILED: %s\n", variants[v].label,
+                           err.localizedDescription.UTF8String); continue; }
+
+        id<MTLBuffer> bP = buf(dev,NULL,N*4), bR = buf(dev,NULL,N*4);
+        id<MTLBuffer> bF = buf(dev,NULL,N*4), bT = buf(dev,NULL,N*4), bM = buf(dev,NULL,N*4);
+        /* ref: two passes, product through memory — unfusable by construction */
+        run1(dev,q,lib,"mul_only",     @[bP,bA,bB]);
+        run1(dev,q,lib,"add_only",     @[bR,bP,bC]);
+        run1(dev,q,lib,"explicit_fma", @[bF,bA,bB,bC]);
+        run1(dev,q,lib,"mul_add",      @[bT,bA,bB,bC]);
+        run1(dev,q,lib,"math_fn",      @[bM,bA]);
+
+        ref[v]=malloc(N*4); dfma[v]=malloc(N*4); test[v]=malloc(N*4); mfn[v]=malloc(N*4);
+        memcpy(ref[v],  bR.contents, N*4);
+        memcpy(dfma[v], bF.contents, N*4);
+        memcpy(test[v], bT.contents, N*4);
+        memcpy(mfn[v],  bM.contents, N*4);
+
+        /* Restrict to elements where contraction is OBSERVABLE on this device:
+           the device's own fma differs from the separately-rounded value. */
+        int observable=0, matches_ref=0, matches_fma=0, matches_neither=0;
+        for (int i=0;i<N;i++){
+            if (memcmp(&ref[v][i], &dfma[v][i], 4) == 0) continue;
+            observable++;
+            if (memcmp(&test[v][i], &ref[v][i], 4)==0) matches_ref++;
+            else if (memcmp(&test[v][i], &dfma[v][i], 4)==0) matches_fma++;
+            else matches_neither++;
+        }
+        printf("\n--- %s\n", variants[v].label);
+        printf("    observable elements (device fma != separately rounded): %d / %d\n", observable, N);
+        printf("    a*b+c matches separately-rounded : %d\n", matches_ref);
+        printf("    a*b+c matches device fma (CONTRACTED): %d\n", matches_fma);
+        printf("    matches neither                  : %d\n", matches_neither);
+        printf("    VERDICT: %s\n",
+               observable == 0 ? "INCONCLUSIVE - no observable element, inputs are useless"
+             : matches_fma == observable ? "CONTRACTED on every observable element"
+             : matches_ref == observable ? "NOT contracted on any observable element"
+                                         : "MIXED");
+    }
+
+    /* ---- cross-variant comparison: does the setting change anything? ---- */
+    printf("\n=== does the setting CHANGE RESULTS? (bit comparison vs DEFAULT) ===\n");
+    for (int v = 1; v < nv; v++) {
+        if (!test[v] || !test[0]) continue;
+        int d_mul=0, d_fn=0;
+        for (int i=0;i<N;i++){
+            if (memcmp(&test[v][i], &test[0][i], 4)) d_mul++;
+            if (memcmp(&mfn[v][i],  &mfn[0][i],  4)) d_fn++;
+        }
+        printf("  %-42s a*b+c differs %6d/%d | sqrt+recip differs %6d/%d\n",
+               variants[v].label, d_mul, N, d_fn, N);
+    }
+    printf("\nIf every row is 0/%d, Metal accepts these options and ignores them.\n", N);
+    free(A); free(B); free(C);
+  }
+  return 0;
+}

--- a/tools/probes/metal_math_mode_probe.m
+++ b/tools/probes/metal_math_mode_probe.m
@@ -196,10 +196,30 @@ int main(void) {
     };
     int nv = sizeof(variants)/sizeof(variants[0]);
 
-    float *test[16], *dfma[16], *ref[16], *mfn[16];
+    /* Zero-initialised: a variant whose compile fails `continue`s without
+       assigning these, and the cross-variant comparison below tests them for
+       NULL. Indeterminate pointers there would compare garbage and report it
+       as a measurement. */
+    float *test[16] = {0}, *dfma[16] = {0}, *ref[16] = {0}, *mfn[16] = {0};
 
     for (int v = 0; v < nv; v++) {
         MTLCompileOptions *o = [MTLCompileOptions new];
+        /* mathMode / mathFloatingPointFunctions are macOS 15.0+ / iOS 18.0+.
+           Assigning them on an older SDK is an unrecognised selector, i.e. a
+           crash, which would read as "the probe is broken" rather than "this
+           OS cannot express the setting". Report and skip instead. */
+        if (variants[v].set_math_mode >= 0
+            && ![o respondsToSelector:@selector(setMathMode:)]) {
+            printf("  %-58s SKIPPED: setMathMode: unavailable on this OS\n",
+                   variants[v].label);
+            continue;
+        }
+        if (variants[v].set_fp_functions >= 0
+            && ![o respondsToSelector:@selector(setMathFloatingPointFunctions:)]) {
+            printf("  %-58s SKIPPED: setMathFloatingPointFunctions: unavailable\n",
+                   variants[v].label);
+            continue;
+        }
         if (variants[v].set_math_mode >= 0)    o.mathMode = (MTLMathMode)variants[v].set_math_mode;
         if (variants[v].set_fp_functions >= 0) o.mathFloatingPointFunctions = (MTLMathFloatingPointFunctions)variants[v].set_fp_functions;
         if (variants[v].set_fast_math >= 0) {

--- a/tools/probes/metal_math_mode_probe.m
+++ b/tools/probes/metal_math_mode_probe.m
@@ -5,7 +5,7 @@
  *
  * That distinction is the whole point. A compile that succeeds proves plumbing,
  * not semantics — the same trap that made the OpenCL FP liveness control
- * valuable (docs/fp-contraction-policy.md §10.2: rusticl accepts every
+ * valuable (docs/fp-contraction-policy.md §9.2: rusticl accepts every
  * -cl-* FP option and honours none of them). Until this probe was run, Sarek
  * asked Metal for non-fast math and had no evidence Metal was listening.
  *
@@ -74,7 +74,7 @@
  * that is source-level: see tools/probes/metal_contraction_barrier_probe.m and
  * Sarek_ir_metal.metal_fp_contract_pragma.
  *
- * Full write-up: docs/fp-contraction-policy.md §11.
+ * Full write-up: docs/fp-contraction-policy.md §10.
  * ---------------------------------------------------------------------------
  */
 #import <Foundation/Foundation.h>

--- a/tools/probes/opencl_build_options_probe.c
+++ b/tools/probes/opencl_build_options_probe.c
@@ -1,9 +1,9 @@
-/* opencl_build_options_probe.c — #136
+/* opencl_build_options_probe.c — backlog #136
  *
  * What is an EMPTY clBuildProgram option string actually accepting, and does
  * setting the options explicitly change anything on the devices at hand?
  *
- * Until #136 the OpenCL backend called clBuildProgram with no options at all,
+ * Until backlog #136 the OpenCL backend called clBuildProgram with no options at all,
  * so it inherited each vendor's default — including a sqrt of up to 3 ulp,
  * which is what made test_real64's df64 fallback fail at 1.81e-14 on NVIDIA.
  * This probe is the instrument that decided the SHAPE of the fix.
@@ -129,7 +129,7 @@ static const char *EFFECT_OPTS[] = {
   "-DSAREK_PROBE_SCALE=1.0000001f",
 };
 static const char *EFFECT_LABELS[] = {
-  "baseline (empty, what Sarek shipped before #136)",
+  "baseline (empty, what Sarek shipped before backlog #136)",
   "-cl-fp32-correctly-rounded-divide-sqrt  (the fix)",
   "-cl-fast-relaxed-math                   (FP LIVENESS CONTROL)",
   "-D<macro>                               (PLUMBING CONTROL)",
@@ -232,15 +232,27 @@ int main(int argc, char **argv) {
     B[i] = (float)((seed >> 8) & 0xFFFFFF) / 4096.0f + 1e-3f;
   }
 
+  /* clGetPlatformIDs / clGetDeviceIDs report the TRUE count through the output
+     parameter even when num_entries caps how many IDs were written, so the
+     returned count can exceed the array. Iterating on it unclamped would read
+     uninitialised stack and hand junk IDs to the runtime. Clamp both. */
   cl_platform_id plats[8]; cl_uint nplat = 0;
   if (clGetPlatformIDs(8, plats, &nplat) != CL_SUCCESS || nplat == 0) {
     printf("no OpenCL platform found\n"); return 1;
+  }
+  if (nplat > 8) {
+    printf("note: %u platforms present, examining the first 8\n", nplat);
+    nplat = 8;
   }
   for (cl_uint p = 0; p < nplat; p++) {
     char pname[256] = {0};
     clGetPlatformInfo(plats[p], CL_PLATFORM_NAME, sizeof pname, pname, NULL);
     cl_device_id devs[8]; cl_uint ndev = 0;
     if (clGetDeviceIDs(plats[p], CL_DEVICE_TYPE_ALL, 8, devs, &ndev) != CL_SUCCESS) continue;
+    if (ndev > 8) {
+      printf("note: %u devices on this platform, examining the first 8\n", ndev);
+      ndev = 8;
+    }
     for (cl_uint d = 0; d < ndev; d++) {
       char dname[256]={0}, dver[128]={0}, drv[128]={0};
       cl_device_fp_config fp = 0;

--- a/tools/probes/opencl_build_options_probe.c
+++ b/tools/probes/opencl_build_options_probe.c
@@ -1,0 +1,307 @@
+/* opencl_build_options_probe.c — #136
+ *
+ * What is an EMPTY clBuildProgram option string actually accepting, and does
+ * setting the options explicitly change anything on the devices at hand?
+ *
+ * Until #136 the OpenCL backend called clBuildProgram with no options at all,
+ * so it inherited each vendor's default — including a sqrt of up to 3 ulp,
+ * which is what made test_real64's df64 fallback fail at 1.81e-14 on NVIDIA.
+ * This probe is the instrument that decided the SHAPE of the fix.
+ *
+ * Standalone C rather than an OCaml test, for the same reason
+ * opencl_f16_contraction_probe.c is: it must be able to say something about
+ * the OpenCL stack with none of Sarek's codegen in the loop.
+ *
+ * Build:
+ *   gcc -O2 -Wno-deprecated-declarations -I<repo>/dependencies \
+ *       opencl_build_options_probe.c -o probe -lOpenCL -lm
+ *
+ * Run:
+ *   ./probe accept    # which build options does each device accept?
+ *   ./probe effect    # accuracy + cost of the FP options, with controls
+ *   ./probe           # both
+ *
+ * ---------------------------------------------------------------------------
+ * MEASURED 2026-07-26, rusticl/radeonsi driver 26.1.4-arch3.1, on
+ * "AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)"
+ * and "AMD Ryzen 9 7950X 16-Core Processor (radeonsi, raphael_mendocino, ...)".
+ * There is NO NVIDIA and NO Apple device on this machine.
+ *
+ * accept mode:
+ *   Both devices report CL_DEVICE_SINGLE_FP_CONFIG = 0x6, i.e.
+ *   CL_FP_INF_NAN | CL_FP_ROUND_TO_NEAREST — NEITHER CL_FP_DENORM NOR
+ *   CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT.
+ *   Both nevertheless return CL_SUCCESS for
+ *   -cl-fp32-correctly-rounded-divide-sqrt, which the OpenCL spec says must be
+ *   CL_INVALID_BUILD_OPTIONS when the capability is absent. rusticl is
+ *   permissive here, so THIS MACHINE CANNOT DETECT AN UNGATED FLAG. That is
+ *   the argument for gating the option on CL_DEVICE_SINGLE_FP_CONFIG in
+ *   Opencl_fp.conformance_options rather than passing it unconditionally: on a
+ *   conformant implementation an ungated flag fails EVERY kernel build, and
+ *   nothing on this box would have shown it.
+ *   (Control that the accept/refuse distinction is real: the deliberately
+ *   invalid -cl-this-option-does-not-exist is REFUSED on both devices, so
+ *   "ACCEPTED" is not this probe's answer to everything.)
+ *
+ * effect mode, 2^20 inputs per device:
+ *   baseline (empty)                        sqrt <=1 ulp, div <=2 ulp
+ *   -cl-fp32-correctly-rounded-divide-sqrt  sqrt <=1 ulp, div <=2 ulp,
+ *                                           BIT-IDENTICAL to baseline (0/1048576)
+ *   PLUMBING control (-D<macro>)            differs on 1048576/1048576  <- passes
+ *   FP LIVENESS control (-cl-fast-relaxed-math)
+ *                                           BIT-IDENTICAL to baseline  <- FAILS
+ *
+ *   Read those two controls together before believing anything else here. The
+ *   plumbing control proves the option string really does reach rusticl's
+ *   compiler and that this comparison can go non-zero. The FP liveness control
+ *   then FAILS: even -cl-fast-relaxed-math changes nothing. So rusticl accepts
+ *   the FP-relaxing options and ignores them, and on this stack "the flag
+ *   changed nothing" is INDISTINGUISHABLE from "the flag was discarded".
+ *
+ *   Consequently NO accuracy claim and NO cost claim for
+ *   -cl-fp32-correctly-rounded-divide-sqrt may be founded on these devices.
+ *   The timings this probe prints for it (-3.0% / +0.2% on the two devices)
+ *   are run-to-run noise around an unchanged kernel, NOT a measured cost. The
+ *   only real measurement of this option's effect is the sm_61 one quoted in
+ *   Sarek_df64's PRECISION CONTRACT: 1.81e-14 FAIL -> 8.87e-15 PASS on a
+ *   GTX 1070 Max-Q, and that device is not present here.
+ * ---------------------------------------------------------------------------
+ */
+#define CL_TARGET_OPENCL_VERSION 300
+#include <CL/cl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+
+/* The vendored dependencies/CL/cl.h is OpenCL 1.0-era and predates both of
+   these bits. Values from the OpenCL 1.2+ headers. Opencl_fp.ml spells them
+   out for the same reason. */
+#ifndef CL_FP_SOFT_FLOAT
+#define CL_FP_SOFT_FLOAT (1 << 6)
+#endif
+#ifndef CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT
+#define CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT (1 << 7)
+#endif
+
+#define N (1 << 20)
+#define REPS 200
+
+static const char *SRC =
+"#ifndef SAREK_PROBE_SCALE\n#define SAREK_PROBE_SCALE 1.0f\n#endif\n"
+"__kernel void k(__global float *os, __global float *od,\n"
+"                __global const float *a, __global const float *b) {\n"
+"  int i = get_global_id(0);\n"
+"  os[i] = sqrt(a[i]) * SAREK_PROBE_SCALE;\n"
+"  od[i] = a[i] / b[i];\n"
+"}\n"
+"__kernel void hot(__global float *o, __global const float *a,\n"
+"                  __global const float *b, int reps) {\n"
+"  int i = get_global_id(0);\n"
+"  float x = a[i], y = b[i], acc = 0.0f;\n"
+"  for (int r = 0; r < reps; r++) { acc += sqrt(x + (float)r) + x / (y + (float)r); }\n"
+"  o[i] = acc;\n"
+"}\n";
+
+/* Every option Sarek could plausibly inherit or be handed, plus a deliberately
+   invalid one as the control that "ACCEPTED" is a real verdict. */
+static const char *ACCEPT_OPTS[] = {
+  "",
+  "-cl-fp32-correctly-rounded-divide-sqrt",
+  "-cl-denorms-are-zero",
+  "-cl-no-signed-zeros",
+  "-cl-unsafe-math-optimizations",
+  "-cl-finite-math-only",
+  "-cl-fast-relaxed-math",
+  "-cl-mad-enable",
+  "-cl-opt-disable",
+  "-cl-std=CL1.2",
+  "-cl-single-precision-constant",
+  "-cl-this-option-does-not-exist",   /* CONTROL: must be refused */
+};
+static const int N_ACCEPT = sizeof(ACCEPT_OPTS)/sizeof(ACCEPT_OPTS[0]);
+
+static const char *EFFECT_OPTS[] = {
+  "",
+  "-cl-fp32-correctly-rounded-divide-sqrt",
+  "-cl-fast-relaxed-math",
+  "-DSAREK_PROBE_SCALE=1.0000001f",
+};
+static const char *EFFECT_LABELS[] = {
+  "baseline (empty, what Sarek shipped before #136)",
+  "-cl-fp32-correctly-rounded-divide-sqrt  (the fix)",
+  "-cl-fast-relaxed-math                   (FP LIVENESS CONTROL)",
+  "-D<macro>                               (PLUMBING CONTROL)",
+};
+static const int N_EFFECT = sizeof(EFFECT_OPTS)/sizeof(EFFECT_OPTS[0]);
+
+static int ulp_diff(float a, float b) {
+  int ia, ib; memcpy(&ia, &a, 4); memcpy(&ib, &b, 4);
+  if (ia < 0) ia = 0x80000000 - ia;
+  if (ib < 0) ib = 0x80000000 - ib;
+  int d = ia - ib; return d < 0 ? -d : d;
+}
+static double now(void) {
+  struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
+  return t.tv_sec + t.tv_nsec * 1e-9;
+}
+static void print_fp_config(cl_device_fp_config fp) {
+  printf("    CL_DEVICE_SINGLE_FP_CONFIG = 0x%llx  [%s%s%s%s%s%s]\n",
+         (unsigned long long)fp,
+         (fp & CL_FP_DENORM) ? "DENORM " : "",
+         (fp & CL_FP_INF_NAN) ? "INF_NAN " : "",
+         (fp & CL_FP_ROUND_TO_NEAREST) ? "RTN " : "",
+         (fp & CL_FP_FMA) ? "FMA " : "",
+         (fp & CL_FP_SOFT_FLOAT) ? "SOFT " : "",
+         (fp & CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT) ? "CR_DIV_SQRT " : "");
+}
+
+struct res { float *s, *d; double ms; int max_ulp_s, max_ulp_d; int ok; };
+
+static void run_effect(cl_context ctx, cl_device_id dev, cl_command_queue q,
+                       const char *opt, float *A, float *B, struct res *out) {
+  cl_int err;
+  out->ok = 0;
+  cl_program prog = clCreateProgramWithSource(ctx, 1, &SRC, NULL, &err);
+  if (err != CL_SUCCESS) { printf("    (clCreateProgramWithSource failed: %d)\n", err); return; }
+  cl_int b = clBuildProgram(prog, 1, &dev, opt, NULL, NULL);
+  if (b != CL_SUCCESS) { printf("    BUILD FAILED (%d) for option '%s'\n", b, opt); return; }
+  cl_kernel kk = clCreateKernel(prog, "k", &err);
+  cl_kernel kh = clCreateKernel(prog, "hot", &err);
+  size_t bytes = (size_t)N * 4;
+  cl_mem ma = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, bytes, A, &err);
+  cl_mem mb = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, bytes, B, &err);
+  cl_mem ms = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err);
+  cl_mem md = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err);
+  cl_mem mo = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err);
+  clSetKernelArg(kk,0,sizeof(cl_mem),&ms); clSetKernelArg(kk,1,sizeof(cl_mem),&md);
+  clSetKernelArg(kk,2,sizeof(cl_mem),&ma); clSetKernelArg(kk,3,sizeof(cl_mem),&mb);
+  size_t gs = N;
+  clEnqueueNDRangeKernel(q, kk, 1, NULL, &gs, NULL, 0, NULL, NULL);
+  clFinish(q);
+  out->s = malloc(bytes); out->d = malloc(bytes);
+  clEnqueueReadBuffer(q, ms, CL_TRUE, 0, bytes, out->s, 0, NULL, NULL);
+  clEnqueueReadBuffer(q, md, CL_TRUE, 0, bytes, out->d, 0, NULL, NULL);
+
+  out->max_ulp_s = out->max_ulp_d = 0;
+  for (int i = 0; i < N; i++) {
+    int u = ulp_diff(out->s[i], sqrtf(A[i]));
+    if (u > out->max_ulp_s) out->max_ulp_s = u;
+    u = ulp_diff(out->d[i], A[i] / B[i]);
+    if (u > out->max_ulp_d) out->max_ulp_d = u;
+  }
+
+  int reps = REPS;
+  clSetKernelArg(kh,0,sizeof(cl_mem),&mo); clSetKernelArg(kh,1,sizeof(cl_mem),&ma);
+  clSetKernelArg(kh,2,sizeof(cl_mem),&mb); clSetKernelArg(kh,3,sizeof(int),&reps);
+  for (int w = 0; w < 3; w++) clEnqueueNDRangeKernel(q,kh,1,NULL,&gs,NULL,0,NULL,NULL);
+  clFinish(q);
+  double best = 1e30;
+  for (int t = 0; t < 7; t++) {
+    double t0 = now();
+    clEnqueueNDRangeKernel(q, kh, 1, NULL, &gs, NULL, 0, NULL, NULL);
+    clFinish(q);
+    double dt = (now() - t0) * 1000.0;
+    if (dt < best) best = dt;
+  }
+  out->ms = best;
+  out->ok = 1;
+
+  clReleaseMemObject(ma); clReleaseMemObject(mb); clReleaseMemObject(ms);
+  clReleaseMemObject(md); clReleaseMemObject(mo);
+  clReleaseKernel(kk); clReleaseKernel(kh); clReleaseProgram(prog);
+}
+
+int main(int argc, char **argv) {
+  int do_accept = 1, do_effect = 1;
+  if (argc > 1) {
+    do_accept = (strcmp(argv[1], "accept") == 0);
+    do_effect = (strcmp(argv[1], "effect") == 0);
+    if (!do_accept && !do_effect) {
+      fprintf(stderr, "usage: %s [accept|effect]\n", argv[0]); return 2;
+    }
+  }
+
+  float *A = malloc((size_t)N*4), *B = malloc((size_t)N*4);
+  unsigned seed = 12345;
+  for (int i = 0; i < N; i++) {
+    seed = seed * 1103515245u + 12345u;
+    A[i] = (float)((seed >> 8) & 0xFFFFFF) / 1024.0f + 1e-3f;
+    seed = seed * 1103515245u + 12345u;
+    B[i] = (float)((seed >> 8) & 0xFFFFFF) / 4096.0f + 1e-3f;
+  }
+
+  cl_platform_id plats[8]; cl_uint nplat = 0;
+  if (clGetPlatformIDs(8, plats, &nplat) != CL_SUCCESS || nplat == 0) {
+    printf("no OpenCL platform found\n"); return 1;
+  }
+  for (cl_uint p = 0; p < nplat; p++) {
+    char pname[256] = {0};
+    clGetPlatformInfo(plats[p], CL_PLATFORM_NAME, sizeof pname, pname, NULL);
+    cl_device_id devs[8]; cl_uint ndev = 0;
+    if (clGetDeviceIDs(plats[p], CL_DEVICE_TYPE_ALL, 8, devs, &ndev) != CL_SUCCESS) continue;
+    for (cl_uint d = 0; d < ndev; d++) {
+      char dname[256]={0}, dver[128]={0}, drv[128]={0};
+      cl_device_fp_config fp = 0;
+      clGetDeviceInfo(devs[d], CL_DEVICE_NAME, sizeof dname, dname, NULL);
+      clGetDeviceInfo(devs[d], CL_DEVICE_VERSION, sizeof dver, dver, NULL);
+      clGetDeviceInfo(devs[d], CL_DRIVER_VERSION, sizeof drv, drv, NULL);
+      clGetDeviceInfo(devs[d], CL_DEVICE_SINGLE_FP_CONFIG, sizeof fp, &fp, NULL);
+      printf("\n=== platform=%s\n    device=%s\n    version=%s driver=%s\n",
+             pname, dname, dver, drv);
+      print_fp_config(fp);
+
+      cl_int err;
+      cl_context ctx = clCreateContext(NULL, 1, &devs[d], NULL, NULL, &err);
+      if (err != CL_SUCCESS) { printf("    (no context: %d)\n", err); continue; }
+
+      if (do_accept) {
+        printf("  -- accept mode --\n");
+        for (int o = 0; o < N_ACCEPT; o++) {
+          cl_program prog = clCreateProgramWithSource(ctx, 1, &SRC, NULL, &err);
+          if (err != CL_SUCCESS) continue;
+          cl_int b = clBuildProgram(prog, 1, &devs[d], ACCEPT_OPTS[o], NULL, NULL);
+          const char *verdict =
+            (b == CL_SUCCESS) ? "ACCEPTED"
+            : (b == CL_INVALID_BUILD_OPTIONS) ? "REFUSED (CL_INVALID_BUILD_OPTIONS)"
+            : "REFUSED (build failure)";
+          printf("    %-42s -> %-36s (err %d)\n",
+                 ACCEPT_OPTS[o][0] ? ACCEPT_OPTS[o] : "(empty option string)", verdict, b);
+          clReleaseProgram(prog);
+        }
+      }
+
+      if (do_effect) {
+        printf("  -- effect mode --\n");
+        cl_command_queue q = clCreateCommandQueue(ctx, devs[d], 0, &err);
+        struct res r[4]; memset(r, 0, sizeof r);
+        for (int v = 0; v < N_EFFECT; v++) {
+          run_effect(ctx, devs[d], q, EFFECT_OPTS[v], A, B, &r[v]);
+          if (!r[v].ok) continue;
+          printf("    %-60s sqrt max %d ulp | div max %d ulp | hot %.3f ms\n",
+                 EFFECT_LABELS[v], r[v].max_ulp_s, r[v].max_ulp_d, r[v].ms);
+        }
+        for (int v = 1; v < N_EFFECT; v++) {
+          if (!r[v].ok || !r[0].ok) continue;
+          int ds = 0, dd = 0;
+          for (int i = 0; i < N; i++) {
+            if (memcmp(&r[v].s[i], &r[0].s[i], 4)) ds++;
+            if (memcmp(&r[v].d[i], &r[0].d[i], 4)) dd++;
+          }
+          printf("    vs baseline, %-38s : sqrt differs %d/%d, div differs %d/%d\n",
+                 EFFECT_OPTS[v], ds, N, dd, N);
+        }
+        printf("    NOTE: read the two controls before the numbers above. If the\n"
+               "          PLUMBING control differs and the FP LIVENESS control does\n"
+               "          NOT, this stack ignores FP build options and no accuracy or\n"
+               "          cost conclusion about them may be drawn from this device.\n");
+        for (int v = 0; v < N_EFFECT; v++) { free(r[v].s); free(r[v].d); }
+        clReleaseCommandQueue(q);
+      }
+      clReleaseContext(ctx);
+    }
+  }
+  free(A); free(B);
+  return 0;
+}

--- a/tools/probes/opencl_build_options_probe.c
+++ b/tools/probes/opencl_build_options_probe.c
@@ -159,30 +159,78 @@ static void print_fp_config(cl_device_fp_config fp) {
 
 struct res { float *s, *d; double ms; int max_ulp_s, max_ulp_d; int ok; };
 
+/* Every OpenCL call is checked, and ANY failure leaves out->ok == 0.
+
+   This matters more here than in ordinary code: the whole purpose of this
+   probe is to produce trustworthy numbers, and the previous version ignored
+   every error after the build, then set out->ok = 1 unconditionally. A run
+   where the enqueue silently failed would have reported the contents of a
+   never-written buffer as a measurement. A probe that fabricates results is
+   worse than one that crashes, because the fabrication is quiet. */
+#define CK(expr, what)                                                        \
+  do {                                                                        \
+    cl_int e_ = (expr);                                                       \
+    if (e_ != CL_SUCCESS) {                                                   \
+      printf("    ABORT: %s failed (%d) for option '%s'\n", what, e_, opt);    \
+      goto cleanup;                                                           \
+    }                                                                         \
+  } while (0)
+
+#define CKP(ptr, what)                                                        \
+  do {                                                                        \
+    if ((ptr) == NULL || err != CL_SUCCESS) {                                 \
+      printf("    ABORT: %s failed (%d) for option '%s'\n", what, err, opt);   \
+      goto cleanup;                                                           \
+    }                                                                         \
+  } while (0)
+
 static void run_effect(cl_context ctx, cl_device_id dev, cl_command_queue q,
                        const char *opt, float *A, float *B, struct res *out) {
-  cl_int err;
-  out->ok = 0;
-  cl_program prog = clCreateProgramWithSource(ctx, 1, &SRC, NULL, &err);
-  if (err != CL_SUCCESS) { printf("    (clCreateProgramWithSource failed: %d)\n", err); return; }
-  cl_int b = clBuildProgram(prog, 1, &dev, opt, NULL, NULL);
-  if (b != CL_SUCCESS) { printf("    BUILD FAILED (%d) for option '%s'\n", b, opt); return; }
-  cl_kernel kk = clCreateKernel(prog, "k", &err);
-  cl_kernel kh = clCreateKernel(prog, "hot", &err);
+  cl_int err = CL_SUCCESS;
+  cl_program prog = NULL;
+  cl_kernel kk = NULL, kh = NULL;
+  cl_mem ma = NULL, mb = NULL, ms = NULL, md = NULL, mo = NULL;
   size_t bytes = (size_t)N * 4;
-  cl_mem ma = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, bytes, A, &err);
-  cl_mem mb = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, bytes, B, &err);
-  cl_mem ms = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err);
-  cl_mem md = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err);
-  cl_mem mo = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err);
-  clSetKernelArg(kk,0,sizeof(cl_mem),&ms); clSetKernelArg(kk,1,sizeof(cl_mem),&md);
-  clSetKernelArg(kk,2,sizeof(cl_mem),&ma); clSetKernelArg(kk,3,sizeof(cl_mem),&mb);
   size_t gs = N;
-  clEnqueueNDRangeKernel(q, kk, 1, NULL, &gs, NULL, 0, NULL, NULL);
-  clFinish(q);
-  out->s = malloc(bytes); out->d = malloc(bytes);
-  clEnqueueReadBuffer(q, ms, CL_TRUE, 0, bytes, out->s, 0, NULL, NULL);
-  clEnqueueReadBuffer(q, md, CL_TRUE, 0, bytes, out->d, 0, NULL, NULL);
+  int reps = REPS;
+
+  out->ok = 0;
+  out->s = out->d = NULL;
+
+  prog = clCreateProgramWithSource(ctx, 1, &SRC, NULL, &err);
+  CKP(prog, "clCreateProgramWithSource");
+
+  err = clBuildProgram(prog, 1, &dev, opt, NULL, NULL);
+  if (err != CL_SUCCESS) {
+    printf("    BUILD FAILED (%d) for option '%s'\n", err, opt);
+    goto cleanup;
+  }
+
+  kk = clCreateKernel(prog, "k", &err);   CKP(kk, "clCreateKernel(k)");
+  kh = clCreateKernel(prog, "hot", &err); CKP(kh, "clCreateKernel(hot)");
+
+  ma = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, bytes, A, &err);
+  CKP(ma, "clCreateBuffer(a)");
+  mb = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, bytes, B, &err);
+  CKP(mb, "clCreateBuffer(b)");
+  ms = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err); CKP(ms, "clCreateBuffer(sqrt)");
+  md = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err); CKP(md, "clCreateBuffer(div)");
+  mo = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, bytes, NULL, &err); CKP(mo, "clCreateBuffer(hot)");
+
+  CK(clSetKernelArg(kk,0,sizeof(cl_mem),&ms), "clSetKernelArg(k,0)");
+  CK(clSetKernelArg(kk,1,sizeof(cl_mem),&md), "clSetKernelArg(k,1)");
+  CK(clSetKernelArg(kk,2,sizeof(cl_mem),&ma), "clSetKernelArg(k,2)");
+  CK(clSetKernelArg(kk,3,sizeof(cl_mem),&mb), "clSetKernelArg(k,3)");
+
+  CK(clEnqueueNDRangeKernel(q, kk, 1, NULL, &gs, NULL, 0, NULL, NULL), "enqueue(k)");
+  CK(clFinish(q), "clFinish(k)");
+
+  out->s = malloc(bytes);
+  out->d = malloc(bytes);
+  if (!out->s || !out->d) { printf("    ABORT: host allocation failed\n"); goto cleanup; }
+
+  CK(clEnqueueReadBuffer(q, ms, CL_TRUE, 0, bytes, out->s, 0, NULL, NULL), "read(sqrt)");
+  CK(clEnqueueReadBuffer(q, md, CL_TRUE, 0, bytes, out->d, 0, NULL, NULL), "read(div)");
 
   out->max_ulp_s = out->max_ulp_d = 0;
   for (int i = 0; i < N; i++) {
@@ -192,25 +240,39 @@ static void run_effect(cl_context ctx, cl_device_id dev, cl_command_queue q,
     if (u > out->max_ulp_d) out->max_ulp_d = u;
   }
 
-  int reps = REPS;
-  clSetKernelArg(kh,0,sizeof(cl_mem),&mo); clSetKernelArg(kh,1,sizeof(cl_mem),&ma);
-  clSetKernelArg(kh,2,sizeof(cl_mem),&mb); clSetKernelArg(kh,3,sizeof(int),&reps);
-  for (int w = 0; w < 3; w++) clEnqueueNDRangeKernel(q,kh,1,NULL,&gs,NULL,0,NULL,NULL);
-  clFinish(q);
-  double best = 1e30;
-  for (int t = 0; t < 7; t++) {
-    double t0 = now();
-    clEnqueueNDRangeKernel(q, kh, 1, NULL, &gs, NULL, 0, NULL, NULL);
-    clFinish(q);
-    double dt = (now() - t0) * 1000.0;
-    if (dt < best) best = dt;
-  }
-  out->ms = best;
-  out->ok = 1;
+  CK(clSetKernelArg(kh,0,sizeof(cl_mem),&mo), "clSetKernelArg(hot,0)");
+  CK(clSetKernelArg(kh,1,sizeof(cl_mem),&ma), "clSetKernelArg(hot,1)");
+  CK(clSetKernelArg(kh,2,sizeof(cl_mem),&mb), "clSetKernelArg(hot,2)");
+  CK(clSetKernelArg(kh,3,sizeof(int),&reps),  "clSetKernelArg(hot,3)");
 
-  clReleaseMemObject(ma); clReleaseMemObject(mb); clReleaseMemObject(ms);
-  clReleaseMemObject(md); clReleaseMemObject(mo);
-  clReleaseKernel(kk); clReleaseKernel(kh); clReleaseProgram(prog);
+  for (int w = 0; w < 3; w++)
+    CK(clEnqueueNDRangeKernel(q,kh,1,NULL,&gs,NULL,0,NULL,NULL), "warmup(hot)");
+  CK(clFinish(q), "clFinish(warmup)");
+
+  {
+    double best = 1e30;
+    for (int t = 0; t < 7; t++) {
+      double t0 = now();
+      CK(clEnqueueNDRangeKernel(q, kh, 1, NULL, &gs, NULL, 0, NULL, NULL), "enqueue(hot)");
+      CK(clFinish(q), "clFinish(hot)");
+      double dt = (now() - t0) * 1000.0;
+      if (dt < best) best = dt;
+    }
+    out->ms = best;
+  }
+
+  out->ok = 1;   /* reached ONLY if every call above succeeded */
+
+cleanup:
+  if (!out->ok) { free(out->s); free(out->d); out->s = out->d = NULL; }
+  if (ma) clReleaseMemObject(ma);
+  if (mb) clReleaseMemObject(mb);
+  if (ms) clReleaseMemObject(ms);
+  if (md) clReleaseMemObject(md);
+  if (mo) clReleaseMemObject(mo);
+  if (kk) clReleaseKernel(kk);
+  if (kh) clReleaseKernel(kh);
+  if (prog) clReleaseProgram(prog);
 }
 
 int main(int argc, char **argv) {
@@ -224,6 +286,7 @@ int main(int argc, char **argv) {
   }
 
   float *A = malloc((size_t)N*4), *B = malloc((size_t)N*4);
+  if (!A || !B) { fprintf(stderr, "host allocation failed\n"); free(A); free(B); return 1; }
   unsigned seed = 12345;
   for (int i = 0; i < N; i++) {
     seed = seed * 1103515245u + 12345u;
@@ -287,6 +350,11 @@ int main(int argc, char **argv) {
       if (do_effect) {
         printf("  -- effect mode --\n");
         cl_command_queue q = clCreateCommandQueue(ctx, devs[d], 0, &err);
+        if (!q || err != CL_SUCCESS) {
+          printf("    (no command queue: %d) - skipping effect mode\n", err);
+          clReleaseContext(ctx);
+          continue;
+        }
         struct res r[4]; memset(r, 0, sizeof r);
         for (int v = 0; v < N_EFFECT; v++) {
           run_effect(ctx, devs[d], q, EFFECT_OPTS[v], A, B, &r[v]);


### PR DESCRIPTION
Backlog **#136** and **#125** (backlog numbering — see the CodeRabbit note below; these are *not* the GitHub PRs of those numbers).

---

## The headline: the measurement killed the fix

An Apple M4 was made available mid-review, so **#125 no longer ships unverified — and running it showed the fix was the wrong lever.**

The original change set `fastMathEnabled = NO` and presented it as a contraction defence. On `o = a*b + c`, over the **8773 of 65536** elements where the device's *own* `fma` differs from the separately-rounded value:

| build | contracted |
|---|---|
| default options | 8773 / 8773 |
| `mathMode = MTLMathModeSafe` | **8773 / 8773** |
| `mathMode=Safe` + `fpFunctions=Precise` | **8773 / 8773** |
| `fastMathEnabled = NO` | **8773 / 8773** |
| **`#pragma METAL fp contract(off)`** | **0 / 8773** |

**It would have defeated zero contractions.** `a*b+c` is bit-identical under every compile-option setting; only the source pragma moves the number.

This is the **third** barrier in this repository that protected nothing — after the CUDA `"+f"` inline asm (§4) and the GLSL `precise`/`NoContraction` decoration on the RADV f16 narrowing (§6). §1 corollary 2 is now the most load-bearing sentence in the policy doc: *a flag that names the hazard is not a mechanism that prevents it.*

`Sarek_ir_metal` now emits the pragma in every kernel. The compile options are still set — but for math-function accuracy, and they are no longer described as anything else.

### Checked, not assumed: the options *are* honoured

A successful compile proves plumbing, not semantics, so this needed its own liveness check — the same discipline that made the OpenCL control valuable. On `sqrt(a) + 1/a`, 65536 inputs, vs default:

| setting | results changed |
|---|---|
| `mathMode = Safe` | 16017 / 65536 |
| `mathMode=Safe` + `fpFunctions=Precise` | **22135 / 65536** |
| `fastMathEnabled = NO` | 22135 / 65536 |
| `mathMode = Fast` / `fastMathEnabled = YES` | 0 (confirms the default) |

So Metal is **not** in rusticl's class: it honours these options, they are simply orthogonal to contraction. And it is **two knobs, not one** — a fresh `MTLCompileOptions` reports `mathMode=2` (Fast) *and* `mathFloatingPointFunctions=0` (Fast); setting `mathMode` alone leaves math functions on `metal::fast`, which is the 16017-vs-22135 gap. I would have missed the second knob without reading the SDK headers.

---

## #136 — OpenCL: `clBuildProgram` with no options

`Opencl_api.Program.build` passed an empty option string and every caller in the tree passed nothing. An empty option string is not "no policy" — it is whatever each vendor decided, and OpenCL's default permits a 3-ulp `sqrt` and a 2.5-ulp divide against §1's requirement that both are correctly rounded.

`Opencl_fp.build_options` now assembles the string at `Opencl_api.Program.build` — the single point an option string reaches `clBuildProgram`, so the guard covers flags a *future maintainer of this module* adds, not merely a caller's. Same placement argument as `Cuda_nvrtc.compile_with_string_opts` (§5).

### The measurement, and its limits

**Prove red before trusting green — and the red is not here.**

- The red is **quoted, not reproduced**: 1.81e-14 FAIL → 8.87e-15 PASS on a GTX 1070 Max-Q (sm_61, CUDA 12.9, driver 580.119.02), measured during #298. That device is not on this machine.
- **The red does not reproduce locally.** `test_real64` on rusticl/radeonsi 26.1.4-arch3.1, RX 7900 XTX and Raphael iGPU: OpenCL `sqrt` **9.68e-15 — already a PASS**.

**Measured OpenCL cost, as asked: not measurable on this box, and here is why rather than a number.** `tools/probes/opencl_build_options_probe.c`, 2^20 inputs/device, carries two controls:

| variant | sqrt vs correctly-rounded | bit-differs from baseline |
|---|---|---|
| baseline (empty string) | ≤1 ulp | — |
| `-cl-fp32-correctly-rounded-divide-sqrt` | ≤1 ulp | **0 / 1048576** |
| `-cl-fast-relaxed-math` (**FP liveness control**) | ≤1 ulp | **0 / 1048576** |
| `-DSAREK_PROBE_SCALE=…` (**plumbing control**) | 3 ulp | 1048576 / 1048576 |

The plumbing control **passes** — the option string does reach rusticl's compiler. The FP liveness control **fails** — even `-cl-fast-relaxed-math` changes nothing. rusticl delivers FP build options and ignores them, so *"the flag changed nothing"* is indistinguishable from *"the flag was discarded"*, and no accuracy or cost claim may be founded on these devices. The probe prints −3.0% / +0.2%; **those are run-to-run noise around an unchanged kernel and are labelled as such in the probe, the module and the policy.** The CUDA ~12% on `bench_nbody` is a different backend on a different device and does not transfer.

### The flag is capability-gated, and that is the load-bearing decision

The spec permits `-cl-fp32-correctly-rounded-divide-sqrt` only when `CL_DEVICE_SINGLE_FP_CONFIG` carries `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT`; otherwise `clBuildProgram` returns `CL_INVALID_BUILD_OPTIONS`. Unconditional, it fails **every kernel build** on every device without the capability — total, not numerical.

**This machine would not have caught that.** Measured: both local devices report `fp_config = 0x6` (`INF_NAN | ROUND_TO_NEAREST`, no `CR_DIV_SQRT`, no `DENORM`) and **both accept the flag with `CL_SUCCESS` anyway** — rusticl permissive where the spec says refuse. Control: `-cl-this-option-does-not-exist` *is* refused, so "ACCEPTED" isn't the probe's answer to everything.

### The full audit — every default now chosen

| option | decision | why |
|---|---|---|
| `-cl-fp32-correctly-rounded-divide-sqrt` | **set**, gated | default off ⇒ 3-ulp sqrt / 2.5-ulp div; `Sarek_df64`'s Newton/Karp step squares its seed error |
| `-cl-denorms-are-zero` | never passed; **refused** | flushes binary32 subnormals, forbidden by §1 |
| `-cl-fast-relaxed-math` | never passed; **refused** | implies unsafe+finite math, permits `native_*` |
| `-cl-unsafe-math-optimizations` | never passed; **refused** | reassociation — destroys an EFT outright |
| `-cl-finite-math-only` | never passed; **refused** | assumes no NaN/Inf; the oracle assumes no such thing |
| `-cl-no-signed-zeros` | never passed; **refused** | `Sarek_df64` renormalisation relies on signed zero |
| `-cl-mad-enable` | never passed; **refused** | the contraction hazard by name |
| `-cl-single-precision-constant` | never passed; **refused** | silently demotes double literals |
| `-cl-opt-disable` | **allowed** | conservative; cannot relax FP semantics |
| `FP_CONTRACT` | **not addressable** | on by default, no build option turns it off; the source pragma was already measured not to work here. Still defeated by construction via `mul_rn` |

**Refused, not countered**: unlike HIP's append-last trick, OpenCL has no option that undoes `-cl-fast-relaxed-math`. Same reasoning as §5.

**Subnormals are flushed here regardless** — neither local device advertises `CL_FP_DENORM`. A device property Sarek cannot correct; recorded, not fixed.

### The guard has been seen to fire

Seven mutations, each red with a distinct message. The two that matter most are anti-vacuity:

- **assembled-string** — the gate could "pass" while assembling a string nobody uses.
- **fp-config-query-is-live** — the gate is *off* on every device here, so a silently broken `CL_DEVICE_SINGLE_FP_CONFIG` query would disable it everywhere and make every "correctly gated off" case pass while checking nothing.

---

## #125 — Metal: measured on an M4, and the measurement contradicted the fix

**Apple hardware became available, so this is no longer unverified — and running it changed the answer.** Apple M4, macOS 15.6.1 (24G90), Apple clang 17.0.0, Metal.framework from the Command Line Tools SDK. No Xcode needed: `newLibraryWithSource:options:error:` compiles through the driver at runtime, which is exactly the call under test.

### The previous revision of this PR was wrong

It set `fastMathEnabled = NO` and presented it as a contraction defence. On `o = a*b + c`, over the **8773 of 65536** elements where the *device's own* `fma` differs from the separately-rounded value:

| build | contracted |
|---|---|
| default options | 8773 / 8773 |
| `mathMode = MTLMathModeSafe` | **8773 / 8773** |
| `mathMode=Safe` + `fpFunctions=Precise` | **8773 / 8773** |
| `fastMathEnabled = NO` | **8773 / 8773** |
| **`#pragma METAL fp contract(off)`** | **0 / 8773** |

`a*b+c` is bit-identical under every compile-option setting. **This is §1 corollary 2 for the third time in this repo** — a flag that names the hazard is not a mechanism that prevents it. `Sarek_ir_metal` now emits `#pragma METAL fp contract(off)` in every kernel, and the compile options are no longer described as a contraction defence.

Method: the separately-rounded reference is computed in **two kernel passes** with the product round-tripped through device memory so it cannot itself be fused, and the `fma` is **read from the device** rather than modelled — the RADV lesson in §6.

### The options are still worth setting, and they *are* honoured

A compile that succeeds proves plumbing, not semantics, so this needed its own liveness check. On `sqrt(a) + 1/a`, 65536 inputs, vs default:

| setting | results changed |
|---|---|
| `mathMode = Safe` | 16017 / 65536 |
| `mathMode=Safe` + `fpFunctions=Precise` | **22135 / 65536** |
| `fastMathEnabled = NO` | 22135 / 65536 |
| `mathMode = Fast` / `fastMathEnabled = YES` | 0 (confirms the default) |

**Metal is not in rusticl's class** — it does not accept these and discard them.

### Two knobs, not one

A fresh `MTLCompileOptions` reports `mathMode = 2` (Fast) **and** `mathFloatingPointFunctions = 0` (Fast). Setting `mathMode` alone leaves math functions on `metal::fast` — that is the 16017-vs-22135 gap. Both are now set. "Metal defaults to fast math" was quoted from Apple's docs; it is now measured, and it is two defaults.

### `mathMode` vs `fastMathEnabled` — settled by measurement, as asked

The enum values are **read from the SDK** (`MTLLibrary.h:241-246`, `258-262`), which retires the previous revision's stated reason for avoiding `setMathMode:`. `fastMathEnabled` is deprecated since macOS 15.0 but `mathMode` doesn't exist before it, so **both** are kept, selected by `respondsToSelector:`. They are **equivalent, measured**: `fastMathEnabled=NO` and `mathMode=Safe + fpFunctions=Precise` are **bit-identical over 65536 elements** of `sqrt+recip+sin+log+exp`. The pre-15 fallback is exact, not degraded.

Also verified on the M4: all four selector strings the binding registers exist, and the raw `long`-taking `objc_msgSend` signature the ctypes code uses lands both values. All nine byte-exact generated goldens compile on the device with the pragma in place.

### Interpreter agreement: measured on the M4, and it holds

`test_df64` and `test_real64` now run on Apple M4 / macOS 15.6.1 / Apple clang 17. **Metal reproduces the interpreter's figures exactly, on every op:**

| op | Metal | Interpreter | tol | |
|---|---|---|---|---|
| `mul` | 9.07e-15 | 9.07e-15 | 1.42e-14 | PASS |
| `add` | 5.33e-15 | 5.33e-15 | 7.11e-15 | PASS |
| `sub` | 6.51e-15 | 6.51e-15 | 7.11e-15 | PASS |
| `div` | 5.08e-15 | 5.08e-15 | 1.42e-14 | PASS |
| `sqrt` | 8.53e-15 | 8.53e-15 | 1.42e-14 | PASS |

Sampled maxima over each test's input set, one device, agreement between summary statistics — not bounds, not element-wise identity.

### The pragma does *not* move df64 — and that is the correct answer

Rebuilt with the pragma emptied (binary confirmed rebuilt: new mtime, 80 bytes smaller), re-run: **every figure identical to the digit.**

That is `Sarek_df64` working as designed, not a failure of the pragma. The library defeats contraction **by construction** — `mul_rn` routes products through `fma`, so no fusable multiply survives — which is exactly why §2 already records "no flag" as the CUDA and OpenCL mechanism. **df64 is immune to contraction by design and therefore cannot detect it.** Expecting it to move the way `sqrt.rn.f32` did on NVIDIA conflates two mechanisms: that was an approximate *seed inside the algorithm*, which `mul_rn` doesn't protect against; this is contraction, which it does.

So the pragma protects exactly what df64 cannot: **caller-written kernels** — the §3 hazard that "lives in caller code, and no gate in this repository can see". `a*b+c` is contracted 8773/8773 without it and 0/8773 with it. The synthetic probe is the right instrument, and the only one.

### Can Metal leave "may NOT rely on"? Partially — and here is the line

**Yes for f32 arithmetic.** Moved off the list.

**No for:** f16 (never probed on Metal), subnormals (never probed), element-wise identity, any other device or OS, and **kernels using records or variants — which do not compile on Metal at all.**

### Two separate defects the M4 uncovered

1. **Two of nine generated Metal goldens do not compile at all.** `record_kernel`/`variant_kernel` emit `constant T* &` buffer params; Metal rejects the pointee address space. **Pre-existing** — control with the pragma stripped fails identically — and not fixed here, since `device` vs `constant` is a design decision. Needs its own issue.

2. **Six `opencl_validation_sweep` float64 cases fail on macOS**, because Apple Silicon's OpenCL has no `cl_khr_fp64`. Environmental, and impossible for this branch to have caused (it touches no OpenCL codegen, no f64 path). But worth flagging: cases 7-8 of that same sweep **SKIP** on f64 while 16-20 **FAIL** — the sweep's capability gating disagrees with itself, and is a good candidate for the "a skip is not a pass" treatment.

Everything else on the M4 is green, including all six `metal_contraction_pragma` cases.

**ladon was left exactly as found:** throwaway `/tmp` clone, nothing installed, no `opam switch` changed, and Mathias's dirty `apple_m4_benchmarks` checkout never touched.

## CodeRabbit

**Round 1 — three findings, all valid, all addressed** (commits `0e8a5b5`..`520359c5`):

- **`Metal_bindings.ml:334` — leak on fallback.** Real: after `init` succeeded, the selector-probing path returned `None` without releasing the object. Fixed.
- **`opencl_build_options_probe.c` — unclamped loops.** Real: `clGetPlatformIDs`/`clGetDeviceIDs` report the *true* count even when `num_entries` caps what was written, so >8 platforms/devices would read uninitialised stack. Both clamped, with a note printed on truncation.
- **Stale `#125` / `#136`.** Real ambiguity — but *removing* them, as suggested, would be wrong: they are **backlog** numbers, and this repo's numbering collides with GitHub's (`main` already says "tracked as #136"; the pre-existing `#57`/`#110`/`#111`/`#116` likewise don't match those GitHub PRs). Spelled **`backlog #NNN`**: keeps the identifier, drops the false link. Pre-existing bare numbers in untouched prose left alone — renaming the project's citation convention is a maintainer decision.

**Round 2 — the `CHANGES_REQUESTED` is stale, not new.** The three comments carry the same IDs and the same `2026-07-26T17:39:37Z` timestamp as round 1, and the check run reports `CodeRabbit — Review rate limited`, so it never re-reviewed the new commits. One of its own comments already reads *"✅ Addressed in commits 0e8a5b5 to 520359c"*. I re-verified all three against current code rather than trusting that: the clamps are at `opencl_build_options_probe.c:243,252`, the release is on the post-`init` `None` path, and every Metal reference reads `backlog #NNN`. Nothing further to fix; the review needs re-running or dismissing.

---

## HIP — does it share the omission? No. It had a neighbouring one.

Measured here, ROCm 7.2.4 / AMD clang 22.0.0git, gfx1100, `out = sqrtf(a) + a/b`:

| build | divide / sqrt | `denorm_mode_32` |
|---|---|---|
| what Sarek passed | refined: `v_div_scale`/`v_div_fmas`/`v_div_fixup_f32` + Newton sqrt (13 instrs) | **3** |
| `-fno-hip-fp32-correctly-rounded-divide-sqrt` (**control**) | bare `v_rcp`/`v_sqrt` + frexp/ldexp, no `v_div_fixup_f32` (10) | 3 |
| `-fgpu-flush-denormals-to-zero` (**control**) | refined | **0** |
| **with the two flags set explicitly** | **identical**, all 13 | 3 |

So HIP's inherited defaults were already conformant. The two flags are set anyway — **measured ISA-identical, zero cost** — because an inherited default is a choice nobody made. Since `base_options` is appended last, a caller passing either negated form is now neutralised (verified: denorm returns to 3, `v_div_fixup_f32` returns), and a future clang default change becomes a no-op instead of a silent regression.

**The limit of append-last, measured**: `-ffast-math` removes `v_div_fixup_f32` and is **not** rescued by appending the conformance flag, and nothing was found that undoes the `-cl-*` spellings.

**HIP's real gap was silence.** These passed the warning list unwarned, each measured to change gfx1100 codegen — now covered: `-Ofast`, `-cl-fast-relaxed-math`, `-cl-unsafe-math-optimizations`, `-fapprox-func`, `-fgpu-flush-denormals-to-zero`, `-fno-hip-fp32-correctly-rounded-divide-sqrt`, `-munsafe-fp-atomics`.

**Deliberately not done** — the first four are not neutralisable by anything, which is exactly when §5 says *reject*, not warn. That is a caller-visible behaviour change and belongs in its own issue. Until then a caller can still relax HIP float semantics and only read a warning.

Also drops the disputed **"373"** from `Hip_rtc.ml` and `test_hip_rtc_options.ml` — §2 records it as one of two mutually inconsistent in-tree uses. No count is asserted in its place, because the right one has not been established.

---

## Verification

- `dune build @all` — exit 0. `dune build @fmt` — exit 0.
- `dune runtest` — exit 0, zero `[FAIL]`.
- `test_real64` — **byte-identical** to the pre-change baseline. `test_df64` PASSED.
- `check-test-alias-coverage.sh` — OK, all 81 e2e executables wired. New tests are in `(tests (names …))` blocks, so dune wires them to `runtest`.
- **Every new check proved red by mutation** — 7 OpenCL, 4 HIP, 1 Metal fail-soft, 1 Metal codegen pragma (emitted an empty pragma → 5 goldens red) — then restored green.
- `ci/assert-toolchain.sh` fails **pre-existing** on this box: 3/10 checks, missing CUDA headers on an AMD-only machine. The identical script from `origin/main` fails the same way, and this PR touches nothing under `ci/`. Note it reports **10** checks, not the 12 expected — worth a look, separately.

**Hardware.** AMD box: RX 7900 XTX (radeonsi/rusticl OpenCL, RADV, HIP gfx1100) + Raphael iGPU — no NVIDIA. Apple M4 / macOS 15.6.1 / Apple clang 17.0.0 over SSH for all Metal figures. Nothing was installed or changed on the Mac; probes were built with the Command Line Tools already present and run from `/tmp`. Every figure is from one of those two machines unless explicitly marked as quoted from sm_61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenCL floating-point conformance is now enforced per device capability, using computed effective build options.
  - HIP compilation uses stricter divide/sqrt rounding and denormal/flush handling defaults.
  - Metal code generation disables floating-point contraction via emitted kernel pragma, improving accuracy consistency.
- **Bug Fixes**
  - Metal now correctly applies conformant compile options (previously ineffective), restoring intended accuracy behavior.
  - Unsafe “relaxing” OpenCL FP-related build options are rejected.
- **Tests**
  - Added/expanded OpenCL, HIP, and Metal option-handling and contraction-regression suites; updated golden shader expectations.
- **Documentation**
  - Refreshed cross-backend floating-point contraction policy and mechanism/guard mappings with new evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



