### PR TITLE
Make backend arm divergence deliberate, and stop the wildcards that succeed (#94)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
           # red-path coverage behind a 50-second container pull is how a gate
           # ends up untested.
           ./scripts/check-proof-ledger.test.sh
+          # #94. Lexical companion to sarek/tests/unit/test_backend_arm_parity.ml:
+          # asserts every intrinsic name matched by any backend's `arm` table has
+          # a row in that test's matrix. The test itself probes BEHAVIOUR (it has
+          # to — pre_hook/post_hook handle names that appear in no arm), but it
+          # can only probe names it was told about, so a name added to one
+          # backend and to no list would leave it green having checked nothing.
+          ./scripts/check-arm-parity-coverage.sh
 
       - name: Formal proofs admit gate
         run: |

--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -287,7 +287,15 @@ and cuda_backend =
         (* Same framework tag the pure-registry lookup uses: without it this
            fallback emitted the CUDA spelling on every backend. *)
         let framework = Option.value ~default:"CUDA" !current_framework in
-        Dispatch.emit_registry_template ~gen_expr ~framework buf path name args);
+        Dispatch.emit_registry_template
+          ~gen_expr
+          ~framework
+          ~invalid_arg_count:bad_arity
+          buf
+          path
+          name
+          args);
+    invalid_arg_count = bad_arity;
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -713,6 +713,7 @@ and glsl_backend =
           true)
         else false);
     post_hook = (fun _ _ _ _ -> false);
+    invalid_arg_count = bad_arity;
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));
@@ -794,15 +795,25 @@ and glsl_backend =
         | "float" ->
             Some
               (fun buf args ->
-                Buffer.add_string buf "float(" ;
-                (match args with [e] -> gen_expr buf e | _ -> ()) ;
-                Buffer.add_char buf ')')
+                Dispatch.emit_unary
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~prefix:"float("
+                  ~suffix:")"
+                  ~opname:"float"
+                  args)
         | "int_of_float" ->
             Some
               (fun buf args ->
-                Buffer.add_string buf "int(" ;
-                (match args with [e] -> gen_expr buf e | _ -> ()) ;
-                Buffer.add_char buf ')')
+                Dispatch.emit_unary
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~prefix:"int("
+                  ~suffix:")"
+                  ~opname:"int_of_float"
+                  args)
         | _ -> None);
   }
 

--- a/sarek/codegen/Sarek_ir_intrinsic_dispatch.ml
+++ b/sarek/codegen/Sarek_ir_intrinsic_dispatch.ml
@@ -44,6 +44,13 @@ type 'e spec = {
   on_unknown : string -> unit;
       (** Raise the backend's located [unknown_intrinsic] error. Never returns.
       *)
+  invalid_arg_count : string -> int -> int -> unit;
+      (** Raise the backend's located invalid-argument-count error, given the
+          operation name, the expected count and the given one. Never returns.
+          Each backend already had this as a local [bad_arity] for
+          {!emit_atomic}; putting it in the spec is what lets the shared
+          pipeline enforce {!intrinsic_arity} centrally instead of at ~130
+          identical call sites. *)
 }
 
 (** The thread/grid position intrinsics, identical across all five backends. *)
@@ -75,6 +82,63 @@ let thread_intrinsic_names =
     "global_size";
   ]
 
