### PR TITLE
fix(codegen): Metal address space, OpenCL fp64 gating, WGSL switch default, single-sourced f16 refusal

### DIFF
--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -16,6 +16,13 @@
 #   sarek-cuda/test/test_cuda_nvrtc_gate.ml       -> libnvrtc
 #     opencl_validation_sweep                     -> clang (OpenCL C)
 #   sarek/tests/unit/test_opencl_gate.ml          -> clang (OpenCL C)
+#     metal_validation_sweep, layer 2              -> xcrun metal (macOS ONLY)
+#
+# The Metal compile layer is the one gate this script cannot assert: `metal`
+# ships inside Xcode and no Linux CI image can have it. That is precisely why
+# metal_validation_sweep carries layer 1 (Metal_gate.Metal_addrspace), a pure
+# text check that needs no toolchain and runs everywhere — see #139, where two
+# committed Metal goldens had never compiled on any machine.
 #   sarek-cuda/test/test_cuda_f16_sass.ml         -> ptxas + nvdisasm
 #   sarek-cuda/test/test_cuda_fp_conformance.ml   -> nvcc + nvdisasm (hazard
 #                                                    control only; the guard
@@ -46,7 +53,7 @@ set -uo pipefail
 # is tautological by construction and can never report a gap on its own.
 #
 # The Rocq section below is deliberately NOT counted; see its comment.
-EXPECTED_CHECKS=12
+EXPECTED_CHECKS=13
 
 failures=0
 checks=0
@@ -301,6 +308,30 @@ CL
     ok "clang compiled a probe OpenCL kernel"
   else
     fail "clang is on PATH but cannot compile a trivial OpenCL kernel:
+$out"
+  fi
+
+  # fp64 (#140). The fp32 probe above deliberately says nothing about `double`,
+  # and that silence is what let the sweep report two verdicts for one missing
+  # capability on an Apple M4: two float64 cases skipped (for an unrelated
+  # hardcoded exclusion) while five failed on
+  #   error: use of type 'double' requires cl_khr_fp64 support
+  # The gate now asks Opencl_clang.fp64_available() first and skips ALL seven
+  # float64 cases with one stated reason when the answer is no. That skip is
+  # honest on a Mac and unacceptable in CI, where fp64 is the whole point of the
+  # float64 corpus — so it is asserted here, exactly as the tool presence is.
+  cat >"$tmpdir/probe64.cl" <<'CL'
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+__kernel void probe64(__global double *o) { o[get_global_id(0)] = 1.0; }
+CL
+  checks=$((checks + 1))
+  if out=$(clang -x cl -cl-std=CL1.2 -Xclang -finclude-default-header \
+             -fsyntax-only "$tmpdir/probe64.cl" 2>&1); then
+    ok "clang compiled a probe OpenCL kernel using double (cl_khr_fp64)"
+  else
+    fail "clang is on PATH but cannot compile an OpenCL kernel using \`double\`. \
+The seven float64 cases of opencl_validation_sweep would then all SKIP with a \
+stated fp64 reason and CI would validate no float64 codegen at all:
 $out"
   fi
   rm -rf "$tmpdir"

--- a/ci/assert-toolchain.sh
+++ b/ci/assert-toolchain.sh
@@ -16,13 +16,17 @@
 #   sarek-cuda/test/test_cuda_nvrtc_gate.ml       -> libnvrtc
 #     opencl_validation_sweep                     -> clang (OpenCL C)
 #   sarek/tests/unit/test_opencl_gate.ml          -> clang (OpenCL C)
-#     metal_validation_sweep, layer 2              -> xcrun metal (macOS ONLY)
+#     metal_validation_sweep, layer 2              -> Metal driver (macOS ONLY)
 #
-# The Metal compile layer is the one gate this script cannot assert: `metal`
-# ships inside Xcode and no Linux CI image can have it. That is precisely why
-# metal_validation_sweep carries layer 1 (Metal_gate.Metal_addrspace), a pure
-# text check that needs no toolchain and runs everywhere — see #139, where two
-# committed Metal goldens had never compiled on any machine.
+# The Metal compile layer is the one gate this script cannot assert: it needs a
+# Metal device, and no Linux CI image has one. It does NOT need Xcode — it
+# compiles through newLibraryWithSource:, which the Command Line Tools are
+# enough for, deliberately, because the reference M4 has no Xcode and a gate
+# keyed on `xcrun metal` would have skipped on the one machine that could run
+# it. That is also precisely why metal_validation_sweep carries layer 1
+# (Metal_gate.Metal_addrspace), a pure text check that needs no toolchain and
+# runs everywhere — see #139, where two committed Metal goldens had never
+# compiled on any machine.
 #   sarek-cuda/test/test_cuda_f16_sass.ml         -> ptxas + nvdisasm
 #   sarek-cuda/test/test_cuda_fp_conformance.ml   -> nvcc + nvdisasm (hazard
 #                                                    control only; the guard

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -1068,9 +1068,35 @@ pass there. This branch touches no OpenCL codegen (its OpenCL changes are all in
 `sarek-opencl/` runtime bindings) and no f64 path, so it cannot be the cause.
 Worth noting nonetheless: cases 7-8 of the same sweep **SKIP** on f64 while
 16-20 **FAIL**, so the sweep's own capability gating is inconsistent — some f64
-cases detect the missing extension and some do not. That is a test-scoping bug
-in the sweep, pre-existing, and a good candidate for the "a skip is not a pass"
-treatment the CUDA gates got.
+cases detect the missing extension and some do not.
+
+**FIXED (#140).** The investigation found something worse than "some paths
+check": *neither* did. Cases 7-8 skipped for a completely unrelated reason — a
+hardcoded `validation_exclusions` entry for `Float64.abs_float` /
+`Float64.copysign`, which are user-callable but absent from
+`Sarek_pure_registry.float64_list` and therefore die at codegen — and would have
+skipped identically on a machine with full fp64. Cases 16-20 simply ran and hit
+the toolchain. There was no fp64 predicate anywhere in the gate.
+
+Note also what the capability *is* here. The sweep never touches a device; it
+compiles with `clang -x cl`. So the authority is not the device's `cl_khr_fp64`
+(`Opencl_api.ml`'s `supports_fp64`, which the e2e suite uses) but whether *this
+clang* can compile a `double` kernel — Apple clang's `arm64-apple-darwin` target
+does not list the extension, so the `#pragma OPENCL EXTENSION cl_khr_fp64 :
+enable` the production path emits is ignored with a warning and `double` is an
+error. `Opencl_clang.fp64_available ()` establishes that by compiling a `double`
+probe, the same way `available ()` establishes clang itself. The sweep now asks
+it **before** the exclusion list, so on a toolchain without fp64 all *seven*
+float64 cases report one verdict for one stated reason.
+
+Reproduced on Linux rather than argued: `SAREK_OPENCL_GATE_NO_FP64=1` adds
+`-cl-ext=-cl_khr_fp64` to every invocation, which makes clang 22.1.6 emit the
+identical `error: use of type 'double' requires cl_khr_fp64 support`. With the
+new predicate disabled that reproduces the M4 split exactly — 7, 8 SKIP and
+16-20 FAIL; with it enabled, seven uniform SKIPs. `ci/assert-toolchain.sh` now
+carries an fp64 positive control so the skip cannot become CI's normal outcome,
+and `test_opencl_gate.ml` re-runs itself under the switch so a suppression that
+did nothing would fail rather than pass.
 
 All six `metal_contraction_pragma` cases pass on the M4.
 
@@ -1085,7 +1111,47 @@ qualifications are device and constant"*.
 **Pre-existing and unrelated to the FP work** — a control run with the pragma
 stripped from those same two sources fails identically. It is a codegen
 correctness bug that had never been observable, because nothing in this project
-had ever compiled Metal on Apple hardware. **Not fixed here**: choosing between
-`device` and `constant` for record and variant buffers is a design decision, not
-a typo. Recorded because it is the clearest illustration of what "unverified
-backend" was actually costing.
+had ever compiled Metal on Apple hardware.
+
+**FIXED (#139), and the design decision is `device`.** The cause: the
+`DParam (v, None)` arm of `gen_param_metal` treated *every* parameter without an
+`array_info` as a scalar and emitted `constant <ty> &name`; for a vec-typed `v`,
+`metal_type_of_elttype` returns a pointer type, so the emission was a reference
+to a pointer whose pointee had no address space.
+
+`constant` is not a live option for a Sarek `vec`, so the choice is not close:
+objects in `constant` are read-only for the lifetime of the kernel (MSL 3.2
+§4.2/§4.3) and both offending kernels *write* through the parameter
+(`pts[idx] = ...`, `out[idx] = ...`), `constant` carries an
+implementation-defined size limit and expects per-dispatch-invariant data, and
+every other backend already lowers a vec parameter to a mutable global pointer
+(CUDA `T* __restrict__`, OpenCL `__global T* restrict`). Metal's own
+`metal_param_type` and `metal_memspace Global` already said `device`; this arm
+was the single place in the backend that disagreed with them.
+
+The gate that would have caught it now exists: `metal_validation_sweep`, with
+`Metal_gate.Metal_addrspace` (layer 1, pure text, no toolchain — so it runs on
+the Linux machines where the defect was introduced) and
+`Metal_gate.Metal_compile` (layer 2, `xcrun metal`, macOS only, honest skip with
+a stated reason elsewhere). Layer 1's red path is driven permanently by
+`sarek/tests/unit/test_metal_gate.ml`, which feeds it the pre-fix golden
+verbatim.
+
+### 10.12 A third defect, found the same way (#132)
+
+`wgsl_validation_sweep`'s corpus contained no multi-field variant payload and,
+worse, no `SMatch` at all — `variant_kernel` only *constructs* variants — so
+every accessor and every `switch` the WGSL match emitter can produce was
+unreachable from any executable gate. The field-naming half of #132 had already
+been closed by PR #306 (`EMatch` and all five `SMatch` paths now share one
+`payload_layout`, and WGSL's `indexed = true` spelling `.MkPair_v_0` matches its
+flat struct). What the coverage hole was still hiding was a different, live bug:
+the emitter wrote `default:` only when the source match had a wildcard arm, and
+WGSL requires exactly one default clause in every `switch`. Every exhaustive
+match therefore produced a module `naga` rejects with *"missing default case"* —
+i.e. the ordinary case. C's `switch` needs no default and GLSL's likewise, so
+WGSL was the odd one out here too, exactly as it was for payload spelling.
+
+Adding `smatch_multi_payload` to the sweep turned it red on the first run;
+emitting a synthetic empty `default` when no `PWild` arm is present turned it
+green.

--- a/sarek-metal/test/test_sarek_ir_metal.ml
+++ b/sarek-metal/test/test_sarek_ir_metal.ml
@@ -201,6 +201,61 @@ let test_indent_nested () =
   let nested = Sarek_ir_metal.indent_nested "  " in
   Alcotest.(check string) "indent_nested adds two spaces" "    " nested
 
+(* Local address space on a buffer parameter is REFUSED (#139 / PR #316 review).
+
+   [metal_memspace Local] is "", so without this guard the emitter produced
+   " float* v [[buffer(0)]]" — a pointer with no address space, the other half
+   of MSL 3.2 §4.2 and precisely the shape Metal_gate.Metal_addrspace rejects.
+   The emitter would have been generating source its own gate refuses.
+
+   Both routes are exercised: the explicit [array_info] and the bare [TArray]
+   the DParam-without-info arm derives its space from. The second is the newly
+   reachable one. *)
+let expect_local_refused label decl =
+  let buf = Buffer.create 64 in
+  match Sarek_ir_metal.gen_param_metal buf [] 0 decl with
+  | (_ : int) ->
+      Alcotest.failf
+        "%s: Local was accepted and emitted %S — a pointer with no address \
+         space, which Metal rejects"
+        label
+        (Buffer.contents buf)
+  | exception _ -> ()
+
+let test_local_buffer_param_refused () =
+  let v =
+    {var_name = "v"; var_id = 0; var_type = TFloat32; var_mutable = false}
+  in
+  expect_local_refused
+    "explicit array_info"
+    (DParam (v, Some {arr_elttype = TFloat32; arr_memspace = Local})) ;
+  let a =
+    {
+      var_name = "a";
+      var_id = 0;
+      var_type = TArray (TFloat32, Local);
+      var_mutable = false;
+    }
+  in
+  expect_local_refused "TArray (_, Local) with no array_info" (DParam (a, None)) ;
+  (* Control: Global on the same shapes still emits, so the guard rejects Local
+     specifically rather than everything. *)
+  let g =
+    {
+      var_name = "g";
+      var_id = 0;
+      var_type = TArray (TFloat32, Global);
+      var_mutable = false;
+    }
+  in
+  let buf = Buffer.create 64 in
+  let _ = Sarek_ir_metal.gen_param_metal buf [] 0 (DParam (g, None)) in
+  Alcotest.(check bool)
+    "Global still emits a device pointer"
+    true
+    (String.length (Buffer.contents buf) > 0
+    && String.sub (Buffer.contents buf) 0 6 = "device")
+
 let () =
   Alcotest.run
     "Sarek_ir_metal"
@@ -221,6 +276,13 @@ let () =
       ("atomics", [Alcotest.test_case "atomic operations" `Quick test_atomics]);
       ("types", [Alcotest.test_case "type mapping" `Quick test_type_mapping]);
       ("var_decl", [Alcotest.test_case "var declaration" `Quick test_var_decl]);
+      ( "param_address_space",
+        [
+          Alcotest.test_case
+            "Local buffer parameter is refused"
+            `Quick
+            test_local_buffer_param_refused;
+        ] );
       ( "array_decl",
         [Alcotest.test_case "array declaration" `Quick test_array_decl] );
       ("indent", [Alcotest.test_case "indent helper" `Quick test_indent_nested]);

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -281,12 +281,7 @@ let rec glsl_type_of_elttype = function
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct
            "f16"
-           "GLSL: float16 is refused by measurement, not pending \
-            implementation — RADV's ACO backend absorbs the f32->f16 narrowing \
-            into the arithmetic that feeds it, so 2912/63488 binary16 inputs \
-            disagree with the interpreter on a single narrowing, and `precise` \
-            does not prevent it. See docs/fp-contraction-policy.md (#57 slice \
-            2b).")
+           Sarek_ir_codegen.glsl_float16_refusal)
   | TFloat32 -> "float"
   | TFloat64 -> "double" (* Requires GL_ARB_gpu_shader_fp64 *)
   | TBool -> "bool"
@@ -1602,11 +1597,7 @@ let reject_float16_kernel (k : kernel) : unit =
     Codegen_error.raise_error
       (Codegen_error.unsupported_construct
          "f16"
-         "GLSL: float16 is refused by measurement, not pending implementation \
-          — RADV's ACO backend absorbs the f32->f16 narrowing into the \
-          arithmetic that feeds it, so 2912/63488 binary16 inputs disagree \
-          with the interpreter on a single narrowing, and `precise` does not \
-          prevent it. See docs/fp-contraction-policy.md (#57 slice 2b).")
+         Sarek_ir_codegen.glsl_float16_refusal)
 
 (** Generate complete GLSL source for a kernel.
     @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -663,11 +663,74 @@ let rec gen_stmt buf indent = function
     Metal-specific {!gen_param_metal} below (buffer-index variant). *)
 let is_vec_type = Sarek_ir_codegen.is_vec_type
 
