### PR TITLE
chore(roster): let the ledger record a deliberate skip (backlog-135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
           node scripts/check-review-convergence-hardening.test.js
           node scripts/check-mandated-steps.test.js
           node scripts/check-alcotest-registration.test.js
+          # backlog-135. The ledger schema had no covering test of its own --
+          # it was exercised only incidentally by the post-hook's test, which
+          # cares about the hook rather than the rules. The skip record it now
+          # carries exists to REJECT something (a skip that names no reason and
+          # no actor), so it gets a test that watches it reject.
+          node scripts/ledger-schema.test.js
           ./scripts/check-review-bundle-tracked.test.sh
           ./scripts/agent-worktree-bootstrap.test.sh
           ./scripts/roster-implement-posthook.test.sh

--- a/scripts/ledger-schema.test.js
+++ b/scripts/ledger-schema.test.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: CECILL-B
+// SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+//
+// Covering test for scripts/lib/ledger-schema.js.
+//
+// The schema had no test of its own — it was exercised only incidentally, via
+// roster-implement-posthook.test.sh, which cares about the hook rather than
+// the rules. backlog-135 adds a rule whose entire value is that it REJECTS
+// something, so it gets a test that watches it reject.
+//
+// Every case here is a proof of rejection or a paired positive control. A
+// validator that accepts everything and a validator that is correct are
+// indistinguishable from a green run, which is the failure mode this
+// repository keeps finding.
+"use strict";
+
+const {
+  SEQ,
+  VOCAB,
+  SKIPPED,
+  validateLedger,
+  expectLatestPhase,
+  phaseGaps,
+} = require("./lib/ledger-schema.js");
+
+let pass = 0;
+let fail = 0;
+
+function check(desc, got, want) {
+  const g = JSON.stringify(got);
+  const w = JSON.stringify(want);
+  if (g === w) {
+    console.log(`  PASS: ${desc}`);
+    pass += 1;
+  } else {
+    console.log(`  FAIL: ${desc} -- expected ${w}, got ${g}`);
+    fail += 1;
+  }
+}
+
+// Asserts invalid AND that some error mentions `needle`. "It went red" is not
+// enough: a rule that rejects for the wrong reason still rejects, and would
+// keep passing this test after the rule it is named for was deleted.
+function checkRejects(desc, ledger, needle) {
+  const r = validateLedger(ledger, ledger.task);
+  const hit = r.errors.some((e) => e.includes(needle));
+  check(`${desc} (rejected)`, r.valid, false);
+  check(`${desc} (for the right reason: ${JSON.stringify(needle)})`, hit, true);
+}
+
+console.log("ledger-schema.js covering test");
+
+// A minimal well-formed ledger, used as the base for mutation below.
+const base = () => ({
+  task: "demo",
+  mode: "full",
+  current_phase: "implement",
+  events: [
+    { phase: "intake", outcome: "VALIDATED", by: "roster-intake" },
+    { phase: "plan", outcome: "COMPLETED", by: "roster-plan" },
+    { phase: "implement", outcome: "COMPLETED", by: "roster-implement" },
+  ],
+});
+
+// ── Positive control ────────────────────────────────────────────────────────
+// Without this, every rejection below could be a validator that says no to
+// everything.
+check("a well-formed ledger validates", validateLedger(base(), "demo").valid, true);
+
+// ── backlog-135: a skip is recordable, and only when it says what and who ───
+
+// The load-bearing case. Before this change `intake` had no SKIPPED in its
+// vocabulary, so the only way to express "we deliberately did not do intake"
+// was to omit the event — indistinguishable from losing it.
+const withSkip = base();
+withSkip.events[0] = {
+  phase: "intake",
+  outcome: SKIPPED,
+  by: "mathias",
+  reason: "hygiene task, scope fixed by the backlog item; no intake needed",
+};
+check(
+  "a skip WITH a reason and a `by` validates",
+  validateLedger(withSkip, "demo").valid,
+  true
+);
+
+// Every phase, not just spec. The old vocabulary allowed SKIPPED on `spec`
+// alone, which is why the corpus expresses skips by omission everywhere else.
+for (const phase of Object.keys(VOCAB)) {
+  check(
+    `SKIPPED is legal for phase ${phase}`,
+    VOCAB[phase].includes(SKIPPED),
+    true
+  );
+}
+
+// A skip that does not say why records less than the omission it replaces.
+const noReason = base();
+noReason.events[0] = { phase: "intake", outcome: SKIPPED, by: "mathias" };
+checkRejects("a skip with no reason", noReason, "non-empty reason");
+
+const noBy = base();
+noBy.events[0] = { phase: "intake", outcome: SKIPPED, reason: "not needed" };
+checkRejects("a skip with no `by`", noBy, "non-empty by");
+
+// Blank and whitespace-only are the obvious way to satisfy a presence check
+// while recording nothing, so they are rejected like a missing field.
+for (const [label, value] of [["empty", ""], ["whitespace-only", "   \t "]]) {
+  const blank = base();
+  blank.events[0] = { phase: "intake", outcome: SKIPPED, by: "x", reason: value };
+  checkRejects(`a skip with a ${label} reason`, blank, "non-empty reason");
+
+  const blankBy = base();
+  blankBy.events[0] = { phase: "intake", outcome: SKIPPED, by: value, reason: "x" };
+  checkRejects(`a skip with a ${label} \`by\``, blankBy, "non-empty by");
+}
+
+// Non-string reason/by must not slip through the trim().
+const numericBy = base();
+numericBy.events[0] = { phase: "intake", outcome: SKIPPED, by: 7, reason: "x" };
+checkRejects("a skip with a non-string `by`", numericBy, "non-empty by");
+
+// The reason/by requirement must apply ONLY to skips: a normal event has never
+// been required to carry a `by`, and 48 real ledgers depend on that.
+const noByRan = base();
+delete noByRan.events[0].by;
+check(
+  "a non-skipped event still needs no `by`",
+  validateLedger(noByRan, "demo").valid,
+  true
+);
+
+// ── Pre-existing rules, still enforced ──────────────────────────────────────
+
+const badOutcome = base();
+badOutcome.events[1].outcome = "GO";
+checkRejects("an outcome illegal for its phase", badOutcome, "is not legal for phase plan");
+
+const badReason = base();
+badReason.events[1].reason = false;
+checkRejects("a non-string reason on a normal event", badReason, "reason must be a string");
+
+const badMode = base();
+badMode.mode = "turbo";
+checkRejects("an unknown mode", badMode, "mode must be one of");
+
+const mismatched = base();
+mismatched.current_phase = "review";
+checkRejects("current_phase not matching the last event", mismatched, "does not match the last event");
+
+const noEvents = base();
+noEvents.events = [];
+checkRejects("an empty events array", noEvents, "non-empty array");
+
+const unknownPhase = base();
+unknownPhase.events[1].phase = "deploy";
+checkRejects("an unknown phase", unknownPhase, "not a known phase");
+
+// ── expectLatestPhase, unchanged behaviour ──────────────────────────────────
+
+check(
+  "expectLatestPhase accepts the matching latest phase",
+  expectLatestPhase(base(), "implement").valid,
+  true
+);
+check(
+  "expectLatestPhase rejects a stale ledger",
+  expectLatestPhase(base(), "review").valid,
+  false
+);
+check(
+  "expectLatestPhase names a phase absent entirely",
+  expectLatestPhase(base(), "review").errors.some((e) => e.includes("STALE ledger")),
+  true
+);
+
+// ── phaseGaps: the distinction backlog-135 exists to create ─────────────────
+
+// The whole point, in one assertion pair: two ledgers that reach the same
+// phase, one having skipped `spec` on purpose and one having lost it, must be
+// told apart. Before this change both looked exactly like the second.
+const gapLedger = {
+  task: "demo",
+  mode: "full",
+  current_phase: "plan",
+  events: [
+    { phase: "question", outcome: "COMPLETED" },
+    { phase: "research", outcome: "COMPLETED" },
+    { phase: "intake", outcome: "VALIDATED" },
+    { phase: "spec", outcome: SKIPPED, by: "mathias", reason: "no API change" },
+    { phase: "plan", outcome: "COMPLETED" },
+  ],
+};
+check("phaseGaps: a declared skip lands in `skipped`", phaseGaps(gapLedger).skipped, ["spec"]);
+check("phaseGaps: nothing is missing when the skip is declared", phaseGaps(gapLedger).missing, []);
+
+const lostSpec = JSON.parse(JSON.stringify(gapLedger));
+lostSpec.events.splice(3, 1);
+check("phaseGaps: an omitted phase lands in `missing`", phaseGaps(lostSpec).missing, ["spec"]);
+check("phaseGaps: and NOT in `skipped`", phaseGaps(lostSpec).skipped, []);
+
+// Only phases up to current_phase are due — a run sitting at `plan` has not
+// failed to ship, it has not got there yet. An enforcer without this would
+// fire on every in-flight ledger.
+check(
+  "phaseGaps: phases after current_phase are not due",
+  phaseGaps(gapLedger).missing.includes("ship"),
+  false
+);
+check("phaseGaps: ran lists the phases that ran", phaseGaps(gapLedger).ran, [
+  "question",
+  "research",
+  "intake",
+  "plan",
+]);
+
+// A phase with both a skip and a real event counts as ran — re-entry after a
+// skip is a real sequence (spec SKIPPED, then bounced back and specced).
+const skipThenRan = JSON.parse(JSON.stringify(gapLedger));
+skipThenRan.events.splice(4, 0, { phase: "spec", outcome: "VALIDATED" });
+check("phaseGaps: a phase later actually run counts as ran", phaseGaps(skipThenRan).ran.includes("spec"), true);
+
+check("phaseGaps: an unknown mode reports unknownMode", phaseGaps({ mode: "turbo" }).unknownMode, true);
+
+// Express mode has a shorter sequence; a phase it never runs is not missing.
+check(
+  "phaseGaps: express mode does not miss `spec`",
+  phaseGaps({
+    mode: "express",
+    current_phase: "ship",
+    events: [
+      { phase: "implement", outcome: "COMPLETED" },
+      { phase: "review", outcome: "GO" },
+      { phase: "ship", outcome: "COMPLETED" },
+    ],
+  }).missing,
+  []
+);
+check("SEQ still declares all three modes", Object.keys(SEQ).sort(), ["express", "fast", "full"]);
+
+console.log();
+console.log(`passed: ${pass}   failed: ${fail}`);
+if (fail !== 0) process.exit(1);
+console.log("OK: ledger-schema.js records skips with a reason and an actor,");
+console.log("    rejects a skip that states neither, and can tell a declared");
+console.log("    skip from an omitted phase (backlog-135)");

--- a/scripts/lib/ledger-schema.js
+++ b/scripts/lib/ledger-schema.js
@@ -17,33 +17,73 @@ const SEQ = {
   full: ["question", "research", "intake", "spec", "plan", "implement", "review", "qa", "ship"],
 };
 
+// SKIPPED is legal for EVERY phase (backlog-135), not just `spec`.
+//
+// Before this, `spec` was the only phase with a skip vocabulary, and even that
+// was mostly written into briefs/<task>-spec.md rather than the ledger — no
+// -state.json in the 48-ledger corpus contained a SKIPPED event at all. Every
+// other phase could only be skipped by not appearing, which is byte-identical
+// to a phase that was supposed to run and did not.
+//
+// The rule is the one the mandated-step ledger already applies one level down
+// (scripts/lib/mandated-steps-rules.js, schema/mandated-steps-schema.md:29 —
+// "Skipping is allowed. Skipping silently is not."): skipping is permitted,
+// skipping without saying so is not. A SKIPPED event therefore carries a
+// `reason` and a `by`, and both are REQUIRED — see requiredSkipFields below.
+// Whether a reason is a *good* reason stays a human judgement; what is
+// enforced is that one exists and is attributable.
+//
+// KNOWN CONSEQUENCE for the jq cross-check. roster-implement-posthook.sh
+// compares this schema's verdict against the LEDGER_SCHEMA jq predicate in
+// .harness/skills/roster-run.md, which is untracked and carries the OLD
+// vocabulary. The first ledger to record a non-spec skip will make the two
+// disagree, and the hook will correctly report SCHEMA DRIFT. That is the
+// detector working, not a regression: the predicate in the skill file needs
+// the same SKIPPED vocabulary. It cannot be changed here because it lives
+// outside the repository.
+const SKIPPED = "SKIPPED";
+
 const VOCAB = {
-  question: ["COMPLETED"],
-  research: ["COMPLETED"],
-  intake: ["VALIDATED"],
-  spec: ["VALIDATED", "SKIPPED", "BOUNCED"],
-  plan: ["COMPLETED"],
-  implement: ["COMPLETED", "PARTIAL"],
-  review: ["GO", "NO-GO"],
-  qa: ["GO", "NO-GO"],
-  ship: ["COMPLETED", "BLOCKED"],
+  question: ["COMPLETED", SKIPPED],
+  research: ["COMPLETED", SKIPPED],
+  intake: ["VALIDATED", SKIPPED],
+  spec: ["VALIDATED", SKIPPED, "BOUNCED"],
+  plan: ["COMPLETED", SKIPPED],
+  implement: ["COMPLETED", "PARTIAL", SKIPPED],
+  review: ["GO", "NO-GO", SKIPPED],
+  qa: ["GO", "NO-GO", SKIPPED],
+  ship: ["COMPLETED", "BLOCKED", SKIPPED],
 };
 
-// WHAT THIS DELIBERATELY DOES NOT CHECK: phase ORDER.
+// PHASE ORDER: still not enforced here, but no longer unenforceable.
 //
-// The obvious next rule is "a phase may not appear before its predecessors in
-// SEQ". Measured against the 34 real ledgers in briefs/, a rule of that shape
-// flags 7 of them — `research > spec > plan` (no intake), `intake > plan` (no
-// spec), and so on. Full-mode runs legitimately skip optional phases, and the
-// ledger records nothing that distinguishes a phase deliberately skipped from
-// one erroneously missing. A rule that fires on a fifth of valid input is not
-// a gate; it is something people learn to ignore.
+// The note this replaces read: "the ledger records nothing that distinguishes
+// a phase deliberately skipped from one erroneously missing. A rule that fires
+// on a fifth of valid input is not a gate; it is something people learn to
+// ignore." Measured against the 34 ledgers of the day, a naive order rule
+// flagged 7 — `research > spec > plan` (no intake), `intake > plan` (no spec).
 //
-// The specific failure this was meant to catch — a phase that did not run,
-// with the stale ledger handed to the next phase anyway — is caught precisely
-// instead, by the caller asserting which phase must be the LAST event
-// (roster-implement-posthook.sh --expect-phase). That has no false positives
-// by construction: the hook runs only after that phase.
+// That was a statement about the SCHEMA, not about the rule. With a recordable
+// skip, the seven ledgers that a phase-order gate would have libelled can say
+// what they did, and the distinction the gate needs becomes expressible:
+//
+//     absent        -> the phase did not run and nobody said it wouldn't
+//     SKIPPED       -> the phase did not run, on purpose, for a stated reason,
+//                      decided by a named actor
+//     any other     -> the phase ran
+//
+// `phaseGaps` below computes exactly that distinction. It is deliberately a
+// REPORTING function and not a gate: this change makes enforcement possible,
+// and the corpus has to be migrated before enforcement is honest. Turning it
+// into a gate today would fail the 48 existing ledgers, none of which record
+// a skip, for a defect they predate. See the header of phaseGaps for what an
+// enforcer built on it would then be able to check.
+//
+// The specific failure the missing order-check was meant to catch — a phase
+// that did not run, with the stale ledger handed to the next phase anyway —
+// remains caught precisely by the caller asserting which phase must be the
+// LAST event (roster-implement-posthook.sh --expect-phase). That has no false
+// positives by construction: the hook runs only after that phase.
 
 // Returns { valid, errors[] }. Every rule reports its own message: "the ledger
 // is invalid" is useless to whoever has to repair it by hand.
@@ -94,6 +134,25 @@ function validateLedger(ledger, task) {
     if (Object.prototype.hasOwnProperty.call(e, "reason") && typeof e.reason !== "string") {
       bad(`${at}.reason must be a string when present, got ${JSON.stringify(e.reason)}`);
     }
+    // ...except on a SKIPPED event, where it is the entire point (backlog-135).
+    //
+    // A skip record with no reason and no actor records strictly less than the
+    // omission it replaces: it says the phase did not run, which was already
+    // visible, and drops the "on purpose, and here is who decided" that is the
+    // only reason to write it down. Blank and whitespace-only are rejected for
+    // the same reason a missing field is — `reason: ""` is not a reason.
+    if (e.outcome === SKIPPED) {
+      for (const field of ["reason", "by"]) {
+        const v = e[field];
+        if (typeof v !== "string" || v.trim() === "") {
+          bad(
+            `${at}: a SKIPPED ${e.phase} event must record a non-empty ${field} — ` +
+              `got ${JSON.stringify(v)}. Skipping is allowed; skipping silently is not, ` +
+              `so a skip states why (reason) and who decided (by).`
+          );
+        }
+      }
+    }
   });
 
   const last = ledger.events[ledger.events.length - 1];
