### PR TITLE
fix(ptx,metal): check the atomic/array index register class; correct the Metal warp barrier

### DIFF
--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -174,7 +174,8 @@ static), 1.1–1.3× on multi-pointer-param bandwidth-bound kernels. Not started
 
 ### 3. Warp primitives (roadmap "half-built")
 
-`SWarpBarrier` / the `warp_barrier` intrinsic exist and emit `bar.warp.sync`;
+`SWarpBarrier` exists and emits `bar.warp.sync`, but there is no `warp_barrier`
+intrinsic: no PPX syntax constructs the statement, so it is emitter-only today;
 warp **shuffle** (`shfl.sync`) is not modelled in the IR or emitted. Adding it
 is an IR-surface + typer + emitter change (a new intrinsic family), larger than
 either item above and not blocking SoA. Scope as its own task.

--- a/sarek-cuda/README.md
+++ b/sarek-cuda/README.md
@@ -1120,7 +1120,11 @@ atomic_cas : 'a array -> int -> 'a -> 'a -> 'a
 (* Block-level barrier *)
 barrier : unit -> unit           (* __syncthreads() *)
 
-(* Warp-level barrier (CUDA 9.0+) *)
+(* NOT CALLABLE from a kernel: `warp_barrier` and the fences below are IR
+   statements (SWarpBarrier / SMemFence) with a CUDA lowering, but no PPX
+   syntax constructs them and they are not declared as core primitives.
+   `block_barrier` is the only synchronisation name a kernel can write.
+   Listed here as the emitter contract, not as an API. *)
 warp_barrier : unit -> unit      (* __syncwarp() *)
 
 (* Memory fence *)

--- a/sarek-metal/README.md
+++ b/sarek-metal/README.md
@@ -83,7 +83,7 @@ Metal_error.feature_not_supported "raw pointer arguments"
 | Sarek Intrinsic | Metal C Equivalent | Description |
 |-----------------|-------------------|-------------|
 | `barrier()` | `threadgroup_barrier(mem_flags::mem_threadgroup)` | Threadgroup barrier |
-| `warp_barrier()` | `sub_group_threadgroup_barrier(...)` | Subgroup barrier |
+| `warp_barrier()` | `simdgroup_barrier(mem_flags::mem_threadgroup)` | SIMD-group barrier |
 | `memfence()` | `threadgroup_barrier(mem_flags::mem_device)` | Device memory fence |
 
 ### Atomic Operations

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -608,11 +608,16 @@ let rec gen_stmt buf indent = function
       Buffer.add_string buf indent ;
       Buffer.add_string buf "threadgroup_barrier(mem_flags::mem_threadgroup);\n"
   | SWarpBarrier ->
-      (* Metal doesn't have warp-level sync, use sub_group_barrier if available *)
+      (* MSL's warp-level ("SIMD-group") barrier is simdgroup_barrier. The old
+         text here, sub_group_threadgroup_barrier, is an OpenCL-shaped name that
+         MSL does not declare, so it would have been a hard MSL compile error.
+         It survived because nothing constructs SWarpBarrier from PPX syntax
+         yet, so the arm has never reached a Metal compiler --- and because the
+         repo's own Metal plugin table (sarek-metal/Metal_plugin.ml) already
+         said simdgroup_barrier, the two disagreed in silence. Pinned by
+         sarek/tests/unit/test_sync_stmt_emission.ml. *)
       Buffer.add_string buf indent ;
-      Buffer.add_string
-        buf
-        "sub_group_threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+      Buffer.add_string buf "simdgroup_barrier(mem_flags::mem_threadgroup);\n"
   | SMemFence ->
       Buffer.add_string buf indent ;
       Buffer.add_string buf "threadgroup_barrier(mem_flags::mem_device);\n"

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1512,6 +1512,9 @@ and intr_new_atom_result alloc = function
    PTX space name and the address register. *)
 and intr_atomic_addr buf alloc (env : env) ~intr ~global_only ~elt_shift arr
     r_idx =
