### PR TITLE
measure(metal): the f16 narrowing does not fuse, and simdgroup_matrix has no integer path (#63 slices 5-6)

### DIFF
--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -11,6 +11,15 @@ proportional to the strength of the evidence). **No refusal is lifted by this
 change.** **Issues:** #62, #63; depends on the f16 scalar type (#57) and the
 capability model (#64). **Date:** 2026-07-27.
 
+**Amended 2026-07-27 (Metal measurement).** §7 slices 5 and 6 are **done** — an
+Apple M4 became reachable, both probes ran, and the results are wired in: §2
+gains a Metal row (**strict**, 0/63488, no relaxation needed) and the document's
+first **Regime B** rows. Two things changed that are not just new rows: **§1.3's
+ceiling was wrong** and is corrected to evaluate at the elided narrowing rather
+than on the final value, with the counterexample that broke it; and **§8's
+integer-coopmat fallback is Vulkan-only**, because Metal has no integer
+`simdgroup_matrix` at all. **Still no refusal is lifted by this change.**
+
 **Read §0.1 first.** It is one paragraph and it is the argument every other
 choice here follows from.
 
@@ -153,16 +162,63 @@ decide whether it is a near-miss or garbage. Mirroring
 `Test_helpers.df64_collapsed_ceiling`:
 
 > **`f16_relaxed_ceiling`** — no admitted deviation may exceed **1 ulp of the
-> binary16 result**, measured on the final value, with subnormal results compared
-> absolutely against `2^-24` (the binary16 subnormal spacing). Derivation, not a
-> round number: every deviation in the admitted class is the *elision of exactly
-> one round-to-nearest step*, and a single elided rounding moves a value by at
-> most half an ulp at the elided step, which is at most one ulp at the final step.
-> Anything larger is not a rounding difference and must not be filed as one.
+> binary16 value produced by the narrowing at which the rounding was elided**,
+> with subnormal results compared absolutely against `2^-24` (the binary16
+> subnormal spacing). Derivation, not a round number: every deviation in the
+> admitted class is the *elision of exactly one round-to-nearest step*, and a
+> single elided rounding moves a value by at most half an ulp at the elided step,
+> hence at most one ulp of that step's own result. Anything larger is not a
+> rounding difference and must not be filed as one.
+
+**The ceiling is evaluated at the elided narrowing, NOT on the kernel's final
+value, and that is a correction.** The first version of this section said "the
+final value", on the reasoning that half an ulp at the elided step is "at most
+one ulp at the final step". **That last inference is false**, and it was measured
+false on Metal — the one backend swept with a control able to compute the
+admitted model exactly (`fp-contraction-policy.md` §10.14,
+`tools/probes/metal_f16_narrowing_probe.m`).
+
+> **The case that broke it.** Shape `f16(f16(x*1.1) + 1000)` at
+> **`x = -907.5`**. The exact product is `-998.250021636…`, whose binary32
+> rounding is **exactly `-998.25`** — a binary16 tie in the binade [512, 1024),
+> where the ulp is 0.5. `S_strict` rounds that tie to even and gets `-998`, then
+> `-998 + 1000 = ` **`2.0`**. `S_fuse_mul_into_narrowing` narrows the exact
+> product instead, is not sitting on the tie, gets `-998.5`, then
+> `-998.5 + 1000 = ` **`1.5`**.
+>
+> The deviation at the elided narrowing is `-998` against `-998.5`: **exactly 1
+> ulp of binary16 there**, as the derivation says. But 2.0 and 1.5 lie in the
+> binade [1, 2), where the binary16 ulp is `2^-10`, so on the **final** value the
+> same deviation measures **512 ulp** (against the smaller magnitude, 1.5) or
+> **256 ulp** (against 2.0) — the count depends on which of the two you take as
+> the denominator, and a gate must say which. Either way it is hundreds of ulps
+> against a ceiling of one, produced by the *admitted* model on a *conforming*
+> device.
+
+The mechanism is general and has nothing to do with Metal: the `+ 1000` cancels
+the leading bits, so the result lands in a far smaller binade than the value the
+rounding was elided at, and the ulp is re-scaled by the ratio of the two binades.
+Any expression in which a narrowing is followed by a cancelling operation does
+this. A final-value ceiling is therefore not merely loose — it **rejects correct
+results**, which is worse than the failure mode it was written to catch.
+
+**Consequences for the harness.** `classify_f16_result` (§7 slice 0) must
+evaluate the ceiling per *narrowing*, which means the reference models have to
+expose their intermediates rather than only their final value. That is a small
+change to `ref_discipline` / `ref_fused` — they already compute the intermediates
+— but it must be made deliberately, because the natural implementation compares
+only what the kernel wrote to memory. Where a shape's intermediates are not
+observable, the ceiling is **not applicable** and must be reported as such rather
+than silently evaluated on the final value.
 
 The ceiling is **necessary and not sufficient** — §1.1 is the proof, since the
 IGC dropped-narrowing defect sits exactly at 1 ulp. Both checks run; both must
-pass.
+pass. Note that §0.1 and §1.1 are unaffected by this correction and were
+re-read against it: both argue about a deviation *at the narrowing* — the
+dropped-narrowing defect and the fused multiply are compared where they occur —
+so the observation that a pure ulp gate cannot separate them stands exactly as
+written, and if anything is strengthened, since the correct evaluation point is
+now stated rather than left to the reader.
 
 ### 1.4 What "deterministic" means, operationally
 
@@ -249,9 +305,9 @@ ambiguous and the two answers differ in kind, not degree.
 
 These are the numbers this design holds itself to, for **Regime A** (scalar f16,
 §1.2). Every row names the device and the driver, per `fp-contraction-policy.md`
-§1 corollary 3. Evidence tiers are that document's. Regime B has no rows here —
-no coopmat implementation's numerics have been measured at all (§4, last
-paragraph).
+§1 corollary 3. Evidence tiers are that document's. **Regime B now has rows too**,
+below the Regime A table — Metal's `simdgroup_matrix`, measured 2026-07-27. RADV's
+coopmat numerics remain unmeasured (§4, last paragraph).
 
 **No stack in this table is settled as relaxable.** Both non-zero rows are
 **candidates**, and neither has met the acceptance rule of §1.2: rusticl's