+(* A buffer parameter: pointer into an address space, plus its length.
+
+   ADDRESS SPACE IS [device], NOT [constant], and that is a decision rather than
+   an accident (#139). Metal has no default address space for a pointer
+   parameter, so the choice has to be made explicitly; [constant] is the wrong
+   half of it for a Sarek [vec]:
+
+   - MSL 3.2 §4.2/§4.3: objects in [constant] are read-only for the whole
+     lifetime of the kernel. Sarek vecs are read-write — [record_kernel] writes
+     [pts[idx] = ...] and [variant_kernel] writes [out[idx] = ...] — so
+     [constant] would not compile even if the reference form below were fixed.
+   - [constant] additionally carries an implementation-defined size limit and
+     wants argument data that does not change per dispatch; a Sarek vec is a
+     general MTLBuffer bound with [setBuffer:].
+   - Every other backend already maps a vec param to a mutable global pointer
+     (CUDA [T* __restrict__], OpenCL [__global T* restrict]), and Metal's own
+     {!metal_param_type} and [metal_memspace Global] already say [device]. The
+     [DParam (_, None)] arm was the single place in the backend that disagreed.
+
+   The defect this replaces: that arm treated EVERY [DParam (v, None)] as a
+   scalar and emitted [constant <ty> &name]. For a vec-typed [v],
+   [metal_type_of_elttype] returns a pointer type, so the emission was
+   [constant Point2* &pts] — a reference to a pointer whose POINTEE has no
+   address space, which Metal rejects outright ("must have address space
+   qualifier"). Both such goldens (record_kernel, variant_kernel) had never
+   compiled; nothing on Linux could see it. *)
+let gen_buffer_param buf atomic_vars idx v ~memspace ~elttype =
+  Buffer.add_string buf (metal_memspace memspace) ;
+  Buffer.add_char buf ' ' ;
+  (* Use atomic type if this variable is used with atomics *)
+  let type_str =
+    if List.mem v.var_name atomic_vars then metal_atomic_type_of_elttype elttype
+    else metal_type_of_elttype elttype
+  in
+  Buffer.add_string buf type_str ;
+  Buffer.add_string buf "* " ;
+  Buffer.add_string buf v.var_name ;
+  Buffer.add_string buf " [[buffer(" ;
+  Buffer.add_string buf (string_of_int idx) ;
+  Buffer.add_string buf ")]], constant int &sarek_" ;
+  Buffer.add_string buf v.var_name ;
+  Buffer.add_string buf "_length [[buffer(" ;
+  Buffer.add_string buf (string_of_int (idx + 1)) ;
+  Buffer.add_string buf ")]]" ;
+  idx + 2
+
 (** Generate parameter with Metal buffer attributes, returns next buffer index
 *)
 let gen_param_metal buf atomic_vars idx = function
+  (* Vec/array parameter carrying no [array_info]. The element type and the
+     memory space come from the variable's own type; a bare [TVec] is a global
+     buffer, exactly as {!metal_param_type} already assumed. *)
+  | DParam (v, None) when is_vec_type v.var_type ->
+      let memspace, elttype =
+        match v.var_type with
+        | TVec elt -> (Global, elt)
+        | TArray (elt, ms) -> (ms, elt)
+        | _ ->
+            (* unreachable: [is_vec_type] is exactly TVec | TArray *)
+            Codegen_error.raise_error
+              (Codegen_error.unsupported_construct
+                 "gen_param_metal"
+                 "is_vec_type accepted a non-vec type")
+      in
+      gen_buffer_param buf atomic_vars idx v ~memspace ~elttype
   | DParam (v, None) ->
-      (* Scalar parameter - wrap in constant buffer *)
+      (* Scalar parameter - wrap in constant buffer. A scalar genuinely is
+         uniform and read-only per dispatch, so [constant T &] is right here. *)
       Buffer.add_string buf "constant " ;
       Buffer.add_string buf (metal_type_of_elttype v.var_type) ;
       Buffer.add_string buf " &" ;
@@ -675,37 +738,16 @@ let gen_param_metal buf atomic_vars idx = function
       Buffer.add_string buf " [[buffer(" ;
       Buffer.add_string buf (string_of_int idx) ;
       Buffer.add_string buf ")]]" ;
-      (* Add length parameter for vectors *)
-      if is_vec_type v.var_type then begin
-        Buffer.add_string buf ", constant int &sarek_" ;
-        Buffer.add_string buf v.var_name ;
-        Buffer.add_string buf "_length [[buffer(" ;
-        Buffer.add_string buf (string_of_int (idx + 1)) ;
-        Buffer.add_string buf ")]]" ;
-        idx + 2
-      end
-      else idx + 1
+      idx + 1
   | DParam (v, Some arr) ->
       (* Array with explicit info - always needs length *)
-      Buffer.add_string buf (metal_memspace arr.arr_memspace) ;
-      Buffer.add_char buf ' ' ;
-      (* Use atomic type if this variable is used with atomics *)
-      let type_str =
-        if List.mem v.var_name atomic_vars then
-          metal_atomic_type_of_elttype arr.arr_elttype
-        else metal_type_of_elttype arr.arr_elttype
-      in
-      Buffer.add_string buf type_str ;
-      Buffer.add_string buf "* " ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf " [[buffer(" ;
-      Buffer.add_string buf (string_of_int idx) ;
-      Buffer.add_string buf ")]], constant int &sarek_" ;
-      Buffer.add_string buf v.var_name ;
-      Buffer.add_string buf "_length [[buffer(" ;
-      Buffer.add_string buf (string_of_int (idx + 1)) ;
-      Buffer.add_string buf ")]]" ;
-      idx + 2
+      gen_buffer_param
+        buf
+        atomic_vars
+        idx
+        v
+        ~memspace:arr.arr_memspace
+        ~elttype:arr.arr_elttype
   | DLocal _ | DShared _ ->
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -663,6 +663,13 @@ let rec gen_stmt buf indent = function
     Metal-specific {!gen_param_metal} below (buffer-index variant). *)
 let is_vec_type = Sarek_ir_codegen.is_vec_type
 
+(* "Will [metal_type_of_elttype] hand back a pointer?" — a different question
+   from {!is_vec_type}, which asks "does this carry a trailing length argument?"
+   and answers [true] for [TVec] alone. Conflating the two is what let [TArray]
+   parameters reach the scalar arm and emit [constant T* &v]. *)
+let is_pointer_type (t : elttype) =
+  match t with TVec _ | TArray _ -> true | _ -> false
+
 (* A buffer parameter: pointer into an address space, plus its length.
 
    ADDRESS SPACE IS [device], NOT [constant], and that is a decision rather than
@@ -689,7 +696,25 @@ let is_vec_type = Sarek_ir_codegen.is_vec_type
    address space, which Metal rejects outright ("must have address space
    qualifier"). Both such goldens (record_kernel, variant_kernel) had never
    compiled; nothing on Linux could see it. *)
-let gen_buffer_param buf atomic_vars idx v ~memspace ~elttype =
+let gen_buffer_param buf atomic_vars idx v ~memspace ~elttype ~with_length =
+  (* [metal_memspace Local] is [""], so a Local buffer parameter would emit a
+     leading space and then a pointer with NO address space — the other half of
+     MSL 3.2 §4.2, and exactly the shape Metal_gate.Metal_addrspace rejects. The
+     emitter would be producing source its own gate refuses.
+
+     Unreachable from the current corpus, but reachable in principle, and newly
+     so: the [DParam (v, None)] arm above derives the space from the variable's
+     type and passes [TArray (elt, Local)] straight through. Rejecting here
+     keeps the invariant in the emitter, where it belongs, rather than resting
+     on the corpus happening not to contain the case. *)
+  (match memspace with
+  | Local ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "gen_buffer_param"
+           "Metal kernel buffer parameters need an explicit address space \
+            (device or threadgroup); Local has none")
+  | Global | Shared -> ()) ;
   Buffer.add_string buf (metal_memspace memspace) ;
   Buffer.add_char buf ' ' ;
   (* Use atomic type if this variable is used with atomics *)
@@ -702,32 +727,50 @@ let gen_buffer_param buf atomic_vars idx v ~memspace ~elttype =
   Buffer.add_string buf v.var_name ;
   Buffer.add_string buf " [[buffer(" ;
   Buffer.add_string buf (string_of_int idx) ;
-  Buffer.add_string buf ")]], constant int &sarek_" ;
-  Buffer.add_string buf v.var_name ;
-  Buffer.add_string buf "_length [[buffer(" ;
-  Buffer.add_string buf (string_of_int (idx + 1)) ;
   Buffer.add_string buf ")]]" ;
-  idx + 2
+  (* Only a [TVec] carries the implicit trailing [sarek_<name>_length] argument
+     — that is the documented meaning of {!Sarek_ir_codegen.is_vec_type}. A
+     [TArray] has a size known at codegen time and no length argument, so
+     emitting one here would shift every following buffer index past what the
+     host binds. *)
+  if with_length then begin
+    Buffer.add_string buf ", constant int &sarek_" ;
+    Buffer.add_string buf v.var_name ;
+    Buffer.add_string buf "_length [[buffer(" ;
+    Buffer.add_string buf (string_of_int (idx + 1)) ;
+    Buffer.add_string buf ")]]" ;
+    idx + 2
+  end
+  else idx + 1
 
 (** Generate parameter with Metal buffer attributes, returns next buffer index
 *)
 let gen_param_metal buf atomic_vars idx = function
-  (* Vec/array parameter carrying no [array_info]. The element type and the
-     memory space come from the variable's own type; a bare [TVec] is a global
-     buffer, exactly as {!metal_param_type} already assumed. *)
-  | DParam (v, None) when is_vec_type v.var_type ->
-      let memspace, elttype =
+  (* Any POINTER-typed parameter carrying no [array_info]. The element type and
+     the memory space come from the variable's own type; a bare [TVec] is a
+     global buffer, exactly as {!metal_param_type} already assumed.
+
+     The test is deliberately NOT [is_vec_type]: that predicate means "carries a
+     trailing length argument" and is [TVec] only, so guarding on it left
+     [TArray] parameters falling through to the scalar arm below — which emits
+     [constant float* &a], the very #139 reference-to-pointer shape this change
+     exists to remove, in a second constructor. Caught by the Local-address-space
+     test in sarek-metal/test/test_sarek_ir_metal.ml. What matters here is
+     whether [metal_type_of_elttype] will produce a pointer, so that is what is
+     asked. *)
+  | DParam (v, None) when is_pointer_type v.var_type ->
+      let memspace, elttype, with_length =
         match v.var_type with
-        | TVec elt -> (Global, elt)
-        | TArray (elt, ms) -> (ms, elt)
+        | TVec elt -> (Global, elt, true)
+        | TArray (elt, ms) -> (ms, elt, false)
         | _ ->
-            (* unreachable: [is_vec_type] is exactly TVec | TArray *)
+            (* unreachable: [is_pointer_type] is exactly TVec | TArray *)
             Codegen_error.raise_error
               (Codegen_error.unsupported_construct
                  "gen_param_metal"
-                 "is_vec_type accepted a non-vec type")
+                 "is_pointer_type accepted a non-pointer type")
       in
-      gen_buffer_param buf atomic_vars idx v ~memspace ~elttype
+      gen_buffer_param buf atomic_vars idx v ~memspace ~elttype ~with_length
   | DParam (v, None) ->
       (* Scalar parameter - wrap in constant buffer. A scalar genuinely is
          uniform and read-only per dispatch, so [constant T &] is right here. *)
@@ -748,6 +791,7 @@ let gen_param_metal buf atomic_vars idx = function
         v
         ~memspace:arr.arr_memspace
         ~elttype:arr.arr_elttype
+        ~with_length:true
   | DLocal _ | DShared _ ->
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -100,11 +100,7 @@ let rec opencl_type_of_elttype = function
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct
            "f16"
-           "OpenCL: float16 is not supported — not because the codegen is \
-            missing, but because rusticl/radeonsi fuses the f32 multiply into \
-            the f32->f16 narrowing (620/63488 binary16 inputs disagree with \
-            the interpreter) and no affordable source-level barrier exists on \
-            this path. See docs/fp-contraction-policy.md (#57 slice 2a).")
+           Sarek_ir_codegen.opencl_float16_refusal)
   | TFloat32 -> "float"
   | TFloat64 -> "double"
   | TBool -> "int"
@@ -765,11 +761,7 @@ let reject_float16_kernel (k : kernel) : unit =
     Codegen_error.raise_error
       (Codegen_error.unsupported_construct
          "f16"
-         "OpenCL: float16 is refused by measurement, not pending \
-          implementation — rusticl/radeonsi fuses the f32 multiply into the \
-          f32->f16 narrowing, so 620/63488 binary16 inputs disagree with the \
-          interpreter, and no affordable barrier exists on this path. See \
-          docs/fp-contraction-policy.md (#57 slice 2a).")
+         Sarek_ir_codegen.opencl_float16_refusal)
 
 (** {1 Recursion Resolution}
 

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -960,6 +960,28 @@ let rec gen_stmt buf indent = function
           gen_stmt buf (indent ^ "    ") body ;
           Buffer.add_string buf (indent ^ "  }\n"))
         cases ;
