### PR TITLE
chore(scripts): make the suite counter fail on an empty log (backlog-150)

### DIFF
--- a/scripts/test-suite-counts.sh
+++ b/scripts/test-suite-counts.sh
@@ -36,9 +36,10 @@
 # Verified by removing the gate from test_ptx_stride_spike and re-running: the
 # suite reported "1 failure! in 0.000s. 1 test run." (cuInit, no driver), which
 # is the positive control -- a suite with no registered cases could not have
-# gone red. The 4 accounts for exactly the 23 SKIPs' worth of CUDA-less
-# hardware on the machine that produced the log, and it is expected to be 0 on
-# a runner with a CUDA device.
+# gone red. Between them the four register FIVE cases, so they account for 5 of
+# the 23 SKIPs on the machine that produced the log; the other 18 come from
+# suites that also ran real cases and so are not zero-case. All four are
+# expected to report cases on a runner with a CUDA device.
 #
 # This is NOT the defect this repo has seen before, where a `Printf` "[SKIP]"
 # was swallowed by Alcotest's stdout capture and the case rendered [OK]. These

--- a/scripts/test-suite-counts.sh
+++ b/scripts/test-suite-counts.sh
@@ -22,25 +22,153 @@
 # run nothing is the "gate that cannot fail" shape: usually legitimate
 # hardware gating, but never something to discover by accident.
 #
+# THE FOUR ZERO-CASE SUITES, RESOLVED (backlog-150)
+#
+# `zero-case suites: 4` has appeared in this output on every branch since the
+# script was written, and had never been run down. They are ptx_stride_spike,
+# ptx_atomics_probe, ptx_mma_probe (one case each) and cuda_f16_sass (two).
+# All four are genuine hardware gates, not inert suites: each registers real
+# Alcotest cases and calls `Alcotest.skip ()` when `Cuda_api.is_driver_available
+# ()` is false or no ptxas is present. Alcotest's "N tests run" counts only
+# cases that actually EXECUTED, so an all-skipped suite reports 0 -- compare
+# ptx_external in the same run, 1 OK + 1 SKIP, which reports "1 test run.".
+#
+# Verified by removing the gate from test_ptx_stride_spike and re-running: the
+# suite reported "1 failure! in 0.000s. 1 test run." (cuInit, no driver), which
+# is the positive control -- a suite with no registered cases could not have
+# gone red. The 4 accounts for exactly the 23 SKIPs' worth of CUDA-less
+# hardware on the machine that produced the log, and it is expected to be 0 on
+# a runner with a CUDA device.
+#
+# This is NOT the defect this repo has seen before, where a `Printf` "[SKIP]"
+# was swallowed by Alcotest's stdout capture and the case rendered [OK]. These
+# four print a [SKIP] line AND return skip status to the runner, which is why
+# they show as [SKIP] rather than [OK]. test_ptx_mma_probe.ml:166-169 documents
+# that distinction at the call site.
+#
+# AND IT REFUSES TO ANSWER FROM NOTHING (backlog-150)
+#
+# The version of this script that shipped with the paragraphs above accepted an
+# empty log and printed "0 cases / 0 FAIL / 0 SKIP", exit 0. A fully-cached
+# `dune test` (no --force) produces exactly that: no output at all. So did a
+# log truncated before the first suite finished, and so did a file that was not
+# a test log in the first place. Every one of them rendered as a green run.
+#
+# That is the "gate given nothing to check" shape -- in the instrument this
+# repo uses to audit its other gates, which makes it worse than an ordinary
+# one. The whole argument above is that "0 FAIL out of N" is only as
+# trustworthy as N; an N of zero is not a small N, it is the absence of a
+# measurement, and it must not be reported in the same shape as a result.
+#
+# So: a log with no recognisable suite epilogue is a USAGE ERROR (exit 2) and
+# prints no counts at all. Given-but-empty is never a fallback.
+#
+# There is also a plausibility floor. A run of this repository that reports a
+# handful of suites is a caching or invocation problem, not a result -- the
+# whole tree is ~112 suites, and the failure mode is partial caching, which
+# yields a plausible-looking-but-wrong number rather than nothing. Below
+# --min-suites (default 10) the counts are printed *and* the exit is 3, so the
+# caller sees what was parsed and is still told not to quote it.
+#
 # Usage:
