### PR TITLE
measure(f16): #62 slice 1 — both ACO stacks match named models element-wise; §9.3 closed

### DIFF
--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -20,6 +20,19 @@ than on the final value, with the counterexample that broke it; and **§8's
 integer-coopmat fallback is Vulkan-only**, because Metal has no integer
 `simdgroup_matrix` at all. **Still no refusal is lifted by this change.**
 
+**Amended 2026-07-27 (slice 1, ACO measurement).** §7 slice 1 has **run**, on
+the two shapes this project has device numbers for. Both ACO stacks are
+**admitted under Regime A** on those shapes: every kernel variant is
+bit-identical to exactly one named closed-form model on 63488/63488 inputs, on
+both local devices, with zero inputs matching no model. **§9.3's open risk is
+closed** — RADV's two-narrowing shape matches a model plain *and* with
+`precise`, and the `precise` puzzle is reconciled at machine-code tier: the
+decoration forbids a multiply-into-**add** contraction and cannot reach a
+**conversion** absorbing its operand. §1.2 gains **two** admitted members and
+one explicitly **refused** named function. **No refusal is lifted by this
+change** — slice 3 is still where that happens, and 18 of the 20 emittable
+shapes remain unmeasured and therefore refused.
+
 **Read §0.1 first.** It is one paragraph and it is the argument every other
 choice here follows from.
 
@@ -146,6 +159,33 @@ compute exactly:
   f32→f16 narrowing is evaluated at binary32 (or better) and narrowed in a
   **single** rounding. Already implemented as `ref_fused` in the same two files,
   and as the `fusedctl` variant of `tools/probes/opencl_f16_contraction_probe.c`.
+
+**Two further members were added on 2026-07-27 by slice 1**, both measured
+element-wise on RADV over the whole finite binary16 domain on two devices
+(`fp-contraction-policy.md` §12.4). They exist because a *two*-narrowing shape
+gives ACO a second combine that a one-narrowing shape cannot exhibit:
+
+- **`S_absorb_all_into_final_narrowing`** — the multiply, the intermediate
+  binary16 narrowing and the f32 add are **all** absorbed into the final
+  narrowing: one rounding where the DSL mandates four. RADV emits this as a
+  single `v_fma_mixlo_f16` taking `x`, `1.1` and `1000`.
+- **`S_f32_mul_then_absorb_add`** — the same, except the multiply keeps its own
+  correctly-rounded binary32 result. This is what `precise` buys on RADV, and
+  therefore **the model the shipped codegen actually runs under**, since
+  `Sarek_ir_glsl.gen_var_decl` emits `precise` on every float local.
+
+**One function is named and deliberately NOT admitted**, and it is the reason
+this section is a set of names rather than a bound:
+
+- **`S_drop_intermediate_narrowing`** — the intermediate binary16 narrowing is
+  dropped outright, the add still rounding to f32. This is the **IGC defect** of
+  `fp-contraction-policy.md` §11.4 — and slice 1 found it is also reachable on
+  RADV, exactly, by barriering the f32 intermediates and nothing else. So the
+  same closed-form function is a plain defect on one stack and an
+  on-demand behaviour on another, it sits at 1 ulp like everything else here,
+  and **the only instrument that keeps it out is that it is not on the list**.
+  §0.1 argued a tolerance could not separate a characterised deviation from this
+  defect; slice 1 turned that argument into a measurement.
 
 This is exact agreement, not a tolerance, so it is strictly *tighter* than
 today's bit-identity requirement in every direction except the one deviation it
