### PR TITLE
feat(capability): #64 slice 1 — capability vocabulary + Metal's silent f64 truncation

### DIFF
--- a/docs/design/capability-model.md
+++ b/docs/design/capability-model.md
@@ -69,7 +69,7 @@ supported") and it deserves a name that says otherwise.
 
 ## 3. The verdict algebra
 
-```
+```ocaml
 type verdict = Available | Unavailable of t | Unknown of string
 val permits : verdict -> bool   (* Available only *)
 ```
@@ -106,8 +106,18 @@ codegen path can consult capabilities today. Requires extending
 `spoc/framework/test/` — a cost worth paying once, for a set-valued feature field
 rather than another bool. Also migrates the OpenCL/GLSL f16 refusals from
 hand-written strings to structured `Toolchain_semantic` + `Policy` values, and
-fixes the GLSL fp64 hole found during slice 1 (it emits `double` while never
-declaring `GL_ARB_gpu_shader_fp64`).
+picks up the GLSL `int64_t` hole (#142).
+
+> **Correction.** Slice 1 recorded this as a GLSL *fp64* hole — "emits `double`
+> while never declaring `GL_ARB_gpu_shader_fp64`". That was **measured false** by
+> #141: `glsl_header` takes `~uses_float64` and emits the extension, and
+> `glslangValidator` accepts the f64 kernel (exit 0). The real hole is one type
+> over — GLSL `int64_t`, whose `#extension` emission is gated on the float64
+> conditions only, so a plain `int64 vector` kernel emitted a shader glslang
+> rejects. It is `Device_optional`, not `Backend_structural`: GLSL *can* spell
+> `int64_t`, but a Vulkan device may not provide `shaderInt64` — so it needs the
+> device probe that `kind_needs_device Device_optional = true` calls for and
+> that slice 1 deliberately does not build.
 
 **Slice 3 — host-toolchain and flag-legality probes.** Needs machinery that does
 not exist: a host trial-compile, and retention of the OpenCL extension string
@@ -163,6 +173,36 @@ facts that motivated it is worse than none.
   target but not the kernel source line. #64 asked for a *located* error; slice 1
   delivers a named one. The fix is to thread `Sarek_ast.loc` through
   `Sarek_lower_ir` into the IR — slice 4, and a large change on its own.
+
+### 5.1 What does not belong in the table
+
+**A width mismatch with a correct in-language lowering is a codegen bug, not a
+missing capability.**
+
+The first real test of this was Metal `TBool`. It looks identical to the f64
+case — same backend, same silence, same class of wrong answer — and the table is
+right there as a convenient hook. It was correctly declined. A capability entry
+is an assertion that a target **cannot provide** something; filing `TBool` there
+would make the table claim Metal cannot express booleans, which is false. Metal
+has `bool`, and a correct lowering exists (`int`, which CUDA and OpenCL already
+emit). What was wrong was the emitter, and the fix belongs in the emitter.
+
+The test is not "is it silent?" or "is it a width mismatch?" — both are true of
+`TBool` and of Metal f64 alike. It is: **does a correct lowering exist in the
+target language?** If yes, it is a codegen bug however much it resembles a
+capability gap. If no, it is a capability.
+
+This matters more as the table grows, because the pressure runs one way: the
+table is discoverable, it produces a decent diagnostic for free, and filing
+against it feels like progress. Every entry that should have been a codegen fix
+is a permanent false claim about what a target can do, and it removes a working
+feature from users of that backend.
+
+The corollary is that the capability table and a codegen-correctness sweep are
+**complementary instruments, neither subsuming the other**. The sweep finds
+wrong lowerings of things the target supports; the table records things the
+target does not support. A defect found by one is not evidence about the other,
+and "we have a capability model now" is not a reason to stop sweeping.
 
 ## 6. Open decision
 