+(** Argument count of the intrinsics whose arity is the same on every backend.
+
+    Checked once, centrally, in {!gen_intrinsic}. It has to be central: the
+    lowering for these names is [emit_call], which takes whatever argument list
+    it is handed and writes [callee(a, b, c)] — so [sin(x, y)] used to emit
+    verbatim on all five backends and the pipeline returned [Ok]. There are ~26
+    such names per backend and the call sites are identical, which is precisely
+    why the check does not belong at the call sites (audit #94).
+
+    Deliberately NOT listed here:
+
+    - the atomics, which accept both [(addr, value)] and [(arr, idx, value)] —
+      {!emit_atomic} checks them against the form it was given;
+    - [float] / [int_of_float] / [rsqrt], guarded at their arms by
+      {!emit_unary}, whose wrapper text differs per backend;
+    - [block_barrier], which ignores its arguments on every backend;
+    - anything reached through [pre_hook] or the FFI registry, where the arity
+      is the polyfill's or the template's business, not this table's.
+
+    A name absent from this table is unconstrained, which is the safe default:
+    an entry here rejects code, so a wrong entry breaks a working kernel. *)
+let intrinsic_arity =
+  [
+    ("acos", 1);
+    ("asin", 1);
+    ("atan", 1);
+    ("atan2", 2);
+    ("cbrt", 1);
+    ("ceil", 1);
+    ("cos", 1);
+    ("cosh", 1);
+    ("exp", 1);
+    ("exp2", 1);
+    ("fabs", 1);
+    ("floor", 1);
+    ("fma", 3);
+    ("log", 1);
+    ("log10", 1);
+    ("log2", 1);
+    ("max", 2);
+    ("min", 2);
+    ("pow", 2);
+    ("round", 1);
+    (* [rsqrt] is guarded at WGSL's arm by [emit_unary] too, because its wrapper
+       text is `(1.0f / sqrt(...))` rather than a call. It is listed here
+       regardless: the other four backends reach it through [emit_call], where
+       nothing checked, and a guard that covers one of five backends is the
+       shape this table exists to remove. *)
+    ("rsqrt", 1);
+    ("sin", 1);
+    ("sinh", 1);
+    ("sqrt", 1);
+    ("tan", 1);
+    ("tanh", 1);
+    ("trunc", 1);
+  ]
+
 (** The dotted OCaml source name of an intrinsic ([Float64.log10], [sin], ...).
 *)
 let full_name path name =
@@ -88,6 +152,32 @@ let emit_args ~gen_expr buf args =
       if i > 0 then Buffer.add_string buf ", " ;
       gen_expr buf e)
     args
+
+(** Emit a fixed-arity wrapper [prefix arg suffix], failing loudly on any other
+    argument count.
+
+    This exists because the shape it replaces did not. Four backend arms were
+    written as
+
+    {[
+      Buffer.add_string buf "f32(" ;
+      (match args with [e] -> gen_expr buf e | _ -> ()) ;
+      Buffer.add_char buf ')'
+    ]}
+
+    — a wildcard that SUCCEEDS on the wrong argument count, emitting [f32()]
+    with no argument at all and returning normally, so the pipeline yields [Ok]
+    and the defect surfaces as a shader-compiler error with no connection to the
+    kernel that caused it. That is the same failure mode as the raw-name
+    fall-through audit #48 closed for unknown intrinsics; it survived inside the
+    arms that WERE handled (audit #94). *)
+let emit_unary ~gen_expr ~invalid_arg_count buf ~prefix ~suffix ~opname args =
+  match args with
+  | [e] ->
+      Buffer.add_string buf prefix ;
+      gen_expr buf e ;
+      Buffer.add_string buf suffix
+  | _ -> invalid_arg_count opname 1 (List.length args)
 
 (** Emit a plain call [callee(arg0, arg1, ...)]. *)
 let emit_call ~gen_expr buf callee args =
@@ -133,7 +223,8 @@ let count_placeholders s =
 (** Expand a Metal/CUDA/OpenCL FFI-registry ([Sarek_registry]) device template
     for [path.name]. Returns [false] when the registry has no template (caller
     then raises the unknown-intrinsic error); [true] once emitted. *)
-let emit_registry_template ~gen_expr ~framework buf path name args =
+let emit_registry_template ~gen_expr ~framework ~invalid_arg_count buf path name
+    args =
   match
     Sarek_registry.fun_device_template ~module_path:path ~framework name
   with
@@ -166,7 +257,19 @@ let emit_registry_template ~gen_expr ~framework buf path name args =
                 arg1
                 arg2
                 arg3
-          | _ -> template ^ "(" ^ String.concat ", " arg_strs ^ ")"
+          | _ ->
+              (* A template with N placeholders applied to M <> N arguments.
+                 This used to fall back to `template(args...)`, which emits the
+                 template TEXT — `%s` and all — as if it were a function name,
+                 and returns normally: the registry's operator or cast shape is
+                 discarded and the pipeline reports success. There is no reading
+                 of a placeholder/argument mismatch under which the right answer
+                 is to emit something; it is a registry declaration that does
+                 not match its call site, and it has to say so. *)
+              invalid_arg_count
+                (full_name path name)
+                num_placeholders
+                (List.length arg_strs)
       in
       Buffer.add_string buf result ;
       true
@@ -176,6 +279,14 @@ let emit_registry_template ~gen_expr ~framework buf path name args =
     thread list, arm, post_hook, else raise via on_unknown (audit #48). *)
 let gen_intrinsic (spec : 'e spec) buf path name (args : 'e list) =
   let full = full_name path name in
+  (* Arity first, before any lowering path can emit. See [intrinsic_arity]: the
+     lowering these names reach is [emit_call], which formats whatever argument
+     list it is given, so without this `sin(x, y)` produced valid-looking source
+     calling a device function with the wrong signature on all five backends. *)
+  (match List.assoc_opt name intrinsic_arity with
+  | Some expected when List.length args <> expected ->
+      spec.invalid_arg_count name expected (List.length args)
+  | _ -> ()) ;
   if spec.pre_hook buf ~full_name:full path name args then ()
   else
     let pure_registry_hit =

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -356,7 +356,15 @@ and metal_backend =
         (* Same framework tag the pure-registry lookup uses: without it this
            fallback emitted the CUDA spelling on every backend. *)
         let framework = Option.value ~default:"Metal" !current_framework in
-        Dispatch.emit_registry_template ~gen_expr ~framework buf path name args);
+        Dispatch.emit_registry_template
+          ~gen_expr
+          ~framework
+          ~invalid_arg_count:bad_arity
+          buf
+          path
+          name
+          args);
+    invalid_arg_count = bad_arity;
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -333,7 +333,15 @@ and opencl_backend =
         (* Same framework tag the pure-registry lookup uses: without it this
            fallback emitted the CUDA spelling on every backend. *)
         let framework = Option.value ~default:"OpenCL" !current_framework in
-        Dispatch.emit_registry_template ~gen_expr ~framework buf path name args);
+        Dispatch.emit_registry_template
+          ~gen_expr
+          ~framework
+          ~invalid_arg_count:bad_arity
+          buf
+          path
+          name
+          args);
+    invalid_arg_count = bad_arity;
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -706,6 +706,7 @@ and wgsl_backend =
                 (Codegen_error.invalid_arg_count "fmod" 2 (List.length args))
         else false);
     post_hook = (fun _ _ _ _ -> false);