@@ -269,17 +325,62 @@ neither. Read the verdict column as the current status, not as a plan.
 | **OpenCL / pocl (x86), Intel IGC, Intel oneAPI CPU** | AMD EPYC 7763 (CI), Intel Arc Graphics (MTL), Core Ultra 9 185H | **0 / 63488** | n/a | executed | **strict**; refusal is currently over-broad here |
 | **Vulkan / RADV** | RX 7900 XTX (NAVI31) + Raphael iGPU (RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1 | **2912 / 63488** on `f16(x*1.1)`; **5075** plain / **4776** with `precise` on `f16(f16(x*1.1)+1000)` | one-narrowing shape: **exact, 0/63488 against a single-rounding model**. Two-narrowing shape: **not measured against any model**, and `precise` changes the count, so a single model does not obviously cover it | executed | **candidate for the one-narrowing shape only**; blocked on slice 1 |
 | **Vulkan / ANV** | Intel Arc Graphics (MTL), Mesa 26.1.2-arch3.1 | **0 / 63488** | n/a | executed | **strict**; refusal is currently over-broad here |
-| **Metal** | — | **never probed** | — | none | **`Unknown` → refused.** Needs ladon (§7) |
+| **Metal** | Apple M4, macOS 15.6.1 (24G90), Apple clang 17.0.0 (clang-1700.0.13.5), Metal.framework from the Command Line Tools SDK | **0 / 63488** on `f16(x*1.1)` **and 0 / 63488** on `f16(f16(x*1.1)+1000)`; unchanged under `#pragma METAL fp contract(off)`, `#pragma clang fp contract(off)`, a `volatile thread` barrier and an `as_type` bitcast barrier | n/a — no deviation to model. The `fusedctl` control, on the same source, compile options and dispatch, reproduces `S_fuse_mul_into_narrowing` on **63488 / 63488** and reports 2912 / 620 | executed, **element-wise** over the whole finite binary16 domain | **strict**; refusal is currently over-broad here |
 | **WGSL / naga** | — | **never probed** | — | none | **`Unknown` → refused** |
 | **PTX** | — | refuses kernel-level f16 by design (#57 slice 2) | — | by-construction | nothing to relax |
 
-Three things this table says that are easy to miss:
+**Regime B rows — cooperative matrix (§5), Metal only.** These are the first
+numeric measurements of any cooperative-matrix implementation in this project;
+§4's Vulkan row records availability and explicitly says nothing about what RADV
+*computes*. Instrument: `tools/probes/metal_simdgroup_matrix_probe.m`,
+`fp-contraction-policy.md` §10.15. `D = A×B + C` with `C` nonzero throughout, so
+the constant is `γ_8` and not the `C = 0` degenerate case; §5.3's exactness
+invariant is asserted by the harness (21 binades, 50 bits, binary64 has 53); both
+of §5.4's controls fire.
+
+| configuration | device | within §5's bound? | closed-form model? | evidence | regime |
+|---|---|---|---|---|---|
+| `simdgroup_half8x8 × half8x8 → float8x8`, 8×8×8 | Apple M4, as above | **0 / 65536 outside**; worst 2.67e-07 against `γ_8` = 4.7684e-07 | **YES — bit-equal on 65536 / 65536** to *"initialise the accumulator to `C`, then add the eight products in index order, all in binary32"* | executed, element-wise | **A** (migrated from B — see below) |
+| `simdgroup_half8x8 × half8x8 → half8x8`, 8×8×8 | Apple M4, as above | **0 / 65536 outside**; worst 2.12e-03 against `γ_8` = 3.9216e-03 | **no** — 65520 / 65536 against sequential binary16; the 16 stragglers match neither pairwise binary16 nor a binary32 chain narrowed at the end | executed, element-wise | **B**; §5.4's "do not admit without a separate argued case" now rests on a measurement |
+
+> **This is the first configuration to migrate B → A, and that matters more than
+> the row.** §1.6's last table row says a Regime B configuration moves to Regime A
+> *"if a given implementation's accumulation order is ever pinned to a closed
+> form"*, and §6.1's corollary says friction falls with it, "with no new decision
+> needed". That was written as a mechanism nobody had exercised. It has now been
+> exercised: Metal's f16×f16→f32 `simdgroup_matrix` MulAdd is not merely inside
+> the bound, it **is** a named closed-form function of its inputs, agreed
+> bit-for-bit on every one of 65536 elements. Under §1.6 it is therefore Regime A,
+> and under §6.1 the DSL author gets a **loud one-time diagnostic rather than a
+> mandatory `accept_relaxed_f16` opt-in**. No decision was needed to move it; the
+> measurement moved it. **The migration path is real rather than theoretical**,
+> which is the part that makes the regime split credible rather than a way of
+> having two rules.
+>
+> Scope, stated so the row is not over-read: one implementation, one tile size
+> (8×8×8, the only one Metal offers), `C` drawn from one distribution, and
+> **nothing here constrains RADV**, whose coopmat numerics remain entirely
+> unmeasured. A Regime A verdict is per *(implementation, configuration)*, exactly
+> as §1.2's model set is per *(backend, driver, shape)*.
+>
+> One methodological note, because it is the reason the row says "C FIRST".
+> An earlier revision of the probe pinned `C = 0` and reported 65536/65536
+> against "sequential binary32". That claim was *underdetermined*, not wrong:
+> with `C = 0` the C-first and C-last orders are the same function. A nonzero `C`
+> separates them decisively — 65536 against 51850 — so **the closed form could
+> not have been identified at all without §5.1's insistence that the operation is
+> `A×B + C`.** §5.1 records that correction as having been made on paper; this is
+> it reproduced from the measurement side.
+
+Three things the Regime A table says that are easy to miss:
 
 1. **The relaxation is a candidate on exactly two stacks** — rusticl and RADV,
    both ACO — and admitted on none of them yet. Everything else either already
    meets `S_strict` or has never been measured. Even in the best case this is a
    much narrower change than "relax f16"; in the worst case (§9.3) it is narrower
-   still, covering one shape on one driver.
+   still, covering one shape on one driver. **Metal has now joined the strict
+   group rather than the candidate group**, which is the outcome that needed no
+   relaxation at all.
 2. **The RADV two-narrowing shape is the open risk.** 5075 plain against 4776
    with `precise` means the decoration *changes the answer* while
    `fp-contraction-policy.md` §6 shows it produces byte-identical ISA on the
@@ -288,11 +389,13 @@ Three things this table says that are easy to miss:
    it stays refused and the contract becomes per-shape — a materially worse
    design, and the owner should hear about it before more effort is spent. Slice 1
    is the decision point.
-3. **pocl, IGC, ANV and the Intel CPU runtime are refused today for a defect they
-   do not have.** `capability-model.md` §5 already records this as the
+3. **pocl, IGC, ANV, the Intel CPU runtime and now Metal are refused today for a
+   defect they do not have.** `capability-model.md` §5 already records this as the
    over-refusal that follows from having no compiler-identity probe. It is not
    made worse by this design, and slice 2's `VkPhysicalDeviceDriverProperties`
-   plumbing narrows the Vulkan half of it.
+   plumbing narrows the Vulkan half of it. Metal is the clearest case: it is
+   measured strict **element-wise** on both shapes, which is a stronger evidence
+   tier than any other row in the table carries, and it is still refused.
 
 ---
 
@@ -460,7 +563,11 @@ wrong, and a correct result with a nonzero `C` would have failed the gate.
 - **Stated against `Σ|terms|`, never against the result.** A cancelling dot
   product has unbounded *relative-to-result* error under any summation order, so a
   relative-to-result bound would be a number that cannot fail. The denominator is
-  `Σ_k |A[m][k]·B[k][n]| + |C[m][n]|`.
+  `Σ_k |A[m][k]·B[k][n]| + |C[m][n]|`. **Re-checked against §1.3's correction and
+  unaffected:** the defect that forced §1.3 to move off the final value is
+  cancellation re-scaling the unit of measure, and this bound already refuses to
+  measure against the result for the same underlying reason. Regime B needed no
+  change; Regime A did.
 - **The bound assumes the implementation's intermediate accumulation is at
   least binary32.** If it is wider, the true error is smaller and the bound still
   holds. If it is *narrower* — an implementation accumulating the f32-result
@@ -635,15 +742,15 @@ branch on it rather than discovering it in a diagnostic.
 Each slice names what it proves and what hardware it needs. Nothing below lifts a
 refusal before slice 3.
 
-| # | slice | proves | hardware | lifts a refusal? |
-|---|---|---|---|---|
-| **0** | the contract, as a testable classifier | the gate can tell `S_fuse_mul_into_narrowing` from a dropped narrowing | none (host-only) | no |
-| **1** | element-wise model characterisation of ACO scalar f16, all emittable shapes | whether the contract of §1.2 is deliverable at all | RX 7900 XTX (local) | no |
-| **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no |
-| **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist |
-| **4** | #62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) |
-| **5** | #63 Metal — **scalar f16 first** | the Metal row of §2, which does not exist | **ladon (M4) — permission needed** | no |
-| **6** | #63 Metal `simdgroup_matrix` | the Apple tensor-core path | **ladon** | yes |
+| # | slice | proves | hardware | lifts a refusal? | status |
+|---|---|---|---|---|---|
+| **0** | the contract, as a testable classifier | the gate can tell `S_fuse_mul_into_narrowing` from a dropped narrowing | none (host-only) | no | open — and now also carries §1.3's per-narrowing ceiling |
+| **1** | element-wise model characterisation of ACO scalar f16, all emittable shapes | whether the contract of §1.2 is deliverable at all | RX 7900 XTX (local) | no | open (decision point) |
+| **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | open |
+| **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist | open |
+| **4** | #62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | open |
+| **5** | #63 Metal — **scalar f16 first** | the Metal row of §2 | ladon (M4) | no | **DONE 2026-07-27 — strict, 0/63488** |
+| **6** | #63 Metal `simdgroup_matrix` | the Apple tensor-core path | ladon (M4) | yes | **DONE 2026-07-27 — availability + numerics; no integer path** |
 
 ### Slice 0 — make the contract fail-able (host-only, lands first)
 
@@ -659,9 +766,22 @@ recorded there.
 
 Calibration, running with no GPU: the two host models must separate on exactly
 **620** over the finite binary16 domain — the figure independently reproduced on
-hiprtc/gfx1100, rusticl/radeonsi and `fusedctl` on Intel Arc.
-`test_opencl_f16_tripwire` already does this after §11.5 and it is the model to
-copy.
+hiprtc/gfx1100, rusticl/radeonsi, `fusedctl` on Intel Arc, and now by the Metal
+probe's round-to-odd control on the M4 (`fp-contraction-policy.md` §10.14), which
+is four unrelated stacks. `test_opencl_f16_tripwire` already does this after
+§11.5 and it is the model to copy.
+
+**`f16_relaxed_ceiling` is per-narrowing, not per-result (§1.3), and slice 0 is
+where that is built rather than retrofitted.** The models must expose their
+intermediate binary16 values so the ceiling can be evaluated where the rounding
+was elided; a `classify_f16_result` that compares only final values cannot
+implement §1.3 as corrected and will reject correct results on any shape with a
+cancelling operation after a narrowing. Add a host-only calibration for exactly
+that: the shape `f16(f16(x*1.1)+1000)` at **`x = -907.5`**, where the two models
+differ by **1 ulp at the narrowing** and by **512 ulp on the final value** — the
+case that broke the first formulation. It must classify as `Known_relaxation`,
+and a ceiling evaluated on the final value must be shown to *fail* it, or the
+correction is not actually in force.
 
 **Proves, and this is the whole point of the slice:** feed the classifier the
 IGC dropped-narrowing signature (4774/63488, first divergence `x = 0.681640625`)
@@ -759,7 +879,8 @@ and needs nothing from the DSL:
   rather than advisory**:
 
   - **Dimensions are not hard-coded.** Must accommodate 16×16×16 subgroup-scope
-    (Vulkan, measured §4) *and* 8×8×8 (`simdgroup_half8x8`, Metal).
+    (Vulkan, measured §4) *and* 8×8×8 (Metal, measured §7 slice 6 — 8×8 is the
+    **only** size MSL offers, so this is a hard requirement and not a guess).
   - **Component types admit integers from the start** — `u8`/`s8` operands with
     `u32`/`s32` accumulate, including the saturating variants. This is §8's
     recommendation and it is adopted: 12 of the 14 configurations advertised on
@@ -776,6 +897,17 @@ and needs nothing from the DSL:
     contract, and #62 is not blocked on the accuracy question at all. That
     fallback only exists if 4b was built for it.
 
+    **The fallback is #62's, not #63's — measured, not assumed.** Metal has *no*
+    integer `simdgroup_matrix`: the only element types are `half`, `float` and
+    `bfloat`, and integers fail a named `is_simdgroup_matrix_element<T>`
+    static_assert, so the enumeration is closed (§7 slice 6). An earlier reading
+    of this bullet implied every backend had a strict-contract path to fall back
+    on. **#63 does not.** On Metal the tensor-core path is reachable only through
+    the relaxation, which makes #63 strictly more exposed to it than #62 — if the
+    relaxation were withdrawn, #62 could still ship integer configurations and
+    #63 could ship nothing. Admitting integer component types remains right for
+    the reasons above; it is simply not a universal safety net.
+
   The *slicing* is deliberately **not** reordered to put integers first — f16
   scalar is a prerequisite for #63 and for bf16 regardless
   (`f16-dsl-element-type.md` §11.1), so the relaxation work is resequenced rather
@@ -785,35 +917,82 @@ and needs nothing from the DSL:
 - **4c — GLSL codegen for the fragment type**, gated on the `Device_optional`
   coopmat capability. The Raphael iGPU is the free negative device (§4).
 
-### Slices 5 and 6 — #63, Metal (needs ladon; permission not yet requested)
+### Slices 5 and 6 — #63, Metal — **DONE, 2026-07-27**
 
-**#63 cannot start at the matrix layer.** `fp-contraction-policy.md` §3 lists
-Metal f16 on the "may NOT rely on" list with the note that it has **never been
-probed**, and §2's Metal row covers f32 only. There is no Metal row in §2 of this
-document because there is no measurement to put in it. So:
+Both were unschedulable pending access to an Apple GPU. Access was granted, the
+probes were run on ladon, and both slices are complete. Recorded in
+`fp-contraction-policy.md` §10.14 and §10.15; the rows are in §2 above.
 
-- **Slice 5 — scalar f16 on Metal.** A standalone probe in the shape of the
-  existing `tools/probes/metal_math_mode_probe.m` and
-  `metal_contraction_barrier_probe.m`: exhaustive sweep of all 63488 finite
-  binary16 inputs against `S_strict` and `S_fuse_mul_into_narrowing`, with the
-  `fusedctl`-style positive control. Note Metal's contraction defence is a
-  *source pragma* (`#pragma METAL fp contract(off)`) and none of the compile
-  options stop contraction (§2, §10.5 of the policy doc) — so the probe must
-  sweep with and without the pragma. This is a **measurement, not a code
-  change**, and it produces the Metal row that §2 lacks.
-- **Slice 6 — `simdgroup_matrix`.** Enumerate what MSL actually offers on the M4
-  (`simdgroup_half8x8` / `simdgroup_float8x8`), then the 4a-equivalent
-  hand-written kernel against the §5-style derived bound, recomputed for K = 8.
+- **Slice 5 — scalar f16 on Metal. Done: it does not fuse.** 0 / 63488 from
+  `S_strict` on both swept shapes, element-wise, on the naive kernel and under
+  every barrier. Instrument `tools/probes/metal_f16_narrowing_probe.m`. Two
+  results worth carrying forward beyond the row:
+  - `#pragma METAL fp contract(off)` **does not govern this hazard**, in either
+    direction — it does not move the plain kernel and does not disturb the
+    control. That is not inertness: §10.5 measures the same pragma taking
+    `a*b+c` from 8773/8773 to 0/8773 on this device. Contraction of `a*b+c` and
+    absorption of a multiply into an f32→f16 narrowing are two behaviours, and
+    Metal exhibits neither.
+  - The control had to be built differently, and that is a portability note for
+    slice 0: **MSL has no `double`**, so the `fusedctl` construction used on
+    OpenCL is not expressible. The Metal control reconstructs the exact product
+    from a double-float pair with a round-to-odd step. It reproduces **620**,
+    which is now four unrelated stacks agreeing on that figure.
+  - It also produced the counterexample that corrected §1.3. See there.
+- **Slice 6 — `simdgroup_matrix`. Done, and it disproved a planning assumption.**
+  MSL offers exactly three instantiations, all 8×8: `half`, `float`, `bfloat`.
+  Every other size fails `_valid_simdgroup_matrix_size` and every integer type
+  fails `is_simdgroup_matrix_element<T>`, both named `static_assert`s — so this is
+  a **closed enumeration, not a sample**. Numerics are in §2's Regime B rows: the
+  f32-accumulate configuration matches a closed-form model element-wise and
+  migrates to Regime A; the f16-accumulate one does not.
 
-**Ladon usage: not requested, not used.** An M4 is reachable at
-`ssh -i ~/.ssh/id_ed25519 ladon`. Nothing in this document has touched it. The
-minimum ask, if permission is granted, is: build and run two standalone probe
-binaries in a scratch directory, install nothing, change no settings, touch no
-working tree. Slices 5 and 6 are unschedulable until that is agreed.
+> **The integer-coopmat fallback is Vulkan-only. It does not exist on Metal.**
+> §8 and slice 4b both keep an integer configuration as the route that lands
+> under Sarek's *existing strict contract* if slice 1 finds no closed-form model
+> for the ACO shapes — resting on the fact that 12 of the 14 configurations RADV
+> advertises are integer. **That reasoning does not transfer to Metal, and this
+> document previously implied a universal fallback.** There is no integer
+> `simdgroup_matrix` at all, so **#63 has no strict-contract route**: on Metal it
+> is f16 or bf16 or nothing, and it is reachable *only* through the relaxation.
+>
+> Two consequences the plan has to carry:
+> - **Slice 4b's integer requirement keeps its justification but loses its
+>   universality.** Admitting integer component types in the IR fragment type is
+>   still right — it is nearly free at design time, expensive to retrofit, and it
+>   is what keeps #62 deliverable if slice 1 goes badly. But it is a **#62
+>   fallback, not a #62-and-#63 fallback**, and slice 4b should say so rather than
+>   let a reader infer that every backend has a strict-contract path.
+> - **#63 is more exposed to the relaxation than #62 is.** If the relaxation were
+>   ever withdrawn, #62 could still ship its integer configurations and #63 could
+>   ship nothing. That asymmetry did not exist in the plan as written and should
+>   be visible when the two are prioritised against each other.
+>
+> `bfloat` 8×8 is available, is not in the plan anywhere, and has **not** been
+> swept — nothing is claimed about what it computes. It is the obvious cheap
+> extension of slice 6 and needs no new hardware access.
+
+**Ladon usage: requested, granted, used.** Two standalone probe binaries were
+built and run in a scratch directory under `/tmp`; nothing installed, no settings
+changed, no working tree touched. The absence of Xcode (Command Line Tools only,
+so no offline `metal` compiler) turned out not to matter —
+`newLibraryWithSource:options:error:` compiles through the driver at runtime,
+which is the call under test anyway.
+
+**What slices 5 and 6 did NOT cover**, neither needing new hardware access:
+the 20-shape catalogue of
+`docs/optimization/amdgpu-f16-fusion-shape-audit.md` (only two shapes were
+swept), a `bfloat` 8×8 sweep, subnormal-specific analysis, and Metal **codegen** —
+both probes compile hand-written MSL and therefore measure the driver, exactly as
+§7(c) of the policy document says of the GLSL tripwire. A Sarek-generated-shader
+gate is a separate slice.
 
 ### Hardware this plan does not have
 
-- **Apple GPU** — ladon, permission needed. Blocks slices 5–6 entirely.
+- ~~**Apple GPU** — ladon, permission needed. Blocks slices 5–6 entirely.~~
+  **Resolved 2026-07-27**: access granted, slices 5 and 6 both executed on an
+  Apple M4. What Metal still lacks is not hardware but coverage — the 20-shape
+  catalogue, a `bfloat` sweep, and a codegen-side gate.
 - **NVIDIA Ampere or newer** — the GTX 1070 is sm_61 with no tensor cores, no
   bf16 and no FP8 (`capability-model.md` §1). Nothing in this plan constrains the
   CUDA/PTX tensor-core path, and no f16 *performance* claim is available from
@@ -857,6 +1036,18 @@ most of the intended audience.
 > §7 slice 4b. It is nearly free at design time, expensive to retrofit, and it is
 > what keeps a strict-contract coopmat path available as a fallback if slice 1
 > finds no closed-form model for the ACO shapes.
+>
+> **AMENDED 2026-07-27, after the Metal measurement.** This whole section is
+> scoped to **#62**. It reads as though "the cheapest first tensor-core slice
+> needs no relaxation" were a statement about tensor cores in general; it is a
+> statement about *Vulkan*, and it holds only because RADV advertises integer
+> configurations. **Metal advertises none** — `simdgroup_matrix` exists for
+> `half`, `float` and `bfloat` only, integers failing a named static_assert, a
+> closed enumeration (§7 slice 6). So the objection's escape route is unavailable
+> to #63 entirely, and the sequencing argument is stronger than it looked: f16 is
+> not merely a prerequisite for #63 "regardless", it is the **only** element type
+> #63 can be built on. Nothing in the resolution changes; its scope is now
+> stated.
 
 ---
 
@@ -930,8 +1121,13 @@ contract and #62 is not blocked on the accuracy question at all.
 
 ## 10. Tests added by this change
 
-**None.** This change adds a design document and one read-only Vulkan query probe
-(`tools/probes/vulkan_coopmat_probe.c`, standalone, not wired into dune —
-matching the convention of the four probes already there). No Sarek behaviour
-changes, no refusal is lifted, and there is nothing new to gate. The test
-strategy is §7 slice 0, which is the first slice of the follow-on work.
+**None.** This change adds a design document and three standalone probes, none
+wired into dune, matching the convention of the ones already there:
+`tools/probes/vulkan_coopmat_probe.c` (read-only Vulkan query), and — from the
+2026-07-27 amendment — `tools/probes/metal_f16_narrowing_probe.m` and
+`tools/probes/metal_simdgroup_matrix_probe.m`. No Sarek behaviour changes, no
+refusal is lifted, and there is nothing new to gate. The test strategy is §7
+slice 0, which is the first slice of the follow-on work — and which now has two
+extra obligations from the Metal measurement: the ceiling must be evaluated
+per-narrowing (§1.3), and the `x = -907.5` case must be a host-only calibration
+that a final-value ceiling is shown to fail.

--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -925,7 +925,9 @@ probes were run on ladon, and both slices are complete. Recorded in
 
 - **Slice 5 — scalar f16 on Metal. Done: it does not fuse.** 0 / 63488 from
   `S_strict` on both swept shapes, element-wise, on the naive kernel and under
-  every barrier. Instrument `tools/probes/metal_f16_narrowing_probe.m`. Two
+  every barrier — and the control goes red on **each** shape separately
+  (2912 / 63488 on `f16(x*1.1)`, 620 / 63488 on `f16(f16(x*1.1)+1000)`), so
+  neither zero rests on discrimination demonstrated only for the other shape. Instrument `tools/probes/metal_f16_narrowing_probe.m`. Two
   results worth carrying forward beyond the row:
   - `#pragma METAL fp contract(off)` **does not govern this hazard**, in either
     direction — it does not move the plain kernel and does not disturb the
@@ -936,8 +938,9 @@ probes were run on ladon, and both slices are complete. Recorded in
   - The control had to be built differently, and that is a portability note for
     slice 0: **MSL has no `double`**, so the `fusedctl` construction used on
     OpenCL is not expressible. The Metal control reconstructs the exact product
-    from a double-float pair with a round-to-odd step. It reproduces **620**,
-    which is now four unrelated stacks agreeing on that figure.
+    from a double-float pair with a round-to-odd step. It reproduces **2912** on
+    the one-narrowing shape and **620** on the two-narrowing shape; the 620 is
+    now four unrelated stacks agreeing on that figure.
   - It also produced the counterexample that corrected §1.3. See there.
 - **Slice 6 — `simdgroup_matrix`. Done, and it disproved a planning assumption.**
   MSL offers exactly three instantiations, all 8×8: `half`, `float`, `bfloat`.

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -153,7 +153,7 @@ because the one non-Mesa stack that does fuse is AMD's own.
 | **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as rusticl, reached through a second front end — HIP's identical-count defect comes from LLVM's AMDGPU backend instead — and a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on an AMD GPU compiler and does not fuse here, so the locus is *the AMD GPU compilers*, not *OpenCL* and not *SPIR-V*. Note what it does **not** localise: rusticl and HIP/AMDGPU do not share a compiler (see "Two AMD compilers" above), so their identical 620 is two compilers agreeing, not one bug seen twice. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any OpenCL implementation outside its `"ACO"` device-string scope is found to fuse — and which was itself wrong until §11.5. Read that predicate as "not Mesa", not as "not AMD": an AMD GPU reached through ROCm's OpenCL would be compiled by LLVM's AMDGPU backend, i.e. by a compiler this document expects to fuse, while sitting outside the key |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV now measured too** (§11.2): Intel Arc Graphics (Meteor Lake-P), Mesa 26.1.2-arch3.1, same 0 of 7 / 0 of 7 with `fma()` controls 4/4 — and unlike RADV, ANV does not fuse the f16 narrowing either, so no combine has been found on ANV where `NoContraction` is ignored. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound; ANV shows the same signature (mul 5.84e-08 / div 5.86e-08, §11.1) |
-| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. **The f16 narrowing is now probed and does NOT fuse** — 0/63488 from the discipline on both swept shapes, element-wise, with a validated positive control reproducing 620 (§10.14); the pragma changes nothing there, in either direction, because there is no fusion to prevent. Subnormals still unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
+| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. **The f16 narrowing is now probed and does NOT fuse** — 0/63488 from the discipline on **both** swept shapes, element-wise, with a validated positive control that goes red on **both**: the same control reports **2912/63488** on `f16(x*1.1)` and **620/63488** on `f16(f16(x*1.1)+1000)`, the latter being the figure already measured on hiprtc/gfx1100, rusticl/radeonsi and Intel Arc (§10.14). Two shapes, two independently-nonzero controls, two zeros; the pragma changes nothing there, in either direction, because there is no fusion to prevent. Subnormals still unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
 
@@ -204,8 +204,9 @@ because the one non-Mesa stack that does fuse is AMD's own.
   (§10.7), with contraction defeated by `#pragma METAL fp contract(off)` in
   every generated kernel (§10.5). **The Metal f16 narrowing has now moved off
   too**, on the strongest evidence in this document: element-wise agreement with
-  the discipline on all 63488 finite binary16 inputs, on both swept shapes, with
-  a validated positive control (§10.14). What is still NOT covered: subnormals
+  the discipline on all 63488 finite binary16 inputs, on **both** swept shapes,
+  each with its own validated positive control proven able to go red — 2912/63488
+  on `f16(x*1.1)` and 620/63488 on `f16(f16(x*1.1)+1000)` (§10.14). What is still NOT covered: subnormals
   (never probed), f32 element-wise identity (that agreement is still between
   summary maxima — the f16 result *is* element-wise), the f16 shapes beyond the
   two swept here, any device or OS other than that one, and kernels using
@@ -738,7 +739,8 @@ this is where they are collected):
   `test_real64` PASS on every op and reproduce the interpreter's figures
   exactly (§10.7), so Metal **f32** has left the §3 "may NOT rely on" list, and
   **Metal f16 left it too on 2026-07-27** (§10.14, element-wise over the whole
-  finite binary16 domain). Metal subnormals and record/variant kernels have not — the last of
+  finite binary16 domain, on both swept shapes, each with a control reproducing
+  its own nonzero figure — 2912 and 620 respectively). Metal subnormals and record/variant kernels have not — the last of
   those because they do not compile (§10.11).
 
 ---
@@ -1115,7 +1117,8 @@ and the only one; df64 passing either way is consistent with both.
 - **Subnormals.** Not probed at all on Metal.
 - ~~**f16 on Metal.** Not probed.~~ **Probed on 2026-07-27 — see §10.14.** The
   f16 narrowing meets the discipline on all 63488 finite binary16 inputs, on
-  both swept shapes. This bullet is kept struck through rather than deleted
+  both swept shapes, each with a positive control that reproduces its own
+  nonzero figure (2912 and 620) on the same source and dispatch. This bullet is kept struck through rather than deleted
   because §3's "may NOT rely on" list leaned on it.
 - **The two kernels that do not compile** (§10.11) are excluded from every
   figure above, because they never ran.
@@ -1414,9 +1417,13 @@ OpenCL probe's `(double)x * (double)1.1f` control is not expressible; the Metal
 control reconstructs the exact product from a double-float pair and applies a
 round-to-odd step before the narrowing. It is then **validated against the host
 reference element-wise** — 0 of 63488 differ from
-`S_fuse_mul_into_narrowing` — and it reproduces **620**, the figure independently
-measured on hiprtc/gfx1100, on rusticl/radeonsi, and by `fusedctl` on Intel Arc.
-Same source, same compile options, same dispatch as the variants reporting 0. A
+`S_fuse_mul_into_narrowing` — on **both** shapes. It reproduces **2912** on the
+one-narrowing shape and **620** on the two-narrowing shape, the latter being the
+figure independently measured on hiprtc/gfx1100, on rusticl/radeonsi, and by
+`fusedctl` on Intel Arc. **Both zeros therefore sit next to a nonzero from the
+same control**, on the same source, the same compile options and the same
+dispatch as the variants reporting 0 — the discrimination is demonstrated per
+shape, not carried from one shape to the other. A
 host calibration runs first and refuses to print any device number unless the
 binary16 round-trip is clean and the two models separate on 2912 and 620.
 
@@ -1496,40 +1503,72 @@ nothing. `bfloat` 8×8 is available, is not in the current plan, and has not bee
 swept — nothing here says what it computes.
 
 **What the f16 MulAdd computes.** 1024 independent 8×8×8 problems, 65536 output
