### PR TITLE
fix(dune): scope every multi-stanza test directory with explicit (modules) (#143)

### DIFF
--- a/formal/convergence-safety/test/dune
+++ b/formal/convergence-safety/test/dune
@@ -2,22 +2,27 @@
 
 (test
  (name test_convergence_conformance)
+ (modules test_convergence_conformance)
  (libraries qcheck-core qcheck-core.runner))
 
 (test
  (name test_convergence_extraction)
+ (modules test_convergence_extraction)
  (libraries convergence_model qcheck-core qcheck-core.runner))
 
 (test
  (name test_convergence_semantics)
+ (modules test_convergence_semantics)
  (libraries convergence_model qcheck-core qcheck-core.runner))
 
 (test
  (name test_convergence_live)
+ (modules test_convergence_live)
  (libraries sarek_frontend qcheck-core qcheck-core.runner))
 
 (test
  (name test_mutation)
+ (modules test_mutation)
  (libraries convergence_model qcheck-core qcheck-core.runner)
  (flags
   (:standard -w -37)))

--- a/formal/type-safety/test/dune
+++ b/formal/type-safety/test/dune
@@ -2,8 +2,10 @@
 
 (test
  (name test_type_safety_conformance)
+ (modules test_type_safety_conformance)
  (libraries type_safety_model sarek_frontend qcheck-core qcheck-core.runner))
 
 (test
  (name test_mutation)
+ (modules test_mutation)
  (libraries type_safety_model qcheck-core qcheck-core.runner))

--- a/sarek-metal/test/dune
+++ b/sarek-metal/test/dune
@@ -2,12 +2,15 @@
 
 (test
  (name test_metal_error)
+ (modules test_metal_error)
  (libraries sarek_metal sarek_backend_error alcotest str))
 
 (test
  (name test_sarek_ir_metal)
+ (modules test_sarek_ir_metal)
  (libraries sarek_metal sarek_ir alcotest str))
 
 (test
  (name test_metal_compile_options)
+ (modules test_metal_compile_options)
  (libraries sarek_metal alcotest))

--- a/sarek-vulkan/test/dune
+++ b/sarek-vulkan/test/dune
@@ -2,28 +2,35 @@
 
 (test
  (name test_vulkan_error)
+ (modules test_vulkan_error)
  (libraries sarek_vulkan alcotest str))
 
 (test
  (name test_sarek_ir_glsl)
+ (modules test_sarek_ir_glsl)
  (libraries sarek_vulkan sarek_ir alcotest str))
 
 (test
  (name test_vulkan_cache_two_kernels)
+ (modules test_vulkan_cache_two_kernels)
  (libraries sarek_vulkan alcotest))
 
 (test
  (name test_vulkan_ffi_check_funnel)
+ (modules test_vulkan_ffi_check_funnel)
  (libraries sarek_vulkan sarek_backend_error alcotest))
 
 (test
  (name test_vulkan_buffer_index_validation)
+ (modules test_vulkan_buffer_index_validation)
  (libraries sarek_vulkan spoc_framework alcotest str))
 
 (test
  (name test_vulkan_error_observability)
+ (modules test_vulkan_error_observability)
  (libraries sarek_vulkan sarek_ir sarek_backend_error alcotest))
 
 (test
  (name test_vulkan_f16_tripwire)
+ (modules test_vulkan_f16_tripwire)
  (libraries sarek_vulkan spoc_framework alcotest))

--- a/sarek/core/test/dune
+++ b/sarek/core/test/dune
@@ -7,8 +7,17 @@
   test_vector_transfer
   test_kernel_arg
   test_gpu_memory)
+ (modules
+  test_memory
+  test_kernel
+  test_device
+  test_vector
+  test_vector_transfer
+  test_kernel_arg
+  test_gpu_memory)
  (libraries spoc_core ctypes))
 
 (test
  (name test_nativeint_round_trip)
+ (modules test_nativeint_round_trip)
  (libraries spoc_core ctypes sarek_native sarek_interpreter))

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -27,6 +27,34 @@
   test_float16
   test_type_width_totality
   test_diagnostic_locations)
