### PR TITLE
chore(ci): measure whether pocl works on a bare runner (backlog-99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,14 @@ jobs:
   # is a good result -- "a bare runner cannot run an OpenCL kernel either" is
   # information the project does not have today. Promoting this to a gate is a
   # separate decision that needs a green here first.
+  #
+  # MEASURED 2026-07-27 (run 30282252291): VERDICT=POCL-WORKS. Ubuntu 24.04.4,
+  # pocl 5.0, cpu-haswell device; compiled, ran 1024/1024 elements correctly,
+  # and rejected invalid source. backlog-79's "pocl compiles nothing" was pocl
+  # 1.8 + LLVM 11 on jammy inside the image, not a fact about pocl. See the
+  # header of ci/pocl-runner-probe.sh for what this does and does not license.
+  # Still not promoted to a gate: one green is not a stability record, and this
+  # installs an unpinned apt package.
   pocl-runner-probe:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,15 @@ jobs:
           # is the positive control without which "went red" and "is always
           # red" would be the same observation.
           ./scripts/check-license-headers.test.sh
+          # backlog-99. The pocl probe is informational and exits 0 by design,
+          # which is the shape that rots unnoticed: nothing reads its exit
+          # code, so a probe that stopped measuring would keep printing a
+          # verdict indistinguishable from a real one. This asserts the verdict
+          # tracks the stages, and that no combination of failures -- including
+          # a probe that never built -- can report POCL-WORKS. It is hermetic
+          # (a stub compiler supplies the stage results) and needs no pocl, so
+          # it runs here rather than in the probe job.
+          ./ci/pocl-runner-probe.test.sh
 
       - name: Formal proofs admit gate
         run: |
@@ -341,6 +350,62 @@ jobs:
   # rocq/rocq-prover image already ships the exact version these proofs were
   # developed against, and pinning it here costs an image pull instead of a
   # multi-minute Rocq build baked into every CI image rebuild.
+  # backlog-99. EXPERIMENTAL, INFORMATIONAL, GATES NOTHING.
+  #
+  # Every OpenCL claim this project makes rests on one runtime: the Intel
+  # oneAPI CPU ICD inside ci/Dockerfile. Nobody has measured what a bare
+  # GitHub runner does, so there is no second, independent OpenCL execution
+  # environment and no way to tell an oneAPI-specific result from a real one.
+  #
+  # backlog-79 tried pocl once, in the image, and pinned e2e to it: pocl 1.8 +
+  # LLVM 11 on jammy compiled no kernel, the float32 tests SKIPPED, and CI went
+  # green having validated nothing. ci/assert-toolchain.sh records that and
+  # says the retry belongs in "a separate experimental PR that installs it
+  # unpinned and reports whether it can compile on the real GitHub runner".
+  # This is that. The measured failure was a property of jammy's pocl, and
+  # ubuntu-latest ships one several major versions newer.
+  #
+  # Deliberately: `continue-on-error` and a probe that exits 0 on its own. No
+  # test is redirected to pocl, no gate consults the verdict, and a red result
+  # is a good result -- "a bare runner cannot run an OpenCL kernel either" is
+  # information the project does not have today. Promoting this to a gate is a
+  # separate decision that needs a green here first.
+  pocl-runner-probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Unpinned on purpose: whatever the runner's distribution ships is the
+      # thing being measured. Pinning a version would answer a question nobody
+      # asked.
+      - name: Install pocl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pocl-opencl-icd ocl-icd-opencl-dev clinfo
+          apt-cache policy pocl-opencl-icd || true
+
+      - name: Probe whether pocl can compile and run a kernel
+        run: ./ci/pocl-runner-probe.sh
+
+      # The verdict is the deliverable, so it goes somewhere a human reads
+      # without opening the log.
+      - name: Record the verdict in the job summary
+        if: always()
+        run: |
+          {
+            echo "## pocl on a bare runner (backlog-99)"
+            echo
+            echo '```'
+            ./ci/pocl-runner-probe.sh 2>&1 | tail -30
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   formal-proofs:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/ci/pocl-runner-probe.sh
+++ b/ci/pocl-runner-probe.sh
@@ -23,6 +23,42 @@
 # the container image; whether a bare runner can execute a kernel at all is
 # unmeasured, and that is the gap.
 #
+# MEASURED RESULT, 2026-07-27, run 30282252291 on `ubuntu-latest`:
+#
+#     distro:       Ubuntu 24.04.4 LTS
+#     package:      pocl-opencl-icd 5.0-2.1build3
+#     ICD:          pocl.icd -> libpocl.so.2.12.0
+#     device:       cpu-haswell-AMD EPYC 9V74 80-Core Processor
+#     version:      OpenCL 3.0 PoCL HSTR: cpu-x86_64-pc-linux-gnu-haswell
+#     icd/enumerate/compile/execute/reject : all pass
+#     VERDICT:      POCL-WORKS
+#
+# So the answer to backlog-99 is yes: a bare runner CAN compile and run an
+# OpenCL kernel, 1024/1024 elements correct, and it rejects invalid source.
+#
+# This does not contradict backlog-79, it localises it. That failure was pocl
+# 1.8 against LLVM 11 on jammy, inside the CI image; the runner is noble with
+# pocl 5.0, four major versions on. The conclusion "pocl cannot compile" was
+# never a fact about pocl, only about that pairing — which is exactly why it
+# was worth measuring somewhere else rather than inferring.
+#
+# WHAT IT IMPLIES for the existing OpenCL gates: a second, independent OpenCL
+# execution environment is now known to be available, so the project's OpenCL
+# claims no longer HAVE to rest solely on the image's Intel oneAPI ICD. Two
+# things that follow, neither done here:
+#
+#   * ci/assert-toolchain.sh's "NOT asserted here: the OpenCL ICD inventory"
+#     note says the checks belong there "when that lands". They can now.
+#   * A differential run — the same kernels under oneAPI and under pocl — would
+#     catch the class of bug a single ICD cannot: generated OpenCL that one
+#     runtime accepts and another does not. That is the real prize, and it is a
+#     separate change with a real cost, so it is proposed rather than smuggled
+#     in here.
+#
+# Promoting this job to a gate needs a second consideration this run cannot
+# supply: one green is not a stability record, and pinning CI to an unpinned
+# apt package is how a green turns red on someone else's release schedule.
+#
 # THIS IS NOT A GATE.
 #
 # It installs pocl, reports what happened, and exits 0 regardless. Nothing is

--- a/ci/pocl-runner-probe.sh
+++ b/ci/pocl-runner-probe.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+#
+# Does pocl actually work on a bare GitHub runner? (backlog-99)
+#
+# WHY THIS EXISTS
+#
+# The CI image ships exactly one OpenCL ICD, the Intel oneAPI CPU runtime.
+# An earlier attempt (backlog-79) added pocl as a second, conformant CPU ICD
+# and pinned the e2e tests to it. That was strictly worse: pocl 1.8 against
+# LLVM 11 on jammy compiled no kernel at all -- `error: unknown target CPU
+# 'generic'` -- so the float32 math tests SKIPPED, and a SKIP is not a pass.
+# ci/assert-toolchain.sh records the outcome and says the retry "moves to a
+# separate experimental PR that installs it unpinned and reports whether it
+# can compile on the real GitHub runner. When that lands, the checks belong
+# here." This is that probe.
+#
+# The measured failure was a property of that IMAGE -- pocl 1.8 + LLVM 11 on
+# Ubuntu 22.04 -- and says nothing about the runner. `ubuntu-latest` is a
+# different distribution with a pocl several major versions newer, and nobody
+# has measured what it does. Today the project's whole OpenCL story rests on
+# the container image; whether a bare runner can execute a kernel at all is
+# unmeasured, and that is the gap.
+#
+# THIS IS NOT A GATE.
+#
+# It installs pocl, reports what happened, and exits 0 regardless. Nothing is
+# pinned to pocl, no test is redirected to it, and a red result is a perfectly
+# good result -- "pocl cannot compile a kernel on ubuntu-latest either" is
+# information the project does not currently have. Pass --strict to make the
+# verdict the exit code; the covering test uses that, and a future promotion
+# to a real gate would.
+#
+# WHAT IT CHECKS, AND WHY IT IS IN THIS ORDER
+#
+# Each stage can fail independently, and lumping them together is how a probe
+# ends up reporting "OpenCL is broken" when the truth was "no ICD file was
+# installed". The stages, in the order a kernel actually needs them:
+#
+#   A  icd        an ICD manifest exists for pocl
+#   B  enumerate  clGetPlatformIDs/clGetDeviceIDs return a pocl device
+#   C  compile    clBuildProgram accepts a trivial kernel  <- where #79 died
+#   D  execute    the kernel RUNS and the arithmetic is right
+#   E  reject     an INVALID kernel is refused
+#
+# D and E are what make the green trustworthy. A build that succeeds is not a
+# kernel that ran, which is the whole reason this repository distrusts a
+# reported SKIP; and a compiler that accepts everything, including nonsense,
+# reports success without compiling. E is the positive control for C: without
+# it, "pocl compiled our kernel" and "pocl says yes to any string" produce the
+# same output.
+set -uo pipefail
+
+STRICT=0
+[ "${1:-}" = "--strict" ] && STRICT=1
+
+WORK="${POCL_PROBE_WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/pocl-probe.XXXXXX")}"
+mkdir -p "$WORK"
+
+# Stage results, all "unknown" until measured. An unrun stage must never read
+# as a passed one.
+declare -A RESULT=([icd]=unknown [enumerate]=unknown [compile]=unknown \
+  [execute]=unknown [reject]=unknown)
+
+note() { printf '  %s\n' "$*"; }
+stage() { printf '\n== %s ==\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+stage "environment"
+note "uname:    $(uname -srm)"
+if [ -r /etc/os-release ]; then
+  note "distro:   $(. /etc/os-release && echo "$PRETTY_NAME")"
+fi
+for pkg in pocl-opencl-icd libpocl2 ocl-icd-libopencl1; do
+  if command -v dpkg-query >/dev/null 2>&1; then
+    v="$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null)" && \
+      note "package:  $pkg $v"
+  fi
+done
+command -v clinfo >/dev/null 2>&1 && note "clinfo:   $(command -v clinfo)"
+
+# ---------------------------------------------------------------------------
+stage "A. ICD manifest"
+ICD_DIR="${OCL_ICD_VENDORS:-/etc/OpenCL/vendors}"
+if [ -d "$ICD_DIR" ]; then
+  note "vendors dir: $ICD_DIR"
+  for f in "$ICD_DIR"/*.icd; do
+    [ -e "$f" ] || continue
+    note "  $(basename "$f") -> $(cat "$f" 2>/dev/null)"
+  done
+  if ls "$ICD_DIR"/*pocl*.icd >/dev/null 2>&1; then
+    RESULT[icd]=pass
+  else
+    RESULT[icd]=fail
+    note "no pocl ICD manifest present"
+  fi
+else
+  RESULT[icd]=fail
+  note "no $ICD_DIR directory at all"
+fi
+
+# ---------------------------------------------------------------------------
+# The probe proper. Written in C against the OpenCL API rather than driven
+# through clinfo, because clinfo answers "is there a device" and the question
+# is "can it run a kernel" -- the two came apart in exactly this way on #79,
+# where pocl enumerated fine and compiled nothing.
+#
+# It reports one `PROBE <stage> <pass|fail>` line per stage so this script
+# never has to infer a stage result from an exit code.
+cat > "$WORK/probe.c" <<'CEOF'
+#define CL_TARGET_OPENCL_VERSION 120
+#include <CL/cl.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char *SRC_OK =
+    "__kernel void twice(__global float *o, __global const float *i) {\n"
+    "  size_t g = get_global_id(0);\n"
+    "  o[g] = i[g] * 2.0f + 1.0f;\n"
+    "}\n";
+
+/* Not a kernel. If clBuildProgram accepts this, a successful build of the
+   real kernel above means nothing. */
+static const char *SRC_BAD =
+    "__kernel void broken(__global float *o) {\n"
+    "  this is not OpenCL C at all;\n"
+    "}\n";
+
+#define N 1024
+
+static void report(const char *stage, int ok) {
+  printf("PROBE %s %s\n", stage, ok ? "pass" : "fail");
+  fflush(stdout);
+}
+
+int main(void) {
+  cl_uint nplat = 0;
+  cl_platform_id plats[16];
+  cl_platform_id plat = NULL;
+  cl_device_id dev = NULL;
+  char name[512];
+
+  if (clGetPlatformIDs(16, plats, &nplat) != CL_SUCCESS || nplat == 0) {
+    printf("  no OpenCL platform enumerated\n");
+    report("enumerate", 0);
+    return 0;
+  }
+  for (cl_uint p = 0; p < nplat; p++) {
+    name[0] = 0;
+    clGetPlatformInfo(plats[p], CL_PLATFORM_NAME, sizeof name, name, NULL);
+    printf("  platform: %s\n", name);
+    /* Match pocl specifically. Any other ICD present on the runner must not
+       be able to make this probe report success on pocl's behalf. */
+    if (strstr(name, "Portable Computing Language") || strstr(name, "PoCL") ||
+        strstr(name, "pocl")) {
+      cl_device_id d[8];
+      cl_uint nd = 0;
+      if (clGetDeviceIDs(plats[p], CL_DEVICE_TYPE_ALL, 8, d, &nd) == CL_SUCCESS &&
+          nd > 0) {
+        plat = plats[p];
+        dev = d[0];
+        name[0] = 0;
+        clGetDeviceInfo(dev, CL_DEVICE_NAME, sizeof name, name, NULL);
+        printf("  pocl device: %s\n", name);
+        name[0] = 0;
+        clGetDeviceInfo(dev, CL_DEVICE_VERSION, sizeof name, name, NULL);
+        printf("  pocl device version: %s\n", name);
+      }
+    }
+  }
+  if (!dev) {
+    printf("  no pocl device found among %u platform(s)\n", nplat);
+    report("enumerate", 0);
+    return 0;
+  }
+  report("enumerate", 1);
+
+  cl_int err = CL_SUCCESS;
+  cl_context ctx = clCreateContext(NULL, 1, &dev, NULL, NULL, &err);
+  if (!ctx || err != CL_SUCCESS) {
+    printf("  clCreateContext failed: %d\n", (int)err);
+    report("compile", 0);
+    return 0;
+  }
+
+  /* C -- compile. This is where pocl 1.8 + LLVM 11 failed. On failure the
+     build log is the whole point: "it did not compile" without the compiler's
+     reason is not a measurement anyone can act on. */
+  cl_program prog = clCreateProgramWithSource(ctx, 1, &SRC_OK, NULL, &err);
+  err = clBuildProgram(prog, 1, &dev, "", NULL, NULL);
+  if (err != CL_SUCCESS) {
+    size_t len = 0;
+    static char log[65536];
+    clGetProgramBuildInfo(prog, dev, CL_PROGRAM_BUILD_LOG, sizeof log, log, &len);
+    printf("  clBuildProgram failed: %d\n", (int)err);
+    printf("  --- build log ---\n%.*s\n  --- end log ---\n", (int)len, log);
+    report("compile", 0);
+    return 0;
+  }
+  report("compile", 1);
+
+  /* D -- execute. A build is not a run. */
+  cl_command_queue q = clCreateCommandQueue(ctx, dev, 0, &err);
+  float in[N], out[N];
+  for (int i = 0; i < N; i++) { in[i] = (float)i; out[i] = -1.0f; }
+  cl_mem din = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                              sizeof in, in, &err);
+  cl_mem dout = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY, sizeof out, NULL, &err);
+  cl_kernel k = clCreateKernel(prog, "twice", &err);
+  if (err != CL_SUCCESS) {
+    printf("  clCreateKernel failed: %d\n", (int)err);
+    report("execute", 0);
+    return 0;
+  }
+  clSetKernelArg(k, 0, sizeof(cl_mem), &dout);
+  clSetKernelArg(k, 1, sizeof(cl_mem), &din);
+  size_t gws = N;
+  err = clEnqueueNDRangeKernel(q, k, 1, NULL, &gws, NULL, 0, NULL, NULL);
+  if (err != CL_SUCCESS) {
+    printf("  clEnqueueNDRangeKernel failed: %d\n", (int)err);
+    report("execute", 0);
+    return 0;
+  }
+  clFinish(q);
+  err = clEnqueueReadBuffer(q, dout, CL_TRUE, 0, sizeof out, out, 0, NULL, NULL);
+  if (err != CL_SUCCESS) {
+    printf("  clEnqueueReadBuffer failed: %d\n", (int)err);
+    report("execute", 0);
+    return 0;
+  }
+  /* Check the ARITHMETIC, not just that the call returned. A queue that
+     silently drops the kernel leaves the buffer at its initial value, and
+     that must not read as success. */
+  int bad = 0;
+  for (int i = 0; i < N; i++) {
+    float want = (float)i * 2.0f + 1.0f;
+    if (out[i] != want) {
+      if (bad < 3)
+        printf("  out[%d] = %g, expected %g\n", i, out[i], want);
+      bad++;
+    }
+  }
+  if (bad) {
+    printf("  %d/%d elements wrong\n", bad, N);
+    report("execute", 0);
+    return 0;
+  }
+  printf("  kernel ran; all %d elements correct\n", N);
+  report("execute", 1);
+
+  /* E -- reject. The positive control for C. */
+  cl_program badp = clCreateProgramWithSource(ctx, 1, &SRC_BAD, NULL, &err);
+  err = clBuildProgram(badp, 1, &dev, "", NULL, NULL);
+  if (err == CL_SUCCESS) {
+    printf("  INVALID kernel source COMPILED -- pocl's build step is not\n"
+           "  checking anything, so the `compile` pass above is worthless.\n");
+    report("reject", 0);
+  } else {
+    printf("  invalid kernel correctly rejected (%d)\n", (int)err);
+    report("reject", 1);
+  }
+  return 0;
+}
+CEOF
+
+stage "B-E. compile and run a kernel"
+CC_BIN="${CC:-cc}"
+# OPENCL_CFLAGS lets the covering test point at vendored Khronos headers when
+# the distribution package is not installed.
+# shellcheck disable=SC2086
+if ! "$CC_BIN" ${OPENCL_CFLAGS:-} -O1 -o "$WORK/probe" "$WORK/probe.c" -lOpenCL \
+     > "$WORK/cc.log" 2>&1; then
+  note "could not build the probe (no CL headers or no libOpenCL):"
+  /usr/bin/sed 's/^/    /' "$WORK/cc.log"
+  RESULT[enumerate]=unbuilt
+  RESULT[compile]=unbuilt
+  RESULT[execute]=unbuilt
+  RESULT[reject]=unbuilt
+else
+  "$WORK/probe" 2>&1 | /usr/bin/tee "$WORK/probe.log" | /usr/bin/sed 's/^/  /'
+  while read -r _ st verdict; do
+    [ -n "${st:-}" ] && RESULT[$st]="$verdict"
+  done < <(/usr/bin/grep '^PROBE ' "$WORK/probe.log" || true)
+fi
+
+# ---------------------------------------------------------------------------
+stage "VERDICT"
+for s in icd enumerate compile execute reject; do
+  printf '  %-10s %s\n' "$s" "${RESULT[$s]}"
+done
+
+# The single line a human or a later job reads. "unknown" is deliberately in
+# the same bucket as "fail": a stage that did not run is not a stage that
+# passed, which is the mistake this whole file is a reaction to.
+if [ "${RESULT[compile]}" = "pass" ] && [ "${RESULT[execute]}" = "pass" ] \
+   && [ "${RESULT[reject]}" = "pass" ]; then
+  VERDICT="POCL-WORKS"
+  MSG="pocl compiled, ran and correctly rejected -- a bare runner can execute an OpenCL kernel."
+elif [ "${RESULT[compile]}" = "pass" ] && [ "${RESULT[reject]}" != "pass" ]; then
+  VERDICT="POCL-UNTRUSTWORTHY"
+  MSG="pocl built our kernel but also built invalid source; the build step is not checking anything."
+elif [ "${RESULT[enumerate]}" = "pass" ]; then
+  VERDICT="POCL-ENUMERATES-ONLY"
+  MSG="pocl offers a device but cannot compile or run a kernel -- the backlog-79 outcome, again."
+else
+  VERDICT="POCL-ABSENT"
+  MSG="no usable pocl device was reachable from this probe."
+fi
+
+echo
+echo "POCL_PROBE_VERDICT=$VERDICT"
+echo "  $MSG"
+echo
+echo "This step is informational (backlog-99). It gates nothing, and no test is"
+echo "pinned to pocl. If the verdict is not POCL-WORKS, the practical reading is"
+echo "that the project's OpenCL coverage still rests entirely on the container"
+echo "image's Intel oneAPI runtime, and that a bare runner cannot be used as a"
+echo "second, independent OpenCL execution environment."
+
+if [ "$STRICT" -eq 1 ] && [ "$VERDICT" != "POCL-WORKS" ]; then
+  exit 1
+fi
+exit 0