-elements, against an exactly-computed host reference. Anti-vacuity first,
-because the first version of this test drew operands as multiples of 2⁻⁹ in
-[−1, 1] — every product was then a multiple of 2⁻¹⁸ below 8, the sum of 8 of
-them was exactly representable in binary32, every accumulation order agreed, and
-it reported 64/64 exact while measuring nothing. The operands now carry a full
-11-bit significand over a 13-wide exponent range, so the sum needs ~46 bits:
-outside binary32, inside binary64. On that input set sequential and pairwise
-binary32 accumulation differ on 27597/65536, and a host binary16 accumulator is
-rejected by the f32 bound on 65452/65536 — both checks can fail.
+elements, `D = A×B + C` with **`C` nonzero throughout**, against an exactly
+computed host reference.
+
+`f16-relaxed-accuracy.md` §5.1 records that an earlier draft of that section
+bounded only the products and would have failed a correct result with a nonzero
+`C`. The first version of *this* probe made the mirror-image mistake — it pinned
+`C = 0` — and it cost a wrong conclusion, so it is worth stating plainly: with
+`C = 0` the "C added first" and "C added last" accumulation orders are the **same
+function**, and the probe reported 65536/65536 against "sequential binary32"
+without being able to say which. A nonzero `C` separates them decisively. The
+constant is therefore `γ_8` and not the `γ_7` of the `C = 0` degenerate case,
+which §5.2 says must not be used unless `C` is pinned.
+
+Two anti-vacuity problems were found and fixed before any number below was
+trusted, and both are the same failure: a check that could not fail.
+
+1. **The input set.** The first version drew operands as multiples of 2⁻⁹ in
+   [−1, 1] — every product was then a multiple of 2⁻¹⁸ below 8, the sum of 8 of
+   them was exactly representable in binary32, **every accumulation order
+   agreed**, and it reported 64/64 exact while measuring nothing. The operands
+   now carry a full 11-bit significand over an 11-wide exponent range, so
+   accumulation order is observable: sequential and pairwise binary32 differ on
+   **23291 / 65536**.
+2. **The reference's own exactness.** §5.3 warns that binary64 is *not*
+   sufficient in general and must be asserted. The harness now computes the term
+   exponent span and refuses to print any device number unless it fits: measured
+   **21 binades, needing 50 bits against binary64's 53**.
+
+Both of §5.4's required controls run, each a deliberately wrong reference the
+bound must reject: the **binary16 accumulator**, rejected on 65433 / 65536, and
+the **`C`-dropping reference**, rejected on 65498 / 65536. The exact reference is
+rejected by its own bound on 0.
 
 | | `half8x8 × half8x8 → float8x8` | `half8x8 × half8x8 → half8x8` |
 |---|---|---|
-| bit-equal to **sequential binary32** accumulate | **65536 / 65536** | 7 / 65536 |
-| bit-equal to pairwise binary32 accumulate | 37939 / 65536 | 5 / 65536 |
-| bit-equal to **sequential binary16** accumulate | 7 / 65536 | **65528 / 65536** |
-| bit-equal to pairwise binary16 accumulate | 9 / 65536 | 41109 / 65536 |
-| worst error / Σ\|pᵢ\| | 2.79e-07 (bound 4.17e-07) | 1.75e-03 (bound 3.43e-03) |
+| bit-equal to **sequential binary32, `C` FIRST** | **65536 / 65536** | 7 / 65536 |
+| bit-equal to sequential binary32, `C` last | 51850 / 65536 | 9 / 65536 |
+| bit-equal to pairwise binary32, `C` last | 34914 / 65536 | 11 / 65536 |
+| bit-equal to **sequential binary16, `C` first** | 9 / 65536 | **65520 / 65536** |
+| bit-equal to pairwise binary16 | 10 / 65536 | 32712 / 65536 |
+| bit-equal to the exact dot product | 538 / 65536 | 0 / 65536 |
+| worst error / Σ\|terms\| | 2.67e-07 (`γ_8` = 4.7684e-07) | 2.12e-03 (`γ_8` = 3.9216e-03) |
+| elements outside the bound | 0 / 65536 | 0 / 65536 |
 
 **The f32-accumulate configuration matches a named closed-form model
-element-wise on every element.** That is stronger than `f16-relaxed-accuracy.md`
-§5 anticipated — §5 proposes a *bound* because the accumulation order is
-implementation-dependent, and on this implementation the order is observable and
-is plainly sequential. §6.1's corollary applies directly: friction falls as
-evidence improves, so this configuration belongs in the loud-diagnostic row
-rather than the mandatory-opt-in row. The model cannot separate "exact products
-then sequential adds" from an fma chain and does not need to — an f16 × f16
-product is exact in binary32 (11 + 11 = 22 bits inside 24), so those are the
-same function. Evidence tier for *that* step: **by-construction**.
+element-wise on every element**: initialise the accumulator to `C`, then add the
+eight products in index order, all in binary32. That is stronger than
+`f16-relaxed-accuracy.md` §5 anticipated — §5 proposes a *bound* because the
+accumulation order is implementation-dependent, and on this implementation the
+order is observable and is pinned. §1.6's migration row and §6.1's corollary
+apply directly: this configuration moves from Regime B to Regime A, and its
+friction falls from a mandatory opt-in to a diagnostic, with no new decision
+needed. **The closed form could not have been identified without §5.1's
+insistence that the operation is `A×B + C`** — 65536 against 51850 is the whole
+difference between naming the order and guessing it.
 
-**The f16-accumulate configuration matches no closed-form model**: 8 elements in
-65536 differ from sequential binary16 by 1–2 ulp16, and match neither pairwise
-binary16 nor a binary32 chain narrowed at the end. §5 recommends not admitting
-that configuration on the width of its bound; the recommendation now also rests
-on the measurement.
+The model cannot separate "exact products then sequential adds" from an fma chain
+and does not need to — an f16 × f16 product is exact in binary32 (11 + 11 = 22
+bits inside 24), so those are the same function. Evidence tier for *that* step:
+**by-construction**.
+
+**The f16-accumulate configuration matches no closed-form model**: 16 elements in
+65536 differ from sequential binary16, and match neither pairwise binary16 nor a
+binary32 chain narrowed at the end. §5.4 recommends not admitting that
+configuration on the width of its bound; the recommendation now also rests on the
+measurement.
 
 **Determinism (§1.4).** Bit-identical across two processes, and bit-identical
 across threadgroup sizes 32 / 64 / 128 / 256 — 0/65536 differ in each case. §1.4

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -153,7 +153,7 @@ because the one non-Mesa stack that does fuse is AMD's own.
 | **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as rusticl, reached through a second front end — HIP's identical-count defect comes from LLVM's AMDGPU backend instead — and a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on an AMD GPU compiler and does not fuse here, so the locus is *the AMD GPU compilers*, not *OpenCL* and not *SPIR-V*. Note what it does **not** localise: rusticl and HIP/AMDGPU do not share a compiler (see "Two AMD compilers" above), so their identical 620 is two compilers agreeing, not one bug seen twice. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any OpenCL implementation outside its `"ACO"` device-string scope is found to fuse — and which was itself wrong until §11.5. Read that predicate as "not Mesa", not as "not AMD": an AMD GPU reached through ROCm's OpenCL would be compiled by LLVM's AMDGPU backend, i.e. by a compiler this document expects to fuse, while sitting outside the key |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV now measured too** (§11.2): Intel Arc Graphics (Meteor Lake-P), Mesa 26.1.2-arch3.1, same 0 of 7 / 0 of 7 with `fma()` controls 4/4 — and unlike RADV, ANV does not fuse the f16 narrowing either, so no combine has been found on ANV where `NoContraction` is ignored. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound; ANV shows the same signature (mul 5.84e-08 / div 5.86e-08, §11.1) |
-| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. f16 and subnormals unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
+| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. **The f16 narrowing is now probed and does NOT fuse** — 0/63488 from the discipline on both swept shapes, element-wise, with a validated positive control reproducing 620 (§10.14); the pragma changes nothing there, in either direction, because there is no fusion to prevent. Subnormals still unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
 
@@ -198,15 +198,18 @@ because the one non-Mesa stack that does fuse is AMD's own.
 **You may NOT rely on:**
 
 - **WGSL float semantics at all.**
-- **Metal f16, Metal subnormals, and Metal record/variant kernels.** Metal
-  **f32 arithmetic** has moved OFF this list: `test_df64` and `test_real64`
-  agree with the interpreter on every op on an Apple M4 / macOS 15.6.1 / Apple
-  clang 17.0.0 (§10.7), with contraction defeated by
-  `#pragma METAL fp contract(off)` in every generated kernel (§10.5). What is
-  still NOT covered: f16 (never probed on Metal), subnormals (never probed),
-  element-wise identity (the agreement is between summary maxima), any device
-  or OS other than that one, and kernels using **records or variants**, which
-  do not compile on Metal at all (§10.11).
+- **Metal subnormals and Metal record/variant kernels.** Metal **f32
+  arithmetic** has moved OFF this list: `test_df64` and `test_real64` agree with
+  the interpreter on every op on an Apple M4 / macOS 15.6.1 / Apple clang 17.0.0
+  (§10.7), with contraction defeated by `#pragma METAL fp contract(off)` in
+  every generated kernel (§10.5). **The Metal f16 narrowing has now moved off
+  too**, on the strongest evidence in this document: element-wise agreement with
+  the discipline on all 63488 finite binary16 inputs, on both swept shapes, with
+  a validated positive control (§10.14). What is still NOT covered: subnormals
+  (never probed), f32 element-wise identity (that agreement is still between
+  summary maxima — the f16 result *is* element-wise), the f16 shapes beyond the
+  two swept here, any device or OS other than that one, and kernels using
+  **records or variants**, which do not compile on Metal at all (§10.11).
 - **Vulkan `fma` being correctly rounded.** On Mesa RADV it is not, and
   `Sarek_df64` mul/div is ~5.8e-08 there — a *documented*, unfixed deviation,
   not a bug to rediscover. Note this is a distinct failure from contraction:
@@ -733,8 +736,9 @@ this is where they are collected):
   source pragma instead. Full account and the three things still open in §10.
   Interpreter agreement has since been executed on that M4: `test_df64` and
   `test_real64` PASS on every op and reproduce the interpreter's figures
-  exactly (§10.7), so Metal **f32** has left the §3 "may NOT rely on" list.
-  Metal f16, subnormals, and record/variant kernels have not — the last of
+  exactly (§10.7), so Metal **f32** has left the §3 "may NOT rely on" list, and
+  **Metal f16 left it too on 2026-07-27** (§10.14, element-wise over the whole
+  finite binary16 domain). Metal subnormals and record/variant kernels have not — the last of
   those because they do not compile (§10.11).
 
 ---
@@ -751,6 +755,8 @@ this is where they are collected):
 | `tools/probes/opencl_build_options_probe.c` | which OpenCL build options a stack accepts, and whether they do anything — with plumbing and FP liveness controls |
 | `tools/probes/metal_math_mode_probe.m` | Metal's real defaults, and whether its options change results (M4) |
 | `tools/probes/metal_contraction_barrier_probe.m` | the Metal contraction barrier sweep, and the deprecated/modern API equivalence |
+| `tools/probes/metal_f16_narrowing_probe.m` | the exhaustive Metal f16 narrowing sweep against the named rounding models, with the round-to-odd positive control (§10.14) |
+| `tools/probes/metal_simdgroup_matrix_probe.m` | which `simdgroup_matrix` configurations exist on the M4, and what the 8×8×8 f16 MulAdd computes (§10.15) |
 | `sarek/codegen/Sarek_ir_cuda.ml` | `sarek_f32_barrier` — load-bearing on HIP, a documented identity on NVIDIA |
 | `sarek-cuda/Cuda_nvrtc.ml` | `check_fp_conformance` — rejects subnormal-flushing / approximate-div options |
 | `sarek/Sarek_df64/Sarek_df64.ml` | the `mul_rn` contraction barrier, its per-backend precision table, and the caller-side hazard |
@@ -1107,10 +1113,10 @@ and the only one; df64 passing either way is consistent with both.
   measured for *equivalence* on macOS 15 but has never run on the pre-15 OS that
   is its only reason to exist.
 - **Subnormals.** Not probed at all on Metal.
-- **f16 on Metal.** Not probed. The three other backends that reach an AMD
-  (ACO or LLVM/AMDGPU) or NVIDIA compiler each needed a separate exhaustive f16
-  sweep before anything
-  could be said; Metal has had none.
+- ~~**f16 on Metal.** Not probed.~~ **Probed on 2026-07-27 — see §10.14.** The
+  f16 narrowing meets the discipline on all 63488 finite binary16 inputs, on
+  both swept shapes. This bullet is kept struck through rather than deleted
+  because §3's "may NOT rely on" list leaned on it.
 - **The two kernels that do not compile** (§10.11) are excluded from every
   figure above, because they never ran.
 
@@ -1371,6 +1377,165 @@ Found by the backend twin, whose pinned-exemption-set assertion reported the
 duplicate directly. Both `unfold`s are fixed, and both files now assert
 **distinctness** as well as length, which is the property a count alone cannot
 establish.
+
+### 10.14 The f16 narrowing on Metal: **it does not fuse** (#63 slice 5)
+
+§10.9 listed f16 as the largest thing Metal had never been probed for, and
+[`docs/design/f16-relaxed-accuracy.md`](design/f16-relaxed-accuracy.md) §2 has a
+Metal row reading *"never probed → `Unknown` → refused"* for the same reason.
+This is the measurement that fills it.
+
+**Device and toolchain, as §1 corollary 3 requires:** Apple M4, macOS 15.6.1
+(24G90), arm64, Apple clang 17.0.0 (clang-1700.0.13.5), Metal.framework from the
+Command Line Tools SDK. Instrument:
+`tools/probes/metal_f16_narrowing_probe.m`, standalone, in the shape of the two
+Metal probes already in that directory. Evidence tier: **executed**, element-wise
+over the whole finite binary16 domain — not a sampled maximum.
+
+Two shapes, the two the other backends were swept on, each over all 63488 finite
+binary16 inputs, deviation from the discipline (`S_strict`):
+
+| variant | `f16(x*1.1)` | `f16(f16(x*1.1)+1000)` |
+|---|---|---|
+| plain (naive codegen) | **0 / 63488** | **0 / 63488** |
+| `#pragma METAL fp contract(off)` | 0 / 63488 | 0 / 63488 |
+| `#pragma clang fp contract(off)` | 0 / 63488 | 0 / 63488 |
+| `volatile thread` barrier | 0 / 63488 | 0 / 63488 |
+| `as_type` bitcast barrier | 0 / 63488 | 0 / 63488 |
+| **FUSEDCTL — positive control** | **2912 / 63488** | **620 / 63488** |
+
+**Metal is in the strict class.** No barrier is needed, none is emitted, and the
+refusal of f16 in `Sarek_ir_metal` is currently over-broad in the same way §11.3
+found pocl's and IGC's to be.
+
+**Why the zeros are readable.** §11.5 is this document's own record of a null
+that was not a result, so the control is the point. MSL has no `double`, so the
+OpenCL probe's `(double)x * (double)1.1f` control is not expressible; the Metal
+control reconstructs the exact product from a double-float pair and applies a
+round-to-odd step before the narrowing. It is then **validated against the host
+reference element-wise** — 0 of 63488 differ from
+`S_fuse_mul_into_narrowing` — and it reproduces **620**, the figure independently
+measured on hiprtc/gfx1100, on rusticl/radeonsi, and by `fusedctl` on Intel Arc.
+Same source, same compile options, same dispatch as the variants reporting 0. A
+host calibration runs first and refuses to print any device number unless the
+binary16 round-trip is clean and the two models separate on 2912 and 620.
+
+**The pragma does not govern this hazard — and does not need to.** `#pragma
+METAL fp contract(off)` changes nothing on either shape, in either direction: it
+does not move the plain kernel (already strict) and it does not disturb the
+control (620 with and without). That is **not** the pragma being inert; §10.5
+measures it taking `a*b+c` from 8773/8773 to 0/8773 on this device. Contraction
+of `a*b+c` and absorption of a multiply into an f32→f16 narrowing are two
+behaviours, the pragma is measured on one of them, and Metal exhibits neither.
+`Sarek_ir_metal.metal_fp_contract_pragma` keeps its §10.5 justification
+unchanged and gains no new one here.
+
+**A defect this surfaced in the relaxed contract itself, not in Metal.**
+`f16-relaxed-accuracy.md` §1.3 proposes `f16_relaxed_ceiling` — *"no admitted
+deviation may exceed 1 ulp of the binary16 result, measured on the final
+value"*. The validated control computes the admitted model exactly, so it can be
+used to test the ceiling, and **the admitted model violates it**. At
+`x = -907.5`: the exact product is `-998.25000216…`, whose binary32 rounding is
+exactly `-998.25` — a binary16 tie in the binade [512, 1024) — which rounds to
+even, giving `S_strict` `-998 + 1000 = 2`. The single-rounding model narrows the
+exact product, is not at the tie, gets `-998.5`, and gives `1.5`. **2 and 1.5 are
+512 ulp of binary16 apart**, because the `+1000` cancels the leading bits away
+and re-scales the ulp.
+
+The §1.3 derivation is sound where it is stated — an elided rounding moves a
+value by at most half an ulp *at the elided step*. What does not follow is the
+restatement on the final value, once a later operation can cancel. The ceiling
+has to be evaluated at the narrowing where the rounding was elided. This is a
+property of the contract and not of any device; it is recorded here because this
+is where it was measured, and the design document's own §1.3 is where it needs
+fixing.
+
+**Determinism (§1.4 a and b):** the whole sweep is bit-identical across two runs
+in separate processes.
+
+**Not established.** Only the two shapes above — the 20-shape catalogue of
+`docs/optimization/amdgpu-f16-fusion-shape-audit.md` has not been run on Metal.
+Subnormal *inputs* are in the sweep (all 63488 finite values are), but no
+subnormal-specific analysis was done. One device, one OS. And this measures the
+**driver**, from hand-written MSL: it is not a codegen gate, exactly as §7(c)
+says of the GLSL tripwire.
+
+### 10.15 `simdgroup_matrix` on the M4: three configurations, none of them integer
+
+The #63 prerequisite, measured the same day with
+`tools/probes/metal_simdgroup_matrix_probe.m` on the same device and toolchain.
+Evidence tier: **executed**.
+
+`simdgroup_matrix<T, Cols, Rows>` instantiates for exactly three configurations,
+and every other candidate is a compile-time refusal with a named
+`static_assert`, so the enumeration is closed rather than sampled:
+
+| configuration | available |
+|---|---|
+| `half` 8×8 | **yes** |
+| `float` 8×8 | **yes** |
+| `bfloat` 8×8 | **yes** |
+| 16×16, 8×16, 16×8, 4×4, 32×8, 8×32 (any type) | no — `_valid_simdgroup_matrix_size` |
+| `char`, `uchar`, `short`, `int` 8×8 | no — `is_simdgroup_matrix_element<T>` |
+
+`threadExecutionWidth` is 32, so one 8×8 fragment is one full simdgroup. GPU
+families Apple1–9 and Metal3 are all supported and the runtime compiler accepts
+MSL 2.4 through 3.2.
+
+**There is no integer `simdgroup_matrix`, and that removes a fallback.**
+`f16-relaxed-accuracy.md` §8 and §7 slice 4b keep an integer cooperative-matrix
+path as the route that lands *under the existing strict contract* if the ACO
+scalar shapes match no closed-form model — 12 of the 14 configurations RADV
+advertises are integer. **That fallback is Vulkan-only.** #63 has no
+strict-contract route available to it at all; on Metal it is f16/bf16 or
+nothing. `bfloat` 8×8 is available, is not in the current plan, and has not been
+swept — nothing here says what it computes.
+
+**What the f16 MulAdd computes.** 1024 independent 8×8×8 problems, 65536 output
+elements, against an exactly-computed host reference. Anti-vacuity first,
+because the first version of this test drew operands as multiples of 2⁻⁹ in
+[−1, 1] — every product was then a multiple of 2⁻¹⁸ below 8, the sum of 8 of
+them was exactly representable in binary32, every accumulation order agreed, and
+it reported 64/64 exact while measuring nothing. The operands now carry a full
+11-bit significand over a 13-wide exponent range, so the sum needs ~46 bits:
+outside binary32, inside binary64. On that input set sequential and pairwise
+binary32 accumulation differ on 27597/65536, and a host binary16 accumulator is
+rejected by the f32 bound on 65452/65536 — both checks can fail.
+
+| | `half8x8 × half8x8 → float8x8` | `half8x8 × half8x8 → half8x8` |
+|---|---|---|
+| bit-equal to **sequential binary32** accumulate | **65536 / 65536** | 7 / 65536 |
+| bit-equal to pairwise binary32 accumulate | 37939 / 65536 | 5 / 65536 |
+| bit-equal to **sequential binary16** accumulate | 7 / 65536 | **65528 / 65536** |
+| bit-equal to pairwise binary16 accumulate | 9 / 65536 | 41109 / 65536 |
+| worst error / Σ\|pᵢ\| | 2.79e-07 (bound 4.17e-07) | 1.75e-03 (bound 3.43e-03) |
+
+**The f32-accumulate configuration matches a named closed-form model
+element-wise on every element.** That is stronger than `f16-relaxed-accuracy.md`
+§5 anticipated — §5 proposes a *bound* because the accumulation order is
+implementation-dependent, and on this implementation the order is observable and
+is plainly sequential. §6.1's corollary applies directly: friction falls as
+evidence improves, so this configuration belongs in the loud-diagnostic row
+rather than the mandatory-opt-in row. The model cannot separate "exact products
+then sequential adds" from an fma chain and does not need to — an f16 × f16
+product is exact in binary32 (11 + 11 = 22 bits inside 24), so those are the
+same function. Evidence tier for *that* step: **by-construction**.
+
+**The f16-accumulate configuration matches no closed-form model**: 8 elements in
+65536 differ from sequential binary16 by 1–2 ulp16, and match neither pairwise
+binary16 nor a binary32 chain narrowed at the end. §5 recommends not admitting
+that configuration on the width of its bound; the recommendation now also rests
+on the measurement.
+
+**Determinism (§1.4).** Bit-identical across two processes, and bit-identical
+across threadgroup sizes 32 / 64 / 128 / 256 — 0/65536 differ in each case. §1.4
+records that a coopmat result may legitimately move with the dispatch shape and
+that nobody had measured whether it does. On this device, at this tile size, it
+does not.
+
+**Not measured: throughput.** Whether the M4 has dedicated matrix hardware
+behind these three instantiations is not answered here and cannot be read off
+availability; that needs a benchmark against a scalar kernel.
 
 ---
 

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -1438,9 +1438,13 @@ used to test the ceiling, and **the admitted model violates it**. At
 `x = -907.5`: the exact product is `-998.25000216…`, whose binary32 rounding is
 exactly `-998.25` — a binary16 tie in the binade [512, 1024) — which rounds to
 even, giving `S_strict` `-998 + 1000 = 2`. The single-rounding model narrows the