+ (modules
+  test_types
+  test_env
+  test_typer
+  test_parse
+  test_core_primitives
+  test_tailrec
+  test_tailrec_analysis
+  test_tailrec_elim
+  test_tailrec_bounded
+  test_tailrec_pragma
+  test_native_helpers
+  test_native_intrinsics
+  test_error
+  test_quote
+  test_lower_ir
+  test_reserved
+  test_ppx_registry
+  test_quote_ir
+  test_convergence
+  test_scheme
+  test_mono
+  test_ir_interp
+  test_execute
+  test_kirc_kernel
+  test_float16
+  test_type_width_totality
+  test_diagnostic_locations)
  ; Link sarek_stdlib to trigger auto-registration of intrinsics
  ; ctypes is listed explicitly (not relied on transitively via sarek): the
  ; GC-root canary in test_float16 asserts the managed-vs-unmanaged asymmetry
@@ -37,12 +65,14 @@
 
 (test
  (name test_cpu_runtime)
+ (modules test_cpu_runtime)
  (libraries sarek alcotest))
 
 ; Fusion tests use sarek library directly (no ppx needed)
 
 (test
  (name test_fusion)
+ (modules test_fusion)
  (libraries sarek))
 
 ; Interpreter tests removed - Sarek_interp was legacy SPOC-dependent
@@ -51,18 +81,21 @@
 
 (test
  (name test_float32)
+ (modules test_float32)
  (libraries sarek))
 
 ; Float64 module tests
 
 (test
  (name test_float64)
+ (modules test_float64)
  (libraries sarek.float64))
 
 ; PTX snapshot test — CPU-only, no CUDA device required
 
 (test
  (name test_ptx_snapshot)
+ (modules test_ptx_snapshot)
  (libraries sarek.codegen alcotest unix str))
 
 ; ptxas sweep over the WHOLE PTX intrinsic surface: one kernel per intrinsic
@@ -71,6 +104,7 @@
 
 (test
  (name test_ptx_intrinsic_sweep)
+ (modules test_ptx_intrinsic_sweep)
  (libraries sarek.codegen alcotest unix str))
 
 ; WGSL identifier escaping: injectivity + legality of escape_wgsl_name, and
@@ -80,6 +114,7 @@
 
 (test
  (name test_wgsl_escape)
+ (modules test_wgsl_escape)
  (libraries sarek.codegen alcotest))
 
 ; Shader-validation gate for recursion + vector-parameter helpers.
@@ -88,6 +123,7 @@
 
 (test
  (name test_shader_recursion_vector)
+ (modules test_shader_recursion_vector)
  (libraries sarek.codegen sarek_backend_error alcotest unix))
 
 ; Software f64 transcendentals for PTX: IR-level accuracy vs the OCaml stdlib