--- a/ci/pocl-runner-probe.test.sh
+++ b/ci/pocl-runner-probe.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+#
+# Covering test for ci/pocl-runner-probe.sh (backlog-99).
+#
+# The probe is informational and exits 0 by design, which is exactly the shape
+# that rots unnoticed: nothing downstream reads its exit code, so a probe that
+# silently stopped measuring would keep printing a verdict nobody could tell
+# from a real one. What has to hold is that the VERDICT tracks the stages, and
+# in particular that no combination of failures can produce POCL-WORKS.
+#
+# It runs on any machine, with or without pocl. The stage results come from a
+# stub compiler that emits chosen PROBE lines, so the classifier is exercised
+# against outcomes this host cannot actually produce -- including the two that
+# matter most and that no CI runner may ever exhibit: a pocl that compiles
+# invalid source, and a pocl that enumerates but cannot build.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROBE="$HERE/pocl-runner-probe.sh"
+[ -x "$PROBE" ] || { echo "FAIL: $PROBE not found or not executable"; exit 2; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/pocl-probe-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+check() {
+  local desc="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    echo "  PASS: $desc"; pass=$((pass + 1))
+  else
+    echo "  FAIL: $desc -- expected '$want', got '$got'"; fail=$((fail + 1))
+  fi
+}
+
+# A stub `cc`: ignores the source, emits a probe binary that prints whatever
+# PROBE lines $STAGES holds. `exit 7` makes it a stub that FAILS to build.
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/stubcc" <<'STUB'
+#!/usr/bin/env bash
+[ "${STUB_CC_FAILS:-0}" = "1" ] && { echo "fatal error: CL/cl.h: No such file"; exit 1; }
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in -o) out="$2"; shift 2;; *) shift;; esac
+done
+{ echo '#!/usr/bin/env bash'; printf '%s\n' "$STAGES" | while IFS= read -r l; do
+    [ -n "$l" ] && echo "echo '$l'"; done; } > "$out"
+chmod +x "$out"
+STUB
+chmod +x "$TMP/bin/stubcc"
+
+# An empty vendors dir: stage A must report fail rather than reading the host's
+# real /etc/OpenCL/vendors, which would make this test's result depend on the
+# machine running it.
+mkdir -p "$TMP/vendors"
+
+run_probe() {
+  STAGES="$1" \
+  STUB_CC_FAILS="${2:-0}" \
+  CC="$TMP/bin/stubcc" \
+  OCL_ICD_VENDORS="$TMP/vendors" \
+  POCL_PROBE_WORKDIR="$TMP/w$RANDOM" \
+    "$PROBE" ${3:-} 2>&1
+}
+verdict_of() { echo "$1" | /usr/bin/grep '^POCL_PROBE_VERDICT=' | /usr/bin/cut -d= -f2; }
+
+ALL_GOOD='PROBE enumerate pass
+PROBE compile pass
+PROBE execute pass
+PROBE reject pass'
+
+echo "ci/pocl-runner-probe.sh covering test"
+
+# Positive control first. Without it every assertion below could be satisfied
+# by a script that always says POCL-ABSENT.
+out="$(run_probe "$ALL_GOOD")"
+check "all stages pass -> POCL-WORKS" "$(verdict_of "$out")" "POCL-WORKS"
+
+# The load-bearing negatives. Each drops exactly one stage.
+out="$(run_probe 'PROBE enumerate pass
+PROBE compile pass
+PROBE execute pass
+PROBE reject fail')"
+check "compiles invalid source -> POCL-UNTRUSTWORTHY" \
+  "$(verdict_of "$out")" "POCL-UNTRUSTWORTHY"
+
+out="$(run_probe 'PROBE enumerate pass
+PROBE compile fail')"
+check "enumerates but cannot compile -> POCL-ENUMERATES-ONLY (the backlog-79 shape)" \
+  "$(verdict_of "$out")" "POCL-ENUMERATES-ONLY"
+
+out="$(run_probe 'PROBE enumerate fail')"
+check "no pocl device -> POCL-ABSENT" "$(verdict_of "$out")" "POCL-ABSENT"
+
+# A build that succeeds is not a kernel that ran. This is the assertion that
+# stops the probe from being downgraded to a compile check later.
+out="$(run_probe 'PROBE enumerate pass
+PROBE compile pass
+PROBE execute fail
+PROBE reject pass')"
+check "compiles but does not run -> not POCL-WORKS" \
+  "$([ "$(verdict_of "$out")" = "POCL-WORKS" ] && echo works || echo "not-works")" \
+  "not-works"
+
+# An unrun stage must never read as a passed one -- the mechanism this whole
+# probe is a reaction to. A compiler that cannot build the probe leaves every
+# stage `unknown`, and unknown is not pass.
+out="$(run_probe "$ALL_GOOD" 1)"
+check "probe that fails to BUILD -> POCL-ABSENT, not POCL-WORKS" \
+  "$(verdict_of "$out")" "POCL-ABSENT"
+check "unbuilt probe marks stages unbuilt, not pass" \
+  "$(echo "$out" | /usr/bin/grep -c 'compile *unbuilt')" "1"
+
+# Stage A is independent of the kernel stages and must read the vendors dir it
+# is told about, not the host's.
+check "empty vendors dir -> icd fail" \
+  "$(echo "$out" | /usr/bin/grep -c 'icd *fail')" "1"
+mkdir -p "$TMP/vendors2" && echo "libpocl.so.2" > "$TMP/vendors2/pocl.icd"
+out2="$(STAGES="$ALL_GOOD" CC="$TMP/bin/stubcc" OCL_ICD_VENDORS="$TMP/vendors2" \
+  POCL_PROBE_WORKDIR="$TMP/wv" "$PROBE" 2>&1)"
+check "a pocl.icd present -> icd pass" \
+  "$(echo "$out2" | /usr/bin/grep -c 'icd *pass')" "1"
+
+# --strict turns the verdict into an exit code. The probe is non-gating in CI,
+# so this is the only place its exit code is meaningful -- and the only way a
+# future promotion to a gate can be trusted.
+run_probe "$ALL_GOOD" 0 --strict >/dev/null 2>&1
+check "--strict exits 0 when pocl works" "$?" "0"
+run_probe 'PROBE enumerate fail' 0 --strict >/dev/null 2>&1
+check "--strict exits non-zero when it does not" \
+  "$([ "$?" -ne 0 ] && echo nonzero || echo zero)" "nonzero"
+run_probe 'PROBE enumerate fail' >/dev/null 2>&1
+check "without --strict the probe stays non-gating (exit 0)" "$?" "0"
+
+echo
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: the pocl probe's verdict tracks its stages, an unrun stage never"
+echo "    reads as a pass, and only a compiled+executed+validating pocl"
+echo "    reports POCL-WORKS (backlog-99)"


