### PR TITLE
measure(intel): ANV + Intel OpenCL — backlog #123, and a defect in our own locus gate

### DIFF
--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -4,7 +4,8 @@ _Cross-backend policy for what a Sarek DSL author may rely on when a device
 compiler is free to fuse, reassociate or flush floating-point operations._
 
 **Status:** normative for this repository. **Issue:** #116 (absorbs #110, #111);
-§6 answers #126 and the HIP row answers #106. **Date:** 2026-07-26.
+§6 answers #126, the HIP row answers #106, and §11 answers backlog #123.
+**Date:** 2026-07-27.
 
 Three separate defects in this project came from the same place — the gap
 between the floating-point semantics we assumed a backend had and the ones it
@@ -30,10 +31,13 @@ actually had:
   into *both* of its consumers, collapsing `df64` mul/div from ~9e-15 to
   5.92e-08 — plain float32. It survived four years.
 - **Vulkan/GLSL.** Vulkan `mul`/`div` degrade to ~5.8e-08 on Mesa RADV
-  (measured here, RX 7900 XTX, Mesa 26.1.4-arch3.1) and on Mesa ANV (quoted,
-  Intel UHD Graphics 630). Attributed to a `fma` that is not correctly rounded,
+  (measured here, RX 7900 XTX, Mesa 26.1.4-arch3.1) and on Mesa ANV (measured,
+  Intel Arc Graphics / Meteor Lake-P, Mesa 26.1.2-arch3.1 — §11.1; and quoted
+  on Intel UHD Graphics 630, a different generation that the Arc measurement
+  does *not* speak for). Attributed to a `fma` that is not correctly rounded,
   *not* to contraction — but the two failure modes look identical from the
-  outside, and telling them apart took a separate measurement.
+  outside, and telling them apart took a separate measurement, now made on both
+  drivers.
 - **Vulkan/RADV, f16.** RADV's ACO backend absorbs an f32→f16 narrowing into
   whatever arithmetic feeds it, and `precise`/`NoContraction` does not stop it —
   the decoration is emitted, and the emitted ISA is byte-identical with and
@@ -107,8 +111,8 @@ Legend for the evidence column:
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C, and no build option turns it off | for contraction, **no flag** — same `mul_rn`-by-construction defence as CUDA. For div/sqrt, `Opencl_fp.conformance_options` requests `-cl-fp32-correctly-rounded-divide-sqrt`, **gated** on `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT` in the device's `CL_DEVICE_SINGLE_FP_CONFIG`; `Opencl_fp.check_fp_conformance` **rejects** the relaxing `-cl-*` options at `Opencl_api.Program.build`, the single point an option string reaches `clBuildProgram` (§9) | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
 | **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, same ACO backend | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c` |
 | **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as HIP and rusticl, reached through a third front end, but a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
-| **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on ACO and does not fuse here, so the locus is *the ACO backend*, not *OpenCL*. That in turn is the second independent reason to read rusticl and HIP/AMDGPU as one bug seen through two front ends rather than two bugs. Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any non-ACO implementation is found to fuse |
-| **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV not measured — no Intel GPU on this machine.** Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound |
+| **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on ACO and does not fuse here, so the locus is *the ACO backend*, not *OpenCL*. That in turn is the second independent reason to read rusticl and HIP/AMDGPU as one bug seen through two front ends rather than two bugs. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any non-ACO implementation is found to fuse — and which was itself wrong until §11.5 |
+| **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV now measured too** (§11.2): Intel Arc Graphics (Meteor Lake-P), Mesa 26.1.2-arch3.1, same 0 of 7 / 0 of 7 with `fma()` controls 4/4 — and unlike RADV, ANV does not fuse the f16 narrowing either, so no combine has been found on ANV where `NoContraction` is ignored. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound; ANV shows the same signature (mul 5.84e-08 / div 5.86e-08, §11.1) |
 | **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. f16 and subnormals unprobed; two record/variant kernels do not compile at all (§10.11) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
@@ -520,9 +524,17 @@ shapes were chosen to probe *contraction* as the term is normally used —
 `a*b+c`. A conversion is also an operation that can absorb its operand, and it
 is not in that family. A null result is only as broad as its shape catalogue.
 
-**Not run: Mesa ANV.** There is no Intel GPU on this machine. The ANV half of
-the original disagreement is a **hardware gap**, not a null result — recorded in
-§7's still-open list.
+**Now run: Mesa ANV — see §11.2.** When this section was written there was no
+Intel GPU on this machine, and the ANV half of the original disagreement was a
+**hardware gap** rather than a null result. An Intel Meteor Lake Arc machine
+became available on 2026-07-27. ANV reproduces RADV's 0 of 7 / 0 of 7 on the
+twelve shapes, and — unlike RADV — does not perform the f16
+multiply-into-narrowing combine either (0/63488 against the discipline, with the
+fused model separating at the calibrating 2912 on the same run). So the campaign
+note claiming ANV *ignores* `NoContraction` is **not supported**; neither is any
+claim that ANV honours it, because ANV never contracted when it was free to.
+That measurement is Xe-LPG and says nothing about the Gen9.5 UHD 630 the
+original ANV figures came from (§11.0).
 
 ### This does not explain the df64 deviation, and never could
 
@@ -595,16 +607,15 @@ architectures ranges, same answer.
 **Still open** (the first is not an NVIDIA gap, but it is a hardware gap and
 this is where they are collected):
 
-- **No Intel GPU: the ANV half of §6 is unrun.** The `precise` /
-  `NoContraction` question was originally disputed for **both** Mesa RADV and
-  Mesa ANV. §6 settles RADV by measurement. ANV is **not** measured and cannot
-  be measured here — the experiment requires executing on the driver in
-  question. Nothing in §6 licenses any statement about ANV in either direction,
-  and the campaign note claiming ANV ignores `NoContraction` remains unverified.
-  One run closes it on any Intel box:
-  `dune build @e2e-gpu` enumerates every Vulkan device present and needs no
-  configuration. AMDVLK and the proprietary AMD Vulkan driver are unmeasured for
-  the same reason — different SPIR-V consumers on the very same GPU.
+- **CLOSED — the ANV half of §6 is run.** An Intel Meteor Lake-P machine became
+  available on 2026-07-27 and the whole bullet is discharged in **§11**: the
+  `NoContraction` question (§11.2), the df64 ANV allowlist entry that had never
+  been executed (§11.1), and — as a bonus the bullet did not ask for — the
+  independent OpenCL implementation that confirms the f16 fusion is ACO's
+  (§11.3). The campaign note claiming ANV ignores `NoContraction` is **not
+  supported**. Scope: **Xe-LPG only**, which is not the Gen9.5 UHD 630 the
+  quoted ANV numbers came from (§11.0). **AMDVLK and the proprietary AMD Vulkan
+  driver remain unmeasured** — different SPIR-V consumers on the very same GPU.
 - **f16 on the PTX backend.** `Sarek_ir_ptx` refuses kernel-level f16 (`#57`
   slice 2). Everything above is the **CUDA/C** path.
 - **One GPU, one architecture.** sm_61 has no tensor cores, no bf16 and no FP8,
@@ -645,14 +656,21 @@ this is where they are collected):
   (rusticl/radeonsi reports `sqrt` 9.68e-15, a PASS) and rusticl ignores FP
   build options outright. The **Vulkan** residual (1.68e-14 on NVIDIA,
   while Intel UHD 630 passes at 1.17e-14) has no established cause — that one is
-  still "do not promote a hypothesis to a cause".
+  still "do not promote a hypothesis to a cause". The red does not reproduce on
+  Intel Arc/ANV either: `test_real64` reports `sqrt` 1.17e-14 there, a PASS, and
+  `test_df64` 9.57e-15 (§11.1). Intel's OpenCL, unlike rusticl, passes both at
+  the interpreter's own figures (8.87e-15 / 8.53e-15).
 - **f16 on Vulkan/GLSL: what slice 2b did NOT close.** The refusal is measured
   and gated, but three things remain unmeasured and must not be read into it.
