### PR TITLE
chore(ci): make the license-header gate pass, and wire it to something (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,15 @@ jobs:
       - name: Dune directory visibility guard
         run: ./scripts/check-dune-dir-visibility.sh
 
+      # #137. This checker existed for months, exited 1 on `main`, and was
+      # referenced by no workflow and no Makefile target -- the fourth
+      # "declared gate that nothing invokes" found in this repo. It is wired
+      # here, and its red path is covered in the harness block below.
+      # Exit 2 means the coverage declaration is broken (a root moved), not
+      # that a header is missing; see scripts/check-license-headers.sh.
+      - name: License header guard
+        run: ./scripts/check-license-headers.sh
+
       # An unregistered Alcotest case compiles, the suite reports green, and
       # the behavior it was written to protect is unguarded. Nothing else in
       # this pipeline can tell that apart from a passing test.
@@ -105,6 +114,13 @@ jobs:
           # trustworthy as N, so the counting rule gets a covering test like
           # any other gate.
           ./scripts/test-suite-counts.test.sh
+          # #137. Red-path coverage for the license guard. Its pre-#137 finder
+          # ended in `2>/dev/null`, so deleting a whole declared root made it
+          # print "All license headers are up-to-date!" about a tree it had
+          # not read. Cases 4 and 5 assert that shape is now exit 2, and case 0
+          # is the positive control without which "went red" and "is always
+          # red" would be the same observation.
+          ./scripts/check-license-headers.test.sh
 
       - name: Formal proofs admit gate
         run: |

--- a/scripts/add-license-headers.sh
+++ b/scripts/add-license-headers.sh
@@ -93,7 +93,15 @@ apply_change() {
         fi
         rm -f "$tmpfile"
     else
-        mv "$tmpfile" "$file"
+        # Write THROUGH the existing file rather than `mv`-ing the temp file
+        # onto it. mktemp creates 0600, and `mv` carries that mode across, so
+        # the previous `mv` silently stripped the executable bit from every
+        # script it stamped -- i.e. running the fixer on scripts/ left the
+        # whole tooling directory non-executable and CI failing with
+        # "Permission denied". Redirecting into $file preserves its mode,
+        # owner and inode.
+        cat "$tmpfile" > "$file"
+        rm -f "$tmpfile"
         echo -e "${GREEN}${label}${NC}: $file"
         UPDATED_COUNT=$((UPDATED_COUNT + 1))
     fi
@@ -251,10 +259,12 @@ EOF
     
     # Append original content
     cat "$file" >> "$tmpfile"
-    
-    # Replace original file
-    mv "$tmpfile" "$file"
-    
+
+    # Write through, not `mv` -- see apply_change for why mode preservation
+    # matters here.
+    cat "$tmpfile" > "$file"
+    rm -f "$tmpfile"
+
     echo -e "${GREEN}UPDATED${NC}: $file"
     UPDATED_COUNT=$((UPDATED_COUNT + 1))
 }
@@ -263,27 +273,133 @@ echo "Adding SPDX license headers..."
 echo "License: $LICENSE"
 echo ""
 
+# ---------------------------------------------------------------------------
+# Coverage scope (#137)
+# ---------------------------------------------------------------------------
+# What is covered is declared here, once, in named lists — not buried in a
+# find expression. Two properties this buys us:
+#
+#   1. A missing root is LOUD. The find calls used to end in `2>/dev/null`,
+#      so renaming or deleting a root directory made find print nothing,
+#      the read loop body never ran, and the gate passed having inspected
+#      no files at all. Every root is now asserted to exist, and the
+#      candidate set is asserted non-empty, before any file is examined.
+#
+#   2. Exemptions are an explicit, reviewable list (EXEMPT_GLOBS) with a
+#      stated reason each, rather than an anonymous `! -path` accumulating
+#      in a find invocation nobody reads.
+#
+# NOT covered, deliberately: scripts/**/*.js and scripts/lib/**/*.js (14
+# files at the time of writing). JavaScript needs a `//` header and no
+# emitter in this script produces one; adding that is a separate change.
+# The omission is recorded here so it is a decision rather than an accident
+# of the find expression.
+
+# Roots holding first-party OCaml sources (*.ml, *.mli).
+OCAML_ROOTS=(sarek sarek-cuda sarek-opencl sarek-vulkan sarek-metal spoc)
+
+# Roots holding first-party tooling. `*.sh` and `*.py` share the `#` comment
+# syntax, so add_shell_header serves both.
+SCRIPT_ROOTS=(scripts ci)
+
+# The only sanctioned way to leave a matching file out. Each entry is a
+# find -path glob plus the reason it is not ours to stamp.
+EXEMPT_GLOBS=(
+    '*/dependencies/*'  # vendored third-party sources — not ours to relicense
+    '*/_build/*'        # dune build output — generated, never committed
+    '*/_opam/*'         # local opam switch — not project source
+    '*/.*'              # dotfile dirs (.git, .github metadata, editor state)
+
+    # Review-tool bundle members. scripts/REVIEW-BUNDLE.md: "These files are
+    # upstream-owned and generated [...] Do not hand-edit any bundle file or
+    # the manifest." Each is pinned by sha256 in review-bundle.manifest.json,
+    # so a header here fails review-bundle-verify immediately and is silently
+    # reverted by the next roster upgrade anyway. Stamping them once already
+    # turned check-review-bundle-tracked.sh red with two SHA MISMATCHes.
+    #
+    # This list is kept by hand rather than derived from the manifest: the
+    # manifest is itself a bundle file, and reading it to decide what to skip
+    # would let an upstream change quietly widen our exemptions.
+    'scripts/check-scope-diff.sh'
+    'scripts/xruntime-exec.sh'
+)
+
+# An exemption for a file that no longer exists is an exemption nobody is
+# reading. Any entry without a wildcard is an exact path and must resolve.
+for glob in "${EXEMPT_GLOBS[@]}"; do
+    case "$glob" in
+        *'*'*) ;;
+        *)
+            if [ ! -e "$glob" ]; then
+                echo "ERROR: stale exemption in EXEMPT_GLOBS: $glob does not exist." >&2
+                echo "       Remove it, or point it at the file's new path." >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+# Build the shared `! -path GLOB ...` argument vector once.
+EXEMPT_ARGS=()
+for glob in "${EXEMPT_GLOBS[@]}"; do
+    EXEMPT_ARGS+=(! -path "$glob")
+done
+
+# Fail loudly if a declared root has moved. Without this the loops below
+# silently inspect nothing and the gate reports success.
+require_roots() {
+    local label="$1"; shift
+    local missing=()
+    local root
+    for root in "$@"; do
+        [ -d "$root" ] || missing+=("$root")
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "ERROR: $label root(s) not found: ${missing[*]}" >&2
+        echo "       Update the *_ROOTS list in scripts/add-license-headers.sh." >&2
+        echo "       Refusing to report success on an un-inspected tree." >&2
+        exit 2
+    fi
+}
+
+# A gate that examined zero files is not a passing gate.
+require_nonempty() {
+    local label="$1"
+    local count="$2"
+    if [ "$count" -eq 0 ]; then
+        echo "ERROR: $label matched 0 files." >&2
+        echo "       Either the roots or EXEMPT_GLOBS in" >&2
+        echo "       scripts/add-license-headers.sh no longer describe this tree." >&2
+        exit 2
+    fi
+}
+
 # Process OCaml files
 echo -e "${BLUE}Processing OCaml files...${NC}"
