### PR TITLE
fix(sarek): make the declared intrinsic surface actually callable

### DIFF
--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -284,7 +284,10 @@ and cuda_backend =
     pre_hook = (fun _ ~full_name:_ _ _ _ -> false);
     post_hook =
       (fun buf path name args ->
-        Dispatch.emit_registry_template ~gen_expr buf path name args);
+        (* Same framework tag the pure-registry lookup uses: without it this
+           fallback emitted the CUDA spelling on every backend. *)
+        let framework = Option.value ~default:"CUDA" !current_framework in
+        Dispatch.emit_registry_template ~gen_expr ~framework buf path name args);
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));

--- a/sarek/codegen/Sarek_ir_intrinsic_dispatch.ml
+++ b/sarek/codegen/Sarek_ir_intrinsic_dispatch.ml
@@ -133,8 +133,10 @@ let count_placeholders s =
 (** Expand a Metal/CUDA/OpenCL FFI-registry ([Sarek_registry]) device template
     for [path.name]. Returns [false] when the registry has no template (caller
     then raises the unknown-intrinsic error); [true] once emitted. *)
-let emit_registry_template ~gen_expr buf path name args =
-  match Sarek_registry.fun_device_template ~module_path:path name with
+let emit_registry_template ~gen_expr ~framework buf path name args =
+  match
+    Sarek_registry.fun_device_template ~module_path:path ~framework name
+  with
   | None -> false
   | Some template ->
       let arg_strs =

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -340,7 +340,10 @@ and metal_backend =
         else false);
     post_hook =
       (fun buf path name args ->
-        Dispatch.emit_registry_template ~gen_expr buf path name args);
+        (* Same framework tag the pure-registry lookup uses: without it this
+           fallback emitted the CUDA spelling on every backend. *)
+        let framework = Option.value ~default:"Metal" !current_framework in
+        Dispatch.emit_registry_template ~gen_expr ~framework buf path name args);
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -330,7 +330,10 @@ and opencl_backend =
     pre_hook = (fun _ ~full_name:_ _ _ _ -> false);
     post_hook =
       (fun buf path name args ->
-        Dispatch.emit_registry_template ~gen_expr buf path name args);
+        (* Same framework tag the pure-registry lookup uses: without it this
+           fallback emitted the CUDA spelling on every backend. *)
+        let framework = Option.value ~default:"OpenCL" !current_framework in
+        Dispatch.emit_registry_template ~gen_expr ~framework buf path name args);
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));

--- a/sarek/interp/Sarek_float32.ml
+++ b/sarek/interp/Sarek_float32.ml
@@ -197,3 +197,49 @@ let to_int x = int_of_float x
 
 (** Pretty print with float32-appropriate precision *)
 let to_string x = Printf.sprintf "%.7g" x