@@ -309,21 +349,28 @@ These are the numbers this design holds itself to, for **Regime A** (scalar f16,
 below the Regime A table — Metal's `simdgroup_matrix`, measured 2026-07-27. RADV's
 coopmat numerics remain unmeasured (§4, last paragraph).
 
-**No stack in this table is settled as relaxable.** Both non-zero rows are
-**candidates**, and neither has met the acceptance rule of §1.2: rusticl's
-agreement with `S_fuse_mul_into_narrowing` is established only at the level of a
-count and a first divergence, not element-wise; RADV's is exact for the
-one-narrowing shape and **unmeasured for the two-narrowing shape**. Slice 1 (§7)
-is what would convert either from candidate to admitted, and it may convert
-neither. Read the verdict column as the current status, not as a plan.
+**SLICE 1 RAN, 2026-07-27, and both candidates met the rule — on the two shapes
+it swept.** Every kernel variant on both ACO stacks is bit-identical to exactly
+one named model on **63488 / 63488** inputs, on both local devices, with zero
+inputs matching no model (`fp-contraction-policy.md` §12). rusticl's
+count-and-first-divergence agreement is upgraded to element-wise; RADV's
+two-narrowing shape, §9.3's open risk, matches a closed-form model under `precise`
+*and* without it, and the `precise` puzzle is reconciled at machine-code tier.
+
+**The admission is per shape, and only two of twenty shapes are measured.**
+§1.2's model set is keyed on *(backend, driver, expression shape)* and always
+was, so this is not the per-shape degradation §9.3 feared — but the other 18
+shapes of `docs/optimization/amdgpu-f16-fusion-shape-audit.md` are unmeasured on
+ACO and under §1.5 stay refused. Read the verdict column as the current status,
+not as a plan.
 
 | backend / driver | device(s) | deviation from `S_strict` | matches `S_fuse_mul_into_narrowing`? | evidence | verdict under Regime A |
 |---|---|---|---|---|---|
 | **CUDA / nvrtc** | GTX 1070 Max-Q, sm_61, CUDA 12.9, driver 580.119.02 | **0 / 63488** | n/a | executed | **strict**, unchanged |
 | **HIP / AMDGPU** | RX 7900 XTX (gfx1100), Raphael iGPU (gfx1036), ROCm hiprtc, with the opacity barrier | **0 / 63488**, all 20 emittable shapes | n/a | executed + machine-code | **strict**, unchanged |
-| **OpenCL / rusticl** | RX 7900 XTX + Raphael iGPU, Mesa 26.1.4-arch3.1 | **620 / 63488** on `f16(f16(x*1.1)+1000)` | **count and first-divergence agreement** (620, first divergence `x = 5.68359375`, device 1006.5 vs reference 1006 — identical to `fusedctl`'s deliberate single-rounding on Intel). **Element-wise agreement not established.** | executed | **candidate**, blocked on slice 1 |
+| **OpenCL / rusticl** | RX 7900 XTX + Raphael iGPU, Mesa 26.1.4-arch3.1 | **620 / 63488** on `f16(f16(x*1.1)+1000)`; **2912 / 63488** on `f16(x*1.1)` (newly swept, slice 1) | **YES — bit-identical on 63488 / 63488, on BOTH shapes and BOTH devices.** Green control (`volatile __local` round-trip) reproduces `S_strict` exactly; positive control reproduces the fused model exactly | executed, **element-wise** over the whole finite binary16 domain (`fp-contraction-policy.md` §12.3) | **ADMITTED under Regime A** on the two swept shapes; the other 18 shapes are `Unknown` and stay refused |
 | **OpenCL / pocl (x86), Intel IGC, Intel oneAPI CPU** | AMD EPYC 7763 (CI), Intel Arc Graphics (MTL), Core Ultra 9 185H | **0 / 63488** | n/a | executed | **strict**; refusal is currently over-broad here |
-| **Vulkan / RADV** | RX 7900 XTX (NAVI31) + Raphael iGPU (RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1 | **2912 / 63488** on `f16(x*1.1)`; **5075** plain / **4776** with `precise` on `f16(f16(x*1.1)+1000)` | one-narrowing shape: **exact, 0/63488 against a single-rounding model**. Two-narrowing shape: **not measured against any model**, and `precise` changes the count, so a single model does not obviously cover it | executed | **candidate for the one-narrowing shape only**; blocked on slice 1 |
+| **Vulkan / RADV** | RX 7900 XTX (NAVI31) + Raphael iGPU (RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1 | **2912 / 63488** on `f16(x*1.1)` (plain and `precise` alike); **5075** plain / **4776** with `precise` on `f16(f16(x*1.1)+1000)` | **YES, each count is a different named model, all bit-identical on 63488 / 63488 on both devices.** `f16(x*1.1)` → `S_fuse_mul_into_narrowing`. `f16(f16(x*1.1)+1000)` plain → `S_absorb_all_into_final_narrowing`; with `precise` → `S_f32_mul_then_absorb_add`, which is **the model the shipped codegen runs under**. `precise` is honoured, not ignored: it forbids a multiply-into-add contraction and cannot reach a conversion absorbing its operand (§9.3) | executed **element-wise**, plus **machine-code** for the reconciliation (`fp-contraction-policy.md` §12.4) | **ADMITTED under Regime A** on the two swept shapes, each with its own named model; the other 18 shapes are `Unknown` and stay refused |
 | **Vulkan / ANV** | Intel Arc Graphics (MTL), Mesa 26.1.2-arch3.1 | **0 / 63488** | n/a | executed | **strict**; refusal is currently over-broad here |
 | **Metal** | Apple M4, macOS 15.6.1 (24G90), Apple clang 17.0.0 (clang-1700.0.13.5), Metal.framework from the Command Line Tools SDK | **0 / 63488** on `f16(x*1.1)` **and 0 / 63488** on `f16(f16(x*1.1)+1000)`; unchanged under `#pragma METAL fp contract(off)`, `#pragma clang fp contract(off)`, a `volatile thread` barrier and an `as_type` bitcast barrier | n/a — no deviation to model. The `fusedctl` control, on the same source, compile options and dispatch, reproduces `S_fuse_mul_into_narrowing` on **63488 / 63488** and reports 2912 / 620 | executed, **element-wise** over the whole finite binary16 domain | **strict**; refusal is currently over-broad here |
 | **WGSL / naga** | — | **never probed** | — | none | **`Unknown` → refused** |
@@ -374,21 +421,22 @@ of §5.4's controls fire.
 
 Three things the Regime A table says that are easy to miss:
 
-1. **The relaxation is a candidate on exactly two stacks** — rusticl and RADV,
-   both ACO — and admitted on none of them yet. Everything else either already
-   meets `S_strict` or has never been measured. Even in the best case this is a
-   much narrower change than "relax f16"; in the worst case (§9.3) it is narrower
-   still, covering one shape on one driver. **Metal has now joined the strict
+1. **The relaxation is admitted on exactly two stacks** — rusticl and RADV,
+   both ACO — **and on two expression shapes**. Everything else either already
+   meets `S_strict` or has never been measured. This is a much narrower change
+   than "relax f16": it is four (stack, shape) pairs, each with a named function
+   attached, and 18 shapes per stack still refused. **Metal joined the strict
    group rather than the candidate group**, which is the outcome that needed no
    relaxation at all.
-2. **The RADV two-narrowing shape is the open risk.** 5075 plain against 4776
-   with `precise` means the decoration *changes the answer* while
-   `fp-contraction-policy.md` §6 shows it produces byte-identical ISA on the
-   one-narrowing shape. Those two facts are not obviously consistent and nobody
-   has reconciled them. If the two-narrowing shape matches no closed-form model,
-   it stays refused and the contract becomes per-shape — a materially worse
-   design, and the owner should hear about it before more effort is spent. Slice 1
-   is the decision point.
+2. **The RADV two-narrowing shape WAS the open risk, and it is closed.** 5075
+   plain against 4776 with `precise` is two different named models, each matched
+   bit-for-bit on 63488/63488, and the ISA says why: `NoContraction` forbids
+   contracting a multiply into an **addition** and cannot reach a **conversion**
+   absorbing its operand. The one-narrowing shape contains no addition, so the
+   decoration binds nothing and the ISA is byte-identical; the two-narrowing
+   shape contains one, so it binds, the multiply survives as its own
+   `v_fma_mix_f32`, and the model changes. Both facts, one mechanism. §9.3
+   records the resolution.
 3. **pocl, IGC, ANV, the Intel CPU runtime and now Metal are refused today for a
    defect they do not have.** `capability-model.md` §5 already records this as the
    over-refusal that follows from having no compiler-identity probe. It is not
@@ -689,7 +737,7 @@ we know the deviation.*
 
 | evidence for the deviation | what the author gets |
 |---|---|
-| exact match to a named closed-form model, swept exhaustively (`S_fuse_mul_into_narrowing` on ACO, if slice 1 confirms it) | a **one-time runtime diagnostic** on first launch of an f16 kernel on that device, naming the model and the doc section, on by default; silenceable only by an explicit call, never by accident |
+| exact match to a named closed-form model, swept exhaustively (on ACO: `S_fuse_mul_into_narrowing`, `S_absorb_all_into_final_narrowing` and `S_f32_mul_then_absorb_add`, all confirmed element-wise by slice 1 on 2026-07-27) | a **one-time runtime diagnostic** on first launch of an f16 kernel on that device, naming the model and the doc section, on by default; silenceable only by an explicit call, never by accident |
 | a *bounded* deviation with no closed form (the coopmat case, §5) | **explicit opt-in required** — `Sarek.accept_relaxed_f16 ~reason` or equivalent, and the launch fails without it |
 | unmeasured | refused, as today |
 
@@ -745,7 +793,7 @@ refusal before slice 3.
 | # | slice | proves | hardware | lifts a refusal? | status |
 |---|---|---|---|---|---|
 | **0** | the contract, as a testable classifier | the gate can tell `S_fuse_mul_into_narrowing` from a dropped narrowing | none (host-only) | no | open — and now also carries §1.3's per-narrowing ceiling |
-| **1** | element-wise model characterisation of ACO scalar f16, all emittable shapes | whether the contract of §1.2 is deliverable at all | RX 7900 XTX (local) | no | open (decision point) |
+| **1** | element-wise model characterisation of ACO scalar f16 | whether the contract of §1.2 is deliverable at all | RX 7900 XTX + Raphael iGPU (local) | no | **DONE 2026-07-27 for 2 of 20 shapes — deliverable; 18 shapes still open** |
 | **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | open |
 | **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist | open |
 | **4** | #62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | open |
@@ -812,13 +860,56 @@ Two outcomes, and they are not equally good:
   mitigation (§7 slice 4b's integer component types, which put an
   existing-strict-contract coopmat path within reach regardless).
 
+> **OUTCOME, 2026-07-27 — the first outcome, on the shapes swept.** Executed on
+> both local devices for each stack: `AMD Radeon RX 7900 XTX` and the Raphael
+> iGPU, under rusticl/radeonsi and under RADV, Mesa 26.1.4-arch3.1, Vulkan
+> 1.4.354. Full record in `fp-contraction-policy.md` §12; instruments are
+> `sarek-opencl/probe/probe_opencl_f16_model_agreement.ml`,
+> `sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml` and the shared
+> `tools/f16_model_set/`.
+>
+> | stack, shape, variant | model | agreement |
+> |---|---|---|
+> | rusticl, `f16(x*1.1)` | `S_fuse_mul_into_narrowing` | 63488 / 63488 |
+> | rusticl, `f16(f16(x*1.1)+1000)` | `S_fuse_mul_into_narrowing` | 63488 / 63488 |
+> | RADV, `f16(x*1.1)`, plain and `precise` | `S_fuse_mul_into_narrowing` | 63488 / 63488 |
+> | RADV, `f16(f16(x*1.1)+1000)`, plain | `S_absorb_all_into_final_narrowing` | 63488 / 63488 |
+> | RADV, `f16(f16(x*1.1)+1000)`, `precise` | `S_f32_mul_then_absorb_add` | 63488 / 63488 |
+>
+> **Zero inputs matched no model, on either stack, on either device.** The
+> ceiling of §1.3, evaluated at the elided narrowing, is met everywhere with
+> zero exceedances — and the same deviations measure 512 to 1.7e6 ulp on the
+> final value, so §1.3's correction is reproduced on 63488 inputs rather than
+> resting on one Metal counterexample.
+>
+> **Two things this slice found that were not on its list.** (i) The
+> `double`-based `fusedctl` control does not build on rusticl, which advertises
+> no `cl_khr_fp64`; the control had to be rebuilt on an f32 pair with a
+> round-to-odd step, the same construction MSL forced on the Metal probe. (ii)
+> ACO **defeats** the obvious two-narrowing positive control — a round-to-odd
+> product narrowed and then added to 1000 is re-absorbed, landing on
+> `S_absorb_all_into_final_narrowing` instead of the fused model. The working
+> control has to push the f16 bit pattern through the SSBO as well. A control
+> that a compiler can optimise away is not a control, and this one was caught
+> only because it reported the wrong model rather than a plausible number.
+>
+> **What is NOT settled: 18 of the 20 shapes.** The catalogue in
+> `docs/optimization/amdgpu-f16-fusion-shape-audit.md` has 20 emittable f16
+> shapes and this swept two. Slice 3 must not lift a refusal beyond the shapes a
+> model has been measured for. There is a single candidate generative rule that
+> produces all five results above — *a narrowing absorbs the whole f32 tree
+> feeding it, cut where `NoContraction` forbids a multiply-add* — but its
+> evidence tier is **unverified as a general rule**, and the remaining 18 shapes
+> are exactly what would confirm or break it (`fp-contraction-policy.md` §12.4).
+
 **This slice reports its outcome upward before the next one starts.** It is a
 decision point, not a task on a list; a green result funds slices 2–4 and a red
 one reopens the contract.
 
 Also upgrade the rusticl row of §2 from count-and-first-divergence agreement to
 element-wise agreement, which is what §1.2 actually requires and which nobody has
-run.
+run. **Done** — and the one-narrowing shape, never previously swept on rusticl,
+was added: 2912/63488, the same figure and the same model as RADV.
 
 ### Slice 2 — plumbing (local, no refusal touched)
 
@@ -1099,30 +1190,63 @@ rest remain interpretations this design is responsible for.
    cannot regress anyone. Worth stating explicitly, because it is the reason this
    can be done at all without a deprecation path.
 
-### 9.3 The open risk, unchanged and deliberately not closed
+### 9.3 The open risk — CLOSED, 2026-07-27
 
-**RADV's `precise` behaviour on the two-narrowing shape is not understood, and it
-is the thing most likely to break this design.** 5075/63488 plain against
-4776/63488 with `precise` means the decoration *changes the answer* — while
-`fp-contraction-policy.md` §6 shows the same decoration produces **byte-identical
-ISA** on the one-narrowing shape, and that the one-narrowing shape matches a
-single-rounding model exactly (0/63488). Those facts are not obviously consistent
-and nobody has reconciled them.
+**RADV's `precise` behaviour on the two-narrowing shape is now understood, and
+it does not break the design.** The risk as written was: 5075/63488 plain
+against 4776/63488 with `precise` means the decoration *changes the answer* —
+while `fp-contraction-policy.md` §6 shows the same decoration produces
+**byte-identical ISA** on the one-narrowing shape, and that the one-narrowing
+shape matches a single-rounding model exactly. Those facts looked inconsistent.
 
-If the two-narrowing shape matches **no** closed-form model, the contract of §1.2
-becomes **per-shape** rather than per-backend. That is materially worse: harder to
-document, harder to explain to a user, and a per-shape allowlist is a maintenance
-object of a different order from a per-driver one.
+**They are consistent, and the mechanism is one sentence.** `NoContraction`
+forbids contracting a multiply into an **addition**. A **conversion** absorbing
+its operand is a different combine and the decoration does not reach it.
 
-**Slice 1 is therefore structured as a decision point, not a task**, and the
-owner should hear the outcome **before slices 2–4 are funded** — not after. See
-§7 slice 1. The mitigation, if it goes the wrong way, is §7 slice 4b's integer
-component types: an integer-only coopmat path lands under the existing strict
-contract and #62 is not blocked on the accuracy question at all.
+- `f16(x*1.1)` contains no addition. The decoration is emitted, binds nothing,
+  and the ISA is byte-identical — `v_fma_mixlo_f16` either way. **RADV is not
+  ignoring the decoration here; the decoration is inapplicable.**
+- `f16(f16(x*1.1)+1000)` contains one, once ACO has elided the intermediate
+  narrowing. The decoration **binds**: the multiply is materialised as its own
+  `v_fma_mix_f32` and only the add is absorbed. The ISA changes, and so does
+  the model — from `S_absorb_all_into_final_narrowing` to
+  `S_f32_mul_then_absorb_add`.
+
+Evidence: **executed** element-wise, 63488/63488 for each model on both local
+RADV devices, plus **machine-code** (`RADV_DEBUG=asm`, one shader per run so
+each dump is attributable). Record: `fp-contraction-policy.md` §12.4.
+
+**So the contract does not become per-shape in the sense feared.** §1.2's model
+set was always keyed on *(backend, driver, expression shape)*; what §9.3 feared
+was a shape matching **no** model, which would have forced a refusal that could
+not be stated as a function. Every shape swept matches one exactly. What the
+result *does* cost is that **`S_fuse_mul_into_narrowing` alone does not cover
+RADV** — the admissible set gains two members (§1.2), and the member in force
+depends on whether the codegen emits `precise`. That is a real maintenance
+obligation and it is the honest price of the outcome.
+
+**What remains open is coverage, not mechanism.** Two of the twenty emittable
+shapes are measured. The remaining 18 are `Unknown` and refused under §1.5, and
+slice 3 must not lift a refusal past them. The single generative rule that
+would collapse the per-shape table back to a per-driver one is stated in
+`fp-contraction-policy.md` §12.4 and is **unverified** at that scope.
+
+The mitigation named here — §7 slice 4b's integer component types — is no longer
+needed as a fallback for the accuracy question, but stays a binding requirement
+of that slice for the reasons §8 gives.
 
 ---
 
 ## 10. Tests added by this change
+
+**None as gates.** The 2026-07-27 slice-1 amendment adds two probe
+**executables** — `sarek-opencl/probe/probe_opencl_f16_model_agreement.ml` and
+`sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml` — and the model library
+they share, `tools/f16_model_set/`. They are built by `dune build` and run by
+hand; they are deliberately not `(test)` stanzas, because they measure a driver
+in order to decide whether a contract is deliverable and would otherwise block
+CI on whatever GPU a runner happens to have. The two tripwires that defend the
+current refusals are untouched. The original text of this section follows.
 
 **None.** This change adds a design document and three standalone probes, none
 wired into dune, matching the convention of the ones already there:

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -41,8 +41,11 @@ actually had:
 - **Vulkan/RADV, f16.** RADV's ACO backend absorbs an f32→f16 narrowing into
   whatever arithmetic feeds it, and `precise`/`NoContraction` does not stop it —
   the decoration is emitted, and the emitted ISA is byte-identical with and
-  without it. **2912 of 63488** finite binary16 inputs disagree with the
+  without it *on the one-narrowing shape*, where there is no addition for it to
+  bind to (§12.4). **2912 of 63488** finite binary16 inputs disagree with the
   interpreter on a single narrowing, **5075** on a two-narrowing expression.
+  **All of those counts are now named closed-form functions, matched
+  bit-for-bit on 63488/63488** — see §12.
   Second front end onto the same ACO backend as rusticl/radeonsi, and a wider
   combine than either it or HIP — whose identical-looking fusion comes from a
   *different* compiler, LLVM's AMDGPU backend (§2, "Two AMD compilers"). f16
@@ -149,8 +152,8 @@ because the one non-Mesa stack that does fuse is AMD's own.
 | **CUDA / nvrtc + PTX (f32 `a*b+c`)** | yes, by default (`-fmad=true` is nvrtc's and ptxas's default, and it applies to PTX input too) | **no flag.** `Sarek_df64` denies the compiler a fusable multiply by routing products through `fma` (`mul_rn`) | executed, GTX 1070 Max-Q / sm_61 / CUDA 12.9 / driver 580.119.02: df64 mul 5.92e-08 → 9.07e-15, div 5.64e-08 → 5.08e-15 |
 | **CUDA — subnormal flushing** | `-use_fast_math` / `-ftz=true` would flush binary32 subnormals | `Cuda_nvrtc.check_fp_conformance` **rejects** those options at the only point an option array reaches `nvrtcCompileProgram` | machine-code + test, CUDA 13.3: the hazard is reproduced (`FMUL.FTZ`/`FADD.FTZ` at sm_90) and the guard is proved to fire — see §5 |
 | **OpenCL** | `FP_CONTRACT` is on by default in OpenCL C, and no build option turns it off | for contraction, **no flag** — same `mul_rn`-by-construction defence as CUDA. For div/sqrt, `Opencl_fp.conformance_options` requests `-cl-fp32-correctly-rounded-divide-sqrt`, **gated** on `CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT` in the device's `CL_DEVICE_SINGLE_FP_CONFIG`; `Opencl_fp.check_fp_conformance` **rejects** the relaxing `-cl-*` options at `Opencl_api.Program.build`, the single point an option string reaches `clBuildProgram` (§9) | executed, GTX 1070 Max-Q / NVIDIA OpenCL: mul 5.92e-08 → 9.07e-15, sqrt 2.88e-08 → 9.80e-15 with no OpenCL-specific change (quoted). Re-measured here on RX 7900 XTX / Mesa radeonsi: mul 9.07e-15, div 5.08e-15, sqrt 1.08e-14 |
-| **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, and bit-for-bit the same count — but a **different compiler**: ACO here, LLVM's AMDGPU backend there (see "Two AMD compilers" above) | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c` |
-| **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as rusticl, reached through a second front end — HIP's identical-count defect comes from LLVM's AMDGPU backend instead — and a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml` |
+| **OpenCL / rusticl (f16 narrowing)** | an f32 multiply into the f32→f16 narrowing that consumes it — rounding **once** where the DSL mandates twice. Same defect class as HIP/AMDGPU, and bit-for-bit the same count — but a **different compiler**: ACO here, LLVM's AMDGPU backend there (see "Two AMD compilers" above) | **nothing affordable.** Measured non-fixes, all still 620/63488: `#pragma OPENCL FP_CONTRACT OFF`, a `volatile` local, a `volatile __private` pointer, an `as_half`/`as_ushort` bitcast round-trip, and `convert_half_rte`. HIP's `asm volatile("" : "+v"(x))` **does not compile** here — rusticl goes through SPIR-V, where AMDGPU register constraints do not exist. Only a `volatile __global` round-trip and a `volatile __local` (LDS) round-trip work (both 0/63488), and both cost memory traffic per narrowing; the LDS form additionally needs a workgroup-sized allocation this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_opencl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (navi31) and the integrated Raphael iGPU (gfx1036) — rusticl/radeonsi, DRM 3.64, kernel 7.1.2-3-cachyos. Both report **620/63488**, first divergence at `x=5.68359375` (device 1006.5, interpreter 1006), bit-identical to the HIP figure. Liveness control: the `volatile __global` variant of the same harness reports **0/63488**, so the sweep is proven able to go both red and green. Reproducer: `tools/probes/opencl_f16_contraction_probe.c`. **Upgraded 2026-07-27 to ELEMENT-WISE model agreement (#62 slice 1, §12.3):** the plain kernel is bit-identical to `S_fuse_mul_into_narrowing` on **63488 / 63488** inputs on both devices, on this shape *and* on `f16(x*1.1)` (2912/63488 against the discipline, never previously swept here). The `double`-based `fusedctl` control does **not** build on rusticl, which advertises no `cl_khr_fp64`; the replacement control carries the exact product as an f32 pair and rounds to odd. Instrument: `sarek-opencl/probe/probe_opencl_f16_model_agreement.ml` |
+| **Vulkan / RADV (f16 narrowing)** | an f32→f16 narrowing absorbs whatever arithmetic feeds it (`v_fma_mixlo_f16`) — the multiply, and also the f32 **add**: the plain two-narrowing kernel compiles to a *single* fused instruction, one rounding where the DSL mandates three. Same ACO backend as rusticl, reached through a second front end — HIP's identical-count defect comes from LLVM's AMDGPU backend instead — and a **wider** combine than either | **nothing affordable, and `precise` is not it.** `precise` → SPIR-V `NoContraction` IS honoured (it keeps the f32 multiply as its own `v_fma_mix_f32`) and still leaves 2912/63488, because absorbing a *conversion* is a different combine from contracting `a*b+c`. An f16 bitcast round-trip changes nothing. A `volatile` SSBO round-trip on the f32 intermediates makes ACO drop the intermediate narrowing **entirely** instead (4774/63488). Only forcing the f16 *bit pattern* through global memory works (0/63488), at a global round-trip per narrowing into a scratch buffer this backend does not control. **Consequence: f16 stays REJECTED in `Sarek_ir_glsl`** | **executed**, 2026-07-26, exhaustive sweep of all 63488 finite binary16 inputs on **two** devices — RX 7900 XTX (**RADV NAVI31**) and the integrated Raphael iGPU (**RADV RAPHAEL_MENDOCINO**) — Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Both report identical counts: **2912/63488** on `f16(x*1.1)` (plain and `precise` alike), **5075/63488** on `f16(f16(x*1.1)+1000)` plain, **4776/63488** with `precise`. Calibration: the same host oracle reproduces the independently measured **620** on the HIP/OpenCL kernel shape, and the barriered kernel reports **0/63488**, so the sweep is proven able to go both red and green. Gate: `sarek-vulkan/test/test_vulkan_f16_tripwire.ml`. **Upgraded 2026-07-27 to ELEMENT-WISE model agreement (#62 slice 1, §12.4):** each of those counts is a named closed-form function matched on **63488 / 63488** on both devices — plain `f16(x*1.1)` and `precise` `f16(x*1.1)` are `S_fuse_mul_into_narrowing`; plain `f16(f16(x*1.1)+1000)` is `S_absorb_all_into_final_narrowing` (a **single** `v_fma_mixlo_f16` over x, 1.1 and 1000); the same shape with `precise` is `S_f32_mul_then_absorb_add` (`v_fma_mix_f32` then `v_fma_mixlo_f16`); the f32-barriered variant is `S_drop_intermediate_narrowing`. `precise` is **honoured**, not ignored — it forbids a multiply-into-ADD contraction and cannot reach a conversion absorbing its operand, which is why it is byte-identical on the shape with no addition and changes the answer on the shape with one. Instrument: `sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml` |
 | **OpenCL / pocl on x86 (f16 narrowing)** | in principle the same fusion — but nothing in this stack performs it | **nothing needed.** The naive narrowing already round-trips through binary16 exactly, so the barrier that rusticl requires is unnecessary here | **executed on CI**, 2026-07-26, quoted device `AMD EPYC 7763 64-Core Processor` under pocl on a GitHub-hosted runner: exhaustive sweep of all 63488 finite binary16 inputs, **0** disagreements between the naive and `volatile __local`-barriered narrowings. Observed as a CI failure of `test_opencl_f16_tripwire` before that test was scoped, i.e. the number was produced by a harness that was at the time *trying* to find a difference — so it is a null with the sweep demonstrably live. **This is what localises the defect:** the same source, swept the same way, fuses on an AMD GPU compiler and does not fuse here, so the locus is *the AMD GPU compilers*, not *OpenCL* and not *SPIR-V*. Note what it does **not** localise: rusticl and HIP/AMDGPU do not share a compiler (see "Two AMD compilers" above), so their identical 620 is two compilers agreeing, not one bug seen twice. **Confirmed by a second, independent negative on a real GPU** — Intel Arc Graphics under the Intel Compute Runtime / IGC, a compiler sharing no lineage with Mesa: 0/63488, with the sweep calibrated on the same run against the known 620 (§11.3). Guarded by `test_opencl_f16_tripwire`'s locus check, which fails if any OpenCL implementation outside its `"ACO"` device-string scope is found to fuse — and which was itself wrong until §11.5. Read that predicate as "not Mesa", not as "not AMD": an AMD GPU reached through ROCm's OpenCL would be compiled by LLVM's AMDGPU backend, i.e. by a compiler this document expects to fuse, while sitting outside the key |
 | **Vulkan / GLSL** | contraction and reassociation of float expressions | `precise` on every float local (`Sarek_ir_glsl.gen_var_decl`), which glslang lowers to SPIR-V `NoContraction` — but on RADV nothing needs preventing *for these shapes*: the driver does not contract them even without the decoration. It is **not** the decoration that is protecting them; RADV was separately observed ignoring `NoContraction` on a combine it does want to perform (§6, f16 narrowing) | **executed + machine-code**, RX 7900 XTX (RADV NAVI31) and Raphael iGPU (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1: 0 of 7 contraction shapes contracted with or without `precise`, ISA opcode-identical between the two builds, explicit `fma()` controls fused 4/4 — see §6. Decoration emission: compiler-output, glslc 2026.2 + glslangValidator, 18 `NoContraction` with `precise` / 0 without. **Mesa ANV now measured too** (§11.2): Intel Arc Graphics (Meteor Lake-P), Mesa 26.1.2-arch3.1, same 0 of 7 / 0 of 7 with `fma()` controls 4/4 — and unlike RADV, ANV does not fuse the f16 narrowing either, so no combine has been found on ANV where `NoContraction` is ignored. Separately, `fma` is not correctly rounded on RADV: df64 mul 5.84e-08 / div 5.86e-08, each the measured worst-case relative error over `test_df64`'s own input set on the named device and driver, not a bound; ANV shows the same signature (mul 5.84e-08 / div 5.86e-08, §11.1) |
 | **Metal** | contraction of `a*b+c` — **measured, and NOT preventable by any compile option**; separately, both math defaults are the fast one (`mathMode = MTLMathModeFast`, `mathFloatingPointFunctions = ...Fast`, read from a fresh `MTLCompileOptions`) | **two mechanisms, both required**: `#pragma METAL fp contract(off)` in every generated kernel (`Sarek_ir_metal.metal_fp_contract_pragma`) for contraction, *and* `mathMode = Safe` + `mathFloatingPointFunctions = Precise` in `Metal_bindings.mtl_compile_options_conformant` for math-function accuracy (falling back to the deprecated `fastMathEnabled = NO` before macOS 15) | **executed**, Apple M4 / macOS 15.6.1 (24G90) / Apple clang 17.0.0: on the 8773 of 65536 elements where the device's own `fma` differs from the separately-rounded value, `a*b+c` is contracted 8773/8773 under every compile-option setting **including `mathMode=Safe`**, and 0/8773 with the pragma. Options are honoured (16017 and 22135 of 65536 math-function results change), so Metal is not in rusticl's ignore-it class. **Interpreter agreement now executed on the same device**: `test_df64` and `test_real64` PASS on every op and reproduce the interpreter's figures exactly (mul 9.07e-15, add 5.33e-15, sub 6.51e-15, div 5.08e-15, sqrt 8.53e-15) — sampled maxima over each test's input set, not bounds, and agreement between summary statistics rather than element-wise identity. **The f16 narrowing is now probed and does NOT fuse** — 0/63488 from the discipline on **both** swept shapes, element-wise, with a validated positive control that goes red on **both**: the same control reports **2912/63488** on `f16(x*1.1)` and **620/63488** on `f16(f16(x*1.1)+1000)`, the latter being the figure already measured on hiprtc/gfx1100, rusticl/radeonsi and Intel Arc (§10.14). Two shapes, two independently-nonzero controls, two zeros; the pragma changes nothing there, in either direction, because there is no fusion to prevent. Subnormals still unprobed; two record/variant kernels do not compile at all (§10.11). **f64 is refused outright** — MSL has no `double`, and until #141 `TFloat64` was silently emitted as `float`, striding an 8-byte-per-element host buffer at 4; `Sarek_real64` (df64) is the supported route and is the figure quoted above (§10.13) |
@@ -558,6 +561,24 @@ So the honest status of `precise` on RADV is *not* "inert, and free". It is:
   contract them with or without it, so nothing is being held up;
 - **ignored** for the multiply-into-narrowing combine, where RADV *does*
   contract and the decoration does not stop it.
+
+> **AMENDED 2026-07-27 (#62 slice 1, §12.4): "ignored" is the wrong word, and
+> the right one changes what may be inferred.** The decoration is *inapplicable*
+> here, not disobeyed. `NoContraction` forbids contracting a multiply into an
+> **addition**; a **conversion** absorbing its operand is a different combine
+> and the decoration does not reach it. This shape contains no addition, so
+> there is nothing for the decoration to bind to — hence the byte-identical
+> ISA. On the two-narrowing shape `f16(f16(x*1.1)+1000)` there *is* an addition
+> once ACO has elided the intermediate narrowing, the decoration **binds**, the
+> multiply is materialised as its own `v_fma_mix_f32`, and the emitted ISA and
+> the numeric answer both change (5075 → 4776 disagreements, each an exact
+> match to a different named model). Everything measured in this section stands
+> exactly as recorded; what changes is that RADV has **not** been observed
+> violating `NoContraction`, and the sentence "that is a `NoContraction`
+> violation, observed" above should be read as superseded by §12.4. The
+> practical conclusion is unchanged and if anything firmer: `precise` is not
+> enough to make f16 safe here, because it constrains only one of the two
+> combines in play.
 
 Keep emitting it — it is correct for portability and costs nothing. Do not
 credit it with a guarantee on RADV, in either direction: it is not what makes
@@ -2057,3 +2078,254 @@ Two environmental notes, neither a defect in this repository:
   `VkPhysicalDeviceDriverProperties` plumbing described in §11.1.
 - **AMDVLK and the proprietary AMD Vulkan driver remain unmeasured**, as §7
   notes — different SPIR-V consumers on the same GPU.
+
+---
+
+## 12. ACO's f16 models, measured element-wise — and the `precise` reconciliation (#62 slice 1)
+
+**Executed 2026-07-27** on this workstation. This section is the measurement
+record for slice 1 of
+[`docs/design/f16-relaxed-accuracy.md`](design/f16-relaxed-accuracy.md), which
+that document structures as a **decision point**: §1.2 accepts a device result
+only when it is bit-identical to a **named closed-form model**, and until now
+no ACO figure in this document had ever been compared against one
+element-wise. §2's rusticl row was a *count* and a *first divergence*; §6's
+RADV row said the two-narrowing shape matched no model at all, and §9.3 of the
+design named that the thing most likely to break the design.
+
+**Both are now settled, and the answer is the good one on both stacks.** Every
+kernel variant swept below matches exactly one named model on **63488 / 63488**
+inputs, on **both** local devices, with 0 inputs matching no model.
+
+Instruments, committed with this section:
+`sarek-opencl/probe/probe_opencl_f16_model_agreement.ml`,
+`sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml`, and the model set
+they share, `tools/f16_model_set/f16_model_set.ml`. They are **executables, not
+tests**: they measure a driver in order to decide whether a contract is
+deliverable, and the gates defending the two refusals
+(`test_opencl_f16_tripwire.ml`, `test_vulkan_f16_tripwire.ml`) are untouched.
+
+### 12.1 The models
+
+Four named, closed-form functions, each computed exactly on the host. Naming is
+by **which mandated rounding is elided**, because §1.2 requires a member of the
+admissible set to be a function, not a description of what a device did.
+
+| model | what it elides |
+|---|---|
+| `S_strict` | nothing — the interpreter |
+| `S_fuse_mul_into_narrowing` | the f32 rounding of the multiply, absorbed into the narrowing that consumes it |
+| `S_absorb_all_into_final_narrowing` | multiply, intermediate binary16 narrowing **and** f32 add, all absorbed into the final narrowing: **one** rounding where the DSL mandates four |
+| `S_f32_mul_then_absorb_add` | the intermediate narrowing and the add, with the multiply keeping its own correctly-rounded binary32 result |
+| `S_drop_intermediate_narrowing` | the intermediate binary16 narrowing only; the add still rounds to f32 (the IGC signature of §11.4) |
+
+**The arithmetic is not ordinary OCaml floats, and that is load-bearing.** Three
+of these round to binary16 in a single step from a sum that binary64 cannot hold
+exactly: the exact product `x · fl32(1.1)` is an integer multiple of `2^-47`
+while the addend reaches `2^9`, so the exact sum spans up to 65 bits against
+binary64's 53. Evaluating `p +. 1000.0` would round first, making the model a
+*different function* — and it would differ from the intended one exactly at the
+binary16 ties, which is where §1.3's counterexample lives. Every single-rounding
+model therefore goes through `two_sum` (exact, unevaluated) and a
+round-to-odd-style single-step rounding.
+
+### 12.2 Calibration — run before any device number is read
+
+Four host-only checks, all green, on every run:
+
+1. `f16_bits` re-encodes all **63488** finite binary16 values to their own bit
+   patterns.
+2. `S_strict` and `S_fuse_mul_into_narrowing` separate on exactly **620** on
+   `f16(f16(x*1.1)+1000)` — the figure independently reproduced on
+   hiprtc/gfx1100, rusticl/radeonsi, `fusedctl` on Intel Arc and the M4's
+   round-to-odd control (§10.14).
+3. …and on exactly **2912** on `f16(x*1.1)` — RADV's recorded figure for that
+   shape.
+4. §1.3's counterexample reproduces: at `x = -907.5` the two models differ by
+   **1 ulp at the intermediate narrowing** and by **512 ulp on the final
+   value**.
+
+**The full pairwise separation matrix is printed**, which is the guard against
+the failure this project has already hit once in a neighbouring form: a model
+set whose members coincide on the swept inputs reports "exact agreement" while
+discriminating nothing. Over the finite binary16 domain the separations are
+fixed numbers, and three of them are the figures this document already records:
+
+| pair | inputs where they differ |
+|---|---|
+| `S_strict` vs `S_fuse_mul_into_narrowing` | 620 |
+| `S_strict` vs `S_absorb_all_into_final_narrowing` | **5075** |
+| `S_strict` vs `S_f32_mul_then_absorb_add` | **4776** |
+| `S_strict` vs `S_drop_intermediate_narrowing` | **4774** |
+
+5075, 4776 and 4774 are §2's recorded RADV counts for the plain kernel, the
+`precise` kernel and the f32-barriered kernel respectively — **reproduced by
+closed-form host functions before any device was touched**. One caution the
+matrix also surfaces and which is not visible from the counts:
+`S_f32_mul_then_absorb_add` and `S_drop_intermediate_narrowing` differ on only
+**2** of 63488 inputs, so telling those two apart rests on two inputs. It is a
+real discrimination — both are exercised below and land on opposite sides — but
+it is thin, and a future variant of either model should not be believed to be
+distinguished by a sweep that does not hit those two.
+
+### 12.3 OpenCL / rusticl — element-wise, and the count-agreement upgraded
+
+**Executed on rusticl/radeonsi, Mesa 26.1.4-arch3.1, DRM 3.64, kernel
+7.1.2-3-cachyos, on both local devices**: `AMD Radeon RX 7900 XTX (radeonsi,
+navi31, ACO, …)` and `AMD Ryzen 9 7950X 16-Core Processor (radeonsi,
+raphael_mendocino, ACO, …)`. Identical results on both.
+
+| kernel | model matched | disagreements |
+|---|---|---|
+| `f16(x*1.1)`, plain | **`S_fuse_mul_into_narrowing`** | **0 / 63488** |
+| `f16(f16(x*1.1)+1000)`, plain | **`S_fuse_mul_into_narrowing`** | **0 / 63488** |
+| GREEN CONTROL — `volatile __local` round-trip, both shapes | `S_strict` | 0 / 63488 |
+| POSITIVE CONTROL — deliberate fusion | `S_fuse_mul_into_narrowing` | 0 / 63488 |
+
+Evidence tier: **executed, element-wise over the whole finite binary16 domain**.
+
+Two things this adds beyond upgrading the tier:
+
+- **The one-narrowing shape had never been swept on rusticl.** It reports
+  **2912 / 63488** against the discipline — the same figure as RADV, and exact
+  agreement with the same model. The two ACO front ends behave identically on
+  both shapes.
+- **The `fusedctl` control had to be rebuilt.**
+  `tools/probes/opencl_f16_contraction_probe.c` builds it on `double` and says
+  a device without `cl_khr_fp64` should fail loudly. **rusticl on this box is
+  such a device** — it does not advertise the extension and the build is
+  rejected. The control here carries the exact product as an unevaluated f32
+  pair (Dekker's `twoProd` via `fma`) and rounds to odd before narrowing, the
+  same construction the Metal probe needed because MSL has no `double`
+  (§10.14). Round-to-odd then round-to-nearest is exact here because binary32
+  has 24 significand bits, binary16 has 11, and 24 ≥ 2·11 + 2 — with no margin,
+  which is why it is stated rather than assumed.
+
+### 12.4 Vulkan / RADV — the two-narrowing shape matches a model, and `precise` is reconciled
+
+**Executed on RADV, Mesa 26.1.4-arch3.1, Vulkan 1.4.354, on both local
+devices**: `AMD Radeon RX 7900 XTX (RADV NAVI31)` and `AMD Ryzen 9 7950X
+16-Core Processor (RADV RAPHAEL_MENDOCINO)`. Identical results on both.
+
+| kernel | model matched | vs `S_strict` |
+|---|---|---|
+| `f16(x*1.1)`, plain | **`S_fuse_mul_into_narrowing`**, 0 / 63488 | 2912 |
+| `f16(x*1.1)`, `precise` | **`S_fuse_mul_into_narrowing`**, 0 / 63488 | 2912 |
+| `f16(f16(x*1.1)+1000)`, plain | **`S_absorb_all_into_final_narrowing`**, 0 / 63488 | **5075** |
+| `f16(f16(x*1.1)+1000)`, `precise` | **`S_f32_mul_then_absorb_add`**, 0 / 63488 | **4776** |
+| `f16(f16(x*1.1)+1000)`, volatile SSBO on the **f32 intermediates only** | **`S_drop_intermediate_narrowing`**, 0 / 63488 | **4774** |
+| GREEN CONTROL — f16 **bit pattern** through the SSBO, both shapes | `S_strict`, 0 / 63488 | 0 |
+| POSITIVE CONTROL — deliberate fusion, both shapes | `S_fuse_mul_into_narrowing`, 0 / 63488 | — |
+
+Evidence tier: **executed, element-wise**, plus **machine-code** for the
+reconciliation below.
+
+**Every one of §2's RADV numbers is now a named function.** 5075, 4776 and 4774
+were three unexplained counts; they are `S_absorb_all_into_final_narrowing`,
+`S_f32_mul_then_absorb_add` and `S_drop_intermediate_narrowing`, each matched
+bit-for-bit on all 63488 inputs on two devices.
+
+#### The reconciliation, at machine-code tier
+
+§6 records that `precise` produces **byte-identical ISA** on the one-narrowing
+shape while §2 records it *changing the count* on the two-narrowing shape.
+Those two facts are consistent, and the ISA says why. `RADV_DEBUG=asm`,
+RX 7900 XTX (RADV NAVI31), one shader compiled per run so each dump is
+attributable:
+
+| variant | the arithmetic ACO emits |
+|---|---|
+| `f16(x*1.1)` plain | `v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,1,1]` |
+| `f16(x*1.1)` `precise` | **byte-identical to the above** |
+| `f16(f16(x*1.1)+1000)` plain | `v_fma_mixlo_f16 v2, 0xcccd, v1, s1 op_sel_hi:[0,1,0]` — a **single** instruction taking `x`, `1.1` and `1000` |
+| `f16(f16(x*1.1)+1000)` `precise` | `v_fma_mix_f32 v1, 0xcccd, v1, neg(0)` **then** `v_fma_mixlo_f16 v2, 1.0, v1, 0x63d0` — the multiply survives as its own correctly-rounded f32 operation, and `0x63d0` is binary16 `1000.0` |
+
+> **The rule that explains all four.** `NoContraction` forbids contracting a
+> multiply into an **addition**. It does not forbid a **conversion** absorbing
+> what feeds it — that is a different combine and the decoration does not reach
+> it.
+>
+> On the one-narrowing shape there is no addition at all, so the decoration has
+> nothing to bind to: it is emitted, it binds nothing, and the ISA is
+> byte-identical. On the two-narrowing shape there *is* one, once ACO has
+> elided the intermediate narrowing — so the decoration bites, the multiply is
+> materialised as `v_fma_mix_f32`, and the model moves from
+> `S_absorb_all_into_final_narrowing` to `S_f32_mul_then_absorb_add`. **The
+> decoration is honoured in both cases. It changes the answer only where there
+> was something for it to forbid.**
+
+This **corrects nothing in §6 and completes it**: §6's "inert here, ignored
+there" reading of `precise` on RADV was right about the observations and
+incomplete about the mechanism. "Ignored" is the wrong word — on the
+one-narrowing shape the decoration is *inapplicable*, because a conversion
+absorbing its operand is not a contraction. On the two-narrowing shape it is
+**applied**, and still insufficient, because it constrains only one of the two
+combines in play.
+
+#### A candidate generative rule — stated as a hypothesis, not a measurement
+
+All four observed behaviours are produced by one rule:
+
+> *An f32→f16 narrowing absorbs the entire f32 expression tree feeding it,
+> evaluating it exactly and rounding once — intermediate binary16 narrowings
+> included, hence elided — cut wherever SPIR-V `NoContraction` forbids a
+> multiply-add contraction, at which cut a correctly-rounded binary32 value is
+> materialised.*
+
+Evidence tier: **unverified as a general rule.** It is consistent with four
+kernel variants across two expression shapes on two devices, and with the ISA
+for each; it is not a measurement of the 20-shape catalogue in
+[`docs/optimization/amdgpu-f16-fusion-shape-audit.md`](optimization/amdgpu-f16-fusion-shape-audit.md).
+It matters because it is the difference between a contract keyed on a driver
+and a lookup table keyed on every expression a user might write, and confirming
+or breaking it is what the remaining 18 shapes would do.
+
+### 12.5 §1.3's ceiling, applied — and why the correction was not academic
+
+The design's `f16_relaxed_ceiling` is evaluated **at the narrowing where the
+rounding was elided**, not on the final value. Both denominators are computed
+and printed, because §1.3 requires a gate to say which value it measures the
+ulp against.
+
+| stack / shape | model | worst deviation **at the elided narrowing** | inputs over 1 ulp | the same deviation **on the final value** |
+|---|---|---|---|---|
+| rusticl, `f16(x*1.1)` | `S_fuse_mul_into_narrowing` | 1 ulp | 0 | 1 ulp |
+| rusticl, `f16(f16(x*1.1)+1000)` | `S_fuse_mul_into_narrowing` | 1 ulp | 0 | **512 ulp** |
+| RADV, `f16(f16(x*1.1)+1000)` plain | `S_absorb_all_into_final_narrowing` | 0.500044 ulp | 0 | **1.68e+06 ulp** |
+| RADV, `f16(f16(x*1.1)+1000)` `precise` | `S_f32_mul_then_absorb_add` | 0.5 ulp | 0 | **1.68e+06 ulp** |
+| RADV, f32-barriered | `S_drop_intermediate_narrowing` | 0.5 ulp | 0 | **1.68e+06 ulp** |
+
+Both denominators — S_strict's value at the narrowing and the model's own value
+there — give the same figures to the digits shown, so nothing here depends on
+the choice; a gate must still name one.
+
+**Every admitted deviation is inside the ceiling at the elided narrowing, and
+every one of them blows through it by three to six orders of magnitude on the
+final value.** §1.3 was corrected on a single Metal counterexample; this is the
+correction reproduced on 63488 inputs on a second vendor's hardware, on models
+that were not the one it was derived from. A final-value ceiling would reject
+correct results from an admitted model on **every** ACO stack, not just at
+`x = -907.5`.
+
+The 0.500044 rather than 0.5 for `S_absorb_all_into_final_narrowing` is
+expected and is not slack: that model presents the *exact* product where
+`S_strict` presents a doubly-rounded one, so the gap is half a binary16 ulp plus
+half a binary32 ulp, and `0.5 + 2^-13/2 ≈ 0.50006`.
+
+### 12.6 What slice 1 did NOT measure
+
+- **Two of the 20 emittable f16 shapes.**
+  `docs/optimization/amdgpu-f16-fusion-shape-audit.md` enumerates 20; this
+  measured `f16(x*1.1)` and `f16(f16(x*1.1)+1000)`. The other 18 are
+  **unmeasured on ACO** and under §1.5 stay refused.
+- **One constant, one addend.** `1.1` and `1000` throughout, as in every prior
+  measurement of this hazard, so the counts are comparable — but the models are
+  confirmed against one operand pattern, not a family.
+- **Sarek-generated shaders.** Both probes compile hand-written kernels and
+  therefore measure the driver, exactly as §7(c) says of the GLSL tripwire. A
+  codegen-side gate is §7 slice 3.
+- **Determinism beyond re-run stability.** The Vulkan sweep was executed in
+  several separate processes during this work and reported bit-identical
+  counts each time, which is §1.4(b); §1.4(a)'s in-process repeat and the
+  dispatch-shape variation were not run.
+- **Non-ACO Vulkan and non-Mesa OpenCL on AMD.** Unchanged from §7 and §11.7.

--- a/docs/measurements/f16-slice1-2026-07-27/README.md
+++ b/docs/measurements/f16-slice1-2026-07-27/README.md
@@ -1,0 +1,59 @@
+# #62 slice 1 — preserved run output, 2026-07-27
+
+The numbers in
+[`docs/fp-contraction-policy.md`](../../fp-contraction-policy.md) §12 and in
+[`docs/design/f16-relaxed-accuracy.md`](../../design/f16-relaxed-accuracy.md)
+§2 and §7 slice 1 are read off these files. They are committed because a
+measurement quoted only as prose cannot be checked, and because the two
+tripwires this project already ships were both corrected after a number in a
+document turned out not to be what the harness computed.
+
+## What was run
+
+All on one workstation: AMD Ryzen 9 7950X, Linux 7.1.2-3-cachyos, Mesa
+26.1.4-arch3.1, DRM 3.64.
+
+| file | command | devices |
+|---|---|---|
+| `opencl-rusticl.txt` | `dune exec sarek-opencl/probe/probe_opencl_f16_model_agreement.exe` | `AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)`, `AMD Ryzen 9 7950X 16-Core Processor (radeonsi, raphael_mendocino, ACO, …)` |
+| `vulkan-radv.txt` | `dune exec sarek-vulkan/probe/probe_vulkan_f16_model_agreement.exe` | `AMD Radeon RX 7900 XTX (RADV NAVI31)`, `AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)`, radv / Mesa 26.1.4-arch3.1 / Vulkan 1.4.354 |
+| `vulkan-radv-isa.txt` | `RADV_DEBUG=asm dune exec sarek-vulkan/probe/probe_vulkan_f16_model_agreement.exe -- --variant {s1_plain,s1_precise,s2_plain,s2_precise}` | RX 7900 XTX (RADV NAVI31) |
+
+The ISA capture uses `--variant` deliberately: it compiles **one** shader per
+process, so each `RADV_DEBUG=asm` dump is attributable to a named variant. A
+full run compiles nine shaders in sequence and reading its dump would mean
+guessing which belongs to which, which is not a machine-code evidence tier.
+
+## How to read them
+
+Each sweep prints one line per model. `0 / 63488 disagreements` marked `<==
+EXACT, element-wise` is the model the device is bit-identical to. A line
+`*** N inputs match NO named model ***` is the failure this slice existed to
+look for; there are none in these files.
+
+The controls are printed **before** the measurements, and there are three
+kinds:
+
+- **green** — a barriered kernel that must reproduce `S_strict` exactly. Until
+  it does, a disagreement elsewhere could be a wrong buffer layout rather than
+  a statement about the compiler.
+- **positive** — a kernel that performs the fusion deliberately and must
+  reproduce `S_fuse_mul_into_narrowing` exactly. Without it, a zero cannot be
+  distinguished from a sweep that did not happen.
+- **host, before any device is touched** — the model round-trip, the 620 and
+  2912 separations, §1.3's `x = -907.5` case, and the full pairwise separation
+  matrix. The matrix is the guard against a model set whose members coincide on
+  the swept inputs and therefore discriminate nothing.
+
+## Reproducing
+
+The probes need no arguments and no GPU-specific setup beyond a Mesa driver:
+
+```
+dune exec sarek-opencl/probe/probe_opencl_f16_model_agreement.exe
+dune exec sarek-vulkan/probe/probe_vulkan_f16_model_agreement.exe
+```
+
+Add `-- --host-only` to run the calibration and the separation matrix with no
+device at all; that half is deterministic and machine-independent, and it is
+the half that must be believed before any device number is read.

--- a/docs/measurements/f16-slice1-2026-07-27/opencl-rusticl.txt
+++ b/docs/measurements/f16-slice1-2026-07-27/opencl-rusticl.txt
@@ -1,0 +1,125 @@
+#62 slice 1(a) — element-wise model agreement, OpenCL / rusticl
+
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+
+================================================================
+device: AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)
+================================================================
+  GREEN CONTROL — volatile __local barrier, two-narrowing shape
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    992 / 63488 disagreements
+    S_strict_mul_absorb_add            :    372 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  POSITIVE CONTROL — deliberate fusion via twoProd + round-to-odd
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    372 / 63488 disagreements
+    S_strict_mul_absorb_add            :    992 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  GREEN CONTROL — volatile __local barrier, one-narrowing shape
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+
+  --- shape: f16(x * 1.1) ---
+  plain (naive codegen)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+
+  --- shape: f16(f16(x * 1.1) + 1000) ---
+  plain (naive codegen)
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    372 / 63488 disagreements
+    S_strict_mul_absorb_add            :    992 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 512 ulp.
+
+================================================================
+device: AMD Ryzen 9 7950X 16-Core Processor (radeonsi, raphael_mendocino, ACO, DRM 3.64, 7.1.2-3-cachyos)
+================================================================
+  GREEN CONTROL — volatile __local barrier, two-narrowing shape
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    992 / 63488 disagreements
+    S_strict_mul_absorb_add            :    372 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  POSITIVE CONTROL — deliberate fusion via twoProd + round-to-odd
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    372 / 63488 disagreements
+    S_strict_mul_absorb_add            :    992 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  GREEN CONTROL — volatile __local barrier, one-narrowing shape
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+
+  --- shape: f16(x * 1.1) ---
+  plain (naive codegen)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+
+  --- shape: f16(f16(x * 1.1) + 1000) ---
+  plain (naive codegen)
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    372 / 63488 disagreements
+    S_strict_mul_absorb_add            :    992 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 512 ulp.

--- a/docs/measurements/f16-slice1-2026-07-27/vulkan-radv-isa.txt
+++ b/docs/measurements/f16-slice1-2026-07-27/vulkan-radv-isa.txt
@@ -1,0 +1,299 @@
+########## RADV_DEBUG=asm --variant s1_plain ##########
+Compute Shader
+disasm:
+BB0:
+	s_mov_b32 s0, s3                                            ; be800003
+	s_movk_i32 s3, 0x8000                                       ; b0038000
+	s_load_b256 s[8:15], s[2:3], null                           ; f40c0201 f8000000
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	s_delay_alu instid0(VALU_DEP_1)                             ; bf870001
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	s_waitcnt lgkmcnt(0)                                        ; bf89fc07
+	buffer_load_b32 v1, v0, s[12:15], 0 offen                   ; e0500000 80430100
+	s_waitcnt vmcnt(0)                                          ; bf8903f7
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,1,1]    ; cc214002 920202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	s_delay_alu instid0(VALU_DEP_1)                             ; bf870001
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+	buffer_store_b32 v2, v0, s[8:11], 0 offen                   ; e0680000 80420200
+	s_endpgm                                                    ; bfb00000
+#62 slice 1(b) — element-wise model agreement, Vulkan / RADV
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+variant: s1_plain
+GLSL:
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  outb[i] = pack(float16_t(x * 1.1));
+}
+  s1_plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+
+########## RADV_DEBUG=asm --variant s1_precise ##########
+Compute Shader
+disasm:
+BB0:
+	s_mov_b32 s0, s3                                            ; be800003
+	s_movk_i32 s3, 0x8000                                       ; b0038000
+	s_load_b256 s[8:15], s[2:3], null                           ; f40c0201 f8000000
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	s_delay_alu instid0(VALU_DEP_1)                             ; bf870001
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	s_waitcnt lgkmcnt(0)                                        ; bf89fc07
+	buffer_load_b32 v1, v0, s[12:15], 0 offen                   ; e0500000 80430100
+	s_waitcnt vmcnt(0)                                          ; bf8903f7
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,1,1]    ; cc214002 920202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	s_delay_alu instid0(VALU_DEP_1)                             ; bf870001
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+	buffer_store_b32 v2, v0, s[8:11], 0 offen                   ; e0680000 80420200
+	s_endpgm                                                    ; bfb00000
+#62 slice 1(b) — element-wise model agreement, Vulkan / RADV
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+variant: s1_precise
+GLSL:
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  precise float p = x * 1.1;
+  outb[i] = pack(float16_t(p));
+}
+  s1_precise
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+
+########## RADV_DEBUG=asm --variant s2_plain ##########
+Compute Shader
+disasm:
+BB0:
+	s_mov_b32 s0, s3                                            ; be800003
+	s_movk_i32 s3, 0x8000                                       ; b0038000
+	s_load_b256 s[8:15], s[2:3], null                           ; f40c0201 f8000000
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1) ; bf8704d1
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	s_waitcnt lgkmcnt(0)                                        ; bf89fc07
+	buffer_load_b32 v1, v0, s[12:15], 0 offen                   ; e0500000 80430100
+	s_mov_b32 s1, 0x447a0000                                    ; be8100ff 447a0000
+	s_waitcnt vmcnt(0)                                          ; bf8903f7
+	v_fma_mixlo_f16 v2, 0xcccd, v1, s1 op_sel_hi:[0,1,0]        ; cc210002 100602ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	s_delay_alu instid0(VALU_DEP_1)                             ; bf870001
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+	buffer_store_b32 v2, v0, s[8:11], 0 offen                   ; e0680000 80420200
+	s_endpgm                                                    ; bfb00000
+#62 slice 1(b) — element-wise model agreement, Vulkan / RADV
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+variant: s2_plain
+GLSL:
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float p = x * 1.1;
+  float16_t m = float16_t(p);
+  float q = float(m) + 1000.0;
+  outb[i] = pack(float16_t(q));
+}
+  s2_plain
+    S_strict                           :   5075 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4896 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :   5240 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5419 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+
+########## RADV_DEBUG=asm --variant s2_precise ##########
+Compute Shader
+disasm:
+BB0:
+	s_mov_b32 s0, s3                                            ; be800003
+	s_movk_i32 s3, 0x8000                                       ; b0038000
+	s_load_b256 s[8:15], s[2:3], null                           ; f40c0201 f8000000
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(VALU_DEP_1) ; bf8700d1
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	s_waitcnt lgkmcnt(0)                                        ; bf89fc07
+	buffer_load_b32 v1, v0, s[12:15], 0 offen                   ; e0500000 80430100
+	s_waitcnt vmcnt(0)                                          ; bf8903f7
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_fma_mixlo_f16 v2, 1.0, v1, 0x63d0 op_sel_hi:[0,0,1]       ; cc214002 03fe02f2 000063d0
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	s_delay_alu instid0(VALU_DEP_1)                             ; bf870001
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+	buffer_store_b32 v2, v0, s[8:11], 0 offen                   ; e0680000 80420200
+	s_endpgm                                                    ; bfb00000
+#62 slice 1(b) — element-wise model agreement, Vulkan / RADV
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+variant: s2_precise
+GLSL:
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  precise float p = x * 1.1;
+  float16_t m = float16_t(p);
+  precise float q = float(m) + 1000.0;
+  outb[i] = pack(float16_t(q));
+}
+  s2_precise
+    S_strict                           :   4776 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4851 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :   5195 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5120 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+