-exact product, is not at the tie, gets `-998.5`, and gives `1.5`. **2 and 1.5 are
-512 ulp of binary16 apart**, because the `+1000` cancels the leading bits away
-and re-scales the ulp.
+exact product, is not at the tie, gets `-998.5`, and gives `1.5`. The deviation
+*at the elided narrowing* is `-998` against `-998.5` — **exactly 1 ulp of
+binary16 there**, as the derivation says. On the **final** value it is
+**512 ulp** measured against 1.5, or **256 ulp** measured against 2.0; the count
+depends on which of the two supplies the denominator, and a gate must say which.
+Either way it is hundreds of ulps against a ceiling of one, because the `+1000`
+cancels the leading bits away and re-scales the ulp.
 
 The §1.3 derivation is sound where it is stated — an elided rounding moves a
 value by at most half an ulp *at the elided step*. What does not follow is the

--- a/tools/probes/metal_f16_narrowing_probe.m
+++ b/tools/probes/metal_f16_narrowing_probe.m
@@ -95,8 +95,11 @@
  *      a binary16 tie in the binade [512,1024) and rounds to even -> -998, so
  *      S_strict gives -998 + 1000 = 2. The single-rounding model narrows the
  *      exact product instead, is not at the tie, and gives -998.5 -> 1.5.
- *    2 and 1.5 are **512 ulp of binary16 apart at that magnitude**, because the
- *    +1000 cancels away the leading bits. The half-ulp-at-the-elided-step
+ *    At the ELIDED NARROWING the deviation is -998 vs -998.5, exactly 1 ulp16,
+ *    as the derivation says. On the FINAL value it is 512 ulp16 measured
+ *    against 1.5, or 256 measured against 2.0 — state the denominator; either
+ *    way it is hundreds against a ceiling of one, because the +1000 cancels the
+ *    leading bits away and re-scales the ulp. The half-ulp-at-the-elided-step
  *    derivation in §1.3 is sound; what does not follow is the final-value
  *    restatement, since a later cancellation re-scales the ulp. The ceiling has
  *    to be measured at the narrowing where the rounding was elided, not on the

--- a/tools/probes/metal_f16_narrowing_probe.m
+++ b/tools/probes/metal_f16_narrowing_probe.m
@@ -1,0 +1,461 @@
+/* metal_f16_narrowing_probe.m — #63 slice 5
+ *
+ * The Metal row of docs/design/f16-relaxed-accuracy.md §2 does not exist:
+ * Metal f16 has never been probed (docs/fp-contraction-policy.md §10.9). This
+ * probe produces it.
+ *
+ * Method is the OpenCL probe's (tools/probes/opencl_f16_contraction_probe.c)
+ * ported to Metal, and the Objective-C/Metal boilerplate is
+ * tools/probes/metal_contraction_barrier_probe.m's. Two differences from the
+ * OpenCL probe, both forced by the platform and both load-bearing:
+ *
+ *   1. MSL HAS NO `double`. The OpenCL positive control computes the fused
+ *      answer as `(half)((double)x * (double)1.1f)` — an exactly-representable
+ *      product narrowed in one rounding. That is not expressible here. The
+ *      control below reconstructs the same value from a double-float pair
+ *      (`hi = RN32(x*k)`, `lo = fma(x,k,-hi)` exact) with a round-to-odd step
+ *      before the narrowing, which is the standard way to make a two-step
+ *      narrowing agree with a single rounding. It is then CHECKED element-wise
+ *      against the host `double` reference: the control is only usable if it
+ *      agrees on all 63488, and the probe says so either way.
+ *
+ *   2. Metal's contraction defence is a SOURCE PRAGMA, not a compile option —
+ *      no MTLCompileOptions setting stops contraction (§10.4, §10.5). The
+ *      pragma is known to fix `a*b+c`. Whether it also governs a multiply
+ *      feeding an f32->f16 narrowing is a DIFFERENT question, so every shape is
+ *      swept both with and without it.
+ *
+ * The reference is not a tolerance. Per f16-relaxed-accuracy.md §1.2 the device
+ * result must be BIT-IDENTICAL to a member of a named finite set of rounding
+ * semantics, so every model below is compared element-wise on binary16 bit
+ * patterns, and §1.3's 1-ulp ceiling is reported alongside as the necessary —
+ * not sufficient — check.
+ *
+ * Shapes swept, matching the ones the other backends were swept on:
+ *   S1  f16(x * 1.1)                one narrowing
+ *   S2  f16(f16(x * 1.1) + 1000)    two narrowings
+ *
+ * Build (Command Line Tools are enough; no Xcode, no offline `metal` compiler —
+ * newLibraryWithSource:options:error: compiles through the driver at runtime):
+ *   clang -fobjc-arc -O2 -framework Foundation -framework Metal \
+ *       metal_f16_narrowing_probe.m -o metal_f16_narrowing_probe
+ *
+ * Run: ./metal_f16_narrowing_probe        (no arguments; sweeps everything)
+ *
+ * ---------------------------------------------------------------------------
+ * MEASURED 2026-07-27. Apple M4, macOS 15.6.1 (24G90), arm64, Apple clang
+ * 17.0.0 (clang-1700.0.13.5), Metal.framework from the Command Line Tools SDK
+ * (no Xcode). 63488 finite binary16 inputs. Evidence tier: EXECUTED.
+ *
+ * Host calibration: binary16 round-trip 0 failures; the two host models
+ * separate on 2912 (S1) and 620 (S2) — 620 being the figure independently
+ * reproduced on hiprtc/gfx1100, rusticl/radeonsi and `fusedctl` on Intel Arc.
+ *
+ *   S1  out = f16(x * 1.1f)                 deviation from S_strict
+ *     plain                                        0 / 63488
+ *     #pragma METAL fp contract(off)               0 / 63488
+ *     #pragma clang fp contract(off)               0 / 63488
+ *     volatile thread barrier                      0 / 63488
+ *     as_type bitcast barrier                      0 / 63488
+ *     FUSEDCTL (positive control)               2912 / 63488  <- control lives
+ *     FUSEDCTL + contract(off)                  2912 / 63488
+ *
+ *   S2  out = f16(f16(x * 1.1f) + 1000.0f)   deviation from S_strict
+ *     plain                                        0 / 63488
+ *     #pragma METAL fp contract(off)               0 / 63488
+ *     #pragma clang fp contract(off)               0 / 63488
+ *     volatile thread barrier                      0 / 63488
+ *     as_type bitcast barrier                      0 / 63488
+ *     FUSEDCTL (positive control)                620 / 63488  <- control lives
+ *     FUSEDCTL + contract(off)                   620 / 63488
+ *
+ * **Metal does not fuse the f16 narrowing.** It meets S_strict element-wise on
+ * every finite binary16 input, on both shapes, with and without the pragma, and
+ * with and without every barrier. The 0s are readable because the control on
+ * the same source, same compile options and same dispatch reproduces
+ * S_fuse_mul_into_narrowing on 63488 / 63488 elements and reports 2912 / 620.
+ * Metal joins CUDA/nvrtc, HIP/AMDGPU, pocl, IGC and ANV in the strict class;
+ * the relaxation of f16-relaxed-accuracy.md is not needed here.
+ *
+ * TWO SECONDARY FINDINGS, neither of which was the question:
+ *
+ * 1. **`#pragma METAL fp contract(off)` does not govern this hazard, and does
+ *    not need to.** It changes nothing on either shape — not because it is
+ *    inert (§10.5 measures it taking `a*b+c` from 8773/8773 to 0/8773) but
+ *    because there is no fusion here to prevent. Contraction of `a*b+c` and
+ *    absorption of a multiply into an f32->f16 narrowing are separate
+ *    behaviours and the pragma is measured on only one of them. Symmetrically
+ *    the pragma does not disturb the deliberate fusion in FUSEDCTL: 620 with it
+ *    and 620 without.
+ *
+ * 2. **f16-relaxed-accuracy.md §1.3's 1-ulp ceiling is exceeded by the ADMITTED
+ *    model on the two-narrowing shape**, so it cannot be applied to the final
+ *    value of a multi-narrowing expression as written. At x = -907.5:
+ *      exact x*1.1f = -998.25000216...; RN32 of it is exactly -998.25, which is
+ *      a binary16 tie in the binade [512,1024) and rounds to even -> -998, so
+ *      S_strict gives -998 + 1000 = 2. The single-rounding model narrows the
+ *      exact product instead, is not at the tie, and gives -998.5 -> 1.5.
+ *    2 and 1.5 are **512 ulp of binary16 apart at that magnitude**, because the
+ *    +1000 cancels away the leading bits. The half-ulp-at-the-elided-step
+ *    derivation in §1.3 is sound; what does not follow is the final-value
+ *    restatement, since a later cancellation re-scales the ulp. The ceiling has
+ *    to be measured at the narrowing where the rounding was elided, not on the
+ *    result. This is not a Metal property — it is a property of the contract,
+ *    surfaced here because the control computes the admitted model exactly.
+ *
+ * Determinism (§1.4 a and b): the whole sweep is bit-identical across two runs
+ * in separate processes.
+ * ---------------------------------------------------------------------------
+ */
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+#define NBITS 65536
+
+/* ---- host binary16 helpers --------------------------------------------- */
+
+static float f16_value_of_bits(int b, int *is_finite) {
+  int sign = (b & 0x8000) ? -1 : 1;
+  int exp = (b >> 10) & 0x1f, man = b & 0x3ff;
+  if (exp == 31) { *is_finite = 0; return 0.0f; }
+  *is_finite = 1;
+  if (exp == 0) return sign * (float)man * ldexpf(1.0f, -24);
+  return sign * (float)(1024 + man) * ldexpf(1.0f, exp - 25);
+}
+
+static uint16_t bits_of_f16(_Float16 h) { uint16_t u; memcpy(&u, &h, 2); return u; }
+static _Float16 f16_of_bits(uint16_t u) { _Float16 h; memcpy(&h, &u, 2); return h; }
+
+/* Signed ordering key on binary16 bit patterns. Adjacent representable values
+   differ by exactly 1, including across zero, so |key(a)-key(b)| IS the ulp
+   distance of §1.3's ceiling. Finite inputs only. */
+static int f16_key(uint16_t u) {
+  int mag = u & 0x7fff;
+  return (u & 0x8000) ? -mag : mag;
+}
+
+/* ---- the named rounding models, computed exactly on the host ------------ */
+/* `double` makes every one of these exact: an f16 value carries 11 significant
+   bits and the f32 constant 1.1f carries 24, so their product needs 35 — well
+   inside double's 53. Adding 1000 to an f16 value is likewise exact in double.
+   So `(_Float16)<double expression>` is a SINGLE correctly-rounded narrowing,
+   which is what the fused models mean. */
+
+enum { M_STRICT = 0, M_FUSE_MUL, M_FUSE_BOTH, M_FUSE_ADD, M_DROP_MID, N_MODELS };
+
+static const char *MODEL_NAME[N_MODELS] = {
+  "S_strict            (every narrowing rounded, the interpreter)",
+  "S_fuse_mul_into_narrowing (mul absorbed into the f32->f16 narrowing)",
+  "S_fuse_both         (mul AND add each absorbed into their narrowing)",
+  "S_fuse_add_only     (only the add absorbed)",
+  "S_drop_mid          (intermediate f16 narrowing dropped — the IGC defect)",
+};
+/* Which models are meaningful for a one-narrowing shape. */
+static const int MODEL_IN_S1[N_MODELS] = { 1, 1, 0, 0, 0 };
+
+static void models_S1(float x, uint16_t out[N_MODELS]) {
+  const double K = (double)1.1f;
+  out[M_STRICT]    = bits_of_f16((_Float16)(x * 1.1f));
+  out[M_FUSE_MUL]  = bits_of_f16((_Float16)((double)x * K));
+  out[M_FUSE_BOTH] = out[M_FUSE_MUL];
+  out[M_FUSE_ADD]  = out[M_STRICT];
+  out[M_DROP_MID]  = out[M_STRICT];
+}
+
+static void models_S2(float x, uint16_t out[N_MODELS]) {
+  const double K = (double)1.1f;
+  _Float16 m_strict = (_Float16)(x * 1.1f);
+  _Float16 m_fused  = (_Float16)((double)x * K);
+  out[M_STRICT]    = bits_of_f16((_Float16)((float)m_strict + 1000.0f));
+  out[M_FUSE_MUL]  = bits_of_f16((_Float16)((float)m_fused  + 1000.0f));
+  out[M_FUSE_BOTH] = bits_of_f16((_Float16)((double)m_fused  + 1000.0));
+  out[M_FUSE_ADD]  = bits_of_f16((_Float16)((double)m_strict + 1000.0));
+  /* IGC's signature: the intermediate binary16 narrowing is not performed at
+     all and the whole thing runs in binary32. */
+  out[M_DROP_MID]  = bits_of_f16((_Float16)(x * 1.1f + 1000.0f));
+}
+
+/* ---- device source ------------------------------------------------------ */
+
+static const char *PREAMBLE =
+"#include <metal_stdlib>\n"
+"using namespace metal;\n";
+
+/* The positive control's single-rounding multiply-then-narrow.
+ *
+ * `hi` is forced through the integer domain before `lo` is formed, so that the
+ * compiler cannot have already fused the multiply into a narrowing (§10.5
+ * measures the as_type round-trip defeating contraction on this device); `hi`
+ * is therefore RN32(x*k) whatever the compiler does. `lo = fma(x,k,-hi)` is
+ * then the exact residual, so hi+lo is the exact product. Round-to-odd on `hi`
+ * with respect to the sign of `lo` makes the subsequent narrowing to binary16
+ * agree with a single correctly-rounded narrowing of the exact product.
+ *
+ * There is no `(half)(a*b)` anywhere in this helper, so the value it returns
+ * cannot itself be the thing under test. It is validated element-wise against
+ * the host double reference before any conclusion is drawn from it. */
+static const char *FUSED_HELPER =
+"static inline half fused_mul_narrow(float x, float k) {\n"
+"  float hi = as_type<float>(as_type<uint>(x * k));\n"
+"  float lo = fma(x, k, -hi);\n"
+"  if (lo != 0.0f) {\n"
+"    uint u = as_type<uint>(hi);\n"
+"    if ((u & 1u) == 0u) {\n"
+"      bool up = lo > 0.0f, pos = hi > 0.0f;\n"
+"      u = (up == pos) ? (u + 1u) : (u - 1u);\n"
+"      hi = as_type<float>(u);\n"
+"    }\n"
+"  }\n"
+"  return (half)hi;\n"
+"}\n";
+
+typedef struct {
+  const char *label;
+  const char *pragma;   /* file-scope pragma, or "" */
+  const char *body;     /* uses `float x`, writes `out[i]` */
+  int is_control;       /* 1 = deliberately fused; must match M_FUSE_* */
+} variant;
+
+/* ---- S1: f16(x * 1.1) --------------------------------------------------- */
+static variant V_S1[] = {
+  { "plain",                      "",
+    "  out[i] = (half)(x * 1.1f);\n", 0 },
+  { "#pragma METAL fp contract(off)", "#pragma METAL fp contract(off)\n",
+    "  out[i] = (half)(x * 1.1f);\n", 0 },
+  { "#pragma clang fp contract(off)", "#pragma clang fp contract(off)\n",
+    "  out[i] = (half)(x * 1.1f);\n", 0 },
+  { "volatile thread barrier",     "",
+    "  volatile thread float t = x * 1.1f;\n  out[i] = (half)t;\n", 0 },
+  { "as_type bitcast barrier",     "",
+    "  float t = as_type<float>(as_type<uint>(x * 1.1f));\n  out[i] = (half)t;\n", 0 },
+  { "FUSEDCTL (positive control)", "",
+    "  out[i] = fused_mul_narrow(x, 1.1f);\n", 1 },
+  { "FUSEDCTL + contract(off)",    "#pragma METAL fp contract(off)\n",
+    "  out[i] = fused_mul_narrow(x, 1.1f);\n", 1 },
+};
+static const int NV_S1 = sizeof(V_S1)/sizeof(V_S1[0]);
+
+/* ---- S2: f16(f16(x * 1.1) + 1000) --------------------------------------- */
+static variant V_S2[] = {
+  { "plain",                      "",
+    "  half m = (half)(x * 1.1f);\n  out[i] = (half)((float)m + 1000.0f);\n", 0 },
+  { "#pragma METAL fp contract(off)", "#pragma METAL fp contract(off)\n",
+    "  half m = (half)(x * 1.1f);\n  out[i] = (half)((float)m + 1000.0f);\n", 0 },
+  { "#pragma clang fp contract(off)", "#pragma clang fp contract(off)\n",
+    "  half m = (half)(x * 1.1f);\n  out[i] = (half)((float)m + 1000.0f);\n", 0 },
+  { "volatile thread barrier",     "",
+    "  volatile thread float t = x * 1.1f;\n  half m = (half)t;\n"
+    "  volatile thread float u = (float)m + 1000.0f;\n  out[i] = (half)u;\n", 0 },
+  { "as_type bitcast barrier",     "",
+    "  half m = as_type<half>(as_type<ushort>((half)(x * 1.1f)));\n"
+    "  out[i] = (half)((float)m + 1000.0f);\n", 0 },
+  { "half arithmetic (no f32 mul)", "",
+    "  half m = (half)x * (half)1.1f;\n  out[i] = m + (half)1000.0f;\n", 0 },
+  { "FUSEDCTL (positive control)", "",
+    "  half m = fused_mul_narrow(x, 1.1f);\n  out[i] = (half)((float)m + 1000.0f);\n", 1 },
+  { "FUSEDCTL + contract(off)",    "#pragma METAL fp contract(off)\n",
+    "  half m = fused_mul_narrow(x, 1.1f);\n  out[i] = (half)((float)m + 1000.0f);\n", 1 },
+};
+static const int NV_S2 = sizeof(V_S2)/sizeof(V_S2[0]);
+
+/* ---- Metal plumbing ----------------------------------------------------- */
+
+static id<MTLBuffer> mkbuf(id<MTLDevice> d, const void *s, size_t n) {
+  return s ? [d newBufferWithBytes:s length:n options:MTLResourceStorageModeShared]
+           : [d newBufferWithLength:n options:MTLResourceStorageModeShared];
+}
+
+int main(void) { @autoreleasepool {
+  id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
+  if (!dev) { fprintf(stderr, "no Metal device available\n"); return 1; }
+  id<MTLCommandQueue> q = [dev newCommandQueue];
+  printf("device  = %s\n", dev.name.UTF8String);
+  printf("os      = %s\n",
+         [NSProcessInfo processInfo].operatingSystemVersionString.UTF8String);
+
+  /* ---- host side: enumerate, build the models, calibrate --------------- */
+  int n = 0;
+  static uint16_t inbits[NBITS];
+  static float xval[NBITS];
+  for (int b = 0; b < NBITS; b++) {
+    int fin; float v = f16_value_of_bits(b, &fin);
+    if (fin) { inbits[n] = (uint16_t)b; xval[n] = v; n++; }
+  }
+  printf("finite binary16 inputs: %d\n\n", n);
+
+  static uint16_t mdl_s1[NBITS][N_MODELS], mdl_s2[NBITS][N_MODELS];
+  for (int i = 0; i < n; i++) {
+    models_S1(xval[i], mdl_s1[i]);
+    models_S2(xval[i], mdl_s2[i]);
+  }
+
+  /* Calibration 1: the host binary16 rounding round-trips every input. If this
+     fails, nothing below means anything. */
+  int rt_bad = 0;
+  for (int i = 0; i < n; i++)
+    if (bits_of_f16((_Float16)xval[i]) != inbits[i]) rt_bad++;
+
+  /* Calibration 2: the two host models must SEPARATE, and by the counts other
+     stacks have already reproduced. A model set that does not separate is a
+     gate that cannot fail. */
+  int sep_s1 = 0, sep_s2 = 0;
+  for (int i = 0; i < n; i++) {
+    if (mdl_s1[i][M_STRICT] != mdl_s1[i][M_FUSE_MUL]) sep_s1++;
+    if (mdl_s2[i][M_STRICT] != mdl_s2[i][M_FUSE_MUL]) sep_s2++;
+  }
+  printf("=== host calibration (runs with no GPU) ===\n");
+  printf("  binary16 round-trip failures            : %d  %s\n", rt_bad,
+         rt_bad == 0 ? "OK" : "<<< HOST REFERENCE BROKEN");
+  printf("  S1 strict vs fuse_mul separation        : %d   (expected 2912)%s\n",
+         sep_s1, sep_s1 == 2912 ? "" : "  <<< UNEXPECTED");
+  printf("  S2 strict vs fuse_mul separation        : %d    (expected 620)%s\n",
+         sep_s2, sep_s2 == 620 ? "" : "  <<< UNEXPECTED");
+  if (rt_bad || sep_s1 == 0 || sep_s2 == 0) {
+    fprintf(stderr, "\nhost calibration failed; refusing to report device numbers\n");
+    return 4;
+  }
+  printf("\n");
+
+  id<MTLBuffer> bIn = mkbuf(dev, inbits, (size_t)n * 2);
+
+  /* ---- device sweep ---------------------------------------------------- */
+  for (int shape = 0; shape < 2; shape++) {
+    variant *V = shape == 0 ? V_S1 : V_S2;
+    int NV      = shape == 0 ? NV_S1 : NV_S2;
+    uint16_t (*mdl)[N_MODELS] = shape == 0 ? mdl_s1 : mdl_s2;
+    const int *keep = shape == 0 ? MODEL_IN_S1 : NULL;
+
+    printf("=== shape %s ===\n",
+           shape == 0 ? "S1  out = f16(x * 1.1f)"
+                      : "S2  out = f16(f16(x * 1.1f) + 1000.0f)");
+
+    for (int v = 0; v < NV; v++) {
+      char src[16384];
+      snprintf(src, sizeof src,
+        "%s%s%s"
+        "kernel void midround(device half* out [[buffer(0)]],\n"
+        "                     const device half* in [[buffer(1)]],\n"
+        "                     uint i [[thread_position_in_grid]]) {\n"
+        "  float x = (float)in[i];\n"
+        "%s"
+        "}\n",
+        PREAMBLE, V[v].pragma, FUSED_HELPER, V[v].body);
+
+      MTLCompileOptions *o = [MTLCompileOptions new];
+      o.mathMode = MTLMathModeSafe;
+      o.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
+      NSError *err = nil;
+      id<MTLLibrary> lib =
+        [dev newLibraryWithSource:[NSString stringWithUTF8String:src]
+                          options:o error:&err];
+      if (!lib) {
+        printf("  %-32s COMPILE FAILED: %s\n", V[v].label,
+               err.localizedDescription.UTF8String);
+        continue;
+      }
+      id<MTLFunction> f = [lib newFunctionWithName:@"midround"];
+      id<MTLComputePipelineState> ps =
+        [dev newComputePipelineStateWithFunction:f error:&err];
+      if (!ps) { printf("  %-32s PIPELINE FAILED\n", V[v].label); continue; }
+
+      id<MTLBuffer> bOut = mkbuf(dev, NULL, (size_t)n * 2);
+      id<MTLCommandBuffer> cb = [q commandBuffer];
+      id<MTLComputeCommandEncoder> en = [cb computeCommandEncoder];
+      [en setComputePipelineState:ps];
+      [en setBuffer:bOut offset:0 atIndex:0];
+      [en setBuffer:bIn  offset:0 atIndex:1];
+      [en dispatchThreads:MTLSizeMake(n,1,1)
+            threadsPerThreadgroup:MTLSizeMake(64,1,1)];
+      [en endEncoding]; [cb commit]; [cb waitUntilCompleted];
+      if (cb.error) { printf("  %-32s EXEC FAILED\n", V[v].label); continue; }
+
+      const uint16_t *got = (const uint16_t *)bOut.contents;
+
+      /* element-wise agreement with every named model */
+      int miss[N_MODELS]; int firsti[N_MODELS];
+      for (int m = 0; m < N_MODELS; m++) { miss[m] = 0; firsti[m] = -1; }
+      int none = 0, maxulp = 0, firstnone = -1, maxulpi = -1;
+      for (int i = 0; i < n; i++) {
+        int any = 0;
+        for (int m = 0; m < N_MODELS; m++) {
+          if (keep && !keep[m]) continue;
+          if (got[i] != mdl[i][m]) {
+            if (firsti[m] < 0) firsti[m] = i;
+            miss[m]++;
+          } else any = 1;
+        }
+        if (!any) { none++; if (firstnone < 0) firstnone = i; }
+        int d = f16_key(got[i]) - f16_key(mdl[i][M_STRICT]);
+        if (d < 0) d = -d;
+        if (d > maxulp) { maxulp = d; maxulpi = i; }
+      }
+
+      printf("  %-32s", V[v].label);
+      for (int m = 0; m < N_MODELS; m++) {
+        if (keep && !keep[m]) continue;
+        printf("  %s=%d", m == M_STRICT ? "strict"
+                        : m == M_FUSE_MUL ? "fuse_mul"
+                        : m == M_FUSE_BOTH ? "fuse_both"
+                        : m == M_FUSE_ADD ? "fuse_add" : "drop_mid",
+               miss[m]);
+      }
+      printf("  | no-model=%d | max-ulp16=%d\n", none, maxulp);
+
+      /* first divergence from the strict discipline — the field that lets a
+         later reader tell one rounding model from another */
+      if (firsti[M_STRICT] >= 0) {
+        int i = firsti[M_STRICT];
+        printf("      first divergence from S_strict: x=%.9g  device=%.9g  S_strict=%.9g",
+               xval[i], (double)(float)f16_of_bits(got[i]),
+               (double)(float)f16_of_bits(mdl[i][M_STRICT]));
+        for (int m = 1; m < N_MODELS; m++) {
+          if (keep && !keep[m]) continue;
+          if (got[i] == mdl[i][m]) printf("  == %s", MODEL_NAME[m]);
+        }
+        printf("\n");
+      }
+      /* §1.3's ceiling, and where it is worst. Reported for the controls too,
+         because the ceiling is a claim about the ADMITTED class and a control
+         that reproduces the admitted class exactly is the right thing to test
+         it with. */
+      if (maxulp > 1 && maxulpi >= 0) {
+        int i = maxulpi;
+        printf("      >>> exceeds the 1-ulp16 ceiling of §1.3: x=%.9g "
+               "device=%.9g S_strict=%.9g (%d ulp16 apart)\n",
+               xval[i], (double)(float)f16_of_bits(got[i]),
+               (double)(float)f16_of_bits(mdl[i][M_STRICT]), maxulp);
+      }
+      if (firstnone >= 0) {
+        int i = firstnone;
+        printf("      >>> first input matching NO model: x=%.9g device=%.9g (bits %04x)\n",
+               xval[i], (double)(float)f16_of_bits(got[i]), got[i]);
+      }
+
+      /* A control that does not reproduce the fused model is not a control. */
+      if (V[v].is_control) {
+        int ok = (miss[M_FUSE_MUL] == 0);
+        printf("      CONTROL VALIDITY: %s (%d / %d elements differ from the "
+               "host fused model)\n",
+               ok ? "VALID — reproduces S_fuse_mul_into_narrowing exactly"
+                  : "*** INVALID — do not read any 0 above as a result ***",
+               miss[M_FUSE_MUL], n);
+      }
+    }
+    printf("\n");
+  }
+  return 0;
+} }
+
+/* ===========================================================================
+ * A note on the "half arithmetic (no f32 mul)" variant, which is not a
+ * candidate and is not a Sarek-emittable shape: `(half)x * (half)1.1f` does the
+ * multiply IN binary16, so it is a DIFFERENT expression and matches no model on
+ * 6229 of 63488 inputs. It is kept because it is the only variant that makes
+ * the harness print a nonzero `no-model` count, which is the control for the
+ * no-model detector itself — without it, "no-model=0" everywhere else would be
+ * indistinguishable from a detector that never fires.
+ * ======================================================================== */