+require_roots "OCaml" "${OCAML_ROOTS[@]}"
+OCAML_SEEN=0
 while IFS= read -r -d '' file; do
+    OCAML_SEEN=$((OCAML_SEEN + 1))
     add_ocaml_header "$file"
-done < <(find sarek sarek-cuda sarek-opencl sarek-vulkan sarek-metal spoc \
+done < <(find "${OCAML_ROOTS[@]}" \
     -type f \( -name "*.ml" -o -name "*.mli" \) \
-    ! -path "*/.*" \
-    ! -path "*/_build/*" \
-    ! -path "*/_opam/*" \
-    ! -path "*/dependencies/*" \
-    -print0 2>/dev/null)
+    "${EXEMPT_ARGS[@]}" \
+    -print0)
+require_nonempty "OCaml sources" "$OCAML_SEEN"
 
-# Process shell scripts
+# Process shell and Python tooling
 echo ""
-echo -e "${BLUE}Processing shell scripts...${NC}"
+echo -e "${BLUE}Processing shell and Python scripts...${NC}"
+require_roots "Script" "${SCRIPT_ROOTS[@]}"
+SCRIPT_SEEN=0
 while IFS= read -r -d '' file; do
+    SCRIPT_SEEN=$((SCRIPT_SEEN + 1))
     add_shell_header "$file"