@@ -135,4 +194,72 @@ function expectLatestPhase(ledger, phase) {
   return { valid: errors.length === 0, errors };
 }
 
-module.exports = { SEQ, VOCAB, validateLedger, expectLatestPhase };
+// Classifies every phase the ledger's mode requires up to and including
+// current_phase (backlog-135). REPORTING ONLY — nothing calls this as a gate.
+//
+// Returns { ran[], skipped[], missing[], unknownMode }:
+//
+//   ran      — a non-SKIPPED event exists for the phase
+//   skipped  — a SKIPPED event exists (and, since validateLedger passed, it
+//              carries a reason and a `by`)
+//   missing  — neither. Before backlog-135 this bucket and `skipped` were the
+//              same bucket, which is why phase-order enforcement was blocked.
+//
+// WHAT AN ENFORCER BUILT ON THIS COULD NOW CHECK, and could not before:
+//
+//   1. "No phase of the declared mode is unaccounted for." `missing` being
+//      non-empty is now a real finding rather than an ambiguity: a full-mode
+//      run that reaches `ship` with no `spec` event either skipped spec on
+//      purpose (and can say so) or lost it. Previously indistinguishable.
+//   2. "A skip is attributable." Already enforced by validateLedger, but an
+//      order gate can additionally require that skips of gate-like phases
+//      (review, qa) name a human `by`, the way mandated-steps-rules.js treats
+//      humanOnly steps.
+//   3. "Phases did not run out of order." The original rule — a phase may not
+//      appear before its SEQ predecessors — with `skipped` predecessors
+//      counted as satisfied. That is the rule measured at 7 false positives in
+//      34 ledgers; those 7 are exactly the shape a skip record now describes.
+//   4. "current_phase is reachable." current_phase can be required to be the
+//      first phase after the last accounted-for one, catching a ledger that
+//      jumped.
+//
+// MEASURED, the way this repo requires a proposed rule to be measured before
+// it ships (schema/mandated-steps-schema.md:117-119). Against the 48 real
+// ledgers in briefs/ at the time of writing:
+//
+//   * validateLedger's verdict changed on ZERO of them. The vocabulary change
+//     is strictly additive and no existing ledger becomes invalid. (15 were
+//     already invalid before this change and are still invalid after, for
+//     unrelated pre-existing reasons.)
+//   * phaseGaps reports unaccounted-for phases in 9 of 48 — question 9,
+//     intake 6, research 4, spec 3, plan 1. That is the same order as the
+//     "7 of 34" that blocked the order rule originally, and it is why the
+//     enforcer is still not wired: those 9 predate skip records and would be
+//     failed for a defect they could not have avoided.
+//
+// The migration this waits on is therefore a policy call — grandfather by
+// date, or enforce only on ledgers created after this schema — not a schema
+// one, which is why it is not made here.
+function phaseGaps(ledger) {
+  const seq = SEQ[ledger && ledger.mode];
+  if (!seq) return { ran: [], skipped: [], missing: [], unknownMode: true };
+
+  const events = Array.isArray(ledger.events) ? ledger.events : [];
+  // Only phases up to current_phase are due. A full-mode run sitting at
+  // `plan` has not failed to `ship`; it has not got there yet.
+  const upto = seq.indexOf(ledger.current_phase);
+  const due = upto === -1 ? seq : seq.slice(0, upto + 1);
+
+  const ran = [];
+  const skipped = [];
+  const missing = [];
+  for (const phase of due) {
+    const forPhase = events.filter((e) => e && e.phase === phase);
+    if (forPhase.some((e) => e.outcome !== SKIPPED)) ran.push(phase);
+    else if (forPhase.length > 0) skipped.push(phase);
+    else missing.push(phase);
+  }
+  return { ran, skipped, missing, unknownMode: false };
+}
+
+module.exports = { SEQ, VOCAB, SKIPPED, validateLedger, expectLatestPhase, phaseGaps };


