### PR TITLE
fix(metal): audit the backend type-mapping surface for silent narrowing (#141)

### DIFF
--- a/docs/design/capability-model.md
+++ b/docs/design/capability-model.md
@@ -118,6 +118,18 @@ picks up the GLSL `int64_t` hole (#142).
 > `int64_t`, but a Vulkan device may not provide `shaderInt64` — so it needs the
 > device probe that `kind_needs_device Device_optional = true` calls for and
 > that slice 1 deliberately does not build.
+>
+> **Emitter half fixed in #141**, so #142 is the device probe only. The two
+> float64 conditions the `#extension` was gated on were the softmath helpers
+> that bit-cast a double and a non-finite f64 literal spelled via
+> `int64BitsToDouble`; `Sarek_ir_analysis.Int64` is now OR-ed in, so the line is
+> emitted whenever the kernel uses int64 at all. The rejection before the fix
+> was `syntax error, unexpected IDENTIFIER` at exit 2, exit 0 after. Regression
+> gate: `glsl-validate/int64_only_store`, a validation-only kernel whose only
+> wide type is int64 — the shape the corpus lacked, which is why the gap
+> survived. Until #142 lands, a device without `shaderInt64` still fails at
+> shader load rather than at launch with a Sarek diagnostic: loud and correct,
+> but unattributed.
 
 **Slice 3 — host-toolchain and flag-legality probes.** Needs machinery that does
 not exist: a host trial-compile, and retention of the OpenCL extension string
@@ -138,11 +150,32 @@ facts that motivated it is worse than none.
 
 - Metal has no `double`. `Backend_structural`, refused at codegen, both at the
   per-element-type arm and at a whole-kernel gate. Both are load-bearing and
-  independently tested — an f64 *literal* never reaches the type arm at all.
+  independently tested — an f64 *literal* never reaches the type arm at all, and
+  neither does an f64 *local* whose only appearance is its declared type.
+
+  Those two motivating shapes were found independently — the literal by #64
+  reasoning down from the capability model, the local by #141 reasoning up from
+  the emitted source — and both searches landed on the same detector
+  (`Sarek_ir_analysis.kernel_uses Float64`) at the same two `generate` entries.
+  Convergence from opposite directions is the argument that {arm, whole-kernel}
+  is the *complete* set of entry points, not merely the set someone thought of.
+
+  #141 also revised the severity. Slice 1 described the pre-fix behaviour as "a
+  silent halving of precision"; it was worse than that. The IR element type
+  fixes the buffer stride as well as the arithmetic, and `Vector.float64` is 8
+  bytes per element, so `device float*` strode the host buffer at 4 and every
+  element after the first was a bit-half of its neighbour. The kernel did not
+  lose precision, it read a different array — a wrong-answer defect, not a
+  quality-of-result one.
 
 **Expressible, not yet wired:**
 
-- WGSL/WebGPU has no `f64` — same kind, deferred to slice 1b (#141 coordination).
+- WGSL/WebGPU has no `f64` — same kind, deferred to slice 1b (#141
+  coordination). #141's backend-wide sweep confirms slice 1b is a pure
+  refactor and finds nothing for it to fix: WGSL already refuses `TFloat64`,
+  `TInt64` and `TFloat16` with located errors, and is the only backend that
+  refuses everything it cannot represent at the right width. It was the
+  *precedent* Metal should have followed, not a second instance of the defect.
 - f16 refused on OpenCL and GLSL — representable as `Toolchain_semantic`
   (evidence: the ACO counts) plus `Policy` (verdict). Currently hand-written
   strings; slice 2 structures them.
@@ -153,6 +186,60 @@ facts that motivated it is worse than none.
 - Pascal sm_61 has no tensor cores / bf16 / FP8 — `Device_optional`, and
   `compute_capability` is already in the capabilities record, so the probe is
   cheap. Slice 2.
+- **`int64` on Vulkan/GLSL** — `Device_optional`
+  (`VkPhysicalDeviceFeatures.shaderInt64` / `GL_ARB_gpu_shader_int64`). #141
+  fixed the emitter half; the *device* half is unprobed, so today a device
+  without the feature fails at shader load rather than at launch with a Sarek
+  diagnostic. #142, slice 2. See the correction under §4 slice 2.
+
+**Correctly NOT in the table — see §5.1 for the rule:**
+
+- **Metal `TBool`** was the case that prompted §5.1, and the numbers behind it:
+  MSL `bool` is one byte, the host gives a Sarek `bool` a 4-byte slot
+  (`Sarek_ir_layout.scalar_size TBool = 4`, mirroring `Sarek_ppx`), and `bool`
+  is an accepted `[@@sarek.type]` record field — so host `{bool;bool;int}` at
+  0/4/8, size 12, met an emitted `typedef struct { bool a; bool b; int n; }` at
+  0/1/4, size 8. Fixed in the emitter (#141): Metal now emits `int`.
+
+  The instrument that catches this class is not this table but the totality
+  sweep — `sarek/tests/codegen_golden/test_backend_type_width_totality.ml`. For
+  every backend and every scalar element type it admits exactly **three**
+  outcomes, and it is worth stating all three, because a reader who believes it
+  is two will misread the third as impossible:
+
+  1. the emitted device type occupies exactly `Sarek_ir_layout.scalar_size`
+     bytes — the host's own width;
+  2. the mapper **refuses**, with a diagnostic (`Match_failure`, `Not_found`,
+     `Invalid_argument` and `Failure` are rejected as refusals — an incomplete
+     match is not a policy);
+  3. the device type is recorded as having **no memory form at all**, which
+     exempts it from the width check.
+
+  Outcome 3 is an escape hatch, and it is the one that could be used to defeat
+  the sweep, so it is pinned rather than merely permitted: the complete set
+  lives in `expected_no_memory_form`, and
+  `test_no_memory_form_set_is_exactly_as_recorded` fails on **any** addition or
+  removal. Widening it is a deliberate edit to a literal list, not something a
+  codegen change can do quietly.
+
+  Today that set is six entries, and they are there for two different reasons —
+  a distinction anyone deciding whether their own case belongs there needs:
+
+  - `TUnit` on all five of Metal, CUDA, OpenCL, GLSL and WGSL — **no object
+    representation at all**. C's `void` is not a value, so there is nothing to
+    give a width to; WGSL has no unit type whatsoever and the emitter writes a
+    comment (`/* unit */`), which is not a type either.
+  - `TBool` on WGSL — a **real value the language will not let you put in a
+    buffer**. WGSL `bool` exists and is perfectly usable in registers; it is
+    simply not host-shareable, and `naga` refuses it in a storage binding
+    ("The type is not host-shareable") rather than choosing a width. The
+    failure is loud and at shader-load time, never a wrong stride.
+
+  If a candidate is neither — if the target *would* accept it in a buffer at
+  some width — then it is outcome 1 or outcome 2, not outcome 3.
+
+  This sweep is the concrete form of §5.1's closing point about complementary
+  instruments.
 
 **NOT expressible, and not fixed by any planned slice:**
 

--- a/docs/formal/rocq-value-ledger.md
+++ b/docs/formal/rocq-value-ledger.md
@@ -231,6 +231,61 @@ per line here than deep theorems about the ends.** The boring function is where
 the defects were, and it is boring precisely because the interesting models
 abstracted it away — which is the same reason nobody modelled it.
 
+**That model now exists in executable form, on both halves of the seam** (#141):
+
+- `sarek/tests/unit/test_type_width_totality.ml` — source type → IR element
+  type, the `elttype_of_typ` this entry names;
+- `sarek/tests/codegen_golden/test_backend_type_width_totality.ml` — IR element
+  type → device type string, for all six backends, against
+  `Sarek_ir_layout.scalar_size`.
+
+Each enumerates its finite type language by unfolding a **wildcard-free**
+successor chain, so a new constructor is a compile error *in the test* rather
+than a silently unswept case. Their contracts are not identical, and the
+difference matters to anyone reading them as models:
+
+- the **front half** is two-outcome — `elttype_of_typ` must either preserve the
+  byte width or reject with a located error;
+- the **backend half** is three-outcome — the emitted device type must occupy
+  exactly `Sarek_ir_layout.scalar_size` bytes, or the mapper must refuse with a
+  diagnostic, or the device type must be recorded as having **no memory form at
+  all** and thereby exempted from the width check.
+
+That third outcome is a real escape hatch and is treated as one. Its complete
+set is pinned in `expected_no_memory_form` — six entries today, for two
+different reasons: `TUnit` on all five of Metal/CUDA/OpenCL/GLSL/WGSL (no object
+representation at all — C's `void` is not a value, and WGSL has no unit type),
+plus WGSL's `TBool` (a real value the language will not let into a buffer;
+`naga` refuses it rather than picking a width).
+`test_no_memory_form_set_is_exactly_as_recorded` fails on
+any addition or removal, so widening the exemption is a deliberate edit to a
+literal list rather than something a codegen change can do quietly. A model
+whose admissible-outcome count is misreported is a model of something else, so
+this is stated here in the same terms as the code.
+
+That is exactly "the exhaustive table settled in an afternoon", and it found the
+two the seam was still hiding on the device side — Metal's
+`TFloat64 -> "float"` (8 bytes read at 4) and `TBool -> "bool"` (4 read at 1).
+
+**What this is and is not.** It is proof by exhaustive cases over a finite
+domain, which is the same argument a Rocq model of a total function would make;
+the difference is only *when* it is checked — `dune runtest` rather than
+`rocq check` — and that the enumeration's totality is enforced by OCaml's
+exhaustiveness checker rather than by `Coq`'s. For a function with no theorems
+worth stating, that trade looks right, and it is the cheapest available reading
+of this lesson. It does not extend to anything with an interesting invariant.
+
+**A caveat this entry should carry, because #141 supplied it.** The
+front-half validator had been green since it was written while **not sweeping
+two of its ten members**: its `unfold` pushed the successor instead of the
+element just visited, dropping the first of each chain and duplicating the last,
+and its own anti-vacuity length check could not see this because one duplicate
+exactly compensated for one omission. A cheap model is only worth its line count
+if the enumeration it rests on is *checked to be the enumeration it claims* —
+both files now assert distinctness as well as length. Machine-checked totality
+is the thing Rocq would have given for free here, and is the honest argument in
+its favour.
+
 ### M-02 — the silently-succeeding-wildcard family, out of scope
 
 | | |

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -113,7 +113,7 @@ Legend for the evidence column:
 | **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as HIP and rusticl, reached through a third front end, but a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on ACO and does not fuse here, so the locus is *the ACO backend*, not *OpenCL*. That in turn is the second independent reason to read rusticl and HIP/AMDGPU as one bug seen through two front ends rather than two bugs. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any non-ACO implementation is found to fuse — and which was itself wrong until §11.5 |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV now measured too** (§11.2): Intel Arc Graphics (Meteor Lake-P), Mesa 26.1.2-arch3.1, same 0 of 7 / 0 of 7 with `fma()` controls 4/4 — and unlike RADV, ANV does not fuse the f16 narrowing either, so no combine has been found on ANV where `NoContraction` is ignored. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound; ANV shows the same signature (mul 5.84e-08 / div 5.86e-08, §11.1) |
-| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. f16 and subnormals unprobed; two record/variant kernels do not compile at all (§10.11) |
+| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. f16 and subnormals unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
 
@@ -1173,6 +1173,160 @@ WGSL was the odd one out here too, exactly as it was for payload spelling.
 Adding `smatch_multi_payload` to the sweep turned it red on the first run;
 emitting a synthetic empty `default` when no `PWild` arm is present turned it
 green.
+
+### 10.13 A fourth defect, found the same way (#141): Metal silently halved f64
+
+Not a contraction defect, but it belongs here because it is a *float-semantics*
+claim the codebase was making and getting wrong, and because §10's Metal work is
+what makes the correct answer available.
+
+`Sarek_ir_metal.metal_type_of_elttype` mapped `TFloat64` to `"float"`, under the
+comment *"Metal doesn't support double precision"* — a true statement used to
+justify the wrong conclusion. There was **no refusal anywhere**: a kernel
+declared over `float64` compiled, ran, and returned a plausible wrong answer.
+
+**Captured before the fix.** For `out.(i) <- inp.(i) *. 2.0` in float64, the
+emitter produced, verbatim:
+
+```cpp
+kernel void f64_scale(device float* out [[buffer(0)]], constant int &sarek_out_length [[buffer(1)]], device float* inp [[buffer(2)]], ...
+```
+
+and for an f64 *local*:
+
+```cpp
+  float x = 0.10000000000000001;
+```
+
+both with no diagnostic on any channel. Note that the cost is **worse than
+halved precision**: the IR element type also fixes the buffer stride, and
+`Spoc_core.Vector.float64` is 8 bytes per element, so `device float*` strode the
+host's buffer at 4 — every element after the first was a bit-half of a
+neighbour. The kernel did not lose precision, it read a different array.
+
+**The fix is a refusal, not a widening**, because MSL has no `double` on any
+Apple GPU and never will. Both the element-type arm and a whole-kernel gate
+(`Sarek_ir_metal.reject_float64_kernel`, on the existing
+`Sarek_ir_analysis.kernel_uses Float64` detector, so an f64 that appears only as
+a `CFloat64` literal or an f64-typed local is also caught) render the same
+`Sarek_capability` row — `float64_absent_metal`, kind `Backend_structural`,
+carrying the remedy — so the fact is stated once and the diagnostic says which
+*kind* of unavailability the author is looking at. See
+[`docs/design/capability-model.md`](design/capability-model.md).
+
+Both entry points were found twice, independently: #64 reasoned down from the
+capability model and was motivated by the f64 **literal** assigned into an f32
+buffer; #141 reasoned up from the emitted source and was motivated by the f64
+**local**. Neither shape reaches the other's detector, and both searches landed
+on the same `kernel_uses Float64` gate at the same two `generate` entries. That
+is the argument that {arm, whole-kernel} is the complete set rather than the set
+somebody happened to think of.
+
+**`Sarek_real64` is that route and it was never broken.** df64 is *double-float*
+— an unevaluated pair of binary32 giving ~2⁻⁴⁶ — so it needs no hardware fp64;
+that is its purpose. `Metal_api.Device` reports `supports_fp64 = false`, and
+`Sarek_real64` already selects `Fallback_df64` on that basis. Measured on the M4
+(§10.7): mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15.
+
+**The contradicting comment is the reason this survived.** `Metal_api.ml`
+documented the field as *"Metal always supports FP64 on macOS"* — the exact
+opposite of the truth, eleven lines above the `supports_fp64 = false` that sets
+it. A comment that says the opposite of its code is not a documentation nit; it
+is how a defect gets read past. Corrected.
+
+#### The class, swept
+
+The point fix closes one arm. The class is *any place a requested element type
+is mapped to a narrower one without a refusal*, and it is now swept by
+`sarek/tests/codegen_golden/test_backend_type_width_totality.ml`: for every
+backend and every scalar IR element type, the mapper must either raise a
+diagnostic or name a device type of exactly `Sarek_ir_layout.scalar_size` bytes.
+That file is the backend twin of `sarek/tests/unit/test_type_width_totality.ml`,
+which enforces the same rule on the *front* half (source type → IR element
+type) and stops at the IR.
+
+The full sweep found **two** silent narrowings, both on Metal, and **no others**:
+
+| backend | `TInt64` | `TFloat16` | `TFloat64` | `TBool` |
+|---|---|---|---|---|
+| **Metal** | `long` ✓ 8 | refused | **`float` ✗ 4 vs 8** | **`bool` ✗ 1 vs 4** |
+| **CUDA** | `long long` ✓ 8 | `__half` ✓ 2 | `double` ✓ 8 | `int` ✓ 4 |
+| **OpenCL** | `long` ✓ 8 | refused | `double` ✓ 8 | `int` ✓ 4 |
+| **GLSL** | `int64_t` ✓ 8 | refused | `double` ✓ 8 | `bool` ✓ 4 (see below) |
+| **WGSL** | refused | refused | refused | `bool` — no memory form (see below) |
+| **PTX** | `.u64` ✓ 8 | refused | `.f64` ✓ 8 | `.u32` ✓ 4 |
+
+`TBool` is the second Metal narrowing and it is reachable — and it is a codegen
+bug, not a capability gap, by the test `docs/design/capability-model.md` §5.1
+sets out: not "is it silent" nor "is it a width mismatch" (both are equally true
+of it and of f64), but **does a correct lowering exist in the target language?**
+For f64 there is none; for bool there is. The host gives a
+Sarek `bool` a 4-byte slot (`Sarek_ppx`'s field-size mapping, mirrored by
+`Sarek_ir_layout.scalar_size TBool = 4`), MSL `bool` is **one** byte, and `bool`
+is an accepted `[@@sarek.type]` record field type. Host `{bool;bool;int}` lays
+out at 0/4/8, size 12; the emitted `typedef struct { bool a; bool b; int n; }`
+lays out at 0/1/4, size 8. Metal now emits `int`, which is what CUDA and OpenCL
+already did.
+
+The other two `bool` spellings are **not** silent, and this was checked rather
+than assumed:
+
+- **GLSL** — glslang lowers a `bool` member of an std430 storage buffer to a
+  32-bit uint, i.e. the host's own width. Verified on the emitted bool-record
+  shader: `glslangValidator -V --target-env vulkan1.2` exits 0, and `spirv-dis`
+  shows `%Flagged_0 = OpTypeStruct %uint %int`, `OpMemberDecorate ... Offset 0`
+  / `Offset 4`, `ArrayStride 8`.
+- **WGSL** — `bool` has no memory form at all there, and `naga` refuses it in a
+  storage binding rather than choosing a width: *"The type is not
+  host-shareable"*. A bool that reaches a buffer is a hard validation failure at
+  shader-load time, never a wrong stride.
+
+#### A fifth defect the same sweep turned up: GLSL int64 with no extension
+
+Loud rather than silent, so not the #141 narrowing class, but broken all the
+same. `glsl_type_of_elttype` maps `TInt64` to `int64_t` at the correct width —
+but that spelling does not exist under plain `#version 450`; it needs
+`#extension GL_ARB_gpu_shader_int64 : require`. That extension was gated on the
+two *float64* conditions only (the softmath helpers that bit-cast a double, and
+a non-finite f64 literal spelled via `int64BitsToDouble`), because nothing in
+the corpus reached int64 any other way. A kernel over a plain `int64 vector`,
+with no float64 anywhere, therefore emitted:
+
+```glsl
+layout(std430, set=0, binding = 0) buffer Buffer_outv { int64_t outv[]; };
+```
+
+with no `#extension` line. `glslangValidator` rejects it —
+`ERROR: :7: '' : syntax error, unexpected IDENTIFIER`, exit 2 — reproduced
+before the fix and exit 0 after. The gate is `glsl-validate/int64_only_store`, a
+validation-only kernel (no golden) whose only wide type is int64, which is
+exactly the shape the corpus lacked. `Sarek_ir_analysis.feature` gained an
+`Int64` constructor to drive it.
+
+The *fp64* extension, by contrast, was already correct and is the measurement
+that retracted a slice-1 claim: `glsl_header` takes
+`~uses_float64:(kernel_uses_float64 k)` and emits
+`#extension GL_ARB_gpu_shader_fp64 : require`, and `glslangValidator` accepts
+the generated f64 kernel at exit 0. `docs/design/capability-model.md` §4
+records the retraction in place. The *capability* half of int64-on-Vulkan —
+`VkPhysicalDeviceFeatures.shaderInt64`, which is `Device_optional` and needs a
+device probe — is #142; only the emitter half is fixed here.
+
+#### And one in the precedent test itself
+
+`sarek/tests/unit/test_type_width_totality.ml` builds its source-type
+enumeration by unfolding a total successor chain, specifically so the list
+cannot drift from the type. Its `unfold` pushed the *successor* onto the
+accumulator instead of the element just visited, so it dropped the **first**
+element of every chain and duplicated the **last**: `T.Int` and
+`T.TPrim T.TInt32` were never swept by any assertion in that file. Its
+anti-vacuity check did not catch it, because one duplicate exactly compensated
+for one omission — the lengths were still 7, 3 and 10.
+
+Found by the backend twin, whose pinned-exemption-set assertion reported the
+duplicate directly. Both `unfold`s are fixed, and both files now assert
+**distinctness** as well as length, which is the property a count alone cannot
+establish.
 
 ---
 

--- a/sarek-metal/Metal_api.ml
+++ b/sarek-metal/Metal_api.ml
@@ -54,7 +54,20 @@ module Device = struct
     name : string;
     max_threads_per_threadgroup : mtl_size structure;
     max_threadgroup_memory : int;
-    supports_fp64 : bool; (* Metal always supports FP64 on macOS *)
+    (* Always [false]. The Metal Shading Language has no `double` type on any
+       Apple GPU, so this is a property of MSL rather than of the device, and
+       [get] below sets it unconditionally.
+
+       This field carried the comment "Metal always supports FP64 on macOS"
+       until #141 — the exact opposite of the value set eleven lines below it,
+       and of the truth. Sarek_real64 reads this field and selects
+       [Fallback_df64] (double-float: an unevaluated pair of binary32, ~2^-46,
+       needing no hardware fp64), which is the supported route to extra
+       precision on Metal and is measured coherent on an Apple M4. The Metal
+       codegen refuses [TFloat64] outright — see
+       [Sarek_capability.float64_absent_metal], the [Backend_structural] entry
+       this fact is now stated in exactly once. *)
+    supports_fp64 : bool;
     is_cpu : bool; (* Metal doesn't distinguish CPU/GPU - always false *)
   }
 

--- a/sarek-metal/test/test_sarek_ir_metal.ml
+++ b/sarek-metal/test/test_sarek_ir_metal.ml
@@ -172,17 +172,31 @@ let test_type_mapping () =
     "float"
     (Sarek_ir_metal.metal_type_of_elttype TFloat32) ;
   (* This assertion used to read `"float64 maps to float (no double)"` and
-     expect `"float"`. It encoded the defect: Metal has no double, so mapping
-     TFloat64 to `float` silently halved the precision of any kernel written
-     against binary64 and the test certified it. #64 slice 1 makes it a
-     refusal; the assertion is inverted to match. *)
+     expect `"float"`. It encoded the defect and certified it as the contract.
+     Metal has no double, which is a reason to REFUSE, not a licence to hand
+     back half the width. #64 slice 1 makes it a refusal; the assertion is
+     inverted to match.
+
+     The severity is higher than "silently halved the precision", which is how
+     this was originally described: the IR element type also fixes the buffer
+     stride, and the host lays a float64 out in 8 bytes, so `device float*`
+     strode the buffer at 4 and every element after the first was a bit-half of
+     its neighbour (#141). Wrong answer, not degraded answer. *)
   (match Sarek_ir_metal.metal_type_of_elttype TFloat64 with
   | (_ : string) ->
       Alcotest.fail "float64 must be refused by Metal, not mapped to a type"
   | exception Sarek_backend_error.Backend_error.Backend_error _ -> ()) ;
+  (* MSL `bool` is 1 byte; the host gives a Sarek bool a 4-byte slot
+     (Sarek_ir_layout.scalar_size TBool = 4, mirroring Sarek_ppx), so a bool
+     record field desynced silently — host {bool;bool;int} at 0/4/8 size 12
+     against a device struct at 0/1/4 size 8. CUDA and OpenCL already emit `int`
+     here. Not a capability refusal, by the §5.1 test: a correct lowering
+     exists in the target language, so it is a codegen bug and gets emitted
+     correctly rather than refused. Width invariant swept for every backend by
+     sarek/tests/codegen_golden/test_backend_type_width_totality.ml. *)
   Alcotest.(check string)
-    "bool maps to bool"
-    "bool"
+    "bool maps to int (host bool slot is 4 bytes, MSL bool is 1)"
+    "int"
     (Sarek_ir_metal.metal_type_of_elttype TBool)
 
 let test_var_decl () =

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -1134,18 +1134,41 @@ let gen_helper_func ~pc_names buf (hf : helper_func) =
       declaring it explicitly keeps the generated source correct against
       stricter/non-glslang GLSL compilers and documents the requirement in the
       emitted shader. Defaults to [false] so kernels that do not use float64
-      never carry the extension. *)
+      never carry the extension.
+    @param uses_int64
+      Whether the kernel needs [int64_t] — either as a user element type, or for
+      the bit manipulation the software f64 transcendentals and the non-finite
+      f64 literal path perform. When [true], emits
+      [#extension GL_ARB_gpu_shader_int64 : require]. Unlike the fp64 line this
+      one is NOT optional: [int64_t] does not parse under plain [#version 450]
+      without it (glslangValidator: "syntax error, unexpected IDENTIFIER").
+      Defaults to [false] on the same byte-identity grounds as [uses_float64].
+*)
 let glsl_header ~kernel_name ?(block = (256, 1, 1)) ?(uses_float64 = false)
     ?(uses_int64 = false) () =
   let bx, by, bz = block in
   let fp64_extension =
     if uses_float64 then "#extension GL_ARB_gpu_shader_fp64 : require\n" else ""
   in
-  (* [GL_ARB_gpu_shader_int64] is required only by the software f64
-     transcendentals, which reinterpret a double's bits as an [int64_t] to
-     extract its exponent/mantissa. Emitted after the fp64 line (a kernel that
-     needs int64 necessarily uses fp64) so its absence keeps every other shader
-     byte-identical. *)
+  (* [GL_ARB_gpu_shader_int64] has THREE triggers, and this comment used to name
+     only the first two — which is precisely how #141's defect survived:
+
+       1. the software f64 transcendentals, which reinterpret a double's bits as
+          an [int64_t] to extract its exponent/mantissa;
+       2. a non-finite f64 constant, spelled via [int64BitsToDouble];
+       3. the user's own [int64] — a plain [int64 vector] kernel, no float64
+          anywhere.
+
+     The old comment also asserted that "a kernel that needs int64 necessarily
+     uses fp64". That was false, and it was load-bearing: it is the reason the
+     extension was gated on the two float64 conditions alone, so trigger 3
+     emitted [int64_t] with no [#extension] line and glslang rejected the
+     shader. Both claims are corrected here rather than deleted, because the
+     ORDERING below still depends on one of them being read correctly: the int64
+     line is emitted after the fp64 line so that a kernel using neither, or only
+     fp64, stays byte-identical to its committed golden. That is a statement
+     about the ORDER of two independent lines, not about one implying the
+     other. *)
   let int64_extension =
     if uses_int64 then "#extension GL_ARB_gpu_shader_int64 : require\n" else ""
   in
@@ -1513,9 +1536,25 @@ let compute_f64_softmath (k : kernel) =
      constant (emitted via int64BitsToDouble in gen_expr — GLSL has no inf/nan
      literal). Gating on both keeps a user-reachable [Float64.infinity] with no
      transcendental from emitting int64 ops without the extension. *)
+  (* AND, third, by the user's own int64: [glsl_type_of_elttype] maps [TInt64]
+     to "int64_t" at the correct width, but that spelling does not EXIST under
+     plain #version 450. Before #141 the extension was gated on the two f64
+     conditions above only, so a kernel over a plain `int64 vector` emitted
+
+       layout(std430, ...) buffer Buffer_outv { int64_t outv[]; };
+
+     with no #extension line, which glslangValidator rejects with
+     "'' : syntax error, unexpected IDENTIFIER" — reproduced, exit 2. Loud
+     rather than silent, so not the #141 narrowing class, but found by the same
+     sweep and broken all the same. [kernel_uses Int64] is the general detector
+     ([Sarek_ir_analysis.Int64], added with this fix); the two f64-specific
+     conditions stay because a kernel can need int64 OPS without an int64 TYPE
+     (the softmath helpers bit-cast a double, and int64BitsToDouble spells a
+     non-finite f64 literal). *)
   current_needs_int64 :=
     List.exists Sarek_ir_softmath.uses_int64 helpers
-    || Sarek_ir_analysis.kernel_uses_nonfinite_float64 k ;
+    || Sarek_ir_analysis.kernel_uses_nonfinite_float64 k
+    || Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Int64 k ;
   current_f64_needs_copysign :=
     List.exists Sarek_ir_softmath.uses_copysign helpers
 

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -58,18 +58,59 @@ let rec metal_type_of_elttype = function
   | TFloat64 ->
       (* Until #64 slice 1 this arm was `"float"`, with a comment saying Metal
          does not support double precision — and no refusal anywhere on the
-         path. A kernel written against binary64 semantics compiled clean and
-         returned binary32 answers: a silent halving of precision, which is the
-         exact defect class #64 exists to make impossible. Metal genuinely has
-         no `double`, so this is Backend_structural and belongs at codegen, not
-         at a launch gate: no device can supply it. *)
+         path. Metal genuinely has no `double`, so this is Backend_structural
+         and belongs at codegen, not at a launch gate: no device can supply it.
+
+         #141 established that the cost is WORSE than the halved precision this
+         comment originally claimed, and the correction matters because it moves
+         the defect from quality-of-result to wrong-answer. The IR element type
+         also fixes the BUFFER STRIDE: a `float64 vector` is 8 bytes per element
+         on the host (Spoc_core.Vector.float64), so `device float* v` strode it
+         at 4 and every element after the first was a bit-half of its neighbour.
+         The kernel did not lose precision — it read a different array. Captured
+         before the fix, the emitted kernel for out.(i) <- inp.(i) * 2.0 in
+         float64 was, verbatim,
+         `kernel void f64_scale(device float* out ..., device float* inp ...)`,
+         with no diagnostic on any channel.
+
+         Same family as the `[@@sarek.type]` payload emitted as `int` and the
+         `Char` vector read at 4-byte stride: a type computed and then narrowed
+         without saying so. The class validator over the whole backend
+         type-mapping surface is
+         sarek/tests/codegen_golden/test_backend_type_width_totality.ml. *)
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct
            "f64"
            (Sarek_capability.explain
               ~target:"Metal"
               Sarek_capability.float64_absent_metal))
-  | TBool -> "bool"
+  | TBool ->
+      (* "int", not "bool", and this is a width fix, not a style choice. The
+         host gives a Sarek `bool` a 4-byte slot everywhere it has a layout:
+         Sarek_ppx's field-size mapping returns 4 for `bool`, and
+         Sarek_ir_layout.scalar_size TBool is 4 to match it. MSL `bool` is ONE
+         byte (MSL spec, size/alignment of scalar data types), so a
+         [@@sarek.type] record with bool fields desynced silently — host
+         {bool;bool;int} lays out at 0/4/8, size 12, while the emitted
+         `typedef struct { bool a; bool b; int n; }` lays out at 0/1/4, size 8.
+         CUDA and OpenCL both already emit `int` here for exactly this reason;
+         Metal was the odd one out. GLSL/WGSL also spell it `bool`, but neither
+         is a silent case: glslang lowers a storage-buffer bool to a 32-bit uint
+         (verified — OpMemberDecorate Offset 0/4, ArrayStride 8), and naga
+         refuses a bool in a storage struct outright ("The type is not
+         host-shareable").
+
+         Deliberately NOT a {!Sarek_capability} entry. The test that decides it
+         is docs/design/capability-model.md §5.1, and it is NOT "is it silent"
+         nor "is it a width mismatch" — both are equally true of this arm and of
+         the TFloat64 one above. It is: DOES A CORRECT LOWERING EXIST IN THE
+         TARGET LANGUAGE? For f64 there is none, so it is a capability. For
+         bool there is — `int`, at the host's width, which CUDA and OpenCL
+         already emit — so it is a codegen bug and the fix belongs here. Filing
+         it as Backend_structural would make the table claim Metal cannot
+         express booleans, which is false, and would remove a working feature
+         from users of this backend. *)
+      "int"
   | TUnit -> "void"
   | TRecord (name, _) -> mangle_name name
   | TVariant (name, _) -> mangle_name name
@@ -1045,7 +1086,19 @@ let reject_float16_kernel =
    Unlike [reject_float16_kernel] this does NOT go through
    [Sarek_ir_codegen.reject_feature]: that composer says "not YET supported
    (#57 slice 2)", a claim about a queue position. Metal will never have
-   `double`, so promising future support would be false. *)
+   `double`, so promising future support would be false.
+
+   CONVERGENT: #141 arrived at this same second entry point independently, from
+   the opposite direction — auditing the emitted source rather than the
+   capability model — and reached the identical detector
+   ([Sarek_ir_analysis.kernel_uses Float64], already the driver of the
+   OpenCL/GLSL fp64 pragma/extension) with the identical placement at both
+   [generate] entries. #141's route in was the f64 LOCAL, captured verbatim from
+   the pre-fix emitter as `float x = 0.10000000000000001;`; #64's was the f64
+   LITERAL assigned into an f32 buffer, which the type arm never sees at all.
+   Two searches, two motivating shapes, one gate. That agreement is the reason
+   to believe {arm, whole-kernel} is the COMPLETE set of entry points rather
+   than the two somebody happened to think of. *)
 let reject_float64_kernel =
   Sarek_capability.refuse_if_used
     ~raise_:(fun reason ->

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -79,3 +79,18 @@
  (libraries sarek_ir sarek_codegen sarek_backend_error alcotest unix)
  (instrumentation
   (backend bisect_ppx)))
+
+; CLASS VALIDATOR for the backend half of the type-mapping surface (#141):
+; IR element type -> device type string. The unit-test twin
+; (sarek/tests/unit/test_type_width_totality.ml) covers the front half, source
+; type -> IR element type, and stops at the IR. Flags make warning 8 an error
+; so a new elttype constructor breaks compilation IN THE TEST.
+
+(test
+ (name test_backend_type_width_totality)
+ (modules test_backend_type_width_totality)
+ (flags
+  (:standard -w +8 -warn-error +8))
+ (libraries sarek_ir sarek_codegen alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek/tests/codegen_golden/test_backend_type_width_totality.ml
+++ b/sarek/tests/codegen_golden/test_backend_type_width_totality.ml
@@ -1,0 +1,640 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * CLASS VALIDATOR for silent width changes on the BACKEND side of the type
+ * mapping surface.
+ *
+ * sarek/tests/unit/test_type_width_totality.ml is the same validator for the
+ * FRONT half of the pipeline: source type -> IR element type. It stops at the
+ * IR. Nothing held the second half — IR element type -> device type string —
+ * to the same rule, and that is exactly where #141 lived:
+ *
+ *   Sarek_ir_metal.metal_type_of_elttype mapped [TFloat64] to "float", with a
+ *   comment saying Metal has no double and no refusal anywhere. A float64
+ *   kernel compiled, ran, and read an 8-byte-per-element host buffer at a
+ *   4-byte stride.
+ *
+ * The invariant enforced here is the one that arm broke:
+ *
+ *   for every backend B and every scalar IR element type T,
+ *     either B's type mapper RAISES a diagnostic for T,
+ *     or     the device type it names occupies exactly
+ *            [Sarek_ir_layout.scalar_size T] bytes,
+ *     or     that device type has no memory form at all on B (and B's own
+ *            validator refuses it in a buffer — see [No_memory_form]).
+ *
+ * [Sarek_ir_layout.scalar_size] is the right denominator and not a restatement:
+ * it IS the width the host marshaller uses (its own comment pins it to
+ * Sarek_ppx's field-size mapping), so a device type that disagrees with it
+ * disagrees with the bytes the host actually wrote.
+ *
+ * WHY THIS GATE CANNOT SILENTLY PASS (see the "gates that cannot fail" list):
+ *
+ *  - the element-type enumeration is not a hand-written list that can go
+ *    stale: it is unfolded from a total successor chain ([next_elt]) whose
+ *    match has no wildcard, so a new constructor on [Sarek_ir_types.elttype]
+ *    fails to COMPILE here (warning 8 is an error in this test's flags);
+ *  - the backend table is likewise checked against a pinned count, so deleting
+ *    a backend from the sweep is a failure rather than a smaller sweep;
+ *  - a device type name this test has never seen is a FAILURE, not a skip: the
+ *    per-backend width tables are closed, so a backend that starts emitting a
+ *    new spelling must have its width recorded before the sweep goes green;
+ *  - [No_memory_form] is the only escape hatch, and its full set is pinned by
+ *    [test_no_memory_form_set_is_exactly_as_recorded]: adding one is a
+ *    deliberate edit to an expected list, not a quiet widening;
+ *  - each backend must exercise at least one NON-refusing, memory-form mapping
+ *    ([test_every_backend_checks_something]), so a backend that starts
+ *    refusing everything cannot pass this file vacuously;
+ *  - a refusal only counts if it is a DIAGNOSTIC. [Match_failure],
+ *    [Not_found], [Invalid_argument] and [Failure] are internal errors, not
+ *    refusals, and are rejected as such.
+ ******************************************************************************)
+
+open Sarek_ir_types
+open Sarek_codegen
+
+(* ------------------------------------------------------------------ *)
+(* Compiler-enforced enumeration of the scalar IR element types.       *)
+(*                                                                     *)
+(* Total match, NO wildcard: adding a constructor to                   *)
+(* [Sarek_ir_types.elttype] fails to compile here. The aggregate arms  *)
+(* end the chain because they have no scalar width (they are laid out  *)
+(* field-by-field from the scalars below, which is what this sweep     *)
+(* pins).                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let next_elt : elttype -> elttype option = function
+  | TInt32 -> Some TInt64
+  | TInt64 -> Some TFloat16
+  | TFloat16 -> Some TFloat32
+  | TFloat32 -> Some TFloat64
+  | TFloat64 -> Some TBool
+  | TBool -> Some TUnit
+  | TUnit -> None
+  | TRecord _ | TVariant _ | TArray _ | TVec _ -> None
+
+(* NB the accumulator carries [x], not [y]. The version of this helper in
+   sarek/tests/unit/test_type_width_totality.ml pushed [y] and so dropped the
+   FIRST element of every chain while duplicating the last — its length check
+   still read 7, because one duplicate exactly replaced one omission. Fixed
+   there too in this change; see that file's [unfold]. *)
+let unfold next first =
+  let rec go acc x =
+    match next x with Some y -> go (x :: acc) y | None -> List.rev (x :: acc)
+  in
+  go [] first
+
+let all_scalar_elts = unfold next_elt TInt32
+
+let name_of_elt = function
+  | TInt32 -> "TInt32"
+  | TInt64 -> "TInt64"
+  | TFloat16 -> "TFloat16"
+  | TFloat32 -> "TFloat32"
+  | TFloat64 -> "TFloat64"
+  | TBool -> "TBool"
+  | TUnit -> "TUnit"
+  | TRecord (n, _) -> "TRecord " ^ n
+  | TVariant (n, _) -> "TVariant " ^ n
+  | TArray _ -> "TArray"
+  | TVec _ -> "TVec"
+
+(* ------------------------------------------------------------------ *)
+(* Device-side widths                                                  *)
+(* ------------------------------------------------------------------ *)
+
+(** What a device type name occupies in a buffer on a given target.
+
+    [No_memory_form reason] is for a spelling that cannot appear in a memory
+    slot at ALL — C's [void], WGSL's [bool]. It is not "we do not know": each
+    one carries the evidence that the target's OWN validator refuses it there,
+    so the failure mode is loud rather than a wrong stride. The complete set is
+    pinned below. *)
+type device_width = Bytes of int | No_memory_form of string
+
+(** Closed per-backend tables. [None] means "this test has never seen that
+    spelling", which the sweep reports as a failure — a backend that starts
+    emitting a new device type must record its width here first. That is what
+    keeps the sweep from being outrun by the code it checks. *)
+
+(* C-family scalar spellings shared by CUDA and OpenCL. Both target 64-bit
+   hosts through their own C dialects; OpenCL C fixes `long` at exactly 64 bits
+   (OpenCL C spec, table of built-in scalar data types) and CUDA reaches 64 bits
+   through `long long`. *)
+let c_family_width = function
+  | "int" -> Some (Bytes 4)
+  | "long" -> Some (Bytes 8)
+  | "long long" -> Some (Bytes 8)
+  | "__half" -> Some (Bytes 2)
+  | "float" -> Some (Bytes 4)
+  | "double" -> Some (Bytes 8)
+  | "void" -> Some (No_memory_form "C `void` has no object representation")
+  | _ -> None
+
+(* Metal Shading Language. Same spellings as C above EXCEPT `bool`, which MSL
+   fixes at ONE byte (MSL spec, size and alignment of scalar data types) where
+   the host uses a 4-byte slot — so `bool` must never be what this backend
+   emits for [TBool], and is deliberately absent from this table: if it comes
+   back, the sweep reports an unrecorded spelling. *)
+let metal_width = function
+  | "int" -> Some (Bytes 4)
+  | "long" -> Some (Bytes 8)
+  | "half" -> Some (Bytes 2)
+  | "float" -> Some (Bytes 4)
+  | "void" -> Some (No_memory_form "MSL `void` has no object representation")
+  | _ -> None
+
+(* GLSL. `bool` is 4 bytes here and that is MEASURED, not assumed: glslang
+   lowers a bool member of an std430 storage buffer to a 32-bit uint. Verified
+   on the emitted bool-record shader with glslangValidator -V --target-env
+   vulkan1.2 (exit 0) and spirv-dis:
+
+     %Flagged_0 = OpTypeStruct %uint %int
+     OpMemberDecorate %Flagged_0 0 Offset 0
+     OpMemberDecorate %Flagged_0 1 Offset 4
+     OpDecorate %_runtimearr_Flagged_0 ArrayStride 8
+
+   i.e. the same 4-byte slot the host writes. *)
+let glsl_width = function
+  | "int" -> Some (Bytes 4)
+  | "int64_t" -> Some (Bytes 8)
+  | "float16_t" -> Some (Bytes 2)
+  | "float" -> Some (Bytes 4)
+  | "double" -> Some (Bytes 8)
+  | "bool" -> Some (Bytes 4)
+  | "void" -> Some (No_memory_form "GLSL `void` cannot be a buffer member")
+  | _ -> None
+
+(* WGSL. `bool` genuinely has no memory form: it is not host-shareable, and
+   naga refuses it in a storage binding rather than picking a width. Verified on
+   the emitted bool-record shader:
+
+     error: Global variable [0] 'pts' is invalid
+     = Alignment requirements for address space Storage ... are not met by [0]
+     = The type is not host-shareable
+
+   so a bool that reaches a buffer is a hard validation failure at shader-load
+   time, never a wrong stride. *)
+let wgsl_width = function
+  | "i32" -> Some (Bytes 4)
+  | "f16" -> Some (Bytes 2)
+  | "f32" -> Some (Bytes 4)
+  | "bool" ->
+      Some
+        (No_memory_form
+           "WGSL `bool` is not host-shareable; naga refuses it in a storage \
+            binding")
+  | "/* unit */" ->
+      Some
+        (No_memory_form "WGSL has no unit type; the emitter writes a comment")
+  | _ -> None
+
+(* PTX register classes. These are the widths ptxas gives each class. *)
+let ptx_width = function
+  | ".u32" -> Some (Bytes 4)
+  | ".u64" -> Some (Bytes 8)
+  | ".f32" -> Some (Bytes 4)
+  | ".f64" -> Some (Bytes 8)
+  | _ -> None
+
+type backend = {
+  bk_name : string;
+  bk_map : elttype -> string;
+  bk_width : string -> device_width option;
+}
+
+let backends =
+  [
+    {
+      bk_name = "Metal";
+      bk_map = Sarek_ir_metal.metal_type_of_elttype;
+      bk_width = metal_width;
+    };
+    {
+      bk_name = "CUDA";
+      bk_map = Sarek_ir_cuda.cuda_type_of_elttype;
+      bk_width = c_family_width;
+    };
+    {
+      bk_name = "OpenCL";
+      bk_map = Sarek_ir_opencl.opencl_type_of_elttype;
+      bk_width = c_family_width;
+    };
+    {
+      bk_name = "GLSL";
+      bk_map = Sarek_ir_glsl.glsl_type_of_elttype;
+      bk_width = glsl_width;
+    };
+    {
+      bk_name = "WGSL";
+      bk_map = Sarek_ir_wgsl.wgsl_type_of_elttype;
+      bk_width = wgsl_width;
+    };
+    {
+      bk_name = "PTX";
+      bk_map = Sarek_ir_ptx_types.ptx_reg_type_of;
+      bk_width = ptx_width;
+    };
+  ]
+
+(* ------------------------------------------------------------------ *)
+(* What counts as a refusal                                            *)
+(* ------------------------------------------------------------------ *)
+
+(** A refusal is admissible only if it is a DIAGNOSTIC. These four are how OCaml
+    reports that the code fell off its own map, and accepting them as "the
+    backend refused" would let an incomplete match masquerade as a policy. *)
+let is_internal_error = function
+  | Match_failure _ | Not_found | Invalid_argument _ | Failure _ -> true
+  | _ -> false
+
+type outcome = Refused of string | Emitted of string
+
+let run_mapper b t =
+  match b.bk_map t with
+  | s -> Emitted s
+  | exception e ->
+      if is_internal_error e then
+        Alcotest.failf
+          "%s/%s: the mapper did not refuse, it CRASHED (%s). An internal \
+           error is not a diagnostic — the caller learns nothing about why the \
+           type is unavailable."
+          b.bk_name
+          (name_of_elt t)
+          (Printexc.to_string e)
+      else Refused (Printexc.to_string e)
+
+(* ------------------------------------------------------------------ *)
+(* Anti-vacuity                                                        *)
+(* ------------------------------------------------------------------ *)
+
+let test_enumeration_is_complete () =
+  Alcotest.(check int)
+    "scalar elttype constructors swept"
+    7
+    (List.length all_scalar_elts) ;
+  Alcotest.(check int) "backends swept" 6 (List.length backends) ;
+  (* A count alone does not prove the chain was walked correctly — see the
+     [unfold] note above. Distinctness is what rules out an off-by-one walk that
+     omits one constructor and duplicates another. *)
+  let labels = List.map name_of_elt all_scalar_elts in
+  if List.length (List.sort_uniq compare labels) <> List.length labels then
+    Alcotest.failf
+      "the element-type enumeration contains duplicates, so some type is going \
+       unswept: %s"
+      (String.concat ", " labels) ;
+  let bnames = List.map (fun b -> b.bk_name) backends in
+  if List.length (List.sort_uniq compare bnames) <> List.length bnames then
+    Alcotest.failf
+      "the backend table contains duplicates: %s"
+      (String.concat ", " bnames)
+
+(** A backend that refused every element type would satisfy the invariant while
+    checking nothing. Each must have at least one type it maps to a real,
+    width-checked memory form. *)
+let test_every_backend_checks_something () =
+  List.iter
+    (fun b ->
+      let n =
+        List.length
+          (List.filter
+             (fun t ->
+               match run_mapper b t with
+               | Refused _ -> false
+               | Emitted s -> (
+                   match b.bk_width s with
+                   | Some (Bytes _) -> true
+                   | Some (No_memory_form _) | None -> false))
+             all_scalar_elts)
+      in
+      if n = 0 then
+        Alcotest.failf
+          "%s maps NO scalar element type to a width-checked device type, so \
+           every assertion about it in this file is vacuous"
+          b.bk_name)
+    backends
+
+(** The [No_memory_form] escape hatch, pinned exactly. Widening it is how this
+    validator would be defeated, so it is a list someone has to edit on purpose.
+    Each entry is (backend, element type). *)
+let expected_no_memory_form =
+  [
+    ("Metal", "TUnit");
+    ("CUDA", "TUnit");
+    ("OpenCL", "TUnit");
+    ("GLSL", "TUnit");
+    ("WGSL", "TBool");
+    ("WGSL", "TUnit");
+  ]
+
+let test_no_memory_form_set_is_exactly_as_recorded () =
+  let actual =
+    List.concat_map
+      (fun b ->
+        List.filter_map
+          (fun t ->
+            match run_mapper b t with
+            | Emitted s -> (
+                match b.bk_width s with
+                | Some (No_memory_form _) -> Some (b.bk_name, name_of_elt t)
+                | _ -> None)
+            | Refused _ -> None)
+          all_scalar_elts)
+      backends
+  in
+  let show l =
+    String.concat
+      ", "
+      (List.map (fun (b, t) -> b ^ "/" ^ t) (List.sort compare l))
+  in
+  if List.sort compare actual <> List.sort compare expected_no_memory_form then
+    Alcotest.failf
+      "the set of device types claiming NO memory form changed.\n\
+       expected: %s\n\
+       actual:   %s\n\
+       This is the one escape hatch in this validator: a type claiming no \
+       memory form is exempt from the width check, so growing the set must be \
+       a deliberate edit backed by evidence that the target's own validator \
+       refuses that type in a buffer."
+      (show expected_no_memory_form)
+      (show actual)
+
+(* ------------------------------------------------------------------ *)
+(* THE INVARIANT                                                       *)
+(* ------------------------------------------------------------------ *)
+
+let test_no_backend_silently_changes_width () =
+  List.iter
+    (fun b ->
+      List.iter
+        (fun t ->
+          let label = Printf.sprintf "%s/%s" b.bk_name (name_of_elt t) in
+          match run_mapper b t with
+          | Refused _ ->
+              (* Loud is always admissible. *)
+              ()
+          | Emitted device_type -> (
+              let host = Sarek_ir_layout.scalar_size t in
+              match b.bk_width device_type with
+              | None ->
+                  Alcotest.failf
+                    "%s emits the device type %S, whose byte width this \
+                     validator has never been told. Record it in this file's \
+                     %s table — until then nothing is checking that a %s value \
+                     occupies the %d bytes the host wrote."
+                    label
+                    device_type
+                    b.bk_name
+                    (name_of_elt t)
+                    host
+              | Some (No_memory_form _) ->
+                  (* Exempt, and the exemption set is pinned above. *)
+                  ()
+              | Some (Bytes w) ->
+                  if w <> host then
+                    Alcotest.failf
+                      "%s maps to the device type %S, which is %d byte(s), but \
+                       the host lays a %s out in %d byte(s) \
+                       (Sarek_ir_layout.scalar_size). A kernel using it would \
+                       compile, run, and stride the buffer wrong with no \
+                       diagnostic. Either map it at the host's width or refuse \
+                       it."
+                      label
+                      device_type
+                      w
+                      (name_of_elt t)
+                      host))
+        all_scalar_elts)
+    backends
+
+(* ------------------------------------------------------------------ *)
+(* #141 point regressions — the captured red                           *)
+(* ------------------------------------------------------------------ *)
+
+let contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i =
+    i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1))
+  in
+  nl = 0 || go 0
+
+(** The exact arm from #141. Pre-fix this returned "float". *)
+let test_metal_refuses_f64_element_type () =
+  match Sarek_ir_metal.metal_type_of_elttype TFloat64 with
+  | s ->
+      Alcotest.failf
+        "Metal mapped TFloat64 to %S instead of refusing. This is #141: the \
+         host writes 8 bytes per element and the device would read 4."
+        s
+  | exception e ->
+      let msg = Printexc.to_string e in
+      if not (contains ~needle:"Sarek_real64" msg) then
+        Alcotest.failf
+          "Metal's f64 refusal must name Sarek_real64 as the supported route \
+           (it is what the runtime already selects — Metal_api reports \
+           supports_fp64 = false). Got: %s"
+          msg
+
+(** The whole-kernel gate. The element-type arm alone does not see a kernel
+    whose f64 only ever appears as a [CFloat64] literal. Both [generate] entry
+    points must refuse. *)
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let f64_scale_kernel () =
+  let out = make_var "out" (TVec TFloat64) in
+  let inp = make_var "inp" (TVec TFloat64) in
+  let idx = make_var "idx" TInt32 in
+  {
+    kern_name = "f64_scale";
+    kern_params =
+      [
+        DParam (out, Some {arr_elttype = TFloat64; arr_memspace = Global});
+        DParam (inp, Some {arr_elttype = TFloat64; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body =
+      SLet
+        ( idx,
+          EIntrinsic ([], "global_thread_id", []),
+          SAssign
+            ( LArrayElem ("out", EVar idx),
+              EBinop (Mul, EArrayRead ("inp", EVar idx), EConst (CFloat64 2.0))
+            ) );
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(** f64 reachable ONLY through a constant and an f64-typed local — the shape the
+    per-element-type arm would not necessarily see. Pre-fix this emitted
+    ["float x = 0.10000000000000001;"], captured verbatim. *)
+let f64_local_kernel () =
+  let out = make_var "out" (TVec TFloat32) in
+  let x = make_var "x" TFloat64 in
+  let idx = make_var "idx" TInt32 in
+  {
+    kern_name = "f64_local";
+    kern_params =
+      [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})];
+    kern_locals = [];
+    kern_body =
+      SLet
+        ( idx,
+          EIntrinsic ([], "global_thread_id", []),
+          SLet
+            ( x,
+              EConst (CFloat64 0.1),
+              SAssign (LArrayElem ("out", EVar idx), ECast (TFloat32, EVar x))
+            ) );
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let expect_metal_kernel_refused label gen =
+  match gen () with
+  | (src : string) ->
+      Alcotest.failf
+        "Metal accepted the f64 kernel %s and emitted:\n%s"
+        label
+        src
+  | exception e ->
+      let msg = Printexc.to_string e in
+      if not (contains ~needle:"float64" msg) then
+        Alcotest.failf
+          "Metal/%s: diagnostic does not name float64: %s"
+          label
+          msg
+
+let test_metal_refuses_f64_kernels () =
+  List.iter
+    (fun (label, k) ->
+      expect_metal_kernel_refused (label ^ "/generate") (fun () ->
+          Sarek_ir_metal.generate k) ;
+      expect_metal_kernel_refused (label ^ "/generate_with_types") (fun () ->
+          Sarek_ir_metal.generate_with_types ~types:k.kern_types k))
+    [("f64_scale", f64_scale_kernel ()); ("f64_local", f64_local_kernel ())]
+
+(** The refusal must be f64-specific: it must not have broken f32 on Metal. *)
+let test_metal_still_accepts_f32 () =
+  let out = make_var "out" (TVec TFloat32) in
+  let inp = make_var "inp" (TVec TFloat32) in
+  let idx = make_var "idx" TInt32 in
+  let k =
+    {
+      kern_name = "f32_scale";
+      kern_params =
+        [
+          DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+          DParam (inp, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_locals = [];
+      kern_body =
+        SLet
+          ( idx,
+            EIntrinsic ([], "global_thread_id", []),
+            SAssign
+              ( LArrayElem ("out", EVar idx),
+                EBinop (Mul, EArrayRead ("inp", EVar idx), EConst (CFloat32 2.0))
+              ) );
+      kern_types = [];
+      kern_variants = [];
+      kern_funcs = [];
+      kern_native_fn = None;
+    }
+  in
+  ignore (Sarek_ir_metal.generate k) ;
+  ignore (Sarek_ir_metal.generate_with_types ~types:k.kern_types k)
+
+(** Both refusal sites must render the SAME capability entry, so the two cannot
+    drift apart the way the OpenCL f16 pair did before #138.
+
+    Since #64 slice 1 the single source is not a string constant but a row in
+    the capability table — [Sarek_capability.float64_absent_metal], rendered by
+    [explain]. Asserting against [explain] rather than against a literal is what
+    makes this a check on the TABLE being the source: a site that reconstructed
+    an equivalent sentence by hand would fail here. *)
+let test_metal_f64_refusal_is_single_sourced () =
+  let msg_of f =
+    match f () with
+    | (_ : string) -> Alcotest.fail "expected a refusal"
+    | exception e -> Printexc.to_string e
+  in
+  let arm = msg_of (fun () -> Sarek_ir_metal.metal_type_of_elttype TFloat64) in
+  let kern = msg_of (fun () -> Sarek_ir_metal.generate (f64_scale_kernel ())) in
+  let expected =
+    Sarek_capability.explain
+      ~target:"Metal"
+      Sarek_capability.float64_absent_metal
+  in
+  if not (contains ~needle:expected arm) then
+    Alcotest.failf
+      "the element-type arm does not render the capability entry: %s"
+      arm ;
+  if not (contains ~needle:expected kern) then
+    Alcotest.failf
+      "the whole-kernel gate does not render the capability entry: %s"
+      kern ;
+  (* And the entry must be the RIGHT kind. A refusal decided at codegen is only
+     legitimate for a kind that needs no device — filing this as, say,
+     Device_optional would make a static refusal over-refuse a device that could
+     have supplied it. *)
+  Alcotest.(check bool)
+    "Metal f64 is decidable without a device"
+    false
+    (Sarek_capability.kind_needs_device
+       Sarek_capability.float64_absent_metal.cap_kind)
+
+let () =
+  Alcotest.run
+    "backend_type_width_totality"
+    [
+      ( "gate is not vacuous",
+        [
+          Alcotest.test_case
+            "enumeration and backend table are complete"
+            `Quick
+            test_enumeration_is_complete;
+          Alcotest.test_case
+            "every backend checks at least one width"
+            `Quick
+            test_every_backend_checks_something;
+          Alcotest.test_case
+            "the no-memory-form exemption set is exactly as recorded"
+            `Quick
+            test_no_memory_form_set_is_exactly_as_recorded;
+        ] );
+      ( "silent-narrowing class validator",
+        [
+          Alcotest.test_case
+            "no backend maps an element type to a different width without \
+             refusing"
+            `Quick
+            test_no_backend_silently_changes_width;
+        ] );
+      ( "#141 Metal f64",
+        [
+          Alcotest.test_case
+            "the element-type arm refuses and names Sarek_real64"
+            `Quick
+            test_metal_refuses_f64_element_type;
+          Alcotest.test_case
+            "both generate entry points refuse an f64 kernel"
+            `Quick
+            test_metal_refuses_f64_kernels;
+          Alcotest.test_case
+            "f32 on Metal is untouched"
+            `Quick
+            test_metal_still_accepts_f32;
+          Alcotest.test_case
+            "both refusal sites quote the single-sourced sentence"
+            `Quick
+            test_metal_f64_refusal_is_single_sourced;
+        ] );
+    ]

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -2312,6 +2312,40 @@ let validation_exclusions : ((string * string) * string) list =
 
 let excluded backend name = List.assoc_opt (backend, name) validation_exclusions
 
+(** Kernels that exist only to be run through the GLSL validator, and carry no
+    golden — same discipline as {!opencl_validation_only_kernels} below.
+
+    WHY THIS EXISTS (#141). [glsl_type_of_elttype] maps [TInt64] to "int64_t",
+    which is the right WIDTH but not a spelling that exists under plain
+    [#version 450]: it needs [#extension GL_ARB_gpu_shader_int64 : require].
+    That extension was gated on the two float64 conditions only — the softmath
+    helpers that bit-cast a double, and a non-finite f64 literal — so a kernel
+    over a plain [int64 vector], with no float64 anywhere, emitted [int64_t]
+    with no extension line at all. glslangValidator rejects it:
+
+    ERROR: :6: '' : syntax error, unexpected IDENTIFIER
+
+    reproduced at exit 2 before the fix, exit 0 after. Nothing in the corpus
+    used int64 except through the f64 transcendentals, which is precisely why
+    the gap survived — hence a kernel whose ONLY wide type is int64. *)
+let glsl_validation_only_kernels () =
+  let out = make_var "out" (TVec TInt64) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign (LArrayElem ("out", EVar idx), EConst (CInt64 7L)) )
+  in
+  let k =
+    empty_kernel
+      "int64_only_store"
+      [DParam (out, Some {arr_elttype = TInt64; arr_memspace = Global})]
+      []
+      body
+  in
+  [("int64_only_store", k)]
+
 (** GLSL corpus = cross-backend kernels + GLSL-only kernels. *)
 let glsl_validation_tests () =
   List.map
@@ -2350,7 +2384,7 @@ let glsl_validation_tests () =
                       kernel_name
                       e
                       glsl)))
-    (test_kernels () @ glsl_only_kernels ())
+    (test_kernels () @ glsl_only_kernels () @ glsl_validation_only_kernels ())
 
 (** Kernels that exist only to be run through the WGSL validator, and carry no
     golden — same discipline as {!opencl_validation_only_kernels} below.

--- a/sarek/tests/unit/test_type_width_totality.ml
+++ b/sarek/tests/unit/test_type_width_totality.ml
@@ -64,9 +64,19 @@ let next_prim : T.prim_type -> T.prim_type option = function
   | T.TBool -> Some T.TUnit
   | T.TUnit -> None
 
+(* The accumulator must carry [x], the element just visited — not [y], the
+   successor about to be visited. Pushing [y] (as this did until #141) drops the
+   FIRST element of the chain and duplicates the LAST, so [T.Int] and
+   [T.TPrim T.TInt32] were never actually swept by any assertion below. The
+   length checks in [test_enumeration_is_complete] did not catch it because one
+   duplicate exactly compensated for one omission: 7 and 3 were still 7 and 3.
+   That is the "gates that cannot fail" pattern this file was written to close,
+   found in this file. Found by the sibling validator
+   sarek/tests/codegen_golden/test_backend_type_width_totality.ml, whose
+   pinned-set assertion reported the duplicate directly. *)
 let unfold next first =
   let rec go acc x =
-    match next x with Some y -> go (y :: acc) y | None -> List.rev (x :: acc)
+    match next x with Some y -> go (x :: acc) y | None -> List.rev (x :: acc)
   in
   go [] first
 
@@ -131,7 +141,17 @@ let test_enumeration_is_complete () =
   Alcotest.(check int)
     "scalar source types swept"
     10
-    (List.length all_scalar_typs)
+    (List.length all_scalar_typs) ;
+  (* A count alone does not prove the chain was walked correctly: the [unfold]
+     bug fixed in #141 kept the count at 10 while omitting one type and
+     duplicating another. Distinctness is what actually rules that out. *)
+  let labels = List.map string_of_typ all_scalar_typs in
+  let distinct = List.sort_uniq compare labels in
+  if List.length distinct <> List.length labels then
+    Alcotest.failf
+      "the enumeration contains duplicates, so it is walking the successor \
+       chain wrong and some source type is going unswept: %s"
+      (String.concat ", " labels)
 
 (** THE INVARIANT. For every scalar source type, [elttype_of_typ] must either
     reject it or preserve its byte width. *)

--- a/spoc/ir/Sarek_ir_analysis.ml
+++ b/spoc/ir/Sarek_ir_analysis.ml
@@ -188,28 +188,35 @@ let exists_folder ~leaf ?(type_leaf = fun _ -> false) ~native
     [Kernel.requirements] capability field reduces to, and it lives in the right
     layer already ([spoc/ir], no backend dependencies). *)
 
-type feature = Float64 | Float16
+type feature = Float64 | Float16 | Int64
 
-let all_features = [Float64; Float16]
+let all_features = [Float64; Float16; Int64]
 
-let feature_name = function Float64 -> "float64" | Float16 -> "float16"
+let feature_name = function
+  | Float64 -> "float64"
+  | Float16 -> "float16"
+  | Int64 -> "int64"
 
 (** Does element type [t] mention the width [f], transitively through records,
     variants, arrays and vectors? *)
 let rec elttype_uses (f : feature) = function
   | TFloat64 -> f = Float64
   | TFloat16 -> f = Float16
+  | TInt64 -> f = Int64
   | TRecord (_, fields) -> List.exists (fun (_, t) -> elttype_uses f t) fields
   | TVariant (_, constrs) ->
       List.exists (fun (_, args) -> List.exists (elttype_uses f) args) constrs
   | TArray (elt, _) | TVec elt -> elttype_uses f elt
-  | TInt32 | TInt64 | TFloat32 | TBool | TUnit -> false
+  | TInt32 | TFloat32 | TBool | TUnit -> false
 
-(** Is constant [c] a literal of width [f]? Only float64 has one; f16 has no
-    literal form, so this is [false] for [Float16] by construction rather than
-    by a missing case. *)
+(** Is constant [c] a literal of width [f]? [Float64] and [Int64] each have one
+    ([CFloat64], [CInt64]); f16 has no literal form, so this is [false] for
+    [Float16] by construction rather than by a missing case. *)
 let const_uses (f : feature) c =
-  match (f, c) with Float64, CFloat64 _ -> true | _ -> false
+  match (f, c) with
+  | Float64, CFloat64 _ -> true
+  | Int64, CInt64 _ -> true
+  | _ -> false
 
 let feature_leaf f = function
   | EConst c -> const_uses f c
@@ -231,7 +238,12 @@ let float64_folder = folder_of Float64
 
 let float16_folder = folder_of Float16
 
-let folder = function Float64 -> float64_folder | Float16 -> float16_folder
+let int64_folder = folder_of Int64
+
+let folder = function
+  | Float64 -> float64_folder
+  | Float16 -> float16_folder
+  | Int64 -> int64_folder
 
 (** Does expression [e] use width [f]? *)
 let expr_uses f e = expr_fold (folder f) false e

--- a/spoc/ir/test/test_sarek_ir_analysis.ml
+++ b/spoc/ir/test/test_sarek_ir_analysis.ml
@@ -1092,8 +1092,34 @@ let test_kernel_requirements () =
     = [Float64; Float16]) ;
   (* Every feature must be reachable from [all_features]; a new constructor that
      is not added there would silently never be required. *)
-  assert (List.length all_features = 2) ;
-  assert (List.map feature_name all_features = ["float64"; "float16"]) ;
+  assert (List.length all_features = 3) ;
+  assert (List.map feature_name all_features = ["float64"; "float16"; "int64"]) ;
+  (* [Int64], added in #141 so the GLSL backend can gate
+     `#extension GL_ARB_gpu_shader_int64` on the user's own int64 and not only
+     on the software-f64 helpers that bit-cast a double. *)
+  let v_i64 : var =
+    {var_name = "l"; var_id = 2; var_type = TVec TInt64; var_mutable = false}
+  in
+  assert (
+    kernel_requirements
+      (feature_kern
+         [DParam (v_i64, Some {arr_elttype = TInt64; arr_memspace = Global})]
+         SEmpty)
+    = [Int64]) ;
+  (* An int64 LITERAL alone is enough — the GLSL emitter needs the extension for
+     the `7L` suffix just as much as for the declared type. *)
+  assert (kernel_uses Int64 (feature_kern [] (SExpr (EConst (CInt64 7L))))) ;
+  (* And Int64 must not be triggered by the other widths. *)
+  assert (
+    not
+      (kernel_uses
+         Int64
+         (feature_kern
+            [
+              DParam
+                (v_f64, Some {arr_elttype = TFloat64; arr_memspace = Global});
+            ]
+            SEmpty))) ;
   print_endline "  kernel_requirements: OK"
 
 let test_kernel_uses_nonfinite_float64 () =


### PR DESCRIPTION
Backlog #141. Rebased onto current `main` (`488abe69`). Single commit, 13 files, `merge-base HEAD origin/main == origin/main`.

## Sequencing: what #320 owns, and what is left here

The Metal f64 refusal is now expressed through **#320's capability table**, not as a standalone check. Both refusal sites render `Sarek_capability.float64_absent_metal` (kind `Backend_structural`) via `explain`; my own `Sarek_ir_codegen.metal_float64_refusal` constant is **deleted**. Two hardcoded refusals for one fact is the duplication #64 exists to remove.

`test_metal_f64_refusal_is_single_sourced` now asserts against `explain` rather than against a literal — so a site that hand-rolled an equivalent sentence fails — and additionally asserts `kind_needs_device` is `false` for that entry, because a refusal decided at codegen is only legitimate for a kind decidable without a device.

### Convergence — worth stating

#320 and this PR found the **same two entry points independently, from opposite directions**, and landed on the same detector (`Sarek_ir_analysis.kernel_uses Float64`) at the same two `generate` entries.

The motivating shapes differ, and **neither reaches the other's detector**:

| | motivating shape | reached by |
|---|---|---|
| #320 (down from the model) | f64 **literal** into an f32 buffer | whole-kernel gate only |
| #141 (up from emitted source) | f64 **local**, `float x = 0.10000000000000001;` | type arm only |

Two searches, two shapes, one gate. That is the argument that {arm, whole-kernel} is the **complete** set of entry points rather than the set somebody happened to think of.

## Severity correction

Slice 1 described the pre-fix behaviour as *"a silent halving of precision"*. It is worse, and the difference moves it from quality-of-result to **wrong-answer**.

The IR element type fixes the **buffer stride** as well as the arithmetic. `Spoc_core.Vector.float64` is 8 bytes per element, so `device float*` strode the host buffer at **4** — every element after the first was a bit-half of its neighbour. The kernel did not lose precision, **it read a different array**.

Red captured before the fix, verbatim:

```
kernel void f64_scale(device float* out [[buffer(0)]], ..., device float* inp [[buffer(2)]], ...
  float x = 0.10000000000000001;
```

Corrected at the arm, in the inverted test, and in the design doc.

---

# The finding: a validator that could not fail, found inside the validator written to prevent exactly that

`sarek/tests/unit/test_type_width_totality.ml` closes the wrong-width class on the front half of the pipeline. It builds its source-type enumeration by unfolding a **total successor chain** — deliberately, so the list cannot drift from the type — and it carries an explicit anti-vacuity check, because its own header names "gates that cannot fail" as the thing it exists to avoid.

Its `unfold` pushed the **successor** onto the accumulator instead of the element just visited:

```ocaml
let rec go acc x =
  match next x with Some y -> go (y :: acc) y | None -> List.rev (x :: acc)
                            (* ^ should be x *)
```

So it **dropped the first element of every chain and duplicated the last**. `T.Int` and `T.TPrim T.TInt32` were never swept by any assertion in that file.

**And the anti-vacuity check did not catch it, because one duplicate exactly compensated for one omission.** The lengths were still 7, 3 and 10 — which is precisely what the check asserts:

```ocaml
Alcotest.(check int) "registered_type constructors" 7 (List.length all_reg) ;
Alcotest.(check int) "prim_type constructors"       3 (List.length all_prim) ;
Alcotest.(check int) "scalar source types swept"   10 (List.length all_scalar_typs)
```

A gate built to close a class, silently not sweeping two of its members, with its own non-vacuity check fooled by an exact compensation. Green for as long as it existed.

Found by the backend twin added in this PR, whose pinned-exemption-set assertion printed the duplicate directly (`CUDA/TUnit, CUDA/TUnit, GLSL/TUnit, GLSL/TUnit, ...`). Both `unfold`s are fixed, and **both files now assert distinctness as well as length** — the property a count alone cannot establish.

---

## Net-new in this PR

### 1. Metal `TBool` — the second silent narrowing

MSL `bool` is **one** byte; the host gives a Sarek `bool` a 4-byte slot (`Sarek_ir_layout.scalar_size TBool = 4`, mirroring `Sarek_ppx`). `bool` is an accepted `[@@sarek.type]` record field, so host `{bool;bool;int}` at 0/4/8 size 12 met a device struct at 0/1/4 size 8. Now `int`, which CUDA and OpenCL already emitted.

**Deliberately not a capability entry.** #320's `dc31288a` formalised this as **§5.1**, in a stronger form than I first argued it, and I have aligned every artefact to that wording. The test is **not** "is it silent?" and **not** "is it a width mismatch?" — both are equally true of `TBool` and of Metal f64. It is:

> **does a correct lowering exist in the target language?**

For f64 there is none, so it is a capability. For bool there is — `int`, at the host's width, which CUDA and OpenCL already emit — so it is a codegen bug and the fix belongs in the emitter. Filing it `Backend_structural` would make the table assert Metal cannot express booleans, and would remove a working feature from users of that backend.

That framing now appears in the `TBool` arm comment, the Metal test, and `docs/fp-contraction-policy.md` §10.13. My earlier weaker §5 block is **deleted** — §5.1 supersedes it; what remains in §5 is only the concrete residue §5.1 does not carry (the 0/4/8-size-12 vs 0/1/4-size-8 layout numbers, and the name of the sweep that catches the class).

### 2. GLSL `int64_t` with no `#extension`

Correct width, but the spelling does not exist under plain `#version 450`. The extension was gated on the two *float64* conditions only, so a plain `int64 vector` kernel emitted `int64_t` bare: `glslangValidator` rejects it (`syntax error, unexpected IDENTIFIER`, exit 2 → exit 0 after). Loud rather than silent, so a different class, but broken. Gate: `glsl-validate/int64_only_store`, a validation-only kernel whose only wide type is int64 — the shape the corpus lacked, which is why it survived. `Sarek_ir_analysis.feature` gained an `Int64` constructor.

**Taxonomy:** the emitter half is fixed here; the *capability* is `Device_optional` (`VkPhysicalDeviceFeatures.shaderInt64`), so it needs a device probe and is explicitly **not** a slice-1 fact. Filed as **#142** for slice 2.

**This measurement is what retracted a slice-1 claim.** The design doc had recorded a *"GLSL fp64 hole — it emits `double` while never declaring `GL_ARB_gpu_shader_fp64`"*. Measured: no such hole. `glsl_header` takes `~uses_float64:(kernel_uses_float64 k)` and emits the extension; `glslangValidator -V --target-env vulkan1.2` accepts the f64 kernel, exit 0. The hole was one type over.

#320's `dc31288a` **retracted it in place** as a visible `> **Correction.**` block and filed the int64 device probe as **#142**. This PR does not restate that retraction — it adds only what the block does not carry: the exact float64 conditions the `#extension` was gated on, the glslang error text and exit codes, the regression-gate name, and the note that until #142 lands a device without `shaderInt64` still fails at shader load rather than at launch with a Sarek diagnostic. Verified: exactly one `> **Correction.**` block in the file, and the retracted wording appears nowhere as an assertion.

### 3. The class validator (`test_backend_type_width_totality`)

Slice 1's static check enforces *one* capability. This enforces the *class*: for every backend and every scalar IR element type, the mapper must either raise a **diagnostic** or name a device type of exactly `Sarek_ir_layout.scalar_size` bytes.

Why it cannot read green while checking nothing:

- the enumeration unfolds from a **wildcard-free** successor chain — a new `elttype` constructor is a compile error *in the test*;
- the per-backend width tables are **closed**: an unrecorded device-type spelling **fails**, it does not skip, so the sweep cannot be outrun by the code it checks;
- the one exemption (types with no memory form) is a **pinned set**;
- each backend must exercise at least one width-checked mapping, so none can pass vacuously;
- `Match_failure` / `Not_found` / `Invalid_argument` / `Failure` are **rejected** as refusals — an incomplete match is not a policy;
- both enumerations assert **distinctness**, not only length.

**The two instruments are complementary and neither subsumes the other.** The sweep would not have caught Metal f64 as a *capability* question; the capability table cannot see a width that is merely wrong.

## Full sweep result

| backend | TInt64 | TFloat16 | TFloat64 | TBool |
|---|---|---|---|---|
| **Metal** | `long` ✓8 | refused | **`float` ✗4/8** | **`bool` ✗1/4** |
| **CUDA** | `long long` ✓8 | `__half` ✓2 | `double` ✓8 | `int` ✓4 |
| **OpenCL** | `long` ✓8 | refused | `double` ✓8 | `int` ✓4 |
| **GLSL** | `int64_t` ✓8 | refused | `double` ✓8 | `bool` ✓4 |
| **WGSL** | refused | refused | refused | `bool` — no memory form |
| **PTX** | `.u64` ✓8 | refused | `.f64` ✓8 | `.u32` ✓4 |

Two silent narrowings, both Metal. **WGSL was already correct** — it refuses `TFloat64`, `TInt64` and `TFloat16` with located errors, the only backend that refuses everything it cannot represent at the right width. It was the **precedent**, not a second instance, which makes slice 1b a pure refactor with nothing to fix.

The other two `bool` spellings were **checked, not assumed**:

- **GLSL** — glslang lowers a storage-buffer `bool` to a 32-bit uint. `spirv-dis`: `%Flagged_0 = OpTypeStruct %uint %int`, `Offset 0` / `Offset 4`, `ArrayStride 8`. The host's own width.
- **WGSL** — no memory form; naga refuses it in a storage binding: *"The type is not host-shareable"*. Hard load-time failure, never a wrong stride.

## Also in this commit

**The two CodeRabbit Minors.**

- **MD040** — the three fences added to `fp-contraction-policy.md` §10.13 now carry a language (`cpp`, `cpp`, `glsl`). Pre-existing unlabelled fences elsewhere in that file are untouched; they are not this PR's diff.
- **The stale `current_needs_int64` comment** was stale in exactly the way that produced the defect, which is worth saying rather than just fixing. It named two triggers and asserted *"a kernel that needs int64 necessarily uses fp64"*. That was false **and load-bearing**: that assertion is *why* the extension was gated on the float64 conditions alone. Rewritten to name all three triggers, and to separate the still-true ordering claim (int64 line after fp64, so existing goldens stay byte-identical) from the false implication it had been resting on. The `~uses_int64` parameter, previously undocumented, now carries an `@param` recording that unlike the fp64 line this one is **not** optional — `int64_t` does not parse under plain `#version 450`.

**The validator's contract has three outcomes, and both docs said two.** (CodeRabbit, 08:16:46Z — a review of the current tree, not a stale one.) `capability-model.md` and `rocq-value-ledger.md` both described the backend sweep as "preserve the width **or** refuse". It admits **three** outcomes: exact host-width emission, a diagnostic refusal, or an explicitly recorded `No_memory_form` exemption.

Not cosmetic. `No_memory_form` is the sweep's only escape hatch — a reader trusting "or refuse" would read a new entry in it as *impossible* rather than as a *deliberate widening*, which is a gate being given nothing to check, arriving by documentation drift instead of by code. Both docs now state all three outcomes **and** the property that makes the hatch safe: the set is pinned in `expected_no_memory_form`, and `test_no_memory_form_set_is_exactly_as_recorded` fails on any addition or removal.

Six entries today, and the two *reasons* are now distinguished, because someone deciding whether their own case belongs there needs it: `TUnit` on all five of Metal/CUDA/OpenCL/GLSL/WGSL has **no object representation at all**, whereas WGSL's `TBool` is a **real value the language will not let into a buffer**. The ledger additionally records that the *front*-half validator genuinely **is** two-outcome — only the backend twin has the hatch — since flattening the two into one sentence is what produced the error.

I proved the pinning claim rather than asserting it: widening the hatch to hide `Metal/TBool` (this PR's own second defect) fails `test_no_memory_form_set_is_exactly_as_recorded`, and the failure prints the six-entry expected set — which is what confirms the documented set is correct verbatim. Checking it also caught an error in my own first draft: the set has `TUnit` on **five** backends, not four.

**Cross-reference to #93's M-01.** That entry concludes what was missing is a model of `elttype_of_typ` — *"a total function from a finite type language to a byte width ... which an exhaustive table would settle in an afternoon"*. That table now exists in executable form on **both** halves of the seam, so M-01 gains a pointer to both validators, with an honest statement of what the executable form does and does not give versus Rocq: it is proof by exhaustive cases over a finite domain, the same argument a Rocq model would make, differing only in *when* it is checked and in what enforces the enumeration's totality.

And the caveat this PR supplies, which argues the other way: the front-half validator was green for its entire life while not sweeping two of its ten members, because its anti-vacuity length check was defeated by an exact compensation. **Machine-checked totality is what Rocq would have given for free there**, and that is the honest argument in its favour.

## Reds, re-verified on the rebased tree

Build success confirmed before reading each result.

| fix | red |
|---|---|
| Metal `TFloat64` | `Metal/TFloat64 maps to the device type "float", which is 4 byte(s), but the host lays a TFloat64 out in 8 byte(s)` |
| Metal `TBool` | `Metal/TBool emits the device type "bool", whose byte width this validator has never been told` |
| GLSL int64 extension | `glslangValidator rejected golden glsl/int64_only_store: ... :7: syntax error, unexpected IDENTIFIER` |

## Verification

Counted and located rather than read off exit codes:

- `dune runtest --force` — **1435 alcotest cases, 0 lines matching `FAIL`**, 23 `[SKIP]`, all pre-existing device/toolchain skips (CUDA, ptxas, nvdisasm, `xcrun metal`, OpenCL fp64), enumerated and confirmed none introduced here.
- `dune build` and `dune build @fmt` clean; working tree `git status --porcelain` = **0 lines**.
- `scripts/check-test-alias-coverage.sh` — 82/82 wired. `scripts/check-arm-parity-coverage.sh` (new in #94) — 5 backends, 40 rows, clean.
- `benchmarks/descriptions/generated/` regenerated; `git status --porcelain benchmarks/` = **0 lines**.
- Rebase integrity: **1** commit ahead of `origin/main`, **13** files, `merge-base HEAD origin/main` = `488abe69` = `origin/main`, no rebase dir left behind.
- **CodeRabbit's Major, re-confirmed on this tree by location**: `reject_float64_kernel k ;` at `Sarek_ir_metal.ml:1147` and `:1212`, each verified by walking back to its enclosing `let generate` / `let generate_with_types`. Both entry points covered.
- Markers located by line: the `unfold` fix at `test_type_width_totality.ml:79` and `test_backend_type_width_totality.ml:86`; `TBool -> "int"` at `Sarek_ir_metal.ml:113`; Int64 gating at `Sarek_ir_glsl.ml:1557`; `int64_only_store` at `test_codegen_golden.ml:2342`; the §5.1 framing at `Sarek_ir_metal.ml:106`; `Sarek_capability.explain` at `Sarek_ir_metal.ml:84` and `test_backend_type_width_totality.ml:572`; the rewritten int64 comment at `Sarek_ir_glsl.ml:1153`; the ledger cross-reference at `rocq-value-ledger.md:234`.
- **Merge-order check on `fp-contraction-policy.md`**, which #326 rewrote heavily: my §10.13 sits at line 1177, before §11 at 1333 — a §10 subsection ahead of the new top-level section, not appended after it. The §2 table conflict was resolved as a **union**: #326's Intel-extended pocl and Vulkan/GLSL rows kept, my Metal row kept, and §11.4 (the IGC barrier finding, #144) is intact at line 1525.

#320's own tests pass unchanged on top of this (`All Sarek_capability tests passed!`).

Evidence in `docs/fp-contraction-policy.md` §10.13 and `docs/design/capability-model.md` §4/§5.

No Apple hardware was used: the defect, the fix and all three reds are observable at the emitter, and the two cross-checks that needed a validator (`glslangValidator`, `naga`) ran locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Metal now reliably refuses unsupported `float64` usage (including kernel generation entry points) and directs users to `Sarek_real64`.
  - Fixed Metal `bool` type/codegen mismatch to prevent incorrect buffer/struct interpretation.
  - GLSL `int64`-using kernels now correctly request the required shader extension.
  - Improved type enumeration validation to prevent missed or duplicated scalar types.

- **Tests**
  - Added backend type-width totality checks and Metal `float64` regression coverage; tightened enumeration and golden shader validation.

- **Documentation**
  - Expanded Metal fp64/int64, capability model, and float contraction policy notes with corrected semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->