### PR TITLE
fix(codegen): pin the f16 barrier to the AMD toolchain arm — #144 needed a gate, not a detector

### DIFF
--- a/docs/design/capability-model.md
+++ b/docs/design/capability-model.md
@@ -253,8 +253,21 @@ facts that motivated it is worse than none.
   through three front ends). The model can *say* a capability is
   `Toolchain_semantic`, but it has no way to *identify* the compiler at runtime,
   so such a verdict can only be blanket-per-backend. That over-refuses on pocl,
-  which measurably does not fuse. Closing this needs a compiler-identity probe
-  that does not exist.
+  which measurably does not fuse — and it now over-refuses on Intel IGC too,
+  which does not fuse either (`docs/fp-contraction-policy.md` §11.3, executed on
+  Intel Arc / Meteor Lake-P). Closing this needs a compiler-identity probe that
+  does not exist.
+
+  > **This gap does not block the f16 barrier, and backlog #144 asked whether it
+  > did.** The barrier's own scoping never depended on runtime identification:
+  > it is emitted from a single site under `#if defined(__HIP__) ||
+  > defined(__HIP_PLATFORM_AMD__)`, and the compilers that could get it wrong
+  > never receive the source, because f16 is refused at codegen on OpenCL, GLSL,
+  > Metal, WGSL and PTX. A preprocessor conditional is the compiler naming
+  > itself, which is strictly stronger than any device-string or probe-based
+  > identification this model could add. The gap is real for a *future*
+  > `Toolchain_semantic` verdict that must be taken with only a device in hand;
+  > it is not real for this one. See `docs/fp-contraction-policy.md` §11.4.
 - **Source locations.** `Sarek_ir_types.kernel` carries no location and the IR
   has no per-node locations, so a codegen refusal names the capability and the
   target but not the kernel source line. #64 asked for a *located* error; slice 1

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -1559,6 +1559,50 @@ narrowing barrier in `Sarek_ir_opencl` must be per-implementation and gated on
 an exhaustive agreement sweep for that implementation, never applied backend-wide
 on the strength of an ACO measurement.
 