### PR DESCRIPTION
The pipeline ledger (`briefs/<task>-state.json`) had no way to say "this phase was deliberately skipped, for this reason, decided by this person". `spec` was the only phase with a `SKIPPED` outcome, and even that was usually written into `briefs/<task>-spec.md` rather than the ledger: across the **48 real ledgers in `briefs/`, not one contains a `SKIPPED` event**. Every other phase could only be skipped by not appearing — byte-identical to a phase that was supposed to run and did not.

`scripts/lib/ledger-schema.js` said so itself, as a deliberate non-decision:

> WHAT THIS DELIBERATELY DOES NOT CHECK: phase ORDER. […] Measured against the 34 real ledgers in briefs/, a rule of that shape flags 7 of them […] the ledger records nothing that distinguishes a phase deliberately skipped from one erroneously missing. A rule that fires on a fifth of valid input is not a gate; it is something people learn to ignore.

That was a statement about the **schema**, not about the rule.

## The change

- `SKIPPED` is legal for **every** phase, not just `spec`.
- A `SKIPPED` event **must** carry a non-empty `reason` and a non-empty `by`. Blank and whitespace-only are rejected like a missing field — a skip that states neither records strictly *less* than the omission it replaces: it says the phase did not run, which was already visible, and drops the "on purpose, and here is who decided" that is the only reason to write it down.
- `reason`/`by` are required **only** on skips. Existing ledgers have normal events without a `by` and stay valid.
- New `phaseGaps(ledger)` sorts the phases a mode requires into `ran` / `skipped` / `missing`. Before this change `skipped` and `missing` were the same bucket — precisely what blocked enforcement.