-  (a) **Only RADV.** No non-RADV Vulkan implementation has been measured for
-  this combine — not ANV, not AMDVLK, not NVIDIA, not lavapipe — so "Vulkan
-  fuses" is not a claim this repository makes; "RADV fuses" is. The tripwire
-  deliberately carries no "non-RADV does not fuse" cross-check for that reason,
-  unlike its OpenCL sibling, which has pocl data behind it.
+  (a) **Effectively only RADV.** "Vulkan fuses" is not a claim this repository
+  makes; "RADV fuses" is. One non-RADV implementation has since been measured —
+  **Mesa ANV on Meteor Lake Arc does not fuse** (§11.2, 0/63488 against the
+  discipline with the fused model calibrating at 2912) — which strengthens the
+  scoping rather than weakening it. AMDVLK, NVIDIA and lavapipe remain
+  unmeasured. The tripwire still carries no "non-RADV does not fuse"
+  cross-check, unlike its OpenCL sibling: one data point is thin ground for a
+  gate, and §11.5 is a demonstration of what a cross-check built on a
+  not-quite-valid oracle does when it meets new hardware.
   (b) **The `shaderFloat16` device feature is not enabled.** Vulkan requires it
   before a shader may use the SPIR-V `Float16` capability;
   `Vulkan_api_device` chains no feature structs beyond core
@@ -1155,3 +1173,335 @@ WGSL was the odd one out here too, exactly as it was for payload spelling.
 Adding `smatch_multi_payload` to the sweep turned it red on the first run;
 emitting a synthetic empty `default` when no `PWild` arm is present turned it
 green.