--- a/tools/probes/metal_simdgroup_matrix_probe.m
+++ b/tools/probes/metal_simdgroup_matrix_probe.m
@@ -1,0 +1,498 @@
+/* metal_simdgroup_matrix_probe.m — #63 slice 6 prerequisite
+ *
+ * docs/design/f16-relaxed-accuracy.md §7 slice 6 asks what MSL actually offers
+ * on the M4. Apple documents `simdgroup_matrix` for Metal 3, but which
+ * (component type, rows, cols) instantiations exist, and whether the device has
+ * matrix hardware behind them, is not something the documentation settles. A
+ * probe is the only way to know.
+ *
+ * Two questions, kept apart on purpose:
+ *
+ *   AVAILABILITY — which `simdgroup_matrix<T,C,R>` instantiations COMPILE, and
+ *   which then load / multiply-accumulate / store without failing. Answered by
+ *   compiling each candidate in isolation through the runtime compiler and
+ *   dispatching it. Evidence tier: executed (or compiler-output for the ones
+ *   that only fail to compile).
+ *
+ *   NUMERICS — what the MulAdd computes. §5's derived bound applies with K = 8
+ *   rather than 16. This probe runs the f16xf16->f32 and f16xf16->f16 8x8x8
+ *   products against an exact host reference (an f16 x f16 product is exact in
+ *   binary32 — 11 + 11 = 22 bits inside binary32's 24 — so a binary64 host
+ *   reference is exact for K = 8), with the REQUIRED negative control of §5: a
+ *   host reference that accumulates in binary16 must be REJECTED by the
+ *   f32-accumulate comparison, or the comparison is a gate that cannot fail.
+ *
+ * This probe does NOT claim anything about whether dedicated matrix hardware is
+ * used. It reports what the API offers and what it computes; a throughput claim
+ * would need a benchmark against a scalar kernel and is out of scope here.
+ *
+ * Build (Command Line Tools; no Xcode, no offline `metal` compiler):
+ *   clang -fobjc-arc -O2 -framework Foundation -framework Metal \
+ *       metal_simdgroup_matrix_probe.m -o metal_simdgroup_matrix_probe
+ *
+ * Run: ./metal_simdgroup_matrix_probe
+ *
+ * ---------------------------------------------------------------------------
+ * MEASURED 2026-07-27. Apple M4, macOS 15.6.1 (24G90), arm64, Apple clang
+ * 17.0.0 (clang-1700.0.13.5), Metal.framework from the Command Line Tools SDK.
+ * GPU families Apple1-9 + Metal3 all supported; MSL 2.4 / 3.0 / 3.1 / 3.2 all
+ * accepted by the runtime compiler. Evidence tier: EXECUTED.
+ *
+ * AVAILABILITY — `simdgroup_matrix<T, Cols, Rows>` exists for exactly THREE
+ * instantiations, all 8x8:
+ *
+ *     half   8x8   YES        float  8x8   YES        bfloat 8x8   YES
+ *
+ * Everything else is a compile-time refusal with a named static_assert, so the
+ * answer is a closed one and not a sampling:
+ *   - any size other than 8x8 (16x16, 8x16, 16x8, 4x4, 32x8, 8x32 all tried)
+ *     fails `_valid_simdgroup_matrix_size(Cols, Rows)`;
+ *   - char / uchar / short / int fail `is_simdgroup_matrix_element<T>::value`.
+ * threadExecutionWidth is 32, so one 8x8 fragment is one 32-wide simdgroup.
+ *
+ * **There is no integer simdgroup_matrix on Metal.** That matters beyond this
+ * probe: f16-relaxed-accuracy.md §8 and §7 slice 4b keep an integer coopmat
+ * path as the fallback if the ACO scalar shapes match no closed-form model, and
+ * 12 of the 14 configurations advertised by RADV are integer. That fallback
+ * exists on Vulkan and does NOT exist on Metal. #63 has no strict-contract
+ * route; it is f16/bf16 or nothing.
+ *
+ * **bfloat 8x8 is available and is not in the plan.** Nothing here says what it
+ * computes — it was compiled and dispatched, not swept.
+ *
+ * NUMERICS — 1024 independent 8x8x8 problems, 65536 output elements. Anti-
+ * vacuity first: on this input set a host binary16 accumulator is rejected by
+ * the f32 bound on 65452/65536, the exact reference is rejected by its own
+ * bound on 0, and sequential vs pairwise binary32 accumulation differ on
+ * 27597/65536 — so both the bound and the element-wise model test can fail.
+ *
+ *   simdgroup_half8x8 x half8x8 -> float8x8
+ *     bit-equal to SEQUENTIAL binary32 accumulate : 65536 / 65536   <-- EXACT
+ *     bit-equal to PAIRWISE   binary32 accumulate : 37939 / 65536
+ *     bit-equal to the exact dot product          :   217 / 65536
+ *     worst error / sum|p_i| 2.79e-07 against the derived bound 4.17e-07
+ *
+ *   simdgroup_half8x8 x half8x8 -> half8x8
+ *     bit-equal to SEQUENTIAL binary16 accumulate : 65528 / 65536   <-- NOT exact
+ *     bit-equal to PAIRWISE   binary16 accumulate : 41109 / 65536
+ *     worst error / sum|p_i| 1.75e-03 against the derived bound 3.43e-03
+ *
+ * **The f32-accumulate configuration matches a NAMED CLOSED-FORM MODEL
+ * element-wise on every element** — sequential accumulation k = 0..7 in
+ * binary32. That is a materially stronger statement than sitting inside §5's
+ * bound, and it is the outcome §6.1's corollary was written for: friction falls
+ * as evidence improves, so this configuration belongs in the loud-diagnostic
+ * row and not the mandatory-opt-in row. Note the model cannot distinguish
+ * "exact products then sequential adds" from an fma chain, and does not need
+ * to: an f16 x f16 product is exact in binary32 (11 + 11 = 22 bits inside 24),
+ * so the two are the same function. Evidence tier for THAT step:
+ * by-construction.
+ *
+ * **The f16-accumulate configuration matches no closed-form model** — 8
+ * elements in 65536 differ from sequential binary16, by 1-2 ulp16, and match
+ * neither pairwise binary16 nor a binary32 chain narrowed at the end. It stays
+ * bounded-only, which is exactly the case §5 recommends NOT admitting; the
+ * recommendation now rests on a measurement rather than on the width of the
+ * bound alone.
+ *
+ * DETERMINISM (§1.4) — bit-identical across two processes, and bit-identical
+ * across threadgroup sizes 32 / 64 / 128 / 256 (0 / 65536 differ in each case).
+ * §1.4 says a coopmat result may legitimately move with the dispatch shape and
+ * that nobody had measured it. On this device, at this tile size, it does not.
+ *
+ * NOT MEASURED: throughput. Whether the M4 has dedicated matrix hardware behind
+ * these three instantiations is not answered by this probe and cannot be read
+ * off it — that needs a benchmark against a scalar kernel.
+ * ---------------------------------------------------------------------------
+ */
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+static id<MTLBuffer> mkbuf(id<MTLDevice> d, const void *s, size_t n) {
+  return s ? [d newBufferWithBytes:s length:n options:MTLResourceStorageModeShared]
+           : [d newBufferWithLength:n options:MTLResourceStorageModeShared];
+}
+
+/* ---- part 1: which instantiations exist -------------------------------- */
+
+typedef struct { const char *t; int rows, cols; } cfg;
+
+static cfg CFGS[] = {
+  { "half",   8,  8 }, { "float",  8,  8 }, { "bfloat", 8,  8 },
+  { "half",  16, 16 }, { "float", 16, 16 }, { "bfloat",16, 16 },
+  { "half",   8, 16 }, { "half",  16,  8 },
+  { "half",   4,  4 }, { "half",  32,  8 }, { "half",   8, 32 },
+  { "char",   8,  8 }, { "uchar",  8,  8 },
+  { "short",  8,  8 }, { "int",    8,  8 },
+};
+static const int NCFG = sizeof(CFGS)/sizeof(CFGS[0]);
+
+/* Declared, loaded, multiply-accumulated and stored — a declaration alone can
+   compile while the operations do not exist for that instantiation. */
+static void avail_source(char *buf, size_t sz, cfg c) {
+  snprintf(buf, sz,
+    "#include <metal_stdlib>\n"
+    "#include <metal_simdgroup_matrix>\n"
+    "using namespace metal;\n"
+    "kernel void k(device %s* out [[buffer(0)]],\n"
+    "              const device %s* a [[buffer(1)]],\n"
+    "              const device %s* b [[buffer(2)]],\n"
+    "              uint tid [[thread_position_in_grid]]) {\n"
+    "  simdgroup_matrix<%s, %d, %d> A, B, C;\n"
+    "  C = simdgroup_matrix<%s, %d, %d>(0);\n"
+    "  simdgroup_load(A, a, %d);\n"
+    "  simdgroup_load(B, b, %d);\n"
+    "  simdgroup_multiply_accumulate(C, A, B, C);\n"
+    "  simdgroup_store(C, out, %d);\n"
+    "}\n",
+    c.t, c.t, c.t, c.t, c.cols, c.rows, c.t, c.cols, c.rows,
+    c.cols, c.cols, c.cols);
+}
+
+/* ---- part 2: what the 8x8x8 f16 MulAdd computes ------------------------ */
+
+/* NT independent 8x8x8 problems, one per simdgroup. */
+#define NT 1024
+
+/* f16 operands, f32 accumulate. */
+static const char *SRC_MMA_F32 =
+"#include <metal_stdlib>\n"
+"#include <metal_simdgroup_matrix>\n"
+"using namespace metal;\n"
+"kernel void k(device float* out [[buffer(0)]],\n"
+"              const device half* a [[buffer(1)]],\n"
+"              const device half* b [[buffer(2)]],\n"
+"              uint tid [[thread_position_in_grid]]) {\n"
+"  uint sg = tid / 32;\n"
+"  simdgroup_half8x8  A, B;\n"
+"  simdgroup_float8x8 C = simdgroup_float8x8(0);\n"
+"  simdgroup_load(A, a + sg * 64, 8);\n"
+"  simdgroup_load(B, b + sg * 64, 8);\n"
+"  simdgroup_multiply_accumulate(C, A, B, C);\n"
+"  simdgroup_store(C, out + sg * 64, 8);\n"
+"}\n";
+
+/* f16 operands, f16 accumulate — §5 recommends NOT admitting this one; the
+   probe measures it so the recommendation rests on a number. */
+static const char *SRC_MMA_F16 =
+"#include <metal_stdlib>\n"
+"#include <metal_simdgroup_matrix>\n"
+"using namespace metal;\n"
+"kernel void k(device half* out [[buffer(0)]],\n"
+"              const device half* a [[buffer(1)]],\n"
+"              const device half* b [[buffer(2)]],\n"
+"              uint tid [[thread_position_in_grid]]) {\n"
+"  uint sg = tid / 32;\n"
+"  simdgroup_half8x8 A, B, C = simdgroup_half8x8(0);\n"
+"  simdgroup_load(A, a + sg * 64, 8);\n"
+"  simdgroup_load(B, b + sg * 64, 8);\n"
+"  simdgroup_multiply_accumulate(C, A, B, C);\n"
+"  simdgroup_store(C, out + sg * 64, 8);\n"
+"}\n";
+
+static id<MTLLibrary> build(id<MTLDevice> dev, const char *src, NSError **err) {
+  MTLCompileOptions *o = [MTLCompileOptions new];
+  o.mathMode = MTLMathModeSafe;
+  o.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
+  return [dev newLibraryWithSource:[NSString stringWithUTF8String:src]
+                           options:o error:err];
+}
+
+int main(void) { @autoreleasepool {
+  id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
+  if (!dev) { fprintf(stderr, "no Metal device available\n"); return 1; }
+  id<MTLCommandQueue> q = [dev newCommandQueue];
+
+  printf("device  = %s\n", dev.name.UTF8String);
+  printf("os      = %s\n",
+         [NSProcessInfo processInfo].operatingSystemVersionString.UTF8String);
+  printf("unified memory = %s\n", dev.hasUnifiedMemory ? "yes" : "no");
+
+  printf("\n=== GPU family support ===\n");
+  struct { const char *n; MTLGPUFamily f; } fams[] = {
+    { "Apple1", MTLGPUFamilyApple1 }, { "Apple2", MTLGPUFamilyApple2 },
+    { "Apple3", MTLGPUFamilyApple3 }, { "Apple4", MTLGPUFamilyApple4 },
+    { "Apple5", MTLGPUFamilyApple5 }, { "Apple6", MTLGPUFamilyApple6 },
+    { "Apple7", MTLGPUFamilyApple7 }, { "Apple8", MTLGPUFamilyApple8 },
+    { "Apple9", MTLGPUFamilyApple9 }, { "Metal3", MTLGPUFamilyMetal3 },
+    { "Common1", MTLGPUFamilyCommon1 }, { "Common2", MTLGPUFamilyCommon2 },
+    { "Common3", MTLGPUFamilyCommon3 },
+  };
+  for (unsigned i = 0; i < sizeof(fams)/sizeof(fams[0]); i++)
+    printf("  %-8s %s\n", fams[i].n,
+           [dev supportsFamily:fams[i].f] ? "yes" : "no");
+
+  printf("\n=== MSL language version accepted by the runtime compiler ===\n");
+  struct { const char *n; MTLLanguageVersion v; } vers[] = {
+    { "2.4", MTLLanguageVersion2_4 }, { "3.0", MTLLanguageVersion3_0 },
+    { "3.1", MTLLanguageVersion3_1 }, { "3.2", MTLLanguageVersion3_2 },
+  };
+  for (unsigned i = 0; i < sizeof(vers)/sizeof(vers[0]); i++) {
+    MTLCompileOptions *o = [MTLCompileOptions new];
+    o.languageVersion = vers[i].v;
+    NSError *e = nil;
+    id<MTLLibrary> l = [dev newLibraryWithSource:
+        @"#include <metal_stdlib>\nkernel void k(){}\n" options:o error:&e];
+    printf("  metal %-4s %s\n", vers[i].n, l ? "accepted" : "rejected");
+  }
+
+  printf("\n=== simdgroup_matrix<T, Cols, Rows> availability ===\n");
+  printf("  (declared + simdgroup_load + multiply_accumulate + store)\n");
+  for (int i = 0; i < NCFG; i++) {
+    char src[4096]; avail_source(src, sizeof src, CFGS[i]);
+    NSError *e = nil;
+    id<MTLLibrary> lib = build(dev, src, &e);
+    if (!lib) {
+      /* keep the first diagnostic line that names the failure, not the module
+         preamble the compiler prints before it */
+      const char *m = e.localizedDescription.UTF8String;
+      const char *w = strstr(m, "error:");
+      if (!w) w = m;
+      char one[240]; size_t k = 0;
+      for (const char *p = w; *p && k < sizeof(one)-1; p++)
+        one[k++] = (*p == '\n') ? ' ' : *p;
+      one[k] = 0;
+      printf("  %-7s %2dx%-2d  NO   %.200s\n", CFGS[i].t, CFGS[i].rows, CFGS[i].cols, one);
+      continue;
+    }
+    id<MTLFunction> f = [lib newFunctionWithName:@"k"];
+    id<MTLComputePipelineState> ps =
+      [dev newComputePipelineStateWithFunction:f error:&e];
+    if (!ps) {
+      printf("  %-7s %2dx%-2d  compiles, PIPELINE FAILED\n",
+             CFGS[i].t, CFGS[i].rows, CFGS[i].cols);
+      continue;
+    }
+    printf("  %-7s %2dx%-2d  YES  (threadExecutionWidth=%lu, "
+           "maxTotalThreadsPerThreadgroup=%lu)\n",
+           CFGS[i].t, CFGS[i].rows, CFGS[i].cols,
+           (unsigned long)ps.threadExecutionWidth,
+           (unsigned long)ps.maxTotalThreadsPerThreadgroup);
+  }
+
+  /* ---- numerics: 8x8x8, f16 operands ---------------------------------- */
+  printf("\n=== 8x8x8 MulAdd numerics (K = 8, %d independent problems) ===\n", NT);
+
+  /* INPUT DESIGN, and it is the part that makes this a check rather than a
+     formality. A first attempt drew operands as multiples of 2^-9 in [-1,1].
+     Every product was then a multiple of 2^-18 below 8, so the sum of 8 of them
+     was EXACTLY representable in binary32 — every accumulation order gives the
+     same answer and the f32 comparison could not fail. It reported 64/64 exact
+     and measured nothing.
+     The operands below carry a full 11-bit significand and an exponent drawn
+     from a 13-wide range, so a product needs 22 bits and the 8 products span 24
+     binades: the sum needs about 46 significant bits. That is far outside
+     binary32, so accumulation order IS observable, and still inside binary64's
+     53, so the host reference remains EXACT. Both halves matter. */
+  static _Float16 A[NT*64], B[NT*64];
+  unsigned s = 12345u;
+  for (int i = 0; i < NT*64; i++) {
+    s = s * 1103515245u + 12345u;
+    int ma = 1024 + (int)((s >> 7) & 0x3ff);       /* 11-bit significand   */
+    int ea = -6 + (int)((s >> 19) & 0xf) % 13;     /* exponent in [-6, 6]  */
+    int sa = (s & 0x40) ? -1 : 1;
+    A[i] = (_Float16)(sa * ldexpf((float)ma, ea - 10));
+    s = s * 1103515245u + 12345u;
+    int mb = 1024 + (int)((s >> 7) & 0x3ff);
+    int eb = -6 + (int)((s >> 19) & 0xf) % 13;
+    int sb = (s & 0x40) ? -1 : 1;
+    B[i] = (_Float16)(sb * ldexpf((float)mb, eb - 10));
+  }
+
+  /* Host models. `refd` is EXACT (see the input design note). The two ordered
+     models are named closed forms: element-wise agreement with one of them is a
+     far stronger statement than sitting inside a bound, and §6.1 turns exactly
+     that distinction into how much friction a user is made to accept. */
+  static double refd[NT*64], sabs[NT*64];
+  static float  seq32[NT*64], tree32[NT*64];
+  static double ref16[NT*64], tree16[NT*64];
+  for (int t = 0; t < NT; t++)
+    for (int r = 0; r < 8; r++)
+      for (int c = 0; c < 8; c++) {
+        const _Float16 *a = A + t*64, *b = B + t*64;
+        int o = t*64 + r*8 + c;
+        double acc = 0.0, sa = 0.0;
+        float p[8];
+        for (int k = 0; k < 8; k++) {
+          p[k] = (float)a[r*8+k] * (float)b[k*8+c];   /* EXACT in binary32 */
+          acc += (double)p[k]; sa += fabs((double)p[k]);
+        }
+        refd[o] = acc; sabs[o] = sa;
+        { float f = 0.0f; for (int k = 0; k < 8; k++) f += p[k]; seq32[o] = f; }
+        { float l0 = (p[0]+p[1]) + (p[2]+p[3]);
+          float l1 = (p[4]+p[5]) + (p[6]+p[7]);
+          tree32[o] = l0 + l1; }
+        { _Float16 h = (_Float16)0.0f;
+          for (int k = 0; k < 8; k++) h = (_Float16)((float)h + p[k]);
+          ref16[o] = (double)(float)h; }
+        { _Float16 h0 = (_Float16)((float)(_Float16)(p[0]+p[1]) + p[2]);
+          h0 = (_Float16)((float)h0 + p[3]);
+          _Float16 h1 = (_Float16)((float)(_Float16)(p[4]+p[5]) + p[6]);
+          h1 = (_Float16)((float)h1 + p[7]);
+          tree16[o] = (double)(float)(_Float16)((float)h0 + (float)h1); }
+      }
+
+  /* K-1 = 7 binary32 additions in any order: |err| <= (7u)/(1-7u) * sum|p| */
+  const double U32 = ldexp(1.0, -24);
+  const double BOUND32 = (7.0 * U32) / (1.0 - 7.0 * U32);
+  const double U16 = ldexp(1.0, -11);
+  const double BOUND16 = (7.0 * U16) / (1.0 - 7.0 * U16);
+  printf("  derived bound, f32 accumulate: %.3g * sum|p_i|\n", BOUND32);
+  printf("  derived bound, f16 accumulate: %.3g * sum|p_i|\n", BOUND16);
+
+  id<MTLBuffer> bA = mkbuf(dev, A, sizeof A), bB = mkbuf(dev, B, sizeof B);
+
+  /* ANTI-VACUITY CONTROL. Before any device number is read: does the f32 bound
+     reject anything at all on this input set? A host binary16 accumulator must
+     be rejected by it, and the exactly-summed reference must be accepted. If
+     the first number is 0 the gate cannot fail and no pass below is readable. */
+  {
+    int rej = 0, self = 0; double worst = 0.0;
+    for (int i = 0; i < NT*64; i++) {
+      double e = fabs(ref16[i] - refd[i]);
+      double rel = sabs[i] > 0 ? e / sabs[i] : 0.0;
+      if (rel > worst) worst = rel;
+      if (e > BOUND32 * sabs[i]) rej++;
+      if (fabs(refd[i] - refd[i]) > BOUND32 * sabs[i]) self++;
+    }
+    printf("  ANTI-VACUITY CONTROL:\n");
+    printf("    host binary16 accumulator rejected by the f32 bound: %d / %d "
+           "(worst rel. error %.3g) -> %s\n", rej, NT*64, worst,
+           rej > 0 ? "the f32 bound CAN fail"
+                   : "*** the f32 bound cannot fail here; do not trust a pass ***");
+    printf("    exact reference accepted by its own bound          : %d rejected\n",
+           self);
+    /* And the f32 accumulation order must actually be observable, or the
+       element-wise model comparison below is equally vacuous. */
+    int sep = 0;
+    for (int i = 0; i < NT*64; i++) if (seq32[i] != tree32[i]) sep++;
+    printf("    sequential vs pairwise binary32 order differ on    : %d / %d "
+           "-> %s\n", sep, NT*64,
+           sep > 0 ? "accumulation order IS observable on this input set"
+                   : "*** order is unobservable here; the model test is vacuous ***");
+  }
+
+  struct { const char *label; const char *src; int f32out; } runs[] = {
+    { "simdgroup_half8x8 x half8x8 -> float8x8", SRC_MMA_F32, 1 },
+    { "simdgroup_half8x8 x half8x8 -> half8x8",  SRC_MMA_F16, 0 },
+  };
+  for (int r = 0; r < 2; r++) {
+    NSError *e = nil;
+    id<MTLLibrary> lib = build(dev, runs[r].src, &e);
+    if (!lib) { printf("  %s: COMPILE FAILED: %s\n", runs[r].label,
+                       e.localizedDescription.UTF8String); continue; }
+    id<MTLFunction> f = [lib newFunctionWithName:@"k"];
+    id<MTLComputePipelineState> ps =
+      [dev newComputePipelineStateWithFunction:f error:&e];
+    if (!ps) { printf("  %s: PIPELINE FAILED\n", runs[r].label); continue; }
+    size_t osz = (size_t)NT * 64 * (runs[r].f32out ? 4 : 2);
+    id<MTLBuffer> bO = mkbuf(dev, NULL, osz);
+    id<MTLCommandBuffer> cb = [q commandBuffer];
+    id<MTLComputeCommandEncoder> en = [cb computeCommandEncoder];
+    [en setComputePipelineState:ps];
+    [en setBuffer:bO offset:0 atIndex:0];
+    [en setBuffer:bA offset:0 atIndex:1];
+    [en setBuffer:bB offset:0 atIndex:2];
+    [en dispatchThreads:MTLSizeMake(32*NT,1,1)
+          threadsPerThreadgroup:MTLSizeMake(32,1,1)];
+    [en endEncoding]; [cb commit]; [cb waitUntilCompleted];
+    if (cb.error) { printf("  %s: EXEC FAILED: %s\n", runs[r].label,
+                           cb.error.localizedDescription.UTF8String); continue; }
+
+    double bound = runs[r].f32out ? BOUND32 : BOUND16;
+    int N = NT*64;
+    int over = 0, exact = 0, eqseq = 0, eqtree = 0, eq16 = 0, eq16t = 0, eqnar = 0;
+    double worst = 0.0; int worsti = -1;
+    for (int i = 0; i < N; i++) {
+      double g = runs[r].f32out ? (double)((const float *)bO.contents)[i]
+                                : (double)(float)((const _Float16 *)bO.contents)[i];
+      double err = fabs(g - refd[i]);
+      double rel = sabs[i] > 0 ? err / sabs[i] : 0.0;
+      if (rel > worst) { worst = rel; worsti = i; }
+      if (err > bound * sabs[i]) over++;
+      if (g == refd[i]) exact++;
+      if (g == (double)seq32[i]) eqseq++;
+      if (g == (double)tree32[i]) eqtree++;
+      if (g == ref16[i]) eq16++;
+      if (g == tree16[i]) eq16t++;
+      if (g == (double)(float)(_Float16)seq32[i]) eqnar++;
+    }
+    printf("  %s\n", runs[r].label);
+    printf("    bit-equal to the exact dot product          : %d / %d\n", exact, N);
+    printf("    bit-equal to SEQUENTIAL binary32 accumulate : %d / %d\n", eqseq, N);
+    printf("    bit-equal to PAIRWISE   binary32 accumulate : %d / %d\n", eqtree, N);
+    printf("    bit-equal to SEQUENTIAL binary16 accumulate : %d / %d\n", eq16, N);
+    printf("    bit-equal to PAIRWISE   binary16 accumulate : %d / %d\n", eq16t, N);
+    printf("    bit-equal to seq. binary32 NARROWED at the end : %d / %d\n",
+           eqnar, N);
+    /* Element-wise agreement is the contract (§1.2), so when a model is close
+       but not exact the residue is the interesting part, not the count. */
+    if (eq16 > 0 && eq16 < N) {
+      int shown = 0;
+      printf("    residue against SEQUENTIAL binary16 (first few):\n");
+      for (int i = 0; i < N && shown < 5; i++) {
+        double g = runs[r].f32out ? (double)((const float *)bO.contents)[i]
+                                  : (double)(float)((const _Float16 *)bO.contents)[i];
+        if (g == ref16[i]) continue;
+        printf("      [%5d] device=%-14.9g seq16=%-14.9g seq32=%-14.9g "
+               "narrowed(seq32)=%-14.9g exact=%.9g\n",
+               i, g, ref16[i], (double)seq32[i],
+               (double)(float)(_Float16)seq32[i], refd[i]);
+        shown++;
+      }
+    }
+    printf("    worst error / sum|p_i|                      : %.3g  (bound %.3g)\n",
+           worst, bound);
+    printf("    elements outside the bound                  : %d / %d -> %s\n",
+           over, N, over == 0 ? "WITHIN BOUND" : "OUTSIDE BOUND");
+    if (worsti >= 0 && worst > 0)
+      printf("    worst element                               : device=%.17g exact=%.17g\n",
+             runs[r].f32out ? (double)((const float *)bO.contents)[worsti]
+                            : (double)(float)((const _Float16 *)bO.contents)[worsti],
+             refd[worsti]);
+  }
+
+  /* §1.4(a) re-run in process, and §1.4(c) vary the dispatch shape. The latter
+     is REPORTED, not asserted: for coopmat the mapping of matrix components to
+     invocations is implementation-dependent, so a shape-dependent result would
+     be legitimate and is exactly what §1.4 says has never been measured. */
+  printf("\n=== determinism (§1.4) ===\n");
+  {
+    NSError *e = nil;
+    id<MTLLibrary> lib = build(dev, SRC_MMA_F32, &e);
+    if (lib) {
+      id<MTLComputePipelineState> ps = [dev newComputePipelineStateWithFunction:
+          [lib newFunctionWithName:@"k"] error:&e];
+      size_t osz = (size_t)NT * 64 * 4;
+      float *ref = malloc(osz);
+      int tgs[] = { 32, 32, 64, 128, 256 };
+      for (unsigned p = 0; p < sizeof(tgs)/sizeof(tgs[0]); p++) {
+        id<MTLBuffer> bO = mkbuf(dev, NULL, osz);
+        id<MTLCommandBuffer> cb = [q commandBuffer];
+        id<MTLComputeCommandEncoder> en = [cb computeCommandEncoder];
+        [en setComputePipelineState:ps];
+        [en setBuffer:bO offset:0 atIndex:0];
+        [en setBuffer:bA offset:0 atIndex:1];
+        [en setBuffer:bB offset:0 atIndex:2];
+        [en dispatchThreads:MTLSizeMake(32*NT,1,1)
+              threadsPerThreadgroup:MTLSizeMake(tgs[p],1,1)];
+        [en endEncoding]; [cb commit]; [cb waitUntilCompleted];
+        if (p == 0) { memcpy(ref, bO.contents, osz); continue; }
+        int d = 0;
+        const float *g = (const float *)bO.contents;
+        for (size_t i = 0; i < osz/4; i++) if (memcmp(&g[i], &ref[i], 4)) d++;
+        printf("  threadgroup %3d : %d / %zu elements differ from the "
+               "threadgroup-32 run%s\n", tgs[p], d, osz/4,
+               d == 0 ? "" : "   <<< SHAPE-DEPENDENT");
+      }
+      free(ref);
+    }
+  }
+  printf("  (a fresh-process re-run is checked by running this binary twice "
+         "and diffing its output)\n");
+  return 0;
+} }