-done < <(find scripts ci \
-    -type f -name "*.sh" \
-    ! -path "*/.*" \
-    -print0 2>/dev/null)
+done < <(find "${SCRIPT_ROOTS[@]}" \
+    -type f \( -name "*.sh" -o -name "*.py" \) \
+    "${EXEMPT_ARGS[@]}" \
+    -print0)
+require_nonempty "Shell/Python tooling" "$SCRIPT_SEEN"
 
 # Process dune files (optional - uncomment if needed)
 # echo ""

--- a/scripts/agent-worktree-bootstrap.sh
+++ b/scripts/agent-worktree-bootstrap.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # agent-worktree-bootstrap.sh — safe dispatch of a worktree-isolated agent.
 #
 # Backlog #101. Four independent ways `isolation: "worktree"` silently produces

--- a/scripts/agent-worktree-bootstrap.test.sh
+++ b/scripts/agent-worktree-bootstrap.test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # Tests for scripts/agent-worktree-bootstrap.sh.
 #
 # A guard nobody has watched trigger is not a guard. Every check in the

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -9,6 +9,16 @@
 # working tree and its result does not depend on whether the tree was
 # already dirty before it ran (no "git diff" against pre-existing changes).
 
+#
+# Exit codes:
+#   0  every covered file has an up-to-date header
+#   1  at least one covered file needs a header change
+#   2  the coverage declaration itself is broken (a declared root directory
+#      is missing, or the candidate set came out empty). This is NOT a
+#      header problem and must not be "fixed" by running the fixer — it
+#      means the gate would otherwise have passed without inspecting
+#      anything. See the coverage-scope block in add-license-headers.sh.
+
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,15 +38,39 @@ echo ""
 # file's would-be output to a temp file and diffs against the original
 # in-place, never touching the real file. Exit code 0 means every header is
 # already up-to-date; exit code 1 means at least one file needs a change.
-if OUTPUT=$("$SCRIPT_DIR/add-license-headers.sh" --check 2>&1); then
-    echo -e "${GREEN}✓ All license headers are up-to-date!${NC}"
-    exit 0
-else
-    echo -e "${RED}✗ Some files need license header updates:${NC}"
-    echo ""
-    echo "$OUTPUT"
-    echo ""
-    echo "To fix, run: ./scripts/add-license-headers.sh"
-    echo "Then review and commit the changes."
-    exit 1
-fi
+# `set -e` must not abort on the checker's own non-zero exit: we need to
+# read the code to tell a header failure (1) from a broken coverage
+# declaration (2).
+set +e
+OUTPUT=$("$SCRIPT_DIR/add-license-headers.sh" --check 2>&1)
+STATUS=$?
+set -e
+
+case "$STATUS" in
+    0)
+        echo -e "${GREEN}✓ All license headers are up-to-date!${NC}"
+        exit 0
+        ;;
+    1)
+        echo -e "${RED}✗ Some files need license header updates:${NC}"
+        echo ""
+        echo "$OUTPUT"
+        echo ""
+        echo "To fix, run: ./scripts/add-license-headers.sh"
+        echo "Then review and commit the changes."
+        exit 1
+        ;;
+    *)
+        # Exit 2, or anything unexpected. Running the fixer will not help and
+        # may make it worse: the tree no longer matches what the script claims
+        # to cover, so "all headers up-to-date" would have been a lie.
+        echo -e "${RED}✗ License-header coverage is broken (exit $STATUS):${NC}"
+        echo ""
+        echo "$OUTPUT"
+        echo ""
+        echo "This is a coverage failure, not a header failure. Do NOT run the"
+        echo "fixer to silence it — fix the roots/exemptions declared in"
+        echo "scripts/add-license-headers.sh so the gate inspects the tree again."
+        exit "$STATUS"
+        ;;
+esac

