### PR TITLE
fix(ci): the marker check compared against itself, and PRs could not see it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          # backlog-152. Load-bearing, not a convenience. The default is
+          # `fetch-depth: 1`, and on a `pull_request` event GitHub fetches
+          # `refs/pull/N/merge` into a detached HEAD with NO
+          # `refs/remotes/origin/main` — so every git-history-dependent gate
+          # here reads a repository in which it cannot look anything up.
+          # `scripts/check-review-convergence-hardening.test.js` did exactly
+          # that: its upstream-diff tier silently ran zero comparisons and
+          # printed ok on every PR, while the same commit failed on push to
+          # main (where checkout DOES create origin/main). Same job name, same
+          # bytes, opposite verdicts, and no `github.event_name` conditional
+          # anywhere — the asymmetry was the checkout, not the workflow. About
+          # twenty PRs merged green onto a main that was already red.
+          #
+          # The gate now fails closed when the history is not there, so a
+          # regression of this line turns the pull_request job RED rather than
+          # returning it to a silent pass.
+          fetch-depth: 0
 
       # Runs on the CI checkout, which is exactly the "fresh clone" case: if the
       # review-tool bundle is workstation-local again, this step is the only

--- a/scripts/check-review-convergence-hardening.test.js
+++ b/scripts/check-review-convergence-hardening.test.js
@@ -548,13 +548,94 @@ check("F4 CONTROL: every required key present and well-formed still passes", () 
 // `#98 patch is DECLARED` below, which fails if this constant ever drifts again.
 const PATCH_REF = "#98 — convergence gate fails closed";
 const PATCH_PATH = "scripts/check-review-convergence.js";
+const MANIFEST_PATH = "scripts/review-bundle.manifest.json";
 // A marker of the applied patch, used to decide whether a declaration is OWED.
 const APPLIED_SENTINEL = "evaluateHardening";
 
 function readManifest() {
-  const file = path.join(REPO, "scripts", "review-bundle.manifest.json");
+  const file = path.join(REPO, MANIFEST_PATH);
   if (!fs.existsSync(file)) return null;
   return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function git(...args) {
+  return spawnSync("git", args, { cwd: REPO, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+// ── the pristine upstream ────────────────────────────────────────────────
+//
+// "Pristine upstream" means: the file as the roster bundle last installed it,
+// BEFORE this repo declared a local patch over it. That is the content an
+// upgrade would restore, and therefore the only content against which "could
+// this marker go missing?" is a real question.
+//
+// It is NOT the merge-base, which is what this check used to read. That worked
+// exactly once — on the branch that introduced the patch, whose merge-base
+// predated it. The moment be25ba58 landed on main, merge-base(HEAD, origin/main)
+// started resolving to a commit that CONTAINS the patch, so "upstream" became
+// the patched file itself and every marker was found in it by construction. The
+// check then stood in direct contradiction with its own neighbour
+// ("markers are PRESENT in every patched path"): the same bytes had to contain
+// the markers and not contain them. Unsatisfiable, and permanently red on main
+// for ~28h.
+//
+// The anchor used instead is the manifest, not the gate's own content: walk the
+// commits that touched scripts/review-bundle.manifest.json, newest first, and
+// take the first one whose manifest does not yet declare PATCH_REF. The gate
+// file at that commit is the pre-declaration, upstream-installed content.
+// Anchoring on the declaration rather than on a marker keeps this from being
+// circular — no marker under test participates in choosing the blob it is
+// compared against.
+//
+// Every failure to RESOLVE that blob is a hard failure, never a downgrade. The
+// previous code did `const base = ok ? sha : null` and then iterated `base ? paths : []`,
+// so a checkout without an `origin/main` ref ran zero comparisons and printed
+// "ok". A GitHub `pull_request` checkout is exactly that checkout — see the
+// fetch-depth note in .github/workflows/ci.yml — which is why this file passed
+// on every PR while failing on every push to main.
+function pristineUpstream(rel) {
+  const inRepo = git("rev-parse", "--is-inside-work-tree");
+  assert.strictEqual(
+    inRepo.status,
+    0,
+    "cannot resolve the pristine upstream: not inside a git work tree, so this check would verify nothing"
+  );
+
+  const shallow = git("rev-parse", "--is-shallow-repository");
+  assert.notStrictEqual(
+    shallow.stdout.trim(),
+    "true",
+    `cannot resolve the pristine upstream of ${rel}: this is a SHALLOW clone, so the pre-patch history is not present. ` +
+      "Re-run with full history (CI: set `fetch-depth: 0` on actions/checkout). Reporting ok here is how this check " +
+      "stayed green on every pull request while main was red."
+  );
+
+  const log = git("log", "--format=%H", "HEAD", "--", MANIFEST_PATH);
+  assert.strictEqual(log.status, 0, `cannot list the history of ${MANIFEST_PATH}: ${log.stderr.trim()}`);
+  const commits = log.stdout.split("\n").filter(Boolean);
+
+  let anchor = null;
+  for (const sha of commits) {
+    const manifest = git("show", `${sha}:${MANIFEST_PATH}`);
+    if (manifest.status !== 0) continue;
+    if (!manifest.stdout.includes(PATCH_REF)) {
+      anchor = sha;
+      break;
+    }
+  }
+  assert.ok(
+    anchor,
+    `cannot resolve the pristine upstream of ${rel}: no reachable commit has a ${MANIFEST_PATH} without ` +
+      `${JSON.stringify(PATCH_REF)}. Either the history is truncated, or the declaration has been in the manifest ` +
+      "since the bundle was first tracked — in both cases this check cannot tell a good marker from a useless one, " +
+      "so it fails rather than reporting a tier it did not reach."
+  );
+
+  const blob = git("show", `${anchor}:${rel}`);
+  // The file genuinely not existing upstream is a real, checkable answer (no
+  // marker can be in a file that is not there) — distinct from being unable to
+  // look, which asserted out above.
+  return { anchor, text: blob.status === 0 ? blob.stdout : null };
 }
 
 function declaredPatch() {
@@ -619,25 +700,12 @@ check("local-patch markers are ABSENT from the pristine upstream file", () => {
   // vacuous gate, inside the test whose subject is markers that must be able to
   // fail. Now it always asserts something real and says which tier it got.
   const { markers, paths } = markersUnderTest();
-  const mergeBase = spawnSync("git", ["merge-base", "HEAD", "origin/main"], { cwd: REPO, encoding: "utf8" });
-  const base = mergeBase.status === 0 ? mergeBase.stdout.trim() : null;
 
-  let compared = 0;
-  for (const rel of base ? paths : []) {
-    const upstream = spawnSync("git", ["show", `${base}:${rel}`], { cwd: REPO, encoding: "utf8" });
-    if (upstream.status !== 0) continue; // not tracked at the merge-base yet (pre-#305)
-    compared += 1;
-    for (const marker of markers) {
-      assert.ok(
-        !upstream.stdout.includes(marker),
-        `marker ${JSON.stringify(marker)} is ALSO in the upstream ${rel} — it can never go missing, so it can never detect a revert`
-      );
-    }
-  }
+  assert.ok(paths.length > 0, "the declaration names no paths, so there is no upstream file to compare against");
 
-  // Weaker tier, but a real assertion rather than an absent one: a marker must
-  // be specific enough that upstream could not plausibly contain it. Runs
-  // ALWAYS, so this check can never report success without checking something.
+  // The specificity tier. Cheap, content-free, and it runs first so that an
+  // obviously-useless marker is named as such before the git tier reports it as
+  // merely "also upstream".
   for (const marker of markers) {
     assert.ok(marker.length >= 8, `marker ${JSON.stringify(marker)} is too short to prove a revert`);
     assert.ok(
@@ -645,12 +713,37 @@ check("local-patch markers are ABSENT from the pristine upstream file", () => {
       `marker ${JSON.stringify(marker)} is a single generic word — upstream could contain it, so it cannot prove a revert`
     );
   }
-  if (compared === 0) {
-    process.stdout.write(
-      "       (tier: specificity only — no declared path is tracked at the merge-base yet;\n" +
-        "        the upstream-diff tier arms itself once #305 lands and the gate is tracked)\n"
-    );
+
+  // The upstream tier. Always reached: pristineUpstream() asserts rather than
+  // returning null when it cannot look, so `compared === 0` can no longer be a
+  // silent pass.
+  let compared = 0;
+  let absentUpstream = 0;
+  for (const rel of paths) {
+    const { anchor, text } = pristineUpstream(rel);
+    if (text === null) {
+      absentUpstream += 1;
+      continue;
+    }
+    compared += 1;
+    for (const marker of markers) {
+      assert.ok(
+        !text.includes(marker),
+        `marker ${JSON.stringify(marker)} is ALSO in the pristine upstream ${rel} (as of ${anchor.slice(0, 8)}, the last commit before ` +
+          `${JSON.stringify(PATCH_REF)} was declared) — an upgrade that restored that file would leave the marker in place, so it can never detect a revert`
+      );
+    }
   }
+
+  assert.strictEqual(
+    compared + absentUpstream,
+    paths.length,
+    "not every declared path was resolved against the pristine upstream — a partial pass is a pass that checked less than it claims"
+  );
+  assert.ok(
+    compared > 0,
+    "no declared path existed in the pristine upstream, so nothing was actually compared — the declaration is checking a file the bundle never shipped"
+  );
 });
 
 // ── teardown ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes backlog-152. `main` has been red since `be25ba58` (2026-07-26T09:32) while every PR opened against it showed green — same job, same workflow, no `github.event_name` conditional. Both halves of that turn out to be one story.

## Defect 1 — the marker check compared the patched file against itself

`scripts/check-review-convergence-hardening.test.js`, case *"local-patch markers are ABSENT from the pristine upstream file"*, read the pristine upstream as `git merge-base HEAD origin/main`.

That is correct exactly once: on the branch that introduces the patch, whose merge-base predates it. The moment `be25ba58` landed on `main`, the merge-base started resolving to a commit that **contains** the patch, so "upstream" became the patched file itself and every marker was found in it by construction.

That put the check in direct contradiction with its own neighbour two cases above — *"markers are PRESENT in every patched path"* — which requires the same markers in the same bytes. Unsatisfiable, and no choice of marker string can satisfy it.

**No marker was actually wrong.** All four (`review-gate-hardening`, `evaluateHardening`, `legacy_skip_authorized`, `--allow-legacy`) occur zero times in the real pristine file (`013c7aaa`, the parent of `be25ba58`; equivalently `6ccbe363`, the last commit whose manifest does not declare the patch). The failure message named `review-gate-hardening` only because it is first in the array and `check()` stops at the first assertion — the other three fail identically against a merge-base that has them all.

The pristine upstream is now resolved **from the manifest, not from the gate's content**: walk the commits touching `scripts/review-bundle.manifest.json` newest-first, take the first whose manifest does not yet declare `"#98 — convergence gate fails closed"`, and read `scripts/check-review-convergence.js` at that commit. That is the pre-declaration, upstream-installed content — what an upgrade would restore. Anchoring on the declaration rather than on a marker keeps the resolution non-circular: no marker under test helps choose the blob it is compared against.

`scripts/review-bundle.manifest.json` is **unchanged**. No sha256 is disturbed; `review-bundle-verify.js` reports `OK — 23 file(s) present and sha-matched (bundle 1.6.0+spoc.3)`.

## Defect 2 — the gate could not fail in the context where merges are decided

Same commit, same bytes, two checkout shapes, opposite verdicts:

| simulated checkout | `origin/main` resolves | test |
|---|---|---|
| `push` to main, `fetch-depth: 1` | yes | **exit 1**, 49 passed / 1 failed |
| `pull_request`, `fetch-depth: 1` | **no** | exit 0, 50 passed / 0 failed |

`actions/checkout@v4` defaults to `fetch-depth: 1`. On a `push` it fetches the branch into `refs/remotes/origin/main`, so the ref exists. On a `pull_request` it fetches `refs/pull/N/merge` into a detached HEAD and creates **no** `refs/remotes/origin/main`. So `git merge-base HEAD origin/main` exited 128, `base` became `null`, and:

```js
for (const rel of base ? paths : []) { ... }   // iterates nothing
...
if (compared === 0) { /* prints a "tier: specificity only" note and passes */ }
```

The check ran zero comparisons and printed `ok`. Nothing in `ci.yml` was conditional on the event — the asymmetry was the checkout.

Two changes:

- The resolver **fails closed**. Not inside a work tree, a shallow clone, or no reachable pre-declaration commit are now assertion failures with an actionable message, not a silent downgrade to the specificity tier. The specificity tier still runs, but as an additional check rather than a fallback.
- The `build` job asks for `fetch-depth: 0`, with a comment saying why it is load-bearing.

These are deliberately belt-and-braces: if someone later drops the `fetch-depth: 0` line, the `pull_request` job goes **red** rather than back to a silent pass.

## Proofs — reds observed, not asserted

Run against simulated `actions/checkout@v4` checkouts built with the real ref layouts (`refs/pull/N/merge` detached, `refs/remotes/origin/main`).

| # | scenario | result |
|---|---|---|
| A | PR shape, `fetch-depth: 1`, fixed test | **RED**, exit 1 — *"this is a SHALLOW clone… Re-run with full history (CI: set `fetch-depth: 0`)"* |
| B | PR shape, `fetch-depth: 0`, fixed test, markers intact | green, exit 0, 50/0 |
| C | PR shape, `fetch-depth: 0`, manifest declares `readFileSync` (a string the pristine gate genuinely contains) | **RED**, exit 1 — *"marker `"readFileSync"` is ALSO in the pristine upstream … as of 6ccbe363, the last commit before … was declared"* |
| C-control | **same broken marker, pre-fix test, shallow PR checkout** | exit 0, 50 passed / 0 failed — **the broken marker merges green.** This is the class of regression the PR closes |
| D | pristine gate restored over the patched one (an upgrade wiping the patch) | **RED**, exit 1, 7 passed / 43 failed, including `FAIL local-patch markers are PRESENT in every patched path` — the mechanism still does its real job |

`C` is the demand "a PR carrying the broken marker must go RED in the PR context", and `C-control` is the same input going green today.

## Verification

- Full CI harness block (all 16 gates and self-tests from `ci.yml`) — pass.
- `scripts/check-review-bundle-tracked.sh`, `.test.sh`, `review-bundle-verify.js` — pass, manifest untouched.
- `dune build @all` exit 0; `dune build @fmt` exit 0 (the doc-comment warnings it prints are pre-existing and in files this PR does not touch).
- `dune runtest --force` exit 0. Log is 4700 lines (non-empty — `test-suite-counts.sh` reports `0 cases / 0 FAIL / exit 0` on an empty log, backlog-150):
  `1612 alcotest / 106 suites + 32 qcheck / 6 suites, 0 FAIL, 23 SKIP` — exactly baseline. The 23 SKIPs are pre-existing; no new skip.
- `*.opam` regenerated with the duplicated `"dune" {>= "3.15" & >= "3.15"}` constraint during the build and were reverted, not committed.

## Not verified

- The proofs use locally reconstructed checkouts, not GitHub-hosted runners. The ref layouts were reproduced from `actions/checkout@v4`'s documented behaviour and confirmed by observing `origin/main` present/absent exactly as predicted, but the first real `pull_request` run on this branch is the confirmation.
- Whether `fetch-depth: 0` measurably slows the `build` job on this repo's history. It should be seconds; unmeasured.
- Nothing here can retroactively validate the ~20 PRs merged green onto a red `main`. Their other checks were genuine; only this one was vacuous on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