+  (* The VALUE operand is class-checked by intr_check_atom_operand; the index
+     was not, though every address computation below assumes it is u32. *)
+  check_index_reg intr r_idx ;
   let r_base = env_lookup env arr.var_name in
   (* PTX has no atom.local — and per-thread memory needs no atomics. *)
   (match arr_space_of alloc arr.var_name with

--- a/sarek/codegen/Sarek_ir_ptx_mem.ml
+++ b/sarek/codegen/Sarek_ir_ptx_mem.ml
@@ -38,6 +38,7 @@ let space_qualifier = function
 (** Element byte address: shared arrays use 32-bit pointer arithmetic (their
     base is a 32-bit window offset); local and global arrays use 64-bit. *)
 let emit_elt_addr buf alloc r_base r_idx elt_type ~space =
+  check_index_reg "array index" r_idx ;
   match space with
   | Some SpaceShared ->
       let r_off = new_u32 alloc in

--- a/sarek/codegen/Sarek_ir_ptx_types.ml
+++ b/sarek/codegen/Sarek_ir_ptx_types.ml
@@ -286,6 +286,31 @@ let reg_class r =
   else if String.length r >= 3 && r.[1] = 'r' && r.[2] = 'd' then RU64
   else RU32
 
+(** Every element-address computation in this backend treats the index register
+    as 32-bit: [shl.b32] on the shared path, [cvt.u64.u32] on the global one
+    (see [Sarek_ir_ptx_mem.emit_elt_addr] and [intr_atomic_addr]). That is the
+    backend-wide invariant — Sarek types array indices as [TInt32] — but it was
+    only ever assumed. An index expression evaluating to a [%rd] or [%f]/[%fd]
+    register produced text like [cvt.u64.u32 %rd4, %rd3;], which is invalid PTX
+    and surfaced only at ptxas/module-load time with no Sarek-level message.
+
+    Reject rather than coerce. Narrowing a u64 index with [cvt.u32.u64] would
+    silently truncate, which is the failure mode this backend already refuses
+    elsewhere (see the M5 stride and space checks); a float index has no meaning
+    at all. [what] names the site so the message says which index. *)
+let check_index_reg what r =
+  match reg_class r with
+  | RU32 -> ()
+  | RU64 ->
+      unsupported
+        (what ^ ": index register " ^ r
+       ^ " is int64; array indices are 32-bit here — convert the index to \
+          int32 first (an implicit narrowing would silently truncate)")
+  | RF32 | RF64 ->
+      unsupported
+        (what ^ ": index register " ^ r
+       ^ " is a float; array indices must be int32")
+
 let mov_op_of_class = function
   | RU32 -> "mov.u32"
   | RU64 -> "mov.u64"

--- a/sarek/codegen/Sarek_ir_ptx_types.mli
+++ b/sarek/codegen/Sarek_ir_ptx_types.mli
@@ -208,6 +208,14 @@ type reg_class = RU32 | RU64 | RF32 | RF64
 (** [reg_class r] is the class of register [r], from its name prefix. *)
 val reg_class : string -> reg_class
 
+(** [check_index_reg what r] raises [unsupported] unless [r] is a 32-bit integer
+    register. Every element-address computation in this backend assumes a u32
+    index ([shl.b32] / [cvt.u64.u32]); a [%rd] or float index silently produced
+    invalid PTX that failed only at ptxas/module-load time. Rejects rather than
+    narrowing, because narrowing a u64 index would silently truncate. [what]
+    names the site (e.g. ["array index"], or the atomic's name). *)
+val check_index_reg : string -> string -> unit
+
 (** [mov_op_of_class c] is the typed PTX mov opcode for class [c]. *)
 val mov_op_of_class : reg_class -> string
 

--- a/sarek/framework/README.md
+++ b/sarek/framework/README.md
@@ -131,10 +131,16 @@ warp_id                                   - Warp/wavefront ID
 *Synchronization (4)*:
 ```
 block_barrier      - Block-level barrier (__syncthreads)
-warp_barrier       - Warp-level barrier
-memory_fence       - Memory fence
-memory_fence_block - Block-level memory fence
+warp_barrier       - Warp-level barrier        [classification only]
+memory_fence       - Memory fence              [classification only]
+memory_fence_block - Block-level memory fence  [classification only]
 ```
+
+Only `block_barrier` is a callable kernel primitive. The other three are names
+in this classification table; `warp_barrier` and `memory_fence` reach a backend
+only via the `SWarpBarrier` / `SMemFence` IR statements, which no PPX syntax
+constructs, and `memory_fence_block` / `memory_fence_device` are declared core
+primitives that every GPU backend rejects as unknown intrinsics.
 
 *Atomic Operations (9)*:
 ```

--- a/sarek/sarek/BSP.md
+++ b/sarek/sarek/BSP.md
@@ -43,8 +43,14 @@ Explicit barriers are also available:
 
 ```ocaml
 Gpu.block_barrier  (* Synchronize all threads in block *)
-Gpu.warp_barrier   (* Synchronize threads within a warp *)
 ```
+
+`block_barrier` is the only synchronisation primitive the front end declares.
+`warp_barrier` and `memory_fence` exist as IR statements (`SWarpBarrier`,
+`SMemFence`) with a lowering in every backend, but no PPX syntax constructs
+them, so they are **not callable from a kernel** today. Earlier revisions of
+this section and of the backend READMEs presented `Gpu.warp_barrier` as
+available; it never was.
 
 ## Convergence Safety
 

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -138,3 +138,12 @@
 (test
  (name test_metal_gate)
  (libraries metal_gate alcotest str))
+
+; Per-backend emission of SBarrier / SWarpBarrier / SMemFence. These are six
+; hand-written match arms with nothing holding them to the instruction each
+; target actually has, and the Metal one had drifted to a non-existent MSL
+; function. See the module header for what these assertions are and are not.
+
+(test
+ (name test_sync_stmt_emission)
+ (libraries sarek.codegen sarek_ppx_lib spoc.ir alcotest))

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -1007,6 +1007,120 @@ let test_atomic_stride_and_space_rejected () =
   | _ -> Alcotest.fail "global-form atomic on shared array should be rejected"
   | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
 
+(** #70(a): the index register class was never checked. Every address
+    computation — [Sarek_ir_ptx_mem.emit_elt_addr] for ordinary indexing and
+    [intr_atomic_addr] for atomics — treats the index register as 32-bit
+    ([shl.b32] on the shared path, [cvt.u64.u32] on the global one). An index
+    expression that evaluates to a [%rd] (u64) or [%f]/[%fd] (float) register
+    therefore produced text like
+
+    cvt.u64.u32 %rd4, %rd3;
+
+    which is invalid PTX. It failed at ptxas or module load with no Sarek-level
+    message, while the VALUE operand of the very same atomic was already
+    class-checked one line earlier ([intr_check_atom_operand]).
+
+    Both call sites are covered here: a fix in only one of them leaves the same
+    hole in the other. *)
+let test_int64_index_rejected () =
+  let idx64 = make_var "idx64" TInt64 in
+  let a = make_var "a" (TVec TFloat32) in
+  let out = make_var "out" (TVec TFloat32) in
+  let params =
+    [
+      DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+    ]
+  in
+  (* Ordinary array read through an int64 index. *)
+  let read_body =
+    SLet
+      ( idx64,
+        EConst (CInt64 3L),
+        SAssign
+          (LArrayElem ("out", EConst (CInt32 0l)), EArrayRead ("a", EVar idx64))
+      )
+  in
+  (match
+     base_kernel "i64_index_read" params read_body [] |> Sarek_ir_ptx.generate
+   with
+  | ptx ->
+      Alcotest.fail
+        (Printf.sprintf
+           "an int64 array index should be rejected, but PTX was emitted:\n%s"
+           ptx)
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()) ;
+  (* Array write through an int64 index. *)
+  let write_body =
+    SLet
+      ( idx64,
+        EConst (CInt64 3L),
+        SAssign (LArrayElem ("out", EVar idx64), EConst (CFloat32 1.0)) )
+  in
+  (match
+     base_kernel "i64_index_write" params write_body [] |> Sarek_ir_ptx.generate
+   with
+  | ptx ->
+      Alcotest.fail
+        (Printf.sprintf
+           "an int64 array-write index should be rejected, but PTX was emitted:\n\
+            %s"
+           ptx)
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()) ;
+  (* Atomic through an int64 index. *)
+  let acc = make_var "acc" (TVec TInt32) in
+  let atomic_body =
+    SLet
+      ( idx64,
+        EConst (CInt64 3L),
+        SExpr
+          (EIntrinsic
+             ( ["Sarek_stdlib"; "Gpu"],
+               "atomic_add_int32",
+               [EVar acc; EVar idx64; EConst (CInt32 1l)] )) )
+  in
+  match
+    base_kernel
+      "i64_index_atomic"
+      [DParam (acc, Some {arr_elttype = TInt32; arr_memspace = Global})]
+      atomic_body
+      []
+    |> Sarek_ir_ptx.generate
+  with
+  | ptx ->
+      Alcotest.fail
+        (Printf.sprintf
+           "an int64 atomic index should be rejected, but PTX was emitted:\n%s"
+           ptx)
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
+(** Positive control for the check above: an ordinary int32 index must still
+    generate, or the rejection would be indistinguishable from "indexing is
+    broken". *)
+let test_int32_index_still_generates () =
+  let tid = make_var "tid" TInt32 in
+  let a = make_var "a" (TVec TFloat32) in
+  let out = make_var "out" (TVec TFloat32) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign (LArrayElem ("out", EVar tid), EArrayRead ("a", EVar tid)) )
+  in
+  let ptx =
+    base_kernel
+      "i32_index"
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ]
+      body
+      []
+    |> Sarek_ir_ptx.generate
+  in
+  assert_contains ptx "cvt.u64.u32" ;
+  assert_contains ptx "ld.global.f32"
+
 (** Check that [ptx] does NOT contain [marker]. *)
 let assert_absent ptx marker ~why =
   let mlen = String.length marker in
@@ -3036,5 +3150,13 @@ let () =
             "SoA leaf name cannot alias a user param named <vec>_soa_<field>"
             `Quick
             test_soa_param_name_collision_safe;
+          Alcotest.test_case
+            "non-u32 array/atomic index is rejected, not emitted as invalid PTX"
+            `Quick
+            test_int64_index_rejected;
+          Alcotest.test_case
+            "int32 index still generates (positive control)"
+            `Quick
+            test_int32_index_still_generates;
         ] );
     ]