-#   scripts/test-suite-counts.sh <logfile>   # parse an existing log
-#   dune test --force 2>&1 | scripts/test-suite-counts.sh   # or a pipe
+#   scripts/test-suite-counts.sh [--min-suites N] <logfile>
+#   dune test --force 2>&1 | scripts/test-suite-counts.sh [--min-suites N]
+#
+#   --min-suites N   floor below which a total is treated as an invocation
+#                    problem (exit 3). 0 disables the floor; use it when
+#                    counting a deliberately small log, as the covering test
+#                    does.
+#
+# Exit codes:
+#   0  counts printed and trustworthy
+#   2  usage error: no such file, no recognisable test output, or a log format
+#      this script can no longer parse. NOT a result.
+#   3  counts printed but below the plausibility floor. NOT a result either.
 #
 # NOTE: `dune test` without --force prints nothing for suites whose results are
 # cached, so an incremental run will under-report. Always --force for a total.
 set -euo pipefail
 
-SRC="${1:--}"
+MIN_SUITES=10
+SRC=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --min-suites)
+      [ $# -ge 2 ] || { echo "ERROR: --min-suites needs a value" >&2; exit 2; }
+      MIN_SUITES="$2"
+      shift 2
+      ;;
+    --min-suites=*)
+      MIN_SUITES="${1#--min-suites=}"
+      shift
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+usage: scripts/test-suite-counts.sh [--min-suites N] <logfile>
+   or: dune test --force 2>&1 | scripts/test-suite-counts.sh [--min-suites N]
+
+  --min-suites N   plausibility floor (default 10); 0 disables it.
+
+exit 0  counts printed and trustworthy
+exit 2  usage error, or no recognisable test output -- NOT a result
+exit 3  counts printed but below the plausibility floor -- NOT a result
+USAGE
+      exit 0
+      ;;
+    -)
+      SRC="-"
+      shift
+      ;;
+    -*)
+      echo "ERROR: unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      [ -z "$SRC" ] || { echo "ERROR: more than one log file given" >&2; exit 2; }
+      SRC="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$MIN_SUITES" in
+  ''|*[!0-9]*) echo "ERROR: --min-suites must be a non-negative integer, got: $MIN_SUITES" >&2; exit 2 ;;
+esac
+
+SRC="${SRC:--}"
 if [ "$SRC" != "-" ] && [ ! -f "$SRC" ]; then
   echo "ERROR: no such log file: $SRC" >&2
   exit 2
 fi
 