+
+---
+
+## 11. Measured on Intel: Meteor Lake Arc, ANV and the Intel Compute Runtime (backlog #123)
+
+An Intel machine became available on 2026-07-27. It is the first Intel GPU this
+project has ever executed on, and it closes three things at once: the df64 ANV
+allowlist entry that was carried on a quotation, the `NoContraction` half of §6
+that §7 lists as a hardware gap, and the "is the f16 narrowing fusion ACO's or
+OpenCL's" question.
+
+**The machine and the toolchains.** Intel Core Ultra 9 185H (Meteor Lake-P),
+Intel Arc Graphics integrated GPU. Three distinct compilers, and every claim
+below names which one it is about:
+
+| stack | device string | compiler |
+|---|---|---|
+| **Vulkan** | `Intel(R) Arc(tm) Graphics (MTL)` | Mesa **ANV** 26.1.2-arch3.1, Vulkan 1.4.348, `driverID = VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA` |
+| **OpenCL (GPU)** | `Intel(R) Arc(TM) Graphics` | Intel Compute Runtime (NEO) / **IGC** — `/usr/lib/intel-opencl/libigdrcl.so`, wholly independent of Mesa |
+| **OpenCL (CPU)** | `Intel(R) Core(TM) Ultra 9 185H` | Intel oneAPI CPU runtime — `/opt/intel/oneapi/compiler/latest/lib/libintelocl.so` |
+
+The two OpenCL platforms are separate ICDs; the probe below picks between them
+with `OCL_ICD_FILENAMES`, since it scans the first platform that has devices.
+
+### 11.0 What a Meteor Lake measurement does and does not establish
+
+**It is not a check on the UHD 630 figures.** The ANV numbers this document and
+`Sarek_df64.ml` previously quoted — mul/div ~5.8e-08 — are from **Intel UHD
+Graphics 630 (CFL GT2)**, a Gen9.5 part. This machine is **Xe-LPG**: a different
+architecture, a different generation, a different ISA, and a decade of driver
+work in between. The quoted figure and the measured one **agree**, and that is
+worth knowing, but the agreement is a second data point about ANV, not a
+confirmation of the first. Had they disagreed, the finding would have been that
+the deviation is generation-dependent, and neither number would have been
+"corrected" by the other. Nothing below should be read as evidence about UHD
+630, and the `is_anv_device` predicate — which matches both — remains a claim
+about the *pair*, held open by whichever measurement is weakest.
+
+### 11.1 df64 on ANV: the allowlist entry is real, and stays
+
+`Test_helpers.df64_known_deviation`'s `Vulkan`/`mul|div`/`is_anv_device` arm had
+never been executed. It is a **strict xfail**, so the two outcomes were "it
+still deviates" or "the run goes red with STALE ALLOWLIST ENTRY and the arm gets
+deleted". It deviates.
+
+Measured on `Intel(R) Arc(tm) Graphics (MTL)`, Mesa ANV 26.1.2-arch3.1, Vulkan
+1.4.348, 2026-07-27. Every figure is the **measured worst-case relative error
+over that test's own input set** on that device and driver — a maximum observed,
+not a bound proved:
+
+| op | `test_df64` | `test_real64` (fallback-df64) | contract |
+|---|---|---|---|
+| mul | **5.84e-08** | **5.93e-08** | 1.42e-14 |
+| div | **5.86e-08** | **5.83e-08** | 1.42e-14 |
+| add | 5.33e-15 | 5.31e-15 | 7.11e-15 |
+| sub | 6.51e-15 | 6.94e-15 | 7.11e-15 |
+| sqrt | 9.57e-15 | 1.17e-14 | 1.42e-14 |
+| of_i32 | 0 | — | 0 |
+
+Both suites exit 0. `test_real64`'s **native** f64 path is clean on ANV (0 on
+add/sub/mul/sqrt, 2.22e-16 on div), so this is specifically the df64 emulation,
+not the device's binary64.
+
+That is RADV's pattern exactly — mul and div collapse to float32 precision while
+add, sub and sqrt meet the strict bound — and the RADV arm attributes it to a
+GLSL `fma` that is not correctly rounded, which destroys TwoProd's error term
+while leaving the paths that do not use `fma` intact.
+
+**Contraction is now ruled out on ANV as well, rather than assumed.** §11.2
+reports 0 of 7 contraction shapes contracted on this device with *and* without
+`precise`, so the compiler is not fusing the multiply that closes
+`quick_two_sum`. What remains is the `fma` explanation. Stated at its true
+strength: this is an **inference from elimination plus an identical error
+signature**, not a direct sweep of `fma` correct-rounding on ANV. The three
+`fma` anchor triples that `test_vulkan_no_contraction` does check agree with
+IEEE on this device — which is a 3-point sample, so it neither establishes
+correct rounding nor contradicts the attribution.
+
+**The predicate stays keyed on the vendor string, and here is the search that
+justifies it.** `is_anv_device` matches `"intel"` in the device name rather than
+a driver token, which would also match a future non-Mesa Intel Vulkan driver. A
+real driver token *does* exist on this driver:
+`VkPhysicalDeviceDriverProperties` reports `driverName = "Intel open-source Mesa
+driver"` and `driverID = VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA`, and that struct
+is Vulkan 1.2 core, so it is reachable on every device this backend supports.
+**Sarek does not plumb it**: `sarek-vulkan/Vulkan_api_device.ml` fills
+`Device.name` from `VkPhysicalDeviceProperties::deviceName` and queries nothing
+else, and ANV puts no driver token there (`Intel(R) Arc(tm) Graphics (MTL)` —
+just as UHD 630 gave `Intel(R) UHD Graphics 630 (CFL GT2)`). Narrowing the key
+is therefore a **Vulkan-backend change**, not a test change, and it is
+deliberately not bundled into a measurement commit. Until then the vendor string
+is the strongest key available at that call site, and the failure direction is
+safe: a non-Mesa Intel Vulkan driver that *meets* the contract trips the
+strict-XPASS branch and names the arm to delete, rather than passing silently.
+
+### 11.2 `NoContraction` on ANV: the §6 gap, closed
+
+§7's first "still open" bullet — *"No Intel GPU: the ANV half of §6 is unrun"* —
+is now **CLOSED**. `sarek/tests/e2e/test_vulkan_no_contraction.ml`, the same
+twelve-shape experiment §6 describes, run unchanged on ANV:
+
+| | no `precise` | `precise` |
+|---|---|---|
+| contraction shapes contracted | **0 of 7** | **0 of 7** |
+| reassociation shapes reassociated | 0 of 2 | 0 of 2 |
+| explicit `fma()` controls fused | 4 of 4 | 4 of 4 |
+
+Identical to RADV, including the four explicit-`fma()` integrity controls
+firing, which is what shows the harness was handed a genuinely fused value to
+compare against. As required by §6's own caveat, the contracted target is the
+device's own `fma` result and not an IEEE model.
+
+So the same reading as RADV, and for the same reason: **INCONCLUSIVE for
+contraction** on this family of shapes. ANV does not contract them even when
+nothing forbids it, so `precise` has nothing to suppress and the experiment
+cannot say whether it would be honoured if it did.
+
+**The follow-up that settled it negatively on RADV settles it positively here.**
+§6 closes the RADV case with the shape RADV *does* want to contract —
+`float16_t(x * 1.1)`, a multiply absorbed by the conversion consuming it — where
+RADV emits `v_fma_mixlo_f16`, produces byte-identical ISA with and without the
+decoration, and disagrees with the interpreter on 2912/63488. Run on ANV via
+`sarek-vulkan/test/test_vulkan_f16_tripwire.ml`, with its scope predicate
+temporarily widened to reach a non-RADV device:
+
+| | no `precise` | `precise` |
+|---|---|---|
+| disagreements with Sarek's f16 discipline, all 63488 finite binary16 inputs | **0** | **0** |
+| disagreements with the single-rounding (fused) model | **2912** | **2912** |
+
+The 2912 is the calibration and it matters: the harness's fused model separates
+from the discipline on exactly the number RADV produces, on this device, on this
+run — so the 0 is a live null and not a broken sweep.
+
+**ANV does not perform the combine.** Therefore:
+
+- The campaign note claiming **ANV ignores `NoContraction`** is **not
+  supported**, on either shape family. It never produced a contracted result.
+- Nothing here shows ANV *honours* it either. On both families ANV declined to
+  contract when it was free to, so the decoration was never load-bearing. The
+  honest status of `precise` on ANV is the same as its status on RADV's f32
+  shapes: **inert**, because nothing needs preventing — with the difference that
+  on RADV there is a known combine where the decoration is demonstrably
+  *ignored*, and on ANV no such combine has been found.
+
+This does **not** license enabling f16 on Vulkan. `Sarek_ir_glsl`'s refusal is a
+backend-wide code path, and it is still warranted by RADV; the refusal would
+have to become per-driver to exploit this, and the `shaderFloat16` plumbing §7
+notes as missing is still missing.
+
+### 11.3 The f16 narrowing on Intel OpenCL: **it does not fuse** — ACO's localisation confirmed
+
+This is the question §2's pocl row calls *"what localises the defect"*. The
+reading before this run: rusticl and HIP are two front ends onto one ACO
+backend (620/63488 identical disagreements), RADV is a third and fuses worse,
+and pocl on x86 does not fuse — so the locus is ACO. pocl is a single negative,
+and pocl is also an LLVM-based CPU stack, which is not very far from ACO's
+family. Intel's IGC is a wholly independent implementation on a real GPU.
+
+`tools/probes/opencl_f16_contraction_probe.c`, unmodified apart from the new
+control described below, exhaustive over all 63488 finite binary16 inputs, on
+the same `f16(f16(x*1.1) + 1000)` shape:
+
+| variant | Arc Graphics (IGC) | Core Ultra 9 185H (oneAPI CPU) |
+|---|---|---|
+| **`fusedctl` — positive control** | **620 / 63488** | **620 / 63488** |
+| `plain` (naive codegen) | **0 / 63488** | **0 / 63488** |
+| `fpcontract` (`#pragma OPENCL FP_CONTRACT OFF`) | 0 | 0 |
+| `convert` (`convert_half_rte`) | 0 | 0 |
+| `bitcast` / `bitcast2` | 0 / 0 | 0 / 0 |
+| `volatile` (volatile `__local` scalar) | **4774** | 0 |
+| `vpriv` (volatile `__private` pointer) | **4774** | 0 |
+| `vglobal` (volatile `__global` round-trip) | **4774** | 0 |
+| `vlocal` (volatile LDS round-trip) | **4774** | 0 |
+
+**The calibration is exact, and it is why the 0 is a result.** A null from an
+exhaustive sweep is worth nothing without showing the same sweep can go nonzero
+on the same device and run. `fusedctl` is a new variant added for this: a kernel
+that performs the fusion *deliberately*, by computing `(half)((double)x *
+(double)1.1f)` — both operands are exactly representable in binary64, so that is
+the exact f32 product narrowed in **one** rounding, which is precisely what
+`v_fma_mixlo_f16` does. It is checked against the untouched host reference. On
+both Intel devices it reports **620/63488, first divergence at x=5.68359375
+(device 1006.5, reference 1006)** — the same count *and the same first
+divergence point* as ACO. So the harness, on this device and toolchain,
+reproduces the known positive to the input, and `plain = 0` is a genuine null.
+
+**Result: neither Intel compiler fuses the f32 multiply into the f32→f16
+narrowing.** The naive codegen is already correct on both. This is the **second
+independent negative** for a non-ACO OpenCL implementation, and the first on a
+GPU with a vendor compiler sharing no lineage with Mesa. The reading in §2 is
+confirmed rather than widened: **the defect is ACO's, not OpenCL's and not
+SPIR-V's.** Had Intel fused, the consequence would have been the opposite one —
+a widespread vendor behaviour Sarek must defend against everywhere.
+
+### 11.4 Unexpected: on IGC, the barrier that fixes ACO **breaks** a correct narrowing
+
+The 4774 column above is a first-contact finding nobody was looking for.
+
+On the Arc GPU, all four `volatile`-based barriers — the ones measured in slice
+2a to be the *only* things that defeat the fusion on rusticl — take a narrowing
+that is **correct** on IGC and make it **wrong on 4774 of 63488 inputs**. First
+divergence at `x = 0.681640625`: the device returns 1000.5 where the discipline
+mandates 1001, which is the signature of the **intermediate binary16 narrowing
+being dropped entirely** (with the mid rounding, `0.75 + 1000 = 1000.75` ties to
+even → 1001; without it, `1000.7498… → 1000.5`). It is the same failure mode,
+and the same 4774, that §2 records for RADV when a `volatile` SSBO round-trip is
+applied to the f32 intermediates — reached on a completely unrelated compiler,
+which is what makes the interpretation credible.
+
+The Intel **CPU** runtime does not do this, so it is IGC-specific, not an Intel
+stack property.
+
+**Where it happens.** The SPIR-V is faithful for both kernels. Compiled with
+`ocloc -device mtl` and disassembled with `spirv-dis`, the plain kernel carries
+`OpFMul` → `OpFConvert %half` → `OpFConvert %float` → `OpFAdd` → `OpFConvert
+%half`, and the barriered kernel carries the identical chain with the two
+`OpStore`/`OpLoad` pairs marked `Volatile|Aligned`. Every mandated rounding is
+present in both. So the divergence is introduced **below SPIR-V, inside IGC**,
+folding the `f32(f16(x))` pair across the volatile boundary — a fold that is
+only valid when the value is exactly representable in binary16. Evidence tier:
+**compiler-output** for that localisation, not machine-code — Gen ISA
+disassembly needs `iga64`, which is not on this machine, and `ocloc disasm`
+without it emits only the ELF section list.
+
+**Policy consequence, and it is not a small one:** a contraction barrier
+measured on one backend is not portable, and applying one unconditionally can
+*introduce* the defect it was written to prevent. Any future decision to emit a
+narrowing barrier in `Sarek_ir_opencl` must be per-implementation and gated on
+an exhaustive agreement sweep for that implementation, never applied backend-wide
+on the strength of an ACO measurement.
+
+### 11.5 The defect this surfaced in our own gate
+
+`dune runtest` across `sarek`, `sarek-opencl`, `sarek-vulkan` and `spoc` on this
+machine produced **exactly one failure**, and it was ours.
+
+`test_opencl_f16_tripwire`'s locus cross-check —
+`non_aco_implementations_do_not_fuse`, the guard §2's pocl row leans on — went
+red on Intel Arc and reported:
+
+> THE LOCUS-IS-ACO CLAIM IS NOW TOO NARROW. `Intel(R) Arc(TM) Graphics` is NOT
+> an ACO device, yet 4774 of 63488 finite binary16 inputs differ between the
+> naive and barriered narrowings — **it fuses too.**
+
+Both sentences are false, and §11.3 shows the plain kernel is correct on all
+63488 inputs. The check compared the plain kernel against the **barriered**
+kernel with no oracle. Two kernels computing the same expression that disagree
+prove one of them is wrong; they do not say which. On ACO the barriered one is
+right, which is where the reading came from — the file described the barriered
+kernel as *"simultaneously the control and the oracle"*. On IGC the barriered
+one is the wrong one, so the check saw the 4774, blamed the plain kernel, and
+instructed the reader, in its own failure text, to weaken a documented claim
+that is correct.
+
+Its self-check did not catch this, and the reason is instructive: the barriered
+kernel's correctness was pinned at **one hand-computed input**, `x = 1.0`. Intel
+passes that point — at `x = 1.0` the dropped rounding does not change the final
+result — while being wrong on 4774 others. A pin a broken oracle passes is not a
+check.
+
+Fixed here, and the fix is a real oracle rather than a narrower predicate:
+
+- `test_opencl_f16_tripwire` gains the **host binary16 reference** ported from
+  its Vulkan sibling (`ref_discipline` / `ref_fused`), which needed one from the
+  start because on RADV no affordable barrier works at all.
+- Two **calibration** cases now run on every invocation, host-only so they also
+  run on GPU-less CI: the host rounding round-trips every finite binary16 input,
+  and the two host models separate on exactly **620** — the figure independently
+  measured on hiprtc/gfx1100, on rusticl/radeonsi, and now by `fusedctl` on
+  Intel Arc. A null from the locus check is only readable because that positive
+  reproduces alongside it.
+- The **oracle-validity** check is now an exhaustive sweep of the barriered
+  kernel against the discipline, replacing the one-point pin. On both ACO
+  devices it is 0/63488, so the barrier really does work there — previously
+  assumed, now measured.
+- The **locus check** compares the plain kernel against the discipline, not
+  against the barrier. It reports the barrier's own deviation alongside, without
+  asserting on it: on Intel that number is 4774 as shipped, and asserting it
+  would pin a permanent red with no action available. The place the barrier's
+  validity is load-bearing is the in-scope path, and that *is* asserted.
+
+Verified on both sides after the change: green on RX 7900 XTX + Raphael iGPU
+(rusticl/radeonsi, ACO), where the in-scope tripwire still reports 620/63488 and
+the barriered sweep is 0/63488; green on both Intel devices, where the locus
+check reports `plain vs discipline 0/63488` and prints the 4774.
+
+> **A construction argument is not a measurement — recorded because it looks
+> obviously right.** The first attempt at a universal oracle split the
+> expression across two kernel launches with the binary16 intermediate in a
+> `__global` buffer, on the reasoning that no compiler can fuse across a
+> dispatch. That reasoning is sound and the conclusion is wrong: the fusion is
+> multiply-into-narrowing and **both** live in the first kernel, so the dispatch
+> boundary separates the wrong pair. Measured on RX 7900 XTX, the two-pass
+> construction reproduces ACO's fused answer exactly — 620/63488 from the
+> discipline. It was caught only because it was swept against a device whose
+> answer was already known.
+
+### 11.6 Everything else the first Intel contact produced
+
+Nothing else. Beyond the locus check, the full `dune runtest` across `sarek`,
+`sarek-opencl`, `sarek-vulkan` and `spoc` is green on this machine, including
+`test_df64`, `test_real64`, `test_vulkan_no_contraction`,
+`test_opencl_fp_conformance` and both f16 tripwires. `test_real64` reports
+`fp64=true` on all three Intel devices and the native binary64 path is exact on
+every op.
+
+Two environmental notes, neither a defect in this repository:
+
+- `dune build @all` fails in that opam switch for want of `js_of_ocaml`,
+  `js_of_ocaml-ppx` and `qcheck-core`, which gate `sarek/core_js/webgpu`,
+  `sarek/transpile/web` and `formal/codegen-ptx/test`. Nothing was installed;
+  the measurements were built as explicit targets.
+- `tools/probes/opencl_f16_contraction_probe.c` scans only the first OpenCL
+  platform that reports devices, so on a multi-platform host it cannot reach the
+  second without help. `OCL_ICD_FILENAMES` selects the ICD; the usage comment
+  now says so.
+
+### 11.7 What is still open after this
+
+- **No Gen ISA.** §11.4's localisation of the IGC fold is compiler-output tier.
+  `iga64` would settle it at machine-code tier.
+- **`fma` correct-rounding on ANV is not directly measured.** §11.1's
+  attribution is elimination plus signature. A dedicated sweep of GLSL `fma`
+  against a correctly-rounded reference would settle it for both ANV and RADV,
+  and neither has one.
+- **Still one Intel generation.** Xe-LPG only. Nothing here constrains Gen9.5
+  (the quoted UHD 630), Xe-HPG discrete Arc, or Xe2.
+- **The `is_anv_device` predicate is still vendor-keyed**, pending the
+  `VkPhysicalDeviceDriverProperties` plumbing described in §11.1.
+- **AMDVLK and the proprietary AMD Vulkan driver remain unmeasured**, as §7
+  notes — different SPIR-V consumers on the same GPU.