+
+(******************************************************************************
+ * Sarek stdlib surface mirror
+ *
+ * The native (cpu_kern) backend lowers an [IntrinsicRef (["Float32"], name)] to
+ * the OCaml identifier [Sarek.Sarek_cpu_runtime.Float32.<name>] with the name
+ * copied VERBATIM (sarek/ppx/Sarek_native_intrinsics.ml: map_stdlib_path, then
+ * Sarek_native_helpers.evar_qualified). So every name declared by
+ * sarek/Sarek_stdlib/Float32.ml must exist here under exactly that spelling,
+ * or the kernel does not compile — the user sees "Unbound value
+ * Sarek.Sarek_cpu_runtime.Float32.<name>" pointing into PPX-generated code.
+ *
+ * The seven names below were declared in the stdlib but missing here, so
+ * Float32.abs_float / expm1 / log1p / hypot / copysign / fmod / minus were
+ * unusable from any native kernel. sarek/tests/unit/test_intrinsic_surface.ml
+ * reconciles the two surfaces so this cannot silently recur.
+ *
+ * The four *_float32 aliases mirror the stdlib's explicit arithmetic
+ * intrinsics. They are reachable only when written as qualified calls
+ * (Float32.add_float32 a b); infix `+.` is lowered structurally by the PPX and
+ * never reaches this module.
+ ******************************************************************************)
+
+let abs_float x = abs x
+
+let minus x y = sub x y
+
+let expm1 x = to_float32 (Stdlib.expm1 x)
+
+let log1p x = to_float32 (Stdlib.log1p x)
+
+let hypot x y = to_float32 (Stdlib.hypot x y) |> check_overflow "hypot"
+
+let copysign x y = to_float32 (Stdlib.copysign x y)
+
+(* C [fmod] semantics: sign of the dividend, magnitude < |divisor|.
+   [Float.rem] is OCaml's [fmod]; the stdlib intrinsic uses the same. *)
+let fmod x y = to_float32 (Float.rem x y)
+
+let add_float32 x y = add x y
+
+let sub_float32 x y = sub x y
+
+let mul_float32 x y = mul x y
+
+let div_float32 x y = div x y

--- a/sarek/interp/Sarek_float32.ml
+++ b/sarek/interp/Sarek_float32.ml
@@ -224,9 +224,30 @@ let abs_float x = abs x
 
 let minus x y = sub x y
 
-let expm1 x = to_float32 (Stdlib.expm1 x)
+(* check_overflow is value-neutral in the default [Silent] mode -- it returns
+   its argument untouched -- so these three report an infinite result in [Warn]
+   and [Exception] mode without changing a single number the interpreter
+   produces as the cross-backend oracle.
 
-let log1p x = to_float32 (Stdlib.log1p x)
+   Reachability was settled by an exhaustive sweep of all 2^32 binary32 inputs
+   against C's expm1f/log1pf (clang 21, glibc, x86-64), replicating
+   float32_of_float_impl exactly; see the PR for the full table.
+     - expm1 overflows to +inf from x > 88.7228394, and that threshold is
+       BIT-IDENTICAL to expm1f's: 0 spurious and 0 missed overflows over the
+       whole domain, and only 2 inputs in 4.28e9 differ by 1 ulp. So the value
+       was already right; only the reporting was missing (the Major finding).
+     - log1p cannot overflow from any finite input -- its only infinity is the
+       pole at x = -1. It is wired anyway because [log] and [log10] above route
+       their pole through check_overflow too, so this is the house convention
+       rather than a dead gate. NaN is unaffected: check_overflow tests only
+       = infinity / = neg_infinity, and NaN compares false to both, so
+       log1p x < -1. still returns NaN exactly as C's log1pf does.
+     - hypot DOES overflow from finite inputs (first at hypot(6.11e37, 3.35e38)),
+       with 0 spurious and 0 missed over a 1.33e8-pair boundary sweep. *)
+
+let expm1 x = to_float32 (Stdlib.expm1 x) |> check_overflow "expm1"
+
+let log1p x = to_float32 (Stdlib.log1p x) |> check_overflow "log1p"
 
 let hypot x y = to_float32 (Stdlib.hypot x y) |> check_overflow "hypot"
 

--- a/sarek/interp/Sarek_float32.mli
+++ b/sarek/interp/Sarek_float32.mli
@@ -144,3 +144,35 @@ val is_inf : float -> bool
 (** {1 Formatting} *)
 
 val to_string : float -> string
+
+(** {1 Sarek stdlib surface mirror}
+
+    Every name declared by [sarek/Sarek_stdlib/Float32.ml] must exist here under
+    exactly that spelling: the native backend copies the intrinsic name verbatim
+    into [Sarek.Sarek_cpu_runtime.Float32.<name>]. Reconciled by
+    [sarek/tests/unit/test_intrinsic_surface.ml]. *)
+
+(** Stdlib spelling of {!abs}. *)
+val abs_float : float -> float
+
+(** Stdlib spelling of {!sub}. *)
+val minus : float -> float -> float
+
+val expm1 : float -> float
+
+val log1p : float -> float
+
+val hypot : float -> float -> float
+
+val copysign : float -> float -> float
+
+(** C [fmod]: result has the sign of the dividend, magnitude < |divisor|. *)
+val fmod : float -> float -> float
+
+val add_float32 : float -> float -> float
+
+val sub_float32 : float -> float -> float
+
+val mul_float32 : float -> float -> float
+
+val div_float32 : float -> float -> float

--- a/sarek/ppx/Sarek_native_intrinsics.ml
+++ b/sarek/ppx/Sarek_native_intrinsics.ml
@@ -108,8 +108,14 @@ let map_stdlib_path = function
   | ["Float32"] | ["Sarek_stdlib"; "Float32"] ->
       ["Sarek"; "Sarek_cpu_runtime"; "Float32"]
   | ["Float64"] | ["Sarek_stdlib"; "Float64"] ->
-      (* Float64 is just OCaml float, use stdlib *)
-      ["Float"]
+      (* NOT OCaml's [Stdlib.Float]: that module shares most of the Float64
+         stdlib's names but not all of them, and the mapping below copies the
+         intrinsic name verbatim. [abs_float], [rsqrt], [fmod], [copysign],
+         [of_int32]/[to_int32], [of_float32]/[to_float32], the four [*_float64]
+         arithmetic names and the eight operator forms have no [Float.<name>],
+         so those kernels failed to compile. Sarek_float64_native mirrors the
+         declared surface exactly; see sarek/tests/unit/test_intrinsic_surface.ml. *)
+      ["Sarek"; "Sarek_cpu_runtime"; "Float64"]
   | ["Int32"] | ["Sarek_stdlib"; "Int32"] -> ["Int32"]
   | ["Int64"] | ["Sarek_stdlib"; "Int64"] -> ["Int64"]
   (* Note: Gpu module functions stay as Gpu.* - only specific functions like

--- a/sarek/sarek/Sarek_cpu_runtime.ml
+++ b/sarek/sarek/Sarek_cpu_runtime.ml
@@ -12,6 +12,8 @@
 (** Re-export Float32 module for use in generated kernels *)
 module Float32 = Sarek_cpu_runtime_types.Float32
 
+module Float64 = Sarek_cpu_runtime_types.Float64
+
 (** {1 Re-exports from sub-modules} *)
 
 type exec_mode = Sarek_cpu_runtime_types.exec_mode =

--- a/sarek/sarek/Sarek_cpu_runtime.mli
+++ b/sarek/sarek/Sarek_cpu_runtime.mli
@@ -15,6 +15,14 @@
     semantics matching GPU behavior. *)
 module Float32 = Sarek_float32
 
+(** {1 Float64 Module}
+
+    CPU implementations of the [sarek.float64] stdlib surface, mirroring
+    [sarek/Sarek_float64/Float64.ml] name-for-name. This is the target the
+    native backend gives to [Float64.<name>] inside a kernel; it replaced
+    OCaml's [Stdlib.Float], which is missing a third of that surface. *)
+module Float64 = Sarek_float64_native
+
 (** {1 Execution Mode} *)
 
 (** Execution mode for native kernels *)

--- a/sarek/sarek/Sarek_cpu_runtime_types.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_types.ml
@@ -6,6 +6,8 @@
 (** Re-export Float32 module for use in generated kernels *)
 module Float32 = Sarek_float32
 
+module Float64 = Sarek_float64_native
+
 (** Execution mode for native kernels *)
 type exec_mode =
   | Sequential  (** Single-threaded, barriers are no-ops *)

--- a/sarek/sarek/Sarek_float32.mli
+++ b/sarek/sarek/Sarek_float32.mli
@@ -144,3 +144,35 @@ val is_inf : float -> bool
 (** {1 Formatting} *)
 
 val to_string : float -> string
+
+(** {1 Sarek stdlib surface mirror}
+
+    Every name declared by [sarek/Sarek_stdlib/Float32.ml] must exist here under
+    exactly that spelling: the native backend copies the intrinsic name verbatim
+    into [Sarek.Sarek_cpu_runtime.Float32.<name>]. Reconciled by
+    [sarek/tests/unit/test_intrinsic_surface.ml]. *)
+
+(** Stdlib spelling of {!abs}. *)
+val abs_float : float -> float
+
+(** Stdlib spelling of {!sub}. *)
+val minus : float -> float -> float
+
+val expm1 : float -> float
+
+val log1p : float -> float
+
+val hypot : float -> float -> float
+
+val copysign : float -> float -> float
+
+(** C [fmod]: result has the sign of the dividend, magnitude < |divisor|. *)
+val fmod : float -> float -> float
+
+val add_float32 : float -> float -> float
+
+val sub_float32 : float -> float -> float
+
+val mul_float32 : float -> float -> float
+
+val div_float32 : float -> float -> float

--- a/sarek/sarek/Sarek_float64_native.ml
+++ b/sarek/sarek/Sarek_float64_native.ml
@@ -1,0 +1,133 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Sarek_float64_native - CPU implementations of the Sarek Float64 stdlib
+ *
+ * Reachable as [Sarek.Sarek_cpu_runtime.Float64], the target that
+ * sarek/ppx/Sarek_native_intrinsics.ml's [map_stdlib_path] gives to
+ * [IntrinsicRef (["Float64"], name)]. The native backend copies the intrinsic
+ * name VERBATIM onto that path, so this module must export EXACTLY the names
+ * declared by sarek/Sarek_float64/Float64.ml — no more, no less.
+ *
+ * It previously mapped to OCaml's [Stdlib.Float], which shares most but not all
+ * of that surface: [abs_float], [rsqrt], [fmod], [copysign], [of_int32],
+ * [to_int32], [of_float32], [to_float32], the four [*_float64] arithmetic names
+ * and the eight operator forms have no [Float.<name>] counterpart, so a native
+ * kernel calling any of them failed to compile with "Unbound value
+ * Float.<name>" pointing into PPX-generated code.
+ *
+ * Each body below is the [ocaml = ...] field of the corresponding
+ * [let%sarek_intrinsic] in Sarek_float64/Float64.ml, copied verbatim: that
+ * field IS the specification of the host-side semantics, and native/interpreter/
+ * GPU agreement depends on not paraphrasing it. In particular [of_float32] and
+ * [to_float32] are the identity — an OCaml [float] is always 64-bit, so the
+ * float32 width narrowing is a device-side concern, exactly as the stdlib
+ * declares.
+ *
+ * Reconciled against the stdlib surface by
+ * sarek/tests/unit/test_intrinsic_surface.ml.
+ ******************************************************************************)
+
+(** {1 Arithmetic} *)
+
+let add_float64 (x : float) (y : float) = x +. y
+
+let sub_float64 (x : float) (y : float) = x -. y
+
+let mul_float64 (x : float) (y : float) = x *. y
+
+let div_float64 (x : float) (y : float) = x /. y
+
+(** {1 Unary math} *)
+
+let sin = Stdlib.sin
+
+let cos = Stdlib.cos
+
+let tan = Stdlib.tan
+
+let asin = Stdlib.asin
+
+let acos = Stdlib.acos
+
+let atan = Stdlib.atan
+
+let sinh = Stdlib.sinh
+
+let cosh = Stdlib.cosh
+
+let tanh = Stdlib.tanh
+
+let exp = Stdlib.exp
+
+let log = Stdlib.log
+
+let log10 = Stdlib.log10
+
+let sqrt = Stdlib.sqrt
+
+let ceil = Stdlib.ceil
+
+let floor = Stdlib.floor
+
+let expm1 = Stdlib.expm1
+
+let log1p = Stdlib.log1p
+
+let abs_float = Stdlib.abs_float
+
+let rsqrt x = 1.0 /. Stdlib.sqrt x
+
+(** {1 Binary math} *)
+
+let pow = Float.pow
+
+let atan2 = Stdlib.atan2
+
+let hypot = Stdlib.hypot
+
+let copysign = Stdlib.copysign
+
+(** C [fmod]: result has the sign of the dividend, magnitude < |divisor|.
+    [Float.rem] is OCaml's [fmod]. *)
+let fmod = Float.rem
+
+(** {1 Conversions} *)
+
+let of_int = Stdlib.float_of_int
+
+let of_int32 = Int32.to_float
+
+let to_int = Stdlib.int_of_float
+
+let to_int32 = Int32.of_float
+
+let of_float32 (x : float) = x
+
+let to_float32 (x : float) = x
+
+(** {1 Operator forms}
+
+    Declared by the stdlib so that [let open Float64 in] shadows the float32
+    operators inside a kernel. Only reachable here when written as a qualified
+    call ([Float64.( +. ) a b]); infix syntax is lowered structurally by the PPX
+    (Sarek_parse_helpers) and never becomes an [IntrinsicRef]. *)
+
+let ( +. ) (x : float) (y : float) = Stdlib.( +. ) x y
+
+let ( -. ) (x : float) (y : float) = Stdlib.( -. ) x y
+
+let ( *. ) (x : float) (y : float) = Stdlib.( *. ) x y
+
+let ( /. ) (x : float) (y : float) = Stdlib.( /. ) x y
+
+let ( <= ) (x : float) (y : float) = Stdlib.( <= ) x y
+
+let ( >= ) (x : float) (y : float) = Stdlib.( >= ) x y
+
+let ( < ) (x : float) (y : float) = Stdlib.( < ) x y
+
+let ( > ) (x : float) (y : float) = Stdlib.( > ) x y

--- a/sarek/sarek/dune
+++ b/sarek/sarek/dune
@@ -25,6 +25,7 @@
   Sarek_ir
   Sarek_fusion
   Sarek_cpu_runtime_types
+  Sarek_float64_native
   Sarek_cpu_runtime_exec
   Sarek_cpu_runtime_pools
   Sarek_cpu_runtime

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -464,6 +464,11 @@
 
 (rule
  (alias runtest)
+ (action
+  (run %{dep:test_intrinsic_native_surface.exe})))
+
+(rule
+ (alias runtest)
  (enabled_if %{lib-available:sarek_vulkan})
  (action
   (run %{dep:test_vulkan_interleaved_push_constants.exe})))
@@ -515,6 +520,26 @@
  (name test_bare_float_is_float32)
  (modules test_bare_float_is_float32)
  (libraries sarek sarek_native sarek_stdlib sarek_ir spoc_core unix)
+ (preprocess
+  (pps sarek_ppx)))
+
+; The stdlib intrinsics that had no native target symbol. Compiling this file
+; at all is the regression guard (pre-fix: "Unbound value
+; Sarek.Sarek_cpu_runtime.Float32.copysign" from PPX-generated code); the value
+; checks additionally pin each one to its declared `ocaml = ...` semantics.
+; Run with: dune exec sarek/tests/e2e/test_intrinsic_native_surface.exe
+
+(executable
+ (name test_intrinsic_native_surface)
+ (modules test_intrinsic_native_surface)
+ (libraries
+  sarek
+  sarek_native
+  sarek_stdlib
+  sarek.float64
+  sarek_ir
+  spoc_core
+  unix)
  (preprocess
   (pps sarek_ppx)))
 

--- a/sarek/tests/e2e/test_intrinsic_native_surface.ml
+++ b/sarek/tests/e2e/test_intrinsic_native_surface.ml
@@ -1,0 +1,159 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * The intrinsics that were declared by the Sarek stdlib but had no native
+ * target, executed on the Native device.
+ *
+ * This file is load-bearing in TWO ways, and the first is the important one:
+ *
+ * (i) IT COMPILES. Before the fix, every kernel below was rejected by the
+ *     OCaml compiler, because the native backend lowers Float32.<name> to
+ *     Sarek.Sarek_cpu_runtime.Float32.<name> and Float64.<name> to
+ *     (formerly) Float.<name>, copying the name verbatim. Neither module
+ *     exported abs_float / expm1 / log1p / hypot / copysign / fmod / minus
+ *     (Float32) nor abs_float / rsqrt / fmod / copysign / of_int32 / to_int32
+ *     (Float64), so the user saw e.g.
+ *         Error: Unbound value Sarek.Sarek_cpu_runtime.Float32.copysign
+ *     pointing into PPX-generated code. A public API that cannot be called is
+ *     a compile-time failure here, so the mere existence of this file as a
+ *     wired, built target is the regression guard.
+ *
+ * (ii) The values are checked against the OCaml stdlib, so a native mapping
+ *      that resolves to the WRONG function (e.g. minus -> add, or fmod
+ *      implemented as truncating division) does not pass. Each expectation is
+ *      the `ocaml = ...` field of the corresponding let%sarek_intrinsic, which
+ *      is that intrinsic's host-side specification.
+ *
+ * Float32 comparisons use a 1e-5 relative-ish tolerance because the runtime
+ * rounds every result through float32; Float64 comparisons are exact where the
+ * operation is exact (copysign, abs_float) and tolerance-based otherwise.
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Float32 = Sarek_stdlib.Float32
+module Float64 = Sarek_float64.Float64
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Sarek_native.Native_plugin.init ()
+
+let n = 16
+
+(* Inputs chosen to exercise sign handling (copysign, abs_float, fmod all
+   depend on it) and to stay away from the poles of log1p/expm1. *)
+let input i = (float_of_int (i - (n / 2)) *. 0.75) +. 0.125
+
+let failures = ref 0
+
+let report name i expected got tol =
+  if
+    Stdlib.abs_float (got -. expected) > tol
+    || Stdlib.compare (got <> got) (expected <> expected) <> 0
+  then begin
+    incr failures ;
+    Printf.printf
+      "MISMATCH %s[%d]: expected %.17g, got %.17g (tol %g)\n%!"
+      name
+      i
+      expected
+      got
+      tol
+  end
+
+(******************************************************************************
+ * Float32
+ ******************************************************************************)
+
+let f32_kernel =
+  [%kernel
+    fun (a : float32 vector) (out : float32 vector) ->
+      let open Std in
+      let tid = global_thread_id in
+      let v = a.(tid) in
+      let av = Float32.abs_float v in
+      let cs = Float32.copysign av v in
+      let hy = Float32.hypot cs (Float32.expm1 av) in
+      let l1 = Float32.log1p av in
+      out.(tid) <- Float32.fmod (Float32.minus hy l1) 3.0]
+
+let f32_expected v =
+  let av = Stdlib.abs_float v in
+  let cs = Stdlib.copysign av v in
+  let hy = Stdlib.hypot cs (Stdlib.expm1 av) in
+  let l1 = Stdlib.log1p av in
+  Float.rem (hy -. l1) 3.0
+
+(******************************************************************************
+ * Float64
+ ******************************************************************************)
+
+let f64_kernel =
+  [%kernel
+    fun (a : float64 vector) (out : float64 vector) ->
+      let open Std in
+      let tid = global_thread_id in
+      let v = a.(tid) in
+      let av = Float64.abs_float v in
+      let cs = Float64.copysign av v in
+      let hy = Float64.hypot cs (Float64.expm1 av) in
+      let rs = Float64.rsqrt (Float64.log1p (Float64.abs_float hy)) in
+      out.(tid) <- Float64.fmod rs 3.0]
+
+let f64_expected v =
+  let av = Stdlib.abs_float v in
+  let cs = Stdlib.copysign av v in
+  let hy = Stdlib.hypot cs (Stdlib.expm1 av) in
+  let rs = 1.0 /. Stdlib.sqrt (Stdlib.log1p (Stdlib.abs_float hy)) in
+  Float.rem rs 3.0
+
+(******************************************************************************
+ * Drive both on the Native device
+ ******************************************************************************)
+
+let ir_of kern =
+  let _, kirc = kern in
+  match kirc.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let run_case label kind kern expected tol =
+  let devs = Device.init ~frameworks:["Native"] () in
+  let dev = devs.(0) in
+  let a = Vector.create kind n in
+  let out = Vector.create kind n in
+  for i = 0 to n - 1 do
+    Vector.set a i (input i) ;
+    Vector.set out i nan
+  done ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of kern)
+    ~args:[Execute.Vec a; Execute.Vec out]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  for i = 0 to n - 1 do
+    report label i (expected (input i)) (Vector.get out i) tol
+  done
+
+let () =
+  run_case "float32" Vector.float32 f32_kernel f32_expected 1e-5 ;
+  run_case "float64" Vector.float64 f64_kernel f64_expected 1e-12 ;
+  if !failures = 0 then
+    print_endline
+      "test_intrinsic_native_surface: PASSED (14 previously-uncallable \
+       intrinsics compiled and evaluated correctly on the Native device)"
+  else begin
+    Printf.printf
+      "test_intrinsic_native_surface: FAILED (%d mismatches)\n"
+      !failures ;
+    exit 1
+  end

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -147,3 +147,23 @@
 (test
  (name test_sync_stmt_emission)
  (libraries sarek.codegen sarek_ppx_lib spoc.ir alcotest))
+
+; Intrinsic-surface reconciliation: derives its expectation from
+; Sarek_registry's link-time record of every let%sarek_intrinsic, and checks it
+; against Sarek_pure_registry (GPU codegen) and Sarek_cpu_runtime (native).
+; Closes the "declared but unroutable" class rather than the reported names.
+
+(test
+ (name test_intrinsic_surface)
+ (libraries
+  sarek
+  sarek.float64
+  sarek.codegen
+  sarek_stdlib
+  sarek_ppx_lib
+  sarek_registry
+  sarek_ir
+  opencl_gate
+  alcotest
+  str
+  unix))

--- a/sarek/tests/unit/test_float32.ml
+++ b/sarek/tests/unit/test_float32.ml
@@ -237,6 +237,63 @@ let () =
     ~got:(F32.of_int 123)
     ~tolerance:1e-6 ;
 
+  (* Overflow reporting for the stdlib-surface functions (#317 review).
+     The interpreter is this project's cross-backend oracle, so two separate
+     properties matter and are checked separately:
+
+     (i)  VALUE-NEUTRALITY. check_overflow must not perturb any number in the
+          default Silent mode, or every agreement test would be comparing
+          against a shifted reference.
+     (ii) REPORTING. In Exception mode an infinite result must actually raise,
+          or Warn/Exception silently miss it -- the reported defect.
+
+     Each has a negative control, so neither can pass by doing nothing. *)
+  Printf.printf "\nOverflow reporting (expm1 / log1p / hypot):\n" ;
+  F32.set_overflow_mode F32.Silent ;
+  (* (i) values in Silent mode. The overflow threshold below (88.7228394) is
+     bit-identical to C expm1f's, established by an exhaustive sweep of all
+     2^32 binary32 inputs; 100.0 is well past it and 1.0 well below. *)
+  test "Silent: expm1 100.0 = infinity" (F32.expm1 100.0 = infinity) ;
+  test
+    "Silent: expm1 1.0 is finite (negative control for the threshold)"
+    (F32.expm1 1.0 < 2.0 && F32.expm1 1.0 > 1.7) ;
+  test
+    "Silent: log1p (-1.0) = neg_infinity (pole)"
+    (F32.log1p (-1.0) = neg_infinity) ;
+  test
+    "Silent: log1p (-2.0) is NaN, not an infinity (matches C log1pf; \
+     check_overflow must not turn a domain error into a pole)"
+    (Float.is_nan (F32.log1p (-2.0))) ;
+  test "Silent: hypot 3e38 3e38 = infinity" (F32.hypot 3e38 3e38 = infinity) ;
+  (* (ii) reporting in Exception mode. *)
+  F32.set_overflow_mode F32.Exception ;
+  let raises f =
+    try
+      ignore (f () : float) ;
+      false
+    with F32.Float32_overflow _ -> true
+  in
+  test
+    "Exception: expm1 100.0 raises Float32_overflow"
+    (raises (fun () -> F32.expm1 100.0)) ;
+  test
+    "Exception: expm1 1.0 does NOT raise (negative control: the check is not \
+     raising unconditionally)"
+    (not (raises (fun () -> F32.expm1 1.0))) ;
+  test
+    "Exception: log1p (-1.0) raises Float32_overflow"
+    (raises (fun () -> F32.log1p (-1.0))) ;
+  test
+    "Exception: log1p (-2.0) does NOT raise (NaN is not an overflow)"
+    (not (raises (fun () -> F32.log1p (-2.0)))) ;
+  test
+    "Exception: hypot 3e38 3e38 raises Float32_overflow"
+    (raises (fun () -> F32.hypot 3e38 3e38)) ;
+  test
+    "Exception: hypot 1.0 1.0 does NOT raise (negative control)"
+    (not (raises (fun () -> F32.hypot 1.0 1.0))) ;
+  F32.set_overflow_mode F32.Silent ;
+
   (* Summary *)
   Printf.printf "\n========================================\n" ;
   Printf.printf

--- a/sarek/tests/unit/test_intrinsic_surface.ml
+++ b/sarek/tests/unit/test_intrinsic_surface.ml
@@ -1,0 +1,527 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Intrinsic-surface reconciliation.
+ *
+ * A Sarek stdlib intrinsic is declared ONCE (let%sarek_intrinsic) but has to be
+ * honoured by three independent tables, each of which had drifted:
+ *
+ *   1. Sarek_registry  (FFI)   - written by the PPX from the declaration itself,
+ *                                so it is the GROUND TRUTH for "which names
+ *                                exist and what device symbol each one means".
+ *   2. Sarek_pure_registry     - a hand-maintained copy used by GPU codegen for
+ *                                path-qualified calls. Float64 entries were a
+ *                                bare NAME list with no name -> symbol mapping,
+ *                                and five declared names were simply absent.
+ *   3. The native (cpu_kern)   - Sarek_native_intrinsics.map_stdlib_path picks a
+ *      target module              module, then the intrinsic name is copied
+ *                                VERBATIM onto it. Any name the target module
+ *                                does not export is a compile error inside
+ *                                PPX-generated code.
+ *
+ * Fixing the reported thirteen names is not enough on its own: nothing stopped
+ * the fourteenth. This test derives the expectation from (1) at link time, so a
+ * new let%sarek_intrinsic that is not routable goes red without anyone
+ * remembering to update a list.
+ *
+ * How it can fail (i.e. it is not vacuous):
+ *   - a stdlib name absent from Sarek_pure_registry     -> test_pure_registry_*
+ *   - a pure-registry symbol disagreeing with the       -> test_symbol_agreement
+ *     declaration's own CUDA/OpenCL spelling
+ *   - a stdlib name with no native target symbol        -> BUILD failure in the
+ *     (the witness below names it explicitly)              witness table
+ *   - a stdlib name missing from the witness table      -> test_native_witness_*
+ *
+ * The witness tables are deliberately hand-written rather than generated: each
+ * entry is an OCaml reference to the real runtime function, so a missing one
+ * cannot compile, and the completeness check below proves the table is not
+ * merely a subset someone stopped extending.
+ ******************************************************************************)
+
+let () = Sarek_stdlib.force_init ()
+
+(* Force sarek_float64's module initialiser, which is what registers the
+   Float64 intrinsics into Sarek_registry. Without this the registry is empty
+   for Float64 and every check below would pass vacuously. *)
+let () = ignore (Sarek_float64.Float64.sin 0.0)
+
+(******************************************************************************
+ * Ground truth
+ ******************************************************************************)
+
+(** Every [(name, cuda_template, opencl_template)] the linked stdlib registered
+    under [ffi_path]. *)
+let declared ffi_path =
+  Hashtbl.fold
+    (fun (path, name) (fi : Sarek_registry.fun_info) acc ->
+      if path = ffi_path then
+        (name, fi.fi_device "CUDA", fi.fi_device "OpenCL") :: acc
+      else acc)
+    Sarek_registry.fun_registry
+    []
+  |> List.sort compare
+
+(** A device template containing [%s] is an operator/cast form: codegen expands
+    it structurally instead of emitting [symbol(args)], so it needs no
+    pure-registry entry. Everything else is a plain call, and a plain call is
+    exactly what the pure registry exists to name. *)
+let is_plain_call template =
+  let rec scan i =
+    if i + 1 >= String.length template then true
+    else if template.[i] = '%' && template.[i + 1] = 's' then false
+    else scan (i + 1)
+  in
+  scan 0
+
+let plain_calls ffi_path =
+  List.filter (fun (_, cuda, _) -> is_plain_call cuda) (declared ffi_path)
+
+(******************************************************************************
+ * 1. Pure registry completeness
+ ******************************************************************************)
+
+(* (label, ffi registration path, user-visible paths a kernel may write) *)
+let float32_surface =
+  ( "Float32",
+    ["Sarek_stdlib"; "Float32"],
+    [["Float32"]; ["Math"; "Float32"]; ["Sarek_stdlib_meta"; "Float32"]] )
+
+let float64_surface = ("Float64", ["Sarek_float64"; "Float64"], [["Float64"]])
+
+let check_pure_completeness (label, ffi_path, user_paths) () =
+  let names = plain_calls ffi_path in
+  Alcotest.(check bool)
+    (label ^ ": stdlib declared at least one plain-call intrinsic")
+    true
+    (names <> []) ;
+  List.iter
+    (fun user_path ->
+      let missing =
+        List.filter
+          (fun (name, _, _) ->
+            Sarek_pure_registry.fun_device_template ~module_path:user_path name
+            = None)
+          names
+      in
+      let printable = String.concat "." user_path in
+      Alcotest.(check (list string))
+        (Printf.sprintf
+           "%s: every name declared by the stdlib resolves under path %s (an \
+            unresolved name reaches GPU codegen as an Unknown intrinsic error, \
+            or falls through to a backend arm that may spell it differently)"
+           label
+           printable)
+        []
+        (List.map (fun (n, _, _) -> n) missing))
+    user_paths
+
+(******************************************************************************
+ * 2. Symbol agreement
+ *
+ * The pure registry must emit the SAME device symbol the declaration itself
+ * names. This is the check that catches a bare name list: adding "abs_float"
+ * to a list of names emits a call to abs_float(), while the declaration says
+ * the symbol is fabs.
+ ******************************************************************************)
+
+let check_symbol_agreement (label, ffi_path, user_paths) () =
+  let names = plain_calls ffi_path in
+  let user_path = List.hd user_paths in
+  List.iter
+    (fun (name, cuda, opencl) ->
+      match
+        Sarek_pure_registry.fun_device_template ~module_path:user_path name
+      with
+      | None ->
+          () (* completeness is checked separately; do not double-report *)
+      | Some device ->
+          Alcotest.(check string)
+            (Printf.sprintf "%s.%s: CUDA symbol" label name)
+            cuda
+            (device ~framework:"CUDA") ;
+          Alcotest.(check string)
+            (Printf.sprintf "%s.%s: OpenCL symbol" label name)
+            opencl
+            (device ~framework:"OpenCL"))
+    names
+
+(******************************************************************************
+ * 3. Native witness
+ *
+ * One entry per declared intrinsic, referencing the runtime function the native
+ * backend will emit a call to. The reference is what makes a missing runtime
+ * function a BUILD error rather than a silent gap; the completeness check makes
+ * a missing witness entry a test failure.
+ *
+ * Read the module aliases as the assertion: these are exactly the modules
+ * Sarek_native_intrinsics.map_stdlib_path resolves ["Float32"] / ["Float64"] to.
+ ******************************************************************************)
+
+module F32 = Sarek.Sarek_cpu_runtime.Float32
+module F64 = Sarek.Sarek_cpu_runtime.Float64
+
+let u f = fun () -> ignore (f 1.0 : float)
+
+let b f = fun () -> ignore (f 1.0 2.0 : float)
+
+let t f = fun () -> ignore (f 1.0 2.0 3.0 : float)
+
+let float32_witness : (string * (unit -> unit)) list =
+  [
+    ("sin", u F32.sin);
+    ("cos", u F32.cos);
+    ("tan", u F32.tan);
+    ("asin", u F32.asin);
+    ("acos", u F32.acos);
+    ("atan", u F32.atan);
+    ("sinh", u F32.sinh);
+    ("cosh", u F32.cosh);
+    ("tanh", u F32.tanh);
+    ("exp", u F32.exp);
+    ("log", u F32.log);
+    ("log10", u F32.log10);
+    ("sqrt", u F32.sqrt);
+    ("ceil", u F32.ceil);
+    ("floor", u F32.floor);
+    ("rsqrt", u F32.rsqrt);
+    ("pow", b F32.pow);
+    ("atan2", b F32.atan2);
+    ("fma", t F32.fma);
+    ("of_int", fun () -> ignore (F32.of_int 1 : float));
+    ("to_int", fun () -> ignore (F32.to_int 1.0 : int));
+    ("add", b F32.add);
+    ("mul", b F32.mul);
+    ("div", b F32.div);
+    (* The seven that had no native target before this change. *)
+    ("abs_float", u F32.abs_float);
+    ("expm1", u F32.expm1);
+    ("log1p", u F32.log1p);
+    ("hypot", b F32.hypot);
+    ("copysign", b F32.copysign);
+    ("fmod", b F32.fmod);
+    ("minus", b F32.minus);
+    ("add_float32", b F32.add_float32);
+    ("sub_float32", b F32.sub_float32);
+    ("mul_float32", b F32.mul_float32);
+    ("div_float32", b F32.div_float32);
+  ]
+
+let float64_witness : (string * (unit -> unit)) list =
+  [
+    ("sin", u F64.sin);
+    ("cos", u F64.cos);
+    ("tan", u F64.tan);
+    ("asin", u F64.asin);
+    ("acos", u F64.acos);
+    ("atan", u F64.atan);
+    ("sinh", u F64.sinh);
+    ("cosh", u F64.cosh);
+    ("tanh", u F64.tanh);
+    ("exp", u F64.exp);
+    ("log", u F64.log);
+    ("log10", u F64.log10);
+    ("sqrt", u F64.sqrt);
+    ("ceil", u F64.ceil);
+    ("floor", u F64.floor);
+    ("expm1", u F64.expm1);
+    ("log1p", u F64.log1p);
+    ("abs_float", u F64.abs_float);
+    ("rsqrt", u F64.rsqrt);
+    ("pow", b F64.pow);
+    ("atan2", b F64.atan2);
+    ("hypot", b F64.hypot);
+    ("copysign", b F64.copysign);
+    ("fmod", b F64.fmod);
+    ("add_float64", b F64.add_float64);
+    ("sub_float64", b F64.sub_float64);
+    ("mul_float64", b F64.mul_float64);
+    ("div_float64", b F64.div_float64);
+    ("of_int", fun () -> ignore (F64.of_int 1 : float));
+    ("of_int32", fun () -> ignore (F64.of_int32 1l : float));
+    ("to_int", fun () -> ignore (F64.to_int 1.0 : int));
+    ("to_int32", fun () -> ignore (F64.to_int32 1.0 : int32));
+    ("of_float32", u F64.of_float32);
+    ("to_float32", u F64.to_float32);
+    ("+.", b F64.( +. ));
+    ("-.", b F64.( -. ));
+    ("*.", b F64.( *. ));
+    ("/.", b F64.( /. ));
+    ("<=", fun () -> ignore (F64.( <= ) 1.0 2.0 : bool));
+    (">=", fun () -> ignore (F64.( >= ) 1.0 2.0 : bool));
+    ("<", fun () -> ignore (F64.( < ) 1.0 2.0 : bool));
+    (">", fun () -> ignore (F64.( > ) 1.0 2.0 : bool));
+  ]
+
+let check_native_witness label ffi_path witness () =
+  let declared_names =
+    List.map (fun (n, _, _) -> n) (declared ffi_path) |> List.sort compare
+  in
+  let witness_names = List.map fst witness |> List.sort compare in
+  Alcotest.(check (list string))
+    (Printf.sprintf
+       "%s: every declared intrinsic has a native witness (a name missing here \
+        has no Sarek_cpu_runtime.%s.<name> to lower to, so any native kernel \
+        calling it fails to compile)"
+       label
+       label)
+    []
+    (List.filter (fun n -> not (List.mem n witness_names)) declared_names) ;
+  Alcotest.(check (list string))
+    (Printf.sprintf
+       "%s: the witness table has no entry the stdlib does not declare"
+       label)
+    []
+    (List.filter (fun n -> not (List.mem n declared_names)) witness_names) ;
+  (* Actually call each one: proves the entries are live values, not just
+     names that typecheck. *)
+  List.iter (fun (_, thunk) -> thunk ()) witness
+
+(******************************************************************************
+ * 4. The native mapping the witness assumes is the one the PPX emits
+ ******************************************************************************)
+
+let check_native_target_paths () =
+  Alcotest.(check (list string))
+    "Float32 native target module"
+    ["Sarek"; "Sarek_cpu_runtime"; "Float32"]
+    (Sarek_native_intrinsics.map_stdlib_path ["Float32"]) ;
+  Alcotest.(check (list string))
+    "Float64 native target module (Stdlib.Float does not export the whole \
+     Float64 surface)"
+    ["Sarek"; "Sarek_cpu_runtime"; "Float64"]
+    (Sarek_native_intrinsics.map_stdlib_path ["Float64"])
+
+(******************************************************************************
+ * Registration
+ ******************************************************************************)
+
+(******************************************************************************
+ * 5. The FFI fallback emits the CALLING backend's spelling
+ *
+ * A PPX kernel writes Float32.sin, and the PPX records the path as
+ * ["Sarek_stdlib"; "Float32"] — the DECLARATION-SITE path, which
+ * Sarek_pure_registry does not register. Such calls therefore land on the
+ * dispatcher's FFI fallback (Sarek_ir_intrinsic_dispatch.emit_registry_template),
+ * which used to ask Sarek_registry for the "generic" framework. cuda_or_opencl
+ * resolves "generic" to the CUDA branch, so an OpenCL or Metal kernel calling
+ * Float32.abs_float was emitted as fabsf(...) — a name neither OpenCL C nor MSL
+ * declares.
+ *
+ * The clang gate below is the positive/negative control pair: it compiles the
+ * emitted OpenCL, and separately confirms that the PRE-FIX spelling is rejected
+ * by the same compiler. Without the negative control this check could pass
+ * while testing nothing.
+ ******************************************************************************)
+
+let f32_call_kernel name arity : Sarek_ir_types.kernel =
+  let open Sarek_ir_types in
+  let a =
+    {var_name = "a"; var_id = 0; var_type = TVec TFloat32; var_mutable = false}
+  in
+  let b =
+    {var_name = "b"; var_id = 1; var_type = TVec TFloat32; var_mutable = false}
+  in
+  let idx =
+    {var_name = "idx"; var_id = 2; var_type = TInt32; var_mutable = false}
+  in
+  let arg = EArrayRead ("a", EVar idx) in
+  {
+    kern_name = "ffi_fallback_" ^ name;
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+    kern_body =
+      SLet
+        ( idx,
+          EIntrinsic ([], "global_thread_id", []),
+          SAssign
+            ( LArrayElem ("b", EVar idx),
+              EIntrinsic
+                ( ["Sarek_stdlib"; "Float32"],
+                  name,
+                  if arity = 1 then [arg] else [arg; arg] ) ) );
+  }
+
+(* Names reached ONLY through the FFI fallback: absent from the pure registry
+   under this path and from the OpenCL backend's hardcoded arm. *)
+let fallback_names =
+  [("abs_float", 1); ("copysign", 2); ("hypot", 2); ("fmod", 2)]
+
+let opencl_source name arity =
+  Sarek_codegen.Sarek_ir_opencl.generate_with_types
+    ~types:[]
+    (f32_call_kernel name arity)
+
+let check_opencl_spelling () =
+  List.iter
+    (fun (name, arity) ->
+      let src = opencl_source name arity in
+      let cuda_spelling =
+        match
+          Sarek_registry.fun_device_template
+            ~module_path:["Sarek_stdlib"; "Float32"]
+            ~framework:"CUDA"
+            name
+        with
+        | Some s -> s
+        | None -> Alcotest.fail (name ^ ": not in the FFI registry")
+      in
+      let opencl_spelling =
+        match
+          Sarek_registry.fun_device_template
+            ~module_path:["Sarek_stdlib"; "Float32"]
+            ~framework:"OpenCL"
+            name
+        with
+        | Some s -> s
+        | None -> Alcotest.fail (name ^ ": not in the FFI registry")
+      in
+      (* Guard against a vacuous test: these names must actually differ between
+         the two branches, or the check below proves nothing. *)
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s: the CUDA and OpenCL declarations differ (%s vs %s), so the \
+            framework the fallback passes is observable"
+           name
+           cuda_spelling
+           opencl_spelling)
+        true
+        (cuda_spelling <> opencl_spelling) ;
+      let contains hay needle =
+        let n = String.length needle and h = String.length hay in
+        let rec go i =
+          i + n <= h && (String.sub hay i n = needle || go (i + 1))
+        in
+        go 0
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "OpenCL kernel calling Float32.%s emits %s"
+           name
+           opencl_spelling)
+        true
+        (contains src (opencl_spelling ^ "(")) ;
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "OpenCL kernel calling Float32.%s does NOT emit the CUDA spelling %s"
+           name
+           cuda_spelling)
+        false
+        (contains src (cuda_spelling ^ "(")))
+    fallback_names
+
+let check_opencl_compiles () =
+  if not (Opencl_gate.Opencl_clang.available ()) then Alcotest.skip ()
+  else
+    List.iter
+      (fun (name, arity) ->
+        let src = opencl_source name arity in
+        (* Positive control: what we emit now compiles. *)
+        (match Opencl_gate.Opencl_clang.run_clang src with
+        | Ok () -> ()
+        | Error log ->
+            Alcotest.failf
+              "emitted OpenCL for Float32.%s does not compile:\n\
+               %s\n\
+               --- source ---\n\
+               %s"
+              name
+              log
+              src) ;
+        (* Negative control: the PRE-FIX spelling is rejected by the same
+           compiler. Proves the positive control above is not vacuous — that
+           clang would in fact have caught the old output. *)
+        let cuda_spelling =
+          Option.get
+            (Sarek_registry.fun_device_template
+               ~module_path:["Sarek_stdlib"; "Float32"]
+               ~framework:"CUDA"
+               name)
+        in
+        let opencl_spelling =
+          Option.get
+            (Sarek_registry.fun_device_template
+               ~module_path:["Sarek_stdlib"; "Float32"]
+               ~framework:"OpenCL"
+               name)
+        in
+        let regressed =
+          Str.global_replace
+            (Str.regexp_string (opencl_spelling ^ "("))
+            (cuda_spelling ^ "(")
+            src
+        in
+        match Opencl_gate.Opencl_clang.run_clang regressed with
+        | Error _ -> ()
+        | Ok () ->
+            Alcotest.failf
+              "NEGATIVE CONTROL FAILED: clang accepted the pre-fix spelling %s \
+               for Float32.%s, so this gate cannot detect the regression it \
+               exists to catch"
+              cuda_spelling
+              name)
+      fallback_names
+
+let () =
+  Alcotest.run
+    "intrinsic-surface"
+    [
+      ( "pure-registry completeness",
+        [
+          Alcotest.test_case
+            "Float32"
+            `Quick
+            (check_pure_completeness float32_surface);
+          Alcotest.test_case
+            "Float64"
+            `Quick
+            (check_pure_completeness float64_surface);
+        ] );
+      ( "symbol agreement",
+        [
+          Alcotest.test_case
+            "Float32"
+            `Quick
+            (check_symbol_agreement float32_surface);
+          Alcotest.test_case
+            "Float64"
+            `Quick
+            (check_symbol_agreement float64_surface);
+        ] );
+      ( "native surface",
+        [
+          Alcotest.test_case
+            "Float32"
+            `Quick
+            (check_native_witness
+               "Float32"
+               ["Sarek_stdlib"; "Float32"]
+               float32_witness);
+          Alcotest.test_case
+            "Float64"
+            `Quick
+            (check_native_witness
+               "Float64"
+               ["Sarek_float64"; "Float64"]
+               float64_witness);
+          Alcotest.test_case "target modules" `Quick check_native_target_paths;
+        ] );
+      ( "framework-aware FFI fallback",
+        [
+          Alcotest.test_case "OpenCL spelling" `Quick check_opencl_spelling;
+          Alcotest.test_case
+            "emitted OpenCL compiles (clang gate)"
+            `Quick
+            check_opencl_compiles;
+        ] );
+    ]

--- a/sarek/tests/unit/test_intrinsic_surface.ml
+++ b/sarek/tests/unit/test_intrinsic_surface.ml
@@ -353,9 +353,21 @@ let f32_call_kernel name arity : Sarek_ir_types.kernel =
   }
 
 (* Names reached ONLY through the FFI fallback: absent from the pure registry
-   under this path and from the OpenCL backend's hardcoded arm. *)
+   under this path and from the OpenCL backend's hardcoded arm. expm1 and log1p
+   belong here for the same reason as the other four -- they are declared
+   [dev "expm1f" "expm1"] / [dev "log1pf" "log1p"], so the discarded framework
+   was observable on them too. (Metal polyfills those two in its pre_hook, which
+   is why they were easy to overlook; OpenCL has no pre_hook and took the CUDA
+   spelling straight through.) *)
 let fallback_names =
-  [("abs_float", 1); ("copysign", 2); ("hypot", 2); ("fmod", 2)]
+  [
+    ("abs_float", 1);
+    ("copysign", 2);
+    ("hypot", 2);
+    ("fmod", 2);
+    ("expm1", 1);
+    ("log1p", 1);
+  ]
 
 let opencl_source name arity =
   Sarek_codegen.Sarek_ir_opencl.generate_with_types

--- a/spoc/ir/Sarek_pure_registry.ml
+++ b/spoc/ir/Sarek_pure_registry.ml
@@ -65,14 +65,23 @@ let float32_math_template ~name ~cuda_name ~generic_name =
   | "GLSL" -> glsl_name ~name ~generic_name
   | _ -> generic_name
 
-(** Same as [float32_math_template] but for functions spelled identically on
-    every backend except GLSL (e.g. Float64 math, which has no CUDA [f]-suffix).
-*)
-let generic_math_template name =
+(** Same as [float32_math_template] but for functions with no CUDA [f]-suffix
+    (Float64 math): one device symbol on every backend, modulo the GLSL rename.
+
+    [name] is the SAREK-SOURCE name ([Float64.abs_float]); [generic_name] is the
+    DEVICE symbol to emit ([fabs]). They differ for exactly the entries where
+    the OCaml stdlib spelling is not the C spelling, and keeping them separate
+    is what stops [Float64.abs_float] from emitting a call to a nonexistent
+    [abs_float]. *)
+let named_math_template ~name ~generic_name =
  fun ~framework ->
   match framework with
-  | "GLSL" -> glsl_name ~name ~generic_name:name
-  | _ -> name
+  | "GLSL" -> glsl_name ~name ~generic_name
+  | _ -> generic_name
+
+(** [named_math_template] for the entries whose source name IS the device
+    symbol. *)
+let generic_math_template name = named_math_template ~name ~generic_name:name
 
 (******************************************************************************
  * Standard stdlib registrations (static table — PR-2 design)
@@ -99,24 +108,30 @@ let generic_math_template name =
  * being hand-duplicated per path.
  *
  * [fmod] is deliberately Float64-only (Float64.fmod), NOT a Math.Float64 name,
- * so it too is absent from math_float64_list — but unlike the 11 below it DOES
+ * so it too is absent from math_float64_list — but unlike the 8 below it DOES
  * have interpreter support (eval_float64_math_intrinsic "fmod"), so its absence
  * is an API-surface choice, not the miscompile hazard the note below describes.
  *
  * IMPORTANT — intentional float64 drift (do not "complete" this table):
- * math_float64_list has 16 entries, missing_from_math_float64 lists the 11
+ * math_float64_list has 16 entries; missing_from_math_float64 lists the 11
  * intrinsics present in float64_list but absent from math_float64_list:
  *   exp2, log2, log10, rsqrt, cbrt, round, trunc, fabs, fma, min, max
- * All 11 lack interpreter support (sarek/interp/Sarek_ir_interp_intrinsics.ml
- * eval_float64_math_intrinsic implements only sin/cos/sqrt/exp/log/abs/of_int)
- * and 8 of the 11 (exp2, log2, cbrt, round, trunc, fma, min, max) also lack a
- * Sarek_float64.Float64 stdlib declaration. Registering any of them into the
- * Math.Float64 tables without adding the missing interpreter (and, for those
- * 8, stdlib) support would convert an honest lookup failure into a silent
- * miscompile: codegen would emit a call to a name the interpreter cannot
- * evaluate. See briefs/backend-dry-correctness-step0.md section (e) for the
- * full per-intrinsic evidence table. This is a tracked follow-up boundary,
- * not an oversight.
+ * Of these, 8 (exp2, log2, cbrt, round, trunc, fma, min, max) have NO
+ * Sarek_float64.Float64 stdlib declaration at all and no interpreter arm, so
+ * registering them into the Math.Float64 tables would convert an honest lookup
+ * failure into a silent miscompile: codegen would emit a call to a name the
+ * interpreter cannot evaluate. See briefs/backend-dry-correctness-step0.md
+ * section (e). This is a tracked follow-up boundary, not an oversight.
+ * (log10, rsqrt and fabs DO have interpreter arms — see
+ * sarek/interp/Sarek_ir_interp_intrinsics.ml eval_float64_math_intrinsic, whose
+ * coverage this comment previously understated as "only sin/cos/sqrt/exp/log/
+ * abs/of_int". Their absence from Math.Float64 is an API-surface choice.)
+ *
+ * The reverse direction — a name DECLARED by the stdlib but absent from these
+ * tables — is the defect class closed by
+ * sarek/tests/unit/test_intrinsic_surface.ml: it reconciles these tables
+ * against Sarek_registry's link-time record of every let%sarek_intrinsic, so a
+ * new stdlib intrinsic cannot ship path-unroutable.
  ******************************************************************************)
 
 (** (name, cuda_name, generic_name) — the 32-entry float32 math list, shared
@@ -158,38 +173,55 @@ let float32_list =
     ("fmod", "fmodf", "fmod");
   ]
 
-(** The 27-entry float64 math list (same name on every backend, modulo the GLSL
-    override), shared verbatim across both float64-exposing paths. *)
+(** (sarek_name, device_symbol) — the float64 math list, shared verbatim across
+    both float64-exposing paths. Same symbol on every backend, modulo the GLSL
+    override.
+
+    The pair, rather than a bare name list, is load-bearing: five of these
+    entries ([abs_float], and historically anything else whose OCaml stdlib
+    spelling differs from its C spelling) would otherwise emit a call to a
+    device function that does not exist. That is why adding a name to this table
+    is safe only together with its symbol — see [named_math_template]. *)
 let float64_list =
   [
-    "sin";
-    "cos";
-    "tan";
-    "asin";
-    "acos";
-    "atan";
-    "sinh";
-    "cosh";
-    "tanh";
-    "exp";
-    "exp2";
-    "log";
-    "log2";
-    "log10";
-    "sqrt";
-    "rsqrt";
-    "cbrt";
-    "floor";
-    "ceil";
-    "round";
-    "trunc";
-    "fabs";
-    "pow";
-    "atan2";
-    "fma";
-    "min";
-    "max";
-    "fmod";
+    ("sin", "sin");
+    ("cos", "cos");
+    ("tan", "tan");
+    ("asin", "asin");
+    ("acos", "acos");
+    ("atan", "atan");
+    ("sinh", "sinh");
+    ("cosh", "cosh");
+    ("tanh", "tanh");
+    ("exp", "exp");
+    ("exp2", "exp2");
+    ("log", "log");
+    ("log2", "log2");
+    ("log10", "log10");
+    ("sqrt", "sqrt");
+    ("rsqrt", "rsqrt");
+    ("cbrt", "cbrt");
+    ("floor", "floor");
+    ("ceil", "ceil");
+    ("round", "round");
+    ("trunc", "trunc");
+    ("fabs", "fabs");
+    ("pow", "pow");
+    ("atan2", "atan2");
+    ("fma", "fma");
+    ("min", "min");
+    ("max", "max");
+    ("fmod", "fmod");
+    (* The five entries below are declared by Sarek_float64.Float64 but were
+       absent from this table, so a path-qualified call to any of them raised
+       "Unknown intrinsic" on CUDA, OpenCL and (for abs_float/copysign) Metal.
+       GLSL survived only because its pre_hook polyfills expm1/log1p/hypot/
+       copysign and its `arm` renames abs_float to `abs`. *)
+    ("abs_float", "fabs");
+    ("copysign", "copysign");
+    ("expm1", "expm1");
+    ("log1p", "log1p");
+    ("hypot", "hypot");
   ]
 
 (** The 16-entry Math.Float64 list — intentionally a strict subset of
@@ -225,8 +257,11 @@ let register_float32_path module_path =
 
 let register_float64_path module_path =
   List.iter
-    (fun name ->
-      register_fun ~module_path name ~device:(generic_math_template name))
+    (fun (name, generic_name) ->
+      register_fun
+        ~module_path
+        name
+        ~device:(named_math_template ~name ~generic_name))
     float64_list
 
 let register_math_float64_path module_path =

--- a/spoc/ir/test/test_sarek_pure_registry.ml
+++ b/spoc/ir/test/test_sarek_pure_registry.ml
@@ -82,6 +82,16 @@ let float64_names =
     "min";
     "max";
     "fmod";
+    (* Declared by Sarek_float64.Float64 but formerly absent from
+       float64_list, so a path-qualified call raised "Unknown intrinsic" on
+       CUDA/OpenCL (and, for abs_float/copysign, Metal). abs_float is the one
+       whose device SYMBOL differs from its Sarek name (fabs) - the reason
+       float64_list is a (name, symbol) list and not a bare name list. *)
+    "abs_float";
+    "copysign";
+    "expm1";
+    "log1p";
+    "hypot";
   ]
 
 let math_float64_names =
@@ -148,7 +158,7 @@ let test_float64_paths () =
     ["Sarek_stdlib_meta"; "Float64"]
     float64_names
     "Sarek_stdlib_meta.Float64" ;
-  print_endline "  Float64 paths expose exactly the 28-entry set: OK"
+  print_endline "  Float64 paths expose exactly the 33-entry set: OK"
 
 let test_math_float64_paths () =
   assert_path_has_all ["Math"; "Float64"] math_float64_names "Math.Float64" ;
@@ -233,10 +243,31 @@ let test_float64_rsqrt_glsl_matches_meta_twin () =
     "  Float64.rsqrt and Sarek_stdlib_meta.Float64.rsqrt agree on GLSL name \
      (inversesqrt): OK"
 
+(** The float64 table is a (sarek_name, device_symbol) list precisely so that a
+    name whose OCaml spelling is not its C spelling emits the C spelling. Pin
+    the one entry where they differ: registering "abs_float" into a bare NAME
+    list would emit a call to abs_float(), which no backend defines - the silent
+    miscompile the table's header comment fences off. *)
+let test_float64_abs_float_emits_fabs () =
+  let device =
+    match fun_device_template ~module_path:["Float64"] "abs_float" with
+    | Some d -> d
+    | None -> failwith "Float64.abs_float not registered"
+  in
+  assert (device ~framework:"CUDA" = "fabs") ;
+  assert (device ~framework:"OpenCL" = "fabs") ;
+  assert (device ~framework:"Metal" = "fabs") ;
+  (* GLSL spells it `abs`; the override is keyed on the SAREK name, so it must
+     survive the name/symbol split. *)
+  assert (device ~framework:"GLSL" = "abs") ;
+  print_endline
+    "  Float64.abs_float emits fabs (abs on GLSL), never abs_float: OK"
+
 let () =
   test_float32_paths () ;
   test_float64_paths () ;
   test_math_float64_paths () ;
   test_math_float64_intentionally_missing () ;
   test_float64_rsqrt_glsl_matches_meta_twin () ;
+  test_float64_abs_float_emits_fabs () ;
   print_endline "All Sarek_pure_registry tests passed!"

--- a/spoc/registry/Sarek_registry.ml
+++ b/spoc/registry/Sarek_registry.ml
@@ -162,14 +162,22 @@ let fun_device_code ?(module_path = []) name dev =
       let path = String.concat "." (module_path @ [name]) in
       failwith ("Unknown intrinsic function: " ^ path)
 
-(** Get device code template for a function, using a minimal device. This is for
-    V2 IR codegens that don't have SPOC device objects. *)
-let fun_device_template ?(module_path = []) name =
+(** Get the device-code template for a function on a given backend. This is for
+    V2 IR codegens that don't have SPOC device objects.
+
+    [framework] is the caller's backend tag ("CUDA", "OpenCL", "Metal", …). It
+    used to be hardcoded to "generic", which [cuda_or_opencl] resolves to the
+    CUDA branch — so every backend reaching this fallback got the CUDA spelling,
+    and an OpenCL or Metal kernel calling e.g. [Float32.abs_float] was emitted
+    as [fabsf(...)]. Neither OpenCL C nor MSL declares [fabsf]; both spell it
+    [fabs]. The stdlib already declares both spellings ([dev "fabsf" "fabs"]);
+    only this lookup was discarding the caller's framework.
+
+    [?framework] defaults to "generic" so existing non-backend callers keep the
+    previous behaviour. *)
+let fun_device_template ?(module_path = []) ?(framework = "generic") name =
   match find_fun ~module_path name with
-  | Some fi ->
-      (* Pass "generic" as the framework string: cuda_or_opencl maps
-         "generic" to the CUDA/default branch, preserving byte-identical output. *)
-      Some (fi.fi_device "generic")
+  | Some fi -> Some (fi.fi_device framework)
   | None -> None
 
 (** Find a record by short name (last component after '.'). This handles cases
@@ -227,7 +235,12 @@ let () =
 
 let cuda_or_opencl (framework : string) cuda_code opencl_code =
   match framework with
-  | "OpenCL" -> opencl_code
+  (* Metal joins OpenCL, not CUDA: across the whole stdlib these two branches
+     differ ONLY in the CUDA `f` suffix (sinf/fabsf/…) — the operator and cast
+     templates are byte-identical in both — and MSL, like OpenCL C, declares the
+     unsuffixed overloads and has no `fabsf`/`sinf`. This matches the spelling
+     Sarek_pure_registry already emits for Metal via its `generic_name`. *)
+  | "OpenCL" | "Metal" -> opencl_code
   | "CUDA" | "Native" | "Interpreter" | _ -> cuda_code
 (* Use CUDA syntax for CUDA, interpreter, and native *)
 


### PR DESCRIPTION
## What this fixes

Thirteen stdlib intrinsics were user-callable and unusable. I swept the whole
intrinsic surface rather than fixing the reported names, and the same class
turned up in **three** independent tables — one of which fails silently rather
than loudly.

A `let%sarek_intrinsic` is declared **once**, but three tables have to honour it,
and all three had drifted from the declaration.

### 1. `Sarek_pure_registry` — bare name list, five names missing

`float64_list` was a bare **name** list with no name→device-symbol mapping, and
five names declared by `Sarek_float64.Float64` were absent from it entirely:
`abs_float`, `copysign`, `expm1`, `log1p`, `hypot` (the report named two).

Observed, on hand-built IR before the fix:

```
[Float64] abs_float | CUDA=RAISE:Unknown intrinsic: Float64.abs_float
                    | OPENCL=RAISE:Unknown intrinsic: Float64.abs_float
                    | METAL=RAISE:Unknown intrinsic: Float64.abs_float
                    | GLSL=b[idx] = abs(a[idx]);
```

GLSL survives only because its `pre_hook` polyfills four of them and its `arm`
renames `abs_float`→`abs`, exactly as reported.

**The obvious one-line fix is the miscompile the table's own header warns
about**: adding `"abs_float"` to a list of *names* emits a call to
`abs_float(...)`, which no backend defines. `float64_list` is now a
`(sarek_name, device_symbol)` list, so `Float64.abs_float` emits `fabs` — and
`abs` on GLSL, since the rename table is keyed on the *Sarek* name and has to
survive the split. That last point is pinned by a test.

### 2. The native (`cpu_kern`) backend — no target symbol

The native backend picks a target module and then copies the intrinsic **name**
onto it verbatim. `Float32` pointed at `Sarek_cpu_runtime.Float32`, which had no
`abs_float` / `expm1` / `log1p` / `hypot` / `copysign` / `fmod` / `minus`;
`Float64` pointed at OCaml's `Stdlib.Float`, which is missing a third of the
Float64 surface (`abs_float`, `rsqrt`, `fmod`, `copysign`, `of_int32`,
`to_int32`, `of_float32`, `to_float32`, the four `*_float64` names, the eight
operator forms).

Both are compile errors inside PPX-generated code. This kernel could not be
written:

```
Error: Unbound value Sarek.Sarek_cpu_runtime.Float32.copysign
```

`Sarek_float32` gains the seven missing names; the new `Sarek_float64_native`
mirrors the Float64 stdlib surface name-for-name, each body copied from that
intrinsic's own `ocaml = ...` field (which is its host-side specification).

### 3. The FFI fallback discarded the caller's backend — silent, and on the hot path

`Sarek_registry.fun_device_template` asked for the framework `"generic"`, which
`cuda_or_opencl` resolves to the **CUDA** branch. Every backend reaching this
fallback got the CUDA spelling.

This is not a corner: a real PPX kernel records the *declaration-site* path
`["Sarek_stdlib";"Float32"]`, which the pure registry does not register, so
ordinary `Float32.*` calls land here. An OpenCL kernel calling
`Float32.abs_float` was emitted as `fabsf(...)`:

```
/tmp/sarek_gate_ocl_4a5c94.cl:3:12: error: use of undeclared identifier 'fabsf'
```

The stdlib already declared both spellings (`dev "fabsf" "fabs"`); only this
lookup was throwing the framework away. Metal joins the OpenCL branch: across
the whole stdlib the two branches differ *only* in the CUDA `f` suffix, and MSL
has no `fabsf` either.

## Closing the class, not the names

`sarek/tests/unit/test_intrinsic_surface.ml` derives its expectation from
`Sarek_registry`'s link-time record of every `let%sarek_intrinsic` — written by
the PPX from the declaration itself, so it is ground truth — and reconciles it
against the other two tables. A new stdlib intrinsic cannot ship unroutable
without someone remembering a list.

The native half uses a **witness table**: each entry references the real runtime
function, so a missing runtime function is a *build* error, and a completeness
check against the registry makes a missing witness entry a *test* failure.

## Every gate observed red before being trusted green

| Gate | Red output |
|---|---|
| pure-registry completeness | `["abs_float"; "copysign"; "expm1"; "hypot"; "log1p"]` |
| native target module | got `["Float"]`, expected `Sarek_cpu_runtime.Float64` |
| witness completeness | `["copysign"]` when one entry is dropped |
| OpenCL spelling + clang gate | `use of undeclared identifier 'fabsf'` |
| e2e native execution | value mismatches when `minus` is wired to `add` |

The clang check carries its **own negative control**: it re-injects the pre-fix
spelling into the emitted kernel and fails if clang accepts it, so a green
result cannot mean "the compiler wasn't looking".

`scripts/check-test-alias-coverage.sh`: `OK: all 82 e2e test executables are
wired to an alias`. `dune build @fmt` exits 0. `dune build @runtest` exits 0.
`benchmarks/descriptions/generated/` regenerated — **no diff** (the benchmarks
don't use the affected intrinsics).

## Hardware and toolchain

Verified on AMD RX 7900 XTX + Ryzen 9 7950X iGPU: rusticl/radeonsi OpenCL, RADV
Vulkan, plus the Native and Interpreter devices; `clang` for the OpenCL syntax
gate. **No NVIDIA, Metal or WebGPU device was involved** — the CUDA/Metal/WGSL
claims here are codegen-level, and toolchain-checked only where a checker exists
locally.

## Deliberately left (evidenced, not overlooked)

- **The pure registry does not register the paths the PPX actually emits.**
  `["Sarek_stdlib";"Float32"]` and `["Sarek_float64";"Float64"]` are what a real
  kernel carries; the registry holds `["Float32"]`, `["Math";"Float32"]`,
  `["Sarek_stdlib_meta";"Float32"]`, `["Float64"]`. So the framework-aware pure
  registry is bypassed on the common path and the FFI fallback does the work.
  Registering them is a two-line change, but it would make the pure registry
  win over WGSL's and Metal's polyfill arms for names those backends have no
  builtin for (`expm1`, `hypot`, `copysign`, `fabs` are not WGSL), converting a
  loud `Unknown intrinsic` into silently-invalid shader source. Doing it safely
  needs per-framework builtin coverage in the registry — and a WGSL/Metal
  toolchain I don't have locally to verify against.
- **WGSL already emits four invalid builtins** on the `["Float32"]` path today
  (`fabs`, `expm1`, `hypot`, `copysign`). Pre-existing, unchanged by this PR,
  and the same follow-up covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native CPU support for Float64 intrinsics (math, conversions, comparisons, and operators).
  * Expanded Float32 intrinsic surface with additional stdlib-compatible math and arithmetic helpers.
* **Bug Fixes**
  * Fixed intrinsic registry device-template spelling by explicitly preserving the active framework across CUDA/Metal/OpenCL.
  * Improved Float64 pure-registry handling when OCaml/stdlib names differ from emitted device symbols.
* **Tests**
  * Added new native e2e + intrinsic surface unit tests, plus additional Float32 overflow regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 1 — both findings fixed

### Major: `expm1` skipped `check_overflow`

This lands in the **interpreter**, which is this project's cross-backend oracle,
so a mechanical `|> check_overflow` was not good enough. If `expm1` overflowed at
a different point here than on a device, every agreement test using it would be
comparing against a reference that is itself wrong at the extremes — and the
disagreement would get attributed to the device.

**Settled by exhaustive sweep, not inspection.** A C program replicating
`float32_of_float_impl` exactly — its clamp and its flush-to-zero included — run
over **all 2^32 binary32 inputs** against C's `expm1f` / `log1pf`:

| | spurious overflow | missed overflow | first `+x` → `inf` | 1-ulp diffs |
|---|---|---|---|---|
| `expm1` | **0** | **0** | `88.7228394` — *identical to `expm1f`* | 2 of 4.28e9 |
| `log1p` | **0** | **0** | `+inf` only — no finite input overflows | 11 of 4.28e9 |
| `exp` *(control, already wired)* | 0 | 0 | `88.7228394` | 314586 |
| `sqrt` *(control, cannot overflow)* | 0 | 0 | — | 0 disagreements at all |

**So the value was already correct, at a bit-identical threshold — only the
reporting was missing.** The defect is real but narrower than it looked: an
observability gap in `Warn`/`Exception`, not an oracle numerical defect. The
remaining ~1.6e7 disagreements per function are entirely flush-subnormals-to-zero,
which is `float32_of_float_impl`'s deliberate module-wide behaviour, shared by the
already-wired `exp` control, and untouched here.

`check_overflow` is **value-neutral in the default `Silent` mode** — it returns its
argument untouched — so this cannot perturb a single number the oracle produces.
The tests assert that property separately from the reporting one.

### Neighbours, checked rather than assumed

- **`log1p`** is wired even though no finite input overflows, because `log` and
  `log10` already route their pole through `check_overflow` — house convention,
  not a dead gate. **NaN is unaffected**: `check_overflow` tests only
  `= infinity` / `= neg_infinity`, and NaN compares false to both, so
  `log1p x < -1.` still returns NaN exactly as C's `log1pf` does. Pinned by a
  test, because propagating `log`'s own NaN→−inf collapse into `log1p` would have
  been a **new** oracle divergence — the opposite of the point.
- **`hypot`** already had it; a 1.33e8-pair boundary sweep confirms it is
  genuinely reachable (first at `hypot(6.11e37, 3.35e38)`), 0 spurious, 0 missed.
- **`copysign`, `fmod`, `abs_float`** cannot overflow (magnitude-preserving,
  `|r| < |divisor|`, `|x| ≤ max`); **`minus`** is `sub`, already wired.

### Minor: `expm1`/`log1p` missing from `fallback_names`

Correct, and not cosmetic — they are declared `dev "expm1f" "expm1"` /
`dev "log1pf" "log1p"`, so the discarded framework was observable on them too.
Verified they **extend** the gate rather than pad it: under the pre-fix
`"generic"` framework, clang rejects the emitted kernel with
`use of undeclared identifier 'expm1f'`. Easy to overlook because Metal polyfills
both in its `pre_hook`; OpenCL has none and took the CUDA spelling straight
through.

### Red before green

```
[FAIL] Exception: expm1 100.0 raises Float32_overflow
[FAIL] Exception: log1p (-1.0) raises Float32_overflow
Tests: 60, Passed: 58, Failed: 2
```

The **value** assertions stayed green throughout — which is what proves the change
is reporting-only. Every new assertion has a negative control (`expm1 1.0` must
*not* raise, `log1p -2.0` must *not* raise, `hypot 1.0 1.0` must *not* raise), so
none can pass by raising unconditionally.

Sweep toolchain: clang 21 / glibc on x86-64 (Ryzen 9 7950X). It models the OCaml
implementation against the host libm; **it is not evidence about any GPU's
`expm1`**, and no GPU was involved.


---

## Rebase note — after a rebase onto a base that touched your gate's dependencies, green is not evidence

Rebased onto `43653248` (which carries #316 and #319). The only conflict was
`sarek/tests/unit/dune`, purely additive on both sides with an empty common
ancestor — #319 appended its `test_sync_stmt_emission` stanza where this branch
appends `test_intrinsic_surface`. Both kept.

Worth stating because it is a failure mode that arrives through **someone else's
merge rather than your own edit**: #316 rewrote
`sarek/tests/codegen_golden/opencl_gate/opencl_clang.ml`, which is the exact file
this PR's clang gate calls into (`available ()` / `run_clang`). Had that changed
behaviour, the gate would have degraded to `Alcotest.skip ()` — which still
prints `[OK]` in the Alcotest summary. A passing run would then have meant
nothing, and no edit of mine would have caused it.

So the gate was re-proven by mutation on the rebased base rather than trusted:
reverting the OpenCL backend to the pre-fix `"generic"` framework still yields

```
FAIL emitted OpenCL for Float32.abs_float does not compile:
/tmp/sarek_gate_ocl_9bb078.cl:3:12: error: use of undeclared identifier 'fabsf'
```

with exit 1 and no `SKIP` in the output. Tree restored and verified clean
afterwards.

Post-rebase verification was by **counting and locating**, not by exit status:
2 commits, 21 files, `merge-base HEAD origin/main == origin/main`, `HEAD` on a
branch, no `rebase-merge` directory left behind, and one distinctive marker from
each commit located **by line number** (`Sarek_pure_registry.ml:220`,
`Sarek_registry.ml:178` and `:243`, `Sarek_native_intrinsics.ml:118`;
`Sarek_float32.ml:248`/`:250`, `test_intrinsic_surface.ml:368`,
`test_float32.ml:251`). Line numbers rather than `grep -c`, because a count
cannot distinguish "the fix is present" from "a comment mentions it".

`dune build`, `@runtest`, `@fmt` (exit 0, zero diffs) and
`check-test-alias-coverage.sh` (82 executables wired) all pass on the rebased
base. `benchmarks/descriptions/generated/` regenerated — empty diff, inspected.


### Review freshness after the rebase — verified, not asserted

The `CodeRabbit` check on the rebased HEAD now reads **`success — Review completed`**
rather than the previous `Review rate limited`, and it is attached to `0257cb3a`.
But it answered a `@coderabbitai review` request in 5 seconds and its own reply
notes that it "does not re-review already reviewed commits" — so a green check
alone cannot distinguish "re-reviewed and found nothing" from "recognised the
content and skipped".

Rather than rely on that, the question was made mechanical: **is the contribution
this PR adds still byte-identical to the one that was reviewed?**

```
git diff a04e7bef...231f97e3   # the reviewed tree's contribution   -> 1573 lines
git diff 43653248...0257cb3a   # the rebased tree's contribution    -> 1573 lines
```

Comparing only the added/removed lines of the two patches, with `+++`/`---`
headers excluded:

```
reviewed +/- lines: 1305
current  +/- lines: 1305
PM_DIFF_EXIT=0   (every added/removed line is identical)
file lists identical
```

The two patches differ **only** in blob index hashes, hunk line offsets
(`@@ -334` → `@@ -330`, `@@ -130` → `@@ -147`) and one hunk's *context* lines in
`sarek/tests/unit/dune`, where the stanza above mine is now #319's
`test_sync_stmt_emission` instead of `test_opencl_gate`. Not one added or removed
line changed.

So the carried-over review covers the current diff exactly. The rebase moved this
contribution, it did not alter it.