### PR DESCRIPTION
Every OpenCL claim this project makes rests on one runtime: the Intel oneAPI CPU ICD inside `ci/Dockerfile`. Nobody has measured what a **bare** GitHub runner does, so there is no second, independent OpenCL execution environment — and no way to tell an oneAPI-specific result from a real one.

backlog-79 tried pocl once, in the image, and pinned e2e to it. pocl 1.8 + LLVM 11 on jammy compiled no kernel at all (`unknown target CPU 'generic'`), the float32 math tests SKIPPED, and CI went green having validated nothing. `ci/assert-toolchain.sh` records that outcome and says the retry belongs in:

> a separate experimental PR that installs it unpinned and reports whether it can compile on the real GitHub runner. When that lands, the checks belong here.

This is that PR. The measured failure was a property of *jammy's* pocl; `ubuntu-latest` ships one several major versions newer, and that is the unmeasured part.

## The point is information, not a gate

The new `pocl-runner-probe` job is `continue-on-error`, installs pocl **unpinned** (whatever the runner ships is the thing being measured), and the probe exits 0 on its own regardless of verdict. **No test is redirected to pocl and nothing consults the result.**

If pocl cannot compile a kernel there, that is a perfectly good result: it means the project's OpenCL coverage still rests entirely on the container image, and a bare runner cannot serve as a second execution environment. Promoting this to a gate is a separate decision that needs a green here first.