+**What Sarek actually ships today, checked rather than assumed (backlog #144).**
+The obvious reading of the paragraph above is that the barrier needs to become
+conditional on the shader compiler, and that Sarek therefore needs a way to
+*identify* ACO at runtime — the gap §5 of
+[`docs/design/capability-model.md`](design/capability-model.md) lists as **NOT
+expressible**. That work is not needed, because the barrier is already scoped,
+by two facts that are structural rather than probabilistic:
+
+1. **The barrier is emitted from one site and it is preprocessor-scoped.**
+   `Sarek_ir_cuda.sarek_f32_barrier_decl` puts the `asm volatile("" : "+v"(x))`
+   body inside `#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)`; the other
+   arm is a bare identity (§4). Its only runtime consumers are `Hip_plugin`
+   (hiprtc) and `Cuda_plugin` / `Cuda_c_plugin` (nvrtc). Evidence:
+   **by-construction**.
+2. **IGC cannot receive that source.** f16 is refused outright by
+   `Sarek_ir_opencl`, `Sarek_ir_glsl`, `Sarek_ir_metal` and `Sarek_ir_wgsl` — at
+   the per-element-type arm *and* at a whole-kernel gate, across every public
+   `generate*` entry point — and `Sarek_ir_ptx` refuses it too. §11.4's 4774 was
+   measured on `tools/probes/opencl_f16_contraction_probe.c`, a research probe,
+   not on generated Sarek code. Evidence: **by-construction**, machine-checked by
+   `sarek/tests/codegen_golden/test_cuda_f16_golden.ml`.
+
+**A device-string denylist or a runtime ACO probe would both be weaker than what
+is already there.** The `#if` is the compiler identifying *itself* at the moment
+it compiles the source; a `CL_DEVICE_VENDOR` match or a `VK_DRIVER_ID` match is a
+guess about a stack from the outside, and a boot-time fusion probe measures a
+device that never sees this code. Neither would be consulted on the only path
+that emits the barrier. **The right shape of the #144 fix was therefore a gate,
+not a mechanism** — the scoping was correct and unpinned, and "correct and
+unpinned" is how §11.5's own tripwire came to encode a wrong claim.
+
+That gate exists now. `test_f16_barrier_is_amd_scoped` requires the opacity body
+to lie between the AMD guard and its `#else`, and the non-AMD arm to contain no
+`asm`/`volatile` once comments are stripped. It was **proved red** by giving the
+non-AMD arm the AMD `"+v"` barrier — a mutation the pre-existing `"+f"`
+assertion does not see, and under which that new case is the only failure.
+
+**Not verified, and deliberately not fixed here:** the guard's `defined(__HIP__)`
+disjunct is also true under `__HIP_PLATFORM_NVIDIA__`, where `"+v"` is not a
+valid constraint. No HIP-on-NVIDIA toolchain exists on this project's machines,
+so the claim that this fails is **unverified**; the failure direction is a loud
+compile error rather than a wrong number, which is why it is recorded rather than
+patched blind.
+
 ### 11.5 The defect this surfaced in our own gate
 
 `dune runtest` across `sarek`, `sarek-opencl`, `sarek-vulkan` and `spoc` on this

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -64,6 +64,44 @@ let check_absent what src needle =
   if contains ~needle src then
     Alcotest.failf "%s: expected NOT to find %S in:\n%s" what needle src
 
+(** First index of [needle] at or after [from], or [-1]. *)
+let index_from ~needle ~from haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i =
+    if i + nl > hl then -1
+    else if String.sub haystack i nl = needle then i
+    else go (i + 1)
+  in
+  go (max 0 from)
+
+let index_of ~needle haystack = index_from ~needle ~from:0 haystack
+
+(** Drop C block- and line-comments, so a structural assertion about emitted
+    CODE cannot be satisfied — or broken — by prose. Without this, an assertion
+    that a preprocessor arm contains no ["volatile"] goes red the day someone
+    writes the word in the comment explaining why there is none. *)
+let strip_c_comments src =
+  let n = String.length src in
+  let buf = Buffer.create n in
+  let rec go i =
+    if i >= n then ()
+    else if i + 1 < n && src.[i] = '/' && src.[i + 1] = '*' then
+      let rec close j =
+        if j + 1 >= n then n
+        else if src.[j] = '*' && src.[j + 1] = '/' then j + 2
+        else close (j + 1)
+      in
+      go (close (i + 2))
+    else if i + 1 < n && src.[i] = '/' && src.[i + 1] = '/' then
+      let rec eol j = if j >= n || src.[j] = '\n' then j else eol (j + 1) in
+      go (eol (i + 2))
+    else (
+      Buffer.add_char buf src.[i] ;
+      go (i + 1))
+  in
+  go 0 ;
+  Buffer.contents buf
+
 (* ------------------------------------------------------------------ *)
 (* Kernels                                                            *)
 (* ------------------------------------------------------------------ *)
@@ -208,6 +246,103 @@ let test_f16_conversions () =
     "NVIDIA branch documents why it is empty"
     src
     "NVIDIA: intentionally an identity" ;
+  ()
+
+(** The opacity barrier must be SCOPED to the AMD toolchain, not merely present
+    (backlog #144).
+
+    [test_f16_conversions] asserts the AMDGPU [asm volatile] appears and that no
+    PTX ["+f"] variant does. Neither assertion looks at WHERE the asm sits, so
+    both survive the mutation that matters here: widening the barrier so it is
+    also emitted on the non-AMD arm.
+
+    Why that mutation is a defect and not a harmless over-approximation.
+    Measured on Intel Arc Graphics (Meteor Lake-P, Intel Compute Runtime / IGC),
+    2026-07-27, exhaustive over all 63488 finite binary16 inputs
+    (docs/fp-contraction-policy.md §11.3 / §11.4): the naive narrowing is
+    correct — 0/63488 against the host binary16 reference, with the [fusedctl]
+    positive control reproducing ACO's 620/63488 on the same device and run —
+    and every volatile-based barrier makes it WRONG on 4774/63488. IGC folds the
+    [f32(f16(x))] pair across the volatile boundary, a fold valid only when the
+    value is exactly representable in binary16. So on that toolchain the barrier
+    is not redundant, it is the defect.
+
+    IGC cannot receive this particular source today: Sarek's OpenCL, GLSL, Metal
+    and WGSL backends all refuse f16 outright, so the only compilers that ever
+    see [sarek_f32_barrier] are hiprtc and nvrtc, and the preprocessor tells
+    those two apart with certainty. That is a STRUCTURAL argument, and
+    structural arguments are what this repository keeps discovering it had
+    stopped re-checking. This case is the re-check: it pins that the opacity
+    body lives inside the AMD arm and that the other arm is a bare identity, so
+    a future maintainer who "simplifies" the [#if] away, or who adds a barrier
+    on the NVIDIA arm on the strength of an AMD measurement, gets a red rather
+    than a silently portable-looking one.
+
+    Evidence tier for the IGC figures: executed (Intel Arc, IGC). For "the
+    preprocessor is the right discriminator": by-construction. *)
+let test_f16_barrier_is_amd_scoped () =
+  let src = gen (f16_scale_kernel ()) in
+  let guard = "#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)" in
+  let i_if = index_of ~needle:guard src in
+  if i_if < 0 then
+    Alcotest.failf
+      "the f32 barrier must be emitted under the AMD toolchain guard %S; it \
+       was not found at all, so nothing scopes the opacity body:\n\
+       %s"
+      guard
+      src ;
+  let i_else = index_from ~needle:"#else" ~from:i_if src in
+  let i_endif = index_from ~needle:"#endif" ~from:i_if src in
+  if not (i_else > i_if && i_endif > i_else) then
+    Alcotest.failf
+      "the AMD guard must be a two-armed #if/#else/#endif (if@%d, else@%d, \
+       endif@%d):\n\
+       %s"
+      i_if
+      i_else
+      i_endif
+      src ;
+  (* The opacity body is inside the AMD arm. *)
+  let i_asm = index_from ~needle:"asm volatile" ~from:i_if src in
+  if not (i_asm > i_if && i_asm < i_else) then
+    Alcotest.failf
+      "the AMDGPU opacity barrier must sit INSIDE the AMD arm of the guard \
+       (if@%d, asm@%d, else@%d). Emitting it outside ships to every toolchain \
+       the barrier was never measured on — and on Intel IGC that same barrier \
+       turns a correct narrowing into 4774/63488 wrong answers \
+       (docs/fp-contraction-policy.md §11.4):\n\
+       %s"
+      i_if
+      i_asm
+      i_else
+      src ;
+  (* And the non-AMD arm carries no barrier of any kind. Comments are stripped
+     first: the arm's whole purpose is a comment explaining why there is no
+     barrier, and that prose must not be able to satisfy or break a check about
+     code. *)
+  let non_amd_arm =
+    strip_c_comments (String.sub src i_else (i_endif - i_else))
+  in
+  List.iter
+    (fun needle ->
+      if contains ~needle non_amd_arm then
+        Alcotest.failf
+          "the non-AMD arm of the barrier guard must be a bare identity, but \
+           it contains %S. A barrier here is not measured-neutral: it is \
+           measured-HARMFUL on Intel IGC (4774/63488) and \
+           measured-zero-instruction on NVIDIA (byte-identical cubins, \
+           sm_75..sm_121). Arm was:\n\
+           %s"
+          needle
+          non_amd_arm)
+    ["asm"; "volatile"] ;
+  (* Non-vacuity: the arm we just proved empty must be the one that really
+     carries the NVIDIA identity, otherwise the substring above could be empty
+     for an unrelated reason. *)
+  check_contains
+    "the non-AMD arm is the NVIDIA identity"
+    non_amd_arm
+    "return x;" ;
   ()
 
 let test_non_f16_kernel_unchanged () =
@@ -395,6 +530,18 @@ let test_deferred_backends_reject_f16 () =
       ~expected_reason:reason_opencl
       (label ^ "/opencl generate_with_types")
       (fun () -> Sarek_ir_opencl.generate_with_types ~types:k.kern_types k) ;
+    (* OpenCL has a THIRD public entry point. It delegates to [generate], so it
+       is covered transitively today — but "covered transitively" is exactly how
+       this repo's previous guard holes were argued, and THIS refusal is what
+       keeps Sarek's f16 narrowing away from IGC, where the ACO barrier is
+       measured to BREAK a correct narrowing (4774/63488, Intel Arc /
+       Meteor Lake-P, docs/fp-contraction-policy.md §11.4). Asserted directly so
+       a future non-delegating implementation cannot reopen it. *)
+    expect_f16_rejected
+      ~backend:"OpenCL"
+      ~expected_reason:reason_opencl
+      (label ^ "/opencl generate_with_fp64")
+      (fun () -> Sarek_ir_opencl.generate_with_fp64 k) ;
     (* GLSL's Backend_error tag is "Vulkan" (that is the framework name). *)
     expect_f16_rejected
       ~tag:"Vulkan"
@@ -577,6 +724,10 @@ let () =
             "conversions use __float2half / C cast"
             `Quick
             test_f16_conversions;
+          Alcotest.test_case
+            "f32 barrier is scoped to the AMD toolchain arm (#144)"
+            `Quick
+            test_f16_barrier_is_amd_scoped;
           Alcotest.test_case
             "non-f16 kernel emits no f16 machinery"
             `Quick


### PR DESCRIPTION
## What #144 asked, and what turned out to be true

#144 reads: the f16 fusion barrier is emitted unconditionally; on Intel IGC that
barrier *breaks* a narrowing that is correct without it (4774/63488, `docs/fp-contraction-policy.md` §11.4);
so make it conditional on the shader compiler, and find a way to detect ACO.

**The barrier is not emitted unconditionally, and no ACO detection is needed.**
That is the substance of this PR, so it is stated first rather than buried:

1. **One emission site, already preprocessor-scoped.** `Sarek_ir_cuda.sarek_f32_barrier_decl`
   puts the `asm volatile("" : "+v"(x))` body inside
   `#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)`; the other arm is a
   bare identity. Its only runtime consumers are `Hip_plugin` (hiprtc) and
   `Cuda_plugin` / `Cuda_c_plugin` (nvrtc).
2. **IGC never receives that source.** f16 is refused at codegen by
   `Sarek_ir_opencl`, `Sarek_ir_glsl`, `Sarek_ir_metal`, `Sarek_ir_wgsl` and
   `Sarek_ir_ptx` — at the per-element-type arm *and* at a whole-kernel gate,
   across every public `generate*` entry point. §11.4's 4774 was measured on
   `tools/probes/opencl_f16_contraction_probe.c`, a research probe, not on
   generated Sarek code.

So the risk #144 describes cannot reach shipped code. What was missing was not a
mechanism but a **gate**: the scoping was correct and nothing pinned it, and
"correct and unpinned" is exactly how §11.5's own tripwire came to encode a wrong
claim.

## Why not a detection mechanism

Both alternatives were rejected, and not on taste:

- **Device/driver-string denylist** (`CL_DEVICE_VENDOR`, `VK_DRIVER_ID`, Mesa
  version). A guess about a stack from the outside, it goes stale, and it would
  not be consulted on the only path that emits the barrier.
- **Runtime fusion probe at device init.** Measures the property instead of
  guessing — genuinely better than a denylist — but it measures a *device*, and
  the device it would measure never sees this code. It would also add a
  compile+dispatch at init to answer a question the preprocessor already answers.

A `#if` is the compiler naming **itself** at the moment it compiles the source.
That is strictly stronger than either. The `Toolchain_semantic` gap in
`capability-model.md` §5 is real for a *future* verdict that must be taken with
only a device in hand; it is not real for this one, and the doc now says so.

## What this PR changes

| file | change |
|---|---|
| `sarek/tests/codegen_golden/test_cuda_f16_golden.ml` | new `test_f16_barrier_is_amd_scoped`; OpenCL's third entry point `generate_with_fp64` added to the f16-refusal coverage; `index_from` / `index_of` / `strip_c_comments` helpers |
| `docs/fp-contraction-policy.md` | §11.4 gains "What Sarek actually ships today, checked rather than assumed (backlog #144)" |
| `docs/design/capability-model.md` | §5's "Which shader compiler is in the stack" bullet notes IGC as a second over-refusal, and that this gap does not block the f16 barrier |

The new case asserts the opacity body lies between the AMD guard and its `#else`,
and that the non-AMD arm contains no `asm`/`volatile` **once comments are
stripped** — that arm's entire content is prose explaining why there is no
barrier, and prose must not be able to satisfy or break a check about code.

**No generator change.** The conditionality #144 asks for is already correct.

## Proved red, not assumed green

Every assertion added was shown to fail under a mutation of the thing it claims
to read:

| mutation | result |
|---|---|
| non-AMD arm given the AMD `"+v"` barrier | **only the new case fails** — `the non-AMD arm of the barrier guard must be a bare identity, but it contains "asm"`. The pre-existing `"+f"` assertion does not see this mutation, which is why the case is not redundant. |
| non-AMD arm given a `"+f"` barrier | new case fails alongside the pre-existing `no inert PTX barrier` assertion |
| guard removed entirely (barrier genuinely unconditional) | new case fails alongside the pre-existing NVIDIA-identity assertion |
| `generate_with_fp64` made non-delegating, **one** OpenCL refusal site neutralised | **stayed green** — the element-type arm caught it. Recorded because it shows the new assertion is defended in depth, not because it is inert. |
| `generate_with_fp64` made non-delegating, **both** OpenCL refusal sites neutralised | fails with `vector-param/opencl generate_with_fp64: expected f16 to be rejected, but generation succeeded` |

All mutations were reverted; `git diff --stat origin/main` is the three files above.

## Executed on hardware — measured, not inferred

**On ACO, the barrier must be present.** Re-measured on the shipped generator:

- **HIP / hiprtc, ROCm `libamdhip64.so.7.2.53211`, AMD Radeon RX 7900 XTX
  (gfx1100)** — `test_hip_f16_shapes`, exhaustive over all 63488 finite binary16
  inputs on 16 shapes: every shape agrees with the interpreter **as shipped**, and
  neutralising `sarek_f32_barrier` breaks 9 of them, including the original
  B1 = **620/63488**, first divergence `x=5.68359375` (device 1006.5, interpreter
  1006). `[PASS] ... the barrier is demonstrably load-bearing`. The positive
  control fires, so the zero is a live null.
- **rusticl / radeonsi, Mesa 26.1.4-1, ACO, DRM 3.64, kernel 7.1.2-3-cachyos**, on
  RX 7900 XTX (navi31) **and** the Ryzen 9 7950X Raphael iGPU —
  `test_opencl_f16_tripwire`: fusion still present, **620/63488** on both, same
  first divergence point.

**On IGC, the barrier must be absent** — this holds by construction (fact 2
above) and is now machine-checked by the codegen gate. It was **not** re-executed
on the Intel machine: there is nothing to execute, because Sarek refuses f16 on
every backend IGC serves. §11.4's 4774 stands as previously recorded.

## Suite

`dune runtest` at the repo root: **exit 0**. `dune build @fmt`: **exit 0**.

`test_cuda_f16_golden`: **10 cases run, 0 FAIL, 0 SKIP** (was 9).

`test_opencl_f16_tripwire` on this ACO-only box: 4 run, 0 FAIL, **1 SKIP** —
`non-ACO OpenCL implementations do not fuse (locus check)`, skipped with
`no non-ACO OpenCL device present to cross-check the locus-is-ACO claim against`.
**Pre-existing**, not introduced here: the case is untouched by this PR and both
OpenCL devices on this machine are ACO. It is the case that would have run on the
Intel box.

## Measured vs inferred, stated plainly

- **Measured (executed):** the 620/63488 on hiprtc/gfx1100 and on rusticl/radeonsi
  on two devices; the barrier being load-bearing on 9 shapes; the 4774/63488 IGC
  figure quoted from §11.3/§11.4.
- **Measured (by-construction, machine-checked):** the barrier reaches only hiprtc
  and nvrtc; IGC cannot receive an f16 kernel.
- **Inferred:** that the preprocessor conditional will remain the right
  discriminator for any future ACO consumer of *this* source. It holds as long as
  the source is only ever compiled by hiprtc and nvrtc, which is what the gate
  and the f16 refusals pin.

## Not verified, and deliberately not fixed here

The guard's `defined(__HIP__)` disjunct is **also true under
`__HIP_PLATFORM_NVIDIA__`**, where `"+v"` is not a valid inline-asm constraint.
The narrower guard would be `defined(__HIP_PLATFORM_AMD__)` alone. No
HIP-on-NVIDIA toolchain exists on this project's machines, so the claim that this
breaks is **unverified**, and the failure direction is a loud compile error rather
than a wrong number. Recorded in §11.4 rather than patched blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