+      (* WGSL requires EXACTLY ONE default clause in every switch (WGSL spec
+         §9.4.3, "must have exactly one default selector"); naga reports
+         "missing default case" and rejects the whole entry point otherwise.
+         C's switch needs no default and GLSL's likewise, so this is a WGSL-only
+         obligation and the four other backends have nothing to do here.
+
+         A Sarek match that is exhaustive over the constructors carries no
+         [PWild] arm, so without this the emitter produced an invalid module for
+         every such match — i.e. for the ordinary case. It was invisible because
+         no WGSL [SMatch] anywhere in the tree was fed to naga (#132); the
+         corpus case [smatch_multi_payload] in the wgsl_validation_sweep is what
+         made it visible, and is what keeps it visible.
+
+         An empty body is the right lowering: the arm is reachable only for a
+         tag outside the declared constructor set, which the type system already
+         excludes, and WGSL has no trap to put here. *)
+      if not (List.exists (fun (p, _) -> p = PWild) cases) then begin
+        Buffer.add_string buf indent ;
+        Buffer.add_string buf "  default: {\n" ;
+        Buffer.add_string buf indent ;
+        Buffer.add_string buf "  }\n"
+      end ;
       Buffer.add_string buf indent ;
       Buffer.add_string buf "}\n"
   | SReturn e ->

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -32,7 +32,13 @@
 (test
  (name test_codegen_golden)
  (modules test_codegen_golden)
- (libraries codegen_golden_backends opencl_gate sarek_ir alcotest unix)
+ (libraries
+  codegen_golden_backends
+  opencl_gate
+  metal_gate
+  sarek_ir
+  alcotest
+  unix)
  (instrumentation
   (backend bisect_ppx)))
 

--- a/sarek/tests/codegen_golden/metal_gate/dune
+++ b/sarek/tests/codegen_golden/metal_gate/dune
@@ -1,0 +1,12 @@
+; Metal validation gate (#139) — see metal_addrspace.ml / metal_compile.ml for
+; what each layer catches and what it provably cannot.
+;
+; Its own library rather than modules of test_codegen_golden so the negative
+; controls in ../../unit/test_metal_gate.ml can drive the same code the sweep
+; drives — a gate whose red path is never executed is not a gate. Layer 2 needs
+; macOS; layer 1 is pure text and runs everywhere, which is the point.
+
+(library
+ (name metal_gate)
+ (modules metal_addrspace metal_compile)
+ (libraries unix))

--- a/sarek/tests/codegen_golden/metal_gate/metal_addrspace.ml
+++ b/sarek/tests/codegen_golden/metal_gate/metal_addrspace.ml
@@ -112,7 +112,14 @@ let split_params (s : string) : string list =
       | c -> Buffer.add_char buf c)
     s ;
   if trim (Buffer.contents buf) <> "" then out := Buffer.contents buf :: !out ;
-  List.rev_map trim !out |> List.rev
+  (* [!out] is accumulated back-to-front, and [List.rev_map] already reverses
+     while mapping — so it alone restores source order. The [List.rev] that used
+     to follow put the list back into reverse, which made the reported offences
+     read bottom-up. Detection was unaffected (each parameter is inspected
+     independently, so no permutation can hide one), but a diagnostic that lists
+     parameters in an order the reader cannot find in the source costs exactly
+     the time this gate is supposed to save. Order is pinned by a test. *)
+  List.rev_map trim !out
 
 let contains_char s c = String.exists (fun x -> x = c) s
 

--- a/sarek/tests/codegen_golden/metal_gate/metal_addrspace.ml
+++ b/sarek/tests/codegen_golden/metal_gate/metal_addrspace.ml
@@ -1,0 +1,151 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Metal kernel-signature address-space check — layer 1 of the Metal gate
+    (#139).
+
+    WHY A TEXT LAYER AT ALL, when {!Metal_compile} exists: the Metal compiler
+    ships only with Xcode, so on every Linux machine in this project — which is
+    where the code is written — {!Metal_compile} is unavailable and skips. That
+    is exactly how two committed Metal goldens ([record_kernel],
+    [variant_kernel]) sat in the tree emitting source that has never once
+    compiled: the byte-exact goldens pinned the bytes, the sweep for the other
+    four backends had no Metal arm, and nothing anywhere read the bytes for
+    meaning.
+
+    This layer needs no toolchain and therefore runs on the machine that
+    introduces the defect. It reads the kernel signature only, and it checks one
+    property that Metal enforces and C does not:
+
+    {b every pointer in a kernel parameter list carries an explicit address
+       space, and no parameter is a reference to a pointer.}
+
+    MSL 3.2 §4.2: Metal has no default address space; a pointer or reference
+    argument to a kernel must be declared in [device], [constant] or
+    [threadgroup]. §4.2.3 further requires that in a reference-to-pointer
+    parameter the POINTEE also carry one, so [constant Point2* &pts] is rejected
+    outright — the form the [DParam (v, None)] arm used to emit for every
+    vec-typed parameter.
+
+    Blind spots, stated so a green run is not read as "our Metal is valid": this
+    layer sees the signature and nothing else. Body-level type errors, wrong
+    intrinsic names, bad struct layout and everything else are
+    {!Metal_compile}'s job, and on Linux nothing covers them. *)
+
+type offence = {param : string; reason : string}
+
+let describe o = Printf.sprintf "  %s\n      -> %s" o.param o.reason
+
+let is_space c = c = ' ' || c = '\t' || c = '\n' || c = '\r'
+
+let trim = String.trim
+
+(* Address spaces Metal accepts on a kernel parameter (MSL 3.2 §4.2). [thread]
+   is legal in the language but cannot appear on a kernel entry point's buffer
+   argument; it is listed so the diagnostic below stays about the missing
+   qualifier rather than about an unfamiliar keyword. *)
+let address_spaces = ["device"; "constant"; "threadgroup"; "thread"]
+
+let starts_with_space_kw s =
+  List.exists
+    (fun kw ->
+      let n = String.length kw in
+      String.length s > n && String.sub s 0 n = kw && is_space s.[n])
+    address_spaces
+
+(** The parameter list of the first [kernel void <name>( ... )] in [src], as
+    written, or [None] if there is none. Scans for the matching close paren so a
+    nested [[[attribute(0)]]] cannot end the list early. *)
+let kernel_signature (src : string) : string option =
+  let n = String.length src in
+  let marker = "kernel void " in
+  let m = String.length marker in
+  let rec find_marker i =
+    if i + m > n then None
+    else if String.sub src i m = marker then Some (i + m)
+    else find_marker (i + 1)
+  in
+  match find_marker 0 with
+  | None -> None
+  | Some after -> (
+      let rec find_open i =
+        if i >= n then None
+        else if src.[i] = '(' then Some i
+        else find_open (i + 1)
+      in
+      match find_open after with
+      | None -> None
+      | Some op -> (
+          let rec close i depth =
+            if i >= n then None
+            else
+              match src.[i] with
+              | '(' -> close (i + 1) (depth + 1)
+              | ')' -> if depth = 1 then Some i else close (i + 1) (depth - 1)
+              | _ -> close (i + 1) depth
+          in
+          match close (op + 1) 1 with
+          | None -> None
+          | Some cl -> Some (String.sub src (op + 1) (cl - op - 1))))
+
+(* Split a parameter list on top-level commas. [[[buffer(0)]]] contains no
+   comma, but a future attribute might, so depth is tracked rather than
+   assumed. *)
+let split_params (s : string) : string list =
+  let out = ref [] in
+  let buf = Buffer.create 64 in
+  let depth = ref 0 in
+  String.iter
+    (fun c ->
+      match c with
+      | '(' | '[' ->
+          incr depth ;
+          Buffer.add_char buf c
+      | ')' | ']' ->
+          decr depth ;
+          Buffer.add_char buf c
+      | ',' when !depth = 0 ->
+          out := Buffer.contents buf :: !out ;
+          Buffer.clear buf
+      | c -> Buffer.add_char buf c)
+    s ;
+  if trim (Buffer.contents buf) <> "" then out := Buffer.contents buf :: !out ;
+  List.rev_map trim !out |> List.rev
+
+let contains_char s c = String.exists (fun x -> x = c) s
+
+(** Every parameter of the kernel in [src] that Metal's address-space rules
+    reject. Empty list = this layer is satisfied. *)
+let offences (src : string) : offence list =
+  match kernel_signature src with
+  | None -> []
+  | Some params ->
+      List.filter_map
+        (fun p ->
+          let p = trim p in
+          if p = "" then None
+          else if contains_char p '*' && contains_char p '&' then
+            Some
+              {
+                param = p;
+                reason =
+                  "reference to a pointer whose POINTEE has no address space. \
+                   This is the #139 shape — `constant T* &v` — and Apple clang \
+                   17 answers it with: \"invalid address space qualification \
+                   for buffer pointee type ... valid address space \
+                   qualifications are device and constant\". A Sarek vec is \
+                   written through, so the answer is `device T* v`.";
+              }
+          else if contains_char p '*' && not (starts_with_space_kw p) then
+            Some
+              {
+                param = p;
+                reason =
+                  "pointer parameter with no address space qualifier. Metal \
+                   has no default address space (MSL 3.2 §4.2); say `device`, \
+                   `constant` or `threadgroup`.";
+              }
+          else None)
+        (split_params params)

--- a/sarek/tests/codegen_golden/metal_gate/metal_compile.ml
+++ b/sarek/tests/codegen_golden/metal_gate/metal_compile.ml
@@ -1,0 +1,84 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Metal Shading Language compile gate — layer 2 of the Metal gate (#139), and
+    the Metal counterpart of {!Opencl_gate.Opencl_clang}, [glslangValidator] and
+    [naga].
+
+    Unlike those three, this one cannot run on the machines this project is
+    developed on: [metal] ships inside Xcode and exists on macOS only. That is
+    the whole reason Metal was the last backend with committed goldens and no
+    validator, and the reason #139's two non-compiling goldens survived. So this
+    layer is deliberately paired with {!Metal_addrspace}, which needs no
+    toolchain and catches the specific class that bit us; a skip here is
+    honestly reported and never silent (see [why_unavailable]), and
+    ci/assert-toolchain.sh states which platform is expected to provide it. *)
+
+let read_file f =
+  try
+    let ic = open_in f in
+    let n = in_channel_length ic in
+    let s = really_input_string ic n in
+    close_in ic ;
+    s
+  with _ -> ""
+
+let write_file f s =
+  let oc = open_out f in
+  output_string oc s ;
+  close_out oc
+
+(** [-fpreserve-invariance] is NOT passed: the backend's contraction defence is
+    the [#pragma METAL fp contract(off)] inside the source (see the
+    metal_contraction_pragma group in test_codegen_golden.ml), and adding a
+    command-line flag here would validate a compile the project never performs.
+    Everything else mirrors a plain AIR compile of one translation unit. *)
+let cmd_for src obj err =
+  Printf.sprintf
+    "xcrun -sdk macosx metal -x metal -std=metal3.0 -c %s -o %s >%s 2>&1"
+    (Filename.quote src)
+    (Filename.quote obj)
+    (Filename.quote err)
+
+let run_metal (source : string) : (unit, string) result =
+  let base = Filename.temp_file "sarek_gate_metal_" "" in
+  let src = base ^ ".metal" in
+  let obj = base ^ ".air" in
+  let err = base ^ ".err" in
+  write_file src source ;
+  let rc = Unix.system (cmd_for src obj err) in
+  let out = read_file err in
+  List.iter (fun f -> try Sys.remove f with _ -> ()) [src; obj; err; base] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+(** Availability is a POSITIVE CONTROL, not [command -v xcrun]: [xcrun] exists
+    on any macOS with the Command Line Tools, and answers "tool 'metal' not
+    found" when the full Xcode/Metal toolchain is absent. "Available" here means
+    "has just compiled something". Mirrors {!Opencl_gate.Opencl_clang} and
+    ci/assert-toolchain.sh. *)
+let probe =
+  "#include <metal_stdlib>\n\
+   using namespace metal;\n\
+   kernel void probe(device int* o [[buffer(0)]],\n\
+  \                  uint3 gid [[thread_position_in_grid]]) {\n\
+  \  o[gid.x] = 1;\n\
+   }\n"
+
+let unavailable_reason : string option Lazy.t =
+  lazy
+    (match Unix.system "command -v xcrun >/dev/null 2>&1" with
+    | Unix.WEXITED 0 -> (
+        match run_metal probe with
+        | Ok () -> None
+        | Error e ->
+            Some
+              ("xcrun is on PATH but the Metal compiler rejected the probe \
+                kernel (no Xcode Metal toolchain?): " ^ e))
+    | _ -> Some "xcrun not on PATH (Metal compiles on macOS only)")
+
+let available () = Lazy.force unavailable_reason = None
+
+let why_unavailable () =
+  match Lazy.force unavailable_reason with Some r -> r | None -> ""

--- a/sarek/tests/codegen_golden/metal_gate/metal_compile.ml
+++ b/sarek/tests/codegen_golden/metal_gate/metal_compile.ml
@@ -7,14 +7,40 @@
     the Metal counterpart of {!Opencl_gate.Opencl_clang}, [glslangValidator] and
     [naga].
 
-    Unlike those three, this one cannot run on the machines this project is
-    developed on: [metal] ships inside Xcode and exists on macOS only. That is
-    the whole reason Metal was the last backend with committed goldens and no
-    validator, and the reason #139's two non-compiling goldens survived. So this
-    layer is deliberately paired with {!Metal_addrspace}, which needs no
-    toolchain and catches the specific class that bit us; a skip here is
-    honestly reported and never silent (see [why_unavailable]), and
-    ci/assert-toolchain.sh states which platform is expected to provide it. *)
+    {1 Why not [xcrun metal]}
+
+    Because it would never have run. The offline [metal] compiler ships inside
+    Xcode, and the reference Apple M4 this project measures on (macOS 15.6.1,
+    Apple clang 17) has only the Command Line Tools:
+
+    {v xcrun: error: unable to find utility "metal", not a developer tool v}
+
+    A gate keyed on [xcrun metal] would therefore have reported an honest,
+    well-worded skip on the exact machine that found #139 — a skip quietly
+    becoming the normal outcome everywhere, which is the failure mode this whole
+    gate exists to stop.
+
+    {1 What runs instead}
+
+    [newLibraryWithSource:options:error:], through a small Objective-C driver
+    built with [clang -framework Metal]. That call compiles through the Metal
+    driver at runtime, needs no Xcode, and is documented as the reason the
+    project's other probes work on this machine (see the build note atop
+    tools/probes/metal_math_mode_probe.m). It is also the call [Sarek_metal]'s
+    runtime actually makes, so this validates the production compile path rather
+    than a neighbouring one.
+
+    Confirmed on the M4 against both shapes of #139: [constant Point2* &pts]
+    gives "invalid address space qualification for buffer pointee type 'const
+    constant Point2 *'" and [device Point2* pts] compiles.
+
+    {1 What it still cannot cover}
+
+    The driver only exists on macOS, so on Linux this layer skips with a stated
+    reason and {!Metal_addrspace} is the only cover — which is precisely why
+    that layer is pure text and needs no toolchain. Nothing here executes a
+    kernel either: a library that compiles is not a library that computes the
+    right answer. *)
 
 let read_file f =
   try
@@ -30,34 +56,105 @@ let write_file f s =
   output_string oc s ;
   close_out oc
 