--- a/sarek-opencl/test/test_opencl_f16_tripwire.ml
+++ b/sarek-opencl/test/test_opencl_f16_tripwire.ml
@@ -39,7 +39,7 @@
  *       device. One variant, no host float16 arithmetic, fails loudly when the
  *       premise expires.
  *
- * HOW IT AVOIDS NEEDING A HOST BINARY16 REFERENCE.
+ * HOW IT TRIED TO AVOID A HOST BINARY16 REFERENCE, AND WHY IT NO LONGER DOES.
  *
  * Both kernels below compute the same value. They differ only in whether the
  * f32 intermediate is forced through a `volatile __local` round-trip — measured
@@ -53,12 +53,41 @@
  * and no OCaml round-to-binary16 is needed anywhere. Decoding binary16 bits to
  * a float IS needed, but decoding is exact and rounding-free (see [f16_decode]).
  *
- * Self-check: comparing two kernels to each other would report "fusion gone" if
- * BOTH were broken into agreement (say, a build that silently produced two
- * copies of the same source). [sanity_barriered_computes_the_right_thing]
- * closes that by pinning the barriered kernel's output for a known input
- * against a value computed by hand, so agreement can only be reported when the
- * kernels are really computing the intended expression.
+ * THAT INFERENCE IS SOUND ONLY WHERE THE BARRIER IS KNOWN TO WORK, and the
+ * barrier is known to work on exactly one compiler. `plain <> barriered` really
+ * says "one of these two kernels is wrong"; reading it as "plain fused" is a
+ * step that borrows its warrant from the ACO measurement. The first non-ACO GPU
+ * this project ever ran on showed the borrowing was not free: on Intel Arc
+ * Graphics (Meteor Lake-P) the barriered kernel is the wrong one (backlog #123,
+ * docs/fp-contraction-policy.md §11).
+ *
+ * So this file now also carries a HOST reference — [ref_discipline], ported
+ * from the Vulkan tripwire, which needed one from the start because on RADV no
+ * affordable barrier works at all. A host reference is an oracle on every
+ * implementation rather than on one, and it is the same discipline the
+ * interpreter implements. It is used:
+ *
+ *   - in [sanity_barriered_computes_the_right_thing], to check over the whole
+ *     domain that the barrier really is defeating the fusion on the in-scope
+ *     device, instead of trusting a single hand-computed point (Intel passes
+ *     that point while being wrong on 4774 inputs);
+ *   - in [non_aco_implementations_do_not_fuse], as the thing the plain kernel
+ *     is compared against, so the locus cross-check cannot blame the plain
+ *     kernel for the barrier's own defects.
+ *
+ * A REJECTED ALTERNATIVE, recorded because it looks obviously right and is not.
+ * Splitting the expression across two kernel launches, with the binary16
+ * intermediate materialised in a __global buffer, seems to give an oracle by
+ * construction: no compiler can fuse across a dispatch. It does not. The
+ * fusion is multiply-into-narrowing, and BOTH of those live in the first
+ * kernel, so the dispatch boundary separates the wrong pair. Measured: the
+ * two-pass construction reproduces ACO's fused answer exactly, 620/63488 away
+ * from the discipline on RX 7900 XTX. A construction argument is not a
+ * measurement, and this one was wrong.
+ *
+ * The in-scope tripwire itself still compares plain against barriered, which is
+ * correct there and keeps the assertion pointed at the ACO behaviour it was
+ * written for — now with the barrier's validity checked rather than assumed.
  ******************************************************************************)
 
 open Sarek_opencl
@@ -131,6 +160,85 @@ let finite_bits =
   done ;
   Array.of_list !acc
 