This is the rule the mandated-step ledger already applies one level down (`schema/mandated-steps-schema.md`): *"Skipping is allowed. Skipping silently is not."* Whether a reason is a **good** reason stays a human judgement; what is enforced is that one exists and is attributable.

## What this makes enforceable

Not built here, deliberately — but now expressible:

1. **"No phase of the declared mode is unaccounted for."** `missing` being non-empty is now a finding rather than an ambiguity. A full-mode run that reaches `ship` with no `spec` event either skipped spec on purpose (and can say so) or lost it.
2. **"A skip is attributable."** Already enforced by `validateLedger`; an order gate can additionally require a *human* `by` for skips of gate-like phases (`review`, `qa`), the way `mandated-steps-rules.js` treats `humanOnly` steps.
3. **The original order rule** — a phase may not appear before its `SEQ` predecessors — with `skipped` predecessors counted as satisfied. That is exactly the rule measured at 7 false positives in 34 ledgers.
4. **"`current_phase` is reachable"** — catching a ledger that jumped.

## Measured against the real corpus first

As this repo requires before shipping a rule of this shape:

- **`validateLedger`'s verdict changed on ZERO of the 48 ledgers.** The vocabulary change is strictly additive; no existing ledger becomes invalid. (15 were already invalid before and after, for unrelated pre-existing reasons.)
- `phaseGaps` reports unaccounted-for phases in **9 of 48** — `question` 9, `intake` 6, `research` 4, `spec` 3, `plan` 1. Same order as the 7-of-34 that blocked the rule originally, and the reason **no enforcer is wired yet**: those 9 predate skip records and would be failed for a defect they could not have avoided. Grandfathering is a policy call, not a schema one.