--- a/scripts/check-license-headers.test.sh
+++ b/scripts/check-license-headers.test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+# Covering test for scripts/check-license-headers.sh (#137).
+#
+# The gate spent its whole life exiting 1 on `main` and being invoked by
+# nothing, so its green was never observed and its red was never trusted.
+# Wiring it into CI without a red-path test would just move an unverified
+# gate into a place where it blocks merges.
+#
+# Two distinct failure modes are asserted here:
+#
+#   * RED on a real problem  -- a covered file loses its header, and the gate
+#     must go to exit 1 AND name the file.
+#   * RED on a broken gate   -- a declared root disappears, or the candidate
+#     set comes out empty. The pre-#137 finder ended in `2>/dev/null`, so this
+#     shape exited 0 having inspected nothing. It must now be exit 2.
+#
+# Every case builds a synthetic project tree in a temp dir, copies the real
+# scripts into its scripts/ directory (they resolve PROJECT_ROOT from their
+# own location, so this redirects them entirely), and runs them there. No
+# case touches the real working tree.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE_SRC="$SCRIPT_DIR/check-license-headers.sh"
+FIXER_SRC="$SCRIPT_DIR/add-license-headers.sh"
+for f in "$GATE_SRC" "$FIXER_SRC"; do
+  [ -x "$f" ] || { echo "FAIL: $f not found or not executable"; exit 2; }
+done
+
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/license-headers-test.XXXXXX")"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass=0
+fail=0
+
+# make_project <name> — a minimal tree with every declared root present and
+# one covered file of each supported kind, all headers already applied by the
+# real fixer. Returns the project root on stdout.
+make_project() {
+  local dir="$TMPROOT/$1"
+  mkdir -p "$dir/scripts" "$dir/ci" \
+           "$dir/sarek" "$dir/sarek-cuda" "$dir/sarek-opencl" \
+           "$dir/sarek-vulkan" "$dir/sarek-metal" "$dir/spoc"
+
+  cp "$GATE_SRC" "$FIXER_SRC" "$dir/scripts/"
+  chmod +x "$dir/scripts/check-license-headers.sh" "$dir/scripts/add-license-headers.sh"
+
+  printf 'let x = 1\n' > "$dir/sarek/covered.ml"
+  printf 'val x : int\n' > "$dir/sarek/covered.mli"
+  printf '#!/usr/bin/env bash\necho hi\n' > "$dir/ci/covered.sh"
+  printf '#!/usr/bin/env python3\nprint(1)\n' > "$dir/scripts/covered.py"
+
+  # The two review-bundle members, deliberately header-less. They are named
+  # as exact-path exemptions, so the gate must stay green over them.
+  printf '#!/usr/bin/env bash\necho scope\n' > "$dir/scripts/check-scope-diff.sh"
+  printf '#!/usr/bin/env bash\necho xruntime\n' > "$dir/scripts/xruntime-exec.sh"
+
+  ( cd "$dir" && git init -q . && git config user.email t@t.t && git config user.name t ) >/dev/null 2>&1
+  # Apply headers with the real fixer so the "good" state is exactly what the
+  # gate expects, rather than a hand-written approximation that could drift.
+  ( cd "$dir" && ./scripts/add-license-headers.sh ) >/dev/null 2>&1
+  echo "$dir"
+}
+
+# expect <desc> <project-dir> <wanted-exit> [substring-that-must-appear]
+expect() {
+  local desc="$1" dir="$2" want="$3" needle="${4:-}"
+  local out got
+  out="$(cd "$dir" && ./scripts/check-license-headers.sh 2>&1)"
+  got=$?
+  if [ "$got" != "$want" ]; then
+    echo "  FAIL: $desc -- expected exit $want, got $got"
+    echo "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+    return
+  fi
+  if [ -n "$needle" ] && ! printf '%s' "$out" | grep -qF -- "$needle"; then
+    echo "  FAIL: $desc -- exit $got as expected, but output never mentioned '$needle'"
+    echo "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+    return
+  fi
+  echo "  PASS: $desc (exit $got)"
+  pass=$((pass + 1))
+}
+
+echo "check-license-headers.sh covering test"
+
+# --- Case 0: positive control ------------------------------------------------
+# Without this, "the gate went red" and "the gate is always red" are the same
+# observation — which is precisely the state #137 found it in.
+d="$(make_project case0)"
+expect "case0: fully-headered tree is GREEN" "$d" 0 "up-to-date"
+
+# --- Case 1: a shell script loses its header ---------------------------------
+d="$(make_project case1)"
+grep -v 'SPDX-' "$d/ci/covered.sh" > "$d/ci/covered.sh.tmp" && mv "$d/ci/covered.sh.tmp" "$d/ci/covered.sh"
+expect "case1: stripped header on ci/covered.sh is RED and names the file" \
+  "$d" 1 "ci/covered.sh"
+
+# --- Case 2: an OCaml source loses its header --------------------------------
+d="$(make_project case2)"
+grep -v 'SPDX-\|^(\*\*' "$d/sarek/covered.ml" > "$d/sarek/covered.ml.tmp" && mv "$d/sarek/covered.ml.tmp" "$d/sarek/covered.ml"
+expect "case2: stripped header on sarek/covered.ml is RED and names the file" \
+  "$d" 1 "sarek/covered.ml"
+
+# --- Case 3: Python coverage is live, not merely declared --------------------
+# scripts/*.py carried headers long before anything checked them. If the
+# extension to .py were declared and not wired, this case would read green.
+d="$(make_project case3)"
+grep -v 'SPDX-' "$d/scripts/covered.py" > "$d/scripts/covered.py.tmp" && mv "$d/scripts/covered.py.tmp" "$d/scripts/covered.py"
+expect "case3: stripped header on scripts/covered.py is RED and names the file" \
+  "$d" 1 "scripts/covered.py"
+
+# --- Case 4: a declared root has vanished ------------------------------------
+# The pre-#137 finder swallowed find's error and exited 0 here, reporting
+# "all headers up-to-date" about a tree it had not read.
+d="$(make_project case4)"
+rm -rf "$d/ci"
+expect "case4: missing declared root is exit 2, not a silent pass" \
+  "$d" 2 "root(s) not found"
+
+# --- Case 5: roots exist but match nothing -----------------------------------
+d="$(make_project case5)"
+rm -f "$d"/sarek/*.ml "$d"/sarek/*.mli
+expect "case5: empty OCaml candidate set is exit 2, not a silent pass" \
+  "$d" 2 "matched 0 files"
+
+# --- Case 6: exempted paths really are exempt --------------------------------
+# A header-less file under an EXEMPT_GLOBS path must NOT turn the gate red;
+# otherwise the exemption list is decorative.
+d="$(make_project case6)"
+mkdir -p "$d/sarek/dependencies/vendored"
+printf 'let vendored = 1\n' > "$d/sarek/dependencies/vendored/thirdparty.ml"
+expect "case6: header-less file under an exempt path stays GREEN" "$d" 0 "up-to-date"
+
+# --- Case 7: JavaScript is out of scope, deliberately ------------------------
+# Documented in add-license-headers.sh's coverage block. Asserted here so the
+# omission stays a decision someone can find and reverse, rather than folklore.
+d="$(make_project case7)"
+printf 'module.exports = 1;\n' > "$d/scripts/uncovered.js"
+expect "case7: header-less .js is out of scope and stays GREEN" "$d" 0 "up-to-date"
+
+# --- Case 8a: the review-bundle exemptions are live --------------------------
+# scripts/check-scope-diff.sh and scripts/xruntime-exec.sh are upstream-owned,
+# sha256-pinned bundle files that REVIEW-BUNDLE.md forbids hand-editing.
+# make_project creates both without headers; case0 above already required the
+# tree to be GREEN, so the exemption is asserted there. Here we check the
+# fixer does not WRITE to them either — an exemption that only silences the
+# report while the fixer still stamps the file is worse than none.
+#
+# The comparison is against the PRISTINE bytes, not against the file as it
+# stands after make_project. make_project runs the fixer itself, so a
+# before/after snapshot taken at this point would compare a
+# possibly-already-stamped file with itself and pass no matter what — the
+# first cut of this case did exactly that and stayed green with the
+# exemptions deleted.
+d="$(make_project case8a)"
+ok=1
+for f in check-scope-diff.sh xruntime-exec.sh; do
+  if head -1 "$d/scripts/$f" | grep -q '^#!' && \
+     ! grep -q 'SPDX-License-Identifier' "$d/scripts/$f"; then
+    :
+  else
+    echo "  FAIL: case8a: scripts/$f was stamped despite being an exempt bundle member"
+    ok=0
+  fi
+done
+if [ "$ok" = 1 ]; then
+  echo "  PASS: case8a: fixer leaves both review-bundle members unstamped"
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+# --- Case 8b: a stale exemption is loud --------------------------------------
+# An exact-path exemption for a file that has moved is an exemption nobody is
+# reading — the file it was meant to protect is now being stamped under its
+# new name, silently.
+d="$(make_project case8b)"
+rm -f "$d/scripts/xruntime-exec.sh"
+expect "case8b: exemption pointing at a missing file is exit 2" \
+  "$d" 2 "stale exemption"
+
+# --- Case 9: the fixer must not change file modes ----------------------------
+# It used to `mv` a mktemp file (0600) over the target, stripping the
+# executable bit from every script it stamped -- so the act of satisfying the
+# license gate broke every OTHER gate with "Permission denied". Asserted on
+# the fixer directly, since the checker never writes.
+d="$(make_project case9)"
+printf '#!/usr/bin/env bash\necho later\n' > "$d/ci/newly-added.sh"
+chmod 755 "$d/ci/newly-added.sh"
+( cd "$d" && ./scripts/add-license-headers.sh ) >/dev/null 2>&1
+mode="$(stat -c %a "$d/ci/newly-added.sh")"
+if [ "$mode" = "755" ]; then
+  echo "  PASS: case9: fixer preserves the executable bit (mode $mode)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: case9: fixer changed mode 755 -> $mode on a file it stamped"
+  fail=$((fail + 1))
+fi
+
+echo ""
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/check-review-bundle-tracked.sh
+++ b/scripts/check-review-bundle-tracked.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # check-review-bundle-tracked.sh — the review-tool bundle must survive a fresh clone.
 #
 # Failure mode this guard exists for (backlog #108): every deterministic quality

--- a/scripts/check-review-bundle-tracked.test.sh
+++ b/scripts/check-review-bundle-tracked.test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # Tests for scripts/check-review-bundle-tracked.sh.
 #
 # The guard is load-bearing: it is the only thing standing between the project

--- a/scripts/check-test-alias-coverage.sh
+++ b/scripts/check-test-alias-coverage.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # Guard against silently-unwired test executables (the "vacuous e2e" failure
 # mode fixed in 2026-07: an (executable) with no run rule builds green but
 # never executes). Fails if any executable declared in sarek/tests/e2e/dune

--- a/scripts/roster-implement-posthook.sh
+++ b/scripts/roster-implement-posthook.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # roster-implement-posthook.sh — runs after /roster-implement, before review.
 #
 # Backlog #103. Three things that were left to prose discipline and therefore

--- a/scripts/roster-implement-posthook.test.sh
+++ b/scripts/roster-implement-posthook.test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # Tests for scripts/roster-implement-posthook.sh and the two checkers it runs.
 #
 # Every check gets a constructed bad input and an asserted refusal, plus a


### PR DESCRIPTION
Backlog #137. `scripts/check-license-headers.sh` exited 1 on `main` and was referenced by no workflow and no Makefile target — the fourth "declared gate that nothing invokes" this repo has turned up. Making it green without wiring it would have left it exactly as useful as it was.

## The failure set, and what happened to each

Nine files, all shell scripts under `scripts/`. Not the same nine an earlier report guessed at in one respect: `check-dune-dir-visibility.sh` and `test-suite-counts.sh` do carry headers and were never in it.

| File | Disposition |
| --- | --- |
| `agent-worktree-bootstrap.sh` + `.test.sh` | header added |
| `check-review-bundle-tracked.sh` + `.test.sh` | header added |
| `check-test-alias-coverage.sh` | header added |
| `roster-implement-posthook.sh` + `.test.sh` | header added |
| `check-scope-diff.sh` | **exempt** — review-bundle member |
| `xruntime-exec.sh` | **exempt** — review-bundle member |

The last two are upstream-owned: pinned by sha256 in `review-bundle.manifest.json`, and `REVIEW-BUNDLE.md` says in as many words *"Do not hand-edit any bundle file or the manifest."* Stamping them turned `check-review-bundle-tracked.sh` red with two SHA MISMATCHes, and the next roster upgrade would have reverted the headers regardless. They are now exact-path entries in `EXEMPT_GLOBS`, alongside the `dependencies/` / `_build/` / `_opam/` / dotfile globs that were previously anonymous `! -path` arguments inside a `find` invocation.

An exemption whose path no longer resolves is itself `exit 2`. A stale exemption is one nobody is reading.

## The gate could not fail for the reason that mattered

Both `find` calls in `add-license-headers.sh` ended in `2>/dev/null`. Delete a declared root directory and `find` printed nothing, the read loop body never ran, and the checker printed **"All license headers are up-to-date!"** about a tree it had never opened.

Roots are now named lists, every root is asserted to exist before any file is read, and an empty candidate set is a failure. Coverage extends to `scripts/**/*.py` — those files already carried headers that nothing was checking. JavaScript stays out of scope (it needs `//` headers no emitter here produces); that is now written down in the coverage block and asserted by a test case, rather than being an accident of the `find` expression.