-(** [-fpreserve-invariance] is NOT passed: the backend's contraction defence is
-    the [#pragma METAL fp contract(off)] inside the source (see the
-    metal_contraction_pragma group in test_codegen_golden.ml), and adding a
-    command-line flag here would validate a compile the project never performs.
-    Everything else mirrors a plain AIR compile of one translation unit. *)
-let cmd_for src obj err =
-  Printf.sprintf
-    "xcrun -sdk macosx metal -x metal -std=metal3.0 -c %s -o %s >%s 2>&1"
-    (Filename.quote src)
-    (Filename.quote obj)
-    (Filename.quote err)
+(* The driver, embedded rather than kept as a file under tools/probes and looked
+   up at run time. A relative-path lookup would depend on dune's sandbox cwd and
+   would degrade into "source not found -> skip" the first time that moved,
+   reintroducing the silent skip by the back door. Embedded, the layer either
+   builds or reports why. *)
+let driver_source =
+  {objc|
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <stdio.h>
+
+int main(int argc, const char **argv) {
+  @autoreleasepool {
+    if (argc != 2) { fprintf(stderr, "usage: %s <file.metal>\n", argv[0]); return 2; }
+    NSError *err = nil;
+    NSString *path = [NSString stringWithUTF8String:argv[1]];
+    NSString *src = [NSString stringWithContentsOfFile:path
+                                              encoding:NSUTF8StringEncoding
+                                                 error:&err];
+    if (src == nil) {
+      fprintf(stderr, "cannot read %s: %s\n", argv[1],
+              err ? [[err localizedDescription] UTF8String] : "?");
+      return 2;
+    }
+    id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
+    if (dev == nil) { fprintf(stderr, "no Metal device\n"); return 2; }
+    /* Defaults on purpose: the contraction defence is the #pragma inside the
+       source (metal_contraction_pragma group), not a compile option. Setting
+       anything here would validate a compile Sarek never performs. */
+    MTLCompileOptions *opts = [MTLCompileOptions new];
+    err = nil;
+    id<MTLLibrary> lib = [dev newLibraryWithSource:src options:opts error:&err];
+    if (lib == nil) {
+      fprintf(stderr, "%s\n",
+              err ? [[err localizedDescription] UTF8String]
+                  : "newLibraryWithSource failed with no error object");
+      return 1;
+    }
+    return 0;
+  }
+}
+|objc}
+
+(* Built once per process. [Error] carries the reason the layer is unusable. *)
+let driver : (string, string) result Lazy.t =
+  lazy
+    (if Sys.command "uname -s | grep -q Darwin" <> 0 then
+       Error
+         "not macOS — the Metal driver (newLibraryWithSource:) exists only \
+          there, so no Metal source can be compiled on this machine"
+     else begin
+       let dir = Filename.temp_file "sarek_metal_drv_" "" in
+       (try Sys.remove dir with _ -> ()) ;
+       (try Unix.mkdir dir 0o700 with _ -> ()) ;
+       let src = Filename.concat dir "probe.m" in
+       let exe = Filename.concat dir "probe" in
+       let log = Filename.concat dir "build.log" in
+       write_file src driver_source ;
+       let rc =
+         Unix.system
+           (Printf.sprintf
+              "clang -fobjc-arc -O1 -framework Foundation -framework Metal %s \
+               -o %s >%s 2>&1"
+              (Filename.quote src)
+              (Filename.quote exe)
+              (Filename.quote log))
+       in
+       match rc with
+       | Unix.WEXITED 0 -> Ok exe
+       | _ ->
+           Error
+             ("could not build the Metal compile driver (clang -framework \
+               Metal): " ^ read_file log)
+     end)
 
 let run_metal (source : string) : (unit, string) result =
-  let base = Filename.temp_file "sarek_gate_metal_" "" in
-  let src = base ^ ".metal" in
-  let obj = base ^ ".air" in
-  let err = base ^ ".err" in
-  write_file src source ;
-  let rc = Unix.system (cmd_for src obj err) in
-  let out = read_file err in
-  List.iter (fun f -> try Sys.remove f with _ -> ()) [src; obj; err; base] ;
-  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+  match Lazy.force driver with
+  | Error e -> Error e
+  | Ok exe -> (
+      let base = Filename.temp_file "sarek_gate_metal_" "" in
+      let src = base ^ ".metal" in
+      let err = base ^ ".err" in
+      write_file src source ;
+      let rc =
+        Unix.system
+          (Printf.sprintf
+             "%s %s >%s 2>&1"
+             (Filename.quote exe)
+             (Filename.quote src)
+             (Filename.quote err))
+      in
+      let out = read_file err in
+      List.iter (fun f -> try Sys.remove f with _ -> ()) [src; err; base] ;
+      match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out)
 
-(** Availability is a POSITIVE CONTROL, not [command -v xcrun]: [xcrun] exists
-    on any macOS with the Command Line Tools, and answers "tool 'metal' not
-    found" when the full Xcode/Metal toolchain is absent. "Available" here means
-    "has just compiled something". Mirrors {!Opencl_gate.Opencl_clang} and
-    ci/assert-toolchain.sh. *)
+(** Availability is a POSITIVE CONTROL, not a [uname] test: a macOS without the
+    Command Line Tools has no [clang], and a headless or virtualised host can
+    have clang and no Metal device. "Available" here means "has just compiled a
+    kernel". Mirrors {!Opencl_gate.Opencl_clang} and ci/assert-toolchain.sh. *)
 let probe =
   "#include <metal_stdlib>\n\
    using namespace metal;\n\
@@ -68,15 +165,9 @@ let probe =
 
 let unavailable_reason : string option Lazy.t =
   lazy
-    (match Unix.system "command -v xcrun >/dev/null 2>&1" with
-    | Unix.WEXITED 0 -> (
-        match run_metal probe with
-        | Ok () -> None
-        | Error e ->
-            Some
-              ("xcrun is on PATH but the Metal compiler rejected the probe \
-                kernel (no Xcode Metal toolchain?): " ^ e))
-    | _ -> Some "xcrun not on PATH (Metal compiles on macOS only)")
+    (match run_metal probe with
+    | Ok () -> None
+    | Error e -> Some ("Metal source compilation is unavailable here: " ^ e))
 
 let available () = Lazy.force unavailable_reason = None
 

--- a/sarek/tests/codegen_golden/opencl_gate/opencl_clang.ml
+++ b/sarek/tests/codegen_golden/opencl_gate/opencl_clang.ml
@@ -28,14 +28,34 @@ let write_file f s =
   output_string oc s ;
   close_out oc
 
+(** fp64 SUPPRESSION SWITCH (#140). With [SAREK_OPENCL_GATE_NO_FP64=1] every
+    invocation below gains [-cl-ext=-cl_khr_fp64], which makes this clang refuse
+    [double] with
+
+    {v error: use of type 'double' requires cl_khr_fp64 support v}
+
+    — byte-for-byte the diagnostic Apple clang 17 produces on an M4, where the
+    extension is simply absent from the target. It is a faithful emulation of
+    the toolchain that exposed the split verdict, not a mock of the check: the
+    probe and the corpus go through the same compiler with the same flag, so "no
+    fp64" is established by compiling, exactly as on the real machine.
+
+    That is what makes the skip path below provable on a machine that HAS fp64.
+*)
+let no_fp64_flag =
+  match Sys.getenv_opt "SAREK_OPENCL_GATE_NO_FP64" with
+  | Some ("1" | "true" | "yes") -> " -Xclang -cl-ext=-cl_khr_fp64"
+  | _ -> ""
+
 (** The invocation. [-cl-std=CL1.2] is the language level Sarek's OpenCL backend
     targets; [-finclude-default-header] supplies the OpenCL builtin declarations
     ([get_global_id], [sqrt], ...) that a real ICD injects, without which every
     kernel would fail on builtins rather than on its own defects. *)
 let cmd_for src err =
   Printf.sprintf
-    "clang -x cl -cl-std=CL1.2 -Xclang -finclude-default-header -fsyntax-only \
-     %s >%s 2>&1"
+    "clang -x cl -cl-std=CL1.2 -Xclang -finclude-default-header%s \
+     -fsyntax-only %s >%s 2>&1"
+    no_fp64_flag
     (Filename.quote src)
     (Filename.quote err)
 
@@ -72,3 +92,53 @@ let available () = Lazy.force unavailable_reason = None
 
 let why_unavailable () =
   match Lazy.force unavailable_reason with Some r -> r | None -> ""
+
+(** {1 fp64 capability (#140)}
+
+    THE DEFECT THIS EXISTS FOR. On an Apple M4 the sweep reported two verdicts
+    for one missing capability: [float64_abs_float_path] and
+    [float64_copysign_path] SKIPPED while five other float64 cases FAILED. The
+    real answer was worse than "one path forgot to check": NEITHER path checked.
+    The two that skipped did so for an unrelated hardcoded exclusion (an
+    unmapped [Float64.abs_float] intrinsic that dies at codegen) and would have
+    skipped on a machine with full fp64 too; the five that failed simply ran and
+    hit the toolchain wall. There was no fp64 predicate anywhere in the gate.
+
+    WHAT THE CAPABILITY ACTUALLY IS, here. It is NOT the device's [cl_khr_fp64]
+    — this gate deliberately never touches a device (see the header). The
+    subject is host clang, and Apple clang targeting [arm64-apple-darwin] does
+    not list [cl_khr_fp64] among the extensions that target supports, so
+    [double] is an error in [-x cl] mode regardless of the
+    [#pragma OPENCL EXTENSION cl_khr_fp64 : enable] the production path emits.
+    On the Linux reference machine the same clang invocation accepts it. So the
+    honest predicate is "can THIS clang compile a double kernel", and it is
+    established the same way availability is: by compiling one.
+
+    Established by a POSITIVE CONTROL, like [available] above: the smallest
+    kernel that uses [double]. [SAREK_OPENCL_GATE_NO_FP64=1] (see
+    [no_fp64_flag]) takes the extension away from the compiler itself, so this
+    probe fails for the real reason and the skip path can be driven — and
+    observed — on a machine that does have fp64. A skip nobody has watched
+    happen is not a skip anybody should trust. *)
+let fp64_probe =
+  "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\
+   __kernel void probe64(__global double *o) { o[get_global_id(0)] = 1.0; }\n"
+
+let no_fp64_reason : string option Lazy.t =
+  lazy
+    (match Lazy.force unavailable_reason with
+    | Some r -> Some ("clang itself is unusable: " ^ r)
+    | None -> (
+        match run_clang fp64_probe with
+        | Ok () -> None
+        | Error e ->
+            Some
+              ("this clang cannot compile an OpenCL kernel using `double` (the \
+                target does not support cl_khr_fp64): " ^ e)))
+
+(** [true] iff the clang this gate drives can compile a [double] OpenCL kernel.
+    The single authority for every float64 case in the sweep. *)
+let fp64_available () = Lazy.force no_fp64_reason = None
+
+let why_no_fp64 () =
+  match Lazy.force no_fp64_reason with Some r -> r | None -> ""

--- a/sarek/tests/codegen_golden/opencl_gate/opencl_clang.ml
+++ b/sarek/tests/codegen_golden/opencl_gate/opencl_clang.ml
@@ -124,17 +124,42 @@ let fp64_probe =
   "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\
    __kernel void probe64(__global double *o) { o[get_global_id(0)] = 1.0; }\n"
 
+(** The fp64 probe's RAW compiler output, kept separate from any wording of
+    ours.
+
+    THE COMPOSED REASON BELOW MUST NOT NAME [cl_khr_fp64], and this split is
+    why. An earlier version wrapped the diagnostic in "(the target does not
+    support cl_khr_fp64)" — so the composed string contained that token whenever
+    the probe failed, {e for any reason at all}. The negative control then
+    asserted "the reason names cl_khr_fp64" against that composed string and was
+    checking our own printf, not clang's behaviour: a probe broken by an
+    unrelated syntax error would have satisfied it. That is a check that cannot
+    fail, which is precisely what this gate exists to rule out.
+
+    So the token is asserted against THIS value, which only clang can put there.
+    [None] when fp64 works, or when clang is unusable for a reason that has
+    nothing to do with fp64. *)
+let no_fp64_diagnostic : string option Lazy.t =
+  lazy
+    (match Lazy.force unavailable_reason with
+    | Some _ -> None
+    | None -> (
+        match run_clang fp64_probe with Ok () -> None | Error e -> Some e))
+
 let no_fp64_reason : string option Lazy.t =
   lazy
     (match Lazy.force unavailable_reason with
     | Some r -> Some ("clang itself is unusable: " ^ r)
     | None -> (
-        match run_clang fp64_probe with
-        | Ok () -> None
-        | Error e ->
+        match Lazy.force no_fp64_diagnostic with
+        | None -> None
+        | Some e ->
+            (* States only what was observed — that this clang rejected a
+               `double` kernel — and then hands over the compiler's own words.
+               No claim about WHY is manufactured here. *)
             Some
-              ("this clang cannot compile an OpenCL kernel using `double` (the \
-                target does not support cl_khr_fp64): " ^ e)))
+              ("this clang cannot compile an OpenCL kernel using `double`: " ^ e)
+        ))
 
 (** [true] iff the clang this gate drives can compile a [double] OpenCL kernel.
     The single authority for every float64 case in the sweep. *)
@@ -142,3 +167,8 @@ let fp64_available () = Lazy.force no_fp64_reason = None
 
 let why_no_fp64 () =
   match Lazy.force no_fp64_reason with Some r -> r | None -> ""
+
+(** The unedited compiler diagnostic from the fp64 probe, or [""]. Assert
+    against this, never against {!why_no_fp64}. *)
+let fp64_diagnostic () =
+  match Lazy.force no_fp64_diagnostic with Some e -> e | None -> ""

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -885,8 +885,8 @@ let () =
     \  float x;\n\
     \  float y;\n\
      } Point2;\n\n\
-     kernel void record_kernel(constant Point2* &pts [[buffer(0)]], constant \
-     int &sarek_pts_length [[buffer(1)]],\n\
+     kernel void record_kernel(device Point2* pts [[buffer(0)]], constant int \
+     &sarek_pts_length [[buffer(1)]],\n\
      uint3 __metal_gid [[thread_position_in_grid]],\n\
      uint3 __metal_tid [[thread_position_in_threadgroup]],\n\
      uint3 __metal_bid [[threadgroup_position_in_grid]],\n\
@@ -922,7 +922,7 @@ let () =
     \  return r;\n\
      }\n\n\
      kernel void variant_kernel(device int* flags [[buffer(0)]], constant int \
-     &sarek_flags_length [[buffer(1)]], constant Opt* &out [[buffer(2)]], \
+     &sarek_flags_length [[buffer(1)]], device Opt* out [[buffer(2)]], \
      constant int &sarek_out_length [[buffer(3)]],\n\
      uint3 __metal_gid [[thread_position_in_grid]],\n\
      uint3 __metal_tid [[thread_position_in_threadgroup]],\n\
@@ -2156,8 +2156,6 @@ let tool_available cmd =
 
 let glslang_available = lazy (tool_available "glslangValidator")
 
-let naga_available = lazy (tool_available "naga")
-
 let read_file f =
   try
     let ic = open_in f in
@@ -2209,6 +2207,46 @@ let naga_ok wgsl =
   let out = read_file err in
   List.iter (fun f -> try Sys.remove f with _ -> ()) [src; err; base] ;
   match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+(* naga availability is a POSITIVE CONTROL, not `command -v` (#132).
+
+   `command -v` answers a question nobody asked. A naga on PATH that cannot
+   validate anything — wrong version, missing shared library, a shim — reports
+   available, and then every case FAILS for a reason that has nothing to do with
+   the shader. Worse in the other direction: when naga is genuinely absent this
+   sweep is the ONLY executable check WGSL has anywhere, so a quiet skip returns
+   the whole backend to unvalidated with a one-line note in a log nobody reads.
+   That is how the WGSL match emitter went uncovered long enough to accumulate
+   two defects (see wgsl_validation_only_kernels above).
+
+   So: probe by validating the smallest well-formed compute module, exactly as
+   Opencl_clang does, and make the skip state its reason. ci/assert-toolchain.sh
+   is what turns a missing naga into a CI FAILURE rather than a skip — the skip
+   stays correct behaviour on a developer machine and is never the normal
+   outcome in CI. *)
+let naga_probe =
+  "@group(0) @binding(0) var<storage, read_write> o : array<i32>;\n\
+  \   @compute @workgroup_size(1)\n\
+  \   fn main(@builtin(global_invocation_id) gid : vec3<u32>) {\n\
+  \    o[gid.x] = 1;\n\
+  \   }\n"
+
+let naga_unavailable_reason : string option Lazy.t =
+  lazy
+    (if not (tool_available "naga") then
+       Some
+         "naga is not on PATH — WGSL then has NO executable validation \
+          anywhere in this repository (ci/assert-toolchain.sh fails CI for \
+          this)"
+     else
+       match naga_ok naga_probe with
+       | Ok () -> None
+       | Error e ->
+           Some
+             ("naga is on PATH but could not validate a trivial compute \
+               module, so it can prove nothing about ours: " ^ e))
+
+let naga_available = lazy (Lazy.force naga_unavailable_reason = None)
 
 (** Per-case exclusions from the validation sweep, each with a cited reason. A
     golden here is still byte-exact-checked above; it is only skipped by the
@@ -2314,7 +2352,74 @@ let glsl_validation_tests () =
                       glsl)))
     (test_kernels () @ glsl_only_kernels ())
 
-(** WGSL corpus = cross-backend kernels + WGSL-only kernels. *)
+(** Kernels that exist only to be run through the WGSL validator, and carry no
+    golden — same discipline as {!opencl_validation_only_kernels} below.
+
+    WHY THIS EXISTS (#132). The sweep corpus had no multi-field variant payload
+    and, worse, no [SMatch] at all: [variant_kernel] only CONSTRUCTS variants
+    (an [SIf] over [EVariant]) and never matches on one. So every accessor and
+    every [switch] the WGSL match emitter can produce was unreachable from any
+    executable gate, and the only coverage of that emitter anywhere was a string
+    comparison in test_ematch_payload_binding.ml. Two separate WGSL defects hid
+    behind that hole; both are named on the arms below. *)
+let wgsl_validation_only_kernels () =
+  (* Pair = MkOne of f32 | MkPair of f32 * f32, matched with SMatch and NO
+     wildcard arm.
+
+     Defect 1 (the one #132 was filed for, and which PR #306 had already
+     closed): the flat struct declares [MkPair_v_0] / [MkPair_v_1] while the
+     accessor used to spell [.MkPair_v._0] — naga: "invalid field accessor
+     'MkPair_v'". Both sites now go through
+     [Sarek_ir_codegen.wgsl_payload_layout], so this arm is the regression check
+     rather than the reproduction.
+
+     Defect 2 (still live when this case was added, fixed in the same commit):
+     the match is exhaustive over the constructors and therefore carries no
+     [PWild] arm, and the emitter only wrote [default:] when it saw one. WGSL
+     requires every [switch] to have exactly one default clause — naga:
+     "missing default case". The C family sidesteps this because C [switch]
+     needs no default, and GLSL likewise, so WGSL is the odd one out here too.
+
+     Both need a multi-payload constructor AND a real match, which is exactly
+     what nothing in the corpus had. *)
+  let pair_constrs =
+    [("MkOne", [TFloat32]); ("MkPair", [TFloat32; TFloat32])]
+  in
+  let pair_ty = TVariant ("Pair", pair_constrs) in
+  let ps = make_var "ps" (TVec pair_ty) in
+  let out = make_var "out" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let a = make_var "a" TFloat32 in
+  let b = make_var "b" TFloat32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SMatch
+          ( EArrayRead ("ps", EVar idx),
+            [
+              ( PConstr ("MkOne", ["a"]),
+                SAssign (LArrayElem ("out", EVar idx), EVar a) );
+              ( PConstr ("MkPair", ["a"; "b"]),
+                SAssign
+                  (LArrayElem ("out", EVar idx), EBinop (Add, EVar a, EVar b))
+              );
+            ] ) )
+  in
+  let k =
+    empty_kernel
+      "smatch_multi_payload"
+      [
+        DParam (ps, None);
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ]
+      []
+      body
+  in
+  [("smatch_multi_payload", {k with kern_variants = [("Pair", pair_constrs)]})]
+
+(** WGSL corpus = cross-backend kernels + WGSL-only kernels + validation-only
+    kernels. *)
 let wgsl_validation_tests () =
   List.map
     (fun (kernel_name, k) ->
@@ -2333,7 +2438,12 @@ let wgsl_validation_tests () =
               Gen_wgsl.reset_state () ;
               let wgsl = Gen_wgsl.generate_with_types ~types:k.kern_types k in
               if not (Lazy.force naga_available) then begin
-                Printf.printf "  SKIP: naga not on PATH\n%!" ;
+                Printf.printf
+                  "  SKIP: %s — %s\n%!"
+                  kernel_name
+                  (Option.value
+                     (Lazy.force naga_unavailable_reason)
+                     ~default:"") ;
                 Alcotest.skip ()
               end
               else
@@ -2345,7 +2455,7 @@ let wgsl_validation_tests () =
                       kernel_name
                       e
                       wgsl)))