## Known consequence

`roster-implement-posthook.sh` cross-checks this schema against the `LEDGER_SCHEMA` jq predicate in `.harness/skills/roster-run.md`, which is **untracked** and carries the old vocabulary. The first ledger to record a non-`spec` skip will make the two disagree and the hook will report `SCHEMA DRIFT`. That is the detector working — the skill file needs the same vocabulary, and it cannot be changed from here.

## Proving it can fail

The schema had **no covering test of its own** — it was exercised only incidentally by `roster-implement-posthook.test.sh`, which cares about the hook rather than the rules. `scripts/ledger-schema.test.js` adds 51 cases, wired into `ci.yml`'s harness self-test block. Each rejection asserts the error **message** too, so a rule that rejects for the wrong reason cannot pass.

| mutation | result |
| --- | --- |
| drop the `reason`/`by` requirement | 14 FAIL |
| accept blank/whitespace strings | 8 FAIL |
| fold `skipped` back into `missing` | 2 FAIL |

The last is the pre-backlog-135 behaviour the whole change exists to end.

## Note: the CI gate that could not see this PR (now fixed upstream)

An earlier revision of this PR carried a note claiming the marker `review-gate-hardening` was present in the pristine upstream file. **That was wrong**, and the correction matters. All four declared markers occur **zero** times in the genuinely pristine file. The check had become *unsatisfiable*: it resolved "pristine upstream" as `git merge-base HEAD origin/main`, which stopped meaning pristine the moment the patch landed on `main`, so it compared the file to itself — in direct contradiction with its neighbour at `:606`, which requires the same bytes to *contain* the markers. `review-gate-hardening` was named only because it is first in the array. No marker string could have fixed it.

Separately, `actions/checkout@v4` defaults to `fetch-depth: 1`, and a `pull_request` checkout is a detached HEAD on `refs/pull/N/merge` with no `refs/remotes/origin/main`, so `merge-base` exited 128, `base` became null, the loop iterated nothing, and the check printed its specificity note and exited 0 — **50 passed / 0 failed on PRs versus 49 / 1 on push.**

Both are fixed and merged in PR #341; the resolver now anchors on the manifest and fails closed on a shallow checkout. This PR is rebased onto `4f5335e0`.

**Why the rebase was necessary rather than cosmetic:** the harness self-test block runs under `set -e` and aborted at position 3, so every check after it — including this PR's covering test — was never reached in CI. The green this PR showed before the rebase did not include its own test. It does now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