## Five stages, reported separately

Lumping them together is how a probe says "OpenCL is broken" when the truth was "no ICD file was installed".

| | stage | |
| --- | --- | --- |
| A | `icd` | an ICD manifest exists for pocl |
| B | `enumerate` | a pocl device is returned |
| C | `compile` | `clBuildProgram` accepts a trivial kernel — **where backlog-79 died** |
| D | `execute` | the kernel RUNS and the arithmetic is checked element-wise |
| E | `reject` | an INVALID kernel is refused |

**D and E are what make a green trustworthy.** A build that succeeded is not a kernel that ran — the same reason this repo distrusts a reported SKIP. And a compiler that accepts nonsense reports success without compiling: E is the positive control for C. The probe matches the pocl platform *by name*, so another ICD present on the runner cannot report success on pocl's behalf.

Verdict is one of `POCL-WORKS` / `POCL-UNTRUSTWORTHY` / `POCL-ENUMERATES-ONLY` / `POCL-ABSENT`, written to the job summary. An `unknown` stage is bucketed with failure, never with pass.

## Verified locally before shipping

No pocl is installed on the dev machine, so the probe's own machinery was validated against the host's real ICD:

- **against rusticl (RX 7900 XTX) with the platform match relaxed**: all five stages pass, kernel returns **1024/1024 correct elements** — so C, D and E are not inert.
- **mutating the kernel to compute the wrong value**: stage D goes red (1023/1024 wrong) — the arithmetic check is real, not decorative.
- **unmodified, with only `rusticl` and `nvidia` ICDs present**: reports `POCL-ABSENT` rather than crediting a non-pocl device.