--- a/docs/measurements/f16-slice1-2026-07-27/vulkan-radv.txt
+++ b/docs/measurements/f16-slice1-2026-07-27/vulkan-radv.txt
@@ -1,0 +1,193 @@
+#62 slice 1(b) — element-wise model agreement, Vulkan / RADV
+
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+
+================================================================
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+================================================================
+
+  --- controls ---
+  GREEN CONTROL — f16 bit pattern through the SSBO, one narrowing
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  GREEN CONTROL — f16 bit pattern through the SSBO, two narrowings
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    992 / 63488 disagreements
+    S_strict_mul_absorb_add            :    372 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  POSITIVE CONTROL — deliberate fusion, one narrowing
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  POSITIVE CONTROL — deliberate fusion, two narrowings
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    372 / 63488 disagreements
+    S_strict_mul_absorb_add            :    992 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+
+  --- shape: f16(x * 1.1) ---
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+
+  --- shape: f16(f16(x * 1.1) + 1000) ---
+  plain
+    S_strict                           :   5075 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4896 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :   5240 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5419 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   4776 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4851 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :   5195 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5120 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  volatile SSBO on the f32 intermediates ONLY
+    S_strict                           :   4774 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4849 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_and_absorb_add          :   5193 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5118 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+
+================================================================
+device: AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)
+================================================================
+
+  --- controls ---
+  GREEN CONTROL — f16 bit pattern through the SSBO, one narrowing
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  GREEN CONTROL — f16 bit pattern through the SSBO, two narrowings
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    992 / 63488 disagreements
+    S_strict_mul_absorb_add            :    372 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  POSITIVE CONTROL — deliberate fusion, one narrowing
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  POSITIVE CONTROL — deliberate fusion, two narrowings
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :    372 / 63488 disagreements
+    S_strict_mul_absorb_add            :    992 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+
+  --- shape: f16(x * 1.1) ---
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+
+  --- shape: f16(f16(x * 1.1) + 1000) ---
+  plain
+    S_strict                           :   5075 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4896 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :   5240 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5419 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   4776 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4851 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    S_fuse_mul_and_absorb_add          :   5195 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5120 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  volatile SSBO on the f32 intermediates ONLY
+    S_strict                           :   4774 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4849 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_and_absorb_add          :   5193 / 63488 disagreements
+    S_strict_mul_absorb_add            :   5118 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.