+    invalid_arg_count = bad_arity;
     on_unknown =
       (fun full ->
         Codegen_error.raise_error (Codegen_error.unknown_intrinsic full));
@@ -721,11 +722,16 @@ and wgsl_backend =
         | "rsqrt" ->
             Some
               (fun buf args ->
-                Buffer.add_string buf "(1.0f / sqrt(" ;
-                (match args with
-                | [e] -> gen_expr buf e
-                | _ -> Dispatch.emit_args ~gen_expr buf args) ;
-                Buffer.add_string buf "))")
+                (* Was: `| _ -> emit_args`, which on the wrong argument count
+                   emitted `(1.0f / sqrt(a, b))` and returned Ok. *)
+                Dispatch.emit_unary
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~prefix:"(1.0f / sqrt("
+                  ~suffix:"))"
+                  ~opname:"rsqrt"
+                  args)
         | "block_barrier" ->
             Some (fun buf _ -> Buffer.add_string buf "workgroupBarrier()")
         | "atomic_add" | "atomic_add_int32" | "atomic_add_global_int32" ->
@@ -773,15 +779,25 @@ and wgsl_backend =
         | "float" ->
             Some
               (fun buf args ->
-                Buffer.add_string buf "f32(" ;
-                (match args with [e] -> gen_expr buf e | _ -> ()) ;
-                Buffer.add_char buf ')')
+                Dispatch.emit_unary
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~prefix:"f32("
+                  ~suffix:")"
+                  ~opname:"float"
+                  args)
         | "int_of_float" ->
             Some
               (fun buf args ->
-                Buffer.add_string buf "i32(" ;
-                (match args with [e] -> gen_expr buf e | _ -> ()) ;
-                Buffer.add_char buf ')')
+                Dispatch.emit_unary
+                  ~gen_expr
+                  ~invalid_arg_count:bad_arity
+                  buf
+                  ~prefix:"i32("
+                  ~suffix:")"
+                  ~opname:"int_of_float"
+                  args)
         | _ -> None);
   }
 

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -148,6 +148,14 @@
  (name test_sync_stmt_emission)
  (libraries sarek.codegen sarek_ppx_lib spoc.ir alcotest))
 