@@ -95,6 +131,7 @@
 
 (test
  (name test_f64_softmath)
+ (modules test_f64_softmath)
  (libraries sarek.codegen spoc.ir alcotest))
 
 ; Aggregate byte-layout test — pins the host ABI (packed offsets, variant
@@ -102,6 +139,7 @@
 
 (test
  (name test_ir_layout)
+ (modules test_ir_layout)
  (libraries spoc.ir alcotest))
 
 ; Regression test: Sarek_ppx.scan_file_for_sarek_types's `with _ -> ()`
@@ -112,12 +150,14 @@
 
 (test
  (name test_ppx_scan_diagnostics)
+ (modules test_ppx_scan_diagnostics)
  (libraries sarek_ppx alcotest))
 
 ; Tier 1a: host-side SoA layout/transpose round-trip (pure ctypes, no device)
 
 (test
  (name test_soa)
+ (modules test_soa)
  (libraries spoc_core spoc.ir ctypes alcotest))
 
 ; Negative controls for the OpenCL validation gate (#127/#128). Proves each
@@ -128,6 +168,7 @@
 
 (test
  (name test_opencl_gate)
+ (modules test_opencl_gate)
  (libraries sarek.codegen spoc.ir opencl_gate alcotest str unix))
 
 ; Negative controls for the Metal validation gate (#139). Layer 2 (xcrun metal)
@@ -137,6 +178,7 @@
 
 (test
  (name test_metal_gate)
+ (modules test_metal_gate)
  (libraries metal_gate alcotest str))
 
 ; Per-backend emission of SBarrier / SWarpBarrier / SMemFence. These are six
@@ -146,6 +188,7 @@
 
 (test
  (name test_sync_stmt_emission)
+ (modules test_sync_stmt_emission)
  (libraries sarek.codegen sarek_ppx_lib spoc.ir alcotest))
 
 ; Cross-backend intrinsic arm parity (#94). Records, per intrinsic, what each of
@@ -154,6 +197,7 @@
 
 (test
  (name test_backend_arm_parity)
+ (modules test_backend_arm_parity)
  (libraries sarek.codegen sarek_ir alcotest))
 
 ; Intrinsic-surface reconciliation: derives its expectation from
@@ -163,6 +207,7 @@
 
 (test
  (name test_intrinsic_surface)
+ (modules test_intrinsic_surface)
  (libraries
   sarek
   sarek.float64


### PR DESCRIPTION
Closes #143.

## Verdict: the red was an artefact. Nothing failed to typecheck.

`dune build @check` was red on `origin/main` while `dune build` and `dune build @all` were both green. **No source file is broken.** The reported errors — `Unbound module Sarek_native`, `Unbound module Convergence_model`, `Could not find the .cmi file for interface …` — are all produced by `@check` semantics interacting with a dune-file hygiene defect, not by any code that does not compile.

### The evidence

Classifying every failing compile action in `dune build @check --verbose` by whether the module being compiled belongs to the stanza compiling it:

```
failing compiles where the module IS the stanza's main module:     0
failing compiles where the module is FOREIGN to the stanza:      763
```

Zero. Not one module fails to typecheck in the stanza that actually owns it. And each individually named "broken" file builds fine on its own:

```
$ dune build sarek/core/test/test_nativeint_round_trip.exe \
             formal/convergence-safety/test/test_convergence_extraction.exe \
             sarek/tests/unit/test_parse.exe
exit 0
```

The hypotheses in the issue are both ruled out by inspection: there is **no `enabled_if` and no `(optional)`** in any of the six affected dune files, and **no `.mli` exists on disk** in any of those source directories.

### The mechanism

Six directories contain multiple executable/test stanzas and **not one `(modules ...)` field between them**:

| file | stanzas | `(modules)` fields |
|---|---|---|
| `sarek/tests/unit/dune` | 18 | 0 |
| `sarek-vulkan/test/dune` | 7 | 0 |
| `formal/convergence-safety/test/dune` | 5 | 0 |
| `sarek-metal/test/dune` | 3 | 0 |
| `formal/type-safety/test/dune` | 2 | 0 |
| `sarek/core/test/dune` | 2 | 0 |

Without `(modules ...)`, a stanza's default module set is **every module in the directory**. So all 18 stanzas in `sarek/tests/unit/` each nominally own all ~44 modules.

`dune build` and `@all` stay green because they link each executable from the transitive dependency closure of its main module — foreign modules are never compiled. `@check` requests `.cmi`/`.cmt` for *every* module of *every* stanza, unpruned, so each module gets recompiled under every other stanza's `(libraries)` and `(preprocess)`. Verified from `--verbose`:

```
ocamlc.opt ... -I .../.test_convergence_conformance.eobjs/byte \
  -I .../qcheck-core -I .../qcheck-core/runner \
  -o .../dune__exe__Test_convergence_extraction.cmo \
  -c -impl formal/convergence-safety/test/test_convergence_extraction.ml
```

`test_convergence_extraction.ml` compiled inside `test_convergence_conformance`'s scope, whose stanza declares only `qcheck-core` — hence `Unbound module Convergence_model`. (`Convergence_model` is an ordinary checked-in library at `formal/convergence-safety/extraction/dune:3-9`, *not* Rocq-extracted at build time.) Same story for `Unbound module Alcotest` ×31, `Sarek_stdlib` ×16, and `Uninterpreted extension 'expr'` (a stanza lacking the `(preprocess (pps ppxlib.metaquot))` its neighbour has).

The `Could not find the .cmi file for interface X.mli` class is the same root cause. There are no `.mli` files in the source tree, but dune's implicit empty interfaces (`executables_implicit_empty_intf`, default since dune lang 3.0) are generated into the shared `_build/default/<dir>/`. That generated `M.mli` sits physically beside `M.ml` for *every* stanza's compile, including stanzas whose bookkeeping schedules no `M.cmi` rule. `ocamlc -impl dir/M.ml` stats `dir/M.mli`, finds it, and demands the `.cmi`.

Minimal repro under `(lang dune 3.15)` — two `(test)` stanzas in one directory, one using `str`:

```
dune build         → 0
dune build @check  → 1   Could not find the .cmi file for interface t/b.mli
(modules) on b only  → still 1
(modules) on BOTH    → 0
```

**Partial coverage does not work.** Every stanza in a directory must be scoped.

## So why fix it rather than just document it?

Because the underlying defect is real even though the error messages were not. Unscoped stanzas mean dune recompiles every shared module once per stanza, any merlin/IDE view of these directories is ambiguous about which stanza owns a file, and `@check` cannot be used as a gate at all — its red carries no signal.

The fix is to add an explicit `(modules ...)` to all 37 stanzas across the six files. **71 added lines, 0 removed** — verified purely additive; no `(libraries)`, `(preprocess)`, `(flags)`, `(deps)` or `(include_subdirs)` field was altered.

The module partition came out **total and disjoint in all six directories**, 1:1 module-to-test throughout. No directory had a shared helper, so nothing needed extracting into a library and no assignment was ambiguous.

## Verification

| | before | after |
|---|---|---|
| `dune build @check` | **exit 1**, 152 error locations, 145 `Error:` lines | **exit 0**, 0 errors |
| `dune build` | 0 | 0 |
| `dune test --force` | 0 | 0 |

Test counts are **unchanged**: 23 SKIP, 0 FAIL, identical case and suite totals before and after. Beyond counts, the two full run logs were diffed with timings, run IDs and qcheck seeds normalised away — **zero differing `[OK]`/`[FAIL]`/`[SKIP]` lines**. All 23 skips are pre-existing hardware/toolchain gates.

Repo guards: `./scripts/check-test-alias-coverage.sh` 0, `node scripts/check-alcotest-registration.js` 0, `dune build @fmt` 0.

### Proving the gate can fail

`@check` going green is only meaningful if it can still go red. Two independent mutation probes, on different files:

- Deleting `(modules test_metal_error)` from `sarek-metal/test/dune` → `@check` exit 1, failing on `test_metal_compile_options.ml` and `test_sarek_ir_metal.ml`.
- Deleting `(modules test_type_safety_conformance)` from `formal/type-safety/test/dune` → `@check` exit 1, `Could not find the .cmi file for interface formal/type-safety/test/test_mutation.mli`.

Both restored to exit 0. Note the shape in each case: removing `(modules)` from *one* stanza breaks the *others* — exactly the leaked-implicit-interface mechanism described above, which is what makes the diagnosis load-bearing rather than a story that merely fits.

## Relationship to #147

Same family, separate PR. #147 (#330) is a directory dune could not see; this is a set of modules dune thought belonged to stanzas that never wanted them. Both are the build system's view of the tree diverging from a human's, and in both the divergence read as green. They are kept apart because the changes share no files and review very differently — #147 is archaeology plus a new CI guard, this is a mechanical scoping pass.

## Notes

- `sarek/tests/unit/ktype_variant_field/` is a nested single-stanza directory; single-stanza directories cannot exhibit this bug, so it is untouched.
- `dune build @fmt` emits pre-existing odoc markup warnings from `test_ptx_snapshot.ml`. Non-fatal, unrelated, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