--- a/sarek-opencl/probe/dune
+++ b/sarek-opencl/probe/dune
@@ -1,0 +1,12 @@
+; #62 slice 1(a) — element-wise model-agreement probe for OpenCL / rusticl.
+;
+; An `executable`, not a `test`: it measures a driver to decide whether a
+; contract is deliverable, and a measurement that blocks CI on whatever GPU the
+; runner happens to have is a gate, not a measurement. The gate defending the
+; OpenCL f16 refusal is sarek-opencl/test/test_opencl_f16_tripwire.ml and is
+; untouched by this directory.
+
+(executable
+ (name probe_opencl_f16_model_agreement)
+ (modules probe_opencl_f16_model_agreement)
+ (libraries sarek_opencl spoc_framework f16_model_set))

--- a/sarek-opencl/probe/probe_opencl_f16_model_agreement.ml
+++ b/sarek-opencl/probe/probe_opencl_f16_model_agreement.ml
@@ -1,0 +1,328 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * #62 slice 1(a) — is rusticl's deviation ELEMENT-WISE a named model?
+ *
+ * WHAT THIS ANSWERS, AND WHY IT IS NOT ALREADY ANSWERED.
+ *
+ * docs/design/f16-relaxed-accuracy.md §2 records rusticl at 620/63488 on
+ * f16(f16(x*1.1)+1000), with agreement to S_fuse_mul_into_narrowing
+ * established as a COUNT and a FIRST DIVERGENCE. §1.2 does not accept a count.
+ * It requires the device result to be BIT-IDENTICAL to one member of the
+ * named model set, on every input the gate sweeps. Two functions can differ
+ * from a third on the same 620 inputs and still not be the same function.
+ *
+ * So this probe compares element-wise, against SEVEN named models rather than
+ * two, and reports the inputs that match none.
+ *
+ * WHY A PROBE AND NOT A TEST. It measures a driver in order to decide whether
+ * a contract is deliverable; it does not defend an invariant. The gate that
+ * defends the OpenCL refusal is test_opencl_f16_tripwire.ml and is untouched.
+ *
+ * Run:
+ *   dune exec sarek-opencl/probe/probe_opencl_f16_model_agreement.exe
+ *   dune exec sarek-opencl/probe/probe_opencl_f16_model_agreement.exe -- --host-only
+ ******************************************************************************)
+
+open Sarek_opencl
+module Backend = Opencl_plugin_base.Opencl
+module M = F16_model_set
+
+let n_local = 256
+
+(* The two-narrowing shape, exactly as test_opencl_f16_tripwire.ml writes it,
+   so the 620 this probe reads is the 620 that document records and not a
+   number from a differently-written kernel. *)
+let src_plain =
+  {|
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+__kernel void midround(__global ushort *out, __global const ushort *in, int n) {
+  int i = get_global_id(0);
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+    half  m = (half)(x * 1.1f);
+    out[i]  = as_ushort((half)((float)m + 1000.0f));
+  }
+}
+|}
+
+(* The one-narrowing shape. rusticl has never been swept on it in this
+   project; RADV has, and comparing the two ACO front ends on the SAME two
+   shapes is what makes the slice-1 verdict a statement about the compiler
+   rather than about one front end. *)
+let src_one_narrowing =
+  {|
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+__kernel void midround(__global ushort *out, __global const ushort *in, int n) {
+  int i = get_global_id(0);
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+    out[i] = as_ushort((half)(x * 1.1f));
+  }
+}
+|}
+
+(* GREEN CONTROL, two-narrowing shape. A volatile __local round-trip on each
+   f32 intermediate — measured to restore the discipline on this stack. It must
+   report S_strict exactly; until it does, a disagreement elsewhere could be a
+   wrong buffer layout rather than a statement about ACO. *)
+let src_barriered =
+  Printf.sprintf
+    {|
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+__kernel void midround(__global ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[%d];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+    s[l] = x * 1.1f;
+    half m = (half)s[l];
+    s[l] = (float)m + 1000.0f;
+    out[i] = as_ushort((half)s[l]);
+  }
+}
+|}
+    n_local
+
+(* GREEN CONTROL, one-narrowing shape. Same barrier, one narrowing. *)
+let src_barriered_one =
+  Printf.sprintf
+    {|
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+__kernel void midround(__global ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[%d];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+    s[l] = x * 1.1f;
+    out[i] = as_ushort((half)s[l]);
+  }
+}
+|}
+    n_local
+
+(* POSITIVE CONTROL. Deliberately performs the fusion, so the harness is shown
+   able to report S_fuse_mul_into_narrowing on a stack that does not fuse on
+   its own. On rusticl the contrast is free (plain 620, barriered 0); the
+   control exists so that this probe keeps discriminating if it is ever pointed
+   at pocl or IGC, where every variant returns the same thing and a
+   silently-broken sweep is indistinguishable from a clean one.
+
+   NOT built on binary64. tools/probes/opencl_f16_contraction_probe.c's
+   `fusedctl` uses `double` and says a device without cl_khr_fp64 should fail
+   loudly — and rusticl on this box IS such a device: it does not advertise the
+   extension and the build is rejected. So the control is built the way the
+   Metal probe had to build it (MSL has no `double` either): the exact product
+   is carried as an unevaluated f32 pair via Dekker's twoProd, rounded to odd,
+   and then narrowed once.
+
+   Why round-to-odd is exact here rather than approximately right: binary32 has
+   24 significand bits and binary16 has 11, and 24 >= 2*11 + 2. That is the
+   condition under which a round-to-odd intermediate followed by
+   round-to-nearest-even gives the same answer as rounding the exact value
+   once. It holds with no margin, which is why it is stated. *)
+let src_fusedctl =
+  {|
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+static inline float exact_prod_ro(float x, float c) {
+  float hi = x * c;
+  float lo = fma(x, c, -hi);   /* hi + lo is EXACTLY x*c */
+  if (lo == 0.0f) return hi;
+  uint u = as_uint(hi);
+  if ((u & 1u) == 0u) u = ((lo > 0.0f) == (hi > 0.0f)) ? u + 1u : u - 1u;
+  return as_float(u);
+}
+__kernel void midround(__global ushort *out, __global const ushort *in, int n) {
+  int i = get_global_id(0);
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+    half  m = (half)exact_prod_ro(x, 1.1f);
+    out[i]  = as_ushort((half)((float)m + 1000.0f));
+  }
+}
+|}
+
+let run_kernel device ~source ~inputs =
+  let n = Array.length inputs in
+  let host_in = Bigarray.(Array1.create int16_unsigned c_layout n) in
+  Array.iteri (fun i b -> host_in.{i} <- b) inputs ;
+  let din = Backend.Memory.alloc device n Bigarray.int16_unsigned in
+  let dout = Backend.Memory.alloc device n Bigarray.int16_unsigned in
+  Backend.Memory.host_to_device ~src:host_in ~dst:din ;
+  let compiled = Backend.Kernel.compile device ~name:"midround" ~source in
+  let args = Backend.Kernel.create_args () in
+  Backend.Kernel.set_arg_buffer args 0 dout ;
+  Backend.Kernel.set_arg_buffer args 1 din ;
+  Backend.Kernel.set_arg_int32 args 2 (Int32.of_int n) ;
+  let block = Spoc_framework.Framework_sig.dims_1d n_local in
+  let grid =
+    Spoc_framework.Framework_sig.dims_1d ((n + n_local - 1) / n_local)
+  in
+  Backend.Kernel.launch compiled ~args ~grid ~block ~shared_mem:0 ~stream:None ;
+  Backend.Device.synchronize device ;
+  let host_out = Bigarray.(Array1.create int16_unsigned c_layout n) in
+  Backend.Memory.device_to_host ~src:dout ~dst:host_out ;
+  Backend.Memory.free din ;
+  Backend.Memory.free dout ;
+  Array.init n (fun i -> host_out.{i})
+
+let contains ~needle haystack =
+  let n = String.length needle and h = String.length haystack in
+  let lower = String.lowercase_ascii in
+  let needle = lower needle and haystack = lower haystack in
+  let rec go i =
+    i + n <= h && (String.sub haystack i n = needle || go (i + 1))
+  in
+  n = 0 || go 0
+
+let describe device = Backend.Device.name device
+
+(* Same key as the tripwire: the COMPILER's own name in the device string.
+   "ACO" is the component that performs the fusion; a device-model substring
+   would be the wrong key and is deliberately not used. *)
+let is_in_scope device = contains ~needle:"aco" (describe device)
+
+let devices () =
+  if not (Backend.is_available ()) then [||]
+  else begin
+    Backend.Device.init () ;
+    Array.init (Backend.Device.count ()) Backend.Device.get
+  end
+
+let strict_of models = List.find (fun m -> m.M.name = "S_strict") models
+
+let sweep device ~label ~source ~models =
+  let got = run_kernel device ~source ~inputs:M.finite_bits in
+  let c = M.classify models got in
+  M.print_classification ~label c ;
+  (got, c)
+
+let report_ceiling models c =
+  let strict = strict_of models in
+  match c.M.exact_matches with
+  | [] -> ()
+  | names ->
+      Printf.printf
+        "    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final \
+         value):\n" ;
+      List.iter
+        (fun n ->
+          let m = List.find (fun m -> m.M.name = n) models in
+          M.ceiling_report ~model:m ~strict)
+        names
+
+let probe_device device =
+  Printf.printf
+    "\n================================================================\n" ;
+  Printf.printf "device: %s\n" (describe device) ;
+  Printf.printf
+    "================================================================\n%!" ;
+
+  (* Controls first. A device number printed before its control is a number
+     nobody can read. *)
+  let _, cb =
+    sweep
+      device
+      ~label:"GREEN CONTROL — volatile __local barrier, two-narrowing shape"
+      ~source:src_barriered
+      ~models:M.shape2_models
+  in
+  let green_ok = List.mem "S_strict" cb.M.exact_matches in
+  if not green_ok then
+    Printf.printf
+      "    *** CONTROL BROKEN: the barriered kernel does not reproduce \
+       S_strict. Nothing below is attributable to ACO. ***\n" ;
+
+  let _, cf =
+    sweep
+      device
+      ~label:"POSITIVE CONTROL — deliberate fusion via twoProd + round-to-odd"
+      ~source:src_fusedctl
+      ~models:M.shape2_models
+  in
+  if not (List.mem "S_fuse_mul_into_narrowing" cf.M.exact_matches) then
+    Printf.printf
+      "    *** CONTROL BROKEN: the deliberate-fusion kernel does not reproduce \
+       S_fuse_mul_into_narrowing element-wise. ***\n" ;
+
+  let _, cb1 =
+    sweep
+      device
+      ~label:"GREEN CONTROL — volatile __local barrier, one-narrowing shape"
+      ~source:src_barriered_one
+      ~models:M.shape1_models
+  in
+  if not (List.mem "S_strict" cb1.M.exact_matches) then
+    Printf.printf "    *** CONTROL BROKEN on the one-narrowing shape. ***\n" ;
+
+  (* The measurements. *)
+  Printf.printf "\n  --- shape: %s ---\n" M.shape1_name ;
+  let _, c1 =
+    sweep
+      device
+      ~label:"plain (naive codegen)"
+      ~source:src_one_narrowing
+      ~models:M.shape1_models
+  in
+  report_ceiling M.shape1_models c1 ;
+
+  Printf.printf "\n  --- shape: %s ---\n" M.shape2_name ;
+  let _, c2 =
+    sweep
+      device
+      ~label:"plain (naive codegen)"
+      ~source:src_plain
+      ~models:M.shape2_models
+  in
+  report_ceiling M.shape2_models c2 ;
+
+  (c1, c2)
+
+let () =
+  let host_only = Array.exists (fun a -> a = "--host-only") Sys.argv in
+  Printf.printf
+    "#62 slice 1(a) — element-wise model agreement, OpenCL / rusticl\n\n" ;
+  (try M.calibrate ()
+   with M.Calibration_failed s ->
+     Printf.printf "CALIBRATION FAILED — read nothing below it:\n  %s\n" s ;
+     exit 1) ;
+  Printf.printf
+    "host calibration PASSED: 63488-value round-trip; the two §1.2 models \
+     separate on exactly 620 (%s) and 2912 (%s); §1.3's x = -907.5 case \
+     reproduces at 1 ulp at the narrowing and 512 ulp on the final value.\n\n"
+    M.shape2_name
+    M.shape1_name ;
+
+  Printf.printf "SHAPE 1 — %s\n" M.shape1_name ;
+  let sep1 = M.separation_matrix M.shape1_models in
+  Printf.printf "\nSHAPE 2 — %s\n" M.shape2_name ;
+  let sep2 = M.separation_matrix M.shape2_models in
+  if not (sep1 && sep2) then
+    Printf.printf
+      "\n\
+       *** at least one model pair coincides on the whole domain — a device \
+       matching one of them is not evidence for either ***\n" ;
+
+  if host_only then exit 0 ;
+
+  let ds = Array.to_list (devices ()) in
+  let in_scope, out_of_scope = List.partition is_in_scope ds in
+  List.iter
+    (fun d -> Printf.printf "\nout of scope: %s\n" (describe d))
+    out_of_scope ;
+  match in_scope with
+  | [] ->
+      Printf.printf
+        "\n\
+         [NO DEVICE] No OpenCL device whose name contains \"ACO\". Saw: %s. \
+         Nothing is measured; this is not a null result.\n"
+        (match ds with
+        | [] -> "no OpenCL devices at all"
+        | l -> String.concat "; " (List.map describe l)) ;
+      exit 2
+  | ds -> List.iter (fun d -> ignore (probe_device d)) ds