Exit codes are split so the two failures are not confusable: `1` is a header problem, `2` is a broken coverage declaration that running the fixer would only paper over.

## A latent bug in the fixer: it un-executabled everything it stamped

`apply_change` did `mv "$tmpfile" "$file"`, and `mktemp` creates `0600`. Running the fixer over `scripts/` left eight gates at mode 600 and CI failing with `Permission denied` — satisfying the license gate broke every other gate. It now writes through the existing file.

## Wiring, and the red

- `ci.yml:66` — the gate itself, beside the dune-visibility guard.
- `ci.yml:123` — `scripts/check-license-headers.test.sh` in the harness self-test block.

Eleven cases, each run against a mutation of what it reads:

- Against the **pre-change fixer**, four go red — both vacuity shapes (missing root, empty candidate set), the `.py` coverage gap, and the mode bug. The vacuity output is verbatim `✓ All license headers are up-to-date!` for a project whose entire `ci/` root had been deleted.
- Deleting the **two bundle exemptions** fails two more.
- Case 0 is the positive control, without which "went red" and "is always red" are the same observation.

The first cut of the bundle-exemption case was itself vacuous: it snapshotted the file *after* the harness had already run the fixer over it, so it stayed green with the exemptions deleted. It is fixed, and the reason is recorded in the source so the next person does not rebuild it the same way.

## Verification

`dune build`, `dune build @fmt`, `dune test --force` all clean. Counts via `scripts/test-suite-counts.sh`: **1612 alcotest / 106 suites, 32 qcheck / 6 suites, 0 FAIL, 23 SKIP** — the expected baseline, unmoved. Every gate `ci.yml` runs was executed locally on this branch and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated license-header verification to the build process.
  * Added clear guidance for missing headers and coverage configuration errors.
  * License updates now preserve executable file permissions.

* **Bug Fixes**
  * Improved handling of license checks so unexpected validation errors are reported distinctly.

* **Tests**
  * Expanded coverage for missing headers, exemptions, invalid paths, and permission preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->