### PR TITLE
docs(fp): the f16 fusion locus is two AMD compilers, not ACO (#145, #146)

### DIFF
--- a/docs/design/capability-model.md
+++ b/docs/design/capability-model.md
@@ -15,11 +15,15 @@ a set of capability facts that do not live at the same layer:
 - **Metal has no `double`.** `Sarek_ir_metal.ml` mapped `TFloat64 -> "float"`
   with a comment saying so and no refusal anywhere on the path. No device query
   can report this; it is a property of the Metal Shading Language.
-- **ACO fuses an f32 multiply into the f32→f16 narrowing** regardless of what the
-  driver advertises — 620/63488 disagreements via rusticl, up to 5075/63488 via
-  RADV, on RX 7900 XTX / gfx1100. pocl on x86 does not fuse, which localises the
-  defect to ACO rather than to the device or the API. The device reports the
-  feature; the feature is broken. A device flag says "yes".
+- **AMD's GPU shader compilers fuse an f32 multiply into the f32→f16 narrowing**
+  regardless of what the driver advertises — 620/63488 disagreements via
+  rusticl/radeonsi and up to 5075/63488 via RADV (both **ACO**, Mesa's
+  compiler), and the same 620/63488 via hiprtc (**LLVM's AMDGPU backend**, a
+  different compiler), on RX 7900 XTX / gfx1100. pocl on x86 and Intel IGC do
+  not fuse, which localises the defect to the vendor's shader compilers rather
+  than to the device or the API — note *compilers*, plural: see
+  `docs/fp-contraction-policy.md` §2, "Two AMD compilers". The device reports
+  the feature; the feature is broken. A device flag says "yes".
 - **Apple Silicon OpenCL has no `cl_khr_fp64`** — and the question that actually
   decides whether a build succeeds there is whether the *host* clang can compile
   `double` for that target, not what the device reports.
@@ -45,7 +49,7 @@ diagnostic or a launch gate is the right instrument — that is
 | `Backend_structural` | the target **language** | statically, no device | Metal has no `double`; WebGPU has no `f64` |
 | `Device_optional` | the **device** | needs a device | `cl_khr_fp64`, `shaderFloat16`, sm_53 for f16, tensor cores |
 | `Host_toolchain` | the **host compiler/headers** | needs a host probe | can Apple clang compile `double` for this target; NVRTC needs `cuda_fp16.h` |
-| `Toolchain_semantic` | the **shader compiler** | only measurable | ACO fusing f32 mul into the f16 narrowing |
+| `Toolchain_semantic` | the **shader compiler** | only measurable | ACO *and* LLVM/AMDGPU fusing f32 mul into the f16 narrowing |
 | `Policy` | **us** | statically | f16 refused on OpenCL because we measured it wrong |
 | `Flag_legality` | a **build option × a device bit** | needs a device | `-cl-fp32-correctly-rounded-divide-sqrt` |
 
@@ -54,7 +58,7 @@ Three distinctions do real work and are worth defending:
 **`Toolchain_semantic` vs `Device_optional`.** A device flag and a compiler
 behaviour are different facts about different components, and the compiler one
 must be able to *override a device saying yes*. Any model where a device query
-is the final authority gets ACO wrong.
+is the final authority gets the AMD f16 fusion wrong.
 
 **`Toolchain_semantic` vs `Policy`.** The first is the evidence, the second the
 verdict. A `Toolchain_semantic` fact is revised by a new **measurement**; a
@@ -177,7 +181,7 @@ facts that motivated it is worse than none.
   refuses everything it cannot represent at the right width. It was the
   *precedent* Metal should have followed, not a second instance of the defect.
 - f16 refused on OpenCL and GLSL — representable as `Toolchain_semantic`
-  (evidence: the ACO counts) plus `Policy` (verdict). Currently hand-written
+  (evidence: the AMD f16 fusion counts) plus `Policy` (verdict). Currently hand-written
   strings; slice 2 structures them.
 - Apple Silicon OpenCL / host clang — `Host_toolchain` exists as a kind; no probe
   machinery exists.
@@ -248,9 +252,14 @@ facts that motivated it is worse than none.
   slow" is a third thing it cannot say. This is the affinity half of the backlog
   title and it is genuinely a different model — a cost, not a predicate. Slice 5,
   and it should not be bolted onto `verdict`.
-- **Which shader compiler is in the stack.** The ACO fact is a property of
-  ACO — not of RADV, not of the device, not of OpenCL-vs-Vulkan (it reproduces
-  through three front ends). The model can *say* a capability is
+- **Which shader compiler is in the stack.** The f16-fusion fact is a property
+  of the **shader compiler** — not of RADV, not of the device, not of
+  OpenCL-vs-Vulkan (it reproduces through three front ends). But there are
+  **two** such compilers and both fuse: ACO (reached via rusticl and via RADV)
+  and LLVM's AMDGPU backend (reached via hiprtc). So "identify ACO at runtime"
+  would be the wrong predicate as well as an unavailable one — the right one is
+  "is this an AMD GPU compiler", and the two are not the same set. See
+  `docs/fp-contraction-policy.md` §2. The model can *say* a capability is
   `Toolchain_semantic`, but it has no way to *identify* the compiler at runtime,
   so such a verdict can only be blanket-per-backend. That over-refuses on pocl,
   which measurably does not fuse — and it now over-refuses on Intel IGC too,

--- a/docs/design/f16-dsl-element-type.md
+++ b/docs/design/f16-dsl-element-type.md
@@ -944,9 +944,19 @@ conversions.
 >
 > **Two generalizable rules.**
 > 1. *Group backends by their backend compiler, not by their source language.*
->    OpenCL and HIP look maximally different at the source level and are the same
->    compiler underneath. GLSL/Vulkan on RADV is a third front end onto ACO and
->    should be assumed to carry this defect until measured.
+>    OpenCL and HIP look maximally different at the source level and hit the
+>    same defect underneath. GLSL/Vulkan on RADV is a second front end onto ACO
+>    and should be assumed to carry this defect until measured.
+>
+>    **Corrected (#145): they are not the same compiler.** rusticl/radeonsi and
+>    RADV compile through **ACO**, Mesa's shader compiler; hiprtc compiles
+>    through **LLVM's AMDGPU backend**. The rule survives — grouping by
+>    compiler still beats grouping by source language — but the group here is
+>    "AMD's two GPU compilers", and the identical 620/63488 is two compilers
+>    agreeing, not one compiler seen twice. That is the stronger reading, and it
+>    is the one that scopes a future barrier correctly: keyed to Mesa/ACO it
+>    would miss hiprtc, keyed to ROCm it would miss rusticl and RADV. See
+>    `docs/fp-contraction-policy.md` §2, "Two AMD compilers".
 >
 >    **Do not over-read the RADV result that landed alongside this** (#106/#126,
 >    the `Vulkan / GLSL` row): RADV was measured *not* to contract **7 f32
@@ -987,7 +997,8 @@ conversions.
 > **Three things this changes, none of which were predictable from the OpenCL
 > result.**
 >
-> *Same locus, different severity.* Rule 1 was right that ACO is the locus, and
+> *Same locus, different severity.* Rule 1 was right that a backend compiler is
+> the locus (ACO here; see its correction above — HIP's is LLVM/AMDGPU), and
 > wrong to imply the count would follow. Through OpenCL C the combine swallows
 > the multiply only. Through SPIR-V it also swallows the f32 **add**: the plain
 > two-narrowing kernel compiles to a *single* `v_fma_mixlo_f16 1.1, x, 1000.0f`

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -43,8 +43,10 @@ actually had:
   the decoration is emitted, and the emitted ISA is byte-identical with and
   without it. **2912 of 63488** finite binary16 inputs disagree with the
   interpreter on a single narrowing, **5075** on a two-narrowing expression.
-  Third front end onto the same ACO backend as HIP and rusticl, and a wider
-  combine than either. f16 stays refused on this backend (§2, §6).
+  Second front end onto the same ACO backend as rusticl/radeonsi, and a wider
+  combine than either it or HIP — whose identical-looking fusion comes from a
+  *different* compiler, LLVM's AMDGPU backend (§2, "Two AMD compilers"). f16
+  stays refused on this backend (§2, §6).
 
 This document states, per backend, what the compiler is permitted to contract,
 what mechanism (if any) actually prevents it, whether that mechanism is
@@ -101,6 +103,44 @@ Legend for the evidence column:
 | **by-construction** | the source hands the compiler nothing it can contract; no flag is relied on |
 | **unverified** | believed, documented, or inherited from a vendor's documentation — not measured here |
 
+### Two AMD compilers, not one
+
+Three rows below are AMD GPUs, and it is tempting — this document did it — to
+read them as one compiler behind several front ends. **They are two compilers:**
+
+| stack | front end | compiler that emits the ISA |
+|---|---|---|
+| HIP / hiprtc (ROCm) | HIP C++ | **LLVM's AMDGPU backend** — ROCm ships its own clang/LLVM; `libamd_comgr` is linked against `libLLVMAMDGPUCodeGen`, and §9.6's HIP measurements are `AMD clang 22.0.0git` |
+| OpenCL / rusticl on radeonsi | OpenCL C → SPIR-V | **ACO**, Mesa's shader compiler — named by Mesa in the device string itself: `AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, …)` |
+| Vulkan / RADV | GLSL → SPIR-V | **ACO**, same compiler, second front end |
+
+Evidence: **by-construction** (what the shipped toolchains are made of). No
+measurement below changes, and no measurement below moves tier because of this
+note.
+
+**What the agreement therefore means.** hiprtc and rusticl produce the *same*
+620 of 63488 disagreements with the same first divergence at `x = 5.68359375`.
+Read as one compiler seen twice, that is a single bug. Read correctly, it is the
+stronger statement: **the f32-multiply-into-f16-narrowing fusion is present in
+both of AMD's GPU compilers independently — it is an AMD-toolchain-wide
+behaviour, not an ACO one.** RADV adds a third data point on the ACO side with a
+*wider* combine.
+
+**Why the distinction is load-bearing and not pedantry.** "The locus is ACO" is
+the sentence someone would use to scope a future barrier, a denylist or a
+detection predicate. Scoped to Mesa/ACO, such a predicate misses the
+LLVM/AMDGPU path that HIP takes; scoped to ROCm, it misses rusticl and RADV. The
+`#if defined(__HIP_PLATFORM_AMD__)` guard on `sarek_f32_barrier` (§4, §11.4) is
+correct precisely because it keys on **the toolchain compiling that source**,
+which no cross-compiler generalisation is needed to get right. Where a predicate
+below *is* keyed on the string `"ACO"` (§3's OpenCL tripwire), that key selects
+Mesa devices and only Mesa devices — see the note there.
+
+**What the non-AMD negatives still establish.** pocl/x86, Intel IGC, the Intel
+oneAPI CPU runtime and NVIDIA all decline to fuse (§11.3). That still rules out
+*OpenCL* and *SPIR-V* as the locus. It no longer supports "ACO specifically",
+because the one non-Mesa stack that does fuse is AMD's own.
+
 | backend | what the compiler may contract | what actually prevents it | evidence |
 |---|---|---|---|
 | **Interpreter** | nothing — it is the oracle | it evaluates the IR directly | executed (any host) |
@@ -109,9 +149,9 @@ Legend for the evidence column:
 | **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C, and no build option turns it off | for contraction, **no flag** — same `mul_rn`-by-construction defence as CUDA. For div/sqrt, `Opencl_fp.conformance_options` requests `-cl-fp32-correctly-rounded-divide-sqrt`, **gated** on `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT` in the device's `CL_DEVICE_SINGLE_FP_CONFIG`; `Opencl_fp.check_fp_conformance` **rejects** the relaxing `-cl-*` options at `Opencl_api.Program.build`, the single point an option string reaches `clBuildProgram` (§9) | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
-| **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, same ACO backend | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c` |
-| **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as HIP and rusticl, reached through a third front end, but a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
-| **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on ACO and does not fuse here, so the locus is *the ACO backend*, not *OpenCL*. That in turn is the second independent reason to read rusticl and HIP/AMDGPU as one bug seen through two front ends rather than two bugs. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any non-ACO implementation is found to fuse — and which was itself wrong until §11.5 |
+| **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, and bit-for-bit the same count — but a **different compiler**: ACO here, LLVM's AMDGPU backend there (see "Two AMD compilers" above) | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c` |
+| **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as rusticl, reached through a second front end — HIP's identical-count defect comes from LLVM's AMDGPU backend instead — and a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
+| **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on an AMD GPU compiler and does not fuse here, so the locus is *the AMD GPU compilers*, not *OpenCL* and not *SPIR-V*. Note what it does **not** localise: rusticl and HIP/AMDGPU do not share a compiler (see "Two AMD compilers" above), so their identical 620 is two compilers agreeing, not one bug seen twice. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any OpenCL implementation outside its `"ACO"` device-string scope is found to fuse — and which was itself wrong until §11.5. Read that predicate as "not Mesa", not as "not AMD": an AMD GPU reached through ROCm's OpenCL would be compiled by LLVM's AMDGPU backend, i.e. by a compiler this document expects to fuse, while sitting outside the key |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV now measured too** (§11.2): Intel Arc Graphics (Meteor Lake-P), Mesa 26.1.2-arch3.1, same 0 of 7 / 0 of 7 with `fma()` controls 4/4 — and unlike RADV, ANV does not fuse the f16 narrowing either, so no combine has been found on ANV where `NoContraction` is ignored. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound; ANV shows the same signature (mul 5.84e-08 / div 5.86e-08, §11.1) |
 | **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. f16 and subnormals unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
@@ -191,7 +231,10 @@ Legend for the evidence column:
   automated — `sarek-opencl/test/test_opencl_f16_tripwire.ml` fails when the
   fusion stops happening, so the refusal cannot quietly outlive its reason.
   That tripwire asserts **only on ACO devices** (it keys on `"ACO"` in the
-  OpenCL device name, which is where Mesa reports its shader compiler) and
+  OpenCL device name, which is where Mesa reports its shader compiler — so the
+  key means "a Mesa stack", not "an AMD GPU": ROCm's OpenCL on the same card
+  compiles through LLVM's AMDGPU backend and is out of scope, see §2's "Two AMD
+  compilers") and
   **skips visibly** elsewhere, naming the devices it rejected. Scoping it was
   not cosmetic: unscoped, it failed on a pocl/x86 CI runner that correctly does
   not fuse — a false positive on a blocking gate, which is the polarity that
@@ -611,8 +654,8 @@ this is where they are collected):
   available on 2026-07-27 and the whole bullet is discharged in **§11**: the
   `NoContraction` question (§11.2), the df64 ANV allowlist entry that had never
   been executed (§11.1), and — as a bonus the bullet did not ask for — the
-  independent OpenCL implementation that confirms the f16 fusion is ACO's
-  (§11.3). The campaign note claiming ANV ignores `NoContraction` is **not
+  independent OpenCL implementation that confirms the f16 fusion belongs to
+  AMD's GPU compilers rather than to OpenCL (§11.3). The campaign note claiming ANV ignores `NoContraction` is **not
   supported**. Scope: **Xe-LPG only**, which is not the Gen9.5 UHD 630 the
   quoted ANV numbers came from (§11.0). **AMDVLK and the proprietary AMD Vulkan
   driver remain unmeasured** — different SPIR-V consumers on the very same GPU.
@@ -1064,8 +1107,9 @@ and the only one; df64 passing either way is consistent with both.
   measured for *equivalence* on macOS 15 but has never run on the pre-15 OS that
   is its only reason to exist.
 - **Subnormals.** Not probed at all on Metal.
-- **f16 on Metal.** Not probed. The three other backends that reach an ACO or
-  NVIDIA compiler each needed a separate exhaustive f16 sweep before anything
+- **f16 on Metal.** Not probed. The three other backends that reach an AMD
+  (ACO or LLVM/AMDGPU) or NVIDIA compiler each needed a separate exhaustive f16
+  sweep before anything
   could be said; Metal has had none.
 - **The two kernels that do not compile** (§10.11) are excluded from every
   figure above, because they never ran.
@@ -1477,7 +1521,7 @@ backend-wide code path, and it is still warranted by RADV; the refusal would
 have to become per-driver to exploit this, and the `shaderFloat16` plumbing §7
 notes as missing is still missing.
 
-### 11.3 The f16 narrowing on Intel OpenCL: **it does not fuse** — ACO's localisation confirmed
+### 11.3 The f16 narrowing on Intel OpenCL: **it does not fuse** — the AMD localisation confirmed
 
 This is the question §2's pocl row calls *"what localises the defect"*. The
 reading before this run: rusticl and HIP are two front ends onto one ACO
@@ -1485,6 +1529,20 @@ backend (620/63488 identical disagreements), RADV is a third and fuses worse,
 and pocl on x86 does not fuse — so the locus is ACO. pocl is a single negative,
 and pocl is also an LLVM-based CPU stack, which is not very far from ACO's
 family. Intel's IGC is a wholly independent implementation on a real GPU.
+
+> **The premise of that reading was wrong, and the correction is recorded in §2
+> ("Two AMD compilers").** hiprtc does *not* compile through ACO: it compiles
+> through **LLVM's AMDGPU backend**, while rusticl/radeonsi and RADV compile
+> through **ACO**, Mesa's shader compiler. Those are two different compilers.
+> The measurements are untouched — 620/63488 on both, same first divergence at
+> `x = 5.68359375` — but what they establish is **not** "one ACO bug seen
+> through two front ends". It is that the f32-multiply-into-f16-narrowing fusion
+> is present in **both** AMD GPU compilers: an AMD-toolchain-wide behaviour.
+> Everything below stands as measured; read "ACO" in it as "the AMD GPU
+> compilers" wherever it is used as a *locus* rather than as the name of the
+> specific Mesa component a given figure came from. Evidence tier for the
+> correction: **by-construction** (toolchain composition); no figure changes
+> tier.
 
 `tools/probes/opencl_f16_contraction_probe.c`, unmodified apart from the new
 control described below, exhaustive over all 63488 finite binary16 inputs, on
@@ -1516,11 +1574,17 @@ reproduces the known positive to the input, and `plain = 0` is a genuine null.
 
 **Result: neither Intel compiler fuses the f32 multiply into the f32→f16
 narrowing.** The naive codegen is already correct on both. This is the **second
-independent negative** for a non-ACO OpenCL implementation, and the first on a
-GPU with a vendor compiler sharing no lineage with Mesa. The reading in §2 is
-confirmed rather than widened: **the defect is ACO's, not OpenCL's and not
+independent negative** for a non-AMD OpenCL implementation, and the first on a
+GPU with a vendor compiler sharing no lineage with either AMD compiler. The
+reading in §2 is confirmed rather than widened on the axis it actually
+constrains: **the defect is AMD's GPU compilers', not OpenCL's and not
 SPIR-V's.** Had Intel fused, the consequence would have been the opposite one —
 a widespread vendor behaviour Sarek must defend against everywhere.
+
+What this run does *not* narrow is which AMD compiler. Both of them fuse
+(§2), so a negative from a third vendor cannot separate them, and no
+measurement here was ever going to: separating ACO from LLVM/AMDGPU needs two
+AMD stacks on the same card, which is exactly the pair already measured.
 
 ### 11.4 Unexpected: on IGC, the barrier that fixes ACO **breaks** a correct narrowing
 
@@ -1569,10 +1633,11 @@ by two facts that are structural rather than probabilistic:
 
 1. **The barrier is emitted from one site and it is preprocessor-scoped.**
    `Sarek_ir_cuda.sarek_f32_barrier_decl` puts the `asm volatile("" : "+v"(x))`
-   body inside `#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)`; the other
-   arm is a bare identity (§4). Its only runtime consumers are `Hip_plugin`
-   (hiprtc) and `Cuda_plugin` / `Cuda_c_plugin` (nvrtc). Evidence:
-   **by-construction**.
+   body inside `#if defined(__HIP_PLATFORM_AMD__)`; the other arm is a bare
+   identity (§4). Its only runtime consumers are `Hip_plugin` (hiprtc) and
+   `Cuda_plugin` / `Cuda_c_plugin` (nvrtc). Evidence: **by-construction**.
+   (That guard read `defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)` until
+   §11.4a below.)
 2. **IGC cannot receive that source.** f16 is refused outright by
    `Sarek_ir_opencl`, `Sarek_ir_glsl`, `Sarek_ir_metal` and `Sarek_ir_wgsl` — at
    the per-element-type arm *and* at a whole-kernel gate, across every public
@@ -1596,12 +1661,88 @@ to lie between the AMD guard and its `#else`, and the non-AMD arm to contain no
 non-AMD arm the AMD `"+v"` barrier — a mutation the pre-existing `"+f"`
 assertion does not see, and under which that new case is the only failure.
 
-**Not verified, and deliberately not fixed here:** the guard's `defined(__HIP__)`
-disjunct is also true under `__HIP_PLATFORM_NVIDIA__`, where `"+v"` is not a
-valid constraint. No HIP-on-NVIDIA toolchain exists on this project's machines,
-so the claim that this fails is **unverified**; the failure direction is a loud
-compile error rather than a wrong number, which is why it is recorded rather than
-patched blind.
+### 11.4a The guard now names the platform, and the hazard it was recorded for does not exist (backlog #146)
+
+§11.4 closed with this, and it is the sentence this section exists to correct:
+
+> **Not verified, and deliberately not fixed here:** the guard's
+> `defined(__HIP__)` disjunct is also true under `__HIP_PLATFORM_NVIDIA__`,
+> where `"+v"` is not a valid constraint.
+
+The second half is right and is now measured. The first half is **not supported
+by the toolchain's own headers**, and recording an unverified hazard is only
+useful if the hazard is stated correctly — this one was not.
+
+**What was measured, on this host (ROCm 7.2.53211, `libhiprtc.so.7`),
+reproducer `tools/probes/hip_macro_probe.c`:**
+
+| probe | result | tier |
+|---|---|---|
+| macros hiprtc predefines | `__HIP__` **defined**, `__HIP_PLATFORM_AMD__` **defined**, `__HIP_PLATFORM_NVIDIA__` **not**, legacy `__HIP_PLATFORM_HCC__` **not** | executed |
+| `#if defined(__HIP__) \|\| defined(__HIP_PLATFORM_AMD__)` (old) | selects the AMD arm, `"+v"` compiles | executed |
+| `#if defined(__HIP_PLATFORM_AMD__)` (new) | selects the AMD arm, `"+v"` compiles | executed |
+| a guard nothing defines (**liveness control**) | takes the other arm — `error: NON_AMD_ARM_TAKEN` | executed |
+| `"+v"` under `clang --target=nvptx64-nvidia-cuda` | **rejected** — `invalid output constraint '+v' in asm`; `"+f"` accepted | executed |
+| `clang -x hip --offload-arch=sm_61` | **refused** — `unsupported HIP gpu architecture`, on ROCm clang 22.0.0git *and* upstream clang 22.1.6 | executed |
+
+The arm-selection probes carry their own control: the non-AMD arm holds an
+`#error`, so "it compiled" is what proves the AMD arm was taken rather than
+merely that nothing broke — and the last row shows the same harness reporting
+the other arm on the same run, so `COMPILES` is a live result rather than a
+`#error` that turned out to be unreachable.
+
+**Why `__HIP__ && __HIP_PLATFORM_NVIDIA__` cannot arise.** `hip/hip_common.h`
+auto-enables `__HIP_PLATFORM_AMD__` whenever `__clang__ && __HIP__`, and
+auto-enables `__HIP_PLATFORM_NVIDIA__` only for `__NVCC__`, or for clang-CUDA
+**without** `__HIP__`; `hip/linker_types.h` then hard-`#error`s unless exactly
+one platform macro is set. So under HIP's own headers `__HIP__` **implies** the
+AMD platform, and the NVIDIA-platform route (`hipcc` → `nvcc`, or the
+`nvidia_detail/` wrappers) is the one on which `__HIP__` is never defined at all.
+Evidence: **by-construction**, reading the shipped headers.
+
+**Decision: narrow the guard anyway, to `#if defined(__HIP_PLATFORM_AMD__)`.**
+This is a **clarity change, not a bug fix**, and it is worth being exact about
+which:
+
+- *It fixes no reachable defect.* Nothing was mis-served by the old guard on any
+  configuration reachable with the compilers on this host.
+- *It cannot lose the AMD arm.* Measured directly above, and structurally
+  guaranteed by `hip_common.h`'s implication.
+- *It removes an ambiguity that has now cost two rounds of analysis.* The asm
+  body is AMD-ISA-specific; the guard should name the target, not the source
+  language. A reader who sees `__HIP__` in a guard around AMDGPU inline asm is
+  right to worry, and twice now has.
+- *The residual risk is named rather than absorbed:* ROCm older than the 4.x
+  `__HIP_PLATFORM_HCC__` → `__HIP_PLATFORM_AMD__` rename would define only the
+  legacy macro. No such toolchain exists here, so this is **unverified**. Its
+  failure direction is the bad one — the AMD arm is skipped and the f16
+  discipline fails *silently*, not loudly. That is why the guard is pinned by a
+  test rather than left to review.
+
+**The gate.** `test_f16_barrier_is_amd_scoped` gains a third assertion, on the
+guard **line** rather than the whole source: the barrier's `#if` must not
+contain `defined(__HIP__)`. (The f16 *include* above it legitimately keys on
+`__HIP__` — there the question really is "is this HIP", and both arms of getting
+it wrong fail loudly at compile time.) Proved red by restoring the disjunction,
+in **both orderings**, because they are caught by different assertions and only
+one of them exercises the new code:
+
+| mutation | case that went red | message |
+|---|---|---|
+| `defined(__HIP__) \|\| defined(__HIP_PLATFORM_AMD__)` | `f32 barrier is scoped to the AMD toolchain` | *the f32 barrier must be emitted under the AMD toolchain guard `"#if defined(__HIP_PLATFORM_AMD__)"`; it was not found at all* — the **pre-existing** exact-guard assertion, which the leading disjunct breaks before the new check is reached |
+| `defined(__HIP_PLATFORM_AMD__) \|\| defined(__HIP__)` | same case | *the barrier guard must not key on `__HIP__`* — the **new** assertion; this ordering is the one that slips past the exact-guard search |
+
+One failing case in each run, out of 114 in that suite, and nothing else moved.
+The second row is the one that matters: without it the new check would be
+unreachable, since the first assertion would always fire first — a check that
+cannot fail, in the shape a reviewer would not notice.
+
+**Still unverified after this**, and settleable in one sitting by anyone with the
+toolchain: what a genuine HIP-on-NVIDIA compile predefines. The prediction from
+the headers is that it defines neither `__HIP__` nor `__HIP_PLATFORM_AMD__`
+(the compiler is `nvcc`), so the identity arm is taken and nothing changes.
+Settling it needs no new code: build `tools/probes/hip_macro_probe.c` against a
+HIP-on-NVIDIA install and read the four macro rows.
 
 ### 11.5 The defect this surfaced in our own gate
 
@@ -1615,6 +1756,11 @@ red on Intel Arc and reported:
 > THE LOCUS-IS-ACO CLAIM IS NOW TOO NARROW. `Intel(R) Arc(TM) Graphics` is NOT
 > an ACO device, yet 4774 of 63488 finite binary16 inputs differ between the
 > naive and barriered narrowings — **it fuses too.**
+
+(That is the text as it stood. The check's wording was corrected again under
+#145 — "not an ACO device" is the right *scope* statement but the wrong *locus*
+statement, since the locus is both AMD GPU compilers and the `"ACO"` key selects
+Mesa stacks only. §2, "Two AMD compilers".)
 
 Both sentences are false, and §11.3 shows the plain kernel is correct on all
 63488 inputs. The check compared the plain kernel against the **barriered**

--- a/sarek-opencl/test/test_opencl_f16_tripwire.ml
+++ b/sarek-opencl/test/test_opencl_f16_tripwire.ml
@@ -539,16 +539,22 @@ let refusal_is_still_warranted () =
 
    Recording the CI observation was the immediate motive: on an AMD EPYC 7763
    runner under pocl, the naive and barriered kernels agree on all 63488 inputs.
-   That is worth keeping, because it is what separates *the ACO backend* from
-   *OpenCL in general* as the locus of the defect — and it is the second
-   independent reason to believe rusticl and HIP are ONE bug seen twice rather
-   than two coincidentally equal ones.
+   That is worth keeping, because it is what separates *AMD's GPU compilers*
+   from *OpenCL in general* as the locus of the defect.
 
-   docs/fp-contraction-policy.md now states that scoping as a claim. A claim
-   deserves a guard, so this asserts it rather than merely printing it: any
-   NON-ACO OpenCL implementation that DOES fuse would falsify "the locus is
-   ACO", and we want to be told. On every implementation measured so far it
-   passes trivially.
+   It does NOT separate the two AMD compilers from each other, and an earlier
+   version of this comment said it did. rusticl/radeonsi compiles through ACO
+   and hiprtc compiles through LLVM's AMDGPU backend — two different compilers
+   that produce the same 620/63488, which is two compilers agreeing rather than
+   one bug seen twice. See docs/fp-contraction-policy.md §2, "Two AMD
+   compilers".
+
+   docs/fp-contraction-policy.md states that scoping as a claim. A claim
+   deserves a guard, so this asserts it rather than merely printing it: an
+   out-of-scope OpenCL implementation that DOES fuse is something we want to be
+   told about, whether it widens the claim (a non-AMD fuser) or merely widens
+   this test's predicate (an AMD stack outside the "ACO" key). On every
+   implementation measured so far it passes trivially.
 
    The tradeoff is deliberate and stated: this can go red on hardware nobody has
    studied, and that red would be a genuine finding about the doc rather than a
@@ -580,7 +586,7 @@ let non_aco_implementations_do_not_fuse () =
   in
   if out_of_scope = [] then begin
     Printf.printf
-      "[SKIP] no non-ACO OpenCL device present to cross-check the locus-is-ACO \
+      "[SKIP] no out-of-scope OpenCL device present to cross-check the locus \
        claim against\n\
        %!" ;
     Alcotest.skip ()
@@ -628,17 +634,26 @@ let non_aco_implementations_do_not_fuse () =
               let d v = match f16_decode v with Some x -> x | None -> nan in
               let i = match first with Some i -> i | None -> 0 in
               Alcotest.failf
-                "THE LOCUS-IS-ACO CLAIM IS NOW TOO NARROW.\n\n\
-                 %s is NOT an ACO device, yet the naive narrowing disagrees \
-                 with Sarek's f16 discipline on %d of %d finite binary16 \
-                 inputs; first at x=%.9g (naive %.9g, discipline %.9g). The \
-                 discipline is the host reference, calibrated on the same run \
-                 by [host_models_reproduce_the_620], so this device really is \
+                "AN OUT-OF-SCOPE OPENCL IMPLEMENTATION FUSES.\n\n\
+                 %s is outside this test's \"ACO\" device-string scope, yet \
+                 the naive narrowing disagrees with Sarek's f16 discipline on \
+                 %d of %d finite binary16 inputs; first at x=%.9g (naive %.9g, \
+                 discipline %.9g). The discipline is the host reference, \
+                 calibrated on the same run by \
+                 [host_models_reproduce_the_620], so this device really is \
                  skipping a mandated rounding.\n\n\
-                 docs/fp-contraction-policy.md attributes this defect to \
-                 Mesa's ACO backend specifically, and cites the fact that \
-                 non-ACO OpenCL does not fuse as evidence that rusticl and HIP \
-                 are one bug seen twice. This device falsifies that scoping.\n\n\
+                 READ THE DEVICE BEFORE READING THE CLAIM. \
+                 docs/fp-contraction-policy.md §2 (\"Two AMD compilers\") \
+                 attributes this defect to BOTH of AMD's GPU compilers — ACO \
+                 and LLVM's AMDGPU backend — not to ACO alone. The \"ACO\" key \
+                 above selects Mesa stacks, so an AMD GPU reached through a \
+                 non-Mesa OpenCL (ROCm's, which compiles through LLVM/AMDGPU \
+                 like HIP) lands here while being an EXPECTED fuser: that is \
+                 not a falsification, it is the documented behaviour arriving \
+                 through an unkeyed door, and the fix is to widen the scope \
+                 predicate. A NON-AMD implementation fusing is the real \
+                 falsification, and it would mean the locus is not the vendor \
+                 toolchain at all.\n\n\
                  Do NOT fix this by excluding the device from the predicate. \
                  Widen the claim: re-measure with \
                  tools/probes/opencl_f16_contraction_probe.c on this platform \
@@ -682,7 +697,7 @@ let () =
             `Quick
             refusal_is_still_warranted;
           Alcotest.test_case
-            "non-ACO OpenCL implementations do not fuse (locus check)"
+            "out-of-scope OpenCL implementations do not fuse (locus check)"
             `Quick
             non_aco_implementations_do_not_fuse;
         ] );