## Proving it can fail

`ci/pocl-runner-probe.test.sh` — 12 cases, wired into the harness self-test block. It covers the verdict classifier hermetically via a stub compiler, so it runs anywhere and exercises outcomes this host cannot produce, notably a pocl that compiles invalid source.

| mutation | result |
| --- | --- |
| drop `execute` from the verdict | 2 FAIL |
| treat an unbuilt probe as passed | 2 FAIL |

The probe is informational and exits 0 by design, which is the shape that rots unnoticed — nothing reads its exit code, so a probe that stopped measuring would keep printing a verdict indistinguishable from a real one. The covering test is what stops that.

## The result

```
distro:   Ubuntu 24.04.4 LTS
package:  pocl-opencl-icd 5.0-2.1build3
device:   cpu-haswell-AMD EPYC 9V74 80-Core Processor
version:  OpenCL 3.0 PoCL HSTR: cpu-x86_64-pc-linux-gnu-haswell

icd / enumerate / compile / execute / reject : all pass
POCL_PROBE_VERDICT=POCL-WORKS
```

**Yes** — a bare runner compiles and runs an OpenCL kernel, 1024/1024 elements correct, and rejects invalid source.

### This reframes backlog-79, it does not contradict it

Worth stating plainly, because the old conclusion is cited elsewhere in the tree (`ci/Dockerfile`, `ci/assert-toolchain.sh:345-354`) and reads as a fact about pocl:

| | backlog-79 | here |
| --- | --- | --- |
| where | inside the CI image | bare runner |
| distro | Ubuntu 22.04 (jammy) | Ubuntu 24.04 (noble) |
| pocl | 1.8 | 5.0 |
| LLVM | 11 | current |
| result | compiles nothing (`unknown target CPU 'generic'`) | compiles, runs, rejects |

**"pocl cannot compile a kernel" was never a fact about pocl** — it was a fact about pocl 1.8 against LLVM 11 on jammy. Both measurements are correct; they are measurements of different things. This is exactly why it was worth measuring somewhere else rather than inferring from the first result.

Recorded in the probe header and the `ci.yml` job comment (second commit) so the next reader gets both halves.

## Note: the CI gate that could not see this PR (now fixed upstream)

An earlier revision of this PR carried a note claiming the marker `review-gate-hardening` was present in the pristine upstream file. **That was wrong**, and the correction matters. All four declared markers occur **zero** times in the genuinely pristine file. The check had become *unsatisfiable*: it resolved "pristine upstream" as `git merge-base HEAD origin/main`, which stopped meaning pristine the moment the patch landed on `main`, so it compared the file to itself — in direct contradiction with its neighbour at `:606`, which requires the same bytes to *contain* the markers. `review-gate-hardening` was named only because it is first in the array. No marker string could have fixed it.