-python3 - "$SRC" <<'PYEOF'
+# Reading from a terminal is never what the caller meant, and hanging on an
+# invisible read is how "the counter produced no output" gets misread as zero.
+if [ "$SRC" = "-" ] && [ -t 0 ]; then
+  echo "ERROR: no log file given and stdin is a terminal." >&2
+  echo "       usage: scripts/test-suite-counts.sh [--min-suites N] <logfile>" >&2
+  echo "          or: dune test --force 2>&1 | scripts/test-suite-counts.sh" >&2
+  exit 2
+fi
+
+# The parser is captured into a variable rather than fed to `python3 -` on a
+# heredoc, and that is load-bearing (backlog-150).
+#
+# `python3 - <<'PYEOF'` hands python its PROGRAM on stdin, which leaves nothing
+# on stdin for the program to read. The advertised pipe form,
+#
+#     dune test --force 2>&1 | scripts/test-suite-counts.sh
+#
+# therefore never worked: `sys.stdin.read()` returned "" and the script
+# reported "0 cases across 0 suites / 0 FAIL", exit 0, for a genuine 1644-case
+# log. It was the same "green from nothing" this file now refuses -- arrived at
+# by a different route, and reached by the usage the header recommends first.
+# Keep the program in a variable so stdin belongs to the caller's pipe.
+PYPROG=$(cat <<'PYEOF'
 import re
 import sys
 
 src = sys.argv[1]
+min_suites = int(sys.argv[2])
 text = sys.stdin.read() if src == "-" else open(src, errors="replace").read()
 
 # Alcotest: "Test Successful in 0.004s. 61 tests run." and the SINGULAR
@@ -60,6 +188,31 @@ epilogues = len(re.findall(r"Test Successful in", text)) + len(
     re.findall(r"\d+ failures?!", text)
 )
 
+# GATE 1 -- did we read a test log at all? (backlog-150)
+#
+# This runs BEFORE any count is printed, because the failure being prevented is
+# a caller reading "0 FAIL" off a run that never happened. A result and the
+# absence of a result must not share an output shape.
+#
+# "Recognisable" is deliberately the union of every suite-level marker, not the
+# case-counts alone: a log truncated mid-epilogue has a "Test Successful in"
+# with no number after it, and that is a drift/truncation error (gate 2), not
+# an empty log. Only when NOTHING matched is the input simply not a test log.
+suites = len(alco) + len(qcheck)
+if epilogues == 0 and suites == 0:
+    what = "stdin" if src == "-" else src
+    print(f"ERROR: no test-suite output recognised in {what}.", file=sys.stderr)
+    print(
+        "       This is not a result of zero cases -- it is the absence of a\n"
+        "       measurement, and it is never reported as a count.\n"
+        "       Most likely: `dune test` without --force (a fully-cached run\n"
+        "       prints nothing), a truncated or empty log, or a file that is\n"
+        "       not a dune test log. Re-run with:\n"
+        "           dune test --force 2>&1 | scripts/test-suite-counts.sh",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
 print(f"alcotest : {sum(alco):5d} cases across {len(alco):3d} suites")
 print(f"qcheck   : {sum(qcheck):5d} cases across {len(qcheck):3d} suites")
 print(f"TOTAL    : {sum(alco) + sum(qcheck):5d} cases across "
@@ -68,10 +221,32 @@ print(f"FAIL     : {fails}")
 print(f"SKIP     : {skips}")
 print(f"zero-case suites: {zero}")
 
+# GATE 2 -- drift/truncation. Every Alcotest suite epilogue should have been
+# parsed. If the "Test Successful" count and the "N test(s) run" count
+# disagree, either the format has drifted or the log was cut mid-epilogue --
+# say so instead of printing a confident wrong total.
 if epilogues != len(alco):
     print()
     print(f"ERROR: {epilogues} Alcotest suite epilogues but {len(alco)} parsed "
-          "case-counts -- the log format has drifted and this total is not "
-          "trustworthy. Fix the pattern in scripts/test-suite-counts.sh.")
+          "case-counts -- the log is truncated or the format has drifted, and "
+          "this total is not trustworthy. Fix the pattern in "
+          "scripts/test-suite-counts.sh.")
     sys.exit(2)
+
+# GATE 3 -- plausibility floor. A partially-cached `dune test` under-reports
+# without any of the markers gates 1 and 2 look for: the suites it does print
+# parse perfectly, there is just an arbitrary subset of them. That is the
+# dangerous shape, because the number looks like a number. The floor cannot
+# tell 111 suites from 112, but it does catch the order-of-magnitude case,
+# which is what partial caching and a wrong invocation actually produce.
+if suites < min_suites:
+    print()
+    print(f"ERROR: {suites} suites is below the plausibility floor of "
+          f"{min_suites}. A run of this repository reports ~112 suites, so "
+          "this is a caching or invocation problem, not a result -- do not "
+          "quote these numbers. Re-run with `dune test --force`, or pass "
+          "--min-suites 0 if you meant to count a small log.")
+    sys.exit(3)
 PYEOF
+)
+python3 -c "$PYPROG" "$SRC" "$MIN_SUITES"

--- a/scripts/test-suite-counts.test.sh
+++ b/scripts/test-suite-counts.test.sh
@@ -42,7 +42,12 @@ Testing `Props'.
 success (ran 12 tests)
 LOG
 
-out="$("$CNT" "$TMP/mixed.log")"
+# --min-suites 0 throughout this block: these logs are deliberately tiny, and
+# the plausibility floor (asserted separately below) would otherwise reject
+# them. Disabling it explicitly is the point -- it is the documented escape,
+# and a covering test that silently depended on the floor being absent would
+# stop noticing when the floor changed.
+out="$("$CNT" --min-suites 0 "$TMP/mixed.log")"
 
 # 61 + 1 + 0 = 62 across 3 alcotest suites. The singular and zero forms are
 # exactly what a `[0-9]+ tests run` pattern drops.
@@ -71,7 +76,7 @@ Testing `A'.
 > [SKIP]        gpu              0   needs hardware.
 1 failure! in 0.001s. 4 tests run.
 LOG
-out2="$("$CNT" "$TMP/redskip.log")"
+out2="$("$CNT" --min-suites 0 "$TMP/redskip.log")"
 check "counts FAIL lines" \
   "$(echo "$out2" | /usr/bin/grep '^FAIL' | /usr/bin/tr -s ' ')" "FAIL : 1"
 check "counts SKIP lines" \
@@ -85,15 +90,128 @@ Test Successful in 0.002s. 61 tests run.
 Testing `B'.
 Test Successful in 0.001s. some-new-format.
 LOG
-"$CNT" "$TMP/drift.log" >/dev/null 2>&1
+"$CNT" --min-suites 0 "$TMP/drift.log" >/dev/null 2>&1
 check "unparseable epilogue exits 2, not a wrong total" "$?" "2"
 
 # Missing file is an error, not a silent zero.
 "$CNT" "$TMP/nope.log" >/dev/null 2>&1
 check "missing log exits 2" "$?" "2"
 
+# ---------------------------------------------------------------------------
+# backlog-150: an empty or unrecognisable log is a USAGE ERROR, never a result.
+#
+# The shipped script accepted all four inputs below and printed
+# "0 cases / 0 FAIL / 0 SKIP", exit 0 -- a green run, reported by the very
+# instrument this repo uses to audit whether its other gates can fail. The
+# cases assert both halves: non-zero exit, AND no count line on stdout, because
+# a caller that greps for `TOTAL` must not find one.
+# ---------------------------------------------------------------------------
+
+: > "$TMP/empty.log"
+
+# Truncated before any suite finished: real `dune test` preamble, cut early.
+cat > "$TMP/trunc-early.log" <<'LOG'
+File "sarek/tests/unit/dune", line 1, characters 0-0:
+Entering directory '/repo'
+Testing `Sarek_float32'.
+This run has ID `IGM5LJHD'.
+
+  [OK]          add                 0   scalar add.
+LOG
+
+# Only skips, no epilogue at all.
+cat > "$TMP/skips-only.log" <<'LOG'
+  [SKIP]        gpu              0   needs hardware.
+  [SKIP]        gpu              1   needs hardware.
+LOG
+
+# Not a test log in the first place -- a build failure, say.
+cat > "$TMP/notalog.log" <<'LOG'
+ocamlfind: Package `sarek' not found
+Command exited with code 2.
+LOG
+
+for case in empty trunc-early skips-only notalog; do
+  got_out="$("$CNT" --min-suites 0 "$TMP/$case.log" 2>/dev/null)"
+  got_rc=$?
+  check "$case log exits non-zero (empty is not a result)" \
+    "$([ "$got_rc" -ne 0 ] && echo nonzero || echo "zero")" "nonzero"
+  check "$case log prints no counts on stdout" \
+    "$(echo "$got_out" | /usr/bin/grep -c 'cases across')" "0"
+done
+
+# Positive control for the four cases above. Without it, "went red on an empty
+# log" and "is red on everything" are the same observation. A log that IS a
+# real run must still come back green and with the right total.
+big=""
+for i in $(seq 1 12); do
+  big="${big}Testing \`Suite_$i'.
+Test Successful in 0.002s. 5 tests run.
+"
+done
+printf '%s' "$big" > "$TMP/plausible.log"
+out3="$("$CNT" "$TMP/plausible.log")"
+check "positive control: a plausible log still exits 0" "$?" "0"
+check "positive control: and counts correctly" \
+  "$(echo "$out3" | /usr/bin/grep '^TOTAL' | /usr/bin/tr -s ' ')" \
+  "TOTAL : 60 cases across 12 suites"
+
+# ---------------------------------------------------------------------------
+# backlog-150: pipe mode must read the caller's pipe.
+#
+# `python3 - <<'PYEOF'` hands python its program on stdin, leaving the program
+# nothing to read. The header's FIRST recommended invocation
+# (`dune test --force 2>&1 | scripts/test-suite-counts.sh`) consequently
+# reported 0 cases for any input whatsoever, exit 0. This is the regression
+# test for that: same log, both routes, same answer.
+# ---------------------------------------------------------------------------
+piped="$(/usr/bin/cat "$TMP/plausible.log" | "$CNT" | /usr/bin/grep '^TOTAL' \
+  | /usr/bin/tr -s ' ')"
+check "pipe mode reads stdin, and agrees with file mode" \
+  "$piped" "TOTAL : 60 cases across 12 suites"
+
+# An empty pipe must be the same usage error an empty file is -- this is the
+# fully-cached `dune test` case, the one that actually happens.
+#
+# --min-suites 0 here is deliberate. Without it the floor also rejects an empty
+# pipe, so the case would pass even with the empty-log gate removed and would
+# be attesting the floor rather than the thing it names.
+: | "$CNT" --min-suites 0 >/dev/null 2>&1
+check "empty pipe exits non-zero" \
+  "$([ "$?" -ne 0 ] && echo nonzero || echo zero)" "nonzero"
+
+# ---------------------------------------------------------------------------
+# backlog-150: the plausibility floor.
+#
+# Partial caching under-reports without tripping either gate above: the suites
+# that do appear parse perfectly, there are just fewer of them. The number
+# looks like a number, which is what makes it worse than nothing.
+# ---------------------------------------------------------------------------
+"$CNT" "$TMP/mixed.log" >/dev/null 2>&1
+check "below the default floor exits 3" "$?" "3"
+
+floor_out="$("$CNT" "$TMP/mixed.log" 2>/dev/null || true)"
+check "below-floor still shows what it parsed" \
+  "$(echo "$floor_out" | /usr/bin/grep -c 'cases across')" "3"
+
+"$CNT" --min-suites 0 "$TMP/mixed.log" >/dev/null 2>&1
+check "--min-suites 0 disables the floor" "$?" "0"
+
+"$CNT" --min-suites 999 "$TMP/plausible.log" >/dev/null 2>&1
+check "floor is honoured at a raised threshold" "$?" "3"
+
+# Argument handling: a malformed invocation is an error, not a default.
+"$CNT" --min-suites nope "$TMP/plausible.log" >/dev/null 2>&1
+check "non-numeric --min-suites exits 2" "$?" "2"
+"$CNT" --bogus >/dev/null 2>&1
+check "unknown option exits 2" "$?" "2"
+"$CNT" "$TMP/plausible.log" "$TMP/mixed.log" >/dev/null 2>&1
+check "two log files exit 2" "$?" "2"
+
 echo
 echo "passed: $pass   failed: $fail"
 [ "$fail" -eq 0 ] || exit 1
 echo "OK: test-suite-counts.sh counts singular/zero/plural Alcotest epilogues,"
-echo "    separates qcheck, and fails closed when the log format drifts"
+echo "    separates qcheck, fails closed when the log format drifts, and"
+echo "    refuses to report a count for an empty, truncated, unrecognisable or"
+echo "    implausibly small log (backlog-150)"

--- a/scripts/test-suite-counts.test.sh
+++ b/scripts/test-suite-counts.test.sh
@@ -131,11 +131,16 @@ ocamlfind: Package `sarek' not found
 Command exited with code 2.
 LOG
 
+# Exit code asserted EXACTLY, not merely as non-zero. Gate 1 is specified to
+# exit 2, and "non-zero" would also be satisfied by a python traceback (1) or
+# by the plausibility floor firing instead (3) -- so a crash, or a regression
+# that moved this input from gate 1 to gate 3, would pass a case whose entire
+# purpose is to pin gate 1. A weakened assertion inside the covering test for
+# the check that could not fail is the same class of defect one level up.
 for case in empty trunc-early skips-only notalog; do
   got_out="$("$CNT" --min-suites 0 "$TMP/$case.log" 2>/dev/null)"
   got_rc=$?
-  check "$case log exits non-zero (empty is not a result)" \
-    "$([ "$got_rc" -ne 0 ] && echo nonzero || echo "zero")" "nonzero"
+  check "$case log exits 2 — usage error, not a result" "$got_rc" "2"
   check "$case log prints no counts on stdout" \
     "$(echo "$got_out" | /usr/bin/grep -c 'cases across')" "0"
 done
@@ -176,9 +181,11 @@ check "pipe mode reads stdin, and agrees with file mode" \
 # --min-suites 0 here is deliberate. Without it the floor also rejects an empty
 # pipe, so the case would pass even with the empty-log gate removed and would
 # be attesting the floor rather than the thing it names.
+#
+# Exact 2 for the same reason as the loop above: non-zero would be satisfied by
+# a crash or by the floor firing, neither of which is this gate.
 : | "$CNT" --min-suites 0 >/dev/null 2>&1
-check "empty pipe exits non-zero" \
-  "$([ "$?" -ne 0 ] && echo nonzero || echo zero)" "nonzero"
+check "empty pipe exits 2 — the fully-cached \`dune test\` case" "$?" "2"
 
 # ---------------------------------------------------------------------------
 # backlog-150: the plausibility floor.


### PR DESCRIPTION
Two defects in the project's canonical suite counter, `scripts/test-suite-counts.sh` — the script written to retire the hand-rolled greps that disagreed, and whose numbers are quoted as the authoritative baseline in reviews.

## 1. The documented usage returned zero for any input

The parser ran as `python3 - <<'PYEOF'`, which hands python its **program** on stdin and leaves the program nothing to read. So the header's *first* recommended invocation —

```
dune test --force 2>&1 | scripts/test-suite-counts.sh
```

— called `sys.stdin.read()`, got `""`, and reported:

```
alcotest :     0 cases across   0 suites
TOTAL    :     0 cases across   0 suites
FAIL     : 0
```

**exit 0, for any input whatsoever.** Confirmed against the pre-change script with the genuine 1644-case log: it printed zero. A counter whose documented usage silently returns zero is worse than one that mishandles an empty log — and it is very likely why the empty-log path below went unnoticed for so long, since anyone using the pipe form got the same confident zero regardless.

The parser now lives in a shell variable and runs via `python3 -c`, so stdin belongs to the caller's pipe. File mode and pipe mode are asserted to agree on the same log.

## 2. An empty log was accepted as a result

A fully-cached `dune test` produces no output, and the script reported `0 cases / 0 FAIL / 0 SKIP`, exit 0. So did a truncated log, a skips-only log, and a file that was not a test log at all. A caller reading any of them sees a green run.

That is the "gate given nothing to check" shape, sitting in the instrument this repo uses to audit whether its *other* gates can fail. The script's own header makes the argument: "0 FAIL out of N" is only as trustworthy as N. An N of zero is not a small N — it is the absence of a measurement, and it must not be reported in the shape of a result.

### Three gates, in order

1. **No recognisable suite epilogue at all → exit 2, and no counts printed.** Given-but-empty is never a fallback.
2. **Epilogue/case-count disagreement → exit 2.** Pre-existing; the message now also names truncation, which is how it actually fires.
3. **Below `--min-suites` (default 10) → counts printed, exit 3.** Partial caching under-reports without tripping 1 or 2: the suites that do appear parse perfectly, there are just fewer of them, so the number looks like a number. `--min-suites 0` disables it.

## 3. `zero-case suites: 4`, resolved — a result, not a non-finding

This has been in the output on every branch since the script was written and had never been run down. "They turned out to be fine" is the outcome, but it is an outcome that had to be *established*: this repo has already been bitten by a suite where a `Printf` `[SKIP]` was swallowed by Alcotest's stdout capture and the case rendered `[OK]`. An empty suite is that same defect one step further on, and until someone checked, these four were indistinguishable from it.

All four are **genuine hardware-gated skips, not inert suites**:

| suite | cases |
| --- | --- |
| `ptx_stride_spike` | 1 |
| `ptx_atomics_probe` | 1 |
| `ptx_mma_probe` | 1 |
| `cuda_f16_sass` | 2 |

Each registers real Alcotest cases and calls `Alcotest.skip ()` when `Cuda_api.is_driver_available ()` is false or no `ptxas` is present. Alcotest's "N tests run" counts only cases that *executed*, so an all-skipped suite reports 0 — compare `ptx_external` in the same run, 1 OK + 1 SKIP, which reports "1 test run.".

**Positive control — the part that makes this a result.** Removing the hardware gate from `test_ptx_stride_spike.ml:71` and re-running gives:

```
1 failure! in 0.000s. 1 test run.
```

A suite with no registered cases could not have produced that. It has a real case, it executes, and it fails when it should — the suite is gated, not empty. And these four differ from the swallowed-printf defect in the observable way: they return skip status to the runner as well as printing it, which is why they render `[SKIP]` and not `[OK]`. `test_ptx_mma_probe.ml:166-169` documents that distinction at the call site.

Expected to be `0` on a runner with a CUDA device. Findings recorded in the script header so the next reader does not have to redo this.

## Counts

Unchanged by this PR, re-established with the fixed counter:

```
alcotest :  1612 cases across 106 suites
qcheck   :    32 cases across   6 suites
TOTAL    :  1644 cases across 112 suites
FAIL     : 0
SKIP     : 23
zero-case suites: 4
```

No doc in the tree quotes these numbers, so nothing else needs updating.

## Proving it can fail

The covering test goes from 8 cases to 27, and was already wired into `ci.yml`'s harness self-test block. Each gate was checked by removing it:

| mutation | result |
| --- | --- |
| gate 1 (empty-log) neutered | 9 FAIL |
| gate 3 (floor) neutered | 2 FAIL |
| stdin stolen from the parser | exactly 1 FAIL |

Restored: 27/27 pass.

## Note: the CI gate that could not see this PR (now fixed upstream)

An earlier revision of this PR carried a note claiming the marker `review-gate-hardening` was present in the pristine upstream file. **That was wrong**, and the correction matters. All four declared markers occur **zero** times in the genuinely pristine file. The check had become *unsatisfiable*: it resolved "pristine upstream" as `git merge-base HEAD origin/main`, which stopped meaning pristine the moment the patch landed on `main`, so it compared the file to itself — in direct contradiction with its neighbour at `:606`, which requires the same bytes to *contain* the markers. `review-gate-hardening` was named only because it is first in the array. No marker string could have fixed it.

Separately, `actions/checkout@v4` defaults to `fetch-depth: 1`, and a `pull_request` checkout is a detached HEAD on `refs/pull/N/merge` with no `refs/remotes/origin/main`, so `merge-base` exited 128, `base` became null, the loop iterated nothing, and the check printed its specificity note and exited 0 — **50 passed / 0 failed on PRs versus 49 / 1 on push.**

Both are fixed and merged in PR #341; the resolver now anchors on the manifest and fails closed on a shallow checkout. This PR is rebased onto `4f5335e0`.

**Why the rebase was necessary rather than cosmetic:** the harness self-test block runs under `set -e` and aborted at position 3, so every check after it — including this PR's covering test — was never reached in CI. The green this PR showed before the rebase did not include its own test. It does now.

## Review findings addressed (second commit)

Both were real.

**The SKIP attribution was an overclaim.** The comment said the four zero-case suites accounted for "exactly the 23 SKIPs". They register **five** cases between them, so they account for **5 of 23**; the other 18 come from suites that also ran real cases and are therefore not zero-case. Recounted off the same log the figures come from. A claim wider than its evidence, in a comment whose job is to justify an audit, is the thing this PR is about — it does not get a pass for being small.

**The gate-1 cases accepted any non-zero exit, where the contract is exit 2.** `scripts/test-suite-counts.test.sh:137-140` and `:179-181` asserted only "non-zero", which is also satisfied by a python traceback (1) and by the plausibility floor firing instead (3). A crash, or a regression moving these inputs from gate 1 to gate 3, would have passed a set of cases whose entire purpose is to pin gate 1. **That is this repository's own class recurring inside its own fix** — a weakened assertion in the covering test for the check that could not fail. Both sites now assert `2` exactly.

Verified by mutation, and the comparison is the whole point. Making gate 1 exit 3 instead of 2:

| | result |
| --- | --- |
| **old** test (assert non-zero) | `27 passed, 0 failed` — **exit 0, silently green** |
| **new** test (assert exactly 2) | **5 FAIL, exit 1** |

Counts unchanged: `1612 alcotest / 106 suites + 32 qcheck / 6 suites, 0 FAIL, 23 SKIP, 4 zero-case`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