--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -808,9 +808,49 @@ let cuda_fp16_include =
     local ptxas knows and fails if the discipline breaks. See
     [docs/fp-contraction-policy.md] and
     [docs/optimization/cuda-f16-fusion-sass-audit.md]. NO f16 kernel has been
-    EXECUTED on NVIDIA hardware; the claim is a machine-code claim. *)
+    EXECUTED on NVIDIA hardware; the claim is a machine-code claim.
+
+    WHY THE GUARD NAMES THE PLATFORM AND NOT THE LANGUAGE (backlog #146). The
+    guard is [defined(__HIP_PLATFORM_AMD__)] alone. It used to be
+    [defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)], and the second form
+    reads as though it admits HIP compiled for an NVIDIA target, where ["+v"] is
+    not a valid constraint. Measured on this host, ROCm 7.2.53211:
+
+    - hiprtc predefines BOTH [__HIP__] and [__HIP_PLATFORM_AMD__], and neither
+      [__HIP_PLATFORM_NVIDIA__] nor the legacy [__HIP_PLATFORM_HCC__]. All three
+      candidate guards select the AMD arm and compile the ["+v"] asm — checked
+      with [#error] in the other arm, so "it compiled" proves which arm was
+      taken. Evidence: EXECUTED (hiprtc).
+    - [hip/hip_common.h] auto-enables [__HIP_PLATFORM_AMD__] whenever
+      [__clang__ && __HIP__], and auto-enables [__HIP_PLATFORM_NVIDIA__] only
+      for [__NVCC__] or clang-CUDA WITHOUT [__HIP__]. [hip/linker_types.h] then
+      hard-[#error]s unless exactly one platform macro is set. So under HIP's
+      own headers [__HIP__] IMPLIES the AMD platform: the removed disjunct was
+      redundant, not load-bearing, and the NVIDIA-target-with-[__HIP__]
+      configuration those headers describe cannot arise. Evidence:
+      BY-CONSTRUCTION (the shipped headers).
+    - Both ROCm clang 22.0.0git and upstream clang 22.1.6 refuse
+      [-x hip --offload-arch=sm_61] outright ("unsupported HIP gpu
+      architecture"), so that configuration is not reachable with either
+      compiler on this host either. Evidence: EXECUTED.
+    - ["+v"] IS invalid on NVPTX, independently of HIP: clang rejects
+      [asm volatile("" : "+v"(x))] for [--target=nvptx64-nvidia-cuda] with
+      "invalid output constraint '+v' in asm", and accepts ["+f"]. Evidence:
+      EXECUTED. This is the part that was previously inferred from the
+      constraint vocabulary alone.
+
+    So this is a CLARITY change, not a bug fix: no reachable configuration was
+    mis-served by the old guard. It is made because the asm is AMD-ISA-specific
+    and the guard should say so — [__HIP__] is a LANGUAGE predicate that
+    constrains no target — and because the redundant disjunct has now twice led
+    a reader to conclude the barrier ships to NVPTX. STILL UNVERIFIED: ROCm
+    older than the 4.x rename, where [__HIP_PLATFORM_HCC__] was the platform
+    macro; no such toolchain exists here. If one is ever in play the AMD arm
+    would be skipped and the f16 discipline would fail silently, which is the
+    one direction this file cares about — [test_f16_barrier_is_amd_scoped] pins
+    the guard so the change cannot happen unnoticed. *)
 let sarek_f32_barrier_decl =
-  {|#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)
+  {|#if defined(__HIP_PLATFORM_AMD__)
 __device__ __forceinline__ float sarek_f32_barrier(float x) {
   asm volatile("" : "+v"(x));
   return x;

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -241,8 +241,11 @@ let rec glsl_type_of_elttype = function
          backend absorbs the f32->f16 narrowing into whatever arithmetic feeds
          it, via v_fma_mixlo_f16 — one rounding where the DSL mandates two.
 
-         This is the SAME backend compiler as the HIP and rusticl defects
-         (ACO), reached through a third front end, but it is NOT the same
+         This is the SAME backend compiler as the rusticl defect (ACO, Mesa's
+         shader compiler), reached through a second front end — and the same
+         defect CLASS as HIP, which reaches it through a different compiler
+         entirely (LLVM's AMDGPU backend; see docs/fp-contraction-policy.md §2,
+         "Two AMD compilers"). It is NOT the same
          severity. On HIP/OpenCL the fusion swallows the multiply only. Here it
          also swallows the f32 add, and — when an f32 barrier is placed around
          the multiply — it drops the intermediate narrowing altogether rather

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -278,11 +278,20 @@ let test_f16_conversions () =
     on the NVIDIA arm on the strength of an AMD measurement, gets a red rather
     than a silently portable-looking one.
 
+    Extended for #146 with the third thing the guard has to get right, after
+    "the asm is inside the AMD arm" and "the other arm is bare": WHICH MACRO the
+    arm is keyed on. [__HIP__] is a language predicate and constrains no target;
+    [__HIP_PLATFORM_AMD__] names the target that makes ["+v"] legal. The guard
+    carried both as a disjunction, and the redundant one is what made two
+    successive readers conclude the barrier ships to NVPTX.
+
     Evidence tier for the IGC figures: executed (Intel Arc, IGC). For "the
-    preprocessor is the right discriminator": by-construction. *)
+    preprocessor is the right discriminator": by-construction. For ["+v"] being
+    invalid on NVPTX: executed (clang 22.1.6, [--target=nvptx64-nvidia-cuda]
+    rejects it, accepts ["+f"]). *)
 let test_f16_barrier_is_amd_scoped () =
   let src = gen (f16_scale_kernel ()) in
-  let guard = "#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)" in
+  let guard = "#if defined(__HIP_PLATFORM_AMD__)" in
   let i_if = index_of ~needle:guard src in
   if i_if < 0 then
     Alcotest.failf
@@ -291,6 +300,30 @@ let test_f16_barrier_is_amd_scoped () =
        %s"
       guard
       src ;
+  (* The guard names the PLATFORM, never the LANGUAGE (#146). [__HIP__] says
+     "this translation unit is HIP", which constrains no target ISA;
+     [__HIP_PLATFORM_AMD__] says "the target is AMD", which is the only thing
+     that makes the "+v" VGPR constraint legal. Measured: clang rejects "+v" for
+     --target=nvptx64-nvidia-cuda ("invalid output constraint '+v' in asm") and
+     accepts "+f". The two are NOT interchangeable keys, even though HIP's own
+     hip_common.h currently makes __HIP__ imply __HIP_PLATFORM_AMD__ under
+     clang — that implication is a header's behaviour, not a language rule, and
+     it is not what this barrier should be resting on. Asserted on the guard
+     LINE rather than on the whole source because the f16 include above
+     legitimately tests __HIP__ (there the question really is "is this HIP",
+     and both arms fail loudly). *)
+  let guard_line =
+    let e = try String.index_from src i_if '\n' with Not_found -> i_if in
+    String.sub src i_if (e - i_if)
+  in
+  if contains ~needle:"defined(__HIP__)" guard_line then
+    Alcotest.failf
+      "the barrier guard must not key on __HIP__: it is a LANGUAGE predicate \
+       and admits any HIP target, while the asm body is AMDGPU-specific (clang \
+       rejects \"+v\" for nvptx64 with \"invalid output constraint\"). Use \
+       __HIP_PLATFORM_AMD__, which names the target. Guard line was:\n\
+       %s"
+      guard_line ;
   let i_else = index_from ~needle:"#else" ~from:i_if src in
   let i_endif = index_from ~needle:"#endif" ~from:i_if src in
   if not (i_else > i_if && i_endif > i_else) then

--- a/spoc/ir/Sarek_capability.mli
+++ b/spoc/ir/Sarek_capability.mli
@@ -13,8 +13,10 @@
 
     - Metal has no [double] at all. No device query can tell you that; it is a
       property of the Metal Shading Language.
-    - ACO fuses an f32 multiply into the f32→f16 narrowing regardless of what
-      the driver advertises. The device reports the feature and the feature is
+    - AMD's GPU shader compilers fuse an f32 multiply into the f32→f16 narrowing
+      regardless of what the driver advertises — ACO (via rusticl and via RADV)
+      and LLVM's AMDGPU backend (via hiprtc), two different compilers producing
+      the same 620/63488. The device reports the feature and the feature is
       broken. A device flag would say "yes".
     - Apple Silicon OpenCL reports no [cl_khr_fp64], but the question that
       actually decides whether a build succeeds there is whether the HOST clang
@@ -61,11 +63,13 @@ type kind =
           compile, never by querying a device. *)
   | Toolchain_semantic
       (** The device has the feature, the driver advertises it, and the shader
-          compiler mistranslates it anyway. ACO fusing an f32 multiply into the
-          f32→f16 narrowing is the type case: three front ends, one backend
-          compiler, and pocl on x86 does not do it — which localises the defect
-          to the compiler, not the device and not the API. Cannot be queried at
-          all. Only measured. A device saying "yes" must NOT override this. *)
+          compiler mistranslates it anyway. AMD's GPU compilers fusing an f32
+          multiply into the f32→f16 narrowing is the type case: three front ends
+          onto TWO backend compilers — ACO (rusticl, RADV) and LLVM's AMDGPU
+          backend (hiprtc) — while pocl on x86 and Intel IGC do not do it, which
+          localises the defect to the vendor's compilers, not the device and not
+          the API. Cannot be queried at all. Only measured. A device saying
+          "yes" must NOT override this. *)
   | Policy
       (** We refuse something that works, by decision. Distinct from
           {!Toolchain_semantic}: that kind is the evidence, this is the verdict.

--- a/tools/probes/hip_macro_probe.c
+++ b/tools/probes/hip_macro_probe.c
@@ -1,0 +1,124 @@
+/* hip_macro_probe.c — backlog #146
+ *
+ * Which macros does hiprtc actually predefine, and does the AMDGPU opacity
+ * barrier of Sarek_ir_cuda.sarek_f32_barrier_decl still land on the AMD arm
+ * under each candidate #if guard?
+ *
+ * The question it answers, from docs/fp-contraction-policy.md §11.4a: the
+ * barrier guard used to read
+ *
+ *   #if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)
+ *
+ * and the first disjunct reads as though it also admits HIP compiled for an
+ * NVIDIA target, where "+v" is not a valid constraint. Narrowing a guard is
+ * only safe if the narrowed form still fires on the path that needs it, and
+ * that is a measurement, not a review opinion.
+ *
+ * Deliberately standalone C rather than an OCaml test, for the same reason as
+ * the OpenCL probes: it must be able to say something about the hiprtc
+ * PREPROCESSOR without Sarek's codegen in the loop. It is a documented
+ * reproducer, not a CI gate — sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+ * (test_f16_barrier_is_amd_scoped) is the gate.
+ *
+ * Non-vacuity: every guard case puts an #error in the NON-AMD arm, so
+ * "COMPILES" proves the AMD arm was taken and that its "+v" asm is legal on
+ * this target. A guard that matched nothing would report FAILS with
+ * NON_AMD_ARM_TAKEN, and the last case exercises exactly that so the harness is
+ * shown able to go both ways on the same run.
+ *
+ * Build:
+ *   gcc -D__HIP_PLATFORM_AMD__ hip_macro_probe.c -I/opt/rocm/include \
+ *       -L/opt/rocm/lib -lhiprtc -Wl,-rpath,/opt/rocm/lib -o hip_macro_probe
+ *   (-D__HIP_PLATFORM_AMD__ is for the HOST compile of hiprtc.h, which errors
+ *    without a platform macro; it does not reach the device source below.)
+ *
+ * Measured 2026-07-27, ROCm 7.2.53211 / libhiprtc.so.7, RX 7900 XTX host:
+ *
+ *   __HIP__                     FAILS  -> defined
+ *   __HIP_PLATFORM_AMD__        FAILS  -> defined
+ *   __HIP_PLATFORM_NVIDIA__     COMPILES -> NOT defined
+ *   __HIP_PLATFORM_HCC__        COMPILES -> NOT defined (legacy, pre-4.x)
+ *
+ *   current: __HIP__ || __HIP_PLATFORM_AMD__   COMPILES  (AMD arm taken)
+ *   narrow:  __HIP_PLATFORM_AMD__ only         COMPILES  (AMD arm taken)
+ *   control: a macro nothing defines           FAILS     (non-AMD arm taken)
+ */
+#include <hip/hiprtc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int try_compile(const char *name, const char *src) {
+  hiprtcProgram p;
+  if (hiprtcCreateProgram(&p, src, "probe.hip", 0, NULL, NULL) !=
+      HIPRTC_SUCCESS) {
+    printf("%-42s CREATE-FAILED\n", name);
+    return -1;
+  }
+  hiprtcResult r = hiprtcCompileProgram(p, 0, NULL);
+  size_t n = 0;
+  hiprtcGetProgramLogSize(p, &n);
+  char *log = calloc(n + 1, 1);
+  if (n > 1) hiprtcGetProgramLog(p, log);
+  printf("%-42s %s", name, r == HIPRTC_SUCCESS ? "COMPILES" : "FAILS");
+  if (r != HIPRTC_SUCCESS) {
+    char *m = strstr(log, "error:");
+    if (m) {
+      char *e = strchr(m, '\n');
+      if (e) *e = 0;
+      printf("  | %s", m);
+    }
+  }
+  printf("\n");
+  free(log);
+  hiprtcDestroyProgram(&p);
+  return r == HIPRTC_SUCCESS;
+}
+
+/* FAILS => the macro IS defined. Stated this way round because a preprocessor
+   can only report a macro's presence by refusing to compile. */
+#define MACRO_PROBE(m)                                                         \
+  "#if defined(" m ")\n#error MACRO_" m "_IS_DEFINED\n#endif\n"                \
+  "__global__ void k(float* o) { o[0] = 1.0f; }\n"
+
+int main(void) {
+  puts("-- macro presence: FAILS => the macro IS defined --");
+  try_compile("__HIP__", MACRO_PROBE("__HIP__"));
+  try_compile("__HIP_PLATFORM_AMD__", MACRO_PROBE("__HIP_PLATFORM_AMD__"));
+  try_compile("__HIP_PLATFORM_NVIDIA__", MACRO_PROBE("__HIP_PLATFORM_NVIDIA__"));
+  try_compile("__HIP_PLATFORM_HCC__ (legacy)",
+              MACRO_PROBE("__HIP_PLATFORM_HCC__"));
+
+  puts("\n-- does each guard select the AMD asm arm, and does it build? --");
+  /* Body verbatim from Sarek_ir_cuda.sarek_f32_barrier_decl, except that the
+     non-AMD arm carries an #error so the taken arm is observable. */
+  const char *body =
+      "__device__ __forceinline__ float sarek_f32_barrier(float x) {\n"
+      "  asm volatile(\"\" : \"+v\"(x));\n"
+      "  return x;\n"
+      "}\n"
+      "#else\n"
+      "__device__ __forceinline__ float sarek_f32_barrier(float x) {\n"
+      "#error NON_AMD_ARM_TAKEN\n"
+      "  return x;\n"
+      "}\n"
+      "#endif\n"
+      "__global__ void k(float* o, const float* i) {\n"
+      "  o[0] = sarek_f32_barrier(i[0] * 1.1f);\n"
+      "}\n";
+  char buf[4096];
+
+  snprintf(buf, sizeof buf,
+           "#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)\n%s", body);
+  try_compile("current: __HIP__ || __HIP_PLATFORM_AMD__", buf);
+
+  snprintf(buf, sizeof buf, "#if defined(__HIP_PLATFORM_AMD__)\n%s", body);
+  try_compile("narrow: __HIP_PLATFORM_AMD__ only", buf);
+
+  /* Liveness control: a guard nothing satisfies must take the other arm and
+     report NON_AMD_ARM_TAKEN. Without this, every COMPILES above could mean
+     "the #error is unreachable for some unrelated reason". */
+  snprintf(buf, sizeof buf, "#if defined(__SAREK_NO_SUCH_MACRO__)\n%s", body);
+  try_compile("control: guard nothing defines", buf);
+  return 0;
+}

--- a/tools/probes/opencl_f16_contraction_probe.c
+++ b/tools/probes/opencl_f16_contraction_probe.c
@@ -2,8 +2,11 @@
  *
  * Standalone reproducer for the finding recorded in
  * docs/fp-contraction-policy.md, row "OpenCL / rusticl (f16 narrowing)":
- * the AMDGPU/ACO backend fuses the f32 multiply into the f32->f16 narrowing
- * that consumes it, rounding ONCE where Sarek's f16 discipline mandates twice.
+ * ACO — Mesa's shader compiler, reached here through rusticl/radeonsi — fuses
+ * the f32 multiply into the f32->f16 narrowing that consumes it, rounding ONCE
+ * where Sarek's f16 discipline mandates twice. (HIP hits the same defect with
+ * the same count through a DIFFERENT compiler, LLVM's AMDGPU backend; see
+ * docs/fp-contraction-policy.md §2, "Two AMD compilers".)
  *
  * Deliberately standalone C rather than an OCaml test: it must be able to say
  * something about the OpenCL stack WITHOUT Sarek's codegen in the loop, since


### PR DESCRIPTION
Closes #145. Closes #146.

## #145 — the fusion locus is misnamed

`docs/fp-contraction-policy.md` §11.3 described hiprtc and rusticl as *"two front ends onto one ACO backend"*. That is wrong. **hiprtc compiles through LLVM's AMDGPU backend; ACO is Mesa's shader compiler**, used by RADV and by rusticl via radeonsi. Two different compilers.

**No measurement changes and no evidence tier moves.** Both still report **620/63488** with the same first divergence at **x = 5.68359375**. What changes is what that means: not one bug seen through two front ends, but the same f32-multiply-into-f16-narrowing fusion present in **both** AMD GPU compilers independently — an AMD-toolchain-wide behaviour.

The non-AMD negatives (pocl/x86, Intel IGC, oneAPI CPU, NVIDIA) still rule out *OpenCL* and *SPIR-V* as the locus. They no longer support "ACO specifically", because the one non-Mesa stack that does fuse is AMD's own.

Evidence for the correction is **by-construction** (toolchain composition), verifiable on this host:

- ROCm ships its own clang/LLVM; `libamd_comgr` links `libLLVMAMDGPUCodeGen`, and §9.6's HIP measurements are already recorded as `AMD clang 22.0.0git`.
- Mesa names its compiler in the device string: `AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, …)`.

### Why this is not pedantry

"The locus is ACO" is exactly the sentence someone would use to scope a future barrier or detection predicate. Scoped to Mesa/ACO it misses the LLVM/AMDGPU path HIP takes; scoped to ROCm it misses rusticl and RADV. One instance was already live in the tree: `test_opencl_f16_tripwire`'s locus check told the reader that *any* non-ACO fuser falsifies the documented claim — but an AMD GPU reached through ROCm's OpenCL compiles through LLVM/AMDGPU and would fuse **by design** while sitting outside its Mesa-keyed `"ACO"` scope. Its failure text now separates "widen the predicate" from "widen the claim".

### Where the conflation appeared

| file | what it said |
|---|---|
| `docs/fp-contraction-policy.md` §11.3 | "rusticl and HIP are two front ends onto one ACO backend" |
| §2 opening bullet (Vulkan/RADV f16) | "Third front end onto the same ACO backend as HIP and rusticl" |
| §2 `OpenCL / rusticl` row | "Same defect class as HIP/AMDGPU, same ACO backend" |
| §2 `Vulkan / RADV` row | "Same ACO backend as HIP and rusticl, reached through a third front end" |
| §2 `OpenCL / pocl` row | "the locus is *the ACO backend*… read rusticl and HIP/AMDGPU as one bug seen through two front ends" |
| §3, §7, §10 | "only on ACO devices", "confirms the f16 fusion is ACO's", "backends that reach an ACO or NVIDIA compiler" |
| §11.5 | quotes the tripwire's "LOCUS-IS-ACO" failure text |
| `docs/design/capability-model.md` | "The ACO fact is a property of ACO — not of RADV, not of the device" (the design note for a future runtime predicate) |
| `spoc/ir/Sarek_capability.mli` | `Toolchain_semantic`: "three front ends, one backend compiler" |
| `docs/design/f16-dsl-element-type.md` | generalizable rule 1: "OpenCL and HIP … are the same compiler underneath" |
| `sarek/codegen/Sarek_ir_glsl.ml` | "the SAME backend compiler as the HIP and rusticl defects (ACO)" |
| `tools/probes/opencl_f16_contraction_probe.c` | "the AMDGPU/ACO backend fuses" |

§6 and §9 were checked and carry no instance. §9.6 already names `AMD clang` for the HIP path and is corroborating rather than conflating.

The corrected claim is stated once, in a new §2 note **"Two AMD compilers"**, and referenced from the rest. Historical quotations (§11.5's failure text, the f16 design-doc log) keep their wording and carry a dated correction rather than being rewritten.

## #146 — the barrier guard

`sarek/codegen/Sarek_ir_cuda.ml` guarded the f16 barrier with `#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)`. **Narrowed to `#if defined(__HIP_PLATFORM_AMD__)`.**

**The recorded hazard does not exist, and that is the more useful finding.** The claim was that `__HIP__` is also defined under `__HIP_PLATFORM_NVIDIA__`. HIP's own headers contradict it: `hip/hip_common.h` auto-enables `__HIP_PLATFORM_AMD__` whenever `__clang__ && __HIP__`, and auto-enables `__HIP_PLATFORM_NVIDIA__` only for `__NVCC__` or clang-CUDA **without** `__HIP__`; `hip/linker_types.h` then hard-`#error`s unless exactly one platform macro is set. Both ROCm clang 22.0.0git and upstream clang 22.1.6 also refuse `-x hip --offload-arch=sm_61` outright.

So this is a **clarity change, not a bug fix**, and §11.4a says so in those words. It is made because the asm body is AMD-ISA-specific and the guard should name the *target*, not the source *language* — and because the redundant disjunct has now twice led a reader to conclude the barrier ships to NVPTX.

Measured on this host, reproducer committed as `tools/probes/hip_macro_probe.c`:

| probe | result |
|---|---|
| macros hiprtc predefines | `__HIP__` ✓, `__HIP_PLATFORM_AMD__` ✓, `__HIP_PLATFORM_NVIDIA__` ✗, legacy `__HIP_PLATFORM_HCC__` ✗ |
| old guard | selects the AMD arm, `"+v"` compiles |
| new guard | selects the AMD arm, `"+v"` compiles |
| a guard nothing defines (**liveness control**) | takes the other arm — `error: NON_AMD_ARM_TAKEN` |
| `"+v"` under `clang --target=nvptx64-nvidia-cuda` | **rejected** — `invalid output constraint '+v' in asm`; `"+f"` accepted |

Each arm-selection case puts an `#error` in the non-AMD arm, so "it compiled" is what proves which arm was taken; the control shows the same harness reporting the other arm on the same run.

The last row is the one #146 asked for: `"+v"` being invalid on NVPTX was previously inferred from the constraint vocabulary, and is now executed.

**Residual risk, named rather than absorbed:** ROCm older than the 4.x `__HIP_PLATFORM_HCC__` → `__HIP_PLATFORM_AMD__` rename would define only the legacy macro, and there the AMD arm would be skipped and the f16 discipline would fail *silently*. No such toolchain exists here, so this is **unverified** — which is why the guard is pinned by a test rather than left to review.

### The gate

`test_f16_barrier_is_amd_scoped` (from #144) is **extended, not duplicated**: a third assertion, on the guard **line** rather than the whole source, requiring that the barrier's `#if` not contain `defined(__HIP__)`. The f16 *include* above it legitimately keys on `__HIP__` and is unaffected.

Proved red in **both** disjunction orderings, because they trip different assertions:

| mutation | case that went red | message |
|---|---|---|
| `defined(__HIP__) \|\| defined(__HIP_PLATFORM_AMD__)` | `f32 barrier is scoped to the AMD toolchain` | *the f32 barrier must be emitted under the AMD toolchain guard `"#if defined(__HIP_PLATFORM_AMD__)"`; it was not found at all* — the **pre-existing** exact-guard assertion |
| `defined(__HIP_PLATFORM_AMD__) \|\| defined(__HIP__)` | same case | *the barrier guard must not key on `__HIP__`* — the **new** assertion |

One failing case per run out of 114 in that suite; nothing else moved. The second row is why it is recorded: without that ordering the new check is unreachable behind the pre-existing search — a check that cannot fail, in the shape a reviewer would not notice.

## One PR, not two

The guard decision's justification *is* the naming correction — #144 closed on "the barrier is `#if`-scoped to the AMD toolchain", and that scoping is only correct because the two AMD compilers are distinguished. Both changes also land in the same section of `docs/fp-contraction-policy.md` (§11.4 / the new §11.4a). Splitting them would leave one PR recording a hazard the other disproves, and would stack a conflict for no review benefit.

## Verification

- `dune runtest --force`: **1447 OK, 0 FAIL, 23 SKIP**, 99 Alcotest suites.
- `dune build @fmt`: clean.
- Every skip is environmental — no NVIDIA device, no Metal, no non-Mesa OpenCL device. **None is new.** The locus check's skip is pre-existing and its `is_in_scope` predicate is untouched; only its label and failure message changed, so it moves in a by-name diff without changing behaviour.

## Not verified

- What a genuine HIP-on-NVIDIA compile predefines. No such toolchain here and none was installed. The prediction from the headers is that it defines neither `__HIP__` nor `__HIP_PLATFORM_AMD__` (the compiler is `nvcc`), so the identity arm is taken and nothing changes. Settleable in one sitting: build `tools/probes/hip_macro_probe.c` against a HIP-on-NVIDIA install and read the four macro rows.
- Pre-4.x ROCm, where only `__HIP_PLATFORM_HCC__` exists.
- The 620/63488 figures were **not** re-measured. The correction is an attribution, not new evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
