### PR TITLE
docs: stop citing internal backlog items as bare #NN (#148)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,42 @@ _build/default/sarek-cuda/test/test_cuda_error.exe
 - Document public APIs
 - Keep README files factual and technical
 - Avoid marketing language or performance claims without evidence
+
+#### Referring to issues, PRs and backlog items
+
+GitHub gives issues and pull requests a *single shared counter* (it is past
+330 in this repository) and auto-links every bare `#NN` in rendered Markdown
+to whatever holds that number. Our internal task tracker has its own,
+much lower numbering, so a bare `#NN` meaning a backlog item almost always
+renders as a live link to an unrelated PR — `#63` means "Metal
+`simdgroup_matrix`" to us and "Cleanup 2026 01" to GitHub.
+
+Three forms, and nothing else:
+
+| Referring to | Write | Renders as |
+| --- | --- | --- |
+| A real GitHub PR or issue | `PR #290`, `issue #135` | a link, to the right thing |
+| An internal backlog item | `backlog-63` | plain text |
+| A numbered row or item **inside the same document** | name it — "row 3, `ld.global.nc`" | plain text |
+
+`backlog-NN` deliberately drops the `#`: GitHub will not link it, so it
+cannot promise the reader a page that does not exist. **The backlog is not
+public.** A `backlog-NN` reference is for people working in this repository;
+it is not something an outside reader can look up, and it should not be
+dressed up to look like it is.
+
+Before writing `#NN`, check that the number resolves to the thing you are
+describing (`gh issue view NN`). If it does not, you mean `backlog-NN`.
+
+**Do not put a GitHub noun in front of a `backlog-NN`.** "Issue backlog-106"
+or "PR backlog-64" re-introduces exactly the claim the form exists to drop:
+the reader is told this is a GitHub issue, and it is not. Front-matter that
+used to read `**Issue:** #107` should read `**Tracked as:** backlog-107`.
+The nouns are fine where they govern a real number — `PR #275 / backlog-66`
+is correct, because `PR` applies to `#275`.
+
+**PR titles and commit subjects are out of scope.** Every existing PR here
+uses a bare `(#NNN)` for a backlog item, and rewriting history to match
+costs more than the ambiguity does — a PR title is read in a context where
+the reader already knows the number is ours. For *new* titles, `(backlog-NN)`
+is preferred; nothing existing needs changing.

--- a/docs/design/backend-factorization-review.md
+++ b/docs/design/backend-factorization-review.md
@@ -1,4 +1,4 @@
-# Backend / Plugin Factorization Review (#58)
+# Backend / Plugin Factorization Review (backlog-58)
 
 **Status:** DESIGN REVIEW — analysis only, no code change proposed for merge here.
 **Date:** 2026-07-25
@@ -21,9 +21,9 @@ one of them: a **shared helper module with per-backend data/closures passed in**
 
 | Precedent | Home | PR | Shape |
 |---|---|---|---|
-| Kernel-compilation cache | `spoc/framework/Guarded_cache.ml` | #275 / #66 | shared module |
-| `gen_intrinsic` (5 backends → 1) | `sarek/codegen/Sarek_ir_intrinsic_dispatch.ml` | #276 / #49 | table-driven dispatcher |
-| 7 `*_uses_*` detectors → 1 | `spoc/ir/Sarek_ir_analysis.ml` (`expr_fold`/`stmt_fold` + `'a folder`) | #277 / #47 | generic fold, per-node record |
+| Kernel-compilation cache | `spoc/framework/Guarded_cache.ml` | PR #275 / backlog-66 | shared module |
+| `gen_intrinsic` (5 backends → 1) | `sarek/codegen/Sarek_ir_intrinsic_dispatch.ml` | PR #276 / backlog-49 | table-driven dispatcher |
+| 7 `*_uses_*` detectors → 1 | `spoc/ir/Sarek_ir_analysis.ml` (`expr_fold`/`stmt_fold` + `'a folder`) | PR #277 / backlog-47 | generic fold, per-node record |
 | Variant-type emission | `spoc/ir/Sarek_ir_codegen.ml` (`mangle_name`, `gen_variant_def ~type_of_elttype`, `gen_variant_def_glsl`) | — | shared module, callback for the one backend-specific datum |
 | Backend error funnel | `Sarek_backend_error.Backend_error.Make(struct let name end)` | — | functor; each `*_error.ml` is ~20 lines |
 | Backend codegen re-export | `sarek-*/Sarek_ir_*.ml` are 9-line `include Sarek_codegen.*` shims | — | codegen already lives once in `sarek_codegen` |
@@ -56,8 +56,8 @@ some lines back).
 
 | # | Opportunity | Dup. today | LOC saved | Value | Safety | Rank | Task tie |
 |---|---|---|---|---|---|---|---|