+(* ---------------------------------------------------------------------- *)
+(* HOST REFERENCE                                                           *)
+(*                                                                          *)
+(* Ported verbatim from sarek-vulkan/test/test_vulkan_f16_tripwire.ml, which *)
+(* needed a host oracle from the start because on RADV NO affordable barrier *)
+(* works, so it had no barriered kernel to lean on. The duplication follows  *)
+(* the existing precedent in these two files (both already carry their own   *)
+(* [f16_decode] and [finite_bits]); they live in different libraries and a   *)
+(* shared test lib for sixty lines is not worth the build-graph edge.        *)
+(*                                                                          *)
+(* Why it is here now (backlog #123). [non_aco_implementations_do_not_fuse]  *)
+(* used the barriered kernel as its oracle on devices where the barrier had  *)
+(* never been checked. That is only sound on ACO. A host reference is sound  *)
+(* everywhere, and it is the same oracle the interpreter implements.        *)
+(* ---------------------------------------------------------------------- *)
+
+(* Round a binary64 to binary32. Every intermediate below is exactly
+   representable in binary64 before this is applied (a binary16 operand times a
+   binary32 constant needs at most 35 significand bits), so this is a single
+   correct rounding and not a double rounding. *)
+let f32 x = Int32.float_of_bits (Int32.bits_of_float x)
+
+let dec b =
+  match f16_decode b with
+  | Some v -> v
+  | None ->
+      if b land 0x3ff <> 0 then Float.nan
+      else if b land 0x8000 <> 0 then Float.neg_infinity
+      else Float.infinity
+
+let round_even v =
+  let f = Float.floor v in
+  let r = v -. f in
+  if r > 0.5 then f +. 1.0
+  else if r < 0.5 then f
+  else if Float.rem f 2.0 = 0.0 then f
+  else f +. 1.0
+
+(* Round-to-nearest-even of an exactly-represented real to a binary16 bit
+   pattern. [round_even] is exact because [a /. ldexp 1.0 k] is a power-of-two
+   rescale, and the rescaled value is below 2048. *)
+let f16_bits d =
+  if Float.is_nan d then 0x7E00
+  else
+    let s = if d < 0.0 || (d = 0.0 && 1.0 /. d < 0.0) then 0x8000 else 0 in
+    let a = Float.abs d in
+    if a = Float.infinity then s lor 0x7C00
+    else if a = 0.0 then s
+    else
+      (* [frexp] is exact by construction: it returns [(m, k)] with
+         [0.5 <= |m| < 1] and [a = m * 2^k], so the unbiased exponent is
+         [k - 1]. *)
+      let e = snd (Float.frexp a) - 1 in
+      if e < -14 then
+        (* subnormal; a carry out of the 10-bit field lands exactly on the
+           smallest normal, which the bit layout already spells correctly *)
+        s lor int_of_float (round_even (a /. ldexp 1.0 (-24)))
+      else
+        let q = round_even (a /. ldexp 1.0 (e - 10)) in
+        let e, q = if q >= 2048.0 then (e + 1, 1024.0) else (e, q) in
+        if e + 15 >= 31 then s lor 0x7C00
+        else s lor ((e + 15) lsl 10) lor (int_of_float q - 1024)
+
+let c11 = f32 1.1
+
+(* The kernel shape above, f16(f16(x*1.1) + 1000), under Sarek's discipline:
+   the multiply rounds to binary32, then to binary16, then the add rounds to
+   binary32 and the result to binary16. Four roundings, all mandated. *)
+let ref_discipline b =
+  let m = f16_bits (f32 (dec b *. c11)) in
+  f16_bits (f32 (dec m +. 1000.0))
+
+(* The same shape with the multiply absorbed into the narrowing that consumes
+   it: the first binary32 rounding is skipped. This is what ACO produces, and
+   it is the model whose separation from [ref_discipline] is the known 620. *)
+let ref_fused b =
+  let m = f16_bits (dec b *. c11) in
+  f16_bits (f32 (dec m +. 1000.0))
+
 let run_kernel device ~source ~inputs =
   let n = Array.length inputs in
   let host_in = Bigarray.(Array1.create int16_unsigned c_layout n) in
@@ -154,6 +262,17 @@ let run_kernel device ~source ~inputs =
   Backend.Memory.free din ;
   Backend.Memory.free dout ;
   Array.init n (fun i -> host_out.{i})
+
+let count_diffs a b =
+  let d = ref 0 and first = ref None in
+  Array.iteri
+    (fun i x ->
+      if x <> b.(i) then begin
+        incr d ;
+        if !first = None then first := Some i
+      end)
+    a ;
+  (!d, !first)
 
 (* ---------------------------------------------------------------------- *)
 (* SCOPE                                                                    *)
@@ -270,7 +389,7 @@ let sanity_barriered_computes_the_right_thing () =
       in
       let inputs = Array.make n_local one in
       let got = run_kernel device ~source:src_barriered ~inputs in
-      match f16_decode got.(0) with
+      (match f16_decode got.(0) with
       | None ->
           Alcotest.failf
             "barriered kernel returned a non-finite binary16 (bits 0x%04X) for \
@@ -281,7 +400,79 @@ let sanity_barriered_computes_the_right_thing () =
           Alcotest.(check (float 0.001))
             "barriered midround(1.0) = 1001.0 (oracle sanity)"
             1001.0
-            v)
+            v) ;
+      (* The one-point pin above is not enough on its own, and Intel hardware
+         proved it: on Intel Arc the barriered kernel drops the intermediate
+         narrowing on 4774 inputs, yet still returns 1001.0 for x=1.0, because
+         at that operand the dropped rounding does not change the final result.
+         A pin that a broken oracle passes is not a check. So sweep the whole
+         domain against the host reference. *)
+      let inputs = finite_bits in
+      let barriered = run_kernel device ~source:src_barriered ~inputs in
+      let want = Array.map ref_discipline inputs in
+      let diffs, first = count_diffs barriered want in
+      if diffs <> 0 then begin
+        let d v = match f16_decode v with Some x -> x | None -> nan in
+        let i = match first with Some i -> i | None -> 0 in
+        Alcotest.failf
+          "THE TRIPWIRE'S ORACLE IS NOT VALID ON THIS DEVICE.\n\n\
+           On %s the `volatile __local` barriered kernel disagrees with \
+           Sarek's f16 discipline on %d of %d finite binary16 inputs; first at \
+           x=%.9g (barriered %.9g, discipline %.9g).\n\n\
+           The barrier is only known to defeat the fusion on Mesa's ACO \
+           backend. Where it does not, [refusal_is_still_warranted]'s \
+           plain-vs-barriered comparison is measuring the barrier, not the \
+           fusion, and its verdict means nothing on this device.\n\n\
+           Do NOT relax this. Either find a barrier that works for this \
+           implementation, or re-express the tripwire against [ref_discipline] \
+           here too."
+          (Backend.Device.name device)
+          diffs
+          (Array.length inputs)
+          (d inputs.(i))
+          (d barriered.(i))
+          (d want.(i))
+      end)
+
+(* CALIBRATION. Host-only, so it runs everywhere including GPU-less CI. *)
+
+let host_rounding_round_trips () =
+  Array.iter
+    (fun b ->
+      if f16_bits (dec b) <> b then
+        Alcotest.failf
+          "host binary16 rounding is wrong: re-encoding the exact value of \
+           0x%04X gives 0x%04X. The locus cross-check below is measured \
+           against this function, so nothing there means anything until it is \
+           fixed."
+          b
+          (f16_bits (dec b)))
+    finite_bits ;
+  Alcotest.(check int)
+    "the exhaustive finite binary16 domain"
+    63488
+    (Array.length finite_bits)
+
+let host_models_reproduce_the_620 () =
+  let disc = Array.map ref_discipline finite_bits in
+  let fused = Array.map ref_fused finite_bits in
+  let diffs, _ = count_diffs disc fused in
+  if diffs <> 620 then
+    Alcotest.failf
+      "CALIBRATION FAILED — do not read any other result in this file.\n\n\
+       On the kernel shape f16(f16(x*1.1) + 1000), this file's own host models \
+       separate the two-roundings discipline from the fused-first-narrowing \
+       behaviour on %d of %d inputs. It must be 620: that is the figure \
+       measured independently on hiprtc/gfx1100 \
+       (sarek-hip/test/test_hip_f16.ml) and on rusticl/radeonsi \
+       (docs/fp-contraction-policy.md), and reproduced on Intel Arc by the \
+       `fusedctl` variant of tools/probes/opencl_f16_contraction_probe.c.\n\n\
+       Reproducing a known positive is what licenses believing the null that \
+       the locus cross-check reports on a non-fusing device. If this number \
+       moved, [f16_bits], [f32] or [dec] is wrong — fix the host reference, do \
+       not adjust this expectation."
+      diffs
+      (Array.length finite_bits)
 
 let refusal_is_still_warranted () =
   with_in_scope_devices (fun device ->
@@ -364,7 +555,24 @@ let refusal_is_still_warranted () =
    flake. It must not be silenced by narrowing the predicate — the message says
    what to do instead. Out-of-scope devices that cannot build or run the kernel
    at all (no cl_khr_fp16, say) are reported and skipped over, since a device
-   that cannot express the computation says nothing about fusion either way. *)
+   that cannot express the computation says nothing about fusion either way.
+
+   WHAT THIS COMPARES, AND WHY IT CHANGED (backlog #123). It used to compare the
+   plain kernel against the BARRIERED kernel, reading any difference as "the
+   plain kernel fused". That is a comparison with no oracle: the two kernels
+   compute the same expression, so a disagreement proves one of them is wrong
+   and says nothing about which. On ACO the barriered kernel is the right one,
+   which is where the reading came from; the first non-ACO GPU this project ever
+   ran on falsified it. On Intel Arc Graphics (Meteor Lake-P) under the Intel
+   Compute Runtime the plain kernel is correct on all 63488 inputs and the
+   BARRIERED kernel is wrong on 4774 — so the old comparison went red and
+   announced, in its own failure text, that Intel "fuses too" and that the
+   documented locus-is-ACO scoping was falsified. Both statements were the exact
+   opposite of what the hardware does.
+
+   So it now compares the plain kernel against [run_oracle], which is correct by
+   construction rather than by measurement on one vendor's compiler. A red here
+   means the plain kernel really does skip a mandated rounding. *)
 let non_aco_implementations_do_not_fuse () =
   let devices = all_devices () in
   let out_of_scope =