Separately, `actions/checkout@v4` defaults to `fetch-depth: 1`, and a `pull_request` checkout is a detached HEAD on `refs/pull/N/merge` with no `refs/remotes/origin/main`, so `merge-base` exited 128, `base` became null, the loop iterated nothing, and the check printed its specificity note and exited 0 — **50 passed / 0 failed on PRs versus 49 / 1 on push.**

Both are fixed and merged in PR #341; the resolver now anchors on the manifest and fails closed on a shallow checkout. This PR is rebased onto `4f5335e0`.

**Why the rebase was necessary rather than cosmetic:** the harness self-test block runs under `set -e` and aborted at position 3, so every check after it — including this PR's covering test — was never reached in CI. The green this PR showed before the rebase did not include its own test. It does now.

## Merge is blocked by token scope, not by this PR

`gh pr merge` refuses: *refusing to allow an OAuth App to create or update workflow `.github/workflows/ci.yml` without `workflow` scope*. The available token carries `gist, read:org, repo` only. This affects the **merge step alone** — the branch, its content and its CI are unaffected (pushes go over SSH, not the API). Any PR touching `.github/workflows/` needs either a widened token or a merge by hand; escalated to Mathias.

Rebased onto `939783ad`. `#339`'s `ledger-schema.test.js` line is now in `main`; it and this PR's `ci/pocl-runner-probe.test.sh` line merged cleanly without a conflict — they sit at opposite ends of the harness block. Both verified present and ordered after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