--- a/sarek-vulkan/probe/dune
+++ b/sarek-vulkan/probe/dune
@@ -1,0 +1,12 @@
+; #62 slice 1(b) — element-wise model-agreement probe for Vulkan / RADV.
+;
+; An `executable`, not a `test`: it measures a driver to decide whether a
+; contract is deliverable, and a measurement that blocks CI on whatever GPU the
+; runner happens to have is a gate, not a measurement. The gate defending the
+; GLSL f16 refusal is sarek-vulkan/test/test_vulkan_f16_tripwire.ml and is
+; untouched by this directory.
+
+(executable
+ (name probe_vulkan_f16_model_agreement)
+ (modules probe_vulkan_f16_model_agreement)
+ (libraries sarek_vulkan spoc_framework f16_model_set))

--- a/sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml
+++ b/sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml
@@ -1,0 +1,408 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * #62 slice 1(b) — the RADV two-narrowing shape, and the `precise` puzzle.
+ *
+ * THE OPEN RISK THIS EXISTS TO SETTLE.
+ *
+ * docs/design/f16-relaxed-accuracy.md §9.3 names one thing as most likely to
+ * break the relaxed-accuracy design: on f16(f16(x*1.1)+1000), RADV disagrees
+ * with the discipline on 5075/63488 plain and 4776/63488 with `precise`, while
+ * fp-contraction-policy.md §6 shows `precise` producing BYTE-IDENTICAL ISA on
+ * the one-narrowing shape. A decoration that changes the answer on one shape
+ * and changes nothing on another is not obviously one behaviour, and nobody
+ * had reconciled the two facts. If the two-narrowing shape matches NO
+ * closed-form model, §1.2's contract cannot be stated per backend.
+ *
+ * Neither count was ever compared against a model. This probe compares
+ * element-wise against seven named models, on both local RADV devices.
+ *
+ * WHY A PROBE AND NOT A TEST. It measures a driver to decide whether a
+ * contract is deliverable; it does not defend an invariant. The gate defending
+ * the GLSL refusal is sarek-vulkan/test/test_vulkan_f16_tripwire.ml and is
+ * untouched.
+ *
+ * Run:
+ *   dune exec sarek-vulkan/probe/probe_vulkan_f16_model_agreement.exe
+ *   RADV_DEBUG=asm dune exec ... 2> isa.txt     (for the machine-code tier)
+ *
+ * THE shaderFloat16 CAVEAT, inherited verbatim from the tripwire. Sarek's
+ * Vulkan device creation chains no feature structs beyond core
+ * VkPhysicalDeviceFeatures, so the SPIR-V Float16 capability is used without
+ * the feature being enabled; RADV accepts it anyway. That plumbing is §7 slice
+ * 2. It does not weaken the finding — the green control below reproduces
+ * S_strict bit-exactly on the same un-enabled path.
+ ******************************************************************************)
+
+open Sarek_vulkan
+module Device = Vulkan_api_device
+module Memory = Vulkan_api_memory
+module Kernel = Vulkan_api_kernel
+module M = F16_model_set
+
+let n_local = 256
+
+(* Buffers are `uint` holding one binary16 bit pattern in the low 16 bits,
+   rather than 16-bit storage: it keeps VK_KHR_16bit_storage out of the picture
+   so the only 16-bit thing in play is the arithmetic under test. Identical
+   framing to the tripwire, so the counts are comparable to the recorded ones. *)
+let sh ?(prelude = "") body =
+  Printf.sprintf
+    {|#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = %d) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+%s
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+%s
+}
+|}
+    n_local
+    prelude
+    body
+
+(* ---------------------------------------------------------------------- *)
+(* SHAPE 1 — f16(x * 1.1)                                                   *)
+(* ---------------------------------------------------------------------- *)
+
+let s1_plain = sh "  outb[i] = pack(float16_t(x * 1.1));"
+
+let s1_precise =
+  sh "  precise float p = x * 1.1;\n  outb[i] = pack(float16_t(p));"
+
+(* GREEN CONTROL: the f32 product forced through the volatile SSBO, which is
+   the one defence measured to work on this backend. *)
+let s1_barriered =
+  sh
+    "  outb[i] = floatBitsToUint(x * 1.1);\n\
+    \  outb[i] = pack(float16_t(uintBitsToFloat(outb[i])));"
+
+(* ---------------------------------------------------------------------- *)
+(* SHAPE 2 — f16(f16(x * 1.1) + 1000)                                       *)
+(* ---------------------------------------------------------------------- *)
+
+let s2_body ~qual =
+  Printf.sprintf
+    "  %sfloat p = x * 1.1;\n\
+    \  float16_t m = float16_t(p);\n\
+    \  %sfloat q = float(m) + 1000.0;\n\
+    \  outb[i] = pack(float16_t(q));"
+    qual
+    qual
+
+let s2_plain = sh (s2_body ~qual:"")
+
+(* `precise` on every float local is exactly what Sarek_ir_glsl.gen_var_decl
+   already emits, so this variant is the one that matters for the shipped
+   codegen — not the plain one. *)
+let s2_precise = sh (s2_body ~qual:"precise ")
+
+(* GREEN CONTROL: BOTH the f32 intermediates AND the f16 bit pattern forced
+   through the volatile SSBO. Barriering only the f32 intermediates is NOT
+   enough here — ACO responds by dropping the intermediate narrowing entirely
+   (fp-contraction-policy.md §2, 4774/63488), which is why the f16 value has to
+   go through memory too. *)
+let s2_barriered =
+  sh
+    "  outb[i] = floatBitsToUint(x * 1.1);\n\
+    \  outb[i] = pack(float16_t(uintBitsToFloat(outb[i])));\n\
+    \  outb[i] = floatBitsToUint(float(unpackFloat2x16(outb[i]).x) + 1000.0);\n\
+    \  outb[i] = pack(float16_t(uintBitsToFloat(outb[i])));"
+
+(* AMBER CONTROL: barrier the f32 intermediates ONLY. Recorded at 4774/63488,
+   the count this document attributes to a dropped intermediate narrowing —
+   which has never been checked element-wise against that model either. *)
+let s2_barriered_f32_only =
+  sh
+    "  outb[i] = floatBitsToUint(x * 1.1);\n\
+    \  float16_t m = float16_t(uintBitsToFloat(outb[i]));\n\
+    \  outb[i] = floatBitsToUint(float(m) + 1000.0);\n\
+    \  outb[i] = pack(float16_t(uintBitsToFloat(outb[i])));"
+
+(* POSITIVE CONTROL. Deliberately performs the multiply-into-narrowing fusion,
+   so the harness is shown able to report S_fuse_mul_into_narrowing on a shape
+   or a driver that does not fuse on its own. Built without `double` — the
+   exact product is carried as an unevaluated f32 pair via Dekker's twoProd,
+   rounded to odd, then narrowed once. Round-to-odd then round-to-nearest is
+   exact here because binary32 has 24 significand bits, binary16 has 11, and
+   24 >= 2*11 + 2. That holds with no margin, which is why it is stated. *)
+let ro_prelude =
+  {|float exact_prod_ro(float a, float c) {
+  float hi = a * c;
+  float lo = fma(a, c, -hi);
+  if (lo == 0.0) return hi;
+  uint u = floatBitsToUint(hi);
+  if ((u & 1u) == 0u) u = ((lo > 0.0) == (hi > 0.0)) ? u + 1u : u - 1u;
+  return uintBitsToFloat(u);
+}|}
+
+(* The two-narrowing control needs the SSBO barrier as well as the round-to-odd
+   product, and that is a measured requirement rather than caution. Written the
+   obvious way —
+
+     float16_t m = float16_t(exact_prod_ro(x, 1.1));
+     outb[i] = pack(float16_t(float(m) + 1000.0));
+
+   — it does NOT construct S_fuse_mul_into_narrowing on RADV: ACO elides the
+   intermediate narrowing anyway and absorbs the add, so the kernel lands on
+   S_absorb_all_into_final_narrowing (63487/63488, the one straggler being the
+   round-to-odd product's double rounding, which is innocuous into binary16 but
+   not into an f32 add). Measured 2026-07-27 on both local RADV devices. So the
+   f16 bit pattern goes through the volatile SSBO here too: the control is
+   allowed to be expensive, it is not allowed to be defeated. *)
+let s2_fusedctl =
+  sh
+    ~prelude:ro_prelude
+    "  outb[i] = floatBitsToUint(exact_prod_ro(x, 1.1));\n\
+    \  outb[i] = pack(float16_t(uintBitsToFloat(outb[i])));\n\
+    \  outb[i] = floatBitsToUint(float(unpackFloat2x16(outb[i]).x) + 1000.0);\n\
+    \  outb[i] = pack(float16_t(uintBitsToFloat(outb[i])));"
+
+let s1_fusedctl =
+  sh ~prelude:ro_prelude "  outb[i] = pack(float16_t(exact_prod_ro(x, 1.1)));"
+
+(* ---------------------------------------------------------------------- *)
+
+let run device ~source ~inputs =
+  let n = Array.length inputs in
+  let host_in = Bigarray.(Array1.create int32 c_layout n) in
+  Array.iteri (fun i b -> host_in.{i} <- Int32.of_int b) inputs ;
+  let din = Memory.alloc device n Bigarray.int32 in
+  let dout = Memory.alloc device n Bigarray.int32 in
+  Memory.host_to_device ~src:host_in ~dst:din ;
+  let compiled = Kernel.compile device ~name:"main" ~source in
+  let args = Kernel.create_args () in
+  Kernel.set_arg_buffer args 0 dout ;
+  Kernel.set_arg_buffer args 1 din ;
+  let block = Spoc_framework.Framework_sig.dims_1d n_local in
+  let grid = Spoc_framework.Framework_sig.dims_1d (n / n_local) in
+  Kernel.launch compiled ~args ~grid ~block ~shared_mem:0 ~stream:None ;
+  Device.synchronize device ;
+  let host_out = Bigarray.(Array1.create int32 c_layout n) in
+  Memory.device_to_host ~src:dout ~dst:host_out ;
+  Memory.free din ;
+  Memory.free dout ;
+  Array.init n (fun i -> Int32.to_int host_out.{i} land 0xFFFF)
+
+let contains ~needle haystack =
+  let n = String.length needle and h = String.length haystack in
+  let lower = String.lowercase_ascii in
+  let needle = lower needle and haystack = lower haystack in
+  let rec go i =
+    i + n <= h && (String.sub haystack i n = needle || go (i + 1))
+  in
+  n = 0 || go 0
+
+let describe device = device.Device.name
+
+(* Keyed on DRIVER identity, as the tripwire is: RADV compiles with ACO, which
+   is the component that performs the combine. Not on a device model. *)
+let is_in_scope device = contains ~needle:"radv" (describe device)
+
+let devices () =
+  if not (Vulkan_api.is_available ()) then [||]
+  else begin
+    Device.init () ;
+    Array.init (Device.count ()) Device.get
+  end
+
+let strict_of models = List.find (fun m -> m.M.name = "S_strict") models
+
+let sweep device ~label ~source ~models =
+  let got = run device ~source ~inputs:M.finite_bits in
+  let c = M.classify models got in
+  M.print_classification ~label c ;
+  c
+
+let report_ceiling models c =
+  let strict = strict_of models in
+  match c.M.exact_matches with
+  | [] ->
+      Printf.printf
+        "    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no \
+         admitted deviation to measure.\n"
+  | names ->
+      Printf.printf
+        "    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final \
+         value):\n" ;
+      List.iter
+        (fun n ->
+          let m = List.find (fun m -> m.M.name = n) models in
+          M.ceiling_report ~model:m ~strict)
+        names
+
+(* One named variant, one device, one shader compiled — so that
+   `RADV_DEBUG=asm` produces an ISA dump attributable to a single shader. With
+   the full run, several shaders are compiled in sequence and reading the ISA
+   means guessing which dump belongs to which, which is not a machine-code
+   evidence tier. *)
+let variants =
+  [
+    ("s1_plain", (s1_plain, M.shape1_models));
+    ("s1_precise", (s1_precise, M.shape1_models));
+    ("s2_plain", (s2_plain, M.shape2_models));
+    ("s2_precise", (s2_precise, M.shape2_models));
+  ]
+
+let probe_one device name =
+  match List.assoc_opt name variants with
+  | None ->
+      Printf.printf
+        "unknown variant %S; known: %s\n"
+        name
+        (String.concat ", " (List.map fst variants)) ;
+      exit 2
+  | Some (source, models) ->
+      Printf.printf
+        "device: %s\nvariant: %s\nGLSL:\n%s\n"
+        (describe device)
+        name
+        source ;
+      let c = sweep device ~label:name ~source ~models in
+      report_ceiling models c
+
+let probe_device device =
+  Printf.printf
+    "\n================================================================\n" ;
+  Printf.printf "device: %s\n" (describe device) ;
+  Printf.printf
+    "================================================================\n%!" ;
+
+  Printf.printf "\n  --- controls ---\n" ;
+  let cg1 =
+    sweep
+      device
+      ~label:"GREEN CONTROL — f16 bit pattern through the SSBO, one narrowing"
+      ~source:s1_barriered
+      ~models:M.shape1_models
+  in
+  if not (List.mem "S_strict" cg1.M.exact_matches) then
+    Printf.printf
+      "    *** CONTROL BROKEN: nothing below is attributable to ACO ***\n" ;
+  let cg2 =
+    sweep
+      device
+      ~label:"GREEN CONTROL — f16 bit pattern through the SSBO, two narrowings"
+      ~source:s2_barriered
+      ~models:M.shape2_models
+  in
+  if not (List.mem "S_strict" cg2.M.exact_matches) then
+    Printf.printf
+      "    *** CONTROL BROKEN: nothing below is attributable to ACO ***\n" ;
+  let cp1 =
+    sweep
+      device
+      ~label:"POSITIVE CONTROL — deliberate fusion, one narrowing"
+      ~source:s1_fusedctl
+      ~models:M.shape1_models
+  in
+  if not (List.mem "S_fuse_mul_into_narrowing" cp1.M.exact_matches) then
+    Printf.printf
+      "    *** POSITIVE CONTROL did not reproduce the fused model ***\n" ;
+  let cp2 =
+    sweep
+      device
+      ~label:"POSITIVE CONTROL — deliberate fusion, two narrowings"
+      ~source:s2_fusedctl
+      ~models:M.shape2_models
+  in
+  if not (List.mem "S_fuse_mul_into_narrowing" cp2.M.exact_matches) then
+    Printf.printf
+      "    *** POSITIVE CONTROL did not reproduce the fused model ***\n" ;
+
+  Printf.printf "\n  --- shape: %s ---\n" M.shape1_name ;
+  let c =
+    sweep device ~label:"plain" ~source:s1_plain ~models:M.shape1_models
+  in
+  report_ceiling M.shape1_models c ;
+  let c =
+    sweep
+      device
+      ~label:"precise (what Sarek_ir_glsl emits)"
+      ~source:s1_precise
+      ~models:M.shape1_models
+  in
+  report_ceiling M.shape1_models c ;
+
+  Printf.printf "\n  --- shape: %s ---\n" M.shape2_name ;
+  let c =
+    sweep device ~label:"plain" ~source:s2_plain ~models:M.shape2_models
+  in
+  report_ceiling M.shape2_models c ;
+  let c =
+    sweep
+      device
+      ~label:"precise (what Sarek_ir_glsl emits)"
+      ~source:s2_precise
+      ~models:M.shape2_models
+  in
+  report_ceiling M.shape2_models c ;
+  let c =
+    sweep
+      device
+      ~label:"volatile SSBO on the f32 intermediates ONLY"
+      ~source:s2_barriered_f32_only
+      ~models:M.shape2_models
+  in
+  report_ceiling M.shape2_models c
+
+let () =
+  let host_only = Array.exists (fun a -> a = "--host-only") Sys.argv in
+  Printf.printf
+    "#62 slice 1(b) — element-wise model agreement, Vulkan / RADV\n\n" ;
+  (try M.calibrate ()
+   with M.Calibration_failed s ->
+     Printf.printf "CALIBRATION FAILED — read nothing below it:\n  %s\n" s ;
+     exit 1) ;
+  Printf.printf
+    "host calibration PASSED: 63488-value round-trip; the two §1.2 models \
+     separate on exactly 620 (%s) and 2912 (%s); §1.3's x = -907.5 case \
+     reproduces at 1 ulp at the narrowing and 512 ulp on the final value.\n\n"
+    M.shape2_name
+    M.shape1_name ;
+
+  Printf.printf "SHAPE 1 — %s\n" M.shape1_name ;
+  let sep1 = M.separation_matrix M.shape1_models in
+  Printf.printf "\nSHAPE 2 — %s\n" M.shape2_name ;
+  let sep2 = M.separation_matrix M.shape2_models in
+  if not (sep1 && sep2) then
+    Printf.printf
+      "\n\
+       *** at least one model pair coincides on the whole domain — a device \
+       matching one of them is not evidence for either ***\n" ;
+
+  if host_only then exit 0 ;
+
+  let ds = Array.to_list (devices ()) in
+  let in_scope, out_of_scope = List.partition is_in_scope ds in
+  List.iter
+    (fun d -> Printf.printf "\nout of scope: %s\n" (describe d))
+    out_of_scope ;
+  match in_scope with
+  | [] ->
+      Printf.printf
+        "\n\
+         [NO DEVICE] No Vulkan device whose name contains \"RADV\". Saw: %s. \
+         Nothing is measured; this is not a null result.\n"
+        (match ds with
+        | [] -> "no Vulkan devices at all"
+        | l -> String.concat "; " (List.map describe l)) ;
+      exit 2
+  | ds -> (
+      let rec only i =
+        if i + 1 >= Array.length Sys.argv then None
+        else if Sys.argv.(i) = "--variant" then Some Sys.argv.(i + 1)
+        else only (i + 1)
+      in
+      match only 1 with
+      | Some v -> probe_one (List.hd ds) v
+      | None -> List.iter probe_device ds)