@@ -386,9 +594,10 @@ let non_aco_implementations_do_not_fuse () =
             let inputs = finite_bits in
             let plain = run_kernel device ~source:src_plain ~inputs in
             let barriered = run_kernel device ~source:src_barriered ~inputs in
-            let diffs = ref 0 in
-            Array.iteri (fun i p -> if p <> barriered.(i) then incr diffs) plain ;
-            Ok (!diffs, Array.length inputs)
+            let want = Array.map ref_discipline inputs in
+            let fused, first = count_diffs plain want in
+            let barrier_harm, _ = count_diffs barriered want in
+            Ok (fused, first, barrier_harm, inputs, plain, want)
           with e -> Error (Printexc.to_string e)
         with
         | Error msg ->
@@ -398,34 +607,70 @@ let non_aco_implementations_do_not_fuse () =
                %!"
               name
               msg
-        | Ok (diffs, n) ->
-            Printf.printf "    %s: %d/%d differ\n%!" name diffs n ;
-            if diffs <> 0 then
+        | Ok (fused, first, barrier_harm, inputs, plain, want) ->
+            let n = Array.length inputs in
+            (* The barrier count is reported, never asserted. It is not what
+               this check is about, and on Intel it is nonzero as shipped: the
+               ACO barrier is measured HARMFUL there. Asserting it would pin a
+               permanent red with no action available. The place it must not go
+               unnoticed is where it is load-bearing, and that IS asserted —
+               see [sanity_barriered_computes_the_right_thing]. *)
+            Printf.printf
+              "    %s: plain vs discipline %d/%d differ (barriered vs \
+               discipline %d/%d, reported only)\n\
+               %!"
+              name
+              fused
+              n
+              barrier_harm
+              n ;
+            if fused <> 0 then begin
+              let d v = match f16_decode v with Some x -> x | None -> nan in
+              let i = match first with Some i -> i | None -> 0 in
               Alcotest.failf
                 "THE LOCUS-IS-ACO CLAIM IS NOW TOO NARROW.\n\n\
-                 %s is NOT an ACO device, yet %d of %d finite binary16 inputs \
-                 differ between the naive and barriered narrowings — it fuses \
-                 too.\n\n\
-                 docs/fp-contraction-policy.md currently attributes this \
-                 defect to Mesa's ACO backend specifically, and cites the fact \
-                 that non-ACO OpenCL does not fuse as evidence that rusticl \
-                 and HIP are one bug seen twice. This device falsifies that \
-                 scoping.\n\n\
+                 %s is NOT an ACO device, yet the naive narrowing disagrees \
+                 with Sarek's f16 discipline on %d of %d finite binary16 \
+                 inputs; first at x=%.9g (naive %.9g, discipline %.9g). The \
+                 discipline is the host reference, calibrated on the same run \
+                 by [host_models_reproduce_the_620], so this device really is \
+                 skipping a mandated rounding.\n\n\
+                 docs/fp-contraction-policy.md attributes this defect to \
+                 Mesa's ACO backend specifically, and cites the fact that \
+                 non-ACO OpenCL does not fuse as evidence that rusticl and HIP \
+                 are one bug seen twice. This device falsifies that scoping.\n\n\
                  Do NOT fix this by excluding the device from the predicate. \
                  Widen the claim: re-measure with \
-                 tools/probes/opencl_f16_contraction_probe.c on this platform, \
-                 correct the OpenCL rows in docs/fp-contraction-policy.md, and \
-                 reconsider whether the refusal in Sarek_ir_opencl should be \
-                 stated per-implementation rather than per-backend-compiler."
+                 tools/probes/opencl_f16_contraction_probe.c on this platform \
+                 (its `fusedctl` variant calibrates the sweep against the \
+                 known 620/63488), correct the OpenCL rows in \
+                 docs/fp-contraction-policy.md, and reconsider whether the \
+                 refusal in Sarek_ir_opencl should be stated \
+                 per-implementation rather than per-backend-compiler."
                 name