-| 1 | Shadow-rename twins (GLSL/WGSL) → shared IR pre-pass | ~110 of ~118 lines identical | ~100 | High | High | **1** | #71/#72 (PR #282/#283) |
-| 2 | EMatch/SMatch payload handling → shared helper + fix divergence | guard dup ×2, SMatch handler dup ×5, EMatch discard dup ×5 | ~80–120 | High | High | **2** | #73/#75 (PR #284) |
+| 1 | Shadow-rename twins (GLSL/WGSL) → shared IR pre-pass | ~110 of ~118 lines identical | ~100 | High | High | **1** | backlog-71 / backlog-72 (PR #282, PR #283) |
+| 2 | EMatch/SMatch payload handling → shared helper + fix divergence | guard dup ×2, SMatch handler dup ×5, EMatch discard dup ×5 | ~80–120 | High | High | **2** | backlog-73 / backlog-75 (PR #284) |
 | 3 | C-family `gen_param`/`is_vec_type`/record typedef → `Sarek_ir_codegen` | verbatim ×3 | ~60–70 | Med | High | **3** | — |
 | 4 | `gen_lvalue` shared traversal (5 backends) | 4 arms ×5, identical | ~40 | Med | High | **4** | — |
 | 5 | `gen_expr` mechanical arms + `gen_stmt` control-flow (C-family trio) | ~90% of trio traversal | large (~hundreds) | High | Med | **5** | — |
@@ -116,12 +116,12 @@ fully captured by the two closures. `test_glsl_name_collision.ml` + golden tests
 The one judgment call: whether to keep the counters per-backend (they must, for name stability of
 each backend's golden files) — the `~fresh_name` closure owns its own counter, so this is fine.
 **Recommend as the first factorization.** Highest value×safety: real duplication, tiny blast
-radius, direct test coverage, and it consolidates two fixes (#71/#72, PRs #282/#283) that were
+radius, direct test coverage, and it consolidates two fixes (backlog-71 / backlog-72, PR #282 and PR #283) that were
 landed in parallel and produced the twin.
 
 ---
 
-### Opportunity 2 — EMatch/SMatch payload handling → shared helper + close the divergence  **[RANK 2]** (ties #75)
+### Opportunity 2 — EMatch/SMatch payload handling → shared helper + close the divergence  **[RANK 2]** (ties backlog-75)
 
 This is the messiest area and the most valuable to get right, because it is **both** duplication
 **and** a live correctness divergence. Three distinct sub-problems are tangled together — keep them
@@ -137,7 +137,7 @@ writes `PConstr (name, _)` — **dropping the binder list**:
 - CUDA `Sarek_ir_cuda.ml:190-219` (discard at `:208`), OpenCL `:208-237` (`:226`),
   Metal `:212-239` (`:228`) — **no guard, silently wrong** if a body uses a binder.
 - GLSL `:482-516` and WGSL `:348-384` added a fail-loud guard (`case_binds_used_payload`,
-  GLSL `:299-328`, WGSL `:196-223`) that raises `unsupported_construct` instead — the #73 fix
+  GLSL `:299-328`, WGSL `:196-223`) that raises `unsupported_construct` instead — the backlog-73 fix
   (PR #284). The `.tag == name` emitter itself (GLSL `:504`, WGSL `:378`) is still the same snippet.
 
 So today CUDA/OpenCL/Metal **silently emit undefined-identifier code** while GLSL/WGSL fail loud —
@@ -160,14 +160,14 @@ All five backends emit a `switch(scrut.tag)` that *does* bind payloads via
    iteri-over-payload loop are identical; only the field-access spelling (`.data.Ctor_v._N` vs
    GLSL/WGSL member syntax) and the decl form vary, both injectable.
 
-**The honest limit (judgment call, ties #75).** A shared *ternary/select* helper unifies the
+**The honest limit (judgment call, ties backlog-75).** A shared *ternary/select* helper unifies the
 fail-loud behavior and de-dups the emitter, but it does **not** make payload-using
 match-*expressions* compile on the ternary backends — a nested ternary is a single expression with
 nowhere to introduce a declaration, which is exactly why GLSL/WGSL chose to fail loud. Genuinely
 supporting payloads in expression position requires **promoting EMatch to SMatch-style lowering**
 (hoist to statement position with real binder decls), which PTX and the interpreter already do.
-That is a *feature*, not a factorization, and should be tracked as such under #75. **Do not
-conflate "fix #75 in one place" with "make it compile":** the factorization delivers *uniform
+That is a *feature*, not a factorization, and should be tracked as such under backlog-75. **Do not
+conflate "fix backlog-75 in one place" with "make it compile":** the factorization delivers *uniform
 fail-loud + one guard site + one SMatch handler*; the feature is a separate follow-up.
 
 **Risk.** Low-Med. Extending the guard to 3 more backends changes their behavior from
@@ -289,10 +289,10 @@ Ordered by value × safety, smallest-blast-radius-first so each lands independen
 golden tests:
 
 1. **Opportunity 1 — shadow-rename twins.** Isolated, ~100 LOC, direct test cover, consolidates
-   #71/#72. Do first.
+   backlog-71 / backlog-72. Do first.
 2. **Opportunity 2a — EMatch guard: share + extend to CUDA/OpenCL/Metal.** Closes the silent-wrong
-   divergence (a real correctness bug), then 2b (share the SMatch handler). Ties #75; explicitly
-   file the "EMatch→SMatch promotion for payload support" as a *separate feature* under #75, not
+   divergence (a real correctness bug), then 2b (share the SMatch handler). Ties backlog-75; explicitly
+   file the "EMatch→SMatch promotion for payload support" as a *separate feature* under backlog-75, not
    part of this factorization.
 3. **Opportunity 3 — C-family `gen_param`/`is_vec_type`/record typedef into `Sarek_ir_codegen`.**
    Proven callback idiom, verbatim duplication, low risk.
@@ -308,9 +308,9 @@ readability/flexibility tradeoff — it is deliberately last.
 
 ## 5. Open judgment calls for the reviewer
 
-- **#75 semantics.** Does #75 want *uniform fail-loud* on payload-using match-expressions (op. 2a
+- **backlog-75 semantics.** Does backlog-75 want *uniform fail-loud* on payload-using match-expressions (op. 2a
   suffices) or *actual payload support* (needs the separate EMatch→SMatch promotion feature)? This
-  changes whether op. 2 "closes" #75 or only de-risks it.
+  changes whether op. 2 "closes" backlog-75 or only de-risks it.
 - **How far to push op. 5.** C-family trio only, or through GLSL? My recommendation: trio first,
   GLSL only if the trio abstraction stays readable; never WGSL.
 - **Counter/name-stability.** The shadow-rename fresh-name counters and prefixes are per-backend by

--- a/docs/design/capability-model.md
+++ b/docs/design/capability-model.md
@@ -2,8 +2,8 @@
 
 _What a kernel requires, what a target provides, and which layer knows._
 
-**Status:** slice 1 landed; slices 2–5 proposed. **Issue:** #64 (absorbs the
-capability half of #57 §7). **Date:** 2026-07-27.
+**Status:** slice 1 landed; slices 2–5 proposed. **Tracked as:** backlog-64 (absorbs the
+capability half of backlog-57 §7). **Date:** 2026-07-27.
 
 ---
 
@@ -99,10 +99,10 @@ that was actively producing wrong answers.
 **Slice 1b — route WGSL f64 through the table.** WGSL already refuses f64, but
 via a bespoke `has_float64` / `params_have_float64` path with hand-written
 strings. Routing it through `Sarek_capability` makes the message uniform and the
-kind explicit. **Deliberately not done here**: #141 is auditing the WGSL backend
+kind explicit. **Deliberately not done here**: backlog-141 is auditing the WGSL backend
 concurrently and this would collide. No WGSL file is touched by slice 1.
 
-**Slice 2 — the dynamic launch gate. Landed in #142, for the wide element types
+**Slice 2 — the dynamic launch gate. Landed in backlog-142, for the wide element types
 only.** `Execute.run` (`sarek/execute/Execute.ml`) is the single point that has
 both the device and the IR, right beside `check_launch_args`;
 `Framework_sig.generate_source` takes no device, so no codegen path can consult
@@ -131,7 +131,7 @@ are the same task and must land together.
 
 > **Correction.** Slice 1 recorded this as a GLSL *fp64* hole — "emits `double`
 > while never declaring `GL_ARB_gpu_shader_fp64`". That was **measured false** by
-> #141: `glsl_header` takes `~uses_float64` and emits the extension, and
+> backlog-141: `glsl_header` takes `~uses_float64` and emits the extension, and
 > `glslangValidator` accepts the f64 kernel (exit 0). The real hole is one type
 > over — GLSL `int64_t`, whose `#extension` emission is gated on the float64
 > conditions only, so a plain `int64 vector` kernel emitted a shader glslang
@@ -140,7 +140,7 @@ are the same task and must land together.
 > device probe that `kind_needs_device Device_optional = true` calls for and
 > that slice 1 deliberately does not build.
 >
-> **Emitter half fixed in #141**, so #142 is the device probe only. The two
+> **Emitter half fixed in backlog-141**, so backlog-142 is the device probe only. The two
 > float64 conditions the `#extension` was gated on were the softmath helpers
 > that bit-cast a double and a non-finite f64 literal spelled via
 > `int64BitsToDouble`; `Sarek_ir_analysis.Int64` is now OR-ed in, so the line is
@@ -148,7 +148,7 @@ are the same task and must land together.
 > was `syntax error, unexpected IDENTIFIER` at exit 2, exit 0 after. Regression
 > gate: `glsl-validate/int64_only_store`, a validation-only kernel whose only
 > wide type is int64 — the shape the corpus lacked, which is why the gap
-> survived. Until #142 lands, a device without `shaderInt64` still fails at
+> survived. Until backlog-142 lands, a device without `shaderInt64` still fails at
 > shader load rather than at launch with a Sarek diagnostic: loud and correct,
 > but unattributed.
 
@@ -174,14 +174,14 @@ facts that motivated it is worse than none.
   independently tested — an f64 *literal* never reaches the type arm at all, and
   neither does an f64 *local* whose only appearance is its declared type.
 
-  Those two motivating shapes were found independently — the literal by #64
-  reasoning down from the capability model, the local by #141 reasoning up from
+  Those two motivating shapes were found independently — the literal by backlog-64
+  reasoning down from the capability model, the local by backlog-141 reasoning up from
   the emitted source — and both searches landed on the same detector
   (`Sarek_ir_analysis.kernel_uses Float64`) at the same two `generate` entries.
   Convergence from opposite directions is the argument that {arm, whole-kernel}
   is the *complete* set of entry points, not merely the set someone thought of.
 
-  #141 also revised the severity. Slice 1 described the pre-fix behaviour as "a
+  backlog-141 also revised the severity. Slice 1 described the pre-fix behaviour as "a
   silent halving of precision"; it was worse than that. The IR element type
   fixes the buffer stride as well as the arithmetic, and `Vector.float64` is 8
   bytes per element, so `device float*` strode the host buffer at 4 and every
@@ -191,8 +191,8 @@ facts that motivated it is worse than none.
 
 **Expressible, not yet wired:**
 
-- WGSL/WebGPU has no `f64` — same kind, deferred to slice 1b (#141
-  coordination). #141's backend-wide sweep confirms slice 1b is a pure
+- WGSL/WebGPU has no `f64` — same kind, deferred to slice 1b (backlog-141
+  coordination). backlog-141's backend-wide sweep confirms slice 1b is a pure
   refactor and finds nothing for it to fix: WGSL already refuses `TFloat64`,
   `TInt64` and `TFloat16` with located errors, and is the only backend that
   refuses everything it cannot represent at the right width. It was the
@@ -208,8 +208,8 @@ facts that motivated it is worse than none.
   `compute_capability` is already in the capabilities record, so the probe is
   cheap. Slice 2.
 - **`int64` on Vulkan/GLSL** — `Device_optional`
-  (`VkPhysicalDeviceFeatures.shaderInt64` / `GL_ARB_gpu_shader_int64`). #141
-  fixed the emitter half. **#142 fixed the device half**, and found that the
+  (`VkPhysicalDeviceFeatures.shaderInt64` / `GL_ARB_gpu_shader_int64`). backlog-141
+  fixed the emitter half. **backlog-142 fixed the device half**, and found that the
   prediction recorded here was wrong in a way worth keeping.
 
   The expectation was "a device without the feature fails at shader load rather
@@ -249,7 +249,7 @@ facts that motivated it is worse than none.
 
   3. *The failure mode is confidence about an API's guarantees, not ignorance
      of a device* — and it recurred inside this very fix. The first version of
-     #142 replaced "we assume fp64" with "we probe fp64", then wrote `Int64`
+     backlog-142 replaced "we assume fp64" with "we probe fp64", then wrote `Int64`
      unconditionally for **every** OpenCL device one file over, reasoning that
      `long` is a core OpenCL C type. It is core only in the FULL profile;
      an `EMBEDDED_PROFILE` device may omit 64-bit integers, advertising them
@@ -273,7 +273,7 @@ facts that motivated it is worse than none.
   (`Sarek_ir_layout.scalar_size TBool = 4`, mirroring `Sarek_ppx`), and `bool`
   is an accepted `[@@sarek.type]` record field — so host `{bool;bool;int}` at
   0/4/8, size 12, met an emitted `typedef struct { bool a; bool b; int n; }` at
-  0/1/4, size 8. Fixed in the emitter (#141): Metal now emits `int`.
+  0/1/4, size 8. Fixed in the emitter (backlog-141): Metal now emits `int`.
 
   The instrument that catches this class is not this table but the totality
   sweep — `sarek/tests/codegen_golden/test_backend_type_width_totality.ml`. For
@@ -337,7 +337,7 @@ facts that motivated it is worse than none.
   Intel Arc / Meteor Lake-P). Closing this needs a compiler-identity probe that
   does not exist.
 
-  > **This gap does not block the f16 barrier, and backlog #144 asked whether it
+  > **This gap does not block the f16 barrier, and backlog-144 asked whether it
   > did.** The barrier's own scoping never depended on runtime identification:
   > it is emitted from a single site under `#if defined(__HIP__) ||
   > defined(__HIP_PLATFORM_AMD__)`, and the compilers that could get it wrong
@@ -349,7 +349,7 @@ facts that motivated it is worse than none.
   > it is not real for this one. See `docs/fp-contraction-policy.md` §11.4.
 - **Source locations.** `Sarek_ir_types.kernel` carries no location and the IR
   has no per-node locations, so a codegen refusal names the capability and the
-  target but not the kernel source line. #64 asked for a *located* error; slice 1
+  target but not the kernel source line. backlog-64 asked for a *located* error; slice 1
   delivers a named one. The fix is to thread `Sarek_ast.loc` through
   `Sarek_lower_ir` into the IR — slice 4, and a large change on its own.
 

--- a/docs/design/f16-dsl-element-type.md
+++ b/docs/design/f16-dsl-element-type.md
@@ -1,6 +1,6 @@
 # Design Spec: f16 (half-precision float) as a Sarek DSL element type
 
-**Task:** #57 (`f16-dsl-element-type`) — roster RESEARCH + SPEC phase.
+**Task:** backlog-57 (`f16-dsl-element-type`) — roster RESEARCH + SPEC phase.
 **Status:** DESIGN SPEC, **AMENDED POST-IMPLEMENTATION**. The original text was
 written before any code existed; slice 1 was then built (PR #290) and proved parts
 of this spec wrong. Those parts are corrected **in place**, next to the claim they
@@ -8,7 +8,7 @@ refute, and flagged with a `CORRECTION` callout. The spec is deliberately kept a
 design document rather than rewritten into an implementation report — the point of
 keeping the wrong claims visible is that the *next* width's spec gets written
 better.
-**Date:** written 2026-07-25; amended 2026-07-25 (post PR #290 / #291).
+**Date:** written 2026-07-25; amended 2026-07-25 (post PR #290 / PR #291).
 **Method:** float32 / float64 traced end-to-end as the template; each layer mapped
 to what f16 needs, with `file:line` anchors verified against the worktree.
 
@@ -22,8 +22,8 @@ to what f16 needs, with `file:line` anchors verified against the worktree.
   reasoned-not-verified unless a callout upgrades it.
 
 **Anchor hygiene.** All `file:line` anchors in the original text were verified
-against the worktree at writing time. They have since drifted: PR #77 factorized
-the C-family codegen, PR #78 (`ba375a36`) deleted `Kirc_Ast.ml` and
+against the worktree at writing time. They have since drifted: backlog-77 factorized
+the C-family codegen, PR #291 (`ba375a36`, backlog-78) deleted `Kirc_Ast.ml` and
 `Sarek_lower.ml` outright, and PR #290 itself moved things. Anchors re-verified
 during this amendment carry their current line; anchors that could not be
 re-verified are marked *(approx.)* rather than guessed at.
@@ -34,7 +34,7 @@ re-verified are marked *(approx.)* rather than guessed at.
 
 Slice 1 shipped as **PR #290** (`feat/f16-dsl-slice1`, three commits: initial
 implementation, review-round-1 must-fixes, review-round-2 duplication collapse +
-soundness holes). **PR #291 / issue #78** (`ba375a36`) separately deleted the dead
+soundness holes). **PR #291** (`ba375a36`, backlog-78) separately deleted the dead
 legacy `Kirc_Ast` path (~2,215 lines removed). Together they change five things in
 this spec:
 
@@ -65,8 +65,8 @@ conversions (§6.3), the slice plan (§8), the type-system exclusion of f16 from
 ## 0. TL;DR
 
 - **f16 SCALAR is the prerequisite** that unlocks every tensor-core path in Sarek:
-  Vulkan cooperative-matrix (#62), Metal `simdgroup_matrix` (#63), HIP rocWMMA from
-  `[%kernel]` (#44 étape B). None are reachable until the DSL can express an f16
+  Vulkan cooperative-matrix (backlog-62), Metal `simdgroup_matrix` (backlog-63), HIP rocWMMA from
+  `[%kernel]` (backlog-44 étape B). None are reachable until the DSL can express an f16
   element type. This spec covers the f16 **scalar** type; f16 **matrix/fragment**
   types are a delineated follow-on (§8, slice 3).
 - **The host storage layer is the EASY part, not the hard part** — contrary to a
@@ -120,7 +120,7 @@ conversions (§6.3), the slice plan (§8), the type-system exclusion of f16 from
 - **Recommended capability gating:** add `supports_fp16` to the device
   capabilities record and reuse the exact `kernel_uses_float64` →
   emit-pragma/extension machinery (a parallel `kernel_uses_float16` detector),
-  plus a launch-time gate — the #64 static-where-known + dynamic-gate model.
+  plus a launch-time gate — the backlog-64 static-where-known + dynamic-gate model.
   **Half held** — the `kernel_uses_float16` detector shipped, generalized into a
   `feature` type; the `supports_fp16` capability field and launch gate did not. See
   the CORRECTION in §7.
@@ -132,10 +132,10 @@ conversions (§6.3), the slice plan (§8), the type-system exclusion of f16 from
 The expressivity-gap analysis already ranks these
 (`docs/optimization/opt-expressivity-gaps.md:82,86`):
 
-- **#62 Vulkan cooperative-matrix** (`VK_KHR_cooperative_matrix`) — cross-vendor
+- **backlog-62 Vulkan cooperative-matrix** (`VK_KHR_cooperative_matrix`) — cross-vendor
   tensor path. Cooperative-matrix fragments are typically f16-input / f32-accumulate.
-- **#63 Metal `simdgroup_matrix`** — `simdgroup_half8x8` fragments are f16.
-- **#44 étape B HIP rocWMMA** — the `mma`-probe (`docs/optimization/l15b-mma-probe.md`)
+- **backlog-63 Metal `simdgroup_matrix`** — `simdgroup_half8x8` fragments are f16.
+- **backlog-44 étape B HIP rocWMMA** — the `mma`-probe (`docs/optimization/l15b-mma-probe.md`)
   shows the WMMA path assembles but is not reachable from `[%kernel]` today; the
   probe kernel itself is `...f32.f16.f16.f32` — f16 inputs.
 
@@ -168,7 +168,7 @@ central structural fact that sizes the work.
 Adding f16 means adding a constructor in **each** vocabulary and extending every
 exhaustive match over it. The blast radius is enumerated in §5.
 
-> **CORRECTION (verified, PR #290 + #291/#78).** "Three vocabularies" was the
+> **CORRECTION (verified, PR #290 and PR #291 / backlog-78).** "Three vocabularies" was the
 > central structural claim of this spec and it framed the cost wrongly in both
 > directions.
 >
@@ -177,7 +177,7 @@ exhaustive match over it. The blast radius is enumerated in §5.
 > (`Kirc_Ast.ml:47`, `:248-249`, `Sarek_lower.ml:219-220`, `Sarek_quote.ml:51-52`),
 > of which a new width forces exactly **one**: `lower_reg_elttype`. Slice 1 did not
 > even add a constructor — it added a twelve-line *rejection* arm, because the path
-> was already dead. **PR #291 (`ba375a36`, issue #78) then deleted `Kirc_Ast.ml` and
+> was already dead. **PR #291 (`ba375a36`, backlog-78) then deleted `Kirc_Ast.ml` and
 > `Sarek_lower.ml` outright** (~2,215 lines). The legacy IR is no longer a
 > consideration for any future width, and §10 question 1 is answered.
 >
@@ -306,7 +306,7 @@ the same free round-trip verified in §3.1.
 >
 > **What the implementation had to do instead** — two kind-independent helpers in
 > `sarek/core/Memory.ml` (mainline: `bigarray_elem_size` at `:22`;
-> `bigarray_void_ptr` added by #290 at `:94`), then patch *every* allocation and
+> `bigarray_void_ptr` added by PR #290 at `:94`), then patch *every* allocation and
 > transfer site:
 >
 > | Backend | sites patched |
@@ -369,7 +369,7 @@ the same free round-trip verified in §3.1.
 `Ptyp_constr {txt=Lident "float32"} -> TReg Float32`. Add `"float16" -> TReg Float16`
 (and optionally `"half"` as an alias — fork §6.1).
 
-> **CORRECTION + HELD.** The `Sarek_lower.ml` anchor is dead (file deleted by #291);
+> **CORRECTION + HELD.** The `Sarek_lower.ml` anchor is dead (file deleted by PR #291);
 > annotation resolution for the live path is `Sarek_types.ml:458`
 > (`TEConstr ("float16", []) -> t_float16`). `"half"` was **not** added as an alias.
 >
@@ -548,7 +548,7 @@ OpenCL `:109,116`, GLSL `:333,353` (double uses `"lf"`), Metal `:113,120`, WGSL
 `:242`, PTX `Sarek_ir_ptx_expr.ml:436,440` (hex bit-pattern). f16 literals (if
 adopted, §6.1) mirror these with the per-backend suffix column above.
 
-**Feature-declaration mechanism (the #64 tie-in).** The OpenCL and GLSL paths are the
+**Feature-declaration mechanism (the backlog-64 tie-in).** The OpenCL and GLSL paths are the
 model: a `Sarek_ir_analysis.kernel_uses_float64 k` predicate gates a prepended
 pragma / `#extension` line. f16 adds a **parallel `kernel_uses_float16`** detector
 (§3.2 / §5) and reuses the identical prepend structure. See §7.
@@ -580,7 +580,7 @@ pragma / `#extension` line. f16 adds a **parallel `kernel_uses_float16`** detect
 `include`s the shared codegen but must be audited for local elttype matches. HIP
 reuses CUDA codegen verbatim (`sarek-hip/Hip_plugin.ml:36`, `Hip_shared.ml:12-13`).
 
-> **Anchor note.** PR #77 factorized the C-family codegen into `Sarek_ir_codegen`
+> **Anchor note.** backlog-77 factorized the C-family codegen into `Sarek_ir_codegen`
 > and shifted everything below ~line 600 in the emitters. Current: CUDA
 > `cuda_header` `656 → 631`; OpenCL `generate_with_fp64` `755-759 → 713-717`; Metal
 > `generate` `909 → 875` (the `#include <metal_stdlib>` is `:882`); WGSL `:1233` is
@@ -794,11 +794,11 @@ params (not just vectors) are wanted early.
 > every place the wider one can be substituted is a silent-truncation site* —
 > enumerate them before shipping.
 
-### 6.5 Capability gating — see §7 (it is the #64 tie-in, treated as its own section).
+### 6.5 Capability gating — see §7 (it is the backlog-64 tie-in, treated as its own section).
 
 ---
 
-## 7. Capability gating (#64 tie-in)
+## 7. Capability gating (backlog-64 tie-in)
 
 f16 support is **not universal** (many OpenCL/Vulkan devices lack it; WebGPU requires
 the `shader-f16` feature; older PTX targets pre-sm_53). An f16 kernel on a
@@ -836,7 +836,7 @@ df64-style substrate machine unless a concrete no-f16-storage device appears.
 
 **⚠ WANT HUMAN INPUT:** whether the launch-time gate should be a hard error or a
 warn-and-emulate-in-f32 fallback. My recommendation is **hard error** (Sarek's
-proof-tier discipline favors explicit over silent), but this composes with #64's
+proof-tier discipline favors explicit over silent), but this composes with backlog-64's
 policy and is the kind of call that should be made deliberately.
 
 > ### CORRECTION — §7 was not built in slice 1, and only half of it should be
@@ -862,7 +862,7 @@ policy and is the kind of call that should be made deliberately.
 > can read a false value from.
 >
 > **The hard-error-vs-fallback question is therefore still open**, but its scope
-> shrank: the recommendation of hard error stands, and #64 should decide it for the
+> shrank: the recommendation of hard error stands, and backlog-64 should decide it for the
 > whole `feature` set at once rather than per width — which is what
 > `kernel_requirements : kernel -> feature list` (`Sarek_ir_analysis.ml:254`) was
 > added to enable.
@@ -901,7 +901,7 @@ conversions.
 - Native/interp: `VFloat16`/`Float16_type` sharing `PFloat`; reuse `get_f32`+rounding
   (§6.4).
 - **One GPU backend: recommend CUDA/HIP** (simplest feature decl — a single
-  `#include`; and it is the tensor-core target for #44). `TFloat16 -> "half"`.
+  `#include`; and it is the tensor-core target for backlog-44). `TFloat16 -> "half"`.
 - Capability: `supports_fp16` field + `kernel_uses_float16` detector + launch gate
   (§7).
 - **Deliberately excludes PTX** (see slice 2 rationale).
@@ -913,7 +913,7 @@ conversions.
 
 > ### CORRECTION — "each is mechanical except WGSL" is refuted for OpenCL
 >
-> **VERIFIED BY EXECUTION** (#57 slice 2a, 2026-07-26). The OpenCL *codegen* is
+> **VERIFIED BY EXECUTION** (backlog-57 slice 2a, 2026-07-26). The OpenCL *codegen* is
 > indeed mechanical — `"half"`, a narrowing arm, and a `cl_khr_fp16` pragma.
 > That was never the binding constraint, and pricing this slice by codegen
 > surface repeated §5's error one width later: **the cost of a backend is not
@@ -948,7 +948,7 @@ conversions.
 >    same defect underneath. GLSL/Vulkan on RADV is a second front end onto ACO
 >    and should be assumed to carry this defect until measured.
 >
->    **Corrected (#145): they are not the same compiler.** rusticl/radeonsi and
+>    **Corrected (backlog-145): they are not the same compiler.** rusticl/radeonsi and
 >    RADV compile through **ACO**, Mesa's shader compiler; hiprtc compiles
 >    through **LLVM's AMDGPU backend**. The rule survives — grouping by
 >    compiler still beats grouping by source language — but the group here is
@@ -958,7 +958,7 @@ conversions.
 >    would miss hiprtc, keyed to ROCm it would miss rusticl and RADV. See
 >    `docs/fp-contraction-policy.md` §2, "Two AMD compilers".
 >
->    **Do not over-read the RADV result that landed alongside this** (#106/#126,
+>    **Do not over-read the RADV result that landed alongside this** (backlog-106 / backlog-126,
 >    the `Vulkan / GLSL` row): RADV was measured *not* to contract **7 f32
 >    contraction shapes**, ISA-identical with and without `precise`. That is a
 >    result about `a*b+c`-style f32 contraction. The f16 defect here is a
@@ -973,7 +973,7 @@ conversions.
 
 > ### CORRECTION — and for GLSL/Vulkan too, worse than for OpenCL
 >
-> **VERIFIED BY EXECUTION** (#57 slice 2b, 2026-07-26). Rule 1 above told slice
+> **VERIFIED BY EXECUTION** (backlog-57 slice 2b, 2026-07-26). Rule 1 above told slice
 > 2b to *assume* RADV carries the defect and to *measure* rather than infer it.
 > Measured: it does. Exhaustive sweep of all 63488 finite binary16 inputs, on
 > both local devices (RX 7900 XTX / **RADV NAVI31** and the Raphael iGPU / **RADV
@@ -1013,7 +1013,7 @@ conversions.
 > the multiply vanishes into the narrowing. So RADV demonstrably **does** honour
 > SPIR-V `NoContraction`. It simply does not reach: absorbing a *conversion* is
 > a different combine from contracting `a*b+c`, and only the latter is what
-> `NoContraction` forbids. The tempting inference from #106/#126 — "we already
+> `NoContraction` forbids. The tempting inference from backlog-106 / backlog-126 — "we already
 > emit `precise`, and RADV was measured not to contract 7 f32 shapes, so f16 is
 > safe" — is therefore false, and is now guarded by a named test case.
 >
@@ -1042,7 +1042,7 @@ conversions.
 - Per-plugin `Sarek_ir_<backend>.ml` audit (§4).
 
 ### Slice 3 — f16 matrix / tensor-core types (the unlock; separate spec)
-**This slice is a follow-on and deserves its own design spec.** It is where #62/#63/#44
+**This slice is a follow-on and deserves its own design spec.** It is where backlog-62 / backlog-63 / backlog-44
 are actually delivered:
 - Packed f16 math (`half2`/`f16x2`, `hfma2`) — the throughput win.
 - An f16 **fragment/matrix** element type in the IR (a new type class, not just a
@@ -1052,7 +1052,7 @@ are actually delivered:
 - Gated by the same `supports_fp16` + a new `supports_cooperative_matrix`-class
   capability.
 
-Slice 3 is explicitly **out of scope** for #57; #57 delivers slices 1–2 (f16 scalar).
+Slice 3 is explicitly **out of scope** for backlog-57; backlog-57 delivers slices 1–2 (f16 scalar).
 The matrix layer is named here only to fix the relationship.
 
 ---
@@ -1080,7 +1080,7 @@ The matrix layer is named here only to fix the relationship.
 > **Direction 1 — `Kirc_Ast` was priced far too high (measured).** `Kirc_Ast.elttype`
 > had **4 constructors and 4 use sites** across the entire tree, exactly **one** of
 > which a new width forces (`lower_reg_elttype`). One line. Slice 1 spent that line
-> on a *rejection*, since the path was already dead. **PR #291 (`ba375a36`, #78) has
+> on a *rejection*, since the path was already dead. **PR #291 (`ba375a36`, backlog-78) has
 > since deleted `Kirc_Ast.ml` and `Sarek_lower.ml` entirely (~2,215 lines).** It is
 > no longer a consideration. The "roughly halve slice 1–2 cost" estimate above was
 > off by an order of magnitude, and a later follow-up investigation repeated the
@@ -1156,15 +1156,15 @@ The matrix layer is named here only to fix the relationship.
 1. **Legacy IR:** is `Kirc_Ast` still required, or may f16 target only `Sarek_ir`?
    (Halves the blast radius if the latter.)
    > **ANSWERED: not required, and gone.** It was fully dead. f16 rejects it; PR
-   > #291 deleted it. It was also never worth half the blast radius — one line (§9).
+   > PR #291 deleted it. It was also never worth half the blast radius — one line (§9).
 2. **Strategic:** is slice 3 (tensor cores) funded? If not, is f16 storage/interchange
    alone worth slices 1–2? (§9.)
    > **ANSWERED: the coopmat-first tensor-core strategy is the funded direction**,
    > which is what makes bf16 rather than f8/f4 the next width (§11).
 3. **Launch gate policy:** hard error vs warn-and-emulate on an f16-lacking device
-   (§7). Composes with #64.
+   (§7). Composes with backlog-64.
    > **STILL OPEN, scope reduced.** Slice 1 needs no launch gate — unsupported
-   > backends reject at codegen. Decide it in #64 for the whole `feature` set at
+   > backends reject at codegen. Decide it in backlog-64 for the whole `feature` set at
    > once (§7).
 4. **Surface taste:** `half` alias alongside `float16`, or `float16` only? (§6.1.)
    > **ANSWERED: `float16` only.** `half` stays reserved but unbound.
@@ -1191,7 +1191,7 @@ these are directional, not verified.
   exactly why it is the right second instance for learning what generalizes.
 - **It fits the funded strategy.** bf16 is among the supported component types of
   `VK_KHR_cooperative_matrix`, so it lands inside the coopmat-first tensor-core path
-  (#62) rather than beside it.
+  (backlog-62) rather than beside it.
 - **Hardware coverage is broad:** NVIDIA Ampere and later, AMD RDNA3 / CDNA2 and
   later, Apple, Intel.
 - **Local testability caveat, stated up front.** RADV on the RX 7900 XTX advertises

--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -1,15 +1,15 @@
 # The relaxed f16 accuracy contract, and the tensor-core paths it unblocks
 
 _What Sarek promises about f16 results when bit-identity with the interpreter is
-no longer required, and how #62 (Vulkan cooperative-matrix) and #63 (Metal
+no longer required, and how backlog-62 (Vulkan cooperative-matrix) and backlog-63 (Metal
 `simdgroup_matrix`) are sliced on top of it._
 
 **Status:** design only; the two decisions this document opened were taken by the
 project owner on 2026-07-27 and are recorded as decided in **§3** (scalar f16 is
 relaxed, as an explicit performance trade) and **§6** (user-facing friction is
 proportional to the strength of the evidence). **No refusal is lifted by this
-change.** **Issues:** #62, #63; depends on the f16 scalar type (#57) and the
-capability model (#64). **Date:** 2026-07-27.
+change.** **Tracked as:** backlog-62, backlog-63; depends on the f16 scalar type (backlog-57) and the
+capability model (backlog-64). **Date:** 2026-07-27.
 
 **Amended 2026-07-27 (Metal measurement).** §7 slices 5 and 6 are **done** — an
 Apple M4 became reachable, both probes ran, and the results are wired in: §2
@@ -52,10 +52,10 @@ is no longer a requirement for f16**, provided the results are correct,
 deterministic, the technical limitation is understood and explained, and all of
 it is documented.
 
-That is a genuine relaxation and it is what makes #62 and #63 reachable. It is
+That is a genuine relaxation and it is what makes backlog-62 and backlog-63 reachable. It is
 also not yet a specification. "Correct" without a bound admits anything; and this
 repository has already shipped a gate whose tolerance was wider than the effect
-it existed to detect (`docs/fp-contraction-policy.md` §11.5, backlog #118), where
+it existed to detect (`docs/fp-contraction-policy.md` §11.5, backlog-118), where
 the consequence was a fully collapsed implementation reading green.
 
 This document turns the decision into something a test can fail.
@@ -374,7 +374,7 @@ not as a plan.
 | **Vulkan / ANV** | Intel Arc Graphics (MTL), Mesa 26.1.2-arch3.1 | **0 / 63488** | n/a | executed | **strict**; refusal is currently over-broad here |
 | **Metal** | Apple M4, macOS 15.6.1 (24G90), Apple clang 17.0.0 (clang-1700.0.13.5), Metal.framework from the Command Line Tools SDK | **0 / 63488** on `f16(x*1.1)` **and 0 / 63488** on `f16(f16(x*1.1)+1000)`; unchanged under `#pragma METAL fp contract(off)`, `#pragma clang fp contract(off)`, a `volatile thread` barrier and an `as_type` bitcast barrier | n/a — no deviation to model. The `fusedctl` control, on the same source, compile options and dispatch, reproduces `S_fuse_mul_into_narrowing` on **63488 / 63488** and reports 2912 / 620 | executed, **element-wise** over the whole finite binary16 domain | **strict**; refusal is currently over-broad here |
 | **WGSL / naga** | — | **never probed** | — | none | **`Unknown` → refused** |
-| **PTX** | — | refuses kernel-level f16 by design (#57 slice 2) | — | by-construction | nothing to relax |
+| **PTX** | — | refuses kernel-level f16 by design (backlog-57 slice 2) | — | by-construction | nothing to relax |
 
 **Regime B rows — cooperative matrix (§5), Metal only.** These are the first
 numeric measurements of any cooperative-matrix implementation in this project;
@@ -466,7 +466,7 @@ alternative rounding* of the same program (Regime A), or inside a derived bound
 those stacks, legitimately. That is the price.
 
 What it buys is that the tensor-core paths become reachable at all. Neither
-`VK_KHR_cooperative_matrix` (#62) nor Metal `simdgroup_matrix` (#63) can be
+`VK_KHR_cooperative_matrix` (backlog-62) nor Metal `simdgroup_matrix` (backlog-63) can be
 expressed without f16 as a DSL element type on those backends
 (`f16-dsl-element-type.md` §1), and both are the funded direction (ibid. §10 Q2).
 
@@ -546,7 +546,7 @@ subgroup`**:
 
 Four consequences for the plan:
 
-1. **#62 is not blocked on hardware.** The path can be built and measured
+1. **backlog-62 is not blocked on hardware.** The path can be built and measured
    locally, end to end.
 2. **Only 2 of 14 configurations need the relaxed contract.** The other 12 are
    integer, and the SPIR-V extension states integer accumulation is exact — they
@@ -755,7 +755,7 @@ Three constraints pin the answer:
    ruling's third clause.
 2. **Mandatory everywhere defeats the unblock.** If every f16 kernel needs an
    acknowledgement before it will run, the tensor-core path is unusable by
-   default, and #62/#63 were unblocked in order to be used.
+   default, and backlog-62/backlog-63 were unblocked in order to be used.
 3. **Mandatory nowhere makes the coopmat bound meaningless.** §5's bound is a
    *bound*, not an identity: a user can be inside it and still be getting an
    answer that depends on the driver's accumulation order. Someone who has not
@@ -785,7 +785,7 @@ branch on it rather than discovering it in a diagnostic.
 
 ---
 
-## 7. Slicing plan for #62 and #63
+## 7. Slicing plan for backlog-62 and backlog-63
 
 Each slice names what it proves and what hardware it needs. Nothing below lifts a
 refusal before slice 3.
@@ -796,9 +796,9 @@ refusal before slice 3.
 | **1** | element-wise model characterisation of ACO scalar f16 | whether the contract of §1.2 is deliverable at all | RX 7900 XTX + Raphael iGPU (local) | no | **DONE 2026-07-27 for 2 of 20 shapes — deliverable; 18 shapes still open** |
 | **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | open |
 | **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist | open |
-| **4** | #62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | open |
-| **5** | #63 Metal — **scalar f16 first** | the Metal row of §2 | ladon (M4) | no | **DONE 2026-07-27 — strict, 0/63488** |
-| **6** | #63 Metal `simdgroup_matrix` | the Apple tensor-core path | ladon (M4) | yes | **DONE 2026-07-27 — availability + numerics; no integer path** |
+| **4** | backlog-62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | open |
+| **5** | backlog-63 Metal — **scalar f16 first** | the Metal row of §2 | ladon (M4) | no | **DONE 2026-07-27 — strict, 0/63488** |
+| **6** | backlog-63 Metal `simdgroup_matrix` | the Apple tensor-core path | ladon (M4) | yes | **DONE 2026-07-27 — availability + numerics; no integer path** |
 
 ### Slice 0 — make the contract fail-able (host-only, lands first)
 
@@ -946,7 +946,7 @@ to unlock (`opt-expressivity-gaps.md`: "OpenCL has no portable equivalent"), so
 lifting it buys nothing but consistency. **Recommend leaving OpenCL refused** and
 saying why, rather than lifting it for symmetry.
 
-### Slice 4 — #62, Vulkan cooperative-matrix (local)
+### Slice 4 — backlog-62, Vulkan cooperative-matrix (local)
 
 Sub-sliced deliberately, because 4a is cheap, is the highest-information step,
 and needs nothing from the DSL:
@@ -985,22 +985,22 @@ and needs nothing from the DSL:
     It is also the **fallback if slice 1 goes the wrong way**: if the ACO shapes
     fail to match a closed-form model and the scalar contract has to become
     per-shape, an integer-only coopmat path still lands, still under the strict
-    contract, and #62 is not blocked on the accuracy question at all. That
+    contract, and backlog-62 is not blocked on the accuracy question at all. That
     fallback only exists if 4b was built for it.
 
-    **The fallback is #62's, not #63's — measured, not assumed.** Metal has *no*
+    **The fallback is backlog-62's, not backlog-63's — measured, not assumed.** Metal has *no*
     integer `simdgroup_matrix`: the only element types are `half`, `float` and
     `bfloat`, and integers fail a named `is_simdgroup_matrix_element<T>`
     static_assert, so the enumeration is closed (§7 slice 6). An earlier reading
     of this bullet implied every backend had a strict-contract path to fall back
-    on. **#63 does not.** On Metal the tensor-core path is reachable only through
-    the relaxation, which makes #63 strictly more exposed to it than #62 — if the
-    relaxation were withdrawn, #62 could still ship integer configurations and
-    #63 could ship nothing. Admitting integer component types remains right for
+    on. **backlog-63 does not.** On Metal the tensor-core path is reachable only through
+    the relaxation, which makes backlog-63 strictly more exposed to it than backlog-62 — if the
+    relaxation were withdrawn, backlog-62 could still ship integer configurations and
+    backlog-63 could ship nothing. Admitting integer component types remains right for
     the reasons above; it is simply not a universal safety net.
 
   The *slicing* is deliberately **not** reordered to put integers first — f16
-  scalar is a prerequisite for #63 and for bf16 regardless
+  scalar is a prerequisite for backlog-63 and for bf16 regardless
   (`f16-dsl-element-type.md` §11.1), so the relaxation work is resequenced rather
   than avoided, and an integer-only tensor-core path is not what the intended
   audience means by "tensor cores". The type admits integers; the plan still
@@ -1008,7 +1008,7 @@ and needs nothing from the DSL:
 - **4c — GLSL codegen for the fragment type**, gated on the `Device_optional`
   coopmat capability. The Raphael iGPU is the free negative device (§4).
 
-### Slices 5 and 6 — #63, Metal — **DONE, 2026-07-27**
+### Slices 5 and 6 — backlog-63, Metal — **DONE, 2026-07-27**
 
 Both were unschedulable pending access to an Apple GPU. Access was granted, the
 probes were run on ladon, and both slices are complete. Recorded in
@@ -1047,18 +1047,18 @@ probes were run on ladon, and both slices are complete. Recorded in
 > for the ACO shapes — resting on the fact that 12 of the 14 configurations RADV
 > advertises are integer. **That reasoning does not transfer to Metal, and this
 > document previously implied a universal fallback.** There is no integer
-> `simdgroup_matrix` at all, so **#63 has no strict-contract route**: on Metal it
+> `simdgroup_matrix` at all, so **backlog-63 has no strict-contract route**: on Metal it
 > is f16 or bf16 or nothing, and it is reachable *only* through the relaxation.
 >
 > Two consequences the plan has to carry:
 > - **Slice 4b's integer requirement keeps its justification but loses its
 >   universality.** Admitting integer component types in the IR fragment type is
 >   still right — it is nearly free at design time, expensive to retrofit, and it
->   is what keeps #62 deliverable if slice 1 goes badly. But it is a **#62
->   fallback, not a #62-and-#63 fallback**, and slice 4b should say so rather than
+>   is what keeps backlog-62 deliverable if slice 1 goes badly. But it is a **backlog-62
+>   fallback, not a backlog-62-and-backlog-63 fallback**, and slice 4b should say so rather than
 >   let a reader infer that every backend has a strict-contract path.
-> - **#63 is more exposed to the relaxation than #62 is.** If the relaxation were
->   ever withdrawn, #62 could still ship its integer configurations and #63 could
+> - **backlog-63 is more exposed to the relaxation than backlog-62 is.** If the relaxation were
+>   ever withdrawn, backlog-62 could still ship its integer configurations and backlog-63 could
 >   ship nothing. That asymmetry did not exist in the plan as written and should
 >   be visible when the two are prioritised against each other.
 >
@@ -1107,18 +1107,18 @@ exact at the precision of the result type. Those configurations are deliverable
 **under Sarek's existing strict contract**, with no accuracy relaxation, no
 allowlist and no `accept_relaxed_f16` opt-in.
 
-They exercise every structurally hard part of #62: the `Device_optional`
+They exercise every structurally hard part of backlog-62: the `Device_optional`
 capability gate, the `VkPhysicalDeviceCooperativeMatrixPropertiesKHR` query, the
 `shaderFloat16`-adjacent feature plumbing, the new IR fragment type, the subgroup
 ABI, and the codegen. Only the *numerics* differ.
 
-**So an alternative slicing exists in which #62's whole skeleton lands before any
+**So an alternative slicing exists in which backlog-62's whole skeleton lands before any
 part of the accuracy relaxation is used**, and the relaxation is then applied to
 one narrow thing (the f16 accumulate path) with the machinery already proven.
 `u8 × u8 → s32` is also a real workload — quantised inference is the main
 consumer of integer tensor cores.
 
-Against it: the f16 scalar type is a prerequisite for #63 and for bf16 regardless
+Against it: the f16 scalar type is a prerequisite for backlog-63 and for bf16 regardless
 (`f16-dsl-element-type.md` §11.1), so the relaxation work is not avoided, only
 resequenced; and an integer-only coopmat path is not what "tensor cores" means to
 most of the intended audience.
@@ -1132,15 +1132,15 @@ most of the intended audience.
 > finds no closed-form model for the ACO shapes.
 >
 > **AMENDED 2026-07-27, after the Metal measurement.** This whole section is
-> scoped to **#62**. It reads as though "the cheapest first tensor-core slice
+> scoped to **backlog-62**. It reads as though "the cheapest first tensor-core slice
 > needs no relaxation" were a statement about tensor cores in general; it is a
 > statement about *Vulkan*, and it holds only because RADV advertises integer
 > configurations. **Metal advertises none** — `simdgroup_matrix` exists for
 > `half`, `float` and `bfloat` only, integers failing a named static_assert, a
 > closed enumeration (§7 slice 6). So the objection's escape route is unavailable
-> to #63 entirely, and the sequencing argument is stronger than it looked: f16 is
-> not merely a prerequisite for #63 "regardless", it is the **only** element type
-> #63 can be built on. Nothing in the resolution changes; its scope is now
+> to backlog-63 entirely, and the sequencing argument is stronger than it looked: f16 is
+> not merely a prerequisite for backlog-63 "regardless", it is the **only** element type
+> backlog-63 can be built on. Nothing in the resolution changes; its scope is now
 > stated.
 
 ---

--- a/docs/formal/rocq-value-ledger.md
+++ b/docs/formal/rocq-value-ledger.md
@@ -193,7 +193,7 @@ discovery, and conflating the two is how these ledgers stop being believed.
 |---|---|
 | Date | 2026-07 |
 | Instances | 5 in a single day (helper return type, variant payload, `Char` stride, …) |
-| Tracked as | audit 2026-07-24 items #55, #244, #261 |
+| Tracked as | audit 2026-07-24 items backlog-55, backlog-244, backlog-261 |
 
 Element widths and aggregate layout are exactly what `formal/codegen-ptx`
 (`PtxLayout.v`) and `formal/type-safety` (`TypeSafetySpec.v`) are about, and five
@@ -231,7 +231,7 @@ per line here than deep theorems about the ends.** The boring function is where
 the defects were, and it is boring precisely because the interesting models
 abstracted it away — which is the same reason nobody modelled it.
 
-**That model now exists in executable form, on both halves of the seam** (#141):
+**That model now exists in executable form, on both halves of the seam** (backlog-141):
 
 - `sarek/tests/unit/test_type_width_totality.ml` — source type → IR element
   type, the `elttype_of_typ` this entry names;
@@ -275,7 +275,7 @@ exhaustiveness checker rather than by `Coq`'s. For a function with no theorems
 worth stating, that trade looks right, and it is the cheapest available reading
 of this lesson. It does not extend to anything with an interesting invariant.
 
-**A caveat this entry should carry, because #141 supplied it.** The
+**A caveat this entry should carry, because backlog-141 supplied it.** The
 front-half validator had been green since it was written while **not sweeping
 two of its ten members**: its `unfold` pushed the successor instead of the
 element just visited, dropping the first of each chain and duplicating the last,
@@ -292,7 +292,7 @@ its favour.
 |---|---|
 | Date | 2026-07 |
 | Instances | 4 in a single day |
-| Tracked as | audit 2026-07-24 items #48, #49; backlog #94 |
+| Tracked as | audit 2026-07-24 items backlog-48, backlog-49; backlog-94 |
 
 Backend intrinsic dispatch emitting a raw name and returning `Ok` for an unknown
 intrinsic, producing invalid device code.
@@ -309,7 +309,7 @@ the cheapest instrument.
 
 | | |
 |---|---|
-| Date | 2026-07-24 (audit), fixed 2026-07-27 (#46) |
+| Date | 2026-07-24 (audit), fixed 2026-07-27 (backlog-46) |
 
 `test_layout_conformance.ml` checked the production layout module against a
 130-line **hand transcription** of `PtxLayout.v`. Every theorem proved about the
@@ -332,7 +332,7 @@ claims about a chain that had an unchecked link in it until 2026-07-27.
 | | |
 |---|---|
 | Date | 2026-07-27 |
-| Work | backlog #46 — extract `PtxLayout.v` to OCaml, drop the transcription |
+| Work | backlog-46 — extract `PtxLayout.v` to OCaml, drop the transcription |
 | Defects found | **0** |
 
 When the 130-line hand transcription was replaced by Rocq's own extraction, the
@@ -350,7 +350,7 @@ than absorb.
 | | |
 |---|---|
 | Date | 2026-07-27 |
-| Work | backlog #95 — generate the ledger, enforce the axiom allowlist |
+| Work | backlog-95 — generate the ledger, enforce the axiom allowlist |
 | Spec/impl defects found | **0** |
 | Apparatus defects found | 4 of 5 count figures wrong, 1 phantom anchor |
 

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -3,8 +3,8 @@
 _Cross-backend policy for what a Sarek DSL author may rely on when a device
 compiler is free to fuse, reassociate or flush floating-point operations._
 
-**Status:** normative for this repository. **Issue:** #116 (absorbs #110, #111);
-§6 answers #126, the HIP row answers #106, and §11 answers backlog #123.
+**Status:** normative for this repository. **Tracked as:** backlog-116 (absorbs backlog-110, backlog-111);
+§6 answers backlog-126, the HIP row answers backlog-106, and §11 answers backlog-123.
 **Date:** 2026-07-27.
 
 Three separate defects in this project came from the same place — the gap
@@ -152,11 +152,11 @@ because the one non-Mesa stack that does fuse is AMD's own.
 | **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C, and no build option turns it off | for contraction, **no flag** — same `mul_rn`-by-construction defence as CUDA. For div/sqrt, `Opencl_fp.conformance_options` requests `-cl-fp32-correctly-rounded-divide-sqrt`, **gated** on `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT` in the device's `CL_DEVICE_SINGLE_FP_CONFIG`; `Opencl_fp.check_fp_conformance` **rejects** the relaxing `-cl-*` options at `Opencl_api.Program.build`, the single point an option string reaches `clBuildProgram` (§9) | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
-| **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, and bit-for-bit the same count — but a **different compiler**: ACO here, LLVM's AMDGPU backend there (see "Two AMD compilers" above) | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c`. **Upgraded 2026-07-27 to ELEMENT-WISE model agreement (#62 slice 1, §12.3):** the plain kernel is bit-identical to `S_fuse_mul_into_narrowing` on **63488 / 63488** inputs on both devices, on this shape *and* on `f16(x*1.1)` (2912/63488 against the discipline, never previously swept here). The `double`-based `fusedctl` control does **not** build on rusticl, which advertises no `cl_khr_fp64`; the replacement control carries the exact product as an f32 pair and rounds to odd. Instrument: `sarek-opencl/probe/probe_opencl_f16_model_agreement.ml` |
-| **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as rusticl, reached through a second front end — HIP's identical-count defect comes from LLVM's AMDGPU backend instead — and a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml`. **Upgraded 2026-07-27 to ELEMENT-WISE model agreement (#62 slice 1, §12.4):** each of those counts is a named closed-form function matched on **63488 / 63488** on both devices — plain `f16(x*1.1)` and `precise` `f16(x*1.1)` are `S_fuse_mul_into_narrowing`; plain `f16(f16(x*1.1)+1000)` is `S_absorb_all_into_final_narrowing` (a **single** `v_fma_mixlo_f16` over x, 1.1 and 1000); the same shape with `precise` is `S_f32_mul_then_absorb_add` (`v_fma_mix_f32` then `v_fma_mixlo_f16`); the f32-barriered variant is `S_drop_intermediate_narrowing`. `precise` is **honoured**, not ignored — it forbids a multiply-into-ADD contraction and cannot reach a conversion absorbing its operand, which is why it is byte-identical on the shape with no addition and changes the answer on the shape with one. Instrument: `sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml` |
+| **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, and bit-for-bit the same count — but a **different compiler**: ACO here, LLVM's AMDGPU backend there (see "Two AMD compilers" above) | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c`. **Upgraded 2026-07-27 to ELEMENT-WISE model agreement (backlog-62 slice 1, §12.3):** the plain kernel is bit-identical to `S_fuse_mul_into_narrowing` on **63488 / 63488** inputs on both devices, on this shape *and* on `f16(x*1.1)` (2912/63488 against the discipline, never previously swept here). The `double`-based `fusedctl` control does **not** build on rusticl, which advertises no `cl_khr_fp64`; the replacement control carries the exact product as an f32 pair and rounds to odd. Instrument: `sarek-opencl/probe/probe_opencl_f16_model_agreement.ml` |
+| **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as rusticl, reached through a second front end — HIP's identical-count defect comes from LLVM's AMDGPU backend instead — and a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml`. **Upgraded 2026-07-27 to ELEMENT-WISE model agreement (backlog-62 slice 1, §12.4):** each of those counts is a named closed-form function matched on **63488 / 63488** on both devices — plain `f16(x*1.1)` and `precise` `f16(x*1.1)` are `S_fuse_mul_into_narrowing`; plain `f16(f16(x*1.1)+1000)` is `S_absorb_all_into_final_narrowing` (a **single** `v_fma_mixlo_f16` over x, 1.1 and 1000); the same shape with `precise` is `S_f32_mul_then_absorb_add` (`v_fma_mix_f32` then `v_fma_mixlo_f16`); the f32-barriered variant is `S_drop_intermediate_narrowing`. `precise` is **honoured**, not ignored — it forbids a multiply-into-ADD contraction and cannot reach a conversion absorbing its operand, which is why it is byte-identical on the shape with no addition and changes the answer on the shape with one. Instrument: `sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on an AMD GPU compiler and does not fuse here, so the locus is *the AMD GPU compilers*, not *OpenCL* and not *SPIR-V*. Note what it does **not** localise: rusticl and HIP/AMDGPU do not share a compiler (see "Two AMD compilers" above), so their identical 620 is two compilers agreeing, not one bug seen twice. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any OpenCL implementation outside its `"ACO"` device-string scope is found to fuse — and which was itself wrong until §11.5. Read that predicate as "not Mesa", not as "not AMD": an AMD GPU reached through ROCm's OpenCL would be compiled by LLVM's AMDGPU backend, i.e. by a compiler this document expects to fuse, while sitting outside the key |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV now measured too** (§11.2): Intel Arc Graphics (Meteor Lake-P), Mesa 26.1.2-arch3.1, same 0 of 7 / 0 of 7 with `fma()` controls 4/4 — and unlike RADV, ANV does not fuse the f16 narrowing either, so no combine has been found on ANV where `NoContraction` is ignored. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound; ANV shows the same signature (mul 5.84e-08 / div 5.86e-08, §11.1) |
-| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. **The f16 narrowing is now probed and does NOT fuse** — 0/63488 from the discipline on **both** swept shapes, element-wise, with a validated positive control that goes red on **both**: the same control reports **2912/63488** on `f16(x*1.1)` and **620/63488** on `f16(f16(x*1.1)+1000)`, the latter being the figure already measured on hiprtc/gfx1100, rusticl/radeonsi and Intel Arc (§10.14). Two shapes, two independently-nonzero controls, two zeros; the pragma changes nothing there, in either direction, because there is no fusion to prevent. Subnormals still unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
+| **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. **The f16 narrowing is now probed and does NOT fuse** — 0/63488 from the discipline on **both** swept shapes, element-wise, with a validated positive control that goes red on **both**: the same control reports **2912/63488** on `f16(x*1.1)` and **620/63488** on `f16(f16(x*1.1)+1000)`, the latter being the figure already measured on hiprtc/gfx1100, rusticl/radeonsi and Intel Arc (§10.14). Two shapes, two independently-nonzero controls, two zeros; the pragma changes nothing there, in either direction, because there is no fusion to prevent. Subnormals still unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until backlog-141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
 | **WGSL** | unconstrained | nothing | unverified, untested |
 | **Native (OCaml host)** | n/a | n/a | float32 is evaluated at OCaml binary64 precision, so error-free transformations cancel; `Sarek_df64` degrades to ~2^-24 there **by design** |
 
@@ -175,7 +175,7 @@ because the one non-Mesa stack that does fuse is AMD's own.
   CUDA/C (nvrtc) path — executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver
   580.119.02, exhaustive over all 63488 finite binary16 inputs, **0**
   disagreements (§7). Note this is the **CUDA/C** path: the PTX backend
-  refuses kernel-level f16 by design (`#57` slice 2, a located
+  refuses kernel-level f16 by design (backlog-57 slice 2, a located
   `Ptx_codegen_error`), so there is nothing to rely on there yet.
 - **`Sarek_df64` meeting its precision contract on CUDA/PTX and OpenCL on
   NVIDIA Pascal, and on OpenCL on AMD** — `sqrt` on CUDA/PTX is now included
@@ -255,7 +255,7 @@ because the one non-Mesa stack that does fuse is AMD's own.
   RAPHAEL_MENDOCINO). `Sarek_ir_glsl` therefore rejects f16 at codegen — a
   *deliberate* refusal backed by a measurement, not an unimplemented feature.
   **Do not reason from `precise`.** This backend already emits `precise` on
-  every float local, and #106/#126 measured RADV not to contract 7 f32 shapes;
+  every float local, and backlog-106/backlog-126 measured RADV not to contract 7 f32 shapes;
   neither is evidence about this combine, and the `precise` variant still
   disagrees on 2912 inputs. Re-test before enabling: the blocker is a Mesa
   optimiser behaviour and could change with a Mesa release. That re-test is
@@ -284,7 +284,7 @@ two worked examples.
 
 ---
 
-## 4. CUDA f16: the barrier bought nothing *at the narrowing*, and has been removed (#110)
+## 4. CUDA f16: the barrier bought nothing *at the narrowing*, and has been removed (backlog-110)
 
 The AMDGPU fix added an opacity barrier around every f32→f16 narrowing. A
 PTX-flavoured variant, `asm volatile("" : "+f"(x))`, was added to the non-HIP
@@ -374,7 +374,7 @@ Full per-architecture detail, flag sweep and residual risk:
 
 ---
 
-## 5. CUDA: `-use_fast_math` / `-ftz=true` are refused (#111)
+## 5. CUDA: `-use_fast_math` / `-ftz=true` are refused (backlog-111)
 
 `-use_fast_math` implies `--ftz=true --prec-div=false --prec-sqrt=false
 --fmad=true`. `-ftz=true` alone flushes binary32 subnormals. Unlike the HIP
@@ -534,7 +534,7 @@ exactly the explicitly-requested `fma()` calls.
 
 What is *not* established by the experiment above is that RADV would honour
 `NoContraction` if it ever did want to contract. That was left open here, and
-**#57 slice 2b closed it — negatively.**
+**backlog-57 slice 2b closed it — negatively.**
 
 ### RADV *does* want to contract somewhere, and there it ignores `NoContraction`
 
@@ -562,7 +562,7 @@ So the honest status of `precise` on RADV is *not* "inert, and free". It is:
 - **ignored** for the multiply-into-narrowing combine, where RADV *does*
   contract and the decoration does not stop it.
 
-> **AMENDED 2026-07-27 (#62 slice 1, §12.4): "ignored" is the wrong word, and
+> **AMENDED 2026-07-27 (backlog-62 slice 1, §12.4): "ignored" is the wrong word, and
 > the right one changes what may be inferred.** The decoration is *inapplicable*
 > here, not disobeyed. `NoContraction` forbids contracting a multiply into an
 > **addition**; a **conversion** absorbing its operand is a different combine
@@ -684,7 +684,7 @@ this is where they are collected):
   supported**. Scope: **Xe-LPG only**, which is not the Gen9.5 UHD 630 the
   quoted ANV numbers came from (§11.0). **AMDVLK and the proprietary AMD Vulkan
   driver remain unmeasured** — different SPIR-V consumers on the very same GPU.
-- **f16 on the PTX backend.** `Sarek_ir_ptx` refuses kernel-level f16 (`#57`
+- **f16 on the PTX backend.** `Sarek_ir_ptx` refuses kernel-level f16 (backlog-57
   slice 2). Everything above is the **CUDA/C** path.
 - **One GPU, one architecture.** sm_61 has no tensor cores, no bf16 and no FP8,
   so nothing here constrains `mma`, bf16 or FP8 contraction, and no f16
@@ -719,7 +719,7 @@ this is where they are collected):
   bug class in a different backend** — `clBuildProgram` is called with no
   options and OpenCL's default permits a 3-ulp `sqrt`; adding
   `-cl-fp32-correctly-rounded-divide-sqrt` moves it to 8.87e-15, measured on the
-  same device. **Fixed in backlog #136 (§9)** — but the fix could not be
+  same device. **Fixed in backlog-136 (§9)** — but the fix could not be
   re-measured here: the red does not reproduce on this machine's OpenCL devices
   (rusticl/radeonsi reports `sqrt` 9.68e-15, a PASS) and rusticl ignores FP
   build options outright. The **Vulkan** residual (1.68e-14 on NVIDIA,
@@ -796,7 +796,7 @@ this is where they are collected):
 
 ---
 
-## 9. OpenCL and HIP: what an unset option was choosing (backlog #136)
+## 9. OpenCL and HIP: what an unset option was choosing (backlog-136)
 
 `Opencl_api.Program.build` called `clBuildProgram` with an **empty option
 string**, and every caller in the tree passed nothing. An empty option string
@@ -815,7 +815,7 @@ accurate default selected by passing nothing.
 OpenCL `sqrt` at **1.81e-14** against a 1.42e-14 tolerance — a FAIL — and
 building with `-cl-fp32-correctly-rounded-divide-sqrt` moved it to **8.87e-15**,
 a PASS coinciding with the interpreter's figure for the same input set.
-Measured during #298 on that device.
+Measured during PR #298 on that device.
 
 **That device is not on this machine, and the red does not reproduce here.**
 Measured 2026-07-26, `test_real64` on rusticl/radeonsi 26.1.4-arch3.1: OpenCL
@@ -960,7 +960,7 @@ semantics by passing `-ffast-math` and reading a warning.
 
 ---
 
-## 10. Metal: measured on an M4 — and the compile options were the wrong lever (backlog #125)
+## 10. Metal: measured on an M4 — and the compile options were the wrong lever (backlog-125)
 
 This section was written as "a statement about code, not behaviour", because
 there was no Apple hardware. An Apple M4 became available on 2026-07-26, and the
@@ -1162,7 +1162,7 @@ Worth noting nonetheless: cases 7-8 of the same sweep **SKIP** on f64 while
 16-20 **FAIL**, so the sweep's own capability gating is inconsistent — some f64
 cases detect the missing extension and some do not.
 
-**FIXED (#140).** The investigation found something worse than "some paths
+**FIXED (backlog-140).** The investigation found something worse than "some paths
 check": *neither* did. Cases 7-8 skipped for a completely unrelated reason — a
 hardcoded `validation_exclusions` entry for `Float64.abs_float` /
 `Float64.copysign`, which are user-callable but absent from
@@ -1205,7 +1205,7 @@ stripped from those same two sources fails identically. It is a codegen
 correctness bug that had never been observable, because nothing in this project
 had ever compiled Metal on Apple hardware.
 
-**FIXED (#139), and the design decision is `device`.** The cause: the
+**FIXED (backlog-139), and the design decision is `device`.** The cause: the
 `DParam (v, None)` arm of `gen_param_metal` treated *every* parameter without an
 `array_info` as a scalar and emitted `constant <ty> &name`; for a vec-typed `v`,
 `metal_type_of_elttype` returns a pointer type, so the emission was a reference
@@ -1229,12 +1229,12 @@ a stated reason elsewhere). Layer 1's red path is driven permanently by
 `sarek/tests/unit/test_metal_gate.ml`, which feeds it the pre-fix golden
 verbatim.
 
-### 10.12 A third defect, found the same way (#132)
+### 10.12 A third defect, found the same way (backlog-132)
 
 `wgsl_validation_sweep`'s corpus contained no multi-field variant payload and,
 worse, no `SMatch` at all — `variant_kernel` only *constructs* variants — so
 every accessor and every `switch` the WGSL match emitter can produce was
-unreachable from any executable gate. The field-naming half of #132 had already
+unreachable from any executable gate. The field-naming half of backlog-132 had already
 been closed by PR #306 (`EMatch` and all five `SMatch` paths now share one
 `payload_layout`, and WGSL's `indexed = true` spelling `.MkPair_v_0` matches its
 flat struct). What the coverage hole was still hiding was a different, live bug:
@@ -1248,7 +1248,7 @@ Adding `smatch_multi_payload` to the sweep turned it red on the first run;
 emitting a synthetic empty `default` when no `PWild` arm is present turned it
 green.
 
-### 10.13 A fourth defect, found the same way (#141): Metal silently halved f64
+### 10.13 A fourth defect, found the same way (backlog-141): Metal silently halved f64
 
 Not a contraction defect, but it belongs here because it is a *float-semantics*
 claim the codebase was making and getting wrong, and because §10's Metal work is
@@ -1288,9 +1288,9 @@ carrying the remedy — so the fact is stated once and the diagnostic says which
 *kind* of unavailability the author is looking at. See
 [`docs/design/capability-model.md`](design/capability-model.md).
 
-Both entry points were found twice, independently: #64 reasoned down from the
+Both entry points were found twice, independently: backlog-64 reasoned down from the
 capability model and was motivated by the f64 **literal** assigned into an f32
-buffer; #141 reasoned up from the emitted source and was motivated by the f64
+buffer; backlog-141 reasoned up from the emitted source and was motivated by the f64
 **local**. Neither shape reaches the other's detector, and both searches landed
 on the same `kernel_uses Float64` gate at the same two `generate` entries. That
 is the argument that {arm, whole-kernel} is the complete set rather than the set
@@ -1357,7 +1357,7 @@ than assumed:
 
 #### A fifth defect the same sweep turned up: GLSL int64 with no extension
 
-Loud rather than silent, so not the #141 narrowing class, but broken all the
+Loud rather than silent, so not the backlog-141 narrowing class, but broken all the
 same. `glsl_type_of_elttype` maps `TInt64` to `int64_t` at the correct width —
 but that spelling does not exist under plain `#version 450`; it needs
 `#extension GL_ARB_gpu_shader_int64 : require`. That extension was gated on the
@@ -1384,7 +1384,7 @@ that retracted a slice-1 claim: `glsl_header` takes
 the generated f64 kernel at exit 0. `docs/design/capability-model.md` §4
 records the retraction in place. The *capability* half of int64-on-Vulkan —
 `VkPhysicalDeviceFeatures.shaderInt64`, which is `Device_optional` and needs a
-device probe — is #142; only the emitter half is fixed here.
+device probe — is backlog-142; only the emitter half is fixed here.
 
 #### And one in the precedent test itself
 
@@ -1402,7 +1402,7 @@ duplicate directly. Both `unfold`s are fixed, and both files now assert
 **distinctness** as well as length, which is the property a count alone cannot
 establish.
 
-### 10.14 The f16 narrowing on Metal: **it does not fuse** (#63 slice 5)
+### 10.14 The f16 narrowing on Metal: **it does not fuse** (backlog-63 slice 5)
 
 §10.9 listed f16 as the largest thing Metal had never been probed for, and
 [`docs/design/f16-relaxed-accuracy.md`](design/f16-relaxed-accuracy.md) §2 has a
@@ -1494,7 +1494,7 @@ says of the GLSL tripwire.
 
 ### 10.15 `simdgroup_matrix` on the M4: three configurations, none of them integer
 
-The #63 prerequisite, measured the same day with
+The backlog-63 prerequisite, measured the same day with
 `tools/probes/metal_simdgroup_matrix_probe.m` on the same device and toolchain.
 Evidence tier: **executed**.
 
@@ -1518,7 +1518,7 @@ MSL 2.4 through 3.2.
 `f16-relaxed-accuracy.md` §8 and §7 slice 4b keep an integer cooperative-matrix
 path as the route that lands *under the existing strict contract* if the ACO
 scalar shapes match no closed-form model — 12 of the 14 configurations RADV
-advertises are integer. **That fallback is Vulkan-only.** #63 has no
+advertises are integer. **That fallback is Vulkan-only.** backlog-63 has no
 strict-contract route available to it at all; on Metal it is f16/bf16 or
 nothing. `bfloat` 8×8 is available, is not in the current plan, and has not been
 swept — nothing here says what it computes.
@@ -1603,7 +1603,7 @@ availability; that needs a benchmark against a scalar kernel.
 
 ---
 
-## 11. Measured on Intel: Meteor Lake Arc, ANV and the Intel Compute Runtime (backlog #123)
+## 11. Measured on Intel: Meteor Lake Arc, ANV and the Intel Compute Runtime (backlog-123)
 
 An Intel machine became available on 2026-07-27. It is the first Intel GPU this
 project has ever executed on, and it closes three things at once: the df64 ANV
@@ -1852,7 +1852,7 @@ narrowing barrier in `Sarek_ir_opencl` must be per-implementation and gated on
 an exhaustive agreement sweep for that implementation, never applied backend-wide
 on the strength of an ACO measurement.
 
-**What Sarek actually ships today, checked rather than assumed (backlog #144).**
+**What Sarek actually ships today, checked rather than assumed (backlog-144).**
 The obvious reading of the paragraph above is that the barrier needs to become
 conditional on the shader compiler, and that Sarek therefore needs a way to
 *identify* ACO at runtime — the gap §5 of
@@ -1880,7 +1880,7 @@ is already there.** The `#if` is the compiler identifying *itself* at the moment
 it compiles the source; a `CL_DEVICE_VENDOR` match or a `VK_DRIVER_ID` match is a
 guess about a stack from the outside, and a boot-time fusion probe measures a
 device that never sees this code. Neither would be consulted on the only path
-that emits the barrier. **The right shape of the #144 fix was therefore a gate,
+that emits the barrier. **The right shape of the backlog-144 fix was therefore a gate,
 not a mechanism** — the scoping was correct and unpinned, and "correct and
 unpinned" is how §11.5's own tripwire came to encode a wrong claim.
 
@@ -1890,7 +1890,7 @@ to lie between the AMD guard and its `#else`, and the non-AMD arm to contain no
 non-AMD arm the AMD `"+v"` barrier — a mutation the pre-existing `"+f"`
 assertion does not see, and under which that new case is the only failure.
 
-### 11.4a The guard now names the platform, and the hazard it was recorded for does not exist (backlog #146)
+### 11.4a The guard now names the platform, and the hazard it was recorded for does not exist (backlog-146)
 
 §11.4 closed with this, and it is the sentence this section exists to correct:
 
@@ -1987,7 +1987,7 @@ red on Intel Arc and reported:
 > naive and barriered narrowings — **it fuses too.**
 
 (That is the text as it stood. The check's wording was corrected again under
-#145 — "not an ACO device" is the right *scope* statement but the wrong *locus*
+backlog-145 — "not an ACO device" is the right *scope* statement but the wrong *locus*
 statement, since the locus is both AMD GPU compilers and the `"ACO"` key selects
 Mesa stacks only. §2, "Two AMD compilers".)
 
@@ -2081,7 +2081,7 @@ Two environmental notes, neither a defect in this repository:
 
 ---
 
-## 12. ACO's f16 models, measured element-wise — and the `precise` reconciliation (#62 slice 1)
+## 12. ACO's f16 models, measured element-wise — and the `precise` reconciliation (backlog-62 slice 1)
 
 **Executed 2026-07-27** on this workstation. This section is the measurement
 record for slice 1 of

--- a/docs/measurements/f16-slice1-2026-07-27/README.md
+++ b/docs/measurements/f16-slice1-2026-07-27/README.md
@@ -1,4 +1,4 @@
-# #62 slice 1 — preserved run output, 2026-07-27
+# backlog-62 slice 1 — preserved run output, 2026-07-27
 
 The numbers in
 [`docs/fp-contraction-policy.md`](../../fp-contraction-policy.md) §12 and in

--- a/docs/optimization/amdgpu-f16-fusion-shape-audit.md
+++ b/docs/optimization/amdgpu-f16-fusion-shape-audit.md
@@ -1,6 +1,6 @@
 # AMDGPU f16 fusion/demotion: exhaustive shape audit
 
-_Issue #106. Measured 2026-07-25/26 on **AMD Radeon RX 7900 XTX (gfx1100)** and
+_Tracked as backlog-106. Measured 2026-07-25/26 on **AMD Radeon RX 7900 XTX (gfx1100)** and
 **AMD Ryzen 9 7950X iGPU (gfx1036)**, ROCm hiprtc, `-ffp-contract=off` forced
 last per `Hip_rtc.base_options`. Disassembly via `hipcc`/ROCm LLVM for gfx1100._
 
@@ -186,6 +186,6 @@ Hint:   Did you mean Sarek.Sarek_cpu_runtime.Float32.of_float?
 
 The same name mismatch affects `expm1`, `log1p`, `hypot`, `copysign`, `fmod` and
 `minus`, all declared in `sarek/Sarek_stdlib/Float32.ml` with no counterpart in
-`sarek/interp/Sarek_float32.ml`. Not fixed here — out of scope for #106, and it
+`sarek/interp/Sarek_float32.ml`. Not fixed here — out of scope for backlog-106, and it
 wants its own test — but it is why this audit uses `0. -. x` for negation and
 `sqrt (x *. x)` rather than `sqrt (abs_float x)`.

--- a/docs/optimization/cuda-f16-fusion-sass-audit.md
+++ b/docs/optimization/cuda-f16-fusion-sass-audit.md
@@ -1,10 +1,10 @@
 # CUDA f16 fusion audit — SASS-level, no NVIDIA device
 
-**Issue:** #107. **Follows:** #290 (`feat/f16-dsl-slice1`, head `434b13ff`).
+**Tracked as:** backlog-107. **Follows:** PR #290 (`feat/f16-dsl-slice1`, head `434b13ff`).
 **Date:** 2026-07-25. **Host:** no NVIDIA GPU. **Toolchain:** CUDA 13.3,
 `ptxas`/`nvdisasm`/`nvcc` V13.3.73, `libnvrtc.so.13.3.33`.
 
-> **Superseded in one respect (#110).** The recommendation at the end of this
+> **Superseded in one respect (backlog-110).** The recommendation at the end of this
 > document — "removing it or keeping it is out of scope" — has since been
 > acted on: the inert `"+f"` barrier was **removed** from the non-HIP branch of
 > `sarek_f32_barrier`, after re-measuring byte-identical cubins on sm_75 through
@@ -14,7 +14,7 @@
 
 ## The question
 
-#290 found that on HIP/gfx1100 the generated C was correct and the machine code
+PR #290 found that on HIP/gfx1100 the generated C was correct and the machine code
 was not. An AMDGPU ISel combine emitted
 
 ```
@@ -43,7 +43,7 @@ that contributes **zero PTX instructions**; the PTX instruction stream is
 identical with and without it, and the resulting cubins are byte-identical on
 all seven targets. The non-fusion comes from `ptxas`, not from the barrier.
 
-> **Correction (#116).** An earlier wording here said NVVM "erases" the block.
+> **Correction (backlog-116).** An earlier wording here said NVVM "erases" the block.
 > It does not: the barriered PTX keeps the `// begin/end inline asm` markers and
 > renumbers virtual registers (`%f<9>` against `%f<5>`, as the diff below in
 > fact shows). What is true is that it emits no instruction, so `ptxas` receives
@@ -145,7 +145,7 @@ generator picks.
 
 ## Flags do not change it (checked, not assumed)
 
-The lesson of #290 is that the obvious flag did nothing, so every flag below was
+The lesson of PR #290 is that the obvious flag did nothing, so every flag below was
 measured rather than reasoned about. Assembled for sm_90, both source variants:
 
 | nvcc flags | arithmetic stream |
@@ -230,7 +230,7 @@ What has **not** been shown:
 The `"+f"` barrier on the CUDA path costs nothing measurable — the cubins are
 byte-identical, so it is zero instructions and zero registers — but it also buys
 nothing, and it reads as protection that is not there. Removing it or keeping it
-is a codegen change and is out of scope for #107; the SASS gate makes the
+is a codegen change and is out of scope for backlog-107; the SASS gate makes the
 guarantee checkable either way, and would catch it if a future toolchain started
 fusing.
 

--- a/docs/optimization/opt-expressivity-gaps.md
+++ b/docs/optimization/opt-expressivity-gaps.md
@@ -82,7 +82,7 @@ cost. The doc framing should lead with these, not apologize for them.
 | 2 | **Half precision (f16/bf16)** + packed math | PTX `.f16`/`.f16x2`, `__half2`, `hfma2`; Triton `tl.float16`/`tl.bfloat16` native | New numeric type end-to-end: PPX type + typer rule, IR type, 6 codegen emitters, host-side packing in `Vector`/`Bigarray` (no f16 in OCaml `Bigarray` — needs a packed-int16 bit-reinterpret layer) | High for ML workloads; zero relevance for the FP32/FP64 numeric-kernel user base this project currently serves | L | P2 |
 | 3 | **Grid-stride loop idiom** | A `for` loop with `blockDim.x*gridDim.x` stride; pure convention, no language support in CUDA either | Nothing — already expressible today with `global_thread_id`, `block_dim_x`, `grid_dim_x` (all in `Sarek_core_primitives.ml:75-179`) and an ordinary bounded loop | None — non-gap | — | N/A |
 | 4 | **Multi-dimensional strided views (Triton tile model)** | Triton `tl.load`/`tl.store` over block pointers with masks, 2D/3D tiles, compiler-managed vectorization/coalescing; CUDA/OpenCL: manual `row*width+col` (same as Sarek today) | Two separable asks — see the dedicated section (c) below | View layer: Medium value, Medium cost. Tile-programming model: different compiler, out of scope | View: M / Tile: XL (out of scope) | View: **P1**, Tile: not recommended |
-| 5 | **Block-level reduce/scan in stdlib** | CUB (`cub::BlockReduce`), Triton `tl.sum`/`tl.max`/associative_scan | A `[@sarek.module]` library building on warp prims (once #1 lands) + shared-memory tree pattern, generic over `+`/`min`/`max`/user monoid | High — every one of `test_reduce.ml`/`test_scan.ml`/`test_histogram.ml`/`test_sort.ml` currently hand-rolls this per-kernel with no shared abstraction | M (blocked on #1) | **P1** |
+| 5 | **Block-level reduce/scan in stdlib** | CUB (`cub::BlockReduce`), Triton `tl.sum`/`tl.max`/associative_scan | A `[@sarek.module]` library building on warp prims (once gap 1 lands) + shared-memory tree pattern, generic over `+`/`min`/`max`/user monoid | High — every one of `test_reduce.ml`/`test_scan.ml`/`test_histogram.ml`/`test_sort.ml` currently hand-rolls this per-kernel with no shared abstraction | M (blocked on gap 1) | **P1** |
 | 6 | **Tensor cores / `mma`/`wmma`** | PTX `mma.sync`, CUDA `wmma::` API, Triton `tl.dot` (lowers to tensor cores transparently) | New instruction class in IR + PTX emitter `mma.sync` support + matching ABI in the other 5 backends (Metal has its own `simdgroup_matrix`, Vulkan needs `VK_KHR_cooperative_matrix`, OpenCL has no portable equivalent) | High in principle (matmul/conv-bound ML), but every other backend either lacks a real equivalent or needs a distinct extension path — this fragments the "one kernel, six backends" value prop rather than extending it | XL | **doc-only** — not recommended as an implementation target now |
 | 7 | **Dynamic parallelism / cooperative groups / cluster sync** | CUDA `cudaLaunchDevice`/cooperative-groups API, Hopper cluster/`cga` primitives | New launch model, host-device re-entrancy, backend-specific (OpenCL/Vulkan/Metal have no equivalent at all) | Low — niche even in native CUDA; no equivalent to target on 5 of 6 backends | XL | **verdict: skip** |
 | 8 | **`printf`/`assert` in kernels** | PTX `vprintf` (device-side, host-buffered); OpenCL 1.2+ `printf` built-in; Metal/Vulkan: no portable device printf | IR node + PTX `vprintf` call convention (varargs marshalling through `.param` space — same class of problem L10 already flags indirect calls as blocked by) + OpenCL builtin passthrough; Metal/Vulkan/WGSL: no target, document as CUDA/OpenCL-only debug feature | Very high DX value — today a wrong-answer kernel bug means bisecting via host-side dumps only | M | **P0** |
@@ -90,7 +90,7 @@ cost. The doc framing should lead with these, not apologize for them.
 | 10 | **Texture/surface memory** | CUDA texture objects (hardware interpolation/clamping, 2D cache locality), OpenCL images | Full new resource type: PPX annotation, IR node, 4 backends' texture-binding ABI, host-side image upload path | Low relative to cost — niche outside graphics/image-processing kernels, and none of the current e2e test surface (compute-oriented) exercises it | L | **verdict: skip** (revisit only if a graphics-kernel use case appears) |
 | 11 | **Occupancy/launch-tuning surface** (`launch_bounds`) | CUDA `__launch_bounds__(maxThreads, minBlocks)` — hints the compiler for register allocation | A PPX attribute forwarded to the PTX emitter's register-budget decision (today implicit, not user-tunable) | Medium — matters once a kernel is register-bound; today the user has no lever at all, whereas CUDA gives one | S | P2 |
 | 12 | **Kernel templates/metaprogramming** | already covered in (a).3 — Sarek's OCaml-level polymorphism is a genuine structural win here, not a gap | — | — | — | (a) |
-| 13 | **Stdlib breadth** (sort networks, prefix-sum, histogram as reusable modules) | CUB, Thrust, Triton's growing `tl.*` library | `[@sarek.module]`-based libraries; mechanically straightforward once #1/#5 exist, since the *kernels* for these already exist as e2e tests and just need extracting into a reusable, generic (not per-test-hardcoded) form | High — closes the gap between "the pattern is demonstrated" and "the pattern is a one-line library call" | S–M per primitive (bitonic sort M, prefix-sum S once #5 lands, histogram S) | P1 |
+| 13 | **Stdlib breadth** (sort networks, prefix-sum, histogram as reusable modules) | CUB, Thrust, Triton's growing `tl.*` library | `[@sarek.module]`-based libraries; mechanically straightforward once gaps 1 and 5 exist, since the *kernels* for these already exist as e2e tests and just need extracting into a reusable, generic (not per-test-hardcoded) form | High — closes the gap between "the pattern is demonstrated" and "the pattern is a one-line library call" | S–M per primitive (bitonic sort M, prefix-sum S once gap 5 lands, histogram S) | P1 |
 
 ---
 
@@ -148,7 +148,7 @@ effort, not a backlog item alongside L8/L9/L10.
 Ranked by (user value × how much of the remaining engineering is
 "already half-done" evidence found in the tree):
 
-1. **Finish warp-level primitives (#1).** The semantic layer already
+1. **Finish warp-level primitives (gap 1).** The semantic layer already
    exists and is tested (`Sarek_core_primitives.ml:380-457`, convergence
    checks in `test_warp_diverged.ml`, `test_core_primitives.ml`) — but
    *zero* backend emits them (`grep` for `warp_shuffle`/`shfl`/`ballot`
@@ -157,25 +157,25 @@ Ranked by (user value × how much of the remaining engineering is
    design work (variance/convergence semantics) is done, only the
    mechanical emitter work (PTX `shfl.sync` variants, OpenCL/Vulkan/Metal
    `sub_group_*`/`simd_*` intrinsics) remains, and it directly unblocks
-   #5 and #13.
-2. **`printf`/`assert` in kernels (#8).** Highest DX-value-per-cost item
+   gaps 5 and 13.
+2. **`printf`/`assert` in kernels (gap 8).** Highest DX-value-per-cost item
    on the list; PTX and OpenCL both have a real target, and the current
    debug workflow (host-side dump-and-diff) is a genuine friction point
    for every kernel author today.
-3. **Multi-dim strided view layer (#4, ask 1 only — not the tile model).**
+3. **Multi-dim strided view layer (gap 4, ask 1 only — not the tile model).**
    Removes a real, recurring bug class (manual stride arithmetic) at
    library cost, with no IR/codegen changes required.
-4. **Block-level reduce/scan stdlib (#5) + broader stdlib breadth (#13).**
-   Bundled because #5 is a prerequisite pattern for #13's prefix-sum/
+4. **Block-level reduce/scan stdlib (gap 5) + broader stdlib breadth (gap 13).**
+   Bundled because gap 5 is a prerequisite pattern for gap 13's prefix-sum/
    histogram entries, and because the *kernels* already exist as e2e
    tests today — this is "extract and genericize," not "invent."
-5. **Occupancy hint surface, `launch_bounds` (#11).** Cheapest item with
+5. **Occupancy hint surface, `launch_bounds` (gap 11).** Cheapest item with
    a real user complaint behind it (no register-budget lever today),
    good low-risk filler once 1-4 are underway.
 
 Explicitly **not** recommended for the near-term roadmap: tensor cores/
-`mma` (#6, doc-only), dynamic parallelism/cooperative groups (#7, skip),
-texture/surface memory (#10, skip), and the Triton tile-programming model
+`mma` (gap 6, doc-only), dynamic parallelism/cooperative groups (gap 7, skip),
+texture/surface memory (gap 10, skip), and the Triton tile-programming model
 proper (different compiler, out of scope as argued in (c)). Half
-precision (#2) and constant memory (#9) are real but lower priority than
+precision (gap 2) and constant memory (gap 9) are real but lower priority than
 the shortlist given the project's current FP32/FP64 numeric-kernel focus.

--- a/docs/optimization/opt-ptx-passes.md
+++ b/docs/optimization/opt-ptx-passes.md
@@ -595,24 +595,24 @@ opportunistically (e.g. bundled with whichever other pass touches
 | 3 | `ld.global.nc` for read-only params | Real, arch-dependent (1.1-1.3x on multi-pointer-param kernels) | S | **High** |
 | 7 | Register-reuse pass (recycle dead virtual regs) | Potentially order-of-magnitude on inline-heavy/recursive kernels; benefits ZLUDA occupancy specifically | M-L | **High** (own project) |
 | 8 | `.maxntid` launch-bounds hint | Real 10-30% on register-bound kernels, IF block size known at codegen time | S (gated on a scoping check) | Medium |
-| 1 | Address-arithmetic CSE | Mostly ptxas-shadowed in-block; feeds #7's register-pressure reduction | S-M | Medium |
+| 1 | Address-arithmetic CSE | Mostly ptxas-shadowed in-block; feeds pass 7's register-pressure reduction | S-M | Medium |
 | 2 | Vectorized `ld/st.v2/v4` | Real if ptxas misses it (likely already recovers our exact addressing shape — verify first) | M-L | Low-Medium (verify before building) |
 | 12 | Constant folding | Near-zero runtime (ptxas already does this); free PTX hygiene | S | Low (opportunistic) |
 | 5 | Induction-variable strength reduction | Real but small, narrow (tight loops w/ aggregate indexing) | M | Low |
 | 6 | Cost-based `selp`-vs-branch | Real only for expensive divergent arms; not evidenced in current kernels | M | Low (documented gap, not scheduled) |
-| 9 | Loop unrolling (literal bounds) | Mostly subsumed by #1/#5 once those exist; ptxas already unrolls small loops | M-L | Low |
+| 9 | Loop unrolling (literal bounds) | Mostly subsumed by passes 1 and 5 once those exist; ptxas already unrolls small loops | M-L | Low |
 | 11 | Shared-memory bank-conflict padding | Large but narrow (2D strided tiles); may not apply — `DShared` is 1D today | M-L / possibly N/A | Low (verify language surface first) |
 | 4 | `ld.param` re-load elimination | N/A — already done by construction | — | N/A |
 | 10 | Barrier/divergence optimization | N/A — current behavior is already the safe baseline | — | N/A (safety constraint, not a gain candidate) |
 
 ## Top-3 recommendation, with reasoning
 
-1. **`ld.global.nc` for read-only params (#3).** Best gain/cost ratio in the
+1. **`ld.global.nc` for read-only params (pass 3).** Best gain/cost ratio in the
    set: a small, provably-safe static write-set check unlocks a real
    cache-path win precisely where ptxas's own alias inference is weakest
    (multi-pointer-param kernels, which is the norm for Sarek kernels reading
    several input arrays).
-2. **Register-reuse pass (#7).** Not cheap, but it's the only candidate with
+2. **Register-reuse pass (pass 7).** Not cheap, but it's the only candidate with
    plausible order-of-magnitude upside, targets a kernel class the project
    already tracks (`fib`, deep `[@sarek.inline]`), and compounds with the
    ZLUDA interest — AMDGPU-path register allocation is less mature than
@@ -620,16 +620,16 @@ opportunistically (e.g. bundled with whichever other pass touches
    survive into real occupancy loss there than on NVIDIA. Scope it as its
    own M-L project with an explicit design for the branch/match-join
    liveness-safety question before writing code.
-3. **`.maxntid` launch-bounds hint (#8)**, *conditional on a quick scoping
+3. **`.maxntid` launch-bounds hint (pass 8)**, *conditional on a quick scoping
    check*: confirm whether block/launch dimensions are available at
    PTX-generation time in the current `Execute` pipeline. If yes, this is a
-   cheap, well-understood, real win and should be pulled ahead of #7 in
+   cheap, well-understood, real win and should be pulled ahead of pass 7 in
    sequencing (much lower cost for a comparable gain class on register-bound
    kernels). If block size truly is only known at launch time with no
    PTX-generation-time hook, drop it from the near-term queue.
 
-Everything else in the list is either already-done (#4), a safety constraint
-rather than a gain (#10), speculative pending a cheap verification experiment
-before committing implementation cost (#2, #11), or real-but-marginal enough
+Everything else in the list is either already-done (pass 4), a safety constraint
+rather than a gain (pass 10), speculative pending a cheap verification experiment
+before committing implementation cost (passes 2 and 11), or real-but-marginal enough
 that it should ride along with other work rather than being scheduled on its
-own (#1, #12, #5, #6, #9).
+own (passes 1, 12, 5, 6 and 9).

--- a/docs/optimization/opt-spoc-runtime.md
+++ b/docs/optimization/opt-spoc-runtime.md
@@ -572,7 +572,7 @@ further.
 |---|------|---------------|------|----------|
 | 1 | SoA↔AoS custom vectors | AoS-only, packed, 1/3-efficiency strided access on partial-field reads | M | **Pursue, opt-in per-vector, flat records only** |
 | 2 | Pinned host memory | Not present (plain Bigarray/Ctypes heap memory, blocking memcpy) | S-M | **High** |
-| 3 | Async transfers + streams | Launch-side streams exist + kernarg retention; transfer-side is 100% blocking | M | Medium-high, after #2 |
+| 3 | Async transfers + streams | Launch-side streams exist + kernarg retention; transfer-side is 100% blocking | M | Medium-high, after row 2 (pinned host memory) |
 | 4 | Kernel fusion | Elementwise/reduction/stencil vertical fusion already implemented, DAG/multi-reduce missing | M (extension) | Medium |
 | 5 | Transfer avoidance | Already implemented via 5-state location machine; only multi-GPU peer-copy path missing | S | Low-medium |
 | 6 | Allocation pooling | Per-vector buffer reuse exists; no cross-vector size-bucketed pool | S-M | Medium |

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -5,7 +5,7 @@ the correctness/benchmark evidence, and the precise Tier 1c handoff._
 
 Companion to [tier1a-soa-pinned-handoff.md](tier1a-soa-pinned-handoff.md)
 (host + transfer half) and [opt-spoc-runtime.md](opt-spoc-runtime.md) §1
-(SoA) / [opt-ptx-passes.md](opt-ptx-passes.md) (#3 `ld.global.nc`, warp prims).
+(SoA) / [opt-ptx-passes.md](opt-ptx-passes.md) (pass 3, `ld.global.nc`, and warp prims).
 
 ## What shipped — the PTX emitter's SoA lowering
 
@@ -163,7 +163,7 @@ and proven. When it lands, extend `test_soa_emitter_equiv` to drive SoA through
 > a kernel mixing a SoA vector `x` (field `y`) with a scalar param `x_soa_y`
 > compiles to distinct PTX operands.
 
-### 2. `ld.global.nc` for read-only params (roadmap #3 — High, cost S)
+### 2. `ld.global.nc` for read-only params (opt-ptx-passes.md pass 3 — High, cost S)
 
 Independent of SoA. A single write-set pass over `kern_body` (+ inlined
 `hf_body`s) collecting `DParam` array names ever used as an `EArrayWrite` /

--- a/docs/plans/website-overhaul-2026-06-02.md
+++ b/docs/plans/website-overhaul-2026-06-02.md
@@ -35,16 +35,16 @@ Architectural prerequisite for the playground (Phase 2) and good design regardle
 
 ## Phase 1 — Quick, high-trust wins (ship first)
 
-**1a. Docs from tested examples (#2).** A build step renders the example pages
+**1a. Docs from tested examples.** A build step renders the example pages
 (vector_add, matrix_mul, reduction, transpose) from `sarek/tests/e2e/*.ml` sources +
 their kernels, so published examples always compile and match the current API. Kills the
 outdated-example drift (audit C1/D3) structurally.
 
-**1b. Backend × feature compatibility matrix (#3).** Generate a single table — backends ×
+**1b. Backend × feature compatibility matrix.** Generate a single table — backends ×
 {fp64, atomics, shared mem, variants, records, barriers, subgroups} × platforms — from
 backend capability flags + `kb/backends/*`. Answers the perennial "does Metal do fp64?".
 
-## Phase 2 — Flagship: in-browser transpiler playground (#1)
+## Phase 2 — Flagship: in-browser transpiler playground
 
 - Compile `Sarek_transpile.of_source` (Phase 0) to JS with **js_of_ocaml** (parsing OCaml
   source in-browser via compiler-libs/ppxlib — proven by existing OCaml playgrounds).
@@ -57,7 +57,7 @@ backend capability flags + `kb/backends/*`. Answers the perennial "does Metal do
 
 ## Phase 3 — Depth
 
-**3a. "The Sarek Book" (#4, reframed).** A structured, accessible **book/tutorial** — not a
+**3a. "The Sarek Book" (reframed).** A structured, accessible **book/tutorial** — not a
 KB dump. Progressive track: first kernel → memory & transfers → reductions → custom types
 (records/variants) → multi-backend → performance/convergence → writing a backend. Rich and
 comprehensive, but **auto-synced**: code snippets from tested sources (Phase 1a), the DSL
@@ -66,7 +66,7 @@ chapters distilled (curated, rewritten for readability) from `kb/` — with a bu
 that flags when referenced symbols/files drift. The KB stays the internal source of truth;
 the Book is the readable, public, synced surface over it.
 
-**3b. Interactive benchmarks portal (#5).** Turn the JSON dashboard into an explorable
+**3b. Interactive benchmarks portal.** Turn the JSON dashboard into an explorable
 performance story: cross-device/backend comparison, hardware filters, historical trends,
 per-kernel generated-code view, "reproduce this" commands. Fix the `benchmark-viewer.js`
 `innerHTML` stored-XSS (audit F1) as part of the rebuild.


### PR DESCRIPTION
Backlog #148. GitHub gives issues and pull requests **one shared counter** — it is past 330 in this repository — and auto-links every bare `#NN` in rendered Markdown. Our task tracker has its own, much lower numbering. So a doc that writes `#63` meaning "Metal `simdgroup_matrix`" ships a live link to *"Cleanup 2026 01"*. Every internal reference in `docs/` was a wrong link, silently, in merged documentation.

## Extent

201 matching lines across 18 files. Resolving every number against the GitHub API (rather than assuming) split them **three** ways, not two:

**1. Genuine, correct GitHub refs — untouched.** PRs #161, #221, #239, #275–#277, #282–#284, #290, #291, #298, #306, #142, #146–#156. Each checked to resolve to the thing its sentence claims.

**2. Internal backlog → `backlog-NN`.** The `#` is what makes GitHub link it, and the tracker is not public — a reference nobody outside this repo can look up should not be dressed as a followable link. Half the docs already said `backlog #136`; this drops the `#`.

**3. Numbers that never meant a tracker item.** `opt-ptx-passes.md` and `opt-expressivity-gaps.md` used `#3`/`#7` for rows of *their own* priority tables; `website-overhaul-2026-06-02.md` for a five-item list that isn't in the document. GitHub linked these to PRs #1–#13. Now "pass 3" / "gap 5", or dropped. Prefixing these would have made them *more* wrong, not less.

## Two misattributions found while checking

`f16-dsl-element-type.md:26,37` credited the `Kirc_Ast` deletion to **"PR #78"** — GitHub #78 is *"feat: Add benchmark results from Intel Arc Graphics"*. The deletion is **PR #291**; #78 is the backlog item it closed. `:583` called the codegen factorization "PR #77" (actually *"Update Prism.js to 1.30.0"*). These matter precisely because they *are* real links, pointing somewhere wrong.

## Review finding: a GitHub noun in front of `backlog-NN`

Correct, and it was a violation of the convention inside its own PR. `Issue backlog-106` still tells the reader this is a GitHub issue. Swept repo-wide; five sites, all front-matter, now `**Tracked as:**` — already the phrase `rocq-value-ledger.md` uses:

| File | Line |
| --- | --- |
| `docs/optimization/amdgpu-f16-fusion-shape-audit.md` | `:3` |
| `docs/optimization/cuda-f16-fusion-sass-audit.md` | `:3` |
| `docs/design/capability-model.md` | `:5` |
| `docs/design/f16-relaxed-accuracy.md` | `:11` |
| `docs/fp-contraction-policy.md` | `:6` |

The noun **stays** where it governs a real number: `PR #275 / backlog-66` is correct as written, because `PR` applies to `#275`. That distinction is now written into the rule (`CONTRIBUTING.md:78`).

## The convention

`CONTRIBUTING.md:52-89` — the three forms, why bare `#NN` is wrong, and the check that matters: confirm `gh issue view NN` is the thing you are describing before writing `#NN` at all. Plus the prefix rule (`:78`), and PR titles / commit subjects explicitly left alone (`:85`) — every existing PR here uses bare `(#NNN)`, and rewriting history costs more than the ambiguity does; `(backlog-NN)` is recorded as preferred for *new* titles only.

## Rebase onto 37a16bb2

`#337` rewrote both coordinated docs substantially (new §12, rewritten rusticl and RADV rows) and added `docs/measurements/`. Both files were **reset to the new text and the reference edits re-derived from scratch**, not resolved hunk-by-hunk — `fp-contraction-policy.md` auto-merged cleanly, which on a file that moved that far is not something to trust.

That the result is reference-form only is checked mechanically: normalize every reference form to a bare digit string in both revisions and diff. All three files come back identical.

The new `docs/measurements/f16-slice1-2026-07-27/README.md:1` heading `# #62` is converted. The preserved `.txt` run outputs beside it are left **byte-for-byte as captured** — rewriting a preserved measurement artifact would falsify the record, and `.txt` is not rendered as Markdown anyway.

## Verification

`dune build`, `dune build @fmt`, `dune test --force` clean. **1612 alcotest / 106 suites, 32 qcheck / 6 suites, 0 FAIL, 23 SKIP** via `scripts/test-suite-counts.sh` — baseline unmoved. The log was checked non-empty (4700 lines) before trusting the count, since that script reports `0 cases / 0 FAIL` and exits 0 on an empty log.

The license gate merged in #335 runs green on this branch, as does its 11-case red-path test.

Residual `#NN` across `docs/` is exactly the 18 verified-genuine PR numbers. The remaining `#NN` in `CONTRIBUTING.md` are illustrative examples inside code spans, which GitHub does not autolink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