--- a/tools/f16_model_set/dune
+++ b/tools/f16_model_set/dune
@@ -1,0 +1,13 @@
+; #62 slice 1 — the named f16 rounding models of
+; docs/design/f16-relaxed-accuracy.md §1.2, as exact host functions.
+;
+; A library rather than a copy in each probe: the two probes that consume it
+; measure two different driver stacks against the SAME model set, and a model
+; set that differs between the two would make the two verdicts incomparable.
+;
+; No dependency on any backend, and no `public_name`: this is measurement
+; machinery for the slice-1 probes, not shipped API.
+
+(library
+ (name f16_model_set)
+ (modules f16_model_set))

--- a/tools/f16_model_set/f16_model_set.ml
+++ b/tools/f16_model_set/f16_model_set.ml
@@ -1,0 +1,579 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * #62 slice 1 — the named f16 rounding models, as host functions.
+ *
+ * WHAT THIS IS.
+ *
+ * docs/design/f16-relaxed-accuracy.md §1.2 does not accept a device result
+ * because it is close to the interpreter's. It accepts it only when it is
+ * BIT-IDENTICAL to one member of a finite set of NAMED, CLOSED-FORM reference
+ * semantics — §0.1 is the argument for why a tolerance cannot work here. This
+ * module is that set, computed exactly on the host, for the two f16 expression
+ * shapes this project has measured on a device.
+ *
+ * It is deliberately NOT [Test_helpers]. §7 slice 0 is the slice that promotes
+ * [ref_discipline] / [ref_fused] into shared test machinery with a
+ * [classify_f16_result] classifier; this module is slice 1's MEASUREMENT
+ * instrument and stays out of the test libraries so that slice 0 is free to
+ * design the classifier without inheriting anything from here.
+ *
+ * WHY THE ARITHMETIC IS NOT JUST OCaml FLOATS.
+ *
+ * Three of the models below round a value to binary16 in a SINGLE step from a
+ * sum that is not exactly representable in binary64. Concretely: the exact
+ * product [x * fl32(1.1)] for a binary16 [x] is an integer multiple of 2^-47
+ * (fl32(1.1) = 9227469 * 2^-23, and x is an integer multiple of 2^-24), while
+ * the addend 1000 reaches 2^9. An exact sum therefore spans up to 2^-47 .. 2^17
+ * — 65 bits — and binary64 has 53. Evaluating [p +. 1000.0] in OCaml would
+ * round FIRST and then the model would be rounding a rounded value, which is a
+ * different function from the one being named. So every single-rounding model
+ * goes through [two_sum], which represents the exact sum as an unevaluated
+ * pair, and through [round_dd], which rounds that pair in one step.
+ *
+ * This matters in exactly the place it is hardest to notice: near a binary16
+ * tie. A double-rounded model and a correctly-rounded one agree everywhere
+ * except on the ties, and the ties are precisely where §1.3's counterexample
+ * (x = -907.5) lives.
+ ******************************************************************************)
+
+(* ------------------------------------------------------------------------ *)
+(* binary64 -> binary32, single correct rounding.                            *)
+(* Valid only when the argument is EXACTLY representable in binary64; every   *)
+(* use below satisfies that and says so.                                      *)
+(* ------------------------------------------------------------------------ *)
+let f32 x = Int32.float_of_bits (Int32.bits_of_float x)
+
+(* ------------------------------------------------------------------------ *)
+(* binary16 decoding. Exact: no rounding is involved, so this cannot itself   *)
+(* be a source of disagreement.                                              *)
+(* ------------------------------------------------------------------------ *)
+let f16_decode b =
+  let sign = if b land 0x8000 <> 0 then -1.0 else 1.0 in
+  let e = (b lsr 10) land 0x1f and m = b land 0x3ff in
+  if e = 31 then None
+  else if e = 0 then Some (sign *. float_of_int m *. ldexp 1.0 (-24))
+  else Some (sign *. float_of_int (1024 + m) *. ldexp 1.0 (e - 25))
+
+let dec b =
+  match f16_decode b with
+  | Some v -> v
+  | None ->
+      if b land 0x3ff <> 0 then Float.nan
+      else if b land 0x8000 <> 0 then Float.neg_infinity
+      else Float.infinity
+
+(* All finite binary16 bit patterns: 63488 of them, so every statement this
+   module supports is exhaustive over the domain rather than sampled. *)
+let finite_bits =
+  let acc = ref [] in
+  for b = 0xFFFF downto 0 do
+    if f16_decode b <> None then acc := b :: !acc
+  done ;
+  Array.of_list !acc
+
+(* ------------------------------------------------------------------------ *)
+(* Exact unevaluated sums.                                                    *)
+(* ------------------------------------------------------------------------ *)
+
+(* Knuth's twoSum: [a +. b] is EXACTLY [s +. e], with no assumption about the
+   relative magnitudes of [a] and [b]. Both outputs are binary64 values, so the
+   pair is an exact representation of a sum that binary64 alone cannot hold. *)
+let two_sum a b =
+  let s = a +. b in
+  let bb = s -. a in
+  let err = a -. (s -. bb) +. (b -. bb) in
+  (s, err)
+
+(* Round the exact value [s + e] to a binary format with [prec] significand
+   bits whose smallest subnormal is 2^[emin_sub], returning the result as a
+   binary64 (exact, since [prec] <= 24 here).
+
+   The residual [e] can only ever matter at an exact tie. |e| <= ulp64(s)/2,
+   and the rescaling below puts the target's ulp at 1, so the rescaled residual
+   is at most 2^-30 for prec = 24 and 2^-43 for prec = 11, while the rescaled
+   [s] is a multiple of at least 2^-29 / 2^-42 respectively. A non-tie fraction
+   is therefore at least one rescaled-ulp away from 0.5 and the residual cannot
+   push it across; a tie is exactly 0.5 and the residual decides. That argument
+   is the whole reason this function exists instead of [s +. e]. *)
+let round_dd ~prec ~emin_sub (s, e) =
+  if Float.is_nan s || Float.is_nan e then Float.nan
+  else if s = 0.0 then e
+  else if Float.abs s = Float.infinity then s
+  else begin
+    let neg = s < 0.0 in
+    let a = Float.abs s in
+    (* sign of the residual RELATIVE TO THE MAGNITUDE of s *)
+    let sticky = if e = 0.0 then 0 else if s > 0.0 = (e > 0.0) then 1 else -1 in
+    let ex = snd (Float.frexp a) - 1 in
+    let ulp_exp = max (ex - prec + 1) emin_sub in
+    let v = a /. ldexp 1.0 ulp_exp in
+    let f = Float.floor v in
+    let r = v -. f in
+    let q =
+      if r > 0.5 then f +. 1.0
+      else if r < 0.5 then f
+      else if sticky > 0 then f +. 1.0
+      else if sticky < 0 then f
+      else if Float.rem f 2.0 = 0.0 then f
+      else f +. 1.0
+    in
+    let m = ldexp 1.0 prec in
+    let q, ulp_exp = if q >= m then (q /. 2.0, ulp_exp + 1) else (q, ulp_exp) in
+    let out = q *. ldexp 1.0 ulp_exp in
+    if neg then -.out else out
+  end
+
+(* ------------------------------------------------------------------------ *)
+(* binary16 encoding of an exactly-representable binary64.                    *)
+(* Ported verbatim from sarek-vulkan/test/test_vulkan_f16_tripwire.ml so the   *)
+(* 620 calibration below is comparing against the same function the shipped    *)
+(* tripwires already calibrate.                                               *)
+(* ------------------------------------------------------------------------ *)
+let round_even v =
+  let f = Float.floor v in
+  let r = v -. f in
+  if r > 0.5 then f +. 1.0
+  else if r < 0.5 then f
+  else if Float.rem f 2.0 = 0.0 then f
+  else f +. 1.0
+
+let f16_bits d =
+  if Float.is_nan d then 0x7E00
+  else
+    let s = if d < 0.0 || (d = 0.0 && 1.0 /. d < 0.0) then 0x8000 else 0 in
+    let a = Float.abs d in
+    if a = Float.infinity then s lor 0x7C00
+    else if a = 0.0 then s
+    else
+      let e = snd (Float.frexp a) - 1 in
+      if e < -14 then s lor int_of_float (round_even (a /. ldexp 1.0 (-24)))
+      else
+        let q = round_even (a /. ldexp 1.0 (e - 10)) in
+        let e, q = if q >= 2048.0 then (e + 1, 1024.0) else (e, q) in
+        if e + 15 >= 31 then s lor 0x7C00
+        else s lor ((e + 15) lsl 10) lor (int_of_float q - 1024)
+
+(* Single-rounding narrowing of the exact sum [a + b] to binary16. *)
+let f16_of_exact_sum a b =
+  f16_bits (round_dd ~prec:11 ~emin_sub:(-24) (two_sum a b))
+
+(* Single-rounding narrowing of the exact sum [a + b] to binary32. *)
+let f32_of_exact_sum a b = round_dd ~prec:24 ~emin_sub:(-149) (two_sum a b)
+
+(* Spacing of binary16 at [v]; the denominator §1.3's ceiling is measured in.
+   Subnormals use the absolute 2^-24 spacing, exactly as §1.3 prescribes. *)
+let ulp16 v =
+  let a = Float.abs v in
+  if a = 0.0 then ldexp 1.0 (-24)
+  else
+    let e = snd (Float.frexp a) - 1 in
+    if e < -14 then ldexp 1.0 (-24) else ldexp 1.0 (e - 10)
+
+(* ------------------------------------------------------------------------ *)
+(* The constant, and the two exact intermediates every model is built from.   *)
+(* ------------------------------------------------------------------------ *)
+
+let c11 = f32 1.1
+
+(* The EXACT product x * fl32(1.1). A binary16 significand (11 bits) times a
+   binary32 one (24 bits) needs at most 35 bits, so this multiplication is
+   exact in binary64 and is not a rounding. *)
+let p_exact b = dec b *. c11
+
+(* The same product rounded to binary32, i.e. what the DSL mandates the
+   multiply produce. *)
+let p32 b = f32 (p_exact b)
+
+(* ------------------------------------------------------------------------ *)
+(* SHAPE 1 — f16(x * 1.1). One narrowing.                                     *)
+(* ------------------------------------------------------------------------ *)
+
+let s1_strict b = f16_bits (p32 b)
+
+let s1_fuse_mul b = f16_bits (p_exact b)
+
+(* ------------------------------------------------------------------------ *)
+(* SHAPE 2 — f16(f16(x * 1.1) + 1000). Two narrowings.                        *)
+(*                                                                            *)
+(* The models are named for WHICH mandated rounding they elide, because that   *)
+(* is what §1.2 requires a member of the admissible set to be: a named,        *)
+(* closed-form function, not "whatever the device did".                        *)
+(*                                                                            *)
+(* [dec m +. 1000.0] where m is a binary16 value is EXACT in binary64 (m's     *)
+(* lowest bit is at worst 2^-24 and 1000's highest is 2^9, so 34 bits), which  *)
+(* is why the two-rounding models can use plain [f32 (... +. 1000.0)] while    *)
+(* the single-rounding ones cannot.                                           *)
+(* ------------------------------------------------------------------------ *)
+
+(* Every mandated rounding performed. The interpreter. *)
+let s2_strict b =
+  let m = f16_bits (p32 b) in
+  f16_bits (f32 (dec m +. 1000.0))
+
+(* S_fuse_mul_into_narrowing: the f32 multiply is absorbed into the f16
+   narrowing that consumes it. The binary32 rounding of the product is elided;
+   the intermediate binary16 value still exists. This is the model measured on
+   hiprtc/gfx1100 and rusticl/radeonsi at 620/63488. *)
+let s2_fuse_mul b =
+  let m = f16_bits (p_exact b) in
+  f16_bits (f32 (dec m +. 1000.0))
+
+(* Everything absorbed into the final narrowing: one rounding for an expression
+   the DSL says has four. This is the shape of a single v_fma_mixlo_f16 that
+   takes x, 1.1 and 1000 as its three operands. *)
+let s2_absorb_all b = f16_of_exact_sum (p_exact b) 1000.0
+
+(* The multiply keeps its own binary32 rounding — what a honoured
+   NoContraction on the OpFMul buys — but the intermediate binary16 narrowing
+   and the binary32 add are both absorbed into the final narrowing. *)
+let s2_absorb_add b = f16_of_exact_sum (p32 b) 1000.0
+
+(* The intermediate binary16 narrowing is dropped outright and the add is still
+   rounded to binary32: the IGC defect signature of fp-contraction-policy.md
+   §11.4, and the model the volatile-SSBO RADV variant matched at 4774/63488. *)
+let s2_drop_inner b = f16_bits (f32_of_exact_sum (p32 b) 1000.0)
+
+(* The multiply is absorbed into the intermediate narrowing AND the add is
+   absorbed into the final one. *)
+let s2_fuse_mul_absorb_add b =
+  f16_of_exact_sum (dec (f16_bits (p_exact b))) 1000.0
+
+(* Only the add is absorbed into the final narrowing; the multiply and the
+   intermediate narrowing are both as the DSL mandates. *)
+let s2_strict_absorb_add b = f16_of_exact_sum (dec (f16_bits (p32 b))) 1000.0
+
+(* ------------------------------------------------------------------------ *)
+(* The model sets, as data.                                                   *)
+(* ------------------------------------------------------------------------ *)
+
+type model = {
+  name : string;
+  descr : string;
+  result : int -> int;
+      (** binary16 bit pattern produced for input bit pattern [b] *)
+  at_inner_narrowing : (int -> float) option;
+      (** The exact real value this model presents at the position where
+          S_strict materialises its intermediate binary16 value — i.e. the value
+          that reaches the rest of the expression in place of the mandated one.
+          §1.3's ceiling is evaluated HERE and not on the final value. [None]
+          means the model materialises nothing comparable there and the ceiling
+          is NOT APPLICABLE, which §1.3 requires be reported as such rather than
+          silently evaluated on the final value. *)
+}
+
+let shape1_name = "f16(x * 1.1)"
+
+let shape1_models =
+  [
+    {
+      name = "S_strict";
+      descr = "every mandated rounding performed (the interpreter)";
+      result = s1_strict;
+      at_inner_narrowing = Some (fun b -> dec (s1_strict b));
+    };
+    {
+      name = "S_fuse_mul_into_narrowing";
+      descr = "the f32 multiply absorbed into the f32->f16 narrowing";
+      result = s1_fuse_mul;
+      at_inner_narrowing = Some (fun b -> dec (s1_fuse_mul b));
+    };
+  ]
+
+let shape2_name = "f16(f16(x * 1.1) + 1000)"
+
+let shape2_models =
+  [
+    {
+      name = "S_strict";
+      descr = "every mandated rounding performed (the interpreter)";
+      result = s2_strict;
+      at_inner_narrowing = Some (fun b -> dec (f16_bits (p32 b)));
+    };
+    {
+      name = "S_fuse_mul_into_narrowing";
+      descr = "f32 multiply absorbed into the intermediate narrowing";
+      result = s2_fuse_mul;
+      at_inner_narrowing = Some (fun b -> dec (f16_bits (p_exact b)));
+    };
+    {
+      name = "S_absorb_all_into_final_narrowing";
+      descr =
+        "multiply, intermediate narrowing and add all absorbed: one rounding";
+      result = s2_absorb_all;
+      at_inner_narrowing = Some p_exact;
+    };
+    {
+      name = "S_f32_mul_then_absorb_add";
+      descr =
+        "multiply rounded to f32; intermediate narrowing and add absorbed into \
+         the final narrowing";
+      result = s2_absorb_add;
+      at_inner_narrowing = Some p32;
+    };
+    {
+      name = "S_drop_intermediate_narrowing";
+      descr =
+        "intermediate binary16 narrowing dropped, add still rounded to f32 \
+         (the IGC signature)";
+      result = s2_drop_inner;
+      at_inner_narrowing = Some p32;
+    };
+    {
+      name = "S_fuse_mul_and_absorb_add";
+      descr =
+        "multiply absorbed into the intermediate narrowing, add absorbed into \
+         the final one";
+      result = s2_fuse_mul_absorb_add;
+      at_inner_narrowing = Some (fun b -> dec (f16_bits (p_exact b)));
+    };
+    {
+      name = "S_strict_mul_absorb_add";
+      descr = "only the add absorbed into the final narrowing";
+      result = s2_strict_absorb_add;
+      at_inner_narrowing = Some (fun b -> dec (f16_bits (p32 b)));
+    };
+  ]
+
+(* ------------------------------------------------------------------------ *)
+(* CALIBRATION — run before any device number is printed.                     *)
+(* ------------------------------------------------------------------------ *)
+
+exception Calibration_failed of string
+
+let failf fmt = Printf.ksprintf (fun s -> raise (Calibration_failed s)) fmt
+
+(* 1. The encoder must round-trip the whole domain. *)
+let check_round_trip () =
+  Array.iter
+    (fun b ->
+      if f16_bits (dec b) <> b then
+        failf
+          "host binary16 rounding is wrong: re-encoding the exact value of \
+           0x%04X gives 0x%04X"
+          b
+          (f16_bits (dec b)))
+    finite_bits ;
+  if Array.length finite_bits <> 63488 then
+    failf
+      "expected 63488 finite binary16 inputs, enumerated %d"
+      (Array.length finite_bits)
+
+(* 2. The two models §1.2 names must separate on exactly the independently
+   measured 620 — the figure reproduced on hiprtc/gfx1100, rusticl/radeonsi,
+   the OpenCL fusedctl control on Intel Arc and the Metal round-to-odd control
+   on an M4. Reproducing a known positive is what licenses believing the rest. *)
+let check_620 () =
+  let n = ref 0 in
+  Array.iter (fun b -> if s2_strict b <> s2_fuse_mul b then incr n) finite_bits ;
+  if !n <> 620 then
+    failf
+      "CALIBRATION FAILED: S_strict and S_fuse_mul_into_narrowing separate on \
+       %d of %d inputs on %s. It must be 620."
+      !n
+      (Array.length finite_bits)
+      shape2_name
+
+(* 3. Shape 1's two models must separate on exactly 2912, the figure RADV
+   reports against the discipline on that shape. *)
+let check_2912 () =
+  let n = ref 0 in
+  Array.iter (fun b -> if s1_strict b <> s1_fuse_mul b then incr n) finite_bits ;
+  if !n <> 2912 then
+    failf
+      "CALIBRATION FAILED: S_strict and S_fuse_mul_into_narrowing separate on \
+       %d of %d inputs on %s. It must be 2912."
+      !n
+      (Array.length finite_bits)
+      shape1_name
+
+(* 4. §1.3's counterexample, host-only. At x = -907.5 the two models differ by
+   exactly 1 ulp AT THE INTERMEDIATE NARROWING and by 512 ulp on the FINAL
+   value. A ceiling evaluated on the final value rejects a result the admitted
+   model produces; this check pins that the models really do reproduce the
+   case, so the ceiling numbers printed later are measuring something. *)
+let check_907_5 () =
+  let b = f16_bits (-907.5) in
+  if dec b <> -907.5 then
+    failf
+      "x = -907.5 is not exactly representable in binary16 (got %.9g)"
+      (dec b) ;
+  let strict_inner = dec (f16_bits (p32 b)) in
+  let fused_inner = dec (f16_bits (p_exact b)) in
+  if strict_inner <> -998.0 || fused_inner <> -998.5 then
+    failf
+      "§1.3's counterexample does not reproduce: intermediate is %.9g strict / \
+       %.9g fused, expected -998 / -998.5"
+      strict_inner
+      fused_inner ;
+  let strict_final = dec (s2_strict b) and fused_final = dec (s2_fuse_mul b) in
+  if strict_final <> 2.0 || fused_final <> 1.5 then
+    failf
+      "§1.3's counterexample does not reproduce: final is %.9g strict / %.9g \
+       fused, expected 2.0 / 1.5"
+      strict_final
+      fused_final ;
+  let inner_ulp =
+    Float.abs (fused_inner -. strict_inner) /. ulp16 strict_inner
+  in
+  let final_ulp =
+    Float.abs (fused_final -. strict_final) /. ulp16 fused_final
+  in
+  if inner_ulp <> 1.0 then
+    failf "§1.3: expected 1 ulp at the narrowing, computed %.9g" inner_ulp ;
+  if final_ulp <> 512.0 then
+    failf "§1.3: expected 512 ulp on the final value, computed %.9g" final_ulp
+
+let calibrate () =
+  check_round_trip () ;
+  check_620 () ;
+  check_2912 () ;
+  check_907_5 ()
+
+(* ------------------------------------------------------------------------ *)
+(* Reporting                                                                  *)
+(* ------------------------------------------------------------------------ *)
+
+(* The trap this guards: a model set whose members happen to coincide on the
+   swept inputs reports "exact agreement" while discriminating nothing. Over
+   the finite binary16 domain the separation is a fixed, checkable number, so
+   it is printed and any zero is called out. *)
+let separation_matrix models =
+  Printf.printf "  pairwise model separation (inputs where the two differ):\n" ;
+  let arr = Array.of_list models in
+  let n = Array.length arr in
+  let coincident = ref [] in
+  for i = 0 to n - 1 do
+    for j = i + 1 to n - 1 do
+      let c = ref 0 in
+      Array.iter
+        (fun b -> if arr.(i).result b <> arr.(j).result b then incr c)
+        finite_bits ;
+      Printf.printf "    %-34s vs %-34s : %6d\n" arr.(i).name arr.(j).name !c ;
+      if !c = 0 then coincident := (arr.(i).name, arr.(j).name) :: !coincident
+    done
+  done ;
+  (match !coincident with
+  | [] -> ()
+  | l ->
+      List.iter
+        (fun (a, b) ->
+          Printf.printf
+            "    *** %s and %s COINCIDE on the whole domain: a device matching \
+             one matches the other, and the pair discriminates nothing ***\n"
+            a
+            b)
+        l) ;
+  !coincident = []
+
+(* Element-wise classification of a device result against the model set. *)
+type classification = {
+  per_model : (string * int) list;  (** model name -> disagreement count *)
+  exact_matches : string list;  (** models agreeing on ALL 63488 *)
+  unexplained : int;  (** inputs matching NO model *)
+  first_unexplained : int;  (** index into [finite_bits], or -1 *)
+}
+
+let classify models device =
+  let per_model =
+    List.map
+      (fun m ->
+        let c = ref 0 in
+        Array.iteri
+          (fun i b -> if device.(i) <> m.result b then incr c)
+          finite_bits ;
+        (m.name, !c))
+      models
+  in
+  let unexplained = ref 0 and first = ref (-1) in
+  Array.iteri
+    (fun i b ->
+      if not (List.exists (fun m -> device.(i) = m.result b) models) then begin
+        incr unexplained ;
+        if !first < 0 then first := i
+      end)
+    finite_bits ;
+  {
+    per_model;
+    exact_matches =
+      List.filter_map (fun (n, c) -> if c = 0 then Some n else None) per_model;
+    unexplained = !unexplained;
+    first_unexplained = !first;
+  }
+
+let print_classification ~label c =
+  Printf.printf "  %s\n" label ;
+  List.iter
+    (fun (n, d) ->
+      Printf.printf
+        "    %-34s : %6d / %d disagreements%s\n"
+        n
+        d
+        (Array.length finite_bits)
+        (if d = 0 then "   <== EXACT, element-wise" else ""))
+    c.per_model ;
+  if c.unexplained = 0 then
+    Printf.printf
+      "    every input matches at least one named model (0 unexplained)\n"
+  else begin
+    let b = finite_bits.(c.first_unexplained) in
+    Printf.printf
+      "    *** %d inputs match NO named model; first at x = %.9g (0x%04X) ***\n"
+      c.unexplained
+      (dec b)
+      b
+  end
+
+(* §1.3's ceiling, evaluated AT THE NARROWING WHERE THE ROUNDING WAS ELIDED.
+   Both denominators are reported because §1.3 requires a gate to name which
+   value it measures the ulp against. The final-value figure is printed
+   alongside solely to show what the pre-correction formulation would have
+   produced. *)
+let ceiling_report ~model ~strict =
+  match (model.at_inner_narrowing, strict.at_inner_narrowing) with
+  | None, _ | _, None ->
+      Printf.printf
+        "    %-34s : ceiling NOT APPLICABLE — the model materialises no value \
+         at the elided narrowing\n"
+        model.name
+  | Some vm, Some vs ->
+      let worst_vs = ref 0.0
+      and worst_vm = ref 0.0
+      and worst_final = ref 0.0
+      and over = ref 0
+      and worst_b = ref (-1) in
+      Array.iter
+        (fun b ->
+          let a = vs b and c = vm b in
+          if Float.is_finite a && Float.is_finite c then begin
+            let d = Float.abs (c -. a) in
+            let u_vs = d /. ulp16 a and u_vm = d /. ulp16 c in
+            if u_vs > !worst_vs then begin
+              worst_vs := u_vs ;
+              worst_b := b
+            end ;
+            if u_vm > !worst_vm then worst_vm := u_vm ;
+            if u_vs > 1.0 && u_vm > 1.0 then incr over
+          end ;
+          let fa = dec (strict.result b) and fc = dec (model.result b) in
+          if Float.is_finite fa && Float.is_finite fc then begin
+            let df = Float.abs (fc -. fa) in
+            let u =
+              df /. ulp16 (if Float.abs fa < Float.abs fc then fa else fc)
+            in
+            if u > !worst_final then worst_final := u
+          end)
+        finite_bits ;
+      Printf.printf
+        "    %-34s : at the elided narrowing, worst = %.6g ulp (denominator: \
+         S_strict's value there) / %.6g ulp (denominator: the model's own \
+         value there); %d inputs exceed 1 ulp under BOTH denominators. On the \
+         FINAL value the same deviation reaches %.6g ulp.\n"
+        model.name
+        !worst_vs
+        !worst_vm
+        !over
+        !worst_final


### PR DESCRIPTION
## #62 slice 1 — the decision point, and both stacks are admissible

`docs/design/f16-relaxed-accuracy.md` §7 structures slice 1 as a **decision point**: it settles whether §1.2's contract — *exact* agreement with a named closed-form model, element-wise, not a tolerance — is deliverable at all on the two candidate stacks. It has run.

**Both candidates met the rule, on the two shapes this project has device numbers for.** Every kernel variant is bit-identical to exactly one named model on **63488 / 63488** finite binary16 inputs, on **both** local devices per stack, with **zero** inputs matching no model.

| stack | shape / variant | model | agreement |
|---|---|---|---|
| rusticl/radeonsi | `f16(x*1.1)` | `S_fuse_mul_into_narrowing` | 63488 / 63488 |
| rusticl/radeonsi | `f16(f16(x*1.1)+1000)` | `S_fuse_mul_into_narrowing` | 63488 / 63488 |
| RADV | `f16(x*1.1)`, plain **and** `precise` | `S_fuse_mul_into_narrowing` | 63488 / 63488 |
| RADV | `f16(f16(x*1.1)+1000)`, plain | `S_absorb_all_into_final_narrowing` | 63488 / 63488 |
| RADV | `f16(f16(x*1.1)+1000)`, `precise` | `S_f32_mul_then_absorb_add` | 63488 / 63488 |

Executed on **rusticl/radeonsi, Mesa 26.1.4-arch3.1, DRM 3.64, kernel 7.1.2-3-cachyos** and on **RADV, Mesa 26.1.4-arch3.1, Vulkan 1.4.354**, each on `AMD Radeon RX 7900 XTX (NAVI31)` and the `AMD Ryzen 9 7950X` Raphael iGPU (`RAPHAEL_MENDOCINO`). Identical results on both devices of each pair.

### (a) rusticl — count-agreement upgraded to element-wise

§2 recorded 620/63488 with agreement established only as a *count and a first divergence*. That is not §1.2's bar, and two functions can differ from a third on the same 620 inputs without being the same function. They are the same function: **0/63488 against `S_fuse_mul_into_narrowing`**, on both devices.

The one-narrowing shape had never been swept on rusticl. It reports **2912/63488** against the discipline — the same figure and the same model as RADV. The two ACO front ends agree on both shapes.

### (b) RADV — §9.3's open risk is CLOSED

The design named this the thing most likely to break it: 5075 plain against 4776 with `precise`, while §6 shows `precise` producing byte-identical ISA on the one-narrowing shape.

**Both facts, one mechanism.** `NoContraction` forbids contracting a multiply into an **addition**. It cannot reach a **conversion** absorbing its operand. `f16(x*1.1)` contains no addition, so the decoration binds nothing and the ISA is byte-identical. `f16(f16(x*1.1)+1000)` contains one — once ACO has elided the intermediate narrowing — so the decoration **binds**, and the model changes.

At **machine-code tier** (`RADV_DEBUG=asm`, one shader per process so each dump is attributable):

```
s2_plain    v_fma_mixlo_f16 v2, 0xcccd, v1, s1          <- ONE instruction: x, 1.1, 1000
s2_precise  v_fma_mix_f32   v1, 0xcccd, v1, neg(0)      <- multiply survives, correctly rounded
            v_fma_mixlo_f16 v2, 1.0,    v1, 0x63d0      <- 0x63d0 is binary16 1000.0
```

**RADV has not been observed violating `NoContraction`.** `fp-contraction-policy.md` §6 said "ignored"; the right word is *inapplicable*, and §6 is amended in place rather than rewritten. The practical conclusion is unchanged and firmer: `precise` is not enough to make f16 safe here, because it constrains one of the two combines in play.

### What it costs the contract

Not the per-shape degradation §9.3 feared — §1.2's model set was always keyed on *(backend, driver, expression shape)*, and the fear was a shape matching **no** model. What it does cost: **`S_fuse_mul_into_narrowing` alone does not cover RADV.** §1.2 gains two members, and which one is in force depends on whether the codegen emits `precise` — it does, so `S_f32_mul_then_absorb_add` is the model the shipped codegen would run under.

One function is named and **deliberately not admitted**: `S_drop_intermediate_narrowing`, the IGC defect of §11.4 — which slice 1 found is also reachable *exactly* on RADV by barriering the f32 intermediates alone. Same closed-form function, plain defect on one stack, on-demand behaviour on another, sitting at 1 ulp like everything else. The only instrument keeping it out is that it is not on the list. §0.1 argued a tolerance could not separate those; this is that argument as a measurement.

### §1.3's ceiling, applied

Evaluated **at the elided narrowing**, both denominators computed and printed because §1.3 requires a gate to name one:

| stack / shape | at the elided narrowing | over 1 ulp | on the **final** value |
|---|---|---|---|
| rusticl, `f16(f16(x*1.1)+1000)` | 1 ulp | 0 | **512 ulp** |
| RADV, plain | 0.500044 ulp | 0 | **1.68e+06 ulp** |
| RADV, `precise` | 0.5 ulp | 0 | **1.68e+06 ulp** |

The correction was derived from one Metal counterexample. It is now reproduced on 63488 inputs on a second vendor, on models it was not derived from. A final-value ceiling would reject correct results from admitted models on **every** ACO stack.

### Verification

Prove a check can fail before trusting that it passed:

- **Host calibration, before any device number is read** — 63488-value encoder round-trip; the §1.2 models separate on exactly **620** and **2912**; §1.3's `x = -907.5` reproduces at 1 ulp at the narrowing and 512 on the final value. The full **pairwise separation matrix** is printed, which is the guard against a model set whose members coincide and discriminate nothing. Three of its entries are 5075, 4776 and 4774 — §2's recorded RADV counts, reproduced by closed-form host functions before a device was touched. It also surfaces a thin pair: `S_f32_mul_then_absorb_add` and `S_drop_intermediate_narrowing` separate on only **2** inputs.
- **Green controls** — barriered kernels reproduce `S_strict` on 63488/63488, both shapes, both stacks.
- **Positive controls** — deliberate-fusion kernels reproduce `S_fuse_mul_into_narrowing` on 63488/63488.

Two traps hit and fixed rather than avoided:

1. The `double`-based `fusedctl` of `tools/probes/opencl_f16_contraction_probe.c` **does not build on rusticl** — no `cl_khr_fp64`. Rebuilt on an unevaluated f32 pair (Dekker `twoProd`) with a round-to-odd step, the construction MSL forced on the Metal probe. Exact because 24 ≥ 2·11 + 2, with no margin.
2. **ACO defeats the obvious two-narrowing positive control**: a round-to-odd product narrowed and then added to 1000 is re-absorbed, landing on `S_absorb_all_into_final_narrowing` (63487/63488) instead of the fused model. The working control pushes the f16 bit pattern through the SSBO too. Caught only because it reported the *wrong model* rather than a plausible number — a count-only harness would have shrugged.

Model arithmetic is not ordinary OCaml floats, and that is load-bearing: the exact product is a multiple of `2^-47` and the addend reaches `2^9`, so the exact sum spans 65 bits against binary64's 53. Evaluating `p +. 1000.0` would round first and make the model a *different function* — differing exactly at the binary16 ties, which is where §1.3's counterexample lives. Every single-rounding model goes through `two_sum` and a single-step rounding.

### What is NOT settled

- **18 of the 20 emittable shapes.** `amdgpu-f16-fusion-shape-audit.md` enumerates 20; this swept 2. The rest are `Unknown` and stay refused under §1.5. **Slice 3 must not lift a refusal past what a model has been measured for.**
- **One constant, one addend** (`1.1`, `1000`) — chosen so counts stay comparable to every prior measurement, but the models are confirmed against one operand pattern.
- **A single generative rule** — *a narrowing absorbs the whole f32 tree feeding it, cut where `NoContraction` forbids a multiply-add* — produces all five results and would collapse the per-shape table to a per-driver one. Recorded as **unverified** at that scope; the remaining 18 shapes are what would confirm or break it.
- **Sarek-generated shaders.** Both probes compile hand-written kernels, so they measure the driver, exactly as §7(c) says of the GLSL tripwire.
- **Determinism.** §1.4(b) holds incidentally — several separate processes gave bit-identical counts. §1.4(a)'s in-process repeat and the dispatch-shape variation were not run.

### Changes

- `tools/f16_model_set/` — the named model set as exact host functions, shared so both stacks are measured against the *same* set.
- `sarek-opencl/probe/`, `sarek-vulkan/probe/` — two probe **executables**. Deliberately not `(test)` stanzas: they measure a driver to decide whether a contract is deliverable, and would otherwise block CI on whatever GPU a runner has. **Both tripwires are untouched.**
- `docs/fp-contraction-policy.md` — new **§12** (the measurement record), §2 rusticl and RADV rows upgraded, §6 amended on "ignored" vs "inapplicable".
- `docs/design/f16-relaxed-accuracy.md` — §1.2 gains two admitted members and one named refusal; §2 verdicts; §7 slice 1 outcome; **§9.3 closed**.
- `docs/measurements/f16-slice1-2026-07-27/` — preserved run output and the ISA dumps.

`dune build @fmt` clean. `dune test --force`: **1644 cases across 112 suites, 0 FAIL, 23 SKIP** (via `scripts/test-suite-counts.sh`). No test stanzas added, so the count is unchanged by construction.

**No refusal is lifted by this change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