--- a/tools/probes/metal_simdgroup_matrix_probe.m
+++ b/tools/probes/metal_simdgroup_matrix_probe.m
@@ -15,12 +15,13 @@
  *   that only fail to compile).
  *
  *   NUMERICS — what the MulAdd computes. §5's derived bound applies with K = 8
- *   rather than 16. This probe runs the f16xf16->f32 and f16xf16->f16 8x8x8
- *   products against an exact host reference (an f16 x f16 product is exact in
- *   binary32 — 11 + 11 = 22 bits inside binary32's 24 — so a binary64 host
- *   reference is exact for K = 8), with the REQUIRED negative control of §5: a
- *   host reference that accumulates in binary16 must be REJECTED by the
- *   f32-accumulate comparison, or the comparison is a gate that cannot fail.
+ *   rather than 16, and the operation is `D = A x B + C` (§5.1), so C is a real
+ *   input here and never zero: the constant is therefore gamma_8 and not the
+ *   gamma_7 of the C = 0 degenerate case, which §5.2 says "must not" be used
+ *   unless C is pinned. §5.3's exactness invariant on the host reference is
+ *   ASSERTED rather than assumed, and both of §5.4's required controls run — a
+ *   binary16-accumulating reference and a C-DROPPING reference, each of which
+ *   the bound must reject, or the bound is a gate that cannot fail.
  *
  * This probe does NOT claim anything about whether dedicated matrix hardware is
  * used. It reports what the API offers and what it computes; a throughput claim
@@ -60,40 +61,54 @@
  * **bfloat 8x8 is available and is not in the plan.** Nothing here says what it
  * computes — it was compiled and dispatched, not swept.
  *
- * NUMERICS — 1024 independent 8x8x8 problems, 65536 output elements. Anti-
- * vacuity first: on this input set a host binary16 accumulator is rejected by
- * the f32 bound on 65452/65536, the exact reference is rejected by its own
- * bound on 0, and sequential vs pairwise binary32 accumulation differ on
- * 27597/65536 — so both the bound and the element-wise model test can fail.
+ * NUMERICS — 1024 independent 8x8x8 problems, 65536 output elements, D = AxB+C
+ * with C nonzero throughout. §5.3's exactness invariant holds with margin: the
+ * term exponent span is 21 binades, needing 50 bits against binary64's 53, so
+ * the host reference is exact — ASSERTED by the harness, which refuses to print
+ * any device number otherwise. Anti-vacuity, both of §5.4's required controls:
+ *   [1] host binary16 accumulator rejected by the f32 bound on 65433 / 65536
+ *   [2] host C-DROPPING reference rejected by the f32 bound on 65498 / 65536
+ *   exact reference accepted by its own bound: 0 rejected
+ *   sequential vs pairwise binary32 differ on 23291 / 65536, so accumulation
+ *   order is observable and the element-wise model test can fail.
  *
- *   simdgroup_half8x8 x half8x8 -> float8x8
- *     bit-equal to SEQUENTIAL binary32 accumulate : 65536 / 65536   <-- EXACT
- *     bit-equal to PAIRWISE   binary32 accumulate : 37939 / 65536
- *     bit-equal to the exact dot product          :   217 / 65536
- *     worst error / sum|p_i| 2.79e-07 against the derived bound 4.17e-07
+ *   simdgroup_half8x8 x half8x8 -> float8x8     (bound gamma_8 = 4.7684e-07)
+ *     bit-equal to SEQUENTIAL binary32, C FIRST : 65536 / 65536  <-- EXACT
+ *     bit-equal to SEQUENTIAL binary32, C last  : 51850 / 65536
+ *     bit-equal to PAIRWISE   binary32, C last  : 34914 / 65536
+ *     bit-equal to the exact dot product        :   538 / 65536
+ *     worst error / sum|terms| 2.67e-07, 0 / 65536 outside the bound
  *
- *   simdgroup_half8x8 x half8x8 -> half8x8
- *     bit-equal to SEQUENTIAL binary16 accumulate : 65528 / 65536   <-- NOT exact
- *     bit-equal to PAIRWISE   binary16 accumulate : 41109 / 65536
- *     worst error / sum|p_i| 1.75e-03 against the derived bound 3.43e-03
+ *   simdgroup_half8x8 x half8x8 -> half8x8      (bound gamma_8 = 3.9216e-03)
+ *     bit-equal to SEQUENTIAL binary16, C FIRST : 65520 / 65536  <-- NOT exact
+ *     bit-equal to PAIRWISE   binary16          : 32712 / 65536
+ *     worst error / sum|terms| 2.12e-03, 0 / 65536 outside the bound
  *
  * **The f32-accumulate configuration matches a NAMED CLOSED-FORM MODEL
- * element-wise on every element** — sequential accumulation k = 0..7 in
- * binary32. That is a materially stronger statement than sitting inside §5's
- * bound, and it is the outcome §6.1's corollary was written for: friction falls
- * as evidence improves, so this configuration belongs in the loud-diagnostic
- * row and not the mandatory-opt-in row. Note the model cannot distinguish
- * "exact products then sequential adds" from an fma chain, and does not need
- * to: an f16 x f16 product is exact in binary32 (11 + 11 = 22 bits inside 24),
- * so the two are the same function. Evidence tier for THAT step:
- * by-construction.
+ * element-wise on every element**: initialise the accumulator to C, then add
+ * the eight products in index order, all in binary32. That is materially
+ * stronger than sitting inside §5's bound, and it is what §1.6's migration row
+ * and §6.1's corollary were written for — this configuration moves from Regime
+ * B to Regime A, and its friction falls from mandatory opt-in to a diagnostic.
  *
- * **The f16-accumulate configuration matches no closed-form model** — 8
- * elements in 65536 differ from sequential binary16, by 1-2 ulp16, and match
- * neither pairwise binary16 nor a binary32 chain narrowed at the end. It stays
- * bounded-only, which is exactly the case §5 recommends NOT admitting; the
- * recommendation now rests on a measurement rather than on the width of the
- * bound alone.
+ * **C's POSITION IN THE SUM IS WHAT A C = 0 PROBE CANNOT SEE, and an earlier
+ * revision of this probe did pin C = 0.** It reported 65536/65536 against
+ * "sequential binary32", and that claim was underdetermined rather than wrong:
+ * with C = 0 the C-first and C-last orders are the same function. Only a
+ * nonzero C separates them, and it separates them decisively — 65536 against
+ * 51850. This is §5.1's correction reproduced from the other side: a probe that
+ * pins C = 0 cannot characterise the operation the specification defines.
+ *
+ * Note the model cannot distinguish "exact products then sequential adds" from
+ * an fma chain, and does not need to: an f16 x f16 product is exact in binary32
+ * (11 + 11 = 22 bits inside 24), so the two are the same function. Evidence
+ * tier for THAT step: by-construction.
+ *
+ * **The f16-accumulate configuration matches no closed-form model** — 16
+ * elements in 65536 differ from sequential binary16, and match neither pairwise
+ * binary16 nor a binary32 chain narrowed at the end. It stays bounded-only,
+ * which is exactly the case §5.4 recommends NOT admitting; the recommendation
+ * now rests on a measurement rather than on the width of the bound alone.
  *
  * DETERMINISM (§1.4) — bit-identical across two processes, and bit-identical
  * across threadgroup sizes 32 / 64 / 128 / 256 (0 / 65536 differ in each case).
@@ -158,7 +173,11 @@ static void avail_source(char *buf, size_t sz, cfg c) {
 /* NT independent 8x8x8 problems, one per simdgroup. */
 #define NT 1024
 
-/* f16 operands, f32 accumulate. */
+/* f16 operands, f32 accumulate.
+   `C` is LOADED, not zero-initialised: f16-relaxed-accuracy.md §5.1 records that
+   the operation is `D = A x B + C` and that an earlier draft which bounded only
+   the products "would have failed a correct result with a nonzero C". A probe
+   that pins C = 0 cannot exercise that, so C is a real input here. */
 static const char *SRC_MMA_F32 =
 "#include <metal_stdlib>\n"
 "#include <metal_simdgroup_matrix>\n"
@@ -166,17 +185,19 @@ static const char *SRC_MMA_F32 =
 "kernel void k(device float* out [[buffer(0)]],\n"
 "              const device half* a [[buffer(1)]],\n"
 "              const device half* b [[buffer(2)]],\n"
+"              const device float* c [[buffer(3)]],\n"
 "              uint tid [[thread_position_in_grid]]) {\n"
 "  uint sg = tid / 32;\n"
 "  simdgroup_half8x8  A, B;\n"
-"  simdgroup_float8x8 C = simdgroup_float8x8(0);\n"
+"  simdgroup_float8x8 C, D;\n"
 "  simdgroup_load(A, a + sg * 64, 8);\n"
 "  simdgroup_load(B, b + sg * 64, 8);\n"
-"  simdgroup_multiply_accumulate(C, A, B, C);\n"
-"  simdgroup_store(C, out + sg * 64, 8);\n"
+"  simdgroup_load(C, c + sg * 64, 8);\n"
+"  simdgroup_multiply_accumulate(D, A, B, C);\n"
+"  simdgroup_store(D, out + sg * 64, 8);\n"
 "}\n";
 
-/* f16 operands, f16 accumulate — §5 recommends NOT admitting this one; the
+/* f16 operands, f16 accumulate — §5.4 recommends NOT admitting this one; the
    probe measures it so the recommendation rests on a number. */
 static const char *SRC_MMA_F16 =
 "#include <metal_stdlib>\n"
@@ -185,13 +206,15 @@ static const char *SRC_MMA_F16 =
 "kernel void k(device half* out [[buffer(0)]],\n"
 "              const device half* a [[buffer(1)]],\n"
 "              const device half* b [[buffer(2)]],\n"
+"              const device half* c [[buffer(3)]],\n"
 "              uint tid [[thread_position_in_grid]]) {\n"
 "  uint sg = tid / 32;\n"
-"  simdgroup_half8x8 A, B, C = simdgroup_half8x8(0);\n"
+"  simdgroup_half8x8 A, B, C, D;\n"
 "  simdgroup_load(A, a + sg * 64, 8);\n"
 "  simdgroup_load(B, b + sg * 64, 8);\n"
-"  simdgroup_multiply_accumulate(C, A, B, C);\n"
-"  simdgroup_store(C, out + sg * 64, 8);\n"
+"  simdgroup_load(C, c + sg * 64, 8);\n"
+"  simdgroup_multiply_accumulate(D, A, B, C);\n"
+"  simdgroup_store(D, out + sg * 64, 8);\n"
 "}\n";
 
 static id<MTLLibrary> build(id<MTLDevice> dev, const char *src, NSError **err) {
@@ -288,28 +311,41 @@ int main(void) { @autoreleasepool {
      binades: the sum needs about 46 significant bits. That is far outside
      binary32, so accumulation order IS observable, and still inside binary64's
      53, so the host reference remains EXACT. Both halves matter. */
-  static _Float16 A[NT*64], B[NT*64];
+  static _Float16 A[NT*64], B[NT*64], Ch[NT*64];
+  static float Cf[NT*64];
   unsigned s = 12345u;
   for (int i = 0; i < NT*64; i++) {
     s = s * 1103515245u + 12345u;
     int ma = 1024 + (int)((s >> 7) & 0x3ff);       /* 11-bit significand   */
-    int ea = -6 + (int)((s >> 19) & 0xf) % 13;     /* exponent in [-6, 6]  */
+    int ea = -5 + (int)((s >> 19) & 0xf) % 11;     /* exponent in [-5, 5]  */
     int sa = (s & 0x40) ? -1 : 1;
     A[i] = (_Float16)(sa * ldexpf((float)ma, ea - 10));
     s = s * 1103515245u + 12345u;
     int mb = 1024 + (int)((s >> 7) & 0x3ff);
-    int eb = -6 + (int)((s >> 19) & 0xf) % 13;
+    int eb = -5 + (int)((s >> 19) & 0xf) % 11;
     int sb = (s & 0x40) ? -1 : 1;
     B[i] = (_Float16)(sb * ldexpf((float)mb, eb - 10));
+    /* C is a real input, never zero (§5.1). Its exponent is drawn from the same
+       range the products occupy, so it neither dominates nor vanishes. */
+    s = s * 1103515245u + 12345u;
+    int mc = 1024 + (int)((s >> 7) & 0x3ff);
+    int ec = -10 + (int)((s >> 19) & 0x1f) % 21;   /* exponent in [-10, 10] */
+    int sc = (s & 0x40) ? -1 : 1;
+    Cf[i] = sc * ldexpf((float)mc, ec - 10);
+    Ch[i] = (_Float16)Cf[i];
+    Cf[i] = (float)Ch[i];   /* keep the two configurations on the SAME C */
   }
 
   /* Host models. `refd` is EXACT (see the input design note). The two ordered
      models are named closed forms: element-wise agreement with one of them is a
      far stronger statement than sitting inside a bound, and §6.1 turns exactly
      that distinction into how much friction a user is made to accept. */
-  static double refd[NT*64], sabs[NT*64];
-  static float  seq32[NT*64], tree32[NT*64];
+  static double refd[NT*64], sabs[NT*64], nodropC[NT*64];
+  static float  seq32[NT*64], tree32[NT*64], cfirst32[NT*64];
   static double ref16[NT*64], tree16[NT*64];
+  int span_max = 0;   /* §5.3: binary64 is exact only if the term exponent span
+                         is small enough; the harness must ASSERT it, not
+                         assume it. 9 terms => need span + 24 + 1 + 4 <= 53. */
   for (int t = 0; t < NT; t++)
     for (int r = 0; r < 8; r++)
       for (int c = 0; c < 8; c++) {
@@ -317,34 +353,67 @@ int main(void) { @autoreleasepool {
         int o = t*64 + r*8 + c;
         double acc = 0.0, sa = 0.0;
         float p[8];
+        int emin = 1000, emax = -1000;
         for (int k = 0; k < 8; k++) {
           p[k] = (float)a[r*8+k] * (float)b[k*8+c];   /* EXACT in binary32 */
           acc += (double)p[k]; sa += fabs((double)p[k]);
+          int e; frexpf(p[k], &e);
+          if (p[k] != 0.0f) { if (e < emin) emin = e; if (e > emax) emax = e; }
         }
-        refd[o] = acc; sabs[o] = sa;
-        { float f = 0.0f; for (int k = 0; k < 8; k++) f += p[k]; seq32[o] = f; }
+        { int e; frexpf(Cf[o], &e);
+          if (Cf[o] != 0.0f) { if (e < emin) emin = e; if (e > emax) emax = e; } }
+        if (emax - emin > span_max) span_max = emax - emin;
+
+        /* D_exact = sum of products + C, evaluated exactly (§5.1). */
+        refd[o] = acc + (double)Cf[o];
+        sabs[o] = sa + fabs((double)Cf[o]);
+        nodropC[o] = acc;   /* §5.4 control 2: the C-DROPPING reference */
+
+        /* Named orders. C's position in the sum is itself a free choice, so it
+           is a model parameter and not an assumption. */
+        { float f = 0.0f; for (int k = 0; k < 8; k++) f += p[k];
+          seq32[o] = f + Cf[o]; }                       /* C added LAST  */
+        { float f = Cf[o]; for (int k = 0; k < 8; k++) f += p[k];
+          cfirst32[o] = f; }                            /* C added FIRST */
         { float l0 = (p[0]+p[1]) + (p[2]+p[3]);
           float l1 = (p[4]+p[5]) + (p[6]+p[7]);
-          tree32[o] = l0 + l1; }
-        { _Float16 h = (_Float16)0.0f;
+          tree32[o] = (l0 + l1) + Cf[o]; }
+        { _Float16 h = Ch[o];
           for (int k = 0; k < 8; k++) h = (_Float16)((float)h + p[k]);
           ref16[o] = (double)(float)h; }
         { _Float16 h0 = (_Float16)((float)(_Float16)(p[0]+p[1]) + p[2]);
           h0 = (_Float16)((float)h0 + p[3]);
           _Float16 h1 = (_Float16)((float)(_Float16)(p[4]+p[5]) + p[6]);
           h1 = (_Float16)((float)h1 + p[7]);
-          tree16[o] = (double)(float)(_Float16)((float)h0 + (float)h1); }
+          tree16[o] = (double)(float)(_Float16)(
+              (float)(_Float16)((float)h0 + (float)h1) + (float)Ch[o]); }
       }
+  /* §5.3's invariant, asserted rather than assumed. */
+  {
+    int need = span_max + 24 + 1 + 4;
+    printf("  §5.3 exactness invariant: term exponent span %d binades, "
+           "needs %d bits, binary64 has 53 -> %s\n", span_max, need,
+           need <= 53 ? "host reference is EXACT"
+                      : "*** HOST REFERENCE IS NOT EXACT — narrow the generator ***");
+    if (need > 53) {
+      fprintf(stderr, "refusing to report numbers against an inexact reference\n");
+      return 5;
+    }
+  }
 
-  /* K-1 = 7 binary32 additions in any order: |err| <= (7u)/(1-7u) * sum|p| */
+  /* §5.2's bound, recomputed for K = 8 with a NONZERO C: n = K + 1 = 9 terms,
+     8 additions, so the constant is gamma_8 and NOT the gamma_7 of the C = 0
+     degenerate case. §5.2 is explicit that the tighter constant "must not" be
+     used unless C is pinned to zero, and it is not pinned here. */
   const double U32 = ldexp(1.0, -24);
-  const double BOUND32 = (7.0 * U32) / (1.0 - 7.0 * U32);
+  const double BOUND32 = (8.0 * U32) / (1.0 - 8.0 * U32);
   const double U16 = ldexp(1.0, -11);
-  const double BOUND16 = (7.0 * U16) / (1.0 - 7.0 * U16);
-  printf("  derived bound, f32 accumulate: %.3g * sum|p_i|\n", BOUND32);
-  printf("  derived bound, f16 accumulate: %.3g * sum|p_i|\n", BOUND16);
+  const double BOUND16 = (8.0 * U16) / (1.0 - 8.0 * U16);
+  printf("  derived bound (gamma_8), f32 accumulate: %.5g * sum|terms|\n", BOUND32);
+  printf("  derived bound (gamma_8), f16 accumulate: %.5g * sum|terms|\n", BOUND16);
 
   id<MTLBuffer> bA = mkbuf(dev, A, sizeof A), bB = mkbuf(dev, B, sizeof B);
+  id<MTLBuffer> bCf = mkbuf(dev, Cf, sizeof Cf), bCh = mkbuf(dev, Ch, sizeof Ch);
 
   /* ANTI-VACUITY CONTROL. Before any device number is read: does the f32 bound
      reject anything at all on this input set? A host binary16 accumulator must
@@ -359,11 +428,22 @@ int main(void) { @autoreleasepool {
       if (e > BOUND32 * sabs[i]) rej++;
       if (fabs(refd[i] - refd[i]) > BOUND32 * sabs[i]) self++;
     }
-    printf("  ANTI-VACUITY CONTROL:\n");
-    printf("    host binary16 accumulator rejected by the f32 bound: %d / %d "
+    printf("  ANTI-VACUITY CONTROLS (§5.4 requires BOTH):\n");
+    printf("    [1] host binary16 accumulator rejected by the f32 bound: %d / %d "
            "(worst rel. error %.3g) -> %s\n", rej, NT*64, worst,
            rej > 0 ? "the f32 bound CAN fail"
                    : "*** the f32 bound cannot fail here; do not trust a pass ***");
+    /* §5.4 control 2: a reference that DROPS C. This is the error §5.1 records
+       an earlier draft of the design as having made, so it is pinned by a test
+       rather than only by a paragraph. It can only fire because C != 0. */
+    { int rejc = 0;
+      for (int i = 0; i < NT*64; i++)
+        if (fabs(nodropC[i] - refd[i]) > BOUND32 * sabs[i]) rejc++;
+      printf("    [2] host C-DROPPING reference rejected by the f32 bound: %d / %d "
+             "-> %s\n", rejc, NT*64,
+             rejc > 0 ? "the bound sees C; the input generator's C is nonzero and material"
+                      : "*** C is not material here; the C-dropping defect would pass ***");
+    }
     printf("    exact reference accepted by its own bound          : %d rejected\n",
            self);
     /* And the f32 accumulation order must actually be observable, or the
@@ -397,6 +477,7 @@ int main(void) { @autoreleasepool {
     [en setBuffer:bO offset:0 atIndex:0];
     [en setBuffer:bA offset:0 atIndex:1];
     [en setBuffer:bB offset:0 atIndex:2];
+    [en setBuffer:(runs[r].f32out ? bCf : bCh) offset:0 atIndex:3];
     [en dispatchThreads:MTLSizeMake(32*NT,1,1)
           threadsPerThreadgroup:MTLSizeMake(32,1,1)];
     [en endEncoding]; [cb commit]; [cb waitUntilCompleted];
@@ -405,7 +486,7 @@ int main(void) { @autoreleasepool {
 
     double bound = runs[r].f32out ? BOUND32 : BOUND16;
     int N = NT*64;
-    int over = 0, exact = 0, eqseq = 0, eqtree = 0, eq16 = 0, eq16t = 0, eqnar = 0;
+    int over = 0, exact = 0, eqseq = 0, eqtree = 0, eq16 = 0, eq16t = 0, eqnar = 0, eqcf = 0;
     double worst = 0.0; int worsti = -1;
     for (int i = 0; i < N; i++) {
       double g = runs[r].f32out ? (double)((const float *)bO.contents)[i]
@@ -416,6 +497,7 @@ int main(void) { @autoreleasepool {
       if (err > bound * sabs[i]) over++;
       if (g == refd[i]) exact++;
       if (g == (double)seq32[i]) eqseq++;
+      if (g == (double)cfirst32[i]) eqcf++;
       if (g == (double)tree32[i]) eqtree++;
       if (g == ref16[i]) eq16++;
       if (g == tree16[i]) eq16t++;
@@ -425,6 +507,7 @@ int main(void) { @autoreleasepool {
     printf("    bit-equal to the exact dot product          : %d / %d\n", exact, N);
     printf("    bit-equal to SEQUENTIAL binary32 accumulate : %d / %d\n", eqseq, N);
     printf("    bit-equal to PAIRWISE   binary32 accumulate : %d / %d\n", eqtree, N);
+    printf("    bit-equal to SEQUENTIAL binary32, C added FIRST : %d / %d\n", eqcf, N);
     printf("    bit-equal to SEQUENTIAL binary16 accumulate : %d / %d\n", eq16, N);
     printf("    bit-equal to PAIRWISE   binary16 accumulate : %d / %d\n", eq16t, N);
     printf("    bit-equal to seq. binary32 NARROWED at the end : %d / %d\n",
@@ -478,6 +561,7 @@ int main(void) { @autoreleasepool {
         [en setBuffer:bO offset:0 atIndex:0];
         [en setBuffer:bA offset:0 atIndex:1];
         [en setBuffer:bB offset:0 atIndex:2];
+        [en setBuffer:bCf offset:0 atIndex:3];
         [en dispatchThreads:MTLSizeMake(32*NT,1,1)
               threadsPerThreadgroup:MTLSizeMake(tgs[p],1,1)];
         [en endEncoding]; [cb commit]; [cb waitUntilCompleted];


### PR DESCRIPTION
`docs/design/f16-relaxed-accuracy.md` §2 carries a Metal row reading **"never probed → `Unknown` → refused"**, and §7 slice 5 says #63 cannot start at the matrix layer until the scalar layer is measured. This measures it, on the M4, and measures the matrix layer's prerequisite at the same time.

**Device and toolchain**, as §1 corollary 3 requires: Apple M4, macOS 15.6.1 (24G90), arm64, Apple clang 17.0.0 (clang-1700.0.13.5), Metal.framework from the Command Line Tools SDK (no Xcode — `newLibraryWithSource:` compiles through the driver at runtime, which is the call under test). Evidence tier throughout: **executed**.

## Metal is strict

Both shapes the other backends were swept on, each over all 63488 finite binary16 inputs, deviation from the discipline:

| variant | `f16(x*1.1)` | `f16(f16(x*1.1)+1000)` |
|---|---|---|
| plain (naive codegen) | **0 / 63488** | **0 / 63488** |
| `#pragma METAL fp contract(off)` | 0 / 63488 | 0 / 63488 |
| `#pragma clang fp contract(off)` | 0 / 63488 | 0 / 63488 |
| `volatile thread` barrier | 0 / 63488 | 0 / 63488 |
| `as_type` bitcast barrier | 0 / 63488 | 0 / 63488 |
| **FUSEDCTL — positive control** | **2912 / 63488** | **620 / 63488** |

No relaxation is needed for Metal and none is proposed. The refusal in `Sarek_ir_metal` is over-broad in the same way §11.3 found pocl's and IGC's to be.

## Why the zeros are readable

§11.5 is this repository's own record of a null that was not a result, so the control is the point. MSL has **no `double`**, so the OpenCL probe's `(double)x * (double)1.1f` single-rounding control is not expressible here. This one reconstructs the exact product from a double-float pair (`hi = RN32(x·k)` forced through the integer domain, `lo = fma(x,k,-hi)` exact) with a round-to-odd step before the narrowing. It is then **validated element-wise against the host reference — 0 of 63488 differ** — and it reproduces **620**, the figure already measured on hiprtc/gfx1100, on rusticl/radeonsi, and by `fusedctl` on Intel Arc. Same source, same compile options, same dispatch as the variants reporting 0.

A host calibration runs first and refuses to print any device number unless the binary16 round-trip is clean and the two models separate on 2912 and 620.

## Three findings beyond the row that was asked for

**1. `#pragma METAL fp contract(off)` does not govern this hazard.** It changes nothing on either shape, in either direction — it does not move the plain kernel and it does not disturb the control. That is *not* the pragma being inert: §10.5 measures it taking `a*b+c` from 8773/8773 to 0/8773 on this device. Contraction of `a*b+c` and absorption of a multiply into an f32→f16 narrowing are two behaviours, the pragma is measured on one of them, and Metal exhibits neither. `metal_fp_contract_pragma` keeps its existing justification and gains no new one.

**2. §1.3's 1-ulp ceiling is violated by the *admitted* model, not by any device.** The validated control computes the admitted model exactly, so it can be used to test the ceiling. At `x = -907.5` the exact product is `-998.25000216…`, whose binary32 rounding is exactly `-998.25` — a binary16 tie in [512, 1024) — which rounds to even, so `S_strict` gives `-998 + 1000 = 2`. The single-rounding model narrows the exact product, is not at the tie, gets `-998.5`, and gives `1.5`. **2 and 1.5 are 512 ulp of binary16 apart**, because the `+1000` cancels the leading bits and re-scales the ulp. The half-ulp-at-the-elided-step derivation is sound; the restatement *on the final value* does not follow once a later operation can cancel. The ceiling has to be evaluated at the narrowing where the rounding was elided.

**3. `simdgroup_matrix` has no integer path.** It instantiates for `half`, `float` and `bfloat` at **8×8 and nothing else** — every other size fails `_valid_simdgroup_matrix_size` and every integer type fails `is_simdgroup_matrix_element<T>`, so the enumeration is closed rather than sampled. §8 and slice 4b keep an integer cooperative-matrix path as the route that lands under the *existing strict contract* if slice 1 goes the wrong way; **that fallback is Vulkan-only.** On Metal, #63 is f16/bf16 or nothing.

On the numerics — 1024 independent 8×8×8 problems, 65536 elements:

| | `half8x8 × half8x8 → float8x8` | `→ half8x8` |
|---|---|---|
| bit-equal to **sequential binary32** accumulate | **65536 / 65536** | 7 / 65536 |
| bit-equal to pairwise binary32 accumulate | 37939 / 65536 | 5 / 65536 |
| bit-equal to **sequential binary16** accumulate | 7 / 65536 | **65528 / 65536** |
| worst error / Σ\|pᵢ\| | 2.79e-07 (bound 4.17e-07) | 1.75e-03 (bound 3.43e-03) |

The f32-accumulate configuration **matches a named closed-form model element-wise on every element**, which is stronger than §5's bound and puts it in §6.1's diagnostic row rather than its opt-in row. The f16-accumulate configuration matches no model and stays bounded-only — §5 recommends not admitting it, and that recommendation now rests on a measurement rather than on the width of the bound.

Determinism (§1.4): bit-identical across two processes for both probes, and bit-identical across threadgroup sizes 32/64/128/256 for the matrix path. §1.4 records that nobody had measured whether a coopmat result moves with the dispatch shape. On this device, at this tile size, it does not.

## Verification

Both probes carry anti-vacuity controls, and the matrix probe records the input design an earlier revision got wrong: operands drawn as multiples of 2⁻⁹ in [−1,1] made every product a multiple of 2⁻¹⁸ below 8, so the sum of 8 was exactly representable in binary32, every accumulation order agreed, and the test reported 64/64 exact while measuring nothing. The operands now need ~46 significant bits — outside binary32, inside binary64 — so accumulation order is observable (sequential vs pairwise differ on 27597/65536) and the host reference is still exact.

## Scope

Standalone probes, not wired into dune, matching the convention of the six already in `tools/probes/`. **No Sarek behaviour changes and no refusal is lifted here.** `docs/design/f16-relaxed-accuracy.md` is deliberately untouched — its §2 Metal row and §1.3 ceiling both want editing, and that belongs on top of #329 rather than in conflict with it. The proposed row is in the review thread.

Not established: only the two shapes above, not the 20-shape catalogue; subnormal-specific analysis; one device, one OS; and this measures the **driver** from hand-written MSL, so it is not a codegen gate — exactly as §7(c) says of the GLSL tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — rebased onto `main` post-#329, and the three follow-ups

Rebased onto current `origin/main`; the PR is now **two commits**. `#329` having landed, the design document is edited directly rather than deferred to the review thread.

**1. §1.3's ceiling was wrong, and this PR fixes it.** The probe's own validated control is what exposed it — the control computes the *admitted* model exactly, so it can be pointed at the contract. Restated to evaluate **at the narrowing where the rounding was elided**, with the `x = -907.5` counterexample kept in the document, the ulp denominator stated explicitly (**512 against 1.5, 256 against 2.0**), and the general mechanism named: a narrowing followed by a cancelling operation re-scales the ulp, so a final-value ceiling does not merely run loose — it **rejects correct results**. §0.1 and §1.1 were re-read against the correction and are unaffected (both already argue at the narrowing). §5's bound was re-checked and needed no change: it already refuses to measure against the result, for the same underlying reason. Slice 0 picks up two new obligations.

**2. A `C = 0` defect in my own matrix probe, found by reading the merged §5.1.** The merged §5 defines the operation as `D = A×B + C` and mandates a nonzero-`C` control; my probe pinned `C = 0`. Fixing it **changed the answer**: with `C = 0` the C-first and C-last accumulation orders are the same function, so the earlier "65536/65536 against sequential binary32" was *underdetermined* rather than wrong. With `C` nonzero they separate decisively — **65536 against 51850** — and the closed form is **`C` added first**. The probe now uses `γ_8` rather than the `C = 0` degenerate `γ_7`, asserts §5.3's exactness invariant instead of assuming it (21 binades, 50 bits of 53, refusing to print otherwise), and runs **both** of §5.4's required controls: the binary16 accumulator (rejected 65433/65536) and the C-dropping reference (rejected 65498/65536). The closed form could not have been identified at all without §5.1's correction — it is that correction reproduced from the measurement side.

**3. §8's integer-coopmat fallback is Vulkan-only.** Metal has no integer `simdgroup_matrix` — `half`/`float`/`bfloat` only, integers failing a named `static_assert`, a closed enumeration. So the fallback is **#62's, not #63's**: on Metal the tensor-core path is reachable *only* through the relaxation, which makes #63 strictly more exposed to it than #62. If the relaxation were ever withdrawn, #62 could still ship its integer configurations and #63 could ship nothing. Slice 4b keeps its integer requirement and its justification; it loses only its claimed universality.

**The B → A migration is exercised, not just described.** §1.6's migration row and §6.1's corollary were written as a mechanism nobody had used. `half8x8 × half8x8 → float8x8` is the first configuration to use it: bit-equal on 65536/65536 to a named closed form, so it is Regime A by measurement rather than by decision, and its friction falls to a diagnostic.

### Identified next steps, none needing new hardware access

- the 20-shape catalogue of `amdgpu-f16-fusion-shape-audit.md` on Metal (only two shapes swept here);
- a `bfloat` 8×8 sweep — the type is available and nothing is claimed about what it computes;
- subnormal-specific analysis;
- a Metal **codegen** gate: both probes compile hand-written MSL and therefore measure the driver, exactly as §7(c) says of the GLSL tripwire.