--- a/sarek/tests/unit/test_sync_stmt_emission.ml
+++ b/sarek/tests/unit/test_sync_stmt_emission.ml
@@ -1,0 +1,191 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Per-backend emission of the synchronisation statements.
+ *
+ * SBarrier / SWarpBarrier / SMemFence are lowered by a hand-written match arm
+ * in each of the six backends, and nothing held those arms to the instruction
+ * each target actually has. They drifted: the Metal arm emitted
+ * `sub_group_threadgroup_barrier(...)`, which is not an MSL function — Metal
+ * spells the SIMD-group barrier `simdgroup_barrier`, which is what this repo's
+ * OWN Metal plugin table (sarek-metal/Metal_plugin.ml) has always said, and
+ * what sarek-metal/README.md documented incorrectly.
+ *
+ * That went unnoticed because no PPX syntax constructs SWarpBarrier or
+ * SMemFence today (see the note at the bottom of this file), so the arm has
+ * never reached a Metal compiler. This test pins all three statements on all
+ * six backends at the IR level, which is the only level at which they are
+ * currently reachable.
+ *
+ * These are STRING assertions against each target's documented spelling, not
+ * device-verified behaviour: no Metal, CUDA or WebGPU device was available.
+ * They are a drift guard — "this arm still says what we decided it says" —
+ * and they are why the Metal arm's disagreement with the Metal plugin table
+ * became visible at all.
+ ******************************************************************************)
+
+open Sarek_ir_types
+
+let sync_kernel stmt : kernel =
+  let out =
+    {var_name = "out"; var_id = 0; var_type = TVec TInt32; var_mutable = false}
+  in
+  let tid =
+    {var_name = "tid"; var_id = 1; var_type = TInt32; var_mutable = false}
+  in
+  {
+    kern_name = "sync_probe";
+    kern_params =
+      [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})];
+    kern_locals = [];
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+    kern_body =
+      SLet
+        ( tid,
+          EIntrinsic ([], "global_thread_id", []),
+          SSeq
+            [stmt; SAssign (LArrayElem ("out", EVar tid), EConst (CInt32 1l))]
+        );
+  }
+
+let backends =
+  [
+    ( "CUDA",
+      fun k ->
+        Sarek_codegen.Sarek_ir_cuda.current_framework := None ;
+        Sarek_codegen.Sarek_ir_cuda.generate_with_types ~types:[] k );
+    ( "OpenCL",
+      fun k -> Sarek_codegen.Sarek_ir_opencl.generate_with_types ~types:[] k );
+    ( "Metal",
+      fun k -> Sarek_codegen.Sarek_ir_metal.generate_with_types ~types:[] k );
+    ( "GLSL",
+      fun k -> Sarek_codegen.Sarek_ir_glsl.generate_with_types ~types:[] k );
+    ( "WGSL",
+      fun k -> Sarek_codegen.Sarek_ir_wgsl.generate_with_types ~types:[] k );
+    ("PTX", fun k -> Sarek_codegen.Sarek_ir_ptx.generate k);
+  ]
+
+let contains hay needle =
+  let n = String.length needle and h = String.length hay in
+  let rec go i = i + n <= h && (String.sub hay i n = needle || go (i + 1)) in
+  go 0
+
+(* (statement, per-backend expected substring) *)
+let expectations =
+  [
+    ( "SBarrier",
+      SBarrier,
+      [
+        ("CUDA", "__syncthreads()");
+        ("OpenCL", "barrier(CLK_LOCAL_MEM_FENCE)");
+        ("Metal", "threadgroup_barrier(mem_flags::mem_threadgroup)");
+        ("GLSL", "barrier()");
+        ("WGSL", "workgroupBarrier()");
+        ("PTX", "bar.sync");
+      ] );
+    ( "SWarpBarrier",
+      SWarpBarrier,
+      [
+        ("CUDA", "__syncwarp()");
+        ("OpenCL", "sub_group_barrier(CLK_LOCAL_MEM_FENCE)");
+        (* MSL's SIMD-group barrier. `sub_group_threadgroup_barrier` is not an
+           MSL function; it was emitted here until #70. *)
+        ("Metal", "simdgroup_barrier(mem_flags::mem_threadgroup)");
+        ("GLSL", "subgroupBarrier()");
+        ("WGSL", "subgroupBarrier()");
+        ("PTX", "bar.warp.sync");
+      ] );
+    ( "SMemFence",
+      SMemFence,
+      [
+        ("CUDA", "__threadfence()");
+        ("OpenCL", "mem_fence(CLK_GLOBAL_MEM_FENCE)");
+        ("Metal", "threadgroup_barrier(mem_flags::mem_device)");
+        ("GLSL", "memoryBarrier()");
+        ("WGSL", "storageBarrier()");
+        ("PTX", "membar");
+      ] );
+  ]
+
+let check_stmt (label, stmt, per_backend) () =
+  let k = sync_kernel stmt in
+  List.iter
+    (fun (backend, gen) ->
+      match List.assoc_opt backend per_backend with
+      | None -> ()
+      | Some expected -> (
+          match gen k with
+          | src ->
+              Alcotest.(check bool)
+                (Printf.sprintf "%s on %s emits %S" label backend expected)
+                true
+                (contains src expected)
+          | exception e ->
+              Alcotest.failf
+                "%s on %s raised %s"
+                label
+                backend
+                (Printexc.to_string e)))
+    backends
+
+(** The Metal arm is the one that had drifted, so assert its old text is gone
+    rather than only asserting the new text is present: a backend emitting both
+    would satisfy the check above. *)
+let check_metal_no_stale_name () =
+  let src =
+    Sarek_codegen.Sarek_ir_metal.generate_with_types
+      ~types:[]
+      (sync_kernel SWarpBarrier)
+  in
+  Alcotest.(check bool)
+    "Metal no longer emits sub_group_threadgroup_barrier (not an MSL function; \
+     the repo's own Metal plugin table says simdgroup_barrier)"
+    false
+    (contains src "sub_group_threadgroup_barrier")
+
+(** Scope note, asserted rather than left as prose: no PPX surface syntax
+    constructs [SWarpBarrier] or [SMemFence] today. [block_barrier] is the only
+    sync name the front end declares ([Sarek_core_primitives], [Gpu.ml]); the
+    [warp_barrier] and [memory_fence] names that several READMEs present as
+    callable user API are not declared anywhere, so the arms pinned above are
+    reachable only from hand-built IR such as this test. This check pins that
+    fact, so if a future change makes them callable it lands together with a
+    deliberate update here rather than silently. *)
+let check_warp_barrier_not_callable () =
+  Alcotest.(check bool)
+    "warp_barrier is not a declared core primitive"
+    false
+    (Sarek_core_primitives.is_core_primitive "warp_barrier") ;
+  Alcotest.(check bool)
+    "block_barrier IS a declared core primitive (positive control: the lookup \
+     above is not vacuously false)"
+    true
+    (Sarek_core_primitives.is_core_primitive "block_barrier")
+
+let () =
+  Alcotest.run
+    "sync-stmt-emission"
+    [
+      ( "per-backend emission",
+        List.map
+          (fun ((label, _, _) as e) ->
+            Alcotest.test_case label `Quick (check_stmt e))
+          expectations );
+      ( "drift guards",
+        [
+          Alcotest.test_case
+            "Metal stale name gone"
+            `Quick
+            check_metal_no_stale_name;
+          Alcotest.test_case
+            "warp_barrier is not user-callable"
+            `Quick
+            check_warp_barrier_not_callable;
+        ] );
+    ]


### PR DESCRIPTION
Two pre-existing minors, both the same shape: an assumption nothing checked.

## (a) PTX: the index register class was never validated

`intr_atomic_addr` and `Sarek_ir_ptx_mem.emit_elt_addr` both compute an element
address assuming the index is a 32-bit integer register — `shl.b32` on the
shared path, `cvt.u64.u32` on the global one. Nothing enforced it. An index
expression evaluating to a `%rd` (u64) or `%f`/`%fd` (float) register emitted:

```
cvt.u64.u32 %rd3, %rd2;
```

which is invalid PTX. It failed at `ptxas` or module load with no Sarek-level
message — while the **value** operand of the very same atomic was already
class-checked one line earlier (`intr_check_atom_operand`). That asymmetry is
the whole bug.

**The fix goes in both call sites, not just the atomic one.** The gap is a
codegen-wide invariant ("indices are u32"); fixing only `intr_atomic_addr`
leaves the identical hole in every ordinary `EArrayRead` and array write.

New `Sarek_ir_ptx_types.check_index_reg` **rejects rather than coerces** —
narrowing a u64 index with `cvt.u32.u64` would silently truncate, which is
exactly the failure mode this backend already refuses in its M5 stride and
space checks — and its message names the fix.

### What I looked at and deliberately left

- **No bounds checking on atomics.** Real, but backend-wide policy: no backend
  bounds-checks anything, and the interpreter is the oracle that does
  (`Sarek_ir_interp_intrinsics.atomic_index` raises `Array_bounds_error`).
- **`cvt.u64.u32` zero-extends a negative index** into a ~4 GiB positive
  offset, where CUDA-C would produce a negative one. Divergent, but only in
  already-OOB territory, and shared with ordinary indexing.

Both belong to a "what does the backend guarantee about out-of-range indices"
decision, not to an atomic-validation fix.

## (b) `warp_barrier` / `memory_fence` exposure

**The Metal backend emitted a function MSL does not have.** `SWarpBarrier`
produced `sub_group_threadgroup_barrier(...)` — an OpenCL-shaped name. MSL
spells the SIMD-group barrier `simdgroup_barrier`, which is what this repo's
**own** Metal plugin table (`sarek-metal/Metal_plugin.ml:154`) has always said.
The two disagreed in silence because no PPX syntax constructs `SWarpBarrier`,
so the arm has never reached a Metal compiler.

New `test_sync_stmt_emission.ml` pins `SBarrier` / `SWarpBarrier` / `SMemFence`
across all six backends. Writing it confirmed the other **seventeen** arms are
correct — only Metal's was wrong — and it is the guard against the next such
drift.

**The rest of the review's finding is documentation.** Four READMEs and one
design doc present `warp_barrier` (and the fences) as callable kernel API. They
are not: `block_barrier` is the only synchronisation name the front end
declares, and `memory_fence_block` / `memory_fence_device` are declared core
primitives that every GPU backend rejects as unknown intrinsics
(`test_glsl_intrinsic_fallback.ml` asserts exactly that). Corrected in
`sarek/sarek/BSP.md`, `sarek-cuda/README.md`, `sarek/framework/README.md`,
`sarek-metal/README.md` and `docs/optimization/tier1b-emitter-soa-handoff.md`.

Asserted, not merely written down: the test checks `warp_barrier` is not a core
primitive, **with `block_barrier` as the positive control** so the check cannot
pass by looking up nothing.

## Red before green

| Gate | Red output |
|---|---|
| int64 array index (read, write, atomic) | `an int64 array index should be rejected, but PTX was emitted:` `cvt.u64.u32 %rd3, %rd2;` |
| int32 index positive control | passes both before and after — the rejection is not "indexing broke" |
| `SWarpBarrier` on Metal | expected `simdgroup_barrier(...)`, got `sub_group_threadgroup_barrier(...)` |

## Hardware and toolchain

Verified on AMD RX 7900 XTX + Ryzen 9 7950X iGPU: rusticl/radeonsi OpenCL, RADV
Vulkan, Native and Interpreter devices.

**No NVIDIA, Metal or WebGPU device was involved, and neither `ptxas` nor an MSL
compiler was run.** The PTX and MSL assertions here are codegen-level string
checks against each target's documented spelling — corroborated for Metal by
this repo's own plugin table, which is why the disagreement was detectable at
all. Treat the Metal change as "now agrees with our own registry and with the
MSL spec", not as "observed to compile".

`dune build`, `dune build @runtest`, `dune build @fmt` (exit 0) and
`scripts/check-test-alias-coverage.sh` (`OK: all 81 e2e test executables are
wired to an alias`) all pass. `benchmarks/descriptions/generated/` regenerated —
no diff.

## Left for a separate change, with evidence

The `intr_codegen` sync tables in **six** plugins are read by nothing except
`test_intrinsic_registry`; the real mapping is the `gen_stmt` match arms. They
are the drift trap that let Metal diverge in the first place, the Vulkan one is
missing `warp_barrier` entirely, and the Native one maps `warp_barrier` to a
**no-op** — the unsafe direction if ever revived, where the live native path
correctly over-synchronises to a full block barrier. Deleting them touches six
plugins and their tests, which is not an atomic-validation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