-                diffs
-                n)
+                fused
+                n
+                (d inputs.(i))
+                (d plain.(i))
+                (d want.(i))
+            end)
       out_of_scope
 
 let () =
   Alcotest.run
     "Opencl_f16_tripwire"
     [
+      ( "calibration",
+        [
+          Alcotest.test_case
+            "host binary16 rounding round-trips every finite input"
+            `Quick
+            host_rounding_round_trips;
+          Alcotest.test_case
+            "host models reproduce the known 620"
+            `Quick
+            host_models_reproduce_the_620;
+        ] );
       ( "refusal_still_warranted",
         [
           Alcotest.test_case

--- a/sarek/Sarek_df64/Sarek_df64.ml
+++ b/sarek/Sarek_df64/Sarek_df64.ml
@@ -140,9 +140,27 @@
  *       does not help, and extending it to two_sum/quick_two_sum makes RADV
  *       strictly worse (see "Contraction barrier").
  *
- *   Vulkan on Intel (UHD Graphics 630, CFL GT2, Mesa ANV)
+ *   Vulkan on Intel (Mesa ANV)
  *       add/sub/sqrt meet the contract, mul/div degrade to ~5.8e-08, same
- *       shape as RADV. UNFIXED, unmeasured cause.
+ *       shape as RADV. UNFIXED.
+ *
+ *       Two devices, two generations, and they agree - but the second does
+ *       NOT confirm the first, it stands beside it:
+ *         - UHD Graphics 630 (CFL GT2, Gen9.5): mul/div ~5.8e-08. QUOTED.
+ *         - Arc Graphics (Meteor Lake-P, Xe-LPG), Mesa 26.1.2-arch3.1,
+ *           Vulkan 1.4.348: MEASURED 2026-07-27, test_df64 mul 5.84e-08 /
+ *           div 5.86e-08 against add 5.33e-15, sub 6.51e-15, sqrt 9.57e-15;
+ *           test_real64 mul 5.93e-08 / div 5.83e-08.
+ *       Different architecture, different generation, a decade of driver work
+ *       apart. Had they disagreed, that would have been a finding about
+ *       generation-dependence, not a correction of either.
+ *
+ *       Cause: same as RADV - a GLSL [fma] that is not correctly rounded.
+ *       Contraction is RULED OUT rather than assumed: on the Arc device
+ *       test_vulkan_no_contraction reports 0 of 7 contraction shapes
+ *       contracted with AND without [precise]. That is an inference from
+ *       elimination plus an identical error signature, not a direct sweep of
+ *       [fma] correct-rounding. See docs/fp-contraction-policy.md 11.1.
  *
  *   Native (OCaml host code)
  *       evaluates float32 at OCaml binary64 precision, so the error-free
@@ -345,7 +363,8 @@ let float x = float_of_int (Int32.to_int x)
  * stating precisely: before, [two_prod]'s HIGH limb was [fl(a*b)] on every
  * backend regardless of fma quality, and only the low limb depended on the
  * fma. Now the high limb is [fma a b 0.0] too, so on a backend whose [fma] is
- * not correctly rounded (RADV, and by inference ANV) the high limb can in
+ * not correctly rounded (RADV, and ANV by the same elimination argument) the
+ * high limb can in
  * principle differ from [fl(a*b)]. No measurable impact: those backends were
  * already at ~5.8e-08 for mul/div before this change and are byte-identical
  * after it. The exposure is newly present but not newly observable.

--- a/sarek/tests/e2e/test_helpers.ml
+++ b/sarek/tests/e2e/test_helpers.ml
@@ -424,18 +424,35 @@ let is_radv_device ~framework ~device =
 
 (** [true] iff [device] is a Mesa ANV (Intel Vulkan) device.
 
-    ANV reports the marketing name only
-    (["Intel(R) UHD Graphics 630 (CFL GT2)"]) with no driver token, so this
-    matches the vendor string. That is looser than [is_radv_device] and it is
-    the weakest predicate here: it would also match a future non-Mesa Intel
-    Vulkan driver.
+    ANV reports the marketing name only —
+    ["Intel(R) UHD Graphics 630 (CFL GT2)"] on the quoted hardware,
+    ["Intel(R) Arc(tm) Graphics (MTL)"] on the hardware this was measured on —
+    with no driver token anywhere in [VkPhysicalDeviceProperties::deviceName].
+    So this matches the vendor string. That is looser than [is_radv_device] and
+    it is the weakest predicate here: it would also match a future non-Mesa
+    Intel Vulkan driver.
 
-    NOT VERIFIED ON THE TASK #118 HARDWARE — there is no Intel GPU on the
-    campaign workstation (RX 7900 XTX + Raphael iGPU only). The entry is carried
-    over from the measurement recorded in Sarek_df64.ml's PER-BACKEND STATUS
-    (UHD Graphics 630, CFL GT2, Mesa ANV: mul/div ~5.8e-08, same shape as RADV).
-    It must be re-measured, and narrowed to a driver token, the first time an
-    Intel device runs this suite. *)
+    NOW MEASURED (backlog #123), and the arm is KEPT because it fired: Intel Arc
+    Graphics (Meteor Lake-P), Mesa ANV 26.1.2-arch3.1, Vulkan 1.4.348,
+    [test_df64] mul 5.84e-08 / div 5.86e-08, [test_real64] mul 5.93e-08 / div
+    5.83e-08, against add 5.33e-15, sub 6.51e-15, sqrt 9.57e-15 on the same run.
+    See docs/fp-contraction-policy.md §11.
+
+    WHY THE VENDOR STRING IS STILL THE KEY, having looked for a better one. A
+    real driver token does exist in the Vulkan API on this driver —
+    [VkPhysicalDeviceDriverProperties] reports [driverName] = "Intel open-source
+    Mesa driver" and a [driverID] of [VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA], and
+    that struct is Vulkan 1.2 core, so it is available on every device this
+    backend can reach. Sarek does not plumb it:
+    [sarek-vulkan/Vulkan_api_device.ml] fills [Device.name] from
+    [VkPhysicalDeviceProperties::deviceName] and queries nothing else, so no
+    driver token reaches this predicate. Narrowing the key is therefore a
+    Vulkan-backend change (query the driver properties, expose the driver ID on
+    [Device.t]), not a test change, and it is deliberately not bundled into a
+    measurement commit. Until then the vendor string is the strongest key
+    available at this call site, and the failure direction is safe: a non-Mesa
+    Intel Vulkan driver that MEETS the contract trips the strict-XPASS branch
+    below and says so by name, rather than passing silently. *)
 let is_anv_device ~framework ~device =
   framework = "Vulkan"
   && string_contains ~needle:"intel" (String.lowercase_ascii device)
@@ -494,10 +511,33 @@ let df64_known_deviation ~framework ~device ~op =
           label = "KNOWN-DEVIATION (RADV fma not correctly rounded)";
         }
   | "Vulkan", ("mul" | "div") when is_anv_device ~framework ~device ->
+      (* Same shape and the same attribution as the RADV arm above, and now on
+         the same evidence rather than on a quotation. Measured on Intel Arc
+         Graphics (Meteor Lake-P), Mesa ANV 26.1.2-arch3.1, Vulkan 1.4.348:
+         mul 5.84e-08, div 5.86e-08, with add/sub/sqrt meeting the strict bound
+         on the same run — exactly RADV's pattern.
+
+         Contraction is RULED OUT as the cause here, not assumed:
+         test_vulkan_no_contraction reports 0 of 7 contraction shapes contracted
+         on this device with AND without `precise`, so the compiler is not
+         fusing the multiply that closes quick_two_sum. What is left is the same
+         explanation the RADV arm carries — a GLSL `fma` that is not correctly
+         rounded, which loses TwoProd's error term while leaving the add/sub/
+         sqrt paths (which do not use it) intact. That is an inference from
+         elimination plus an identical error signature, not a direct sweep of
+         `fma` correct-rounding, and it is written down that way in
+         docs/fp-contraction-policy.md §11.
+
+         NOTE ON GENERATION. This measurement is Xe-LPG (Meteor Lake Arc). The
+         figure this arm was originally quoted from is UHD Graphics 630 (CFL
+         GT2) — a different architecture and a different generation. It is a
+         second data point for ANV, not a confirmation of the first. *)
       Some
         {
           entry = "Vulkan, (mul|div) when is_anv_device";
-          label = "KNOWN-DEVIATION (Mesa ANV mul/div, unmeasured cause)";
+          label =
+            "KNOWN-DEVIATION (Mesa ANV fma not correctly rounded; contraction \
+             ruled out)";
         }
   | _ -> None
 

--- a/tools/probes/opencl_f16_contraction_probe.c
+++ b/tools/probes/opencl_f16_contraction_probe.c
@@ -21,6 +21,13 @@
  *   ./probe fpcontract|volatile|vpriv|bitcast|bitcast2|convert
  *                          # every affordable barrier -> still 620 / 63488
  *   ./probe barrier  0     # HIP's "+v" asm      -> does not compile here
+ *   ./probe fusedctl 0     # POSITIVE CONTROL, deliberately fuses -> 620 / 63488
+ *                          #   on any conforming device; run it whenever a
+ *                          #   variant reports 0, or the 0 is not a result
+ *
+ * Device selection: the loop below scans the first platform that has devices,
+ * so on a multi-platform host use the ICD loader's own filter to choose, e.g.
+ *   OCL_ICD_FILENAMES=/usr/lib/intel-opencl/libigdrcl.so ./probe plain 0
  *
  * Measured 2026-07-26 on RX 7900 XTX (navi31) and the integrated Raphael iGPU
  * (gfx1036), rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both devices
@@ -234,6 +241,39 @@ static const char *SRC_VPRIV =
 "  }\n"
 "}\n";
 
+/* Variant N: POSITIVE CONTROL. Not a barrier and not a codegen candidate — a
+   kernel that performs the fusion *deliberately*, so the harness can be shown
+   able to report nonzero on a device that does not fuse on its own.
+
+   This is required to read a 0 from any of the variants above as a result
+   rather than as a broken harness. On rusticl/ACO the contrast is supplied for
+   free (plain 620, vglobal 0), but on a non-fusing stack every variant returns
+   0 and a silently-broken sweep is indistinguishable from a clean one.
+
+   The semantics are chosen to match the ACO combine exactly, not merely to be
+   wrong. `v_fma_mixlo_f16(x, 1.1f, 0)` rounds the EXACT f32 product straight to
+   binary16 — one rounding where the DSL mandates two. Both `x` and the f32
+   constant `1.1f` are exactly representable in binary64, so `(double)x *
+   (double)1.1f` IS that exact product, and narrowing it in one step reproduces
+   the fused value. The host reference is untouched. The expected count is
+   therefore the SAME 620/63488 that ACO produces, on any conforming device —
+   which makes this a calibration against a known figure, not just a liveness
+   smoke test.
+
+   Requires cl_khr_fp64. On a device without it the build fails loudly, which is
+   the correct outcome: it means the calibration was not obtained. */
+static const char *SRC_FUSED_CTL =
+"#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
+"#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n"
+"__kernel void midround(__global half *out, __global const half *in, int n) {\n"
+"  int i = get_global_id(0);\n"
+"  if (i < n) {\n"
+"    float x = (float)in[i];\n"
+"    half  m = (half)((double)x * (double)1.1f);\n"
+"    out[i] = (half)((float)m + 1000.0f);\n"
+"  }\n"
+"}\n";
+
 /* ---- binary16 helpers (host reference) ---------------------------------- */
 static float f16_value_of_bits(int b, int *is_finite) {
   int sign = (b & 0x8000) ? -1 : 1;
@@ -263,6 +303,7 @@ int main(int argc, char **argv) {
   if (argc > 1 && strcmp(argv[1], "vlocal") == 0) { src = SRC_VLOCAL; label = "VOLATILE LOCAL(LDS)"; }
   if (argc > 1 && strcmp(argv[1], "vpriv") == 0) { src = SRC_VPRIV; label = "VOLATILE PRIVATE PTR"; }
   if (argc > 1 && strcmp(argv[1], "convert") == 0) { src = SRC_CONVERT; label = "convert_half_rte"; }
+  if (argc > 1 && strcmp(argv[1], "fusedctl") == 0) { src = SRC_FUSED_CTL; label = "FUSED (positive control)"; }
 
   cl_platform_id plats[8]; cl_uint nplat = 0;
   clGetPlatformIDs(8, plats, &nplat);


### PR DESCRIPTION
First execution of this project on Intel hardware. Core Ultra 9 185H (Meteor
Lake-P) with integrated Arc Graphics, exercising **three independent
compilers**: Mesa **ANV** 26.1.2-arch3.1 (Vulkan 1.4.348), the Intel Compute
Runtime / **IGC** (OpenCL on the GPU), and the **oneAPI CPU runtime** (OpenCL on
the CPU). Full account in `docs/fp-contraction-policy.md` §11.

### What a Meteor Lake measurement does and does not establish

The in-tree ANV claim was quoted from **Intel UHD Graphics 630 (CFL GT2)** —
Gen9.5. This is **Xe-LPG**: different architecture, different generation, a
decade of driver work apart. The numbers agree, and that is worth knowing, but
this is a **second data point about ANV, not a confirmation of the first**. Had
they disagreed, the finding would have been generation-dependence and neither
number would have been "corrected" by the other. Nothing here is evidence about
UHD 630.

### 1. backlog #123 — the df64 ANV allowlist entry

It is a strict xfail, so the two outcomes were "still deviates" or "red with
STALE ALLOWLIST ENTRY, delete the arm". **It deviates — the arm stays.**

| op | `test_df64` | `test_real64` | contract |
|---|---|---|---|
| mul | **5.84e-08** | **5.93e-08** | 1.42e-14 |
| div | **5.86e-08** | **5.83e-08** | 1.42e-14 |
| add | 5.33e-15 | 5.31e-15 | 7.11e-15 |
| sub | 6.51e-15 | 6.94e-15 | 7.11e-15 |
| sqrt | 9.57e-15 | 1.17e-14 | 1.42e-14 |

Measured worst-case relative error over each test's own input set on the named
device and driver — a maximum observed, not a bound. RADV's pattern exactly.
Contraction is now **ruled out** on ANV rather than assumed (0 of 7 shapes,
§11.2), leaving the same not-correctly-rounded-`fma` attribution the RADV arm
carries — stated as inference-from-elimination plus signature, not a direct
`fma` sweep.

**On narrowing the predicate:** a real driver token does exist here —
`driverName = "Intel open-source Mesa driver"`, `driverID =
VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA`, Vulkan 1.2 core. But
`Vulkan_api_device.ml` reads only `VkPhysicalDeviceProperties::deviceName`, and
ANV puts no driver token there. Narrowing the key is a **Vulkan-backend
change**, not a test change, and is deliberately not bundled into a measurement
commit. The failure direction stays safe: a non-Mesa Intel driver that *meets*
the contract trips strict-XPASS and names the arm to delete.

### 2. Does ANV honour SPIR-V `NoContraction`? — the §6/§7 hardware gap, closed

ANV reproduces RADV's twelve-shape result: **0 of 7** contraction shapes
contracted with *and* without `precise`, 0 of 2 reassociation, `fma()` integrity
controls 4/4. Inconclusive for the same reason as RADV — nothing to suppress.

The follow-up that settled RADV *negatively* settles ANV the other way. On the
`float16_t(x * 1.1)` combine where RADV emits `v_fma_mixlo_f16` and ignores the
decoration, **ANV does not fuse at all**: 0/63488 against the discipline, with
the fused model separating at the calibrating 2912 on the same run.

So the campaign note claiming **ANV ignores `NoContraction` is not supported** —
and neither is any claim that it honours it, because ANV never contracted when
it was free to.

### 3. Does Intel OpenCL fuse the f16 narrowing like ACO? — **No**

| variant | Arc (IGC) | Ultra 9 185H (oneAPI CPU) |
|---|---|---|
| **`fusedctl` — positive control** | **620 / 63488** | **620 / 63488** |
| `plain` | **0 / 63488** | **0 / 63488** |
| `fpcontract`, `convert`, `bitcast`, `bitcast2` | 0 | 0 |
| `volatile`, `vpriv`, `vglobal`, `vlocal` | **4774** | 0 |

The calibration is exact and is what makes the null readable. `fusedctl` is a
new probe variant that fuses **deliberately** — `(half)((double)x *
(double)1.1f)` is the exact f32 product narrowed in one rounding, i.e. what
`v_fma_mixlo_f16` does — checked against the untouched host reference. It
reports 620/63488 **at the same first divergence as ACO** (x=5.68359375, device
1006.5 vs reference 1006).

**Second independent negative, first on a GPU with a vendor compiler sharing no
lineage with Mesa.** The reading is confirmed, not widened: **the defect is
ACO's**, not OpenCL's and not SPIR-V's.

### Unexpected: on IGC the ACO barrier *breaks* a correct narrowing

All four `volatile` barriers — the only things that fix rusticl — take a
narrowing that is **already correct** on IGC and make it wrong on **4774/63488**
inputs, the signature of the intermediate binary16 narrowing being dropped. Same
count and same failure mode §2 records for RADV's SSBO round-trip, reached on an
unrelated compiler. The Intel CPU runtime does not do it.

SPIR-V is faithful for **both** kernels (`ocloc` + `spirv-dis`: every mandated
`OpFConvert` present, volatile stores marked), so the fold is introduced **below
SPIR-V, inside IGC**. Evidence tier **compiler-output**, not machine-code — Gen
ISA needs `iga64`, absent here.

Policy consequence: a contraction barrier measured on one backend is not
portable, and applying one unconditionally can *introduce* the defect it was
written to prevent.

### The defect this surfaced in our own gate

`dune runtest` on this machine produced **exactly one failure**, and it was ours.
`test_opencl_f16_tripwire`'s locus cross-check went red on Arc and reported:

> THE LOCUS-IS-ACO CLAIM IS NOW TOO NARROW. `Intel(R) Arc(TM) Graphics` is NOT
> an ACO device, yet 4774 of 63488 … **it fuses too.**

Both sentences are false. The check compared plain against **barriered** with no
oracle; two kernels computing the same expression that disagree prove one is
wrong, not which. On ACO the barriered one is right — the file called it
"simultaneously the control and the oracle". On IGC it is the wrong one, so the
check blamed the plain kernel and instructed the reader, in its own failure
text, to weaken a claim that is correct. Its self-check was **one hand-computed
input**, which Intel passes while being wrong on 4774 others.

Fixed with a real oracle rather than a narrower predicate:

- the **host binary16 reference** ported from the Vulkan tripwire (which needed
  one from the start, because on RADV no affordable barrier works);
- two **calibration** cases on every run, host-only so they also run on GPU-less
  CI: rounding round-trips every finite input, and the two host models separate
  on exactly **620**;
- the barrier's validity is now an **exhaustive sweep** against the discipline
  instead of a one-point pin — 0/63488 on both ACO devices, previously assumed;
- the **locus check** compares plain against the discipline, and reports the
  barrier's own deviation without asserting on it (4774 on Intel as shipped;
  asserting would pin a permanent red with no action available).

Verified green on RX 7900 XTX + Raphael iGPU (in-scope tripwire still 620/63488,
barrier sweep 0/63488) **and** on both Intel devices.

> **A construction argument is not a measurement**, recorded in the file because
> it looks obviously right: splitting the expression across two kernel launches
> is *not* an oracle by construction. The fusion is multiply-into-narrowing and
> **both** live in the first kernel, so the dispatch boundary separates the
> wrong pair. Measured on RX 7900 XTX, the two-pass construction reproduces
> ACO's fused answer exactly — 620/63488. Caught only because it was swept
> against a device whose answer was already known.

### Everything else the first Intel contact produced

Nothing. Beyond the locus check, the full suite across `sarek`, `sarek-opencl`,
`sarek-vulkan` and `spoc` is green, including both f16 tripwires,
`test_vulkan_no_contraction` and `test_opencl_fp_conformance`. `fp64=true` on
all three devices with the native binary64 path exact on every op.

Two environmental notes, neither a repo defect: `dune build @all` fails in that
switch for want of `js_of_ocaml`/`qcheck-core` (nothing was installed; targets
were built explicitly), and the probe scans only the first OpenCL platform with
devices — `OCL_ICD_FILENAMES` selects the ICD, now documented in its usage
comment.

### Still open

- No Gen ISA for the IGC fold (needs `iga64`).
- `fma` correct-rounding is not *directly* measured on ANV or RADV.
- One Intel generation only — nothing here constrains Gen9.5, discrete Arc or Xe2.
- `is_anv_device` still vendor-keyed, pending the driver-properties plumbing.
- AMDVLK and the proprietary AMD Vulkan driver still unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