-    (test_kernels () @ wgsl_only_kernels ())
+    (test_kernels () @ wgsl_only_kernels () @ wgsl_validation_only_kernels ())
 
 (** {1 OpenCL validation sweep (#128)}
 
@@ -2453,6 +2563,29 @@ let opencl_validation_tests () =
         (Printf.sprintf "opencl-validate/%s" kernel_name)
         `Quick
         (fun () ->
+          (* CAPABILITY FIRST, exclusions second (#140).
+
+             The order is the fix. Previously the exclusion list was consulted
+             first and nothing consulted fp64 at all, so on a toolchain without
+             it the seven float64 cases in this corpus split into two SKIPs (for
+             an unrelated reason that happened to cover two of them) and five
+             FAILs — one missing capability, two verdicts, and no way to tell
+             from the output which was the real story.
+
+             Asking the capability first makes all seven report the same thing
+             for the same reason when it is absent, and lets the exclusions go
+             back to meaning only what they say: a documented codegen gap,
+             reported wherever fp64 is present. *)
+          if
+            Sarek_ir_analysis.kernel_uses_float64 k
+            && not (Opencl_clang.fp64_available ())
+          then begin
+            Printf.printf
+              "  SKIP (no fp64): opencl/%s — %s\n%!"
+              kernel_name
+              (Opencl_clang.why_no_fp64 ()) ;
+            Alcotest.skip ()
+          end ;
           match excluded "opencl" kernel_name with
           | Some reason ->
               Printf.printf
@@ -2528,6 +2661,99 @@ let opencl_validation_tests () =
                           usrc)
               end))
     (test_kernels () @ glsl_only_kernels () @ opencl_validation_only_kernels ())
+
+(** {1 Metal validation sweep (#139)}
+
+    Metal was the LAST backend with committed goldens and no validator, and it
+    cost exactly what that costs: [record_kernel] and [variant_kernel] had been
+    emitting [constant T* &v] — a reference to a pointer whose pointee has no
+    address space, which Metal rejects outright — and nothing in the project
+    could see it. It was found by running on an Apple M4 (macOS 15.6.1, Apple
+    clang 17), and confirmed pre-existing there against a control with the
+    contraction pragma stripped.
+
+    Two layers, and the split matters more here than anywhere else:
+
+    + {b address space} ({!Metal_gate.Metal_addrspace}) — pure text, no
+      toolchain, so it runs on the Linux machines where this code is written and
+      where the defect was introduced. Covers the class above.
+    + {b compile} ({!Metal_gate.Metal_compile}) — [xcrun metal]. macOS only.
+      Everything a signature check cannot see (bodies, struct layout, intrinsic
+      names) lives here, and on Linux nothing covers it. Its skip says so.
+
+    A green run on Linux therefore means "the signatures are well-formed", not
+    "our Metal is valid" — which is a smaller claim than the other three sweeps
+    make, deliberately stated. *)
+
+module Metal_addrspace = Metal_gate.Metal_addrspace
+module Metal_compile = Metal_gate.Metal_compile
+
+let metal_validation_corpus () = test_kernels () @ metal_only_kernels ()
+
+let metal_validation_tests () =
+  List.map
+    (fun (kernel_name, k) ->
+      Alcotest.test_case
+        (Printf.sprintf "metal-validate/%s" kernel_name)
+        `Quick
+        (fun () ->
+          match excluded "metal" kernel_name with
+          | Some reason ->
+              Printf.printf
+                "  SKIP (excluded): metal/%s — %s\n%!"
+                kernel_name
+                reason ;
+              Alcotest.skip ()
+          | None ->
+              Gen_metal.reset_state () ;
+              let src = Gen_metal.generate_with_types ~types:k.kern_types k in
+              (* Layer 1 — always runs, needs no external tool. *)
+              (match Metal_addrspace.offences src with
+              | [] -> ()
+              | os ->
+                  Alcotest.failf
+                    "generated Metal for %s has parameters Metal's \
+                     address-space rules reject:\n\
+                     %s\n\
+                     --- source ---\n\
+                     %s"
+                    kernel_name
+                    (String.concat "\n" (List.map Metal_addrspace.describe os))
+                    src) ;
+              if not (Metal_compile.available ()) then
+                Printf.printf
+                  "  metal address-space OK: %s (compile layer SKIPPED: %s)\n%!"
+                  kernel_name
+                  (Metal_compile.why_unavailable ())
+              else begin
+                (* Layer 2 — the kernel as we ship it. *)
+                match Metal_compile.run_metal src with
+                | Ok () -> Printf.printf "  metal OK: %s\n%!" kernel_name
+                | Error e ->
+                    Alcotest.failf
+                      "the Metal compiler rejected generated metal/%s:\n\
+                       %s\n\
+                       --- source ---\n\
+                       %s"
+                      kernel_name
+                      e
+                      src
+              end))
+    (metal_validation_corpus ())
+
+(* ANTI-VACUITY CONTROL. The sweep above asserts nothing if its corpus is empty,
+   which is what happens the day a fixture list is renamed. Same reason the
+   contraction-pragma group carries one. *)
+let metal_validation_coverage () =
+  Alcotest.test_case
+    "the metal sweep inspects a non-empty corpus"
+    `Quick
+    (fun () ->
+      let n = List.length (metal_validation_corpus ()) in
+      if n = 0 then
+        Alcotest.fail
+          "the Metal validation corpus is empty, so every metal-validate case \
+           above asserted nothing")
 
 (* The Metal contraction defence, pinned separately from the byte-exact goldens.
 
@@ -2610,6 +2836,8 @@ let () =
         ("glsl_validation_sweep", glsl_validation_tests ());
         ("wgsl_validation_sweep", wgsl_validation_tests ());
         ("opencl_validation_sweep", opencl_validation_tests ());
+        ( "metal_validation_sweep",
+          metal_validation_coverage () :: metal_validation_tests () );
         ( "metal_contraction_pragma",
           metal_contraction_pragma_coverage ()
           :: metal_contraction_pragma_tests () );

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -484,6 +484,84 @@ let test_determinism () =
   let b = gen k in
   Alcotest.(check string) "two generations agree" a b
 
+(* ---------------------------------------------------------------------------
+   #138: one measured claim, one copy of it.
+
+   OpenCL and GLSL each refuse f16 in TWO places — the per-element-type arm of
+   [<backend>_type_of_elttype] and the whole-kernel [reject_float16_kernel] —
+   and each had its own copy of the sentence. Those sentences are not prose:
+   they carry the MEASUREMENT that justifies the refusal (620/63488 on OpenCL
+   via rusticl, 2912-5075/63488 on GLSL via RADV, both ACO), and a measurement
+   stated twice is a measurement that will eventually be stated two ways.
+
+   It already had been. Before this change the OpenCL pair read:
+
+     elttype arm: "OpenCL: float16 is not supported — not because the codegen
+                   is missing, but because rusticl/radeonsi fuses ..."
+     kernel arm:  "OpenCL: float16 is refused by measurement, not pending
+                   implementation — rusticl/radeonsi fuses ..."
+
+   Same defect, same numbers, two different openings — and only one of them is
+   the wording the docs and this file's [reason_opencl] pin. That is the drift
+   the shared constant removes, and this case is what would have caught it.
+
+   It also guards the direction that matters next: when one backend's fusion is
+   fixed upstream and its refusal is lifted, a single constant makes every
+   remaining reference obviously stale, whereas duplicates just rot. *)
+
+let reason_of_exn name f =
+  match f () with
+  | (_ : string) ->
+      Alcotest.failf "%s: expected an f16 refusal, but it succeeded" name
+  | exception
+      Sarek_backend_error.Backend_error.Backend_error
+        (Sarek_backend_error.Backend_error.Codegen
+           {
+             backend = _;
+             error =
+               Sarek_backend_error.Backend_error.Unsupported_construct
+                 {construct = _; reason};
+           }) ->
+      reason
+  | exception e ->
+      Alcotest.failf
+        "%s: wrong exception (expected Codegen): %s"
+        name
+        (Printexc.to_string e)
+
+(* Both refusal sites of one backend must produce the SAME string. Compared
+   exactly, and compared against the constant the docs cite, so neither site can
+   drift and neither can drift *together* away from [reason_opencl] /
+   [reason_glsl] above. *)
+let check_one_refusal_text ~backend ~expected ~from_elttype ~from_kernel =
+  let a = reason_of_exn (backend ^ "/elttype arm") from_elttype in
+  let b = reason_of_exn (backend ^ "/kernel arm") from_kernel in
+  Alcotest.(check string)
+    (backend
+   ^ ": the per-element-type arm and the whole-kernel arm state the SAME \
+      measured reason")
+    b
+    a ;
+  Alcotest.(check string)
+    (backend ^ ": that reason is the one the docs and goldens pin")
+    expected
+    a
+
+let test_f16_refusal_text_is_single_sourced () =
+  let k = f16_scale_kernel () in
+  check_one_refusal_text
+    ~backend:"OpenCL"
+    ~expected:reason_opencl
+    ~from_elttype:(fun () ->
+      Sarek_codegen.Sarek_ir_opencl.opencl_type_of_elttype TFloat16)
+    ~from_kernel:(fun () -> Sarek_codegen.Sarek_ir_opencl.generate k) ;
+  check_one_refusal_text
+    ~backend:"GLSL"
+    ~expected:reason_glsl
+    ~from_elttype:(fun () ->
+      Sarek_codegen.Sarek_ir_glsl.glsl_type_of_elttype TFloat16)
+    ~from_kernel:(fun () -> Sarek_codegen.Sarek_ir_glsl.generate k)
+
 let () =
   Alcotest.run
     "cuda_f16_golden"
@@ -522,5 +600,9 @@ let () =
             "opencl/glsl/metal/wgsl still accept f32"
             `Quick
             test_deferred_backends_still_accept_f32;
+          Alcotest.test_case
+            "each backend's f16 refusal text has exactly one source (#138)"
+            `Quick
+            test_f16_refusal_text_is_single_sourced;
         ] );
     ]

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -138,4 +138,4 @@
 
 (test
  (name test_metal_gate)
- (libraries metal_gate alcotest))
+ (libraries metal_gate alcotest str))

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -129,4 +129,13 @@
 
 (test
  (name test_opencl_gate)
- (libraries sarek.codegen spoc.ir opencl_gate alcotest str))
+ (libraries sarek.codegen spoc.ir opencl_gate alcotest str unix))
+
+; Negative controls for the Metal validation gate (#139). Layer 2 (xcrun metal)
+; cannot run outside macOS, so layer 1 (address-space text check) is the only
+; cover on the machines this code is written on — these cases are the proof it
+; can go red, driven from the pre-fix golden verbatim. CPU-only, no device.
+
+(test
+ (name test_metal_gate)
+ (libraries metal_gate alcotest))

--- a/sarek/tests/unit/test_metal_gate.ml
+++ b/sarek/tests/unit/test_metal_gate.ml
@@ -145,6 +145,70 @@ let test_compile_layer_states_its_availability () =
       true
       (String.length (Compile.why_unavailable ()) > 0)
 
+(* Layer 2's own red path.
+
+   The sweep runs layer 1 first, and layer 1 raises, so on a Mac the compile
+   layer is only ever observed SUCCEEDING. A gate that has only ever been seen
+   passing is the thing this file exists to rule out — so drive it red directly,
+   with a defect layer 1 is structurally incapable of seeing.
+
+   The kernel below has a perfectly well-formed signature (layer 1 is silent on
+   it) and an undeclared identifier in the BODY. That asymmetry is the argument
+   for keeping both layers: layer 1 covers the address-space class from Linux,
+   layer 2 covers everything else and only on macOS. *)
+let body_defect_kernel =
+  "#include <metal_stdlib>\n\
+   using namespace metal;\n\
+   kernel void k(device float* a [[buffer(0)]],\n\
+   uint3 gid [[thread_position_in_grid]]) {\n\
+  \  a[gid.x] = no_such_identifier_here;\n\
+   }\n"
+
+let test_compile_layer_goes_red_on_a_body_defect () =
+  if not (Compile.available ()) then begin
+    Printf.printf "  SKIP: %s\n%!" (Compile.why_unavailable ()) ;
+    Alcotest.skip ()
+  end
+  else begin
+    (* Positive control first, so a red result below is attributable to the
+       kernel and not to a driver that rejects everything. *)
+    (match Compile.run_metal Compile.probe with
+    | Ok () -> ()
+    | Error e ->
+        Alcotest.failf
+          "the Metal driver rejected its own probe kernel, so nothing it says \
+           about ours means anything:\n\
+           %s"
+          e) ;
+    (* Layer 1 must be SILENT here — otherwise this case would be proving layer
+       1 again rather than layer 2. *)
+    (match Addr.offences body_defect_kernel with
+    | [] -> ()
+    | os ->
+        Alcotest.failf
+          "layer 1 fired on the body-defect kernel, so this case no longer \
+           isolates layer 2:\n\
+           %s"
+          (String.concat "\n" (List.map Addr.describe os))) ;
+    match Compile.run_metal body_defect_kernel with
+    | Ok () ->
+        Alcotest.fail
+          "the Metal driver ACCEPTED a kernel using an undeclared identifier. \
+           Layer 2 is not compiling what it is given."
+    | Error e ->
+        Alcotest.(check bool)
+          "the failure names the undeclared identifier"
+          true
+          (try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string "no_such_identifier_here")
+                  e
+                  0) ;
+             true
+           with Not_found -> false)
+  end
+
 let () =
   Alcotest.run
     "metal_gate"
@@ -178,5 +242,9 @@ let () =
             "availability is stated, never silent"
             `Quick
             test_compile_layer_states_its_availability;
+          Alcotest.test_case
+            "red on a body defect layer 1 cannot see"
+            `Quick
+            test_compile_layer_goes_red_on_a_body_defect;
         ] );
     ]

--- a/sarek/tests/unit/test_metal_gate.ml
+++ b/sarek/tests/unit/test_metal_gate.ml
@@ -1,0 +1,182 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Negative controls for the Metal validation gate (#139).
+
+    The metal_validation_sweep in test_codegen_golden.ml is the gate; this file
+    is the proof that the gate can go red, and it matters more here than for the
+    other backends: layer 2 ([xcrun metal]) cannot run on Linux at all, so layer
+    1 is the only thing standing between this project and another year of
+    committed Metal that has never compiled. A check that has never been
+    observed failing is not evidence of anything.
+
+    The first case below is the ACTUAL committed golden from before the fix,
+    pasted verbatim. It is the string an Apple M4 (macOS 15.6.1, Apple clang 17)
+    refused, and it is here so the detector stays pinned to the real defect
+    rather than to a synthetic approximation of it. *)
+
+module Addr = Metal_gate.Metal_addrspace
+module Compile = Metal_gate.Metal_compile
+
+(* The record_kernel golden as it stood before #139 was fixed. Apple clang 17
+   rejected it; so must layer 1. *)
+let historical_record_kernel =
+  "#include <metal_stdlib>\n\
+   using namespace metal;\n\
+   #pragma METAL fp contract(off)\n\n\
+   typedef struct {\n\
+  \  float x;\n\
+  \  float y;\n\
+   } Point2;\n\n\
+   kernel void record_kernel(constant Point2* &pts [[buffer(0)]], constant int \
+   &sarek_pts_length [[buffer(1)]],\n\
+   uint3 __metal_gid [[thread_position_in_grid]]) {\n\
+  \  int idx = __metal_gid.x;\n\
+  \  Point2 p = pts[idx];\n\
+   }\n"
+
+(* The same kernel with the fix applied: `device T*`, no reference. *)
+let fixed_record_kernel =
+  "#include <metal_stdlib>\n\
+   using namespace metal;\n\
+   #pragma METAL fp contract(off)\n\n\
+   typedef struct {\n\
+  \  float x;\n\
+  \  float y;\n\
+   } Point2;\n\n\
+   kernel void record_kernel(device Point2* pts [[buffer(0)]], constant int \
+   &sarek_pts_length [[buffer(1)]],\n\
+   uint3 __metal_gid [[thread_position_in_grid]]) {\n\
+  \  int idx = __metal_gid.x;\n\
+  \  Point2 p = pts[idx];\n\
+   }\n"
+
+let test_historical_defect_is_red () =
+  match Addr.offences historical_record_kernel with
+  | [] ->
+      Alcotest.fail
+        "layer 1 accepted `constant Point2* &pts`, the exact parameter an \
+         Apple M4 refused and the reason #139 exists. The gate is not a gate."
+  | [o] ->
+      Alcotest.(check bool)
+        "names the offending parameter"
+        true
+        (o.Addr.param = "constant Point2* &pts [[buffer(0)]]")
+  | os ->
+      Alcotest.failf
+        "expected exactly one offence, got %d:\n%s"
+        (List.length os)
+        (String.concat "\n" (List.map Addr.describe os))
+
+let test_fixed_shape_is_green () =
+  match Addr.offences fixed_record_kernel with
+  | [] -> ()
+  | os ->
+      Alcotest.failf
+        "layer 1 rejected the FIXED signature, so it would block the fix it \
+         exists to force:\n\
+         %s"
+        (String.concat "\n" (List.map Addr.describe os))
+
+(* A pointer with no address space at all — the other half of MSL 3.2 §4.2.
+   Sarek does not currently emit this shape; the control is here so that if a
+   future arm does, the gate says so instead of shrugging. *)
+let test_unqualified_pointer_is_red () =
+  let src =
+    "#include <metal_stdlib>\n\
+     kernel void k(float* a [[buffer(0)]],\n\
+     uint3 gid [[thread_position_in_grid]]) { a[gid.x] = 1.0f; }\n"
+  in
+  match Addr.offences src with
+  | [] ->
+      Alcotest.fail
+        "layer 1 accepted `float* a` with no address space; Metal has no \
+         default address space (MSL 3.2 §4.2)."
+  | _ -> ()
+
+(* Scalars and thread-position builtins must NOT trip the check: `constant int
+   &n` is a reference to a scalar, which is the correct Metal spelling, and
+   `uint3 gid` is not a pointer. A gate that fires on those is noise and would
+   be turned off. *)
+let test_scalar_and_builtin_params_are_green () =
+  let src =
+    "#include <metal_stdlib>\n\
+     kernel void k(device float* a [[buffer(0)]], constant int &n [[buffer(1)]],\n\
+     threadgroup float* scratch [[threadgroup(0)]],\n\
+     uint3 gid [[thread_position_in_grid]]) { a[gid.x] = float(n); }\n"
+  in
+  match Addr.offences src with
+  | [] -> ()
+  | os ->
+      Alcotest.failf
+        "layer 1 fired on well-formed Metal parameters:\n%s"
+        (String.concat "\n" (List.map Addr.describe os))
+
+(* Anti-vacuity: a signature parser that silently returns None turns every case
+   above into a free pass. *)
+let test_signature_is_actually_found () =
+  match Addr.kernel_signature fixed_record_kernel with
+  | None ->
+      Alcotest.fail
+        "kernel_signature found no `kernel void ...(...)`, so every offence \
+         check above inspected an empty parameter list and asserted nothing"
+  | Some params ->
+      Alcotest.(check bool)
+        "the parameter list is non-empty"
+        true
+        (String.trim params <> "")
+
+(* Layer 2's availability is a positive control, not `command -v xcrun`. On
+   Linux it must report unavailable WITH a reason; on macOS with Xcode it must
+   report available. Either way the reason string must be non-empty when
+   unavailable, because that string is the only thing distinguishing an honest
+   skip from a silent one. *)
+let test_compile_layer_states_its_availability () =
+  if Compile.available () then
+    Alcotest.(check string)
+      "available => no reason"
+      ""
+      (Compile.why_unavailable ())
+  else
+    Alcotest.(check bool)
+      "unavailable => a stated reason"
+      true
+      (String.length (Compile.why_unavailable ()) > 0)
+
+let () =
+  Alcotest.run
+    "metal_gate"
+    [
+      ( "addrspace",
+        [
+          Alcotest.test_case
+            "the pre-#139 golden is REJECTED (red proof)"
+            `Quick
+            test_historical_defect_is_red;
+          Alcotest.test_case
+            "the fixed signature is accepted"
+            `Quick
+            test_fixed_shape_is_green;
+          Alcotest.test_case
+            "an unqualified pointer is rejected"
+            `Quick
+            test_unqualified_pointer_is_red;
+          Alcotest.test_case
+            "scalars, threadgroup buffers and builtins are accepted"
+            `Quick
+            test_scalar_and_builtin_params_are_green;
+          Alcotest.test_case
+            "the signature parser finds a non-empty parameter list"
+            `Quick
+            test_signature_is_actually_found;
+        ] );
+      ( "compile",
+        [
+          Alcotest.test_case
+            "availability is stated, never silent"
+            `Quick
+            test_compile_layer_states_its_availability;
+        ] );
+    ]

--- a/sarek/tests/unit/test_metal_gate.ml
+++ b/sarek/tests/unit/test_metal_gate.ml
@@ -209,6 +209,40 @@ let test_compile_layer_goes_red_on_a_body_defect () =
            with Not_found -> false)
   end
 
+(* Parameter order (CodeRabbit, #316). [split_params] used to reverse the list,
+   so offences were reported bottom-up. Detection never depended on order — each
+   parameter is inspected on its own, so no permutation can hide one — but a
+   diagnostic listing parameters in an order the reader cannot find in the
+   source wastes the time this gate exists to save. Pinned here so it cannot
+   silently flip back, and so the claim "order does not affect detection" is
+   checked rather than asserted: the two-offence kernel below must report BOTH,
+   in source order. *)
+let two_offence_kernel =
+  "#include <metal_stdlib>\n\
+   kernel void k(constant Point2* &first [[buffer(0)]],\n\
+   device float* ok [[buffer(1)]],\n\
+   float* second [[buffer(2)]],\n\
+   uint3 gid [[thread_position_in_grid]]) { }\n"
+
+let test_offences_are_reported_in_source_order () =
+  match Addr.offences two_offence_kernel with
+  | [a; b] ->
+      Alcotest.(check bool)
+        "first offending parameter is the one written first"
+        true
+        (a.Addr.param = "constant Point2* &first [[buffer(0)]]") ;
+      Alcotest.(check bool)
+        "second offending parameter is the one written second"
+        true
+        (b.Addr.param = "float* second [[buffer(2)]]")
+  | os ->
+      Alcotest.failf
+        "expected exactly 2 offences (the well-formed `device float* ok` must \
+         not be one), got %d:\n\
+         %s"
+        (List.length os)
+        (String.concat "\n" (List.map Addr.describe os))
+
 let () =
   Alcotest.run
     "metal_gate"
@@ -235,6 +269,10 @@ let () =
             "the signature parser finds a non-empty parameter list"
             `Quick
             test_signature_is_actually_found;
+          Alcotest.test_case
+            "offences are reported in source order"
+            `Quick
+            test_offences_are_reported_in_source_order;
         ] );
       ( "compile",
         [

--- a/sarek/tests/unit/test_opencl_gate.ml
+++ b/sarek/tests/unit/test_opencl_gate.ml
@@ -498,17 +498,33 @@ let subprocess_reports_no_fp64 () =
   (try Sys.remove out with _ -> ()) ;
   match rc with Unix.WEXITED 0 -> Some (String.trim text) | _ -> None
 
+let names_cl_khr_fp64 text =
+  try
+    ignore (Str.search_forward (Str.regexp_string "cl_khr_fp64") text 0) ;
+    true
+  with Not_found -> false
+
 let test_fp64_predicate_goes_red_under_suppression () =
-  if not (Clang.available ()) then
-    Printf.printf "  SKIP: %s\n%!" (Clang.why_unavailable ())
-  else begin
-    (* Positive control first: without suppression this clang HAS fp64, so the
-       negative result below is attributable to the switch and not to a
-       toolchain that never had it. *)
+  if not (Clang.available ()) then begin
+    Printf.printf "  SKIP: %s\n%!" (Clang.why_unavailable ()) ;
+    Alcotest.skip ()
+  end
+  else if not (Clang.fp64_available ()) then
+    (* THIS MACHINE HAS NO fp64 — an Apple M4 is the case in point, and it is
+       the machine that produced #140. Emulating an absence that is already real
+       proves nothing, so assert the thing that IS observable here instead: the
+       predicate says no, and says why in terms a reader can act on. This is the
+       stronger observation of the two; the suppression branch below exists only
+       so the Linux machines can see the same red. *)
     Alcotest.(check bool)
-      "unsuppressed: this clang compiles a double kernel"
+      "fp64 is natively absent here, and the predicate says so, naming \
+       cl_khr_fp64"
       true
-      (Clang.fp64_available ()) ;
+      (names_cl_khr_fp64 (Clang.why_no_fp64 ()))
+  else begin
+    (* fp64 IS available, so the interesting branch is the one that never runs
+       on this machine — the branch that split the M4 into two verdicts. Drive
+       it by taking the extension away from the compiler itself. *)
     match subprocess_reports_no_fp64 () with
     | None ->
         Alcotest.fail "could not re-run this executable with the switch set"
@@ -521,11 +537,7 @@ let test_fp64_predicate_goes_red_under_suppression () =
         Alcotest.(check bool)
           "the stated reason names cl_khr_fp64"
           true
-          (try
-             ignore
-               (Str.search_forward (Str.regexp_string "cl_khr_fp64") report 0) ;
-             true
-           with Not_found -> false)
+          (names_cl_khr_fp64 report)
   end
 
 (* Sub-mode used by the case above. Prints the reason fp64 is unavailable (empty

--- a/sarek/tests/unit/test_opencl_gate.ml
+++ b/sarek/tests/unit/test_opencl_gate.ml
@@ -517,10 +517,11 @@ let test_fp64_predicate_goes_red_under_suppression () =
        stronger observation of the two; the suppression branch below exists only
        so the Linux machines can see the same red. *)
     Alcotest.(check bool)
-      "fp64 is natively absent here, and the predicate says so, naming \
-       cl_khr_fp64"
+      "fp64 is natively absent here, and CLANG'S OWN diagnostic says why — \
+       asserted against the raw compiler output, never against our composed \
+       reason, which must not contain the token it is being searched for"
       true
-      (names_cl_khr_fp64 (Clang.why_no_fp64 ()))
+      (names_cl_khr_fp64 (Clang.fp64_diagnostic ()))
   else begin
     (* fp64 IS available, so the interesting branch is the one that never runs
        on this machine — the branch that split the M4 into two verdicts. Drive
@@ -535,17 +536,41 @@ let test_fp64_predicate_goes_red_under_suppression () =
              switch does nothing, so every \"SKIP (no fp64)\" the sweep prints \
              is unverifiable." ;
         Alcotest.(check bool)
-          "the stated reason names cl_khr_fp64"
+          "clang's own diagnostic under suppression names cl_khr_fp64"
           true
           (names_cl_khr_fp64 report)
   end
+
+(* Guards the split above. If someone reintroduces "cl_khr_fp64" into the
+   composed reason, both assertions in the case above silently become
+   unfalsifiable again — they would find the token in our own text. This is the
+   check that keeps them honest, and it is cheap. *)
+let test_composed_reason_does_not_manufacture_the_token () =
+  if Clang.fp64_available () then
+    Alcotest.(check string)
+      "fp64 available => no reason at all"
+      ""
+      (Clang.why_no_fp64 ())
+  else
+    Alcotest.(check bool)
+      "the composed reason must not itself contain `cl_khr_fp64` — only \
+       clang's quoted output may"
+      false
+      (names_cl_khr_fp64
+         (Str.global_replace
+            (Str.regexp_string (Clang.fp64_diagnostic ()))
+            ""
+            (Clang.why_no_fp64 ())))
 
 (* Sub-mode used by the case above. Prints the reason fp64 is unavailable (empty
    line if it IS available) and exits, so the parent can read the predicate out
    of a fresh process with a different environment. *)
 let () =
   if Array.length Sys.argv > 1 && Sys.argv.(1) = "--fp64-report" then begin
-    print_string (Clang.why_no_fp64 ()) ;
+    (* The RAW compiler diagnostic, not the composed reason: the parent asserts
+       cl_khr_fp64 against this, and a composed string of ours carrying that
+       token would make the assertion unfalsifiable. *)
+    print_string (Clang.fp64_diagnostic ()) ;
     exit 0
   end
 
@@ -572,6 +597,10 @@ let () =
             "the fp64 predicate goes red under suppression"
             `Quick
             test_fp64_predicate_goes_red_under_suppression;
+          Alcotest.test_case
+            "the composed fp64 reason does not manufacture `cl_khr_fp64`"
+            `Quick
+            test_composed_reason_does_not_manufacture_the_token;
         ] );
       ( "layer3_binder_canary",
         [

--- a/sarek/tests/unit/test_opencl_gate.ml
+++ b/sarek/tests/unit/test_opencl_gate.ml
@@ -464,6 +464,79 @@ let test_mutual_recursion_refused () =
         true
         (contains m "mutually recursive")
 
+(* fp64 capability predicate (#140).
+
+   The sweep asks [Clang.fp64_available ()] before deciding what to do with a
+   float64 kernel, and on this machine the answer is normally "yes" — so the
+   interesting branch is the one that never runs here. That is the branch that
+   split the M4 into two verdicts, so it is the one that has to be driven.
+
+   [SAREK_OPENCL_GATE_NO_FP64=1] removes cl_khr_fp64 from the compiler itself
+   ([-cl-ext=-cl_khr_fp64]), producing the same diagnostic Apple clang gives.
+   This case re-executes the test binary with that variable set and requires the
+   predicate to flip — a self-check on the check, because a suppression switch
+   that quietly does nothing would make every "SKIP (no fp64)" a lie. *)
+let subprocess_reports_no_fp64 () =
+  let exe = Sys.executable_name in
+  let out = Filename.temp_file "sarek_fp64_probe_" ".txt" in
+  let rc =
+    Unix.system
+      (Printf.sprintf
+         "SAREK_OPENCL_GATE_NO_FP64=1 %s --fp64-report >%s 2>&1"
+         (Filename.quote exe)
+         (Filename.quote out))
+  in
+  let text =
+    try
+      let ic = open_in out in
+      let n = in_channel_length ic in
+      let s = really_input_string ic n in
+      close_in ic ;
+      s
+    with _ -> ""
+  in
+  (try Sys.remove out with _ -> ()) ;
+  match rc with Unix.WEXITED 0 -> Some (String.trim text) | _ -> None
+
+let test_fp64_predicate_goes_red_under_suppression () =
+  if not (Clang.available ()) then
+    Printf.printf "  SKIP: %s\n%!" (Clang.why_unavailable ())
+  else begin
+    (* Positive control first: without suppression this clang HAS fp64, so the
+       negative result below is attributable to the switch and not to a
+       toolchain that never had it. *)
+    Alcotest.(check bool)
+      "unsuppressed: this clang compiles a double kernel"
+      true
+      (Clang.fp64_available ()) ;
+    match subprocess_reports_no_fp64 () with
+    | None ->
+        Alcotest.fail "could not re-run this executable with the switch set"
+    | Some report ->
+        if report = "" then
+          Alcotest.fail
+            "SAREK_OPENCL_GATE_NO_FP64=1 left fp64 AVAILABLE. The suppression \
+             switch does nothing, so every \"SKIP (no fp64)\" the sweep prints \
+             is unverifiable." ;
+        Alcotest.(check bool)
+          "the stated reason names cl_khr_fp64"
+          true
+          (try
+             ignore
+               (Str.search_forward (Str.regexp_string "cl_khr_fp64") report 0) ;
+             true
+           with Not_found -> false)
+  end
+
+(* Sub-mode used by the case above. Prints the reason fp64 is unavailable (empty
+   line if it IS available) and exits, so the parent can read the predicate out
+   of a fresh process with a different environment. *)
+let () =
+  if Array.length Sys.argv > 1 && Sys.argv.(1) = "--fp64-report" then begin
+    print_string (Clang.why_no_fp64 ()) ;
+    exit 0
+  end
+
 let () =
   Alcotest.run
     "opencl_gate"
@@ -483,6 +556,10 @@ let () =
             "red on a removed declaration"
             `Quick
             test_clang_red_on_mutation;
+          Alcotest.test_case
+            "the fp64 predicate goes red under suppression"
+            `Quick
+            test_fp64_predicate_goes_red_under_suppression;
         ] );
       ( "layer3_binder_canary",
         [

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -67,6 +67,60 @@ let reject_feature ~raise_ ~backend ?hint (feature : Sarek_ir_analysis.feature)
          (Sarek_ir_analysis.feature_name feature)
          detail)
 
+(** {1 Measured f16 refusals (#57 slices 2a/2b, single-sourced by #138)}
+
+    Two backends left {!reject_feature} because "not yet supported" was false of
+    them: their refusal is a MEASUREMENT, not a queue position. Each is refused
+    in two places — the per-element-type arm of [<backend>_type_of_elttype] and
+    the whole-kernel [reject_float16_kernel] — and each sentence used to be
+    written out at both sites.
+
+    That is not a DRY nit. The sentence carries the number that justifies the
+    refusal, and the two OpenCL copies had already drifted apart before this
+    constant existed: one opened "float16 is not supported — not because the
+    codegen is missing", the other "float16 is refused by measurement, not
+    pending implementation", and only the second was the wording the docs and
+    the goldens cite. Two copies of a measured claim become two claims.
+
+    Single-sourcing also fixes the direction that matters next: when Mesa stops
+    fusing and one of these refusals is lifted, one constant makes every
+    remaining reference to it obviously stale. Duplicates just rot.
+
+    The verbatim expectations in
+    sarek/tests/codegen_golden/test_cuda_f16_golden.ml are NOT a third copy in
+    that sense — they are the golden, deliberately spelled out so that
+    re-folding a backend into the shared composer breaks a test rather than
+    passing silently, and one case there asserts both sites of each backend
+    agree. *)
+
+(* Measured 2026-07-26 on RX 7900 XTX (navi31) AND the integrated Raphael iGPU
+   (gfx1036), rusticl/radeonsi. Reproducer:
+   tools/probes/opencl_f16_contraction_probe.c. Full table and method:
+   docs/fp-contraction-policy.md, "OpenCL / rusticl (f16 narrowing)". The long
+   rationale — why the codegen is NOT what is missing, and which barriers were
+   measured not to work — lives on the [TFloat16] arm of
+   [Sarek_ir_opencl.opencl_type_of_elttype]. *)
+let opencl_float16_refusal =
+  "OpenCL: float16 is refused by measurement, not pending implementation — \
+   rusticl/radeonsi fuses the f32 multiply into the f32->f16 narrowing, so \
+   620/63488 binary16 inputs disagree with the interpreter, and no affordable \
+   barrier exists on this path. See docs/fp-contraction-policy.md (#57 slice \
+   2a)."
+
+(* Measured 2026-07-26 on RX 7900 XTX (RADV NAVI31) AND the integrated Raphael
+   iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1, Vulkan 1.4.354; both
+   devices report identical counts, and the two-narrowing shape fails worse
+   (5075/63488). Gate: sarek-vulkan/test/test_vulkan_f16_tripwire.ml. Full
+   table, ISA and method: docs/fp-contraction-policy.md, "Vulkan / RADV (f16
+   narrowing)". Rationale, and why `precise` does not rescue it, on the
+   [TFloat16] arm of [Sarek_ir_glsl.glsl_type_of_elttype]. *)
+let glsl_float16_refusal =
+  "GLSL: float16 is refused by measurement, not pending implementation — \
+   RADV's ACO backend absorbs the f32->f16 narrowing into the arithmetic that \
+   feeds it, so 2912/63488 binary16 inputs disagree with the interpreter on a \
+   single narrowing, and `precise` does not prevent it. See \
+   docs/fp-contraction-policy.md (#57 slice 2b)."
+
 (** Mangle OCaml type name to valid C/GLSL identifier (e.g., "Module.point" ->
     "Module_point") *)
 let mangle_name name = String.map (fun c -> if c = '.' then '_' else c) name

--- a/spoc/ir/Sarek_ir_codegen.mli
+++ b/spoc/ir/Sarek_ir_codegen.mli
@@ -38,6 +38,42 @@ val reject_feature :
   Sarek_ir_types.kernel ->
   unit
 
+(** {1 Measured f16 refusals (#57 slices 2a/2b, single-sourced by #138)}
+
+    Two backends left {!reject_feature} because "not yet supported" was false of
+    them: their refusal is a MEASUREMENT, not a queue position. Each is refused
+    in two places — the per-element-type arm of [<backend>_type_of_elttype] and
+    the whole-kernel [reject_float16_kernel] — and each sentence used to be
+    written out at both sites.
+
+    That is not a DRY nit. The sentence carries the number that justifies the
+    refusal, and the two OpenCL copies had already drifted apart before this
+    constant existed: one opened "float16 is not supported — not because the
+    codegen is missing", the other "float16 is refused by measurement, not
+    pending implementation", and only the second was the wording the docs and
+    the goldens cite. Two copies of a measured claim become two claims.
+
+    Single-sourcing also fixes the direction that matters next: when Mesa stops
+    fusing and one of these refusals is lifted, one constant makes every
+    remaining reference to it obviously stale. Duplicates just rot.
+
+    The verbatim expectations in
+    sarek/tests/codegen_golden/test_cuda_f16_golden.ml are NOT a third copy in
+    that sense — they are the golden, deliberately spelled out so that
+    re-folding a backend into the shared composer breaks a test rather than
+    passing silently, and one case there asserts both sites of each backend
+    agree. *)
+
+(** The OpenCL f16 refusal diagnostic. Raised by both
+    [Sarek_ir_opencl.opencl_type_of_elttype] and
+    [Sarek_ir_opencl.reject_float16_kernel]. *)
+val opencl_float16_refusal : string
+
+(** The GLSL f16 refusal diagnostic. Raised by both
+    [Sarek_ir_glsl.glsl_type_of_elttype] and
+    [Sarek_ir_glsl.reject_float16_kernel]. *)
+val glsl_float16_refusal : string
+
 (** Mangle an OCaml type name into a valid C/GLSL identifier (e.g.
     "Module.point" -> "Module_point"). Replaces '.' with '_'. *)
 val mangle_name : string -> string


### PR DESCRIPTION
Four defects, three of them visible only because the suite was run on an Apple M4 for the first time, and one that had already drifted where nobody was looking. Each fix ships with the check that makes its class visible from Linux, because "nothing in the project could see it" is the actual finding in every case.

Closes #139, #140, #132, #138.

## #139 — two generated Metal goldens had never compiled, anywhere

`gen_param_metal` treated **every** `DParam` without an `array_info` as a scalar and emitted `constant <ty> &name`. For a vec-typed parameter `metal_type_of_elttype` returns a pointer type, so `record_kernel` and `variant_kernel` emitted

```
kernel void record_kernel(constant Point2* &pts [[buffer(0)]], ...)
```

a reference to a pointer whose **pointee** has no address space. Apple clang 17: *"invalid address space qualification for buffer pointee type … valid address space qualifications are device and constant"*.

**Address space: `device`.** Not a coin flip:

- Objects in `constant` are read-only for the lifetime of the kernel (MSL 3.2 §4.2/§4.3), and both offending kernels *write* through the parameter — `pts[idx] = …`, `out[idx] = …`. `constant` would not compile even with the reference form fixed.
- `constant` carries an implementation-defined size limit and expects data that does not change per dispatch. A Sarek `vec` is a general `MTLBuffer` bound with `setBuffer:`.
- Every other backend already lowers a vec parameter to a mutable global pointer (CUDA `T* __restrict__`, OpenCL `__global T* restrict`), and Metal's **own** `metal_param_type` and `metal_memspace Global` already said `device`. This arm was the single place in the backend that disagreed with the rest of it.

**Red proof.** New `metal_validation_sweep`, then the fix reverted:

```
FAIL generated Metal for record_kernel has parameters Metal's address-space rules reject:
  constant Point2* &pts [[buffer(0)]]
      -> reference to a pointer whose POINTEE has no address space. This is the #139
         shape — `constant T* &v` — and Apple clang 17 answers it with: "invalid address
         space qualification for buffer pointee type ..."
2 failures! in 0.002s. 10 tests run.
```

Restored: 10/10. Both goldens updated, and the diff is exactly `constant Point2* &pts` → `device Point2* pts` and `constant Opt* &out` → `device Opt* out`.

**The gate**, since Metal was the last backend with committed goldens and no validator:

| layer | tool | runs on |
|---|---|---|
| `Metal_gate.Metal_addrspace` | none — reads the signature | everywhere, incl. the Linux boxes where this code is written |
| `Metal_gate.Metal_compile` | `xcrun metal` (positive control, not `command -v xcrun`) | macOS only; skips with a stated reason otherwise |

Layer 1 exists precisely because layer 2 cannot run where the defect is introduced. Its red path is executed permanently by `sarek/tests/unit/test_metal_gate.ml`, driven from the **pre-fix golden pasted verbatim** — plus controls that `constant int &n`, `threadgroup float*` and `uint3 gid` do *not* trip it, and an anti-vacuity case on the signature parser.

## #140 — a capability gate that contradicted itself

On the M4, `opencl_validation_sweep` cases 7-8 SKIPPED on float64 while 16-20 FAILED.

**Which path was authoritative: neither.** Cases 7-8 skipped for a completely unrelated hardcoded `validation_exclusions` entry (`Float64.abs_float` / `Float64.copysign` are user-callable but absent from `Sarek_pure_registry.float64_list`, so they die at *codegen*) and would have skipped identically on a machine with full fp64. Cases 16-20 simply ran and hit the toolchain. There was no fp64 predicate anywhere in the gate.

And the capability is not the one it looks like. This gate deliberately never touches a device — it compiles with `clang -x cl`, because on the reference machine a real ICD answers illegal OpenCL with SIGSEGV instead of a build log. So the authority is not `Opencl_api`'s `supports_fp64`/`Device.allows_fp64` (what the e2e suite uses) but **whether this clang can compile a `double` kernel**: Apple clang's `arm64-apple-darwin` target does not list `cl_khr_fp64`, so the `#pragma OPENCL EXTENSION cl_khr_fp64 : enable` the production path emits is ignored with a warning and `double` is an error.

`Opencl_clang.fp64_available ()` establishes that by compiling a `double` probe — the same positive-control discipline as `available ()` — and the sweep asks it **before** the exclusion list, so one capability now yields one verdict.

**Red proof — fp64 pretended absent on a device that has it.** `SAREK_OPENCL_GATE_NO_FP64=1` adds `-cl-ext=-cl_khr_fp64` to every invocation, which makes clang 22.1.6 emit Apple's exact diagnostic. With the new predicate disabled, the M4 split reproduces on Linux:

```
  [SKIP]  opencl_validation_sweep   7   opencl-validate/float64...
  [SKIP]  opencl_validation_sweep   8   opencl-validate/float64...
> [FAIL]  opencl_validation_sweep  16   opencl-validate/float64...
  [FAIL]  ... 17, 18, 19, 20
/tmp/sarek_gate_ocl_090a2c.cl:3:43: error: use of type 'double' requires cl_khr_fp64 support
5 failures! in 0.535s.
```

With it enabled, all seven report one verdict for one reason:

```
  [SKIP]  opencl_validation_sweep   7, 8, 16, 17, 18, 19, 20
Test Successful. 16 tests run.
```

A skip is not a pass, so two things stop it becoming normal: `ci/assert-toolchain.sh` gains an fp64 positive control (`EXPECTED_CHECKS` 12 → 13), and `test_opencl_gate.ml` re-executes itself under the switch and **fails** if the suppression turns out to do nothing — verified by neutering the flag:

```
FAIL SAREK_OPENCL_GATE_NO_FP64=1 left fp64 AVAILABLE. The suppression switch does
nothing, so every "SKIP (no fp64)" the sweep prints is unverifiable.
```

## #132 — what actually remained after #306

**The field-naming half was already closed.** #306 routed `EMatch` and all five `SMatch` paths through one `payload_layout`; WGSL's `indexed = true` gives `.MkPair_v_0`, which matches its flat struct exactly. The nested `.MkPair_v._0` spelling can no longer be produced. All 15 accessor call sites across the five backends go through the helper — no stragglers.

**What remained was the coverage hole, and a second live defect hiding in it.** The sweep corpus had no multi-field payload and no `SMatch` at all — `variant_kernel` only *constructs* variants — so every accessor and every `switch` the WGSL match emitter can produce was unreachable from any executable gate. The only coverage anywhere was a string comparison in `test_ematch_payload_binding.ml`.

Behind it: the emitter wrote `default:` only when the source match had a `PWild` arm. WGSL requires exactly one default clause in every `switch`, so **every exhaustive match** — the ordinary case — produced a module `naga` rejects. C's `switch` needs no default and GLSL's likewise, so WGSL was the odd one out here too, exactly as it was for payload spelling.

**Red proof.** Adding `smatch_multi_payload` (a `MkOne of f32 | MkPair of f32 * f32` matched with no wildcard) turned the sweep red on the first run, before any codegen change:

```
naga rejected golden wgsl/smatch_multi_payload:
error: Entry point main at Compute is invalid
43 │ ╭   switch (ps[idx].tag) {
   │ ╰───^ missing default case
```

The accessors in that same emitted shader are `.MkPair_v_0` / `.MkPair_v_1` — visible confirmation that #306's half is genuinely done. A synthetic empty `default` turned it green.

The sweep also no longer skips quietly when `naga` is off PATH: availability is now a positive control (a `command -v` hit that cannot validate a trivial module is not availability), and the skip names its reason and points at `ci/assert-toolchain.sh`, which is what makes a missing `naga` a CI failure.

## #138 — one measured claim, one copy of it

OpenCL and GLSL each refuse f16 in two places — the per-element-type arm and the whole-kernel `reject_float16_kernel` — and each sentence carries the **measurement** that justifies the refusal.

The OpenCL pair had already drifted, which is the whole argument:

```
elttype arm: "OpenCL: float16 is not supported — not because the codegen is missing,
              but because rusticl/radeonsi fuses ..."
kernel arm:  "OpenCL: float16 is refused by measurement, not pending implementation
              — rusticl/radeonsi fuses ..."
```

Same numbers, two claims, and only the second is the wording the docs and the goldens cite. Both now read `Sarek_ir_codegen.{opencl,glsl}_float16_refusal`.

**Red proof.** The new case in `test_cuda_f16_golden.ml` asserts both sites of each backend produce the same string, and fails on the pre-fix tree:

```
FAIL OpenCL: the per-element-type arm and the whole-kernel arm state the SAME measured reason
   Expected: "OpenCL: float16 is refused by measurement, not pending implementation — ..."
   Received: "OpenCL: float16 is not supported — not because the codegen is missing, ..."
```

The verbatim expectations in that file stay verbatim on purpose — they are the golden that makes re-folding a backend into the shared composer break a test.

## Verification

- `dune build` — exit 0
- `dune runtest` — exit 0 (`test_metal_gate` and `metal_validation_sweep` confirmed attached to the default `runtest` alias; both `(test)` stanzas, no orphans)
- `dune build @fmt` — exit 0
- `benchmarks/descriptions/generated/` regenerated via `generate_backend_code.exe`: **empty diff**. Every benchmark kernel uses `DParam (v, Some arr)`, which was already emitting `device T*`; only the `None` arm was wrong.
- `ci/assert-toolchain.sh`: same three pre-existing CUDA failures as on `main` (no CUDA on this box), one more check running and passing (`3 of 10` → `3 of 11`).
- Every build exit code was read before any test result.

## Verified on the Apple M4 (macOS 15.6.1, Apple clang 17)

Throwaway clone under `/tmp`, `opam exec --switch=/Users/mathias/dev/SPOC --`, nothing installed, `~/dev/SPOC` untouched (still `apple_m4_benchmarks`, 78 uncommitted entries, one January stash).

**The gate's own instrument was wrong, and the M4 is what showed it.** `xcrun metal` lives inside Xcode, and the reference M4 has only the Command Line Tools:

```
xcrun: error: unable to find utility "metal", not a developer tool or in PATH
```

So a gate keyed on it would have skipped on the one machine capable of running it — the failure this gate exists to stop, one notch smaller. Layer 2 now compiles through `newLibraryWithSource:options:error:` via a small ObjC driver built with `clang -framework Metal`, which needs no Xcode (as the project's own probes already document) and is the call `Sarek_metal`'s runtime makes, so it validates the *production* compile path.

**#139 — all nine goldens compile, where seven did before.** Layer 2 genuinely ran; these are not skips:

```
metal OK: scalar_vec_add     metal OK: record_kernel     metal OK: variant_kernel
metal OK: sin_kernel         metal OK: float32_sin_path  metal OK: float32_cbrt_path
metal OK: float32_hypot_path metal OK: float32_expm1_path metal OK: float32_log1p_path
```

Red proved on the M4 too — reverting the codegen fix in the clone gave 2 failures naming `constant Point2* &pts`. And directly, against the driver:

```
=== PRE-FIX (constant T* &) ===
error: invalid address space qualification for buffer pointee type 'const constant Point2 *'
note: valid address space qualifications are device and constant
EXIT=1
=== FIXED (device T*) ===  EXIT=0
```

**#140 — confirmed fixed on the machine that produced it.** The seven float64 cases (7, 8, 16-20) now all SKIP with one stated reason, where the report was 2 SKIP + 5 FAIL:

```
SKIP (no fp64): opencl/float64_abs_float_path — this clang cannot compile an OpenCL kernel using `double`
SKIP (no fp64): opencl/float64_copysign_path  — ... (and cbrt, exp2, fmod, log10, log2)
```

**Two defects in my own gates, found only by going.**

1. `test_opencl_gate`'s fp64 case asserted "unsuppressed: this clang compiles a double kernel" as a positive control — and Apple clang does not, so my control failed on the machine the finding came from. It now branches on the real capability; the suppression experiment only runs where there is something to suppress. Both branches are exercised — the native one on the M4, the other on Linux. (The replacement branch had a defect of its own, which CodeRabbit caught — see the review round below.)
2. Layer 2's red path had never been observed anywhere: the sweep runs layer 1 first and layer 1 raises, so on a Mac the compile layer was only ever seen succeeding. Added a negative control using a defect layer 1 is structurally incapable of seeing (well-formed signature, undeclared identifier in the body), guarded by a positive control and an assertion that layer 1 stays silent. It runs green-because-red on the M4.

**Full M4 results** (`naga`/`glslangValidator` are not installed there, so those sweeps skip with their stated reasons — that is the honest outcome, and `ci/assert-toolchain.sh` is what stops it becoming normal in CI):

| executable | exit | result |
|---|---|---|
| `test_codegen_golden` | 0 | Test Successful, 79 tests |
| `test_metal_gate` | 0 | Test Successful, 7 tests |
| `test_opencl_gate` | 0 | Test Successful, 11 tests |
| `test_cuda_f16_golden` | 0 | Test Successful, 9 tests |

Every build exit code was confirmed 0 before any test output was read.

## Review round — three of CodeRabbit's four findings were still live

All four were filed against the first commit, four minutes before the M4 push, so staleness was plausible. It was only true of one.

**`opencl_clang.ml` — I was asserting against my own printf.** This one is a real hit and it invalidates a claim I made in the M4 section above. `why_no_fp64` wrapped every failed probe in `"(the target does not support cl_khr_fp64)"`, so the composed string carried that token *whatever clang had actually said*. Both branches of the negative control then searched for `cl_khr_fp64` in **our** text rather than clang's — a check that cannot fail. My report's "the predicate reports absent **and** names `cl_khr_fp64`" was verifying a string constant.

Fixed by exposing the raw probe diagnostic separately (`fp64_diagnostic ()`), removing the manufactured *why* from the composed reason, and moving both assertions onto the raw output. A new case forbids the token from reappearing in the composed reason, so the two cannot rot back together.

Proved in both directions by breaking the fp64 probe with a syntax error unrelated to fp64:

| | probe broken for an unrelated reason |
|---|---|
| pre-fix (manufactured token) | **passes**, exit 0 — unfalsifiable |
| post-fix (raw diagnostic) | **fails**, exit 1 — `Expected: true / Received: false` |

On the M4, where fp64 is natively absent, the assertion now runs against Apple clang's own words:

```
warning: unsupported OpenCL extension 'cl_khr_fp64' - ignoring [-Wignored-pragmas]
error: use of type 'double' requires cl_khr_fp64 support
```

**`metal_addrspace.ml` — `split_params` returned parameters reversed.** `rev_map` already restores source order, so the trailing `List.rev` put it back. To answer the concern directly: detection was never affected, because every parameter is inspected independently — no permutation can hide one. Only the diagnostic read bottom-up. Removed, and pinned by a two-offence kernel that also checks the well-formed parameter between them is *not* reported; red proved by reinstating the `List.rev`.

**`Sarek_ir_metal.ml` — `Local` emitted an unqualified pointer, and writing the test for it found a second live instance of #139.** `metal_memspace Local` is `""`, so a `Local` buffer parameter emitted a pointer with no address space — source this backend's own gate rejects. Now refused explicitly.

The larger finding came out of that test: my new arm guarded on `is_vec_type`, which means *"carries a trailing length argument"* and is `TVec` **only**. `TArray` parameters therefore still fell through to the scalar arm and emitted `constant float* &a` — the exact #139 reference-to-pointer shape, in a second constructor I had missed. The guard now asks the question it meant to ask (`is_pointer_type`), and `gen_buffer_param` takes `~with_length` so a `TArray` does not gain a length argument the host never binds and shift every later buffer index.

**`test_opencl_gate.ml` (Major) — already fixed by the M4 round**, and CodeRabbit marked it addressed itself. Their proposed fix was a bare skip where fp64 is absent; the M4 version asserts the stronger observable instead, which is what the raw-diagnostic fix above now makes meaningful.

Re-verified after the round — Linux: `dune build`, `dune runtest`, `dune build @fmt` exit 0, seven uniform fp64 skips under the switch, `benchmarks/descriptions/generated/` byte-identical. M4: `test_codegen_golden` 79, `test_metal_gate` 8, `test_opencl_gate` 12, `test_sarek_ir_metal` 15 — all exit 0, nine Metal goldens still compiling, seven uniform fp64 skips.

## Note on a concurrent PR

This does **not** touch `validation_exclusions` — `git diff origin/main` has no `+`/`-` line mentioning it, `float64_abs_float_path`, `float64_copysign_path`, `Sarek_pure_registry` or `float64_list`. The only change in that area is *ordering*: the fp64 capability is now consulted before the exclusion list is read. So the #133/#134 registry work can delete those two exclusions freely — when it does, those two cases stop skipping where fp64 is present and keep reporting the fp64 reason where it is absent, which is the intended behaviour either way. No merge sequencing needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