--- a/docs/design/capability-model.md
+++ b/docs/design/capability-model.md
@@ -1,0 +1,177 @@
+# The kernel↔backend capability model
+
+_What a kernel requires, what a target provides, and which layer knows._
+
+**Status:** slice 1 landed; slices 2–5 proposed. **Issue:** #64 (absorbs the
+capability half of #57 §7). **Date:** 2026-07-27.
+
+---
+
+## 1. Why a boolean per device is the wrong model
+
+Three days of measured backend defects (`docs/fp-contraction-policy.md`) produced
+a set of capability facts that do not live at the same layer:
+
+- **Metal has no `double`.** `Sarek_ir_metal.ml` mapped `TFloat64 -> "float"`
+  with a comment saying so and no refusal anywhere on the path. No device query
+  can report this; it is a property of the Metal Shading Language.
+- **ACO fuses an f32 multiply into the f32→f16 narrowing** regardless of what the
+  driver advertises — 620/63488 disagreements via rusticl, up to 5075/63488 via
+  RADV, on RX 7900 XTX / gfx1100. pocl on x86 does not fuse, which localises the
+  defect to ACO rather than to the device or the API. The device reports the
+  feature; the feature is broken. A device flag says "yes".
+- **Apple Silicon OpenCL has no `cl_khr_fp64`** — and the question that actually
+  decides whether a build succeeds there is whether the *host* clang can compile
+  `double` for that target, not what the device reports.
+- **`-cl-fp32-correctly-rounded-divide-sqrt` is illegal** unless the device
+  advertises `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT` — and local devices lack the
+  bit and accept the flag anyway. Acceptance is not evidence of support.
+- **Pascal (sm_61) has no tensor cores**, no bf16, no FP8, and runs f16 at 1/64
+  the f32 rate — present-but-catastrophic, which is neither "supported" nor
+  "unsupported".
+
+Collapsing these into one boolean per device is not merely lossy. It is lossy in
+one direction: every one of them, reduced to a flag, reads as **permitted**.
+
+## 2. The taxonomy — six kinds of capability
+
+Implemented as `Sarek_capability.kind` (`spoc/ir/Sarek_capability.mli`). The kind
+determines *when* the question can be answered, and therefore whether a static
+diagnostic or a launch gate is the right instrument — that is
+`kind_needs_device`.
+
+| Kind | Decided by | Answerable | Example |
+|---|---|---|---|
+| `Backend_structural` | the target **language** | statically, no device | Metal has no `double`; WebGPU has no `f64` |
+| `Device_optional` | the **device** | needs a device | `cl_khr_fp64`, `shaderFloat16`, sm_53 for f16, tensor cores |
+| `Host_toolchain` | the **host compiler/headers** | needs a host probe | can Apple clang compile `double` for this target; NVRTC needs `cuda_fp16.h` |
+| `Toolchain_semantic` | the **shader compiler** | only measurable | ACO fusing f32 mul into the f16 narrowing |
+| `Policy` | **us** | statically | f16 refused on OpenCL because we measured it wrong |
+| `Flag_legality` | a **build option × a device bit** | needs a device | `-cl-fp32-correctly-rounded-divide-sqrt` |
+
+Three distinctions do real work and are worth defending:
+
+**`Toolchain_semantic` vs `Device_optional`.** A device flag and a compiler
+behaviour are different facts about different components, and the compiler one
+must be able to *override a device saying yes*. Any model where a device query
+is the final authority gets ACO wrong.
+
+**`Toolchain_semantic` vs `Policy`.** The first is the evidence, the second the
+verdict. A `Toolchain_semantic` fact is revised by a new **measurement**; a
+`Policy` refusal is revised by a **decision**. Keeping them apart is what lets a
+diagnostic tell an author which one they are looking at — and stops a policy
+refusal silently outliving the measurement that justified it.
+
+**`Flag_legality` as its own kind.** Its failure mode is unique: the runtime does
+not enforce it, so the flag is accepted on devices that lack the bit. That is
+precisely the inference a boolean model invites ("it compiled, so it's
+supported") and it deserves a name that says otherwise.
+
+## 3. The verdict algebra
+
+```
+type verdict = Available | Unavailable of t | Unknown of string
+val permits : verdict -> bool   (* Available only *)
+```
+
+Three-valued on purpose. A two-valued answer forces an unprobed device into one
+bucket, and the bucket it lands in is "permitted" every time somebody writes
+`not unsupported`. **`Unknown` does not permit**: a device or toolchain we failed
+to probe is refused, not admitted. This is the module's safety property and it
+has a dedicated test with a red-on-mutation proof.
+
+`permits` is written as an explicit match on all three constructors rather than
+`v = Available`, so adding a fourth verdict is a compile error at the one place
+that decides whether something may run.
+
+## 4. Slicing
+
+**Slice 1 — vocabulary + the static half (this PR).** `Sarek_capability` in
+`spoc/ir` (no backend deps, beside `Sarek_ir_analysis`, whose `feature` type says
+what a kernel *requires* while this says what a target *provides*). The
+`Backend_structural` diagnostic, and Metal's f64 refusal — the one measured fact
+that was actively producing wrong answers.
+
+**Slice 1b — route WGSL f64 through the table.** WGSL already refuses f64, but
+via a bespoke `has_float64` / `params_have_float64` path with hand-written
+strings. Routing it through `Sarek_capability` makes the message uniform and the
+kind explicit. **Deliberately not done here**: #141 is auditing the WGSL backend
+concurrently and this would collide. No WGSL file is touched by slice 1.
+
+**Slice 2 — the dynamic launch gate.** `Execute.run` (`sarek/execute/Execute.ml`)
+is the single point that has both the device and the IR, right beside
+`check_launch_args`; `Framework_sig.generate_source` takes no device, so no
+codegen path can consult capabilities today. Requires extending
+`Framework_sig.capabilities`, which breaks the literal-record tests in
+`spoc/framework/test/` — a cost worth paying once, for a set-valued feature field
+rather than another bool. Also migrates the OpenCL/GLSL f16 refusals from
+hand-written strings to structured `Toolchain_semantic` + `Policy` values, and
+fixes the GLSL fp64 hole found during slice 1 (it emits `double` while never
+declaring `GL_ARB_gpu_shader_fp64`).
+
+**Slice 3 — host-toolchain and flag-legality probes.** Needs machinery that does
+not exist: a host trial-compile, and retention of the OpenCL extension string
+(`Opencl_api.ml` parses `CL_DEVICE_EXTENSIONS` and keeps only the fp64 boolean,
+so the correctly-rounded-divide-sqrt bit is discarded before anyone could check
+it).
+
+**Slice 4 — located diagnostics.** See §5.
+
+**Slice 5 — affinity, not capability.** See §5.
+
+## 5. What the model can and cannot express
+
+Stated explicitly, because a capability model that quietly cannot represent the
+facts that motivated it is worse than none.
+
+**Expressible and enforced today:**
+
+- Metal has no `double`. `Backend_structural`, refused at codegen, both at the
+  per-element-type arm and at a whole-kernel gate. Both are load-bearing and
+  independently tested — an f64 *literal* never reaches the type arm at all.
+
+**Expressible, not yet wired:**
+
+- WGSL/WebGPU has no `f64` — same kind, deferred to slice 1b (#141 coordination).
+- f16 refused on OpenCL and GLSL — representable as `Toolchain_semantic`
+  (evidence: the ACO counts) plus `Policy` (verdict). Currently hand-written
+  strings; slice 2 structures them.
+- Apple Silicon OpenCL / host clang — `Host_toolchain` exists as a kind; no probe
+  machinery exists.
+- `-cl-fp32-correctly-rounded-divide-sqrt` — `Flag_legality` exists as a kind;
+  the device bit is discarded before it can be read.
+- Pascal sm_61 has no tensor cores / bf16 / FP8 — `Device_optional`, and
+  `compute_capability` is already in the capabilities record, so the probe is
+  cheap. Slice 2.
+
+**NOT expressible, and not fixed by any planned slice:**
+
+- **Performance cliffs.** f16 at 1/64 f32 rate on Pascal is *present* and
+  *ruinous*. The model is binary present/absent; "supported but catastrophically
+  slow" is a third thing it cannot say. This is the affinity half of the backlog
+  title and it is genuinely a different model — a cost, not a predicate. Slice 5,
+  and it should not be bolted onto `verdict`.
+- **Which shader compiler is in the stack.** The ACO fact is a property of
+  ACO — not of RADV, not of the device, not of OpenCL-vs-Vulkan (it reproduces
+  through three front ends). The model can *say* a capability is
+  `Toolchain_semantic`, but it has no way to *identify* the compiler at runtime,
+  so such a verdict can only be blanket-per-backend. That over-refuses on pocl,
+  which measurably does not fuse. Closing this needs a compiler-identity probe
+  that does not exist.
+- **Source locations.** `Sarek_ir_types.kernel` carries no location and the IR
+  has no per-node locations, so a codegen refusal names the capability and the
+  target but not the kernel source line. #64 asked for a *located* error; slice 1
+  delivers a named one. The fix is to thread `Sarek_ast.loc` through
+  `Sarek_lower_ir` into the IR — slice 4, and a large change on its own.
+
+## 6. Open decision
+
+Inherited from `docs/design/f16-dsl-element-type.md` §7 and still open: should a
+capability refusal be a hard error or a warn-and-emulate fallback?
+
+Slice 1 takes **hard error**, but only for `Backend_structural`, where the
+question barely arises — there is no in-language emulation to fall back to, and
+`Sarek_real64`'s `Fallback_df64` substrate is the remedy the diagnostic names.
+The question stays genuinely open for `Device_optional`, where a fallback often
+does exist. It should be decided per kind, not once for everything, and it wants
+a human call.

--- a/sarek-metal/test/test_sarek_ir_metal.ml
+++ b/sarek-metal/test/test_sarek_ir_metal.ml
@@ -171,10 +171,15 @@ let test_type_mapping () =
     "float32 maps to float"
     "float"
     (Sarek_ir_metal.metal_type_of_elttype TFloat32) ;
-  Alcotest.(check string)
-    "float64 maps to float (no double)"
-    "float"
-    (Sarek_ir_metal.metal_type_of_elttype TFloat64) ;
+  (* This assertion used to read `"float64 maps to float (no double)"` and
+     expect `"float"`. It encoded the defect: Metal has no double, so mapping
+     TFloat64 to `float` silently halved the precision of any kernel written
+     against binary64 and the test certified it. #64 slice 1 makes it a
+     refusal; the assertion is inverted to match. *)
+  (match Sarek_ir_metal.metal_type_of_elttype TFloat64 with
+  | (_ : string) ->
+      Alcotest.fail "float64 must be refused by Metal, not mapped to a type"
+  | exception Sarek_backend_error.Backend_error.Backend_error _ -> ()) ;
   Alcotest.(check string)
     "bool maps to bool"
     "bool"
@@ -256,6 +261,97 @@ let test_local_buffer_param_refused () =
     (String.length (Buffer.contents buf) > 0
     && String.sub (Buffer.contents buf) 0 6 = "device")
 
+(* #64 slice 1: the whole-kernel f64 gate at Metal's [generate] entry.
+   [test_type_mapping] covers the per-element-type arm; this covers the gate,
+   which exists so the refusal cannot be routed around by a path that formats a
+   type some other way. Both halves are needed — the f16 gate has the same
+   shape for the same reason. *)
+let mk_vec_kernel elt : kernel =
+  let v = make_var "x" (TVec elt) in
+  {
+    kern_name = "capgate";
+    kern_params = [DParam (v, Some {arr_elttype = elt; arr_memspace = Global})];
+    kern_locals = [];
+    kern_body = SEmpty;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let substring_present haystack needle =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i =
+    i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1))
+  in
+  nl = 0 || go 0
+
+let test_float64_kernel_gate () =
+  (* Red: an f64 kernel is refused, and the message names the capability and
+     the target rather than failing anonymously. *)
+  (match
+     try Ok (Sarek_ir_metal.generate (mk_vec_kernel TFloat64))
+     with Sarek_backend_error.Backend_error.Backend_error _ as e ->
+       Error (Printexc.to_string e)
+   with
+  | Ok (_ : string) ->
+      Alcotest.fail "Metal must refuse an f64 kernel, not generate source"
+  | Error msg ->
+      Alcotest.(check bool)
+        "refusal names float64"
+        true
+        (substring_present msg "float64") ;
+      Alcotest.(check bool)
+        "refusal names Metal"
+        true
+        (substring_present msg "Metal")) ;
+  (* Positive control: the gate must discriminate. A gate that raised on every
+     kernel would satisfy the assertion above and be useless. *)
+  match Sarek_ir_metal.generate (mk_vec_kernel TFloat32) with
+  | (_ : string) -> ()
+  | exception Sarek_backend_error.Backend_error.Backend_error _ ->
+      Alcotest.fail
+        "Metal must still generate an f32 kernel (gate fires unconditionally)"
+
+(* The case that makes the whole-kernel gate load-bearing rather than
+   defence-in-depth. An f64 LITERAL never reaches [metal_type_of_elttype]:
+   [gen_expr] emits [EConst (CFloat64 f)] as a bare `%.17g` with no type ever
+   consulted and no `f` suffix (Sarek_ir_metal.ml, the CFloat64 arm). With only
+   the per-element-type arm, this kernel — an f32 buffer written from a binary64
+   constant — generated clean and lost the precision silently, exactly as the
+   TFloat64 arm did. Removing [reject_float64_kernel] turns this test red while
+   leaving the TFloat64 one green, which is what says the two checks are not
+   redundant. *)
+let test_float64_literal_gate () =
+  let v = make_var "x" (TVec TFloat32) in
+  let k : kernel =
+    {
+      kern_name = "caplit";
+      kern_params =
+        [DParam (v, Some {arr_elttype = TFloat32; arr_memspace = Global})];
+      kern_locals = [];
+      kern_body =
+        SAssign (LArrayElem ("x", EConst (CInt32 0l)), EConst (CFloat64 3.14));
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  match
+    try Ok (Sarek_ir_metal.generate k)
+    with Sarek_backend_error.Backend_error.Backend_error _ as e ->
+      Error (Printexc.to_string e)
+  with
+  | Ok src ->
+      Alcotest.fail
+        ("Metal must refuse an f64 literal, not emit it silently; got: " ^ src)
+  | Error msg ->
+      Alcotest.(check bool)
+        "literal refusal names float64"
+        true
+        (substring_present msg "float64")
+
 let () =
   Alcotest.run
     "Sarek_ir_metal"
@@ -275,6 +371,11 @@ let () =
       );
       ("atomics", [Alcotest.test_case "atomic operations" `Quick test_atomics]);
       ("types", [Alcotest.test_case "type mapping" `Quick test_type_mapping]);
+      ( "capability",
+        [
+          Alcotest.test_case "f64 kernel gate" `Quick test_float64_kernel_gate;
+          Alcotest.test_case "f64 literal gate" `Quick test_float64_literal_gate;
+        ] );
       ("var_decl", [Alcotest.test_case "var declaration" `Quick test_var_decl]);
       ( "param_address_space",
         [

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -55,7 +55,20 @@ let rec metal_type_of_elttype = function
            "f16"
            "Metal: float16 not yet supported (#57 slice 2)")
   | TFloat32 -> "float"
-  | TFloat64 -> "float" (* Metal doesn't support double precision *)
+  | TFloat64 ->
+      (* Until #64 slice 1 this arm was `"float"`, with a comment saying Metal
+         does not support double precision — and no refusal anywhere on the
+         path. A kernel written against binary64 semantics compiled clean and
+         returned binary32 answers: a silent halving of precision, which is the
+         exact defect class #64 exists to make impossible. Metal genuinely has
+         no `double`, so this is Backend_structural and belongs at codegen, not
+         at a launch gate: no device can supply it. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "f64"
+           (Sarek_capability.explain
+              ~target:"Metal"
+              Sarek_capability.float64_absent_metal))
   | TBool -> "bool"
   | TUnit -> "void"
   | TRecord (name, _) -> mangle_name name
@@ -1015,6 +1028,25 @@ let reject_float16_kernel =
     ~backend:"Metal"
     Sarek_ir_analysis.Float16
 
+(* Whole-kernel f64 gate (#64 slice 1). The per-element-type arm above catches
+   every type that reaches the emitter, but not every f64 in a kernel reaches
+   it: the same reasoning that gave f16 a whole-kernel gate on top of its arm
+   applies unchanged. Having both means the refusal cannot be routed around by
+   a path that formats a type some other way.
+
+   Unlike [reject_float16_kernel] this does NOT go through
+   [Sarek_ir_codegen.reject_feature]: that composer says "not YET supported
+   (#57 slice 2)", a claim about a queue position. Metal will never have
+   `double`, so promising future support would be false. *)
+let reject_float64_kernel =
+  Sarek_capability.refuse_if_used
+    ~raise_:(fun reason ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct "f64" reason))
+    ~target:"Metal"
+    Sarek_capability.float64_absent_metal
+    Sarek_ir_analysis.Float64
+
 (** The ONLY thing measured to stop Metal contracting [a*b+c].
 
     Metal's compile options do NOT do it. Measured on Apple M4 / macOS 15.6.1
@@ -1051,6 +1083,7 @@ let metal_fp_contract_pragma = "#pragma METAL fp contract(off)\n"
 (** Generate complete Metal source for a kernel *)
 let generate (k : kernel) : string =
   reject_float16_kernel k ;
+  reject_float64_kernel k ;
   let buf = Buffer.create 4096 in
 
   (* Collect variables used with atomic operations *)
@@ -1115,6 +1148,7 @@ let gen_variant_def buf v =
 let generate_with_types ~(types : (string * (string * elttype) list) list)
     (k : kernel) : string =
   reject_float16_kernel k ;
+  reject_float64_kernel k ;
   (* Set current_variants for SMatch binding extraction *)
   current_variants := k.kern_variants ;
   let buf = Buffer.create 4096 in

--- a/spoc/ir/Sarek_capability.ml
+++ b/spoc/ir/Sarek_capability.ml
@@ -1,0 +1,100 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** The kernel/backend capability vocabulary (#64, slice 1). See the .mli for
+    why a capability is not one boolean per device. *)
+
+type kind =
+  | Backend_structural
+  | Device_optional
+  | Host_toolchain
+  | Toolchain_semantic
+  | Policy
+  | Flag_legality
+
+let kind_name = function
+  | Backend_structural -> "backend-structural"
+  | Device_optional -> "device-optional"
+  | Host_toolchain -> "host-toolchain"
+  | Toolchain_semantic -> "toolchain-semantic"
+  | Policy -> "policy"
+  | Flag_legality -> "flag-legality"
+
+(* Backend_structural and Policy are decided by things we already know when we
+   emit code: the target language, and our own recorded decisions. Everything
+   else needs something outside the compiler to be interrogated first — a
+   device, a host compiler, or a measurement. That split is exactly the
+   static/dynamic split of #64, so it is one function rather than a comment. *)
+let kind_needs_device = function
+  | Backend_structural | Policy -> false
+  | Device_optional | Host_toolchain | Toolchain_semantic | Flag_legality ->
+      true
+
+type evidence =
+  | Measured of string
+  | Quoted of string
+  | By_construction of string
+
+let evidence_text = function Measured s | Quoted s | By_construction s -> s
+
+let evidence_provenance = function
+  | Measured _ -> "measured"
+  | Quoted _ -> "quoted"
+  | By_construction _ -> "by construction"
+
+type t = {
+  cap_name : string;
+  cap_kind : kind;
+  cap_why : string;
+  cap_evidence : evidence;
+  cap_remedy : string option;
+}
+
+type verdict = Available | Unavailable of t | Unknown of string
+
+(* The safety property. Written as an explicit match on all three constructors
+   rather than [v = Available] or [function Unavailable _ -> false | _ -> true]
+   so that adding a fourth verdict is a compile error here, at the one place
+   that decides whether something is allowed to run. The failure mode this
+   guards against is a future [Unknown]-like case defaulting to permitted. *)
+let permits = function
+  | Available -> true
+  | Unavailable _ -> false
+  | Unknown _ -> false
+
+let first_refusal verdicts = List.find_opt (fun v -> not (permits v)) verdicts
+
+let explain ~target cap =
+  let remedy = match cap.cap_remedy with None -> "" | Some r -> " " ^ r in
+  Printf.sprintf
+    "%s: %s unavailable — %s [%s; %s: %s]%s"
+    target
+    cap.cap_name
+    cap.cap_why
+    (kind_name cap.cap_kind)
+    (evidence_provenance cap.cap_evidence)
+    (evidence_text cap.cap_evidence)
+    remedy
+
+let refuse_if_used ~raise_ ~target cap (feature : Sarek_ir_analysis.feature)
+    (k : Sarek_ir_types.kernel) : unit =
+  if Sarek_ir_analysis.kernel_uses feature k then raise_ (explain ~target cap)
+
+let float64_absent_metal =
+  {
+    cap_name = "float64";
+    cap_kind = Backend_structural;
+    cap_why =
+      "the Metal Shading Language has no double-precision scalar type, so \
+       there is nothing for binary64 to lower to";
+    cap_evidence =
+      Quoted
+        "Metal Shading Language Specification: `double` is not supported; \
+         Metal's floating-point scalar types are `half` and `float`";
+    cap_remedy =
+      Some
+        "Use float32, or Sarek_real64 — its Fallback_df64 substrate gives \
+         software double precision on devices without native fp64.";
+  }

--- a/spoc/ir/Sarek_capability.mli
+++ b/spoc/ir/Sarek_capability.mli
@@ -1,0 +1,193 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** The kernel/backend capability vocabulary (#64, slice 1).
+
+    A "capability" in Sarek is not one boolean per device. Two days of measured
+    backend defects (docs/fp-contraction-policy.md) produced facts that live at
+    four different layers, and a model that collapses them into a single device
+    flag is wrong — specifically, wrong in the direction of silently permitting
+    things:
+
+    - Metal has no [double] at all. No device query can tell you that; it is a
+      property of the Metal Shading Language.
+    - ACO fuses an f32 multiply into the f32→f16 narrowing regardless of what
+      the driver advertises. The device reports the feature and the feature is
+      broken. A device flag would say "yes".
+    - Apple Silicon OpenCL reports no [cl_khr_fp64], but the question that
+      actually decides whether a build succeeds there is whether the HOST clang
+      can compile [double] for that target.
+    - [-cl-fp32-correctly-rounded-divide-sqrt] is illegal unless the device
+      advertises [CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT] — and local devices lack
+      the bit and accept the flag anyway, so "it was accepted" proves nothing.
+
+    This module is the vocabulary those facts get stated in. It holds no policy
+    of its own and no backend dependencies: it lives in [spoc/ir] beside
+    {!Sarek_ir_analysis}, whose [feature] type says what a kernel REQUIRES,
+    while this says what a target PROVIDES and why it might not.
+
+    {1 Slice scope}
+
+    Slice 1 implements the {b static} half only — the diagnostic for
+    {!Backend_structural} absence, where the answer is known from the backend
+    alone with no device in hand. The other kinds are named here because naming
+    them is what stops the next capability from being modelled as a boolean;
+    their probes are later slices. See docs/design/capability-model.md. *)
+
+(** {1 What kind of thing a capability is} *)
+
+(** The layer that decides whether a capability is present. The kind determines
+    {e when} the question can be answered, and therefore whether a static
+    diagnostic or a launch-time gate is the right instrument. *)
+type kind =
+  | Backend_structural
+      (** The target LANGUAGE cannot express it. Metal has no [double]; WebGPU
+          has no [f64]. Decidable from the backend alone, before any device
+          exists. Never revisable by buying hardware. This is the only kind
+          slice 1 acts on, because it is the only kind that needs no probe. *)
+  | Device_optional
+      (** The backend supports it but a given device may not: OpenCL
+          [cl_khr_fp64] / [cl_khr_fp16], Vulkan [shaderFloat16], CUDA f16 below
+          sm_53, tensor cores absent on Pascal (sm_61). Answerable only with a
+          device in hand — hence a launch-time gate, or a static one when the
+          target device is pinned at compile time. *)
+  | Host_toolchain
+      (** A property of the HOST compiler or headers, not of the device. On
+          Apple Silicon OpenCL the operative question is whether host clang
+          compiles [double] for that target, not what the device reports; NVRTC
+          needs [cuda_fp16.h] on the include path. Probed by attempting a host
+          compile, never by querying a device. *)
+  | Toolchain_semantic
+      (** The device has the feature, the driver advertises it, and the shader
+          compiler mistranslates it anyway. ACO fusing an f32 multiply into the
+          f32→f16 narrowing is the type case: three front ends, one backend
+          compiler, and pocl on x86 does not do it — which localises the defect
+          to the compiler, not the device and not the API. Cannot be queried at
+          all. Only measured. A device saying "yes" must NOT override this. *)
+  | Policy
+      (** We refuse something that works, by decision. Distinct from
+          {!Toolchain_semantic}: that kind is the evidence, this is the verdict.
+          A [Toolchain_semantic] fact is revised by a new MEASUREMENT; a
+          [Policy] refusal is revised by a DECISION. Keeping them apart is what
+          lets the diagnostic say which one the author is looking at. *)
+  | Flag_legality
+      (** A build option that is only legal when a device bit is set —
+          [-cl-fp32-correctly-rounded-divide-sqrt] requires
+          [CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT]. Its own kind because the
+          failure mode is unique: the runtime does not enforce it, so the flag
+          is ACCEPTED on devices that lack the bit. Acceptance is not evidence
+          of support, which is exactly the inference a boolean model invites. *)
+
+(** Stable lowercase-hyphenated rendering, e.g. ["backend-structural"]. Appears
+    in diagnostics, so it is part of the tested message. *)
+val kind_name : kind -> string
+
+(** Whether answering this kind requires a device (or host toolchain) to be
+    probed. [false] for {!Backend_structural} and {!Policy} — those are
+    decidable statically, which is why they can be enforced at codegen.
+
+    This is the predicate that decides static-vs-dynamic, so it is what a later
+    slice consults to know which capabilities still need a launch gate. *)
+val kind_needs_device : kind -> bool
+
+(** {1 Evidence} *)
+
+(** How we know. Kept in the record because the fp-contraction work established
+    that a capability claim without a named device and toolchain is not usable —
+    and because "measured here" and "reported by a vendor document" have
+    different revisability. *)
+type evidence =
+  | Measured of string
+      (** Observed by us. The string must name device AND toolchain. *)
+  | Quoted of string
+      (** Taken from a specification or vendor document, not measured here. *)
+  | By_construction of string
+      (** True of the emitter/type system itself, checkable by reading it. *)
+
+val evidence_text : evidence -> string
+
+(** ["measured"] / ["quoted"] / ["by construction"]. Rendered into the
+    diagnostic so a reader can tell a measurement from a citation without
+    opening this file. *)
+val evidence_provenance : evidence -> string
+
+(** {1 Capabilities} *)
+
+type t = {
+  cap_name : string;  (** e.g. ["float64"]. Matches the DSL-visible name. *)
+  cap_kind : kind;
+  cap_why : string;  (** One sentence: why the target lacks it. *)
+  cap_evidence : evidence;
+  cap_remedy : string option;  (** What the author should do instead. *)
+}
+
+(** {1 Verdicts} *)
+
+(** The result of asking whether a target provides a capability.
+
+    Three-valued on purpose. A two-valued answer forces an unprobed device into
+    one bucket, and the bucket it lands in is "permitted" every time somebody
+    writes [not unsupported]. *)
+type verdict =
+  | Available
+  | Unavailable of t
+  | Unknown of string  (** Could not determine; the string says why. *)
+
+(** [permits Available = true], everything else [false].
+
+    {b The safety property of this module.} [Unknown] does not permit. A device
+    or toolchain we failed to probe is refused, not admitted — because every
+    defect that motivated #64 was a case of something being permitted by
+    default. Anything that needs to know "is this allowed" must go through this
+    function rather than pattern-matching [Unavailable] and treating the rest as
+    fine. *)
+val permits : verdict -> bool
+
+(** The first non-permitting verdict, if any. [None] means every verdict
+    permits. Written in terms of {!permits} so [Unknown] cannot leak through. *)
+val first_refusal : verdict list -> verdict option
+
+(** {1 Rendering} *)
+
+(** The diagnostic sentence. Names the capability and the target, states the
+    kind and the provenance of the evidence, and gives the remedy when there is
+    one. Its exact shape is asserted by the tests: a message that does not name
+    the capability and the target is the failure mode this whole issue exists to
+    remove. *)
+val explain : target:string -> t -> string
+
+(** {1 The static half (slice 1)} *)
+
+(** [refuse_if_used ~raise_ ~target cap feature k] raises (through the backend's
+    own error functor) when [k] uses [feature] and [target] structurally lacks
+    [cap].
+
+    Deliberately NOT {!Sarek_ir_codegen.reject_feature}. That composer says "not
+    YET supported (#57 slice 2)" — a claim about a queue position, true of a
+    backend nobody has got to. This one is for capabilities the target can never
+    have, where a promise of future support would be a lie.
+
+    [raise_] is a parameter for the same reason it is there: [spoc/ir] has no
+    backend dependencies, and each backend raises through its own error functor
+    so the message carries the right backend tag. *)
+val refuse_if_used :
+  raise_:(string -> unit) ->
+  target:string ->
+  t ->
+  Sarek_ir_analysis.feature ->
+  Sarek_ir_types.kernel ->
+  unit
+
+(** {1 Known capabilities} *)
+
+(** Metal has no double precision.
+
+    Until #64 slice 1 this was the project's clearest instance of the defect
+    class the issue exists to kill: [Sarek_ir_metal.metal_type_of_elttype]
+    mapped [TFloat64] to ["float"] with a comment saying Metal does not support
+    double — a SILENT halving of precision, with no refusal anywhere on the
+    path. A kernel written against binary64 semantics compiled clean and
+    returned binary32 answers. *)
+val float64_absent_metal : t

--- a/spoc/ir/dune
+++ b/spoc/ir/dune
@@ -10,6 +10,7 @@
   Sarek_ir_layout
   Sarek_ir_pp
   Sarek_ir_analysis
+  Sarek_capability
   Sarek_ir_codegen
   Sarek_pure_registry)
  (preprocess no_preprocessing)

--- a/spoc/ir/test/dune
+++ b/spoc/ir/test/dune
@@ -3,5 +3,6 @@
   test_sarek_ir_types
   test_sarek_ir_pp
   test_sarek_ir_analysis
+  test_sarek_capability
   test_sarek_pure_registry)
  (libraries sarek_ir))

--- a/spoc/ir/test/test_sarek_capability.ml
+++ b/spoc/ir/test/test_sarek_capability.ml
@@ -1,0 +1,199 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Unit tests for Sarek_capability (#64 slice 1)
+ *
+ * The verdict algebra, the static/dynamic split, the diagnostic rendering, and
+ * the whole-kernel refusal composer.
+ ******************************************************************************)
+
+open Sarek_ir_types
+open Sarek_capability
+
+(* The neighbouring tests in this directory use bare [assert], which `-noassert`
+   compiles out — a build flag away from a suite that passes without checking
+   anything. These checks raise unconditionally instead. *)
+let check name cond =
+  if not cond then failwith ("capability check failed: " ^ name)
+
+let check_string name ~expected ~actual =
+  if expected <> actual then
+    failwith
+      (Printf.sprintf
+         "capability check failed: %s\n  expected: %s\n  actual:   %s"
+         name
+         expected
+         actual)
+
+(** {1 The verdict algebra} *)
+
+let sample_cap =
+  {
+    cap_name = "widget";
+    cap_kind = Backend_structural;
+    cap_why = "the target has no widget";
+    cap_evidence = Quoted "the spec says so";
+    cap_remedy = None;
+  }
+
+(* THE safety property of the module. A two-valued model forces an unprobed
+   device into a bucket, and every `not unsupported` spelling puts it in
+   "permitted". If this test ever goes green with [Unknown] permitting, the
+   capability model has become the thing it was built to prevent. *)
+let test_permits () =
+  check "Available permits" (permits Available) ;
+  check "Unavailable does not permit" (not (permits (Unavailable sample_cap))) ;
+  check
+    "Unknown does not permit"
+    (not (permits (Unknown "probe failed: no device context"))) ;
+  print_endline "  permits: Unknown does not permit: OK"
+
+let test_first_refusal () =
+  check
+    "all-available yields no refusal"
+    (first_refusal [Available; Available] = None) ;
+  (* The interesting case: an [Unknown] sitting between permitting verdicts must
+     still be caught. This is what a `List.find_opt (function Unavailable _ ->
+     true | _ -> false)` written by hand would miss. *)
+  (match first_refusal [Available; Unknown "no probe"; Available] with
+  | Some (Unknown r) ->
+      check_string "unknown reason" ~expected:"no probe" ~actual:r
+  | _ -> failwith "first_refusal must surface an Unknown between Availables") ;
+  (match first_refusal [Available; Unavailable sample_cap] with
+  | Some (Unavailable c) ->
+      check_string "refused cap" ~expected:"widget" ~actual:c.cap_name
+  | _ -> failwith "first_refusal must surface an Unavailable") ;
+  check "empty list permits" (first_refusal [] = None) ;
+  print_endline "  first_refusal: OK"
+
+(** {1 The static/dynamic split} *)
+
+let test_kind_needs_device () =
+  (* This predicate is what a later slice consults to know which capabilities
+     still need a launch gate, so the split is asserted rather than assumed. *)
+  check "structural is static" (not (kind_needs_device Backend_structural)) ;
+  check "policy is static" (not (kind_needs_device Policy)) ;
+  check "device-optional needs a device" (kind_needs_device Device_optional) ;
+  check "host-toolchain needs a probe" (kind_needs_device Host_toolchain) ;
+  check
+    "toolchain-semantic needs a measurement"
+    (kind_needs_device Toolchain_semantic) ;
+  check "flag-legality needs a device bit" (kind_needs_device Flag_legality) ;
+  print_endline "  kind_needs_device: OK"
+
+let test_kind_names () =
+  check_string
+    "structural"
+    ~expected:"backend-structural"
+    ~actual:(kind_name Backend_structural) ;
+  check_string
+    "toolchain-semantic"
+    ~expected:"toolchain-semantic"
+    ~actual:(kind_name Toolchain_semantic) ;
+  check_string
+    "flag-legality"
+    ~expected:"flag-legality"
+    ~actual:(kind_name Flag_legality) ;
+  print_endline "  kind_name: OK"
+
+let test_evidence_provenance () =
+  (* Measured-vs-quoted must survive into the message: the fp-contraction work
+     turned on being able to tell "we observed this on named hardware" from
+     "a vendor document asserts it". *)
+  check_string
+    "measured"
+    ~expected:"measured"
+    ~actual:(evidence_provenance (Measured "x")) ;
+  check_string
+    "quoted"
+    ~expected:"quoted"
+    ~actual:(evidence_provenance (Quoted "x")) ;
+  check_string
+    "by construction"
+    ~expected:"by construction"
+    ~actual:(evidence_provenance (By_construction "x")) ;
+  check_string "text" ~expected:"x" ~actual:(evidence_text (Measured "x")) ;
+  print_endline "  evidence: OK"
+
+(** {1 Rendering} *)
+
+let contains haystack needle =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i =
+    i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1))
+  in
+  nl = 0 || go 0
+
+(* A diagnostic that does not name the capability and the target is the failure
+   mode #64 exists to remove, so it is asserted directly rather than through a
+   golden string (which would drift into asserting punctuation). *)
+let test_explain () =
+  let msg = explain ~target:"Metal" float64_absent_metal in
+  check "names the target" (contains msg "Metal") ;
+  check "names the capability" (contains msg "float64") ;
+  check "names the kind" (contains msg "backend-structural") ;
+  check "names the provenance" (contains msg "quoted") ;
+  check "gives the remedy" (contains msg "Sarek_real64") ;
+  (* Negative control: [explain] must not be a function that says "Metal" no
+     matter what it is handed. *)
+  let other = explain ~target:"WGSL" {sample_cap with cap_name = "float16"} in
+  check "other target named" (contains other "WGSL") ;
+  check "other capability named" (contains other "float16") ;
+  check "no stray Metal" (not (contains other "Metal")) ;
+  print_endline "  explain: OK"
+
+(** {1 The whole-kernel refusal composer} *)
+
+let mk_kernel elt : kernel =
+  let v =
+    {var_name = "x"; var_id = 0; var_type = TVec elt; var_mutable = false}
+  in
+  {
+    kern_name = "test";
+    kern_params = [DParam (v, Some {arr_elttype = elt; arr_memspace = Global})];
+    kern_locals = [];
+    kern_body = SEmpty;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+exception Refused of string
+
+let test_refuse_if_used () =
+  let refuse =
+    refuse_if_used
+      ~raise_:(fun r -> raise (Refused r))
+      ~target:"Metal"
+      float64_absent_metal
+      Sarek_ir_analysis.Float64
+  in
+  (* Red: a kernel that genuinely requests the missing capability is refused,
+     with a message that names it. *)
+  (match refuse (mk_kernel TFloat64) with
+  | () -> failwith "an f64 kernel must be refused"
+  | exception Refused msg ->
+      check "refusal names float64" (contains msg "float64") ;
+      check "refusal names Metal" (contains msg "Metal")) ;
+  (* Positive control. Without this, a composer that raised unconditionally
+     would pass the test above — the gate must DISCRIMINATE, not merely fire. *)
+  (match refuse (mk_kernel TFloat32) with
+  | () -> ()
+  | exception Refused _ ->
+      failwith "an f32 kernel must NOT be refused (gate fires unconditionally)") ;
+  print_endline "  refuse_if_used: fires on f64, silent on f32: OK"
+
+let () =
+  print_endline "Testing Sarek_capability (#64 slice 1)..." ;
+  test_permits () ;
+  test_first_refusal () ;
+  test_kind_needs_device () ;
+  test_kind_names () ;
+  test_evidence_provenance () ;
+  test_explain () ;
+  test_refuse_if_used () ;
+  print_endline "All Sarek_capability tests passed!"


### PR DESCRIPTION
## What this is

Slice 1 of #64, the kernel↔backend capability model: the vocabulary, plus the static half for the one capability kind that needs no probe.

It closes the project's clearest live instance of the defect class #64 exists to kill.

## The defect

`Sarek_ir_metal.metal_type_of_elttype` mapped `TFloat64 -> "float"`, with a comment saying Metal does not support double precision, and **no refusal anywhere on the path**. A kernel written against binary64 semantics compiled clean and returned binary32 answers.

The unit test asserted this as correct behaviour — `"float64 maps to float (no double)"` expecting `"float"`. That is how it survived: the suite certified it.

There is a second path. `gen_expr` emits `EConst (CFloat64 f)` as a bare `%.17g` and never consults `metal_type_of_elttype` at all, so an f64 **literal** slipped past the type mapping entirely. With the type arm alone, this kernel generated clean:

```
x[0] = 3.1400000000000001;
```

— into a language that has no `double`.

## The model

`Sarek_capability` lives in `spoc/ir` (no backend deps), beside `Sarek_ir_analysis` — whose `feature` type says what a kernel **requires**, while this says what a target **provides** and why it might not.

**Six kinds**, because the measured facts do not live at one layer:

| Kind | Decided by | Example |
|---|---|---|
| `Backend_structural` | the target **language** | Metal has no `double` |
| `Device_optional` | the **device** | `cl_khr_fp64`, tensor cores on sm_61 |
| `Host_toolchain` | the **host compiler** | can Apple clang compile `double` for this target |
| `Toolchain_semantic` | the **shader compiler** | ACO fusing f32 mul into the f16 narrowing |
| `Policy` | **us** | f16 refused on OpenCL because we measured it wrong |
| `Flag_legality` | a build option **×** a device bit | `-cl-fp32-correctly-rounded-divide-sqrt` |

Three distinctions do real work. `Toolchain_semantic` vs `Device_optional`: a compiler fact must be able to **override a device saying yes** — ACO mistranslates a feature the driver advertises, and reproduces through three front ends while pocl on x86 does not, which localises it to the compiler. `Toolchain_semantic` vs `Policy`: the first is the evidence, the second the verdict; one is revised by a **measurement**, the other by a **decision**. `Flag_legality` gets its own kind because the runtime does not enforce it, so the flag is *accepted* on devices lacking the bit — acceptance is not evidence of support, which is exactly the inference a boolean invites.

`kind_needs_device` is the static-vs-dynamic split, asserted rather than assumed.

**Three-valued verdicts, and `Unknown` does not permit.** Every defect behind #64 was something permitted by default. A device or toolchain we failed to probe is refused, not admitted. `permits` is an explicit match on all three constructors so a fourth verdict is a compile error at the one place that decides whether something may run.

## Evidence

- **Red observed before green, organically.** The pre-existing `test_type_mapping` failed the moment the arm changed, with the exact new message — the failing assertion *was* the defect.
- **Red on mutation, `Unknown` safety property.** Flipping `permits (Unknown _)` to `true`: build exit 0, then `Fatal error: capability check failed: Unknown does not permit`.
- **Red on mutation, gate independence.** Removing `reject_float64_kernel` leaves the type test green and turns the literal test red — which is what says the two checks are not redundant. The failure output carries the silently-emitted `x[0] = 3.1400000000000001;`.
- **Positive controls throughout.** Every refusal test is paired with an f32 case that must still succeed, so a gate that fired unconditionally would fail.
- Test helpers raise unconditionally rather than using bare `assert`, which `-noassert` compiles out — the neighbouring tests in that directory use `assert`.

`dune build` 0 · `dune build @runtest` 0 · `dune build @fmt` 0 · `check-test-alias-coverage.sh` 0 (82 executables wired). `@check` is red on `origin/main` at baseline, unchanged by this PR.

## What the model cannot express

Stated in the design doc rather than glossed, because a capability model that quietly cannot represent its motivating facts is worse than none:

- **Performance cliffs.** f16 at 1/64 f32 rate on Pascal is *present* and *ruinous*. The model is binary; this is a cost, not a predicate. It should not be bolted onto `verdict`.
- **Shader-compiler identity.** The ACO fact is a property of ACO. The model can *say* a capability is `Toolchain_semantic` but cannot *detect* the compiler, so such a verdict can only be blanket-per-backend — which over-refuses on pocl, which measurably does not fuse.
- **Source locations.** The IR carries none, so refusals name the capability and the target but not the kernel source line. #64 asked for a located error; this delivers a named one. Slice 4.

~~Also found and deferred: GLSL emits `double` while never declaring `GL_ARB_gpu_shader_fp64`.~~ **Retracted — measured false by #141.** `glsl_header` takes `~uses_float64` and emits the extension; glslangValidator accepts the f64 kernel, exit 0. The real hole is one type over — GLSL `int64_t`, gated on the float64 conditions only, so a plain `int64 vector` kernel emitted a shader glslang rejects (#142). It is `Device_optional`, not `Backend_structural`: GLSL *can* spell `int64_t`; a Vulkan device may not provide `shaderInt64`. Corrected in the design doc; the original was stated as measured and was not.

## Scope

No WGSL file is touched — #141 is auditing that backend concurrently. Routing WGSL's bespoke `has_float64` path through the table is slice 1b.

## Open question for you

Hard error vs warn-and-emulate, inherited from `f16-dsl-element-type.md` §7. This takes hard error for `Backend_structural` only, where the question barely arises — there is no in-language fallback, and the diagnostic names `Sarek_real64`'s `Fallback_df64` substrate as the remedy. It stays genuinely open for `Device_optional`, where a fallback often does exist, and I think it wants deciding per kind rather than once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a capability model that classifies backend, device, toolchain, policy, and flag support.
  - Added clear capability verdicts and explanations for supported, unavailable, or unknown features.

- **Bug Fixes**
  - Metal now correctly refuses kernels using 64-bit floating-point values instead of silently treating them as 32-bit floats.
  - Unsupported float64 usage now reports a targeted diagnostic with remediation guidance.

- **Documentation**
  - Added design documentation describing capability checks, diagnostics, and staged rollout considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