+; Cross-backend intrinsic arm parity (#94). Records, per intrinsic, what each of
+; the five source backends does with it — so a divergence gained or lost is a
+; deliberate table edit rather than something a user of one backend discovers.
+
+(test
+ (name test_backend_arm_parity)
+ (libraries sarek.codegen sarek_ir alcotest))
+
 ; Intrinsic-surface reconciliation: derives its expectation from
 ; Sarek_registry's link-time record of every let%sarek_intrinsic, and checks it
 ; against Sarek_pure_registry (GPU codegen) and Sarek_cpu_runtime (native).

--- a/sarek/tests/unit/test_backend_arm_parity.ml
+++ b/sarek/tests/unit/test_backend_arm_parity.ml
@@ -1,0 +1,284 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Cross-backend intrinsic ARM PARITY (audit #94).
+ *
+ * WHAT THIS IS FOR
+ *
+ * The five source backends (CUDA, OpenCL, Metal, WGSL, GLSL) each carry their
+ * own `arm` table: a `string -> emitter option` match giving that backend's
+ * spelling for ~34 intrinsics. #92/#49 unified the DISPATCH around those tables
+ * — the shared pipeline, the argument loop, the unknown-intrinsic raise — but
+ * the tables themselves remain five separate lists, deliberately, because the
+ * spellings genuinely differ (`f32(x)` vs `float(x)` vs `(float)x`).
+ *
+ * Five parallel string matches is a shape the compiler cannot check. A missing
+ * `| "log10" ->` is not a type error, it is a name that works on four backends
+ * and raises Unknown_intrinsic on the fifth, discovered by whoever runs that
+ * backend. Today, mechanically, fifteen of the forty names in the union are
+ * handled by some backends and not others.
+ *
+ * This test does not forbid that. Divergence is often correct — WGSL has no
+ * 64-bit floats, so `f64_bits` cannot mean anything there. What it forbids is
+ * divergence NOBODY DECIDED ON. The table below records, per name, exactly what
+ * each backend does with it today. Any change — a name gained, a name lost, an
+ * error class changed — turns this red, and updating the table is the moment
+ * someone states whether the new divergence is intended.
+ *
+ * WHY IT PROBES BEHAVIOUR RATHER THAN READING THE TABLES
+ *
+ * A backend's `arm` is not the whole story: `pre_hook` and `post_hook` run
+ * before and after it, so GLSL handles `log10` with no `| "log10" ->` arm at
+ * all, and Metal reaches `cbrt` the same way. A lexical comparison of the five
+ * `arm` matches would report divergences that do not exist and miss the ones
+ * that do. So each cell below is the OBSERVED result of generating a kernel
+ * that calls the intrinsic.
+ *
+ * The lexical view is still worth having, and it is the companion check in
+ * scripts/check-arm-parity-coverage.sh: that every string literal appearing as
+ * an arm on any backend appears in the [names] list here. Without it a name
+ * added to one backend and to no list would be invisible to this test — a gate
+ * that passes because it was never told to look.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend_error = Sarek_backend_error.Backend_error
+module Wgsl = Sarek_codegen.Sarek_ir_wgsl
+module Metal = Sarek_codegen.Sarek_ir_metal
+module Cuda = Sarek_codegen.Sarek_ir_cuda
+module Opencl = Sarek_codegen.Sarek_ir_opencl
+module Glsl = Sarek_codegen.Sarek_ir_glsl
+
+(* What a backend did with one intrinsic. *)
+type verdict =
+  | Emitted  (** the backend lowered it *)
+  | Unknown  (** located Unknown_intrinsic — the sanctioned refusal *)
+  | Other of string
+      (** any other backend error: a refusal that is NOT the unknown-intrinsic
+          one, e.g. an unsupported-construct or type error. Distinguished from
+          [Unknown] because "this backend does not know the name" and "this
+          backend knows the name and cannot compile this call" are different
+          facts, and collapsing them is how an arm that stopped working reads as
+          an arm that was never there. *)
+
+let show = function
+  | Emitted -> "emit"
+  | Unknown -> "unknown"
+  | Other e -> "other:" ^ e
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* A minimal kernel calling [name] with [arity] float32 arguments. Bare literal
+   indices so the body introduces no second intrinsic that could mask the one
+   under test. Same shape as test_intrinsic_fallback_all.ml. *)
+let kernel_calling ~name ~arity =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let arg = EArrayRead ("a", EConst (CInt32 0l)) in
+  let args = List.init arity (fun _ -> arg) in
+  {
+    kern_name = "arm_parity_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body =
+      SAssign (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic ([], name, args));
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let backends =
+  [
+    ("CUDA", fun k -> Cuda.generate_with_types ~types:[] k);
+    ("OpenCL", fun k -> Opencl.generate_with_types ~types:[] k);
+    ("Metal", fun k -> Metal.generate_with_types ~types:[] k);
+    ("WGSL", fun k -> Wgsl.generate_with_types ~types:[] k);
+    ("GLSL", fun k -> Glsl.generate_with_types ~types:[] k);
+  ]
+
+let probe generate ~name ~arity =
+  match generate (kernel_calling ~name ~arity) with
+  | (_ : string) -> Emitted
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Codegen
+           {error = Backend_error.Unknown_intrinsic _; backend = _}) ->
+      Unknown
+  | exception Backend_error.Backend_error _ -> Other "backend_error"
+  | exception Failure _ -> Other "failure"
+  | exception Invalid_argument _ -> Other "invalid_argument"
+
+(* ------------------------------------------------------------------------ *)
+(* The matrix. Column order is [backends] above: CUDA, OpenCL, Metal, WGSL,   *)
+(* GLSL. Generated by running this test and pasting its report; every cell is *)
+(* an observation, none is an aspiration.                                     *)
+(* ------------------------------------------------------------------------ *)
+
+let names : (string * int * verdict list) list =
+  [
+    (* The 32 names every backend lowers. A row leaving this block is the
+       signal this test exists for. *)
+    ("acos", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("asin", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("atan", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("atan2", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("atomic_add", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("atomic_add_global_int32", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("atomic_add_int32", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("atomic_max", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("atomic_min", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("block_barrier", 0, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("ceil", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("cos", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("cosh", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("exp", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("exp2", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("fabs", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("floor", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("fma", 3, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("log", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("log2", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("max", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("min", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("pow", 2, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("round", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("rsqrt", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("sin", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("sinh", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("sqrt", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("tan", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("tanh", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    ("trunc", 1, [Emitted; Emitted; Emitted; Emitted; Emitted]);
+    (* The 8 that diverge. Each carries WHY, because an undocumented cell here
+       is indistinguishable from an oversight — which is how three of these
+       got here. Two are recorded as gaps rather than decisions; closing them
+       is separate work, and this table is what stops them being forgotten. *)
+    (* abs: CUDA/OpenCL/Metal expose the float magnitude as `fabs` and reserve
+       `abs` for integers; WGSL and GLSL overload one `abs`. Deliberate. *)
+    ("abs", 1, [Unknown; Unknown; Unknown; Emitted; Emitted]);
+    (* abs_float: GLSL only. No counterpart anywhere else, and `fabs` covers the same
+       thing on all five. Looks vestigial rather than decided — see #94 note. *)
+    ("abs_float", 1, [Unknown; Unknown; Unknown; Unknown; Emitted]);
+    (* atomic_sub: GAP, not a decision. WGSL has `atomicSub` and GLSL reaches the same
+       effect by negating the operand for `atomicAdd`; neither is wired. *)
+    ("atomic_sub", 2, [Emitted; Emitted; Emitted; Unknown; Unknown]);
+    (* bits_f64: GLSL only. WGSL correctly has no f64 at all, but CUDA/OpenCL/Metal do
+       — so three of the four absences are unexplained. See #94 note. *)
+    ("bits_f64", 1, [Unknown; Unknown; Unknown; Unknown; Emitted]);
+    (* cbrt: WGSL has no cube-root builtin and no polyfill is wired; the other four
+       reach it (Metal and GLSL through `pre_hook`, not through `arm`). *)
+    ("cbrt", 1, [Emitted; Emitted; Emitted; Unknown; Emitted]);
+    (* f64_bits: As `bits_f64`: the other half of the same f64 bit-cast pair. *)
+    ("f64_bits", 1, [Unknown; Unknown; Unknown; Unknown; Emitted]);
+    (* float: CUDA/OpenCL/Metal are C-family and take the cast from the surrounding
+       expression rather than an intrinsic. Deliberate. *)
+    ("float", 1, [Unknown; Unknown; Unknown; Emitted; Emitted]);
+    (* int_of_float: As `float`: the C-family backends cast, they do not call. *)
+    ("int_of_float", 1, [Unknown; Unknown; Unknown; Emitted; Emitted]);
+    (* log10: GAP, not a decision. WGSL has `log2`, and log10 x = log2 x * log10 2;
+       the other four all handle it (GLSL through `pre_hook`). *)
+    ("log10", 1, [Emitted; Emitted; Emitted; Unknown; Emitted]);
+  ]
+
+let observed name arity =
+  List.map (fun (_, generate) -> probe generate ~name ~arity) backends
+
+(* One test per intrinsic, so a failure names the intrinsic rather than
+   reporting "the matrix changed". *)
+let test_name (name, arity, expected) () =
+  let got = observed name arity in
+  if got <> expected then
+    Alcotest.failf
+      "%s/%d: backend behaviour changed.\n\
+      \  expected: %s\n\
+      \  observed: %s\n\
+       Columns: %s.\n\
+       If the change is intended, update the row in \
+       sarek/tests/unit/test_backend_arm_parity.ml — that edit is the record \
+       that someone decided this divergence was correct."
+      name
+      arity
+      (String.concat " " (List.map show expected))
+      (String.concat " " (List.map show got))
+      (String.concat "/" (List.map fst backends))
+
+(* ------------------------------------------------------------------------ *)
+(* Arity guards (audit #94, the "no silently-succeeding wildcard" half).      *)
+(*                                                                            *)
+(* Four arms were written as                                                  *)
+(*     Buffer.add_string buf "f32(" ;                                         *)
+(*     (match args with [e] -> gen_expr buf e | _ -> ()) ;                    *)
+(*     Buffer.add_char buf ')'                                                *)
+(* — a wildcard that succeeds on the wrong argument count, emitting `f32()`   *)
+(* with no argument and returning normally, so the pipeline reports Ok and    *)
+(* the defect reaches the driver as an unattributable shader-compiler error.  *)
+(* WGSL's `rsqrt` had the same shape via `emit_args`, yielding                *)
+(* `(1.0f / sqrt(a, b))`.                                                     *)
+(*                                                                            *)
+(* The assertion is deliberately "not Emitted" rather than a specific error   *)
+(* constructor: what matters is that generation REFUSES. Pinning the exact    *)
+(* error would make this test about the message.                              *)
+(* ------------------------------------------------------------------------ *)
+
+let arity_guards =
+  [
+    (* name, wrong arity, backends that lower it at the right arity *)
+    ("float", 2, ["WGSL"; "GLSL"]);
+    ("int_of_float", 2, ["WGSL"; "GLSL"]);
+    ("rsqrt", 2, ["CUDA"; "OpenCL"; "Metal"; "WGSL"; "GLSL"]);
+  ]
+
+let test_arity_guard (name, wrong_arity, handling) () =
+  List.iter
+    (fun (label, generate) ->
+      if List.mem label handling then
+        match probe generate ~name ~arity:wrong_arity with
+        | Emitted ->
+            Alcotest.failf
+              "%s: %s with %d arguments generated code instead of failing. The \
+               arm accepted an argument count it cannot lower and emitted \
+               something anyway — the silently-succeeding wildcard of audit \
+               #94."
+              label
+              name
+              wrong_arity
+        | Unknown | Other _ -> ())
+    backends
+
+(* The list itself must not be able to shrink silently: a row deleted along
+   with the arm it covered would leave this suite green and smaller. *)
+let test_row_count () =
+  Alcotest.(check int)
+    "intrinsic rows covered (update deliberately when adding an arm)"
+    40
+    (List.length names)
+
+let () =
+  let open Alcotest in
+  run
+    "backend arm parity"
+    [
+      ( "per-intrinsic",
+        List.map
+          (fun ((name, arity, _) as row) ->
+            test_case (Printf.sprintf "%s/%d" name arity) `Quick (test_name row))
+          names );
+      ( "arity-guard",
+        List.map
+          (fun ((name, wrong, _) as row) ->
+            test_case
+              (Printf.sprintf "%s/%d must refuse" name wrong)
+              `Quick
+              (test_arity_guard row))
+          arity_guards );
+      ("coverage", [test_case "row count" `Quick test_row_count]);
+    ]

--- a/scripts/check-arm-parity-coverage.sh
+++ b/scripts/check-arm-parity-coverage.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+# ---------------------------------------------------------------------------
+# Every backend `arm` name must be covered by the arm-parity matrix (task #94).
+#
+# WHY A SECOND, LEXICAL CHECK
+#
+# sarek/tests/unit/test_backend_arm_parity.ml probes each of the five source
+# backends with each intrinsic in its table and asserts the observed behaviour
+# has not changed. That is the real check — it sees through `pre_hook` and
+# `post_hook`, which a grep cannot.
+#
+# But it can only probe names it was told about. A name added to one backend's
+# `arm` and to no list is invisible to it: the suite stays green, having verified
+# nothing about the new name. That is not a hypothetical shape — it is the
+# defining property of a hand-maintained list, and this repository has spent two
+# days removing instances of it.
+#
+# So: this script extracts every string literal used as a match arm inside each
+# backend's `arm` field and asserts it appears in the test's `names` list. The
+# pair is the same arrangement as the Rocq `admit` grep beside `rocq check` — a
+# cheap lexical tripwire guarding the entrance to an expensive semantic check,
+# each catching what the other structurally cannot.
+#
+# It deliberately does NOT check the converse (a name in the test with no arm
+# anywhere). That is legitimate and load-bearing: `log10` has no `arm` on GLSL
+# and is handled by `pre_hook`, and several names are reached only through the
+# FFI registry. Requiring an arm for every tested name would forbid exactly the
+# indirection the behavioural test exists to see through.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TEST=sarek/tests/unit/test_backend_arm_parity.ml
+BACKENDS="cuda opencl metal wgsl glsl"
+
+[ -f "$TEST" ] || {
+  echo "::error::$TEST is missing — the arm-parity matrix it guards is gone, \
+so this check would pass having compared nothing."
+  exit 1
+}
+
+# python3 rather than sed: the extraction has to find the `arm = ...` field and
+# stop at its terminating `| _ -> None)`, which is a bracket-matching job, and a
+# regex that got it subtly wrong would silently extract too few names — the
+# exact failure this script exists to prevent, committed by the script itself.
+python3 - "$TEST" $BACKENDS <<'PY'
+import re, sys
+
+test_path, backends = sys.argv[1], sys.argv[2:]
+
+covered = set(re.findall(r'^\s*\("([^"]+)",\s*\d+,\s*\[',
+                         open(test_path, encoding="utf-8").read(), re.M))
+if not covered:
+    print("::error::no rows parsed out of %s. Either the matrix is empty or its "
+          "shape changed and this check is now reading nothing." % test_path)
+    sys.exit(1)
+
+missing, scanned = [], 0
+for be in backends:
+    path = "sarek/codegen/Sarek_ir_%s.ml" % be
+    src = open(path, encoding="utf-8").read()
+    i = src.find("arm =")
+    j = src.find("| _ -> None)", i)
+    if i < 0 or j < 0:
+        print("::error::could not locate the `arm` table in %s (looked for "
+              "'arm =' then '| _ -> None)'). Refusing to report success on a "
+              "backend this script could not read." % path)
+        sys.exit(1)
+    names = []
+    for group in re.findall(r'\|\s*("(?:[^"\\]|\\.)*"(?:\s*\|\s*"(?:[^"\\]|\\.)*")*)\s*->',
+                            src[i:j]):
+        names += re.findall(r'"((?:[^"\\]|\\.)*)"', group)
+    if not names:
+        print("::error::%s: extracted zero arm names. The table cannot be "
+              "empty; the parser is broken." % path)
+        sys.exit(1)
+    scanned += 1
+    for n in sorted(set(names)):
+        if n not in covered:
+            missing.append((be, n))
+
+if scanned != len(backends):
+    print("::error::scanned %d of %d backends." % (scanned, len(backends)))
+    sys.exit(1)
+
+if missing:
+    print("::error::intrinsic arm(s) not covered by the arm-parity matrix in "
+          "%s:" % test_path)
+    for be, n in missing:
+        print("    %-8s %s" % (be, n))
+    print("Add a row for each. Until then nothing checks whether the other four "
+          "backends handle these names, which is the divergence this matrix "
+          "exists to make deliberate.")
+    sys.exit(1)
+
+print("OK: %d backends scanned, every arm name covered by %d matrix rows."
+      % (scanned, len(covered)))
+PY


### PR DESCRIPTION
## What this closes

Backlog **#94** — keep the codegen duplication, but make drift impossible: document each twin in place, add CI checks for arm parity, and no silently-succeeding wildcards.

---

## Part 1 — arm parity

Each backend carries its own `arm` table: a `string -> emitter option` match giving that backend's spelling for ~34 intrinsics. The spellings genuinely differ (`f32(x)` vs `float(x)` vs `(float)x`), so unifying the tables is not the answer — #92/#49 already unified everything around them that could be. What remains is **five parallel string matches, a shape the compiler cannot check**: a missing `| "log10" ->` is not a type error, it is a name that works on four backends and raises on the fifth, discovered by whoever runs that backend.

`sarek/tests/unit/test_backend_arm_parity.ml` records what each backend does with each of the 40 names in the union, and asserts it has not changed.

**It probes behaviour, not the tables** — and that is not incidental. `pre_hook` and `post_hook` run either side of `arm`, so GLSL handles `log10` with **no arm at all** and Metal reaches `cbrt` the same way. A lexical comparison of the five matches would report divergences that do not exist and miss ones that do.

### Measured: 32 of 40 universal, 8 divergent

Each of the eight now carries its reason in place. Two are labelled **GAP, not a decision**:

| name | CUDA | OpenCL | Metal | WGSL | GLSL | |
|---|---|---|---|---|---|---|
| `atomic_sub` | ✓ | ✓ | ✓ | — | — | **GAP** — WGSL has `atomicSub`; GLSL can negate the operand for `atomicAdd`. Neither is wired. |
| `log10` | ✓ | ✓ | ✓ | — | ✓ | **GAP** — WGSL has `log2`, and log10 x = log2 x · log10 2. |
| `abs` | — | — | — | ✓ | ✓ | deliberate: the C-family reserve `abs` for integers and expose `fabs`. |
| `float`, `int_of_float` | — | — | — | ✓ | ✓ | deliberate: the C-family cast, they do not call. |
| `cbrt` | ✓ | ✓ | ✓ | — | ✓ | WGSL has no builtin and no polyfill wired. |
| `abs_float` | — | — | — | — | ✓ | GLSL only, no counterpart anywhere; looks vestigial. |
| `f64_bits`, `bits_f64` | — | — | — | — | ✓ | WGSL correctly has no f64 — but CUDA/OpenCL/Metal do, so three of four absences are unexplained. |

Closing the gaps is separate work. **The table is what stops them being forgotten again**, which is the point: the test does not forbid divergence, it forbids divergence nobody decided on.

### The companion check

`scripts/check-arm-parity-coverage.sh` asserts every string literal used as an arm on any backend has a row in the matrix. It exists because the behavioural test **can only probe names it was told about** — a name added to one backend and to no list would leave it green having checked nothing. Same arrangement as the Rocq admit-grep beside `rocq check`: a cheap lexical tripwire at the entrance to an expensive semantic check, each catching what the other structurally cannot.

---

## Part 2 — no silently-succeeding wildcards

Four arms were written as:

```ocaml
Buffer.add_string buf "f32(" ;
(match args with [e] -> gen_expr buf e | _ -> ()) ;
Buffer.add_char buf ')'
```

A wildcard that **succeeds** on the wrong argument count — emitting `f32()` with no argument and returning normally, so the pipeline reports `Ok` and the defect reaches the driver as a shader-compiler error with nothing pointing back at the kernel. WGSL's `rsqrt` had the same shape via `emit_args`, yielding `(1.0f / sqrt(a, b))`.

This is the same failure mode audit #48 closed for *unknown* intrinsics. It survived inside the arms that **were** handled. `Dispatch.emit_unary` replaces all five.

The dispatcher's FFI-template path had it too: a template whose `%s` count did not match the argument count fell back to `template(args...)`, emitting the template **text** — `%s` and all — as a function name. There is no reading of a placeholder/argument mismatch under which the right answer is to emit something.

### Writing the test found a sixth, larger instance

The audit had noted it and nobody had acted: **`emit_call` performs no arity check at all**. It is the lowering the ~26-name math list reaches on every backend, so `sin(x, y)` emitted verbatim everywhere. The arity guard caught it immediately:

```
FAIL CUDA: rsqrt with 2 arguments generated code instead of failing.
The arm accepted an argument count it cannot lower and emitted something
anyway — the silently-succeeding wildcard of audit #94.
```

Fixed **centrally**, not at ~130 identical call sites: `Dispatch.intrinsic_arity` is consulted once in `gen_intrinsic`, before any lowering path can emit, and each backend's existing `bad_arity` is now reachable from the shared pipeline through the spec record.

Deliberately **absent** from that table: the atomics (they legitimately take two or three arguments, and `emit_atomic` checks the form it was given), and anything reached through `pre_hook` or the registry, where the arity belongs to the polyfill or the template. A name absent from the table is unconstrained — the safe default, since an entry there *rejects* code.

---

## Red before green

**Parity matrix** — removed CUDA's `log10` arm:

```
FAIL log10/1: backend behaviour changed.
  expected: emit emit emit unknown emit
  observed: unknown emit emit unknown emit
Columns: CUDA/OpenCL/Metal/WGSL/GLSL.
```

**Coverage script** — same mutation, which renamed the arm rather than deleting it:

```
::error::intrinsic arm(s) not covered by the arm-parity matrix:
    cuda     __removed_log10
```

**Arity guards** — observed failing against the *unfixed* code (that is how `emit_call` was found), then passing after the fix.

## Verified

- `dune build @install` — exit 0
- `dune build @fmt` — exit 0
- `dune runtest` — exit 0, **0 failures**, including every golden-codegen test: the central arity check refuses no kernel anyone writes
- `scripts/check-arm-parity-coverage.sh` — *5 backends scanned, every arm name covered by 40 matrix rows*
- `scripts/check-test-alias-coverage.sh` — *all 82 e2e test executables are wired to an alias*
- `scripts/check-alcotest-registration.js` — clean

One caution worth recording: a green run of the standalone `.exe` was read once before `dune build` had regenerated it, and reported a failure that no longer existed. The results above are from binaries rebuilt after the final edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
