### PR TITLE
measure(f16): the other 18 shapes — slice 1's generative rule is false, and the corrected one is local

### DIFF
--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -33,6 +33,23 @@ one explicitly **refused** named function. **No refusal is lifted by this
 change** — slice 3 is still where that happens, and 18 of the 20 emittable
 shapes remain unmeasured and therefore refused.
 
+**Amended 2026-07-27 (backlog-151, the other 18 shapes).** The 18 shapes slice 1
+left unmeasured have been swept, on both ACO stacks and all four local devices.
+Three things changed and none of them lifts a refusal. **(i)** Slice 1's
+candidate generative rule is **false** — absorption is a *local* peephole, not a
+whole-tree property, and shapes A11, A12 and B4 break it with the machine code
+for each (`fp-contraction-policy.md` §13.4). **(ii)** The corrected rule holds on
+12 of 12 discriminating shapes on RADV and 11 of 12 on rusticl, and it means
+**§1.2's model set does not grow per shape** — the four members below are *one
+rule at three settings*, not four independent functions (§1.2's new note, and
+§13.5). **(iii)** Two facts this document asserted are narrowed: the two ACO
+front ends are **not** the same function on shapes slice 1 did not sweep, and
+§1.3's ceiling needs an evaluation point stated when a shape has more than one
+intermediate narrowing (§1.3's new note). Separately, RADV returns `-0` for
+`0.0 - x` at `x = +0` on one input, through every barrier — a **failure** under
+§1.2 rather than a relaxation, recorded at §13.6. **The other 18 shapes remain
+refused**: slice 3 is still where a refusal is lifted.
+
 **Read §0.1 first.** It is one paragraph and it is the argument every other
 choice here follows from.
 
@@ -187,6 +204,33 @@ this section is a set of names rather than a bound:
   §0.1 argued a tolerance could not separate a characterised deviation from this
   defect; slice 1 turned that argument into a measurement.
 
+> **These four are ONE rule at three settings, not four members — measured
+> 2026-07-27 (backlog-151).** Read as a list, §1.2 invites the question this
+> design was most exposed to: does the list grow with every expression a user
+> writes? It does not, and the reason is that the list is not primitive. All
+> four are what a single *local* rule produces on the two shapes slice 1
+> measured:
+>
+> *each f32→f16 narrowing absorbs the single f32 operation immediately feeding
+> it — a multiply, an add/sub, or an explicit fma — rounding it once; a multiply
+> feeding an addition is separately contracted into a single-rounded **binary32**
+> fma; an intermediate binary16 narrowing consumed only by f32 arithmetic may be
+> elided; **every other f32 operation keeps its own correctly-rounded binary32
+> result**.*
+>
+> Three booleans — contract, elide, sink-into-a-select — pick the setting, and
+> each is a measured property of a (driver, front end, decoration) triple rather
+> than a free parameter. `fp-contraction-policy.md` §13.4 has the settings, the
+> verification on ten shapes the rule was not fitted to, and the disassembly.
+> **So the model set is `{S_strict}` plus one generator, for any shape.** §13.5
+> is the argument that this is the difference between a contract and a lookup
+> table, and it is the whole reason the 18 shapes were worth sweeping.
+>
+> The rule is **not** the one slice 1 proposed. That one absorbed the *whole*
+> tree and is refuted at machine-code tier: `v_fma_mixlo_f16` takes one
+> multiply-add and one conversion, so a `v_floor_f32` or a `v_cndmask_b32`
+> between the multiply and the narrowing stops it dead (§13.4).
+
 This is exact agreement, not a tolerance, so it is strictly *tighter* than
 today's bit-identity requirement in every direction except the one deviation it
 names. It is the same discipline as `Test_helpers.classify_df64_result` — an
@@ -250,6 +294,25 @@ change to `ref_discipline` / `ref_fused` — they already compute the intermedia
 only what the kernel wrote to memory. Where a shape's intermediates are not
 observable, the ceiling is **not applicable** and must be reported as such rather
 than silently evaluated on the final value.
+
+> **And it needs a point named when a shape has more than one intermediate
+> narrowing — measured 2026-07-27 (backlog-151).** "At the elided narrowing" is
+> unambiguous for every shape this document had seen, all of which have at most
+> one. Shape B4 of the catalogue,
+> `f16(f16(f16(x*1.1)+1000)*1.1)`, has two, and the two answers differ by three
+> orders of magnitude: at the **outer** narrowing the admitted model exceeds the
+> ceiling on **719 of 63488** inputs and reaches 1638 ulp, because two elisions
+> separate it from `S_strict` there and the derivation above covers exactly one;
+> at the **innermost**, where one elision separates them, it is **0.500044 ulp
+> with zero exceedances**. (On the final value the same deviation reaches
+> **1.85e+06 ulp**, which is this correction reproduced on a third shape.)
+>
+> The harness evaluates at the innermost narrowing and reports the
+> intermediate-narrowing count, so a shape with more than one reads as
+> *partially* covered rather than as a clean pass. **What the ceiling should say
+> about the remaining elisions is not settled here** and is work for slice 0,
+> which is where `classify_f16_result` is built. `fp-contraction-policy.md`
+> §13.7.
 
 The ceiling is **necessary and not sufficient** — §1.1 is the proof, since the
 IGC dropped-narrowing defect sits exactly at 1 ulp. Both checks run; both must
@@ -357,12 +420,31 @@ count-and-first-divergence agreement is upgraded to element-wise; RADV's
 two-narrowing shape, §9.3's open risk, matches a closed-form model under `precise`
 *and* without it, and the `precise` puzzle is reconciled at machine-code tier.
 
-**The admission is per shape, and only two of twenty shapes are measured.**
+**The admission is per shape, and only two of twenty shapes are ADMITTED.**
 §1.2's model set is keyed on *(backend, driver, expression shape)* and always
-was, so this is not the per-shape degradation §9.3 feared — but the other 18
-shapes of `docs/optimization/amdgpu-f16-fusion-shape-audit.md` are unmeasured on
-ACO and under §1.5 stay refused. Read the verdict column as the current status,
-not as a plan.
+was, so this is not the per-shape degradation §9.3 feared. **All twenty shapes
+are now MEASURED** (backlog-151, `fp-contraction-policy.md` §13) — but measured
+is not admitted, and under §1.5 the other 18 stay refused until slice 3 decides.
+Read the verdict column as the current status, not as a plan.
+
+**Three things backlog-151 changed in this table's reading, none of which moves a
+verdict.**
+
+1. **The rusticl and RADV rows are not the same function.** §12.3 concluded
+   "the two ACO front ends behave identically on both shapes"; that was true of
+   those two shapes and is false in general. rusticl keeps the intermediate
+   narrowing where RADV elides it, does not contract multiply-add without being
+   asked, and sinks a narrowing into the arms of a select where RADV does not
+   (2863/63488 against RADV's 0 on the same shape). The allowlist has to be
+   keyed on the **front end** as well as the backend.
+2. **`precise` is inert on more shapes than §9.3's reconciliation implied.** It
+   changes the model on exactly two of the twelve discriminating shapes; on the
+   rest, including an explicit `fma()`, the disassembly is byte-identical
+   (§13.4).
+3. **One shape, A10 `f16(0. - x)`, returns a result matching NO model on RADV**
+   — `-0` where IEEE requires `+0`, at `x = +0`, through every barrier. Under
+   §1.2 that is a **failure**, not a candidate for the admissible set: it is not
+   a rounding. rusticl is correct on it. §13.6.
 
 | backend / driver | device(s) | deviation from `S_strict` | matches `S_fuse_mul_into_narrowing`? | evidence | verdict under Regime A |
 |---|---|---|---|---|---|
@@ -793,7 +875,7 @@ refusal before slice 3.
 | # | slice | proves | hardware | lifts a refusal? | status |
 |---|---|---|---|---|---|
 | **0** | the contract, as a testable classifier | the gate can tell `S_fuse_mul_into_narrowing` from a dropped narrowing | none (host-only) | no | open — and now also carries §1.3's per-narrowing ceiling |
-| **1** | element-wise model characterisation of ACO scalar f16 | whether the contract of §1.2 is deliverable at all | RX 7900 XTX + Raphael iGPU (local) | no | **DONE 2026-07-27 for 2 of 20 shapes — deliverable; 18 shapes still open** |
+| **1** | element-wise model characterisation of ACO scalar f16 | whether the contract of §1.2 is deliverable at all | RX 7900 XTX + Raphael iGPU (local) | no | **DONE — all 20 shapes measured (2 in slice 1, the other 18 in backlog-151). Deliverable, and §1.2's set is generated rather than enumerated. 18 shapes measured but NOT admitted.** |
 | **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | open |
 | **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist | open |
 | **4** | backlog-62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | open |
@@ -901,6 +983,42 @@ Two outcomes, and they are not equally good:
 > feeding it, cut where `NoContraction` forbids a multiply-add* — but its
 > evidence tier is **unverified as a general rule**, and the remaining 18 shapes
 > are exactly what would confirm or break it (`fp-contraction-policy.md` §12.4).
+
+> **SETTLED, 2026-07-27 (backlog-151) — and the rule was WRONG.** All 18 were
+> swept, on RADV and rusticl, on all four local devices, element-wise over the
+> whole finite binary16 domain. Full record in `fp-contraction-policy.md` §13;
+> raw output in `docs/measurements/f16-shapes-2026-07-27/`.
+>
+> - **The rule is false.** Absorption is a *local* peephole, and the
+>   disassembly is why: `v_fma_mixlo_f16` takes one multiply-add and one
+>   conversion, so it cannot reach past anything else. `f16(floor(x*1.1))` and
+>   `f16(x>0 ? x*1.1 : x*0.9)` come back **`S_strict`** where the rule predicts
+>   absorption, with the intervening `v_floor_f32` / `v_cndmask_b32` visible in
+>   the ISA. `f16(f16(f16(x*1.1)+1000)*1.1)` is worse: it matches **no single
+>   member of the model set at all** — 63480/63488 against one member and
+>   63486/63488 against another — because ACO performs *two* single-rounding
+>   events at *two* precisions, contracting `x*1.1+1000` into one binary32 fma
+>   and only then absorbing the final multiply.
+> - **The corrected rule is local, and it holds** on 12 of 12 discriminating
+>   shapes on RADV (plain and `precise`) and 11 of 12 on rusticl, verified on
+>   ten shapes it was not fitted to. §13.4 states it; §1.2 carries it.
+> - **The model set does NOT grow per shape** — the outcome this slice was a
+>   decision point for. It is `{S_strict}` plus one generator with three
+>   measured booleans, for any shape a user writes. §13.5.
+> - **Only 12 of the 20 shapes can discriminate at all.** On the other eight
+>   every model is the same function, so a device sweep of them measures
+>   nothing; four of those eight are the shapes the HIP audit already recorded
+>   as *demoted in the machine code and clean in the numbers*. §13.2.
+> - **One residual and one defect.** rusticl mispredicts on
+>   `f16(f16(x*1.1)*1.1)`, where both stacks constant-fold `1.1*1.1` into
+>   binary32 `1.21` **across** the intermediate narrowing — a reassociation
+>   combine, not an absorption one, identified by the literal `0x3f9ae148` in
+>   the ISA and not modelled here (§13.4). And RADV returns `-0` for `0.0 - x`
+>   at `x = +0`, through every barrier, which is a §1.2 **failure** rather than
+>   a relaxation (§13.6).
+>
+> **No refusal is lifted by this.** Slice 3 is still where that happens, and it
+> now has a rule to gate on rather than four measured points.
 
 **This slice reports its outcome upward before the next one starts.** It is a
 decision point, not a task on a list; a green result funds slices 2–4 and a red

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -2329,3 +2329,310 @@ half a binary32 ulp, and `0.5 + 2^-13/2 ≈ 0.50006`.
   counts each time, which is §1.4(b); §1.4(a)'s in-process repeat and the
   dispatch-shape variation were not run.
 - **Non-ACO Vulkan and non-Mesa OpenCL on AMD.** Unchanged from §7 and §11.7.
+
+## 13. The other 18 shapes: §12.4's generative rule is FALSE, and the corrected one is local (backlog-151)
+
+**Executed 2026-07-27** on this workstation, on all four local ACO devices. This
+is the measurement §12.4 asked for in its last paragraph: it stated one
+candidate rule that produced all five of slice 1's results —
+
+> *An f32→f16 narrowing absorbs the entire f32 expression tree feeding it,
+> evaluating it exactly and rounding once — intermediate binary16 narrowings
+> included, hence elided — cut wherever SPIR-V `NoContraction` forbids a
+> multiply-add contraction, at which cut a correctly-rounded binary32 value is
+> materialised.*
+
+— marked it **unverified as a general rule**, and named the remaining 18 of the
+20 emittable shapes of
+[`docs/optimization/amdgpu-f16-fusion-shape-audit.md`](optimization/amdgpu-f16-fusion-shape-audit.md)
+as exactly what would confirm or break it. **It is broken**, on three shapes, on
+both stacks, with the machine code for each. A corrected rule is stated in §13.4
+and holds on 12 of 12 discriminating shapes on RADV and 11 of 12 on rusticl.
+
+This matters structurally rather than as coverage. §12.4 put it plainly: the
+rule "is the difference between a contract keyed on a driver and a lookup table
+keyed on every expression a user might write". §13.5 answers that question, and
+the answer is neither of those two.
+
+Instruments, committed with this section:
+`tools/f16_shape_catalogue/f16_shape_catalogue.ml` (the catalogue, the exact
+evaluator and the rule as code), its host-only probe
+`tools/f16_shape_catalogue/probe/probe_f16_shape_separation.ml`, and a
+`--catalogue` mode added to slice 1's two probes rather than a third and fourth
+probe. Raw output: `docs/measurements/f16-shapes-2026-07-27/`.
+
+### 13.1 The models are GENERATORS, and they are pinned to slice 1 before anything is read
+
+§12 hand-wrote seven closed forms for two shapes. Twenty shapes cannot be
+handled that way without the answer to §13.5's question being decided by the
+instrument. So each of §1.2's named members is restated as a **policy** — a
+decision about which mandated roundings are elided — applied to an expression
+tree. Five policies, twenty shapes.
+
+The hinge is calibration, and it runs before any device is touched. The generic
+evaluator must reproduce §12's **seven hand-written closed forms bit-for-bit on
+all 63488 inputs**, on `f16(x*1.1)` and `f16(f16(x*1.1)+1000)`, and must
+reproduce §12.2's separations — **2912, 620, 5075, 4776, 4774** — computed from
+the generic evaluator rather than from those closed forms. The probes exit
+non-zero and print nothing else if it fails. Without that, agreement on the
+other 18 shapes would be a statement about a new instrument rather than about
+the thing slice 1 measured.
+
+The arithmetic is Shewchuk floating-point expansions plus a sticky flag for
+division, for the reason §12.1 gives: three of the models round to binary16 in a
+single step from a sum spanning 65 bits, and evaluating that in binary64 would
+round first and make the model a *different function* — differing exactly at the
+binary16 ties, which is where §1.3's counterexample lives.
+
+The device source and the host model are generated from the **same tree**, so
+they cannot drift apart and have a sweep measure the drift.
+
+### 13.2 Eight of the twenty shapes cannot discriminate at all, and that is the first result
+
+A shape on which all five policies are the same function over the whole finite
+binary16 domain returns "matches `S_strict`, 0/63488" and that sentence measures
+nothing. Twenty such rows would read as twenty confirmations. So the host pass
+counts the **distinct functions** the policies induce per shape, and labels the
+degenerate ones:
+
+| distinct models | shapes |
+|---|---|
+| **1 — NON-DISCRIMINATING** | A1, A3, A4, A5, A9, A10, A13, C1 |
+| 2 | A2, A7, A8, A11, A12, A14, A15 |
+| 3 | A6 |
+| 4 | B2, B3 |
+| 5 | B1, B4 |
+
+**So the honest denominator is 12, not 20.** A1 and C1 have no arithmetic to
+elide; A3/A4 (add/sub into the narrowing), A9 (`sqrt(x*x)` is `|x|` exactly),
+A10 (negation is exact) and A13 (`x*x` needs 22 bits and is exact in binary32)
+are the four shapes the HIP audit already recorded as **demoted in the machine
+code and clean in the numbers** — the same fact, reached from the model side.
+A5 (`x/3`) joins them: rounding the exact quotient once and rounding it twice
+agree on every one of the 63488 inputs.
+
+### 13.3 What the two ACO stacks return, shape by shape
+
+Both RADV devices returned identical results, and both rusticl devices returned
+identical results. Counts are disagreements with `S_strict` out of 63488;
+`R_*` are the corrected rule's instances (§13.4). Evidence tier: **executed,
+element-wise over the whole finite binary16 domain**, on `AMD Radeon RX 7900 XTX
+(RADV NAVI31)` and `AMD Ryzen 9 7950X (RADV RAPHAEL_MENDOCINO)`, radv / Mesa
+26.1.4-arch3.1 / Vulkan 1.4.354, and on `AMD Radeon RX 7900 XTX (radeonsi,
+navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)` and its Raphael iGPU equivalent.
+
+| shape | models | RADV plain | RADV `precise` | rusticl |
+|---|---|---|---|---|
+| A1 `narrow x` | 1 | 0 | 0 | 0 |
+| A2 `narrow (x*1.1)` | 2 | **2912** `R_local_absorb` | 2912, same | 2912, same |
+| A3 `narrow (x+1000)` | 1 | 0 | 0 | 0 |
+| A4 `narrow (x-1000)` | 1 | 0 | 0 | 0 |
+| A5 `narrow (x/3)` | 1 | 0 | 0 | 0 |
+| A6 `narrow (x*1.1+1000)` | 3 | **484** `R_local_absorb` | **2** `R_local_absorb_nocontract` | **2** `R_local_absorb_opencl` |
+| A7 `narrow ((x+1000)*1.1)` | 2 | **374** `R_local_absorb` | 374, same | 374, same |
+| A8 `narrow (fma x 1.1 1000)` | 2 | **484** `R_local_absorb` | 484, same | 484, same |
+| A9 `narrow (sqrt (x*x))` | 1 | 0 | 0 | 0 |
+| A10 `narrow (0-x)` | 1 | **1 input matches NO model** | same | 0 |
+| A11 `narrow (floor (x*1.1))` | 2 | **0 — `S_strict`** | 0 | 0 |
+| A12 `narrow (x>0 ? x*1.1 : x*0.9)` | 2 | **0 — `S_strict`** | 0 | **2863** `R_local_absorb_opencl` |
+| A13 `narrow (x*x)` | 1 | 0 | 0 | 0 |
+| A14 `narrow (x*1.1*1.1)` | 2 | **308** `R_local_absorb` | 308, same | 308, same |
+| A15 `narrow (x*1.1 + x/3)` | 2 | **744** `R_local_absorb` | **0** `R_local_absorb_nocontract` | **0**, same |
+| B1 `narrow (narrow (x*1.1)+1000)` | 5 | **5075** `R_local_absorb` | **4776** `R_local_absorb_nocontract` | **620** `R_local_absorb_opencl` |
+| B2 `narrow (narrow (x*1.1)*1.1)` | 4 | **17036** `R_local_absorb` | 17036, same | 17036, **the one residual** |
+| B3 `narrow (narrow (x+1000)*1.1)` | 4 | **7803** `R_local_absorb` | 7803, same | **963** `R_local_absorb_opencl` |
+| B4 `narrow (narrow (narrow (x*1.1)+1000)*1.1)` | 5 | **10707 — matched NO SINGLE MODEL under §12.4's rule** | **10707** `R_local_absorb_nocontract` | **1518** `R_local_absorb_opencl` |
+| C1 f16→f16 copy | 1 | 0 | 0 | 0 |
+
+Five of these counts land within one of the HIP audit's barrier-removed figures
+for the same shape — A7 374/374, A8 484/484, A14 308/309, and on rusticl B1
+620/620, B3 963/963, B4 1518/1518 — which is three unrelated compilers agreeing
+on a shape-by-shape signature rather than on one number.
+
+**Zero inputs matched no model anywhere except A10**, and A10 is §13.6.
+
+### 13.4 Why §12.4's rule is false, at machine-code tier
+
+Three shapes break it, and the disassembly says the same thing about all three:
+the absorbing instruction is `v_fma_mixlo_f16`, which takes **one** multiply-add
+and **one** conversion. It is a peephole. It cannot reach past an operation that
+is neither.
+
+`RADV_DEBUG=asm`, RX 7900 XTX (RADV NAVI31), one shader compiled per process so
+each dump is attributable:
+
+| shape / variant | what ACO emits | consequence |
+|---|---|---|
+| **A11** `narrow (floor (x*1.1))`, plain **and** `precise` — byte-identical | `v_fma_mix_f32 v1, 0xcccd, v1` **·** `v_floor_f32_e32 v1, v1` **·** `v_fma_mixlo_f16 v2, 1.0, v1, neg(0)` | the multiply is materialised as its own correctly-rounded f32; the narrowing absorbs only an **identity multiply by 1.0**, i.e. nothing. `S_strict`. |
+| **A12** `narrow (x>0 ? x*1.1 : x*0.9)`, plain **and** `precise` — byte-identical | three `v_fma_mix_f32` **·** `v_cmp_lt_f32` **·** `v_cndmask_b32` **·** `v_fma_mixlo_f16 v4, 1.0, v1, neg(0)` | same: both products are materialised at f32, the select is not absorbable, the narrowing absorbs an identity multiply. `S_strict`. |
+| **B4** plain | `v_fma_mix_f32 v1, 0xcccd, v1, s1` **·** `v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0)` | **two** single-rounding events at **two different precisions**: `x*1.1+1000` contracted into one *binary32* fma, then the final `*1.1` absorbed into the narrowing. No whole-tree model is that. |
+
+B4 is the strongest form of the failure. It matched
+`S_absorb_all_into_final_narrowing` on 63480 of 63488 inputs and
+`S_f32_mul_then_absorb_add` on 63486 — **no single member of the model set
+describes it**, while every individual input matches some member. §1.2 requires
+bit-identity to *one* member on *every* input, so that is a failure of the
+contract as written, and it is the first time the two readings of §1.2 have come
+apart. The harness reports them differently for that reason.
+
+> **The corrected rule, and it is stated as a peephole because that is what the
+> silicon has.**
+>
+> *Each f32→f16 narrowing absorbs the single f32 operation immediately feeding
+> it — a multiply, an add/sub, or an explicit fma — evaluating it exactly from
+> its operands and rounding once. Independently, a multiply feeding an addition
+> is contracted into a single-rounded **binary32** fma. An intermediate binary16
+> narrowing whose value is consumed only by f32 arithmetic may be elided. **Every
+> other f32 operation keeps its own correctly-rounded binary32 result.**
+> `NoContraction` removes the contraction clause only: it does not reach the
+> narrowing's own absorption, nor a plain multiply, nor an explicit fma.*
+>
+> Evidence tier: **executed**, element-wise on 63488 inputs × 12 discriminating
+> shapes × 2 variants × 4 devices, plus **machine-code** for eleven shapes.
+
+It is **one semantics with three boolean knobs**, and the knobs are not a
+degree of freedom left open — each is a measured property of a (driver,
+decoration) pair:
+
+| instance | contract mul+add? | elide intermediate narrowings? | sink a narrowing into a select's arms? | measured on |
+|---|---|---|---|---|
+| `R_local_absorb` | yes | yes | no | RADV, plain |
+| `R_local_absorb_nocontract` | no | yes | no | RADV, `precise` — **what the shipped codegen runs under** |
+| `R_local_absorb_opencl` | no | no | **yes** | rusticl |
+
+All three reduce onto §1.2's existing named members on the two shapes slice 1
+measured, and the calibration asserts it: on A2 all three are
+`S_fuse_mul_into_narrowing`; on B1 they are `S_absorb_all_into_final_narrowing`,
+`S_f32_mul_then_absorb_add` and `S_fuse_mul_into_narrowing` respectively. **The
+four names slice 1 admitted are not four independent members. They are one rule
+seen at three settings on two shapes**, and that could not be seen with two
+shapes.
+
+**Two things the knobs settle that slice 1 could not.**
+
+- **`precise` does NOT cut an explicit `fma()`.** A8's plain and `precise`
+  disassembly are byte-identical — one `v_fma_mixlo_f16 v3, v1, 0xcccd, v2` —
+  so `NoContraction` binds nothing there. That is the literal reading of §12.4's
+  own words: an author-written fma is not a *contraction* of anything. The
+  eager reading, which also cuts it, was implemented first and refuted by this
+  shape; the superseded run is kept at
+  `docs/measurements/f16-shapes-2026-07-27/vulkan-radv-eager-cut.txt` so the
+  choice reads as a measurement rather than as a preference.
+- **The two ACO front ends are NOT the same function.** §12.3 concluded "the two
+  ACO front ends behave identically on both shapes", which was true of the two
+  shapes and is false in general. rusticl **keeps** the intermediate narrowing
+  where RADV elides it (B1, B3, B4), does **not** contract multiply-add (A6,
+  A15 — it matches the `precise` model with no decoration asked for), and
+  **sinks** a narrowing into the arms of a select where RADV does not (A12:
+  2863/63488 against RADV's 0). The backend is shared; the front ends are not,
+  and the f16 allowlist has to be keyed on the pair.
+
+**The one residual: B2, on rusticl.** `narrow(narrow(x*1.1)*1.1)` is the only
+discriminating shape where the corrected rule mispredicts — rusticl elides the
+intermediate narrowing there while keeping it on B1, B3 and B4. The ISA names
+the mechanism and it is not absorption: both stacks emit a single
+`v_fma_mixlo_f16 v2, 0xe148, v1`, whose literal `0x3f9ae148` is **binary32
+1.21** — the compiler has **reassociated and constant-folded `1.1*1.1` across
+the intermediate narrowing**, which requires eliding it. That is a
+reassociation combine sitting beside the absorption one, and this document does
+not model it. RADV's `precise` variant blocks it (A14 `precise` emits two
+instructions where plain emits one), which is the expected behaviour of a
+decoration that forbids reassociation.
+
+### 13.5 Does the model set grow per shape? No — but only after the correction
+
+This is the question §12.4 said the 18 shapes existed to answer.
+
+**Under §12.4's rule as written, the answer would have been yes, and badly.** B4
+plain matches no member, so a per-shape table would need a new entry for it; and
+because that entry is "one binary32 fma then one absorbed multiply", the entry
+for B4 tells you nothing about any other shape. That is a lookup table.
+
+**Under the corrected rule, the answer is no.** §1.2's model set is
+`{S_strict} ∪ {R_local_absorb(shape, knobs)}` — **two names and three bits**,
+for twenty shapes and for any shape a user writes. The four members §1.2 lists
+today are the instances that rule produces on the two shapes slice 1 measured,
+which is why they read as four independent functions.
+
+So the correction is not cosmetic and it is not a downgrade. It replaces four
+measured points with a rule that generates them, and the rule was verified on
+ten shapes it was not fitted to. The cost is that the rule is **per (driver,
+front end, decoration)** rather than per backend, which §12.3 had provisionally
+merged.
+
+### 13.6 A10: RADV returns `-0` for `0.0 - x` at `x = +0`, and the barrier does not fix it
+
+Shape A10 is `narrow(0. - x)`. It is non-discriminating — every model is the
+same function — and on **one** input, `x = +0`, **both RADV devices return
+`0x8000` (`-0`) where IEEE-754 round-to-nearest requires `+0`**: `(+0) − (+0)`
+is `+0` in every rounding mode except round-toward-negative. rusticl returns
+`+0` and is correct.
+
+Three things make this worth a subsection rather than a footnote:
+
+- **It survives the barrier.** The green control forces every temporary through
+  the volatile SSBO and still returns `-0`, so this is not the absorption hazard
+  and no amount of barriering removes it. The likely transform is `0 - x → -x`,
+  which is valid only under a no-signed-zeros assumption nobody asked for.
+- **Under §1.2 as written it is a FAILURE, not a relaxation.** "A result
+  matching no member is a failure, however small the numeric difference" — and
+  this difference is a sign bit on a zero, which is as small as a difference
+  gets while still being one. It is not a candidate for the admissible set,
+  because it is not a rounding at all.
+- **A count-only sweep reports it as `1 / 63488` and nothing else.** It was
+  identifiable only because the harness prints the device bit pattern next to
+  what each model wanted, at the first input matching none. The equivalent
+  hazard in the models themselves was also caught this way and is recorded in
+  the code: an early revision of the division model dropped the sign of `-0/3`,
+  and it showed up as A5 disagreeing with the device on exactly one input.
+
+Not filed as a Sarek defect here — Sarek's f16 GLSL path is refused today and
+§13 lifts nothing — but it is the shape a future slice-3 gate will trip on
+first, and it is the reason the gate must sweep both zeros.
+
+### 13.7 §1.3's ceiling is derived for ONE elided rounding, and B4 has two
+
+§1.3 evaluates the ceiling **at the narrowing where the rounding was elided**,
+deriving 1 ulp from "every deviation in the admitted class is the elision of
+exactly one round-to-nearest step". B4 is the first shape with **two**
+intermediate narrowings, and it therefore has two candidate evaluation points.
+Measured at the outer of them, the admitted model exceeds the ceiling on **719
+of 63488 inputs**, reaching 1638 ulp — because two elisions separate the model
+from `S_strict` there, and the derivation covers one.
+
+Measured at the **innermost** narrowing, where exactly one elision separates
+them, the worst deviation is **0.500044 ulp with zero exceedances** — the same
+figure and the same explanation as §12.5's `S_absorb_all` row (half a binary16
+ulp plus half a binary32 one). On the **final** value the same deviation reaches
+**1.85e+06 ulp**, reproducing §1.3's correction on a third shape.
+
+**§1.3 does not say which narrowing to evaluate at when there is more than one,
+and it must.** The harness evaluates at the innermost and prints the
+intermediate-narrowing count so a shape with more than one is read as *partially*
+covered rather than as a clean pass. Stating the rest of the elisions is left to
+§1.3 rather than settled here.
+
+### 13.8 What this did NOT measure
+
+- **Any driver but ACO.** Nothing here says what nvrtc, IGC, ANV, pocl or Metal
+  do on the 18 shapes; all of them are 0/63488 on the two shapes slice 1 swept
+  and are refused today regardless.
+- **A `precise` equivalent on OpenCL.** rusticl was swept plain only. OpenCL C
+  has no `NoContraction` spelling this project has measured, so
+  `R_local_absorb_opencl`'s `contract = false` is the *default* rusticl
+  behaviour rather than a decoration's effect.
+- **Constant folding across a narrowing**, the B2 residual of §13.4. Its
+  mechanism is identified at machine-code tier and it is not modelled.
+- **One constant, one addend, one divisor.** `1.1`, `1000`, `3` and `0.9`
+  throughout, as in every prior measurement of this hazard, so the counts stay
+  comparable — but the rule is confirmed against one operand pattern per shape,
+  not a family. A15's fdiv happens to agree with correctly-rounded division on
+  all 63488 inputs; SPIR-V permits it not to, and a different divisor might
+  expose that.
+- **The source spelling.** The shapes are emitted in three-address form, one
+  temporary per operation, which is what `Sarek_ir_glsl.gen_var_decl` produces.
+  A12 in particular is a ternary rather than an `if`/`else`, and A11's `floor`
+  result is a named temporary; a different spelling could give a compiler a
+  different peephole to match. This measures a driver on a codegen shape, which
+  is what §7(c) says of every probe in this document.
+- **Sarek-generated shaders.** Still §7 slice 3, unchanged.

--- a/docs/measurements/f16-shapes-2026-07-27/README.md
+++ b/docs/measurements/f16-shapes-2026-07-27/README.md
@@ -1,0 +1,90 @@
+# backlog-151 — the 18 unmeasured f16 shapes: preserved run output, 2026-07-27
+
+The numbers in
+[`docs/fp-contraction-policy.md`](../../fp-contraction-policy.md) §13 are read
+off these files. They are committed for the same reason slice 1's are
+(`../f16-slice1-2026-07-27/README.md`): a measurement quoted only as prose
+cannot be checked.
+
+**What this settles.** `fp-contraction-policy.md` §12.4 closed slice 1 with one
+candidate generative rule — *"a narrowing absorbs the whole f32 tree feeding it,
+cut where `NoContraction` binds"* — marked **unverified as a general rule**, and
+named the remaining 18 of the 20 emittable shapes as what would confirm or break
+it. It is **broken**, and the corrected rule is in §13.
+
+## What was run
+
+All on one workstation: AMD Ryzen 9 7950X, Linux 7.1.2-3-cachyos, Mesa
+26.1.4-arch3.1, DRM 3.64. No remote machine.
+
+| file | command | devices |
+|---|---|---|
+| `host-separation.txt` | `dune exec tools/f16_shape_catalogue/probe/probe_f16_shape_separation.exe` | none — host only |
+| `vulkan-radv.txt` | `dune exec sarek-vulkan/probe/probe_vulkan_f16_model_agreement.exe -- --catalogue` | `AMD Radeon RX 7900 XTX (RADV NAVI31)`, `AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)`, radv / Mesa 26.1.4-arch3.1 / Vulkan 1.4.354 |
+| `opencl-rusticl.txt` | `dune exec sarek-opencl/probe/probe_opencl_f16_model_agreement.exe -- --catalogue` | `AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)` and the Raphael iGPU equivalent |
+| `vulkan-radv-isa.txt` | `RADV_DEBUG=asm dune exec sarek-vulkan/probe/probe_vulkan_f16_model_agreement.exe -- --shape <id> --variant <plain\|precise>` | RX 7900 XTX (RADV NAVI31) |
+| `vulkan-radv-eager-cut.txt` | superseded run, kept as evidence — see below | both RADV devices |
+
+`--shape`/`--variant` compiles **one** shader per process, so each
+`RADV_DEBUG=asm` dump is attributable to a named shape and variant. A full
+catalogue run compiles sixty shaders in sequence and reading its dump would mean
+guessing which belongs to which, which is not a machine-code evidence tier.
+
+## Why `vulkan-radv-eager-cut.txt` is kept
+
+The rule's cut clause says *"cut wherever `NoContraction` forbids a multiply-add
+**contraction**"*. That has two readings, and shape **A8** — `narrow(fma x 1.1
+1000.)` — separates them: does the cut also apply to an fma the *author wrote*,
+which is not a contraction of anything?
+
+`vulkan-radv-eager-cut.txt` is the run under the **eager** reading, where it
+does. A8 `precise` reports `S_absorb_all` there, against a prediction of the cut
+model, so the eager reading is refuted and the literal one is what the code
+implements. The ISA agrees at machine-code tier: A8's `plain` and `precise`
+disassembly are **byte-identical**, a single `v_fma_mixlo_f16 v3, v1, 0xcccd,
+v2`. Keeping the superseded run is the difference between "the code implements
+the literal reading" and "the measurement chose it".
+
+**Read only A8 out of that file.** It predates two other fixes and its A5 and
+A10 rows are wrong for a reason unrelated to the cut: the division model dropped
+the sign of `-0/3`, so it reports `x = -0` as unmatched on A5 where the device is
+correct. That bug is itself worth noting — it was found by the same instrument,
+printing the device bit pattern beside each model's at the first unmatched input,
+and it is fixed in the committed code.
+
+## How to read them
+
+Each sweep prints one line per model; `0 / 63488 disagreements` marked `<==
+EXACT, element-wise` is the model the device is bit-identical to. Three things
+are new relative to slice 1's files and matter when reading:
+
+- **`N distinct models`.** How many distinct functions the five slice-1 policies
+  induce on that shape over the whole domain. **`1 distinct model` means the
+  shape is NON-DISCRIMINATING**: every policy is the same function, so whatever
+  the device returns is not evidence for or against anything. Eight of the
+  twenty shapes are in that state. A table of twenty zeros would otherwise read
+  as twenty confirmations.
+- **`NO SINGLE MODEL (mixture)`** is distinguished from **`NO MODEL (N
+  unmatched)`**. §1.2 requires bit-identity to *one* member on *every* input,
+  which is stronger than every input matching *some* member. Shape B4 `plain`
+  under the old rule was the first case where those two differ.
+- **the reporting control**, printed before any device number: a host-computed
+  **non-strict** model is fed through the same classifier and the harness must
+  *name that model*. Slice 1's re-absorbed control was caught only because the
+  harness reported the wrong model rather than an implausible count; a
+  count-only sweep over twenty shapes would have missed the same thing twenty
+  times.
+
+## Reproducing
+
+```
+dune exec tools/f16_shape_catalogue/probe/probe_f16_shape_separation.exe
+dune exec sarek-vulkan/probe/probe_vulkan_f16_model_agreement.exe -- --catalogue
+dune exec sarek-opencl/probe/probe_opencl_f16_model_agreement.exe -- --catalogue
+```
+
+The first needs no GPU. It runs the calibration that pins the generic evaluator
+to slice 1's seven hand-written closed forms — bit-for-bit on all 63488 inputs,
+on the two shapes slice 1 measured on a device — and refuses to print anything
+else until that passes. Nothing in the other two files is readable if it fails,
+because the generator would then not be the thing slice 1 measured.

--- a/docs/measurements/f16-shapes-2026-07-27/host-separation.txt
+++ b/docs/measurements/f16-shapes-2026-07-27/host-separation.txt
@@ -1,0 +1,1266 @@
+backlog-151 — the 20-shape f16 catalogue, host-only separation analysis
+
+CALIBRATION PASSED.
+  - slice 1's four host checks (63488 round-trip, 620, 2912, x = -907.5);
+  - all 20 shapes x 5 policies are exactly computable;
+  - the GENERIC evaluator reproduces slice 1's seven hand-written closed
+    forms bit-for-bit on A2 and B1, all 63488 inputs;
+  - and reproduces the recorded separations 2912 / 620 / 5075 / 4776 /
+    4774 from the generic evaluator rather than from those closed forms.
+
+SHAPE DISCRIMINATION — how many DISTINCT functions the five policies
+induce on each shape over all 63488 finite binary16 inputs.
+
+  id   shape                                          distinct models
+  A1   narrow x                                       1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+  A2   narrow (x *. 1.1)                              2
+  A3   narrow (x +. 1000.)                            1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+  A4   narrow (x -. 1000.)                            1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+  A5   narrow (x /. 3.)                               1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+  A6   narrow (x *. 1.1 +. 1000.)                     3
+  A7   narrow ((x +. 1000.) *. 1.1)                   2
+  A8   narrow (fma x 1.1 1000.)                       2
+  A9   narrow (sqrt (x *. x))                         1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+  A10  narrow (0. -. x)                               1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+  A11  narrow (floor (x *. 1.1))                      2
+  A12  narrow (if x>0. then x*.1.1 else x*.0.9)       2
+  A13  narrow (x *. x)                                1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+  A14  narrow (x *. 1.1 *. 1.1)                       2
+  A15  narrow (x *. 1.1 +. x /. 3.)                   2
+  B1   narrow (narrow (x *. 1.1) +. 1000.)            5
+  B2   narrow (narrow (x *. 1.1) *. 1.1)              4
+  B3   narrow (narrow (x +. 1000.) *. 1.1)            4
+  B4   narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) 5
+  C1   out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) 1   <== NON-DISCRIMINATING: a device sweep of this shape measures nothing
+
+
+PER-SHAPE PAIRWISE SEPARATION
+
+--- A1 : narrow x ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A2 : narrow (x *. 1.1) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   2912
+    S_strict                           vs S_f32_mul_then_absorb_add          :   2912
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   2912
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :   2912
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :   2912
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A3 : narrow (x +. 1000.) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A4 : narrow (x -. 1000.) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A5 : narrow (x /. 3.) ---
+  NOTE: DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is evidence about fdiv precision and NOT about the absorption rule
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A6 : narrow (x *. 1.1 +. 1000.) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :    484
+    S_strict                           vs S_f32_mul_then_absorb_add          :      2
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :    484
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      2
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A7 : narrow ((x +. 1000.) *. 1.1) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    374
+    S_strict                           vs S_absorb_all_into_final_narrowing  :    374
+    S_strict                           vs S_f32_mul_then_absorb_add          :    374
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :    374
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    374
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :    374
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A8 : narrow (fma x 1.1 1000.) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    484
+    S_strict                           vs S_absorb_all_into_final_narrowing  :    484
+    S_strict                           vs S_f32_mul_then_absorb_add          :    484
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :    484
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A9 : narrow (sqrt (x *. x)) ---
+  NOTE: SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the device's sqrt precision is separately specified
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A10 : narrow (0. -. x) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A11 : narrow (floor (x *. 1.1)) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :    472
+    S_strict                           vs S_f32_mul_then_absorb_add          :    472
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :    472
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :    472
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    472
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :    472
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A12 : narrow (if x>0. then x*.1.1 else x*.0.9) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   2863
+    S_strict                           vs S_f32_mul_then_absorb_add          :   2863
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   2863
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   2863
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :   2863
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :   2863
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A13 : narrow (x *. x) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A14 : narrow (x *. 1.1 *. 1.1) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    308
+    S_strict                           vs S_absorb_all_into_final_narrowing  :    308
+    S_strict                           vs S_f32_mul_then_absorb_add          :    308
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :    308
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    308
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :    308
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- A15 : narrow (x *. 1.1 +. x /. 3.) ---
+  NOTE: DIVISION: as A5 — an fdiv mismatch is not evidence about absorption
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :    744
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :    744
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    744
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    744
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- B1 : narrow (narrow (x *. 1.1) +. 1000.) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+
+--- B2 : narrow (narrow (x *. 1.1) *. 1.1) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   5368
+    S_strict                           vs S_absorb_all_into_final_narrowing  :  17036
+    S_strict                           vs S_f32_mul_then_absorb_add          :  17036
+    S_strict                           vs S_drop_intermediate_narrowing      :  16728
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :  16786
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :  16786
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :  17094
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    308
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :    308
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- B3 : narrow (narrow (x +. 1000.) *. 1.1) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    963
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   7803
+    S_strict                           vs S_f32_mul_then_absorb_add          :   7803
+    S_strict                           vs S_drop_intermediate_narrowing      :   7431
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   7434
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   7434
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   7808
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    374
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :    374
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+--- B4 : narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) ---
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   1518
+    S_strict                           vs S_absorb_all_into_final_narrowing  :  10706
+    S_strict                           vs S_f32_mul_then_absorb_add          :  10707
+    S_strict                           vs S_drop_intermediate_narrowing      :  10671
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :  10734
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :  10733
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :  10771
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :     10
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :     57
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :     59
+
+--- C1 : out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) ---
+  NOTE: NO NARROWING AT ALL: there is nothing for any policy to elide, so every model coincides by construction
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :      0
+    S_strict                           vs S_absorb_all_into_final_narrowing  :      0
+    S_strict                           vs S_f32_mul_then_absorb_add          :      0
+    S_strict                           vs S_drop_intermediate_narrowing      :      0
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :      0
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :      0
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :      0
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :      0
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :      0
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      0
+    *** S_f32_mul_then_absorb_add and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_absorb_all_into_final_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_fuse_mul_into_narrowing and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_drop_intermediate_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_f32_mul_then_absorb_add COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_absorb_all_into_final_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+    *** S_strict and S_fuse_mul_into_narrowing COINCIDE on the whole domain: a device matching one matches the other, and the pair discriminates nothing ***
+
+
+GENERATED SOURCE — GLSL, plain, one per shape
+
+--- A1 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  outb[i] = pack(float16_t(x));
+}
+
+--- A2 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  outb[i] = pack(float16_t(t1));
+}
+
+--- A3 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x + 1000.0;
+  outb[i] = pack(float16_t(t1));
+}
+
+--- A4 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x - 1000.0;
+  outb[i] = pack(float16_t(t1));
+}
+
+--- A5 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x / 3.0;
+  outb[i] = pack(float16_t(t1));
+}
+
+--- A6 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  float t2 = t1 + 1000.0;
+  outb[i] = pack(float16_t(t2));
+}
+
+--- A7 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x + 1000.0;
+  float t2 = t1 * 1.1;
+  outb[i] = pack(float16_t(t2));
+}
+
+--- A8 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = fma(x, 1.1, 1000.0);
+  outb[i] = pack(float16_t(t1));
+}
+
+--- A9 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * x;
+  float t2 = sqrt(t1);
+  outb[i] = pack(float16_t(t2));
+}
+
+--- A10 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = 0.0 - x;
+  outb[i] = pack(float16_t(t1));
+}
+
+--- A11 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  float t2 = floor(t1);
+  outb[i] = pack(float16_t(t2));
+}
+
+--- A12 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  float t2 = x * 0.9;
+  float t3 = (x > 0.0) ? t1 : t2;
+  outb[i] = pack(float16_t(t3));
+}
+
+--- A13 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * x;
+  outb[i] = pack(float16_t(t1));
+}
+
+--- A14 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  float t2 = t1 * 1.1;
+  outb[i] = pack(float16_t(t2));
+}
+
+--- A15 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x / 3.0;
+  float t2 = x * 1.1;
+  float t3 = t2 + t1;
+  outb[i] = pack(float16_t(t3));
+}
+
+--- B1 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  float16_t t2 = float16_t(t1);
+  float t3 = float(t2);
+  float t4 = t3 + 1000.0;
+  outb[i] = pack(float16_t(t4));
+}
+
+--- B2 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  float16_t t2 = float16_t(t1);
+  float t3 = float(t2);
+  float t4 = t3 * 1.1;
+  outb[i] = pack(float16_t(t4));
+}
+
+--- B3 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x + 1000.0;
+  float16_t t2 = float16_t(t1);
+  float t3 = float(t2);
+  float t4 = t3 * 1.1;
+  outb[i] = pack(float16_t(t4));
+}
+
+--- B4 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  float t1 = x * 1.1;
+  float16_t t2 = float16_t(t1);
+  float t3 = float(t2);
+  float t4 = t3 + 1000.0;
+  float16_t t5 = float16_t(t4);
+  float t6 = float(t5);
+  float t7 = t6 * 1.1;
+  outb[i] = pack(float16_t(t7));
+}
+
+--- C1 ---
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+  outb[i] = inb[i] & 0xFFFFu;
+}
+
+
+GENERATED SOURCE — OpenCL C, plain, one per shape
+
+--- A1 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  out[i] = as_ushort((half)(x));
+  }
+}
+
+--- A2 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  out[i] = as_ushort((half)(t1));
+  }
+}
+
+--- A3 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x + 1000.0f;
+  out[i] = as_ushort((half)(t1));
+  }
+}
+
+--- A4 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x - 1000.0f;
+  out[i] = as_ushort((half)(t1));
+  }
+}
+
+--- A5 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x / 3.0f;
+  out[i] = as_ushort((half)(t1));
+  }
+}
+
+--- A6 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  float t2 = t1 + 1000.0f;
+  out[i] = as_ushort((half)(t2));
+  }
+}
+
+--- A7 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x + 1000.0f;
+  float t2 = t1 * 1.1f;
+  out[i] = as_ushort((half)(t2));
+  }
+}
+
+--- A8 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = fma(x, 1.1f, 1000.0f);
+  out[i] = as_ushort((half)(t1));
+  }
+}
+
+--- A9 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * x;
+  float t2 = sqrt(t1);
+  out[i] = as_ushort((half)(t2));
+  }
+}
+
+--- A10 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = 0.0f - x;
+  out[i] = as_ushort((half)(t1));
+  }
+}
+
+--- A11 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  float t2 = floor(t1);
+  out[i] = as_ushort((half)(t2));
+  }
+}
+
+--- A12 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  float t2 = x * 0.9f;
+  float t3 = (x > 0.0f) ? t1 : t2;
+  out[i] = as_ushort((half)(t3));
+  }
+}
+
+--- A13 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * x;
+  out[i] = as_ushort((half)(t1));
+  }
+}
+
+--- A14 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  float t2 = t1 * 1.1f;
+  out[i] = as_ushort((half)(t2));
+  }
+}
+
+--- A15 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x / 3.0f;
+  float t2 = x * 1.1f;
+  float t3 = t2 + t1;
+  out[i] = as_ushort((half)(t3));
+  }
+}
+
+--- B1 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  half t2 = (half)(t1);
+  float t3 = (float)t2;
+  float t4 = t3 + 1000.0f;
+  out[i] = as_ushort((half)(t4));
+  }
+}
+
+--- B2 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  half t2 = (half)(t1);
+  float t3 = (float)t2;
+  float t4 = t3 * 1.1f;
+  out[i] = as_ushort((half)(t4));
+  }
+}
+
+--- B3 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x + 1000.0f;
+  half t2 = (half)(t1);
+  float t3 = (float)t2;
+  float t4 = t3 * 1.1f;
+  out[i] = as_ushort((half)(t4));
+  }
+}
+
+--- B4 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  float t1 = x * 1.1f;
+  half t2 = (half)(t1);
+  float t3 = (float)t2;
+  float t4 = t3 + 1000.0f;
+  half t5 = (half)(t4);
+  float t6 = (float)t5;
+  float t7 = t6 * 1.1f;
+  out[i] = as_ushort((half)(t7));
+  }
+}
+
+--- C1 ---
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[256];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+  out[i] = in[i];
+  }
+}

--- a/docs/measurements/f16-shapes-2026-07-27/opencl-rusticl.txt
+++ b/docs/measurements/f16-shapes-2026-07-27/opencl-rusticl.txt
@@ -1,0 +1,1504 @@
+#62 slice 1(a) — element-wise model agreement, OpenCL / rusticl
+
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+catalogue calibration PASSED: the generic policies reproduce slice 1's hand-written closed forms bit-for-bit on A2 and B1 over all 63488 inputs, and the corrected local rule reduces onto them.
+
+================================================================
+backlog-151 CATALOGUE — device: AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)
+================================================================
+
+  --- A1 : narrow x ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A2 : narrow (x *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   2912 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2912 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :   2912 / 63488 disagreements
+    R_local_absorb_nocontract          :   2912 / 63488 disagreements
+    R_local_absorb_opencl              :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A3 : narrow (x +. 1000.) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A4 : narrow (x -. 1000.) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A5 : narrow (x /. 3.) ---
+    NOTE: DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is evidence about fdiv precision and NOT about the absorption rule
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A6 : narrow (x *. 1.1 +. 1000.) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :      2 / 63488 disagreements
+    R_local_absorb_opencl              :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      2 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      2 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    R_local_absorb                     :    482 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- A7 : narrow ((x +. 1000.) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    374 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    374 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    374 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    374 / 63488 disagreements
+    R_local_absorb_nocontract          :    374 / 63488 disagreements
+    R_local_absorb_opencl              :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A8 : narrow (fma x 1.1 1000.) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :    484 / 63488 disagreements
+    R_local_absorb_opencl              :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A9 : narrow (sqrt (x *. x)) ---
+    NOTE: SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the device's sqrt precision is separately specified
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A10 : narrow (0. -. x) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A11 : narrow (floor (x *. 1.1)) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- A12 : narrow (if x>0. then x*.1.1 else x*.0.9) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2863 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   2863 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2863 / 63488 disagreements
+    R_local_absorb                     :   2863 / 63488 disagreements
+    R_local_absorb_nocontract          :   2863 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A13 : narrow (x *. x) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A14 : narrow (x *. 1.1 *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    308 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    308 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    308 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    308 / 63488 disagreements
+    R_local_absorb_nocontract          :    308 / 63488 disagreements
+    R_local_absorb_opencl              :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A15 : narrow (x *. 1.1 +. x /. 3.) ---
+    NOTE: DIVISION: as A5 — an fdiv mismatch is not evidence about absorption
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- B1 : narrow (narrow (x *. 1.1) +. 1000.) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    R_local_absorb                     :   5075 / 63488 disagreements
+    R_local_absorb_nocontract          :   4776 / 63488 disagreements
+    R_local_absorb_opencl              :    620 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    R_local_absorb                     :   4896 / 63488 disagreements
+    R_local_absorb_nocontract          :   4851 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 512 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 512 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- B2 : narrow (narrow (x *. 1.1) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   5368 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  17036 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  17036 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  16728 / 63488 disagreements
+    R_local_absorb                     :  17036 / 63488 disagreements
+    R_local_absorb_nocontract          :  17036 / 63488 disagreements
+    R_local_absorb_opencl              :   5368 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  16786 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : BROKEN — matched S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract, predicts R_local_absorb_opencl
+
+  --- B3 : narrow (narrow (x +. 1000.) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    963 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   7803 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7803 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7431 / 63488 disagreements
+    R_local_absorb                     :   7803 / 63488 disagreements
+    R_local_absorb_nocontract          :   7803 / 63488 disagreements
+    R_local_absorb_opencl              :    963 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    963 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   7434 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7434 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7808 / 63488 disagreements
+    R_local_absorb                     :   7434 / 63488 disagreements
+    R_local_absorb_nocontract          :   7434 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- B4 : narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   1518 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  10706 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10707 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10671 / 63488 disagreements
+    R_local_absorb                     :  10707 / 63488 disagreements
+    R_local_absorb_nocontract          :  10707 / 63488 disagreements
+    R_local_absorb_opencl              :   1518 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   1518 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :  10734 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10733 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10771 / 63488 disagreements
+    R_local_absorb                     :  10733 / 63488 disagreements
+    R_local_absorb_nocontract          :  10733 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 562 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 562 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- C1 : out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) ---
+    NOTE: NO NARROWING AT ALL: there is nothing for any policy to elide, so every model coincides by construction
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+
+  SUMMARY — AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)
+
+  A1    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A2    2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A3    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A4    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A5    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A6    3 distinct models
+        plain : S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: BROKEN — matched S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  A7    2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A8    2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A9    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A10   1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A11   2 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  A12   2 distinct models
+        plain : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A13   1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A14   2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A15   2 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  B1    5 distinct models
+        plain : S_fuse_mul_into_narrowing = R_local_absorb_opencl
+        green : S_strict
+        §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  B2    4 distinct models
+        plain : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        green : S_strict
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : BROKEN — matched S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract, predicts R_local_absorb_opencl
+  B3    4 distinct models
+        plain : S_fuse_mul_into_narrowing = R_local_absorb_opencl
+        green : S_strict
+        §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  B4    5 distinct models
+        plain : S_fuse_mul_into_narrowing = R_local_absorb_opencl
+        green : S_strict
+        §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  C1    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+
+================================================================
+backlog-151 CATALOGUE — device: AMD Ryzen 9 7950X 16-Core Processor (radeonsi, raphael_mendocino, ACO, DRM 3.64, 7.1.2-3-cachyos)
+================================================================
+
+  --- A1 : narrow x ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A2 : narrow (x *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   2912 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2912 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :   2912 / 63488 disagreements
+    R_local_absorb_nocontract          :   2912 / 63488 disagreements
+    R_local_absorb_opencl              :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A3 : narrow (x +. 1000.) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A4 : narrow (x -. 1000.) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A5 : narrow (x /. 3.) ---
+    NOTE: DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is evidence about fdiv precision and NOT about the absorption rule
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A6 : narrow (x *. 1.1 +. 1000.) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :      2 / 63488 disagreements
+    R_local_absorb_opencl              :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      2 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      2 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    R_local_absorb                     :    482 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- A7 : narrow ((x +. 1000.) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    374 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    374 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    374 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    374 / 63488 disagreements
+    R_local_absorb_nocontract          :    374 / 63488 disagreements
+    R_local_absorb_opencl              :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A8 : narrow (fma x 1.1 1000.) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :    484 / 63488 disagreements
+    R_local_absorb_opencl              :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A9 : narrow (sqrt (x *. x)) ---
+    NOTE: SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the device's sqrt precision is separately specified
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A10 : narrow (0. -. x) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A11 : narrow (floor (x *. 1.1)) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- A12 : narrow (if x>0. then x*.1.1 else x*.0.9) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2863 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   2863 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2863 / 63488 disagreements
+    R_local_absorb                     :   2863 / 63488 disagreements
+    R_local_absorb_nocontract          :   2863 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A13 : narrow (x *. x) ---
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+  --- A14 : narrow (x *. 1.1 *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    308 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    308 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    308 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    308 / 63488 disagreements
+    R_local_absorb_nocontract          :    308 / 63488 disagreements
+    R_local_absorb_opencl              :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : HOLDS
+
+  --- A15 : narrow (x *. 1.1 +. x /. 3.) ---
+    NOTE: DIVISION: as A5 — an fdiv mismatch is not evidence about absorption
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- B1 : narrow (narrow (x *. 1.1) +. 1000.) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    R_local_absorb                     :   5075 / 63488 disagreements
+    R_local_absorb_nocontract          :   4776 / 63488 disagreements
+    R_local_absorb_opencl              :    620 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    620 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   4896 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4851 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4849 / 63488 disagreements
+    R_local_absorb                     :   4896 / 63488 disagreements
+    R_local_absorb_nocontract          :   4851 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 512 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 512 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- B2 : narrow (narrow (x *. 1.1) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   5368 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  17036 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  17036 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  16728 / 63488 disagreements
+    R_local_absorb                     :  17036 / 63488 disagreements
+    R_local_absorb_nocontract          :  17036 / 63488 disagreements
+    R_local_absorb_opencl              :   5368 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  16786 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: HOLDS
+    corrected LOCAL rule : BROKEN — matched S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract, predicts R_local_absorb_opencl
+
+  --- B3 : narrow (narrow (x +. 1000.) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    963 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   7803 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7803 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7431 / 63488 disagreements
+    R_local_absorb                     :   7803 / 63488 disagreements
+    R_local_absorb_nocontract          :   7803 / 63488 disagreements
+    R_local_absorb_opencl              :    963 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    963 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   7434 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7434 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7808 / 63488 disagreements
+    R_local_absorb                     :   7434 / 63488 disagreements
+    R_local_absorb_nocontract          :   7434 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- B4 : narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) ---
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   1518 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  10706 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10707 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10671 / 63488 disagreements
+    R_local_absorb                     :  10707 / 63488 disagreements
+    R_local_absorb_nocontract          :  10707 / 63488 disagreements
+    R_local_absorb_opencl              :   1518 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   1518 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :  10734 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10733 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10771 / 63488 disagreements
+    R_local_absorb                     :  10733 / 63488 disagreements
+    R_local_absorb_nocontract          :  10733 / 63488 disagreements
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 562 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 562 ulp.
+    §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+    corrected LOCAL rule : HOLDS
+
+  --- C1 : out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) ---
+    NOTE: NO NARROWING AT ALL: there is nothing for any policy to elide, so every model coincides by construction
+    NON-DISCRIMINATING: all five slice-1 policies are the SAME FUNCTION here; whatever the device returns is not evidence about the rule.
+  GREEN CONTROL — every temporary through the volatile __local
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: n/a (non-discriminating)
+    corrected LOCAL rule : n/a (non-discriminating)
+
+
+  SUMMARY — AMD Ryzen 9 7950X 16-Core Processor (radeonsi, raphael_mendocino, ACO, DRM 3.64, 7.1.2-3-cachyos)
+
+  A1    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A2    2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A3    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A4    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A5    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A6    3 distinct models
+        plain : S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: BROKEN — matched S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  A7    2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A8    2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A9    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A10   1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A11   2 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  A12   2 distinct models
+        plain : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A13   1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)
+  A14   2 distinct models
+        plain : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : HOLDS
+  A15   2 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  B1    5 distinct models
+        plain : S_fuse_mul_into_narrowing = R_local_absorb_opencl
+        green : S_strict
+        §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  B2    4 distinct models
+        plain : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        green : S_strict
+        §12.4 whole-tree rule: HOLDS
+        corrected LOCAL rule : BROKEN — matched S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract, predicts R_local_absorb_opencl
+  B3    4 distinct models
+        plain : S_fuse_mul_into_narrowing = R_local_absorb_opencl
+        green : S_strict
+        §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  B4    5 distinct models
+        plain : S_fuse_mul_into_narrowing = R_local_absorb_opencl
+        green : S_strict
+        §12.4 whole-tree rule: BROKEN — matched S_fuse_mul_into_narrowing = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing
+        corrected LOCAL rule : HOLDS
+  C1    1 distinct models
+        plain : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: n/a (non-discriminating)
+        corrected LOCAL rule : n/a (non-discriminating)

--- a/docs/measurements/f16-shapes-2026-07-27/vulkan-radv-eager-cut.txt
+++ b/docs/measurements/f16-shapes-2026-07-27/vulkan-radv-eager-cut.txt
@@ -1,0 +1,1433 @@
+#62 slice 1(b) — element-wise model agreement, Vulkan / RADV
+
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+
+catalogue calibration PASSED: the five generic policies reproduce slice 1's seven hand-written closed forms bit-for-bit on A2 and B1 over all 63488 inputs, and reproduce the recorded separations 2912 / 620 / 5075 / 4776 / 4774 from the generic evaluator.
+
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+
+================================================================
+backlog-151 CATALOGUE — device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+================================================================
+
+  --- reporting control (host-injected deviation) ---
+    A2   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A6   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    A7   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A8   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing
+    A11  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A12  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A14  injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A15  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B1   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B2   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B3   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B4   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+
+  --- A1 : narrow x ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A2 : narrow (x *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   2912 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2912 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A3 : narrow (x +. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A4 : narrow (x -. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A5 : narrow (x /. 3.) ---
+    NOTE: DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is evidence about fdiv precision and NOT about the absorption rule
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = -0 (0x8000) ***
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = -0 (0x8000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = -0 (0x8000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A6 : narrow (x *. 1.1 +. 1000.) ---
+    the five policies induce 3 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      2 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      2 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A7 : narrow ((x +. 1000.) *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    374 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    374 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    374 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A8 : narrow (fma x 1.1 1000.) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE BROKEN — matched S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing, rule predicts S_f32_mul_then_absorb_add
+
+  --- A9 : narrow (sqrt (x *. x)) ---
+    NOTE: SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the device's sqrt precision is separately specified
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A10 : narrow (0. -. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A11 : narrow (floor (x *. 1.1)) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_absorb_all_into_final_narrowing ; precise -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_f32_mul_then_absorb_add
+
+  --- A12 : narrow (if x>0. then x*.1.1 else x*.0.9) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_absorb_all_into_final_narrowing ; precise -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_f32_mul_then_absorb_add
+
+  --- A13 : narrow (x *. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A14 : narrow (x *. 1.1 *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    308 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    308 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    308 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A15 : narrow (x *. 1.1 +. x /. 3.) ---
+    NOTE: DIVISION: as A5 — an fdiv mismatch is not evidence about absorption
+    the five policies induce 3 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :    745 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    745 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    744 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    745 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B1 : narrow (narrow (x *. 1.1) +. 1000.) ---
+    the five policies induce 5 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   5075 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4896 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   4776 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4851 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B2 : narrow (narrow (x *. 1.1) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   5368 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  17036 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  17036 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  16728 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B3 : narrow (narrow (x +. 1000.) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    963 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   7803 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7803 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7431 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B4 : narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) ---
+    the five policies induce 5 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   1518 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  10706 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10707 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10671 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      8 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :     10 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1.67731e+06 ulp (denominator: S_strict's value there) / 1638 ulp (denominator: the model's own value there); 719 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+    rule verdict: plain -> RULE BROKEN — matched NO MODEL, rule predicts S_absorb_all_into_final_narrowing ; precise -> RULE HOLDS
+
+  --- C1 : out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) ---
+    NOTE: NO NARROWING AT ALL: there is nothing for any policy to elide, so every model coincides by construction
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+
+  SUMMARY — AMD Radeon RX 7900 XTX (RADV NAVI31)
+  (rule predicts S_absorb_all_into_final_narrowing for plain and S_f32_mul_then_absorb_add for precise)
+
+  id   models plain                              precise                            unexpl.  green control
+  A1   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A2   2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict = S_drop_intermediate_narrowing
+  A3   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A4   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A5   1      NO MODEL                           NO MODEL                           2        NO MODEL
+  A6   3      S_absorb_all_into_final_narrowing  S_f32_mul_then_absorb_add          0        S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+  A7   2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict = S_drop_intermediate_narrowing
+  A8   2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing 0        S_strict = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A9   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A10  1      NO MODEL                           NO MODEL                           2        NO MODEL
+  A11  2      S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+  A12  2      S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+  A13  1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A14  2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict = S_drop_intermediate_narrowing
+  A15  3      S_absorb_all_into_final_narrowing  S_f32_mul_then_absorb_add          0        S_f32_mul_then_absorb_add
+  B1   5      S_absorb_all_into_final_narrowing  S_f32_mul_then_absorb_add          0        S_strict
+  B2   4      S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict
+  B3   4      S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict
+  B4   5      NO MODEL                           S_f32_mul_then_absorb_add          0        S_strict
+  C1   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+
+================================================================
+backlog-151 CATALOGUE — device: AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)
+================================================================
+
+  --- reporting control (host-injected deviation) ---
+    A2   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A6   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    A7   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A8   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing
+    A11  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A12  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A14  injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A15  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B1   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B2   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B3   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B4   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+
+  --- A1 : narrow x ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A2 : narrow (x *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   2912 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2912 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A3 : narrow (x +. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A4 : narrow (x -. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A5 : narrow (x /. 3.) ---
+    NOTE: DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is evidence about fdiv precision and NOT about the absorption rule
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = -0 (0x8000) ***
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = -0 (0x8000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = -0 (0x8000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A6 : narrow (x *. 1.1 +. 1000.) ---
+    the five policies induce 3 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      2 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      2 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A7 : narrow ((x +. 1000.) *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    374 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    374 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    374 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A8 : narrow (fma x 1.1 1000.) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE BROKEN — matched S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing, rule predicts S_f32_mul_then_absorb_add
+
+  --- A9 : narrow (sqrt (x *. x)) ---
+    NOTE: SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the device's sqrt precision is separately specified
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A10 : narrow (0. -. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A11 : narrow (floor (x *. 1.1)) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_absorb_all_into_final_narrowing ; precise -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_f32_mul_then_absorb_add
+
+  --- A12 : narrow (if x>0. then x*.1.1 else x*.0.9) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_absorb_all_into_final_narrowing ; precise -> RULE BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing, rule predicts S_f32_mul_then_absorb_add
+
+  --- A13 : narrow (x *. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A14 : narrow (x *. 1.1 *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    308 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    308 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    308 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- A15 : narrow (x *. 1.1 +. x /. 3.) ---
+    NOTE: DIVISION: as A5 — an fdiv mismatch is not evidence about absorption
+    the five policies induce 3 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :    745 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    745 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    744 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    745 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B1 : narrow (narrow (x *. 1.1) +. 1000.) ---
+    the five policies induce 5 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   5075 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4896 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   4776 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4851 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B2 : narrow (narrow (x *. 1.1) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   5368 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  17036 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  17036 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  16728 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B3 : narrow (narrow (x +. 1000.) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    963 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   7803 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7803 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7431 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    rule verdict: plain -> RULE HOLDS ; precise -> RULE HOLDS
+
+  --- B4 : narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) ---
+    the five policies induce 5 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   1518 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  10706 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10707 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10671 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      8 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :     10 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1.67731e+06 ulp (denominator: S_strict's value there) / 1638 ulp (denominator: the model's own value there); 719 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+    rule verdict: plain -> RULE BROKEN — matched NO MODEL, rule predicts S_absorb_all_into_final_narrowing ; precise -> RULE HOLDS
+
+  --- C1 : out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) ---
+    NOTE: NO NARROWING AT ALL: there is nothing for any policy to elide, so every model coincides by construction
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    rule verdict: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+
+  SUMMARY — AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)
+  (rule predicts S_absorb_all_into_final_narrowing for plain and S_f32_mul_then_absorb_add for precise)
+
+  id   models plain                              precise                            unexpl.  green control
+  A1   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A2   2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict = S_drop_intermediate_narrowing
+  A3   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A4   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A5   1      NO MODEL                           NO MODEL                           2        NO MODEL
+  A6   3      S_absorb_all_into_final_narrowing  S_f32_mul_then_absorb_add          0        S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+  A7   2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict = S_drop_intermediate_narrowing
+  A8   2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing 0        S_strict = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A9   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A10  1      NO MODEL                           NO MODEL                           2        NO MODEL
+  A11  2      S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+  A12  2      S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+  A13  1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing
+  A14  2      S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict = S_drop_intermediate_narrowing
+  A15  3      S_absorb_all_into_final_narrowing  S_f32_mul_then_absorb_add          0        S_f32_mul_then_absorb_add
+  B1   5      S_absorb_all_into_final_narrowing  S_f32_mul_then_absorb_add          0        S_strict
+  B2   4      S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict
+  B3   4      S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add 0        S_strict
+  B4   5      NO MODEL                           S_f32_mul_then_absorb_add          0        S_strict
+  C1   1      S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing 0        S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing

--- a/docs/measurements/f16-shapes-2026-07-27/vulkan-radv-isa.txt
+++ b/docs/measurements/f16-shapes-2026-07-27/vulkan-radv-isa.txt
@@ -1,0 +1,323 @@
+################ shape A2 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,1,1]    ; cc214002 920202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A2 (narrow (x *. 1.1))
+variant: plain
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A2 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,1,1]    ; cc214002 920202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A2 (narrow (x *. 1.1))
+variant: precise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A6 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mixlo_f16 v2, 0xcccd, v1, s1 op_sel_hi:[0,1,0]        ; cc210002 100602ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A6 (narrow (x *. 1.1 +. 1000.))
+variant: plain
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A6 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_fma_mixlo_f16 v2, 1.0, v1, 0x63d0 op_sel_hi:[0,0,1]       ; cc214002 03fe02f2 000063d0
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A6 (narrow (x *. 1.1 +. 1000.))
+variant: precise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A7 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 1.0, v1, lit(0x447a0000) op_sel_hi:[0,1,0] ; cc200001 13fe02f2 447a0000
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A7 (narrow ((x +. 1000.) *. 1.1))
+variant: plain
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A7 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 1.0, v1, lit(0x447a0000) op_sel_hi:[0,1,0] ; cc200001 13fe02f2 447a0000
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A7 (narrow ((x +. 1000.) *. 1.1))
+variant: precise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A8 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_mov_b32_e32 v2, 0x447a0000                                ; 7e0402ff 447a0000
+	v_fma_mixlo_f16 v3, v1, 0xcccd, v2 op_sel_hi:[1,0,0]        ; cc210003 0c09ff01 3f8ccccd
+	v_mov_b16_e32 v3.h, 0                                       ; 7f063880
+	v_cvt_u32_u16_e32 v3, v3.l                                  ; 7e06d703
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A8 (narrow (fma x 1.1 1000.))
+variant: plain
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A8 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_mov_b32_e32 v2, 0x447a0000                                ; 7e0402ff 447a0000
+	v_fma_mixlo_f16 v3, v1, 0xcccd, v2 op_sel_hi:[1,0,0]        ; cc210003 0c09ff01 3f8ccccd
+	v_mov_b16_e32 v3.h, 0                                       ; 7f063880
+	v_cvt_u32_u16_e32 v3, v3.l                                  ; 7e06d703
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A8 (narrow (fma x 1.1 1000.))
+variant: precise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A11 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_floor_f32_e32 v1, v1                                      ; 7e024901
+	v_fma_mixlo_f16 v2, 1.0, v1, neg(0) op_sel_hi:[0,0,1]       ; cc214002 820202f2
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A11 (narrow (floor (x *. 1.1)))
+variant: plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A11 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_floor_f32_e32 v1, v1                                      ; 7e024901
+	v_fma_mixlo_f16 v2, 1.0, v1, neg(0) op_sel_hi:[0,0,1]       ; cc214002 820202f2
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A11 (narrow (floor (x *. 1.1)))
+variant: precise
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A12 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v2, v1, 1.0, neg(0) op_sel_hi:[1,0,0]         ; cc200002 8a01e501
+	v_fma_mix_f32 v3, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200003 920202ff 3f8ccccd
+	v_fma_mix_f32 v1, 0x6666, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f666666
+	v_cmp_lt_f32_e32 vcc, 0, v2                                 ; 7c220480
+	v_cndmask_b32_e32 v1, v1, v3, vcc                           ; 02020701
+	v_fma_mixlo_f16 v4, 1.0, v1, neg(0) op_sel_hi:[0,0,1]       ; cc214004 820202f2
+	v_mov_b16_e32 v4.h, 0                                       ; 7f083880
+	v_cvt_u32_u16_e32 v4, v4.l                                  ; 7e08d704
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A12 (narrow (if x>0. then x*.1.1 else x*.0.9))
+variant: plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A12 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v2, v1, 1.0, neg(0) op_sel_hi:[1,0,0]         ; cc200002 8a01e501
+	v_fma_mix_f32 v3, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200003 920202ff 3f8ccccd
+	v_fma_mix_f32 v1, 0x6666, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f666666
+	v_cmp_lt_f32_e32 vcc, 0, v2                                 ; 7c220480
+	v_cndmask_b32_e32 v1, v1, v3, vcc                           ; 02020701
+	v_fma_mixlo_f16 v4, 1.0, v1, neg(0) op_sel_hi:[0,0,1]       ; cc214004 820202f2
+	v_mov_b16_e32 v4.h, 0                                       ; 7f083880
+	v_cvt_u32_u16_e32 v4, v4.l                                  ; 7e08d704
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A12 (narrow (if x>0. then x*.1.1 else x*.0.9))
+variant: precise
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A14 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mixlo_f16 v2, 0xe148, v1, neg(0) op_sel_hi:[0,1,1]    ; cc214002 920202ff 3f9ae148
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A14 (narrow (x *. 1.1 *. 1.1))
+variant: plain
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape A14 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: A14 (narrow (x *. 1.1 *. 1.1))
+variant: precise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B1 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mixlo_f16 v2, 0xcccd, v1, s1 op_sel_hi:[0,1,0]        ; cc210002 100602ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B1 (narrow (narrow (x *. 1.1) +. 1000.))
+variant: plain
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B1 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_fma_mixlo_f16 v2, 1.0, v1, 0x63d0 op_sel_hi:[0,0,1]       ; cc214002 03fe02f2 000063d0
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B1 (narrow (narrow (x *. 1.1) +. 1000.))
+variant: precise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B2 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mixlo_f16 v2, 0xe148, v1, neg(0) op_sel_hi:[0,1,1]    ; cc214002 920202ff 3f9ae148
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B2 (narrow (narrow (x *. 1.1) *. 1.1))
+variant: plain
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B2 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B2 (narrow (narrow (x *. 1.1) *. 1.1))
+variant: precise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B3 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 1.0, v1, lit(0x447a0000) op_sel_hi:[0,1,0] ; cc200001 13fe02f2 447a0000
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B3 (narrow (narrow (x +. 1000.) *. 1.1))
+variant: plain
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B3 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 1.0, v1, lit(0x447a0000) op_sel_hi:[0,1,0] ; cc200001 13fe02f2 447a0000
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B3 (narrow (narrow (x +. 1000.) *. 1.1))
+variant: precise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B4 / variant plain ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, s1 op_sel_hi:[0,1,0]          ; cc200001 100602ff 3f8ccccd
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B4 (narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1))
+variant: plain
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+################ shape B4 / variant precise ################
+	v_lshl_add_u32 v0, s0, 8, v0                                ; d6460000 04011000
+	v_lshlrev_b32_e32 v0, 2, v0                                 ; 30000082
+	v_fma_mix_f32 v1, 0xcccd, v1, neg(0) op_sel_hi:[0,1,0]      ; cc200001 920202ff 3f8ccccd
+	v_add_f32_e32 v1, 0x447a0000, v1                            ; 060202ff 447a0000
+	v_fma_mixlo_f16 v2, 0xcccd, v1, neg(0) op_sel_hi:[0,0,1]    ; cc214002 820202ff 3f8ccccd
+	v_mov_b16_e32 v2.h, 0                                       ; 7f043880
+	v_cvt_u32_u16_e32 v2, v2.l                                  ; 7e04d702
+device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+shape: B4 (narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1))
+variant: precise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise

--- a/docs/measurements/f16-shapes-2026-07-27/vulkan-radv.txt
+++ b/docs/measurements/f16-shapes-2026-07-27/vulkan-radv.txt
@@ -1,0 +1,2253 @@
+#62 slice 1(b) — element-wise model agreement, Vulkan / RADV
+
+host calibration PASSED: 63488-value round-trip; the two §1.2 models separate on exactly 620 (f16(f16(x * 1.1) + 1000)) and 2912 (f16(x * 1.1)); §1.3's x = -907.5 case reproduces at 1 ulp at the narrowing and 512 ulp on the final value.
+
+catalogue calibration PASSED: the five generic policies reproduce slice 1's seven hand-written closed forms bit-for-bit on A2 and B1 over all 63488 inputs, and reproduce the recorded separations 2912 / 620 / 5075 / 4776 / 4774 from the generic evaluator.
+
+SHAPE 1 — f16(x * 1.1)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :   2912
+
+SHAPE 2 — f16(f16(x * 1.1) + 1000)
+  pairwise model separation (inputs where the two differ):
+    S_strict                           vs S_fuse_mul_into_narrowing          :    620
+    S_strict                           vs S_absorb_all_into_final_narrowing  :   5075
+    S_strict                           vs S_f32_mul_then_absorb_add          :   4776
+    S_strict                           vs S_drop_intermediate_narrowing      :   4774
+    S_strict                           vs S_fuse_mul_and_absorb_add          :    992
+    S_strict                           vs S_strict_mul_absorb_add            :    372
+    S_fuse_mul_into_narrowing          vs S_absorb_all_into_final_narrowing  :   4896
+    S_fuse_mul_into_narrowing          vs S_f32_mul_then_absorb_add          :   4851
+    S_fuse_mul_into_narrowing          vs S_drop_intermediate_narrowing      :   4849
+    S_fuse_mul_into_narrowing          vs S_fuse_mul_and_absorb_add          :    372
+    S_fuse_mul_into_narrowing          vs S_strict_mul_absorb_add            :    992
+    S_absorb_all_into_final_narrowing  vs S_f32_mul_then_absorb_add          :    482
+    S_absorb_all_into_final_narrowing  vs S_drop_intermediate_narrowing      :    484
+    S_absorb_all_into_final_narrowing  vs S_fuse_mul_and_absorb_add          :   5240
+    S_absorb_all_into_final_narrowing  vs S_strict_mul_absorb_add            :   5419
+    S_f32_mul_then_absorb_add          vs S_drop_intermediate_narrowing      :      2
+    S_f32_mul_then_absorb_add          vs S_fuse_mul_and_absorb_add          :   5195
+    S_f32_mul_then_absorb_add          vs S_strict_mul_absorb_add            :   5120
+    S_drop_intermediate_narrowing      vs S_fuse_mul_and_absorb_add          :   5193
+    S_drop_intermediate_narrowing      vs S_strict_mul_absorb_add            :   5118
+    S_fuse_mul_and_absorb_add          vs S_strict_mul_absorb_add            :    620
+
+================================================================
+backlog-151 CATALOGUE — device: AMD Radeon RX 7900 XTX (RADV NAVI31)
+================================================================
+
+  --- reporting control (host-injected deviation) ---
+    A2   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A6   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    A7   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A8   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A11  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A12  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A14  injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A15  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B1   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B2   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B3   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B4   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+
+  --- A1 : narrow x ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A2 : narrow (x *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   2912 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2912 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :   2912 / 63488 disagreements
+    R_local_absorb_nocontract          :   2912 / 63488 disagreements
+    R_local_absorb_opencl              :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A3 : narrow (x +. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A4 : narrow (x -. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A5 : narrow (x /. 3.) ---
+    NOTE: DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is evidence about fdiv precision and NOT about the absorption rule
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A6 : narrow (x *. 1.1 +. 1000.) ---
+    the five policies induce 3 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :      2 / 63488 disagreements
+    R_local_absorb_opencl              :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :    482 / 63488 disagreements
+    R_local_absorb_opencl              :    482 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      2 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      2 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    R_local_absorb                     :    482 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A7 : narrow ((x +. 1000.) *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    374 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    374 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    374 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    374 / 63488 disagreements
+    R_local_absorb_nocontract          :    374 / 63488 disagreements
+    R_local_absorb_opencl              :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A8 : narrow (fma x 1.1 1000.) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :    484 / 63488 disagreements
+    R_local_absorb_opencl              :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A9 : narrow (sqrt (x *. x)) ---
+    NOTE: SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the device's sqrt precision is separately specified
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A10 : narrow (0. -. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    R_local_absorb                     :      1 / 63488 disagreements
+    R_local_absorb_nocontract          :      1 / 63488 disagreements
+    R_local_absorb_opencl              :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+      first unmatched input x = 0 (0x0000): device 0x8000, S_strict 0x0000, S_fuse_mul_into_narrowing 0x0000, S_absorb_all_into_final_narrowing 0x0000, S_f32_mul_then_absorb_add 0x0000, S_drop_intermediate_narrowing 0x0000, R_local_absorb 0x0000, R_local_absorb_nocontract 0x0000, R_local_absorb_opencl 0x0000
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    R_local_absorb                     :      1 / 63488 disagreements
+    R_local_absorb_nocontract          :      1 / 63488 disagreements
+    R_local_absorb_opencl              :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+      first unmatched input x = 0 (0x0000): device 0x8000, S_strict 0x0000, S_fuse_mul_into_narrowing 0x0000, S_absorb_all_into_final_narrowing 0x0000, S_f32_mul_then_absorb_add 0x0000, S_drop_intermediate_narrowing 0x0000, R_local_absorb 0x0000, R_local_absorb_nocontract 0x0000, R_local_absorb_opencl 0x0000
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    R_local_absorb                     :      1 / 63488 disagreements
+    R_local_absorb_nocontract          :      1 / 63488 disagreements
+    R_local_absorb_opencl              :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+      first unmatched input x = 0 (0x0000): device 0x8000, S_strict 0x0000, S_fuse_mul_into_narrowing 0x0000, S_absorb_all_into_final_narrowing 0x0000, S_f32_mul_then_absorb_add 0x0000, S_drop_intermediate_narrowing 0x0000, R_local_absorb 0x0000, R_local_absorb_nocontract 0x0000, R_local_absorb_opencl 0x0000
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A11 : narrow (floor (x *. 1.1)) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_f32_mul_then_absorb_add
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A12 : narrow (if x>0. then x*.1.1 else x*.0.9) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_f32_mul_then_absorb_add
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A13 : narrow (x *. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A14 : narrow (x *. 1.1 *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    308 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    308 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    308 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    308 / 63488 disagreements
+    R_local_absorb_nocontract          :    308 / 63488 disagreements
+    R_local_absorb_opencl              :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A15 : narrow (x *. 1.1 +. x /. 3.) ---
+    NOTE: DIVISION: as A5 — an fdiv mismatch is not evidence about absorption
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    744 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    744 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    744 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    744 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :    744 / 63488 disagreements
+    R_local_absorb_opencl              :    744 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B1 : narrow (narrow (x *. 1.1) +. 1000.) ---
+    the five policies induce 5 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    R_local_absorb                     :   5075 / 63488 disagreements
+    R_local_absorb_nocontract          :   4776 / 63488 disagreements
+    R_local_absorb_opencl              :    620 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   5075 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4896 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :    482 / 63488 disagreements
+    R_local_absorb_opencl              :   4896 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   4776 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4851 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    R_local_absorb                     :    482 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   4851 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B2 : narrow (narrow (x *. 1.1) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   5368 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  17036 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  17036 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  16728 / 63488 disagreements
+    R_local_absorb                     :  17036 / 63488 disagreements
+    R_local_absorb_nocontract          :  17036 / 63488 disagreements
+    R_local_absorb_opencl              :   5368 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  16786 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  16786 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B3 : narrow (narrow (x +. 1000.) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    963 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   7803 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7803 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7431 / 63488 disagreements
+    R_local_absorb                     :   7803 / 63488 disagreements
+    R_local_absorb_nocontract          :   7803 / 63488 disagreements
+    R_local_absorb_opencl              :    963 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   7434 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   7434 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B4 : narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) ---
+    the five policies induce 5 distinct functions here
+    2 intermediate narrowings: §1.3's ceiling is derived for the elision of ONE rounding, so it is evaluated at the INNERMOST narrowing and covers only that elision on this shape
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   1518 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  10706 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10707 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10671 / 63488 disagreements
+    R_local_absorb                     :  10707 / 63488 disagreements
+    R_local_absorb_nocontract          :  10707 / 63488 disagreements
+    R_local_absorb_opencl              :   1518 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      8 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      2 / 63488 disagreements
+    R_local_absorb_opencl              :  10733 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :     10 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    R_local_absorb                     :      2 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  10733 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+    §12.4 whole-tree rule: plain -> BROKEN — matched R_local_absorb, predicts S_absorb_all_into_final_narrowing ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- C1 : out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) ---
+    NOTE: NO NARROWING AT ALL: there is nothing for any policy to elide, so every model coincides by construction
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+
+  SUMMARY — AMD Radeon RX 7900 XTX (RADV NAVI31)
+  (rule predicts S_absorb_all_into_final_narrowing for plain and S_f32_mul_then_absorb_add for precise)
+
+  A1    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A2    2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A3    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A4    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A5    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A6    3 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = R_local_absorb
+        precise : S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A7    2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A8    2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A9    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A10   1 distinct models, 2 unmatched inputs
+        plain   : NO MODEL (1 unmatched)
+        precise : NO MODEL (1 unmatched)
+        green   : NO MODEL (1 unmatched)
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A11   2 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_f32_mul_then_absorb_add
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A12   2 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        precise : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        green   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_f32_mul_then_absorb_add
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A13   1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A14   2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A15   2 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = R_local_absorb
+        precise : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B1    5 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = R_local_absorb
+        precise : S_f32_mul_then_absorb_add = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B2    4 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        precise : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B3    4 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        precise : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B4    5 distinct models, 0 unmatched inputs
+        plain   : R_local_absorb
+        precise : S_f32_mul_then_absorb_add = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> BROKEN — matched R_local_absorb, predicts S_absorb_all_into_final_narrowing ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  C1    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+================================================================
+backlog-151 CATALOGUE — device: AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)
+================================================================
+
+  --- reporting control (host-injected deviation) ---
+    A2   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A6   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    A7   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A8   injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A11  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A12  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A14  injected S_absorb_all_into_final_narrowing  -> reported S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    A15  injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B1   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+    B2   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B3   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add
+    B4   injected S_absorb_all_into_final_narrowing  -> reported S_absorb_all_into_final_narrowing
+
+  --- A1 : narrow x ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A2 : narrow (x *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   2912 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   2912 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2912 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :   2912 / 63488 disagreements
+    R_local_absorb_nocontract          :   2912 / 63488 disagreements
+    R_local_absorb_opencl              :   2912 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   2912 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :   2912 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A3 : narrow (x +. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A4 : narrow (x -. 1000.) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A5 : narrow (x /. 3.) ---
+    NOTE: DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is evidence about fdiv precision and NOT about the absorption rule
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A6 : narrow (x *. 1.1 +. 1000.) ---
+    the five policies induce 3 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :      2 / 63488 disagreements
+    R_local_absorb_opencl              :      2 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :    482 / 63488 disagreements
+    R_local_absorb_opencl              :    482 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      2 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      2 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    R_local_absorb                     :    482 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A7 : narrow ((x +. 1000.) *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    374 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    374 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    374 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    374 / 63488 disagreements
+    R_local_absorb_nocontract          :    374 / 63488 disagreements
+    R_local_absorb_opencl              :    374 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    374 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A8 : narrow (fma x 1.1 1000.) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    484 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    484 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    484 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    484 / 63488 disagreements
+    R_local_absorb_nocontract          :    484 / 63488 disagreements
+    R_local_absorb_opencl              :    484 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    484 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A9 : narrow (sqrt (x *. x)) ---
+    NOTE: SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the device's sqrt precision is separately specified
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A10 : narrow (0. -. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    R_local_absorb                     :      1 / 63488 disagreements
+    R_local_absorb_nocontract          :      1 / 63488 disagreements
+    R_local_absorb_opencl              :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+      first unmatched input x = 0 (0x0000): device 0x8000, S_strict 0x0000, S_fuse_mul_into_narrowing 0x0000, S_absorb_all_into_final_narrowing 0x0000, S_f32_mul_then_absorb_add 0x0000, S_drop_intermediate_narrowing 0x0000, R_local_absorb 0x0000, R_local_absorb_nocontract 0x0000, R_local_absorb_opencl 0x0000
+    *** GREEN CONTROL did not reproduce S_strict: the two rows below are not attributable to ACO ***
+  plain
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    R_local_absorb                     :      1 / 63488 disagreements
+    R_local_absorb_nocontract          :      1 / 63488 disagreements
+    R_local_absorb_opencl              :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+      first unmatched input x = 0 (0x0000): device 0x8000, S_strict 0x0000, S_fuse_mul_into_narrowing 0x0000, S_absorb_all_into_final_narrowing 0x0000, S_f32_mul_then_absorb_add 0x0000, S_drop_intermediate_narrowing 0x0000, R_local_absorb 0x0000, R_local_absorb_nocontract 0x0000, R_local_absorb_opencl 0x0000
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      1 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      1 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      1 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      1 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      1 / 63488 disagreements
+    R_local_absorb                     :      1 / 63488 disagreements
+    R_local_absorb_nocontract          :      1 / 63488 disagreements
+    R_local_absorb_opencl              :      1 / 63488 disagreements
+    *** 1 inputs match NO named model; first at x = 0 (0x0000) ***
+      first unmatched input x = 0 (0x0000): device 0x8000, S_strict 0x0000, S_fuse_mul_into_narrowing 0x0000, S_absorb_all_into_final_narrowing 0x0000, S_f32_mul_then_absorb_add 0x0000, S_drop_intermediate_narrowing 0x0000, R_local_absorb 0x0000, R_local_absorb_nocontract 0x0000, R_local_absorb_opencl 0x0000
+    §1.3 ceiling: NOT EVALUATED — no model matched, so there is no admitted deviation to measure.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A11 : narrow (floor (x *. 1.1)) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    472 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    472 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_f32_mul_then_absorb_add
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A12 : narrow (if x>0. then x*.1.1 else x*.0.9) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :   2863 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   2863 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   2863 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_f32_mul_then_absorb_add
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A13 : narrow (x *. x) ---
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+  --- A14 : narrow (x *. 1.1 *. 1.1) ---
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    308 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    308 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :    308 / 63488 disagreements
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    308 / 63488 disagreements
+    R_local_absorb_nocontract          :    308 / 63488 disagreements
+    R_local_absorb_opencl              :    308 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :    308 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- A15 : narrow (x *. 1.1 +. x /. 3.) ---
+    NOTE: DIVISION: as A5 — an fdiv mismatch is not evidence about absorption
+    the five policies induce 2 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :    744 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :    744 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    744 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    744 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :    744 / 63488 disagreements
+    R_local_absorb_opencl              :    744 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 1 ulp (denominator: S_strict's value there) / 1 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :    744 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :    744 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B1 : narrow (narrow (x *. 1.1) +. 1000.) ---
+    the five policies induce 5 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    620 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   5075 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   4776 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   4774 / 63488 disagreements
+    R_local_absorb                     :   5075 / 63488 disagreements
+    R_local_absorb_nocontract          :   4776 / 63488 disagreements
+    R_local_absorb_opencl              :    620 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   5075 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4896 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :    482 / 63488 disagreements
+    S_drop_intermediate_narrowing      :    484 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :    482 / 63488 disagreements
+    R_local_absorb_opencl              :   4896 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   4776 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   4851 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :    482 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      2 / 63488 disagreements
+    R_local_absorb                     :    482 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   4851 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.67731e+06 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B2 : narrow (narrow (x *. 1.1) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   5368 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  17036 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  17036 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  16728 / 63488 disagreements
+    R_local_absorb                     :  17036 / 63488 disagreements
+    R_local_absorb_nocontract          :  17036 / 63488 disagreements
+    R_local_absorb_opencl              :   5368 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  16786 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  17036 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  16786 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    308 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  16786 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B3 : narrow (narrow (x +. 1000.) *. 1.1) ---
+    the five policies induce 4 distinct functions here
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :    963 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :   7803 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :   7803 / 63488 disagreements
+    S_drop_intermediate_narrowing      :   7431 / 63488 disagreements
+    R_local_absorb                     :   7803 / 63488 disagreements
+    R_local_absorb_nocontract          :   7803 / 63488 disagreements
+    R_local_absorb_opencl              :    963 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   7434 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :   7803 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :   7434 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :    374 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :   7434 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1 ulp.
+    §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- B4 : narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1) ---
+    the five policies induce 5 distinct functions here
+    2 intermediate narrowings: §1.3's ceiling is derived for the elision of ONE rounding, so it is evaluated at the INNERMOST narrowing and covers only that elision on this shape
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :   1518 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :  10706 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :  10707 / 63488 disagreements
+    S_drop_intermediate_narrowing      :  10671 / 63488 disagreements
+    R_local_absorb                     :  10707 / 63488 disagreements
+    R_local_absorb_nocontract          :  10707 / 63488 disagreements
+    R_local_absorb_opencl              :   1518 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :      8 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      2 / 63488 disagreements
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      2 / 63488 disagreements
+    R_local_absorb_opencl              :  10733 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    R_local_absorb                     : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :  10707 / 63488 disagreements
+    S_fuse_mul_into_narrowing          :  10733 / 63488 disagreements
+    S_absorb_all_into_final_narrowing  :     10 / 63488 disagreements
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :     59 / 63488 disagreements
+    R_local_absorb                     :      2 / 63488 disagreements
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :  10733 / 63488 disagreements
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0.5 ulp (denominator: S_strict's value there) / 0.5 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0.500044 ulp (denominator: S_strict's value there) / 0.500044 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 1.84525e+06 ulp.
+    §12.4 whole-tree rule: plain -> BROKEN — matched R_local_absorb, predicts S_absorb_all_into_final_narrowing ; precise -> HOLDS
+    corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+
+  --- C1 : out.(i) <- inp.(i)   (f16 -> f16 copy, no cast) ---
+    NOTE: NO NARROWING AT ALL: there is nothing for any policy to elide, so every model coincides by construction
+    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on this shape over all 63488 inputs. Whatever the device returns, this row is not evidence for or against the rule.
+  GREEN CONTROL — every temporary through the volatile SSBO
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+  plain
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+  precise (what Sarek_ir_glsl emits)
+    S_strict                           :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_fuse_mul_into_narrowing          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_absorb_all_into_final_narrowing  :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_f32_mul_then_absorb_add          :      0 / 63488 disagreements   <== EXACT, element-wise
+    S_drop_intermediate_narrowing      :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb                     :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_nocontract          :      0 / 63488 disagreements   <== EXACT, element-wise
+    R_local_absorb_opencl              :      0 / 63488 disagreements   <== EXACT, element-wise
+    every input matches at least one named model (0 unexplained)
+    §1.3 ceiling, evaluated AT THE ELIDED NARROWING (not on the final value):
+    S_strict                           : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_fuse_mul_into_narrowing          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_absorb_all_into_final_narrowing  : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_f32_mul_then_absorb_add          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    S_drop_intermediate_narrowing      : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb                     : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_nocontract          : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    R_local_absorb_opencl              : at the elided narrowing, worst = 0 ulp (denominator: S_strict's value there) / 0 ulp (denominator: the model's own value there); 0 inputs exceed 1 ulp under BOTH denominators. On the FINAL value the same deviation reaches 0 ulp.
+    §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+    corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+
+
+  SUMMARY — AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)
+  (rule predicts S_absorb_all_into_final_narrowing for plain and S_f32_mul_then_absorb_add for precise)
+
+  A1    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A2    2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A3    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A4    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A5    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A6    3 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = R_local_absorb
+        precise : S_f32_mul_then_absorb_add = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A7    2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A8    2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A9    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A10   1 distinct models, 2 unmatched inputs
+        plain   : NO MODEL (1 unmatched)
+        precise : NO MODEL (1 unmatched)
+        green   : NO MODEL (1 unmatched)
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A11   2 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl, predicts S_f32_mul_then_absorb_add
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A12   2 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        precise : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        green   : S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract
+        §12.4 whole-tree rule: plain -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_absorb_all_into_final_narrowing ; precise -> BROKEN — matched S_strict = S_fuse_mul_into_narrowing = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract, predicts S_f32_mul_then_absorb_add
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A13   1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+  A14   2 distinct models, 0 unmatched inputs
+        plain   : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_drop_intermediate_narrowing
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  A15   2 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = R_local_absorb
+        precise : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B1    5 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = R_local_absorb
+        precise : S_f32_mul_then_absorb_add = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B2    4 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        precise : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B3    4 distinct models, 0 unmatched inputs
+        plain   : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        precise : S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = R_local_absorb = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> HOLDS ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  B4    5 distinct models, 0 unmatched inputs
+        plain   : R_local_absorb
+        precise : S_f32_mul_then_absorb_add = R_local_absorb_nocontract
+        green   : S_strict
+        §12.4 whole-tree rule: plain -> BROKEN — matched R_local_absorb, predicts S_absorb_all_into_final_narrowing ; precise -> HOLDS
+        corrected LOCAL rule : plain -> HOLDS ; precise -> HOLDS
+  C1    1 distinct models, 0 unmatched inputs
+        plain   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        precise : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        green   : S_strict = S_fuse_mul_into_narrowing = S_absorb_all_into_final_narrowing = S_f32_mul_then_absorb_add = S_drop_intermediate_narrowing = R_local_absorb = R_local_absorb_nocontract = R_local_absorb_opencl
+        §12.4 whole-tree rule: plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)
+        corrected LOCAL rule : plain -> n/a (non-discriminating) ; precise -> n/a (non-discriminating)

--- a/sarek-opencl/probe/dune
+++ b/sarek-opencl/probe/dune
@@ -9,4 +9,4 @@
 (executable
  (name probe_opencl_f16_model_agreement)
  (modules probe_opencl_f16_model_agreement)
- (libraries sarek_opencl spoc_framework f16_model_set))
+ (libraries sarek_opencl spoc_framework f16_model_set f16_shape_catalogue))

--- a/sarek-opencl/probe/probe_opencl_f16_model_agreement.ml
+++ b/sarek-opencl/probe/probe_opencl_f16_model_agreement.ml
@@ -30,6 +30,7 @@
 open Sarek_opencl
 module Backend = Opencl_plugin_base.Opencl
 module M = F16_model_set
+module C = F16_shape_catalogue
 
 let n_local = 256
 
@@ -283,8 +284,112 @@ let probe_device device =
 
   (c1, c2)
 
+(* ---------------------------------------------------------------------- *)
+(* backlog-151 — the 20-shape catalogue on the OTHER ACO front end          *)
+(*                                                                          *)
+(* rusticl compiles the same ACO backend through a different front end, so   *)
+(* the corrected local rule of F16_shape_catalogue is a claim about ACO only *)
+(* if both front ends produce it. There is no `precise` here: OpenCL C has   *)
+(* no NoContraction spelling that slice 1 measured, so this sweep runs the   *)
+(* plain kernel and the green control, and the rule is tested in its         *)
+(* contraction-allowed form alone.                                          *)
+(* ---------------------------------------------------------------------- *)
+
+let name_of c =
+  match c.M.exact_matches with
+  | [] when c.M.unexplained = 0 -> "NO SINGLE MODEL (mixture)"
+  | [] -> Printf.sprintf "NO MODEL (%d unmatched)" c.M.unexplained
+  | [n] -> n
+  | l -> String.concat " = " l
+
+let catalogue_device device =
+  Printf.printf
+    "\n================================================================\n" ;
+  Printf.printf "backlog-151 CATALOGUE — device: %s\n" (describe device) ;
+  Printf.printf
+    "================================================================\n%!" ;
+  let rows = ref [] in
+  List.iter
+    (fun sh ->
+      let models = C.models_with_local sh in
+      let distinct = C.distinct_model_count sh in
+      Printf.printf "\n  --- %s : %s ---\n" sh.C.id sh.C.descr ;
+      if sh.C.discriminating_note <> "" then
+        Printf.printf "    NOTE: %s\n" sh.C.discriminating_note ;
+      if distinct = 1 then
+        Printf.printf
+          "    NON-DISCRIMINATING: all five slice-1 policies are the SAME \
+           FUNCTION here; whatever the device returns is not evidence about \
+           the rule.\n" ;
+      let run_v ~label ~barrier =
+        let source = C.source ~dialect:C.Opencl ~precise:false ~barrier sh in
+        let got, c = sweep device ~label ~source ~models in
+        if c.M.unexplained > 0 then begin
+          let idx = c.M.first_unexplained in
+          let b = M.finite_bits.(idx) in
+          Printf.printf
+            "      first unmatched input x = %.9g (0x%04X): device 0x%04X"
+            (M.dec b)
+            b
+            got.(idx) ;
+          List.iter
+            (fun m -> Printf.printf ", %s 0x%04X" m.M.name (m.M.result b))
+            models ;
+          Printf.printf "\n"
+        end ;
+        c
+      in
+      let cg =
+        run_v
+          ~label:"GREEN CONTROL — every temporary through the volatile __local"
+          ~barrier:true
+      in
+      if not (List.mem "S_strict" cg.M.exact_matches) then
+        Printf.printf
+          "    *** GREEN CONTROL did not reproduce S_strict: the row below is \
+           not attributable to ACO ***\n" ;
+      let cp = run_v ~label:"plain" ~barrier:false in
+      report_ceiling models cp ;
+      let verdict want =
+        if distinct = 1 then "n/a (non-discriminating)"
+        else if List.mem want cp.M.exact_matches then "HOLDS"
+        else if cp.M.unexplained > 0 then
+          Printf.sprintf "BROKEN — %d inputs match no model" cp.M.unexplained
+        else Printf.sprintf "BROKEN — matched %s, predicts %s" (name_of cp) want
+      in
+      Printf.printf
+        "    §12.4 whole-tree rule: %s\n    corrected LOCAL rule : %s\n"
+        (verdict C.rule_plain.C.pname)
+        (verdict C.aco_opencl.C.lname) ;
+      rows :=
+        ( sh.C.id,
+          distinct,
+          name_of cp,
+          name_of cg,
+          verdict C.rule_plain.C.pname,
+          verdict C.aco_opencl.C.lname )
+        :: !rows)
+    C.shapes ;
+  Printf.printf "\n\n  SUMMARY — %s\n\n" (describe device) ;
+  List.iter
+    (fun (id, d, p, g, r, l) ->
+      Printf.printf
+        "  %-4s  %d distinct models\n\
+        \        plain : %s\n\
+        \        green : %s\n\
+        \        §12.4 whole-tree rule: %s\n\
+        \        corrected LOCAL rule : %s\n"
+        id
+        d
+        p
+        g
+        r
+        l)
+    (List.rev !rows)
+
 let () =
   let host_only = Array.exists (fun a -> a = "--host-only") Sys.argv in
+  let catalogue = Array.exists (fun a -> a = "--catalogue") Sys.argv in
   Printf.printf
     "#62 slice 1(a) — element-wise model agreement, OpenCL / rusticl\n\n" ;
   (try M.calibrate ()
@@ -325,4 +430,18 @@ let () =
         | [] -> "no OpenCL devices at all"
         | l -> String.concat "; " (List.map describe l)) ;
       exit 2
-  | ds -> List.iter (fun d -> ignore (probe_device d)) ds
+  | ds ->
+      if catalogue then begin
+        (try C.calibrate ()
+         with C.Calibration_failed s ->
+           Printf.printf
+             "CATALOGUE CALIBRATION FAILED — read nothing below it:\n  %s\n"
+             s ;
+           exit 1) ;
+        Printf.printf
+          "catalogue calibration PASSED: the generic policies reproduce slice \
+           1's hand-written closed forms bit-for-bit on A2 and B1 over all \
+           63488 inputs, and the corrected local rule reduces onto them.\n" ;
+        List.iter catalogue_device ds
+      end
+      else List.iter (fun d -> ignore (probe_device d)) ds

--- a/sarek-vulkan/probe/dune
+++ b/sarek-vulkan/probe/dune
@@ -9,4 +9,4 @@
 (executable
  (name probe_vulkan_f16_model_agreement)
  (modules probe_vulkan_f16_model_agreement)
- (libraries sarek_vulkan spoc_framework f16_model_set))
+ (libraries sarek_vulkan spoc_framework f16_model_set f16_shape_catalogue))

--- a/sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml
+++ b/sarek-vulkan/probe/probe_vulkan_f16_model_agreement.ml
@@ -37,11 +37,35 @@
  * S_strict bit-exactly on the same un-enabled path.
  ******************************************************************************)
 
+(******************************************************************************
+ * backlog-151 EXTENSION — `--catalogue`, the other 18 shapes.
+ *
+ * Slice 1 left one candidate GENERATIVE RULE
+ * (docs/fp-contraction-policy.md §12.4) marked "unverified as a general rule",
+ * and named the remaining 18 of the 20 emittable f16 shapes as what would
+ * settle it. `--catalogue` sweeps all 20 — the two already measured included,
+ * as the regression anchor — against the five POLICIES of
+ * [F16_shape_catalogue], which are slice 1's four named models restated as
+ * functions of an arbitrary expression tree.
+ *
+ * Two hazards this mode is built against, both of which slice 1 hit:
+ *
+ *  - A COUNT-ONLY sweep would miss ACO re-absorbing a control 18 times over,
+ *    exactly as it missed it once on the two-narrowing shape. Every variant
+ *    here is classified ELEMENT-WISE and the harness prints WHICH MODEL
+ *    matched, never a bare count.
+ *  - A shape on which all five policies coincide reports "S_strict, 0/63488"
+ *    while measuring nothing. The host-only separation pass runs first and any
+ *    such shape is labelled NON-DISCRIMINATING in its own row, so that a table
+ *    of zeros cannot be read as twenty confirmations.
+ ******************************************************************************)
+
 open Sarek_vulkan
 module Device = Vulkan_api_device
 module Memory = Vulkan_api_memory
 module Kernel = Vulkan_api_kernel
 module M = F16_model_set
+module C = F16_shape_catalogue
 
 let n_local = 256
 
@@ -355,8 +379,211 @@ let probe_device device =
   in
   report_ceiling M.shape2_models c
 
+(* ---------------------------------------------------------------------- *)
+(* backlog-151 — the 20-shape catalogue                                     *)
+(* ---------------------------------------------------------------------- *)
+
+(* What the generative rule of §12.4 PREDICTS, per variant. Written down before
+   any device is read, so the sweep is a test of a prediction and not a
+   description of an outcome. *)
+let predicted ~precise =
+  if precise then C.rule_precise.C.pname else C.rule_plain.C.pname
+
+(* What the CORRECTED local rule predicts. Stated here, next to the rule it
+   replaces, so both predictions are written down before any device is read. *)
+let predicted_local ~precise =
+  if precise then "R_local_absorb_nocontract" else "R_local_absorb"
+
+type row = {
+  r_id : string;
+  r_distinct : int;
+  r_plain : string;
+  r_precise : string;
+  r_unexpl : int;
+  r_green : string;
+  r_rule : string;
+  r_local : string;
+}
+
+(* §1.2 requires the device result to be bit-identical to ONE member of the set
+   on every input. That is strictly stronger than "every input matches some
+   member", and the difference is not academic: shape B4 plain matches
+   S_absorb_all on 63480 inputs and S_f32_mul_then_absorb_add on 63486, so no
+   single member describes it while every individual input is covered. The two
+   outcomes are therefore named differently. *)
+let name_of c =
+  match c.M.exact_matches with
+  | [] when c.M.unexplained = 0 -> "NO SINGLE MODEL (mixture)"
+  | [] -> Printf.sprintf "NO MODEL (%d unmatched)" c.M.unexplained
+  | [n] -> n
+  | l -> String.concat " = " l
+
+let catalogue_device device =
+  Printf.printf
+    "\n================================================================\n" ;
+  Printf.printf "backlog-151 CATALOGUE — device: %s\n" (describe device) ;
+  Printf.printf
+    "================================================================\n%!" ;
+
+  (* REPORTING CONTROL, host-side. The trap slice 1 hit was a control ACO
+     re-absorbed, caught only because the harness reported the WRONG MODEL
+     rather than an implausible count. So before any device number is read,
+     feed the classifier a host-computed NON-STRICT model and require it to
+     name that model. A classifier that answers "S_strict" to everything would
+     report twenty false confirmations here. *)
+  Printf.printf "\n  --- reporting control (host-injected deviation) ---\n" ;
+  let control_ok = ref true in
+  List.iter
+    (fun sh ->
+      if C.distinct_model_count sh > 1 then begin
+        let models = C.models_of sh in
+        let injected =
+          Array.map (C.result C.rule_plain sh.C.expr) M.finite_bits
+        in
+        let c = M.classify models injected in
+        let got = name_of c in
+        let ok =
+          List.mem C.rule_plain.C.pname c.M.exact_matches && c.M.unexplained = 0
+        in
+        if not ok then control_ok := false ;
+        Printf.printf
+          "    %-4s injected %-34s -> reported %s%s\n"
+          sh.C.id
+          C.rule_plain.C.pname
+          got
+          (if ok then "" else "   *** REPORTING CONTROL BROKEN ***")
+      end)
+    C.shapes ;
+  if not !control_ok then
+    Printf.printf
+      "    *** the classifier does not name an injected deviation; nothing \
+       below is readable ***\n" ;
+
+  let rows = ref [] in
+  List.iter
+    (fun sh ->
+      let models = C.models_with_local sh in
+      let distinct = C.distinct_model_count sh in
+      Printf.printf "\n  --- %s : %s ---\n" sh.C.id sh.C.descr ;
+      if sh.C.discriminating_note <> "" then
+        Printf.printf "    NOTE: %s\n" sh.C.discriminating_note ;
+      if distinct = 1 then
+        Printf.printf
+          "    NON-DISCRIMINATING: all five policies are the SAME FUNCTION on \
+           this shape over all 63488 inputs. Whatever the device returns, this \
+           row is not evidence for or against the rule.\n"
+      else
+        Printf.printf
+          "    the five policies induce %d distinct functions here\n"
+          distinct ;
+      let nin = C.inner_narrowing_count sh.C.expr in
+      if nin > 1 then
+        Printf.printf
+          "    %d intermediate narrowings: §1.3's ceiling is derived for the \
+           elision of ONE rounding, so it is evaluated at the INNERMOST \
+           narrowing and covers only that elision on this shape\n"
+          nin ;
+      (* Same sweep, but the device array is kept so an input matching NO model
+         can be shown as a bit pattern next to what each model wanted. A bare
+         "N inputs match no model" leaves the reader unable to tell a fusion
+         hazard from a sign-of-zero difference, and on this catalogue two shapes
+         turn out to be the latter. *)
+      let sweep_v ~label ~precise ~barrier =
+        let source = C.source ~dialect:C.Glsl ~precise ~barrier sh in
+        let got = run device ~source ~inputs:M.finite_bits in
+        let c = M.classify models got in
+        M.print_classification ~label c ;
+        if c.M.unexplained > 0 then begin
+          let idx = c.M.first_unexplained in
+          let b = M.finite_bits.(idx) in
+          Printf.printf
+            "      first unmatched input x = %.9g (0x%04X): device 0x%04X"
+            (M.dec b)
+            b
+            got.(idx) ;
+          List.iter
+            (fun m -> Printf.printf ", %s 0x%04X" m.M.name (m.M.result b))
+            models ;
+          Printf.printf "\n"
+        end ;
+        c
+      in
+      let cg =
+        sweep_v
+          ~label:"GREEN CONTROL — every temporary through the volatile SSBO"
+          ~precise:false
+          ~barrier:true
+      in
+      if not (List.mem "S_strict" cg.M.exact_matches) then
+        Printf.printf
+          "    *** GREEN CONTROL did not reproduce S_strict: the two rows \
+           below are not attributable to ACO ***\n" ;
+      let cp = sweep_v ~label:"plain" ~precise:false ~barrier:false in
+      report_ceiling models cp ;
+      let cq =
+        sweep_v
+          ~label:"precise (what Sarek_ir_glsl emits)"
+          ~precise:true
+          ~barrier:false
+      in
+      report_ceiling models cq ;
+      let verdict ~want ~precise c =
+        let want = want ~precise in
+        if distinct = 1 then "n/a (non-discriminating)"
+        else if List.mem want c.M.exact_matches then "HOLDS"
+        else if c.M.unexplained > 0 then
+          Printf.sprintf "BROKEN — %d inputs match no model" c.M.unexplained
+        else Printf.sprintf "BROKEN — matched %s, predicts %s" (name_of c) want
+      in
+      let v want =
+        Printf.sprintf
+          "plain -> %s ; precise -> %s"
+          (verdict ~want ~precise:false cp)
+          (verdict ~want ~precise:true cq)
+      in
+      Printf.printf "    §12.4 whole-tree rule: %s\n" (v predicted) ;
+      Printf.printf "    corrected LOCAL rule : %s\n" (v predicted_local) ;
+      rows :=
+        {
+          r_id = sh.C.id;
+          r_distinct = distinct;
+          r_plain = name_of cp;
+          r_precise = name_of cq;
+          r_unexpl = cp.M.unexplained + cq.M.unexplained;
+          r_green = name_of cg;
+          r_rule = v predicted;
+          r_local = v predicted_local;
+        }
+        :: !rows)
+    C.shapes ;
+
+  Printf.printf
+    "\n\n  SUMMARY — %s\n  (rule predicts %s for plain and %s for precise)\n\n"
+    (describe device)
+    C.rule_plain.C.pname
+    C.rule_precise.C.pname ;
+  List.iter
+    (fun r ->
+      Printf.printf
+        "  %-4s  %d distinct models, %d unmatched inputs\n\
+        \        plain   : %s\n\
+        \        precise : %s\n\
+        \        green   : %s\n\
+        \        §12.4 whole-tree rule: %s\n\
+        \        corrected LOCAL rule : %s\n"
+        r.r_id
+        r.r_distinct
+        r.r_unexpl
+        r.r_plain
+        r.r_precise
+        r.r_green
+        r.r_rule
+        r.r_local)
+    (List.rev !rows)
+
 let () =
   let host_only = Array.exists (fun a -> a = "--host-only") Sys.argv in
+  let catalogue = Array.exists (fun a -> a = "--catalogue") Sys.argv in
   Printf.printf
     "#62 slice 1(b) — element-wise model agreement, Vulkan / RADV\n\n" ;
   (try M.calibrate ()
@@ -369,6 +596,20 @@ let () =
      reproduces at 1 ulp at the narrowing and 512 ulp on the final value.\n\n"
     M.shape2_name
     M.shape1_name ;
+
+  if catalogue then begin
+    (try C.calibrate ()
+     with C.Calibration_failed s ->
+       Printf.printf
+         "CATALOGUE CALIBRATION FAILED — read nothing below it:\n  %s\n"
+         s ;
+       exit 1) ;
+    Printf.printf
+      "catalogue calibration PASSED: the five generic policies reproduce slice \
+       1's seven hand-written closed forms bit-for-bit on A2 and B1 over all \
+       63488 inputs, and reproduce the recorded separations 2912 / 620 / 5075 \
+       / 4776 / 4774 from the generic evaluator.\n\n"
+  end ;
 
   Printf.printf "SHAPE 1 — %s\n" M.shape1_name ;
   let sep1 = M.separation_matrix M.shape1_models in
@@ -398,11 +639,37 @@ let () =
         | l -> String.concat "; " (List.map describe l)) ;
       exit 2
   | ds -> (
-      let rec only i =
+      let rec flag name i =
         if i + 1 >= Array.length Sys.argv then None
-        else if Sys.argv.(i) = "--variant" then Some Sys.argv.(i + 1)
-        else only (i + 1)
+        else if Sys.argv.(i) = name then Some Sys.argv.(i + 1)
+        else flag name (i + 1)
       in
-      match only 1 with
-      | Some v -> probe_one (List.hd ds) v
-      | None -> List.iter probe_device ds)
+      match flag "--shape" 1 with
+      | Some id ->
+          (* One shape, one variant, one shader compiled — so RADV_DEBUG=asm
+             produces an ISA dump attributable to a single shader. With a full
+             catalogue run, sixty shaders are compiled in sequence and reading
+             the ISA means guessing, which is not a machine-code tier. *)
+          let sh = C.shape_by_id id in
+          let variant =
+            match flag "--variant" 1 with Some v -> v | None -> "plain"
+          in
+          let precise = variant = "precise" and barrier = variant = "barrier" in
+          let source = C.source ~dialect:C.Glsl ~precise ~barrier sh in
+          let device = List.hd ds in
+          Printf.printf
+            "device: %s\nshape: %s (%s)\nvariant: %s\nGLSL:\n%s\n"
+            (describe device)
+            sh.C.id
+            sh.C.descr
+            variant
+            source ;
+          let models = C.models_with_local sh in
+          let c = sweep device ~label:variant ~source ~models in
+          report_ceiling models c
+      | None -> (
+          match flag "--variant" 1 with
+          | Some v when not catalogue -> probe_one (List.hd ds) v
+          | _ ->
+              if catalogue then List.iter catalogue_device ds
+              else List.iter probe_device ds))

--- a/tools/f16_shape_catalogue/dune
+++ b/tools/f16_shape_catalogue/dune
@@ -1,0 +1,15 @@
+; backlog-151 — the 20-shape f16 expression catalogue, and the generative rule
+; of docs/fp-contraction-policy.md §12.4 written as five POLICIES rather than
+; as one closed form per shape.
+;
+; A separate library from f16_model_set rather than a second module inside it:
+; that library's single module carries the library's own name, which makes it
+; the library interface, and slice 1's probes consume it as such. Extending it
+; in place would change how it is referenced. This one depends on it and adds.
+;
+; No `public_name`: measurement machinery, not shipped API.
+
+(library
+ (name f16_shape_catalogue)
+ (modules f16_shape_catalogue)
+ (libraries f16_model_set))

--- a/tools/f16_shape_catalogue/f16_shape_catalogue.ml
+++ b/tools/f16_shape_catalogue/f16_shape_catalogue.ml
@@ -1,0 +1,1120 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-151 — the 20-shape f16 catalogue, and the GENERATIVE RULE as code.
+ *
+ * WHAT QUESTION THIS MODULE EXISTS TO ANSWER.
+ *
+ * docs/fp-contraction-policy.md §12.4 closes slice 1 with one candidate rule
+ * that produces all five of its results:
+ *
+ *   "An f32->f16 narrowing absorbs the entire f32 expression tree feeding it,
+ *    evaluating it exactly and rounding once — intermediate binary16
+ *    narrowings included, hence elided — cut wherever SPIR-V NoContraction
+ *    forbids a multiply-add contraction, at which cut a correctly-rounded
+ *    binary32 value is materialised."
+ *
+ * and marks it **unverified as a general rule**. The stakes are structural,
+ * not a coverage metric: if the rule holds, docs/design/f16-relaxed-accuracy.md
+ * §1.2's model set is a handful of NAMED GENERATORS applied to whatever shape
+ * the user wrote; if it fails, §1.2 degrades to a per-expression lookup table.
+ *
+ * SO THE MODELS HERE ARE GENERATORS, NOT ENTRIES.
+ *
+ * F16_model_set hand-writes seven closed forms for two specific shapes. This
+ * module writes FIVE POLICIES, each a way of deciding which mandated roundings
+ * a compiler elides, and applies them to a 20-shape expression catalogue. Five
+ * names for twenty shapes is the whole point: a model set that grows with the
+ * shape catalogue is a lookup table wearing a contract's clothing.
+ *
+ * The five policies are not new semantics. On the two shapes slice 1 measured
+ * they must reproduce F16_model_set's hand-written functions BIT-FOR-BIT, and
+ * [calibrate] refuses to let anything else be read until they do. That is the
+ * hinge of this module's credibility: the generator is trusted on the other 18
+ * shapes precisely because it is pinned to slice 1's four named models on the
+ * two shapes that have device numbers.
+ *
+ * ONE SOURCE OF TRUTH FOR THE SHAPE.
+ *
+ * The device source and the host model are generated from the SAME expression
+ * tree. A hand-written GLSL kernel next to a hand-written host reference can
+ * drift apart silently and the sweep then measures the drift; here they cannot,
+ * because there is only one tree.
+ *
+ * EXACT ARITHMETIC, AND WHY ORDINARY FLOATS WILL NOT DO.
+ *
+ * The absorbing policies round a value to binary16 in a SINGLE step from a sum
+ * binary64 cannot hold: the exact product x * fl32(1.1) is a multiple of 2^-47
+ * while the addend reaches 2^9, so the exact sum spans 65 bits against
+ * binary64's 53. Evaluating it in OCaml floats would round first and the model
+ * would be a DIFFERENT FUNCTION — differing exactly at the binary16 ties, which
+ * is where §1.3's counterexample lives. So the evaluator below works on
+ * Shewchuk floating-point EXPANSIONS (exact, unevaluated sums of non-
+ * overlapping binary64 values) with a sticky flag for the one operation that
+ * cannot be exact, division.
+ ******************************************************************************)
+
+module M = F16_model_set
+
+(* ========================================================================= *)
+(* 1. Exact arithmetic: Shewchuk expansions + a sticky residual              *)
+(* ========================================================================= *)
+
+(* An exact real value, represented as:
+     - [terms]: non-overlapping binary64 components in INCREASING magnitude
+       whose sum is exact. Interior zeros are eliminated, Shewchuk-style, but
+       the LEADING component is always kept even when it is a zero — because
+       binary16 has two zeros, [f16_bits] distinguishes them, and the HIP
+       reference this catalogue mirrors propagates the sign of zero through
+       every shape. Dropping it would make the models disagree with the device
+       on exactly one input, x = -0, which is precisely the kind of
+       one-input-wide difference this whole exercise exists to detect.
+     - [st]: the sign of a residual too small to represent, strictly below the
+       magnitude of the smallest term. Only division ever sets it.
+   The value is  (sum terms) + (an unrepresented residual of sign [st]). *)
+type ex = {terms : float list; st : int}
+
+exception Not_exactly_computable of string
+
+let nec fmt = Printf.ksprintf (fun s -> raise (Not_exactly_computable s)) fmt
+
+let single v = {terms = [v]; st = 0}
+
+let zero = single 0.0
+
+(* Knuth's twoSum: [a +. b] is EXACTLY [s +. e], no magnitude assumption. *)
+let two_sum a b =
+  let s = a +. b in
+  let bb = s -. a in
+  let err = a -. (s -. bb) +. (b -. bb) in
+  (s, err)
+
+(* Dekker/FMA twoProd: [a *. b] is EXACTLY [p +. e]. Exact because [Float.fma]
+   computes a*b with a single rounding, so the residual is representable. *)
+let two_prod a b =
+  let p = a *. b in
+  let e = Float.fma a b (-.p) in
+  (p, e)
+
+(* Shewchuk grow_expansion_zeroelim: add a scalar to an expansion, exactly. *)
+let grow e b =
+  let rec go q acc = function
+    | [] -> List.rev (q :: acc)
+    | ei :: t ->
+        let s, err = two_sum q ei in
+        go s (if err <> 0.0 then err :: acc else acc) t
+  in
+  go b [] e
+
+(* Exact sum of two expansions. *)
+let expansion_sum e f = List.fold_left grow e f
+
+(* Shewchuk scale_expansion_zeroelim: expansion times a scalar, exactly. *)
+let scale e b =
+  match e with
+  | [] -> []
+  | e0 :: rest ->
+      let q0, h0 = two_prod e0 b in
+      let acc = if h0 <> 0.0 then [h0] else [] in
+      let rec go q acc = function
+        | [] -> List.rev (q :: acc)
+        | ei :: t ->
+            let pi, ei' = two_prod ei b in
+            let s1, e1 = two_sum q ei' in
+            let acc = if e1 <> 0.0 then e1 :: acc else acc in
+            let s2, e2 = two_sum pi s1 in
+            let acc = if e2 <> 0.0 then e2 :: acc else acc in
+            go s2 acc t
+      in
+      go q0 acc rest
+
+let ex_neg a = {terms = List.map (fun v -> -.v) a.terms; st = -a.st}
+
+let ex_add a b = {terms = expansion_sum a.terms b.terms; st = a.st + b.st}
+
+let ex_sub a b = ex_add a (ex_neg b)
+
+(* Every multiply in the 20-shape catalogue has at least one operand that is a
+   single binary64 value (a binary16 input, an f32 constant, or an already-
+   rounded intermediate). [scale] is then exact. A multiply of two genuine
+   expansions is refused loudly rather than approximated. *)
+let ex_mul a b =
+  if a.st <> 0 || b.st <> 0 then
+    nec "multiply of a value carrying an inexact residual" ;
+  match (a.terms, b.terms) with
+  | [], _ | _, [] -> zero
+  | _, [s] -> {terms = scale a.terms s; st = 0}
+  | [s], _ -> {terms = scale b.terms s; st = 0}
+  | _ -> nec "multiply of two multi-term expansions"
+
+(* Division is the one operation that cannot be exact. [q] is the binary64
+   quotient — correctly rounded, so within 2^-53 relative of the truth — and
+   the FMA residual gives the exact SIGN of what is missing. That is enough for
+   a single correct rounding to binary32 or binary16: a target ulp is at least
+   2^-24 relative, so a residual below 2^-53 relative can only ever matter when
+   the quotient sits exactly on a target tie, and there the sign decides. *)
+let ex_div a b =
+  if a.st <> 0 || b.st <> 0 then nec "divide involving an inexact residual" ;
+  match (a.terms, b.terms) with
+  | [], _ -> zero
+  | _, [] -> nec "division by zero"
+  | [x], [y] ->
+      let q = x /. y in
+      if not (Float.is_finite q) then {terms = [q]; st = 0}
+      else
+        let r = Float.fma (-.q) y x in
+        let st = if r = 0.0 then 0 else if r > 0.0 = (y > 0.0) then 1 else -1 in
+        (* [q] is kept even when it is a zero: (-0)/3 is -0, and binary16 has
+           two zeros. An earlier revision dropped it and the model then claimed
+           +0 where both IEEE and the device say -0 — a one-input-wide error, on
+           the exact input a coarse sweep is least likely to look at. *)
+        {terms = [q]; st}
+  | _ -> nec "division of a multi-term expansion"
+
+(* sqrt is exact only when the argument is a perfect square of a binary64. In
+   this catalogue it appears once, as sqrt(x*x) for a binary16 x — where x*x is
+   exact in binary64 (22 significand bits) and its root is |x| exactly. Any
+   other use is refused. *)
+let ex_sqrt a =
+  match (a.terms, a.st) with
+  | [], 0 -> zero
+  | [v], 0 when v >= 0.0 ->
+      let r = sqrt v in
+      if r *. r = v then single r else nec "sqrt is not exact on this argument"
+  | _ -> nec "sqrt of an expansion or of a negative value"
+
+(* floor is exact on a single-term expansion, which is what the catalogue's one
+   floor sees (floor(x * 1.1), whose argument is 35 significand bits). *)
+let ex_floor a =
+  match (a.terms, a.st) with
+  | [], 0 -> zero
+  | [v], 0 -> single (Float.floor v)
+  | _ -> nec "floor of a multi-term expansion or an inexact value"
+
+(* The residual's sign: the sign of everything below the largest term. The
+   components are non-overlapping and decreasing, so the sign of their sum is
+   the sign of the largest of them; below those, [st]. *)
+let residual_sign a =
+  match List.rev a.terms with
+  | [] | [_] -> a.st
+  | _ :: second :: _ -> if second > 0.0 then 1 else -1
+
+(* Round the exact value to [prec] significand bits with smallest subnormal
+   2^[emin_sub], in ONE step. Delegates the rounding itself to
+   F16_model_set.round_dd, so this module and slice 1's cannot round
+   differently: only the sign of the residual is passed, which is all round_dd
+   consults it for (the leading term already fixes which ulp interval the value
+   is in — the rest is non-overlapping and hence below half an ulp64 of it). *)
+let round_ex ~prec ~emin_sub a =
+  match List.rev a.terms with
+  | [] -> 0.0
+  | hi :: rest ->
+      let s = residual_sign a in
+      (* A zero leading term means the value IS a zero (the components are
+         decreasing, so nothing can be below a zero). Return it as it is:
+         round_dd's [s = 0.0 -> e] branch would lose the sign, and binary16
+         has two zeros. *)
+      if hi = 0.0 && rest = [] && s = 0 then hi
+      else
+        let e = if s = 0 then 0.0 else float_of_int s *. ldexp 1.0 (-1074) in
+        M.round_dd ~prec ~emin_sub (hi, e)
+
+let to_f32 a = single (round_ex ~prec:24 ~emin_sub:(-149) a)
+
+let to_f16_bits a = M.f16_bits (round_ex ~prec:11 ~emin_sub:(-24) a)
+
+let to_f16_value a = M.dec (to_f16_bits a)
+
+(* ========================================================================= *)
+(* 2. The expression language                                                *)
+(* ========================================================================= *)
+
+type e =
+  | X  (** the widened binary16 input, exact *)
+  | K of float * string
+      (** an f32 constant: exact value, and its source text *)
+  | Add of e * e
+  | Sub of e * e
+  | Mul of e * e
+  | Div of e * e
+  | Fma of e * e * e
+  | Sqrt of e
+  | Floor of e
+  | Sel of e * e  (** [x > 0.0 ? a : b] *)
+  | Nar of e  (** an f32 -> f16 narrowing, widened back to f32 *)
+
+let k11 = K (M.f32 1.1, "1.1")
+
+let k09 = K (M.f32 0.9, "0.9")
+
+let k1000 = K (1000.0, "1000.0")
+
+let k3 = K (3.0, "3.0")
+
+let k0 = K (0.0, "0.0")
+
+(* ========================================================================= *)
+(* 3. The five policies — the generative rule, and its neighbours            *)
+(* ========================================================================= *)
+
+(* Each policy is a decision about which mandated roundings a compiler elides.
+   The naming is F16_model_set's and deliberately so: these are the SAME four
+   named members of §1.2, restated as functions of an arbitrary shape rather
+   than as closed forms for two of them. *)
+type policy = {
+  pname : string;
+  pdescr : string;
+  exact : bool;  (** f32 operations are not rounded — the absorbing policies *)
+  inner_nar : bool;  (** intermediate binary16 narrowings are performed *)
+  fuse_mul : bool;
+      (** a multiply/fma DIRECTLY consumed by a narrowing is absorbed into it,
+          and nothing else is — §1.2's [S_fuse_mul_into_narrowing], verbatim *)
+  cut : bool;
+      (** NoContraction: a multiply feeding an addition, and an explicit fma,
+          materialise a correctly-rounded binary32 value *)
+}
+
+let p_strict =
+  {
+    pname = "S_strict";
+    pdescr = "every mandated rounding performed (the interpreter)";
+    exact = false;
+    inner_nar = true;
+    fuse_mul = false;
+    cut = false;
+  }
+
+let p_fuse_mul =
+  {
+    pname = "S_fuse_mul_into_narrowing";
+    pdescr = "every f32 multiply immediately consumed by a narrowing absorbed";
+    exact = false;
+    inner_nar = true;
+    fuse_mul = true;
+    cut = false;
+  }
+
+let p_absorb_all =
+  {
+    pname = "S_absorb_all_into_final_narrowing";
+    pdescr =
+      "the whole f32 tree, intermediate narrowings included, absorbed into the \
+       final narrowing: ONE rounding";
+    exact = true;
+    inner_nar = false;
+    fuse_mul = false;
+    cut = false;
+  }
+
+let p_cut_mul =
+  {
+    pname = "S_f32_mul_then_absorb_add";
+    pdescr =
+      "the same, cut where NoContraction forbids a multiply-add: the multiply \
+       keeps its own binary32 result";
+    exact = true;
+    inner_nar = false;
+    fuse_mul = false;
+    cut = true;
+  }
+
+let p_drop_inner =
+  {
+    pname = "S_drop_intermediate_narrowing";
+    pdescr =
+      "intermediate binary16 narrowings dropped; every f32 op still rounds to \
+       f32 (the IGC signature)";
+    exact = false;
+    inner_nar = false;
+    fuse_mul = false;
+    cut = false;
+  }
+
+(* THE RULE UNDER TEST is exactly two of these five: [p_absorb_all] is the rule
+   with nothing cut, [p_cut_mul] is the rule with the NoContraction cut applied.
+   The other three are its neighbours, present so that a shape which fails the
+   rule is not merely reported as "no match" but placed. *)
+let all_policies = [p_strict; p_fuse_mul; p_absorb_all; p_cut_mul; p_drop_inner]
+
+let rule_plain = p_absorb_all
+
+let rule_precise = p_cut_mul
+
+(* ------------------------------------------------------------------------ *)
+(* THE CORRECTED RULE — absorption is LOCAL, not whole-tree.                 *)
+(*                                                                           *)
+(* The five policies above are slice 1's. Shapes A11, A12 and B4 refute the   *)
+(* whole-tree reading of §12.4's rule, and the ISA says exactly why: the      *)
+(* absorbing instruction is v_fma_mixlo_f16, which takes ONE multiply-add and *)
+(* ONE conversion. It cannot reach past an operation that is not one of those *)
+(* — a v_floor_f32 (A11) or a v_cndmask_b32 (A12) between the multiply and    *)
+(* the narrowing leaves the multiply materialised as its own v_fma_mix_f32,   *)
+(* and the result is S_strict.                                               *)
+(*                                                                           *)
+(* B4 refutes it harder: with two intermediate narrowings elided, ACO emits a *)
+(* v_fma_mix_f32 contracting x*1.1+1000 into ONE binary32 rounding and only   *)
+(* THEN absorbs the final multiply into the narrowing. That is two separate   *)
+(* single-rounding events at two different precisions, which no whole-tree    *)
+(* model can be.                                                             *)
+(*                                                                           *)
+(* So the corrected rule is stated as a LOCAL peephole and evaluated below:   *)
+(*                                                                           *)
+(*   Each f32->f16 narrowing absorbs the single f32 operation immediately     *)
+(*   feeding it — a multiply, an add/sub, or an explicit fma — evaluating it  *)
+(*   exactly from its operands and rounding once. An intermediate binary16    *)
+(*   narrowing whose value is consumed only by f32 arithmetic is elided.      *)
+(*   Independently, a multiply feeding an addition is contracted into a       *)
+(*   single-rounded binary32 fma. EVERY OTHER f32 OPERATION KEEPS ITS OWN     *)
+(*   CORRECTLY-ROUNDED BINARY32 RESULT. NoContraction removes the second      *)
+(*   clause only; it does not reach the narrowing's own absorption, nor a     *)
+(*   plain multiply, nor an explicit fma.                                     *)
+(* ------------------------------------------------------------------------ *)
+
+(* The rule is ONE semantics with three boolean knobs, not one rule per driver
+   and certainly not one per shape. Each (driver, decoration) pair picks a
+   setting; the settings measured on this workstation are [aco_vulkan_plain],
+   [aco_vulkan_precise] and [aco_opencl] below.
+
+   The knobs exist because rusticl and RADV — the SAME ACO backend behind two
+   different front ends — measured differently, which slice 1 could not see
+   with two shapes: on B1 rusticl keeps the intermediate narrowing where RADV
+   elides it, and on A12 rusticl sinks the conversion into the arms of a select
+   where RADV does not. Both facts are invisible unless the catalogue is swept. *)
+type lrule = {
+  lname : string;
+  contract : bool;  (** a multiply feeding an add becomes one f32 fma *)
+  elide_inner : bool;  (** intermediate binary16 narrowings are dropped *)
+  sink_select : bool;  (** a narrowing sinks into the arms of a select *)
+}
+
+let aco_vulkan_plain =
+  {
+    lname = "R_local_absorb";
+    contract = true;
+    elide_inner = true;
+    sink_select = false;
+  }
+
+let aco_vulkan_precise =
+  {
+    lname = "R_local_absorb_nocontract";
+    contract = false;
+    elide_inner = true;
+    sink_select = false;
+  }
+
+let aco_opencl =
+  {
+    lname = "R_local_absorb_opencl";
+    contract = false;
+    elide_inner = false;
+    sink_select = true;
+  }
+
+let local_rules = [aco_vulkan_plain; aco_vulkan_precise; aco_opencl]
+
+(* An ELIDED intermediate narrowing is not there as far as the peephole is
+   concerned, so "is this absorbable?" and "is this a multiply feeding an add?"
+   must look through one — but only when the rule elides it. *)
+let rec strip_nar r e =
+  match e with Nar s when r.elide_inner -> strip_nar r s | e -> e
+
+let absorbable r e =
+  match strip_nar r e with
+  | Mul _ | Add _ | Sub _ | Fma _ -> true
+  | Sel _ -> r.sink_select
+  | X | K _ | Div _ | Sqrt _ | Floor _ | Nar _ -> false
+
+let is_mul r e = match strip_nar r e with Mul _ -> true | _ -> false
+
+(* [unrounded] means "my consumer performs the rounding": either the narrowing
+   that absorbs me, or the fma my multiply is contracted into. *)
+let rec ev_local r x ~unrounded e =
+  let rd v = if unrounded then v else to_f32 v in
+  let sub s = ev_local r x ~unrounded:false s in
+  let addend s =
+    (* the operand of an addition: a multiply is contracted into the fma unless
+       NoContraction is in force *)
+    if r.contract && is_mul r s then ev_local r x ~unrounded:true s else sub s
+  in
+  match e with
+  | X -> single x
+  | K (v, _) -> single v
+  | Nar s ->
+      if r.elide_inner then ev_local r x ~unrounded s
+      else
+        (* the narrowing is performed, and absorbs the one op feeding it *)
+        single (to_f16_value (ev_local r x ~unrounded:(absorbable r s) s))
+  | Add (a, b) -> rd (ex_add (addend a) (addend b))
+  | Sub (a, b) -> rd (ex_sub (addend a) (addend b))
+  | Mul (a, b) -> rd (ex_mul (sub a) (sub b))
+  | Div (a, b) -> rd (ex_div (sub a) (sub b))
+  | Fma (a, b, c) -> rd (ex_add (ex_mul (sub a) (sub b)) (sub c))
+  | Sqrt a -> rd (ex_sqrt (sub a))
+  | Floor a -> rd (ex_floor (sub a))
+  | Sel (a, b) ->
+      let arm = if x > 0.0 then a else b in
+      if unrounded && r.sink_select then
+        (* the conversion is sunk into this arm and absorbs the arm's own top
+           operation; that is one narrowing per arm, not one for the select *)
+        ev_local r x ~unrounded:(absorbable r arm) arm
+      else sub arm
+
+let local_result r expr x_bits =
+  let x = M.dec x_bits in
+  match expr with
+  | Nar s -> to_f16_bits (ev_local r x ~unrounded:(absorbable r s) s)
+  | e -> to_f16_bits (ev_local r x ~unrounded:false e)
+
+(* [local_model] is completed after the ceiling helpers below, because §1.3's
+   ceiling needs the value the rule presents at the elided narrowing and that
+   needs [deepest_nar_in]. *)
+
+(* ========================================================================= *)
+(* 4. The evaluator                                                          *)
+(* ========================================================================= *)
+
+let rec strip_elided pol e =
+  match e with Nar s when not pol.inner_nar -> strip_elided pol s | e -> e
+
+let is_mul_or_fma = function Mul _ | Fma _ -> true | _ -> false
+
+(* [unrounded] suppresses the f32 rounding of the TOP operation only: it is how
+   [fuse_mul] expresses "absorbed into the narrowing that consumes it". *)
+let rec ev pol x ~unrounded e =
+  let r32 v = if pol.exact || unrounded then v else to_f32 v in
+  let sub s = ev pol x ~unrounded:false s in
+  (* Under the NoContraction cut, an operand of an addition that is (through
+     any elided narrowing) a multiply or an fma materialises its binary32
+     value. This is the single place the rule's "cut" lives. *)
+  let cut_operand s =
+    let v = sub s in
+    if pol.exact && pol.cut && is_mul_or_fma (strip_elided pol s) then to_f32 v
+    else v
+  in
+  match e with
+  | X -> single x
+  | K (v, _) -> single v
+  | Nar s ->
+      if not pol.inner_nar then sub s
+      else
+        let inner_unrounded = pol.fuse_mul && is_mul_or_fma s in
+        single (to_f16_value (ev pol x ~unrounded:inner_unrounded s))
+  | Add (a, b) -> r32 (ex_add (cut_operand a) (cut_operand b))
+  | Sub (a, b) -> r32 (ex_sub (cut_operand a) (cut_operand b))
+  | Mul (a, b) -> r32 (ex_mul (sub a) (sub b))
+  | Div (a, b) -> r32 (ex_div (sub a) (sub b))
+  | Fma (a, b, c) ->
+      (* An EXPLICIT fma is not a contraction: the author wrote the fused
+         operation, so there is no multiply-add for NoContraction to forbid and
+         the cut does not apply. That reading is the rule's own words ("cut
+         wherever NoContraction forbids a multiply-add CONTRACTION"), and it is
+         not a matter of taste — shape A8 separates it from the eager reading
+         that also cuts explicit fmas, and RADV measured on the literal side.
+         See docs/measurements/f16-shapes-2026-07-27/vulkan-radv-eager-cut.txt,
+         where A8 `precise` reports S_absorb_all rather than the cut model. *)
+      r32 (ex_add (ex_mul (sub a) (sub b)) (sub c))
+  | Sqrt a -> r32 (ex_sqrt (sub a))
+  | Floor a -> r32 (ex_floor (sub a))
+  | Sel (a, b) -> if x > 0.0 then sub a else sub b
+
+(* The kernel's result, as a binary16 bit pattern. The outermost narrowing
+   always rounds — it is the one that writes memory. *)
+let result pol expr x_bits =
+  let x = M.dec x_bits in
+  match expr with
+  | Nar s ->
+      let unrounded = pol.fuse_mul && is_mul_or_fma s in
+      to_f16_bits (ev pol x ~unrounded s)
+  | e -> to_f16_bits (ev pol x ~unrounded:false e)
+
+(* §1.3's ceiling is evaluated AT THE NARROWING WHERE THE ROUNDING WAS ELIDED,
+   and its derivation is "the elision of exactly ONE round-to-nearest step".
+   That phrasing has a consequence nobody needed before: a shape with TWO
+   intermediate narrowings has two candidate evaluation points, and at the
+   OUTER of them the absorbing policies have elided two roundings, not one, so
+   the derivation does not cover it and the measured figure is unbounded.
+   Shape B4 is that shape and it is the first in the project.
+   So the ceiling is evaluated at the INNERMOST intermediate narrowing, where
+   exactly one elision separates the policies, and [inner_narrowing_count]
+   below is reported so a >1 row is read as partial rather than as a clean
+   pass. *)
+let rec deepest_nar_in e =
+  match e with
+  | Nar s -> ( match deepest_nar_in s with Some d -> Some d | None -> Some e)
+  | Add (a, b) | Sub (a, b) | Mul (a, b) | Div (a, b) | Sel (a, b) -> (
+      match deepest_nar_in a with None -> deepest_nar_in b | s -> s)
+  | Fma (a, b, c) -> (
+      match deepest_nar_in a with
+      | None -> (
+          match deepest_nar_in b with None -> deepest_nar_in c | s -> s)
+      | s -> s)
+  | Sqrt a | Floor a -> deepest_nar_in a
+  | X | K _ -> None
+
+let rec count_nar e =
+  match e with
+  | Nar s -> 1 + count_nar s
+  | Add (a, b) | Sub (a, b) | Mul (a, b) | Div (a, b) | Sel (a, b) ->
+      count_nar a + count_nar b
+  | Fma (a, b, c) -> count_nar a + count_nar b + count_nar c
+  | Sqrt a | Floor a -> count_nar a
+  | X | K _ -> 0
+
+(* Intermediate narrowings only: the final one is not "elided" by anything. *)
+let inner_narrowing_count expr =
+  match expr with Nar s -> count_nar s | e -> count_nar e
+
+let at_inner_narrowing pol expr =
+  match match expr with Nar s -> deepest_nar_in s | _ -> None with
+  | None -> None
+  | Some (Nar s) ->
+      Some
+        (fun b ->
+          let x = M.dec b in
+          if pol.inner_nar then
+            let inner_unrounded = pol.fuse_mul && is_mul_or_fma s in
+            to_f16_value (ev pol x ~unrounded:inner_unrounded s)
+          else
+            (* the narrowing is elided: what reaches the rest of the expression
+               is the unrounded f32-tree value at that position *)
+            let v = ev pol x ~unrounded:false s in
+            let v =
+              if pol.exact && pol.cut && is_mul_or_fma s then to_f32 v else v
+            in
+            round_ex ~prec:53 ~emin_sub:(-1074) v)
+  | Some _ -> None
+
+(* The value the corrected local rule presents where S_strict materialises its
+   innermost intermediate binary16 value. The rule elides that narrowing, so
+   what reaches the rest of the expression is the subtree's value UNROUNDED —
+   which is precisely the claim "this rounding was elided", and therefore the
+   right thing for §1.3's ceiling to measure against. *)
+let local_at_inner r expr =
+  match match expr with Nar s -> deepest_nar_in s | _ -> None with
+  | Some (Nar s) ->
+      Some
+        (fun b ->
+          round_ex
+            ~prec:53
+            ~emin_sub:(-1074)
+            (ev_local r (M.dec b) ~unrounded:true s))
+  | _ -> None
+
+let local_model r expr =
+  {
+    M.name = r.lname;
+    M.descr =
+      Printf.sprintf
+        "the corrected LOCAL rule (contract=%b, elide_inner=%b, \
+         sink_select=%b): each narrowing absorbs the one operation feeding it; \
+         every other f32 op keeps its own binary32 result"
+        r.contract
+        r.elide_inner
+        r.sink_select;
+    M.result = local_result r expr;
+    M.at_inner_narrowing =
+      (match local_at_inner r expr with
+      | Some f -> Some f
+      | None -> Some (fun b -> M.dec (local_result r expr b)));
+  }
+
+(* ========================================================================= *)
+(* 5. The 20 shapes                                                          *)
+(* ========================================================================= *)
+
+type shape = {
+  id : string;
+  descr : string;
+  expr : e;
+  discriminating_note : string;
+      (** stated up front where something OTHER than the absorption rule governs
+          the shape, so a mismatch is not silently read as evidence against the
+          rule *)
+}
+
+let shapes =
+  [
+    {id = "A1"; descr = "narrow x"; expr = Nar X; discriminating_note = ""};
+    {
+      id = "A2";
+      descr = "narrow (x *. 1.1)";
+      expr = Nar (Mul (X, k11));
+      discriminating_note = "";
+    };
+    {
+      id = "A3";
+      descr = "narrow (x +. 1000.)";
+      expr = Nar (Add (X, k1000));
+      discriminating_note = "";
+    };
+    {
+      id = "A4";
+      descr = "narrow (x -. 1000.)";
+      expr = Nar (Sub (X, k1000));
+      discriminating_note = "";
+    };
+    {
+      id = "A5";
+      descr = "narrow (x /. 3.)";
+      expr = Nar (Div (X, k3));
+      discriminating_note =
+        "DIVISION: Vulkan/SPIR-V allow OpFDiv 2.5 ULP, so a mismatch here is \
+         evidence about fdiv precision and NOT about the absorption rule";
+    };
+    {
+      id = "A6";
+      descr = "narrow (x *. 1.1 +. 1000.)";
+      expr = Nar (Add (Mul (X, k11), k1000));
+      discriminating_note = "";
+    };
+    {
+      id = "A7";
+      descr = "narrow ((x +. 1000.) *. 1.1)";
+      expr = Nar (Mul (Add (X, k1000), k11));
+      discriminating_note = "";
+    };
+    {
+      id = "A8";
+      descr = "narrow (fma x 1.1 1000.)";
+      expr = Nar (Fma (X, k11, k1000));
+      discriminating_note = "";
+    };
+    {
+      id = "A9";
+      descr = "narrow (sqrt (x *. x))";
+      expr = Nar (Sqrt (Mul (X, X)));
+      discriminating_note =
+        "SQRT: exact here only because sqrt(x*x) = |x| for a binary16 x; the \
+         device's sqrt precision is separately specified";
+    };
+    {
+      id = "A10";
+      descr = "narrow (0. -. x)";
+      expr = Nar (Sub (k0, X));
+      discriminating_note = "";
+    };
+    {
+      id = "A11";
+      descr = "narrow (floor (x *. 1.1))";
+      expr = Nar (Floor (Mul (X, k11)));
+      discriminating_note = "";
+    };
+    {
+      id = "A12";
+      descr = "narrow (if x>0. then x*.1.1 else x*.0.9)";
+      expr = Nar (Sel (Mul (X, k11), Mul (X, k09)));
+      discriminating_note = "";
+    };
+    {
+      id = "A13";
+      descr = "narrow (x *. x)";
+      expr = Nar (Mul (X, X));
+      discriminating_note = "";
+    };
+    {
+      id = "A14";
+      descr = "narrow (x *. 1.1 *. 1.1)";
+      expr = Nar (Mul (Mul (X, k11), k11));
+      discriminating_note = "";
+    };
+    {
+      id = "A15";
+      descr = "narrow (x *. 1.1 +. x /. 3.)";
+      expr = Nar (Add (Mul (X, k11), Div (X, k3)));
+      discriminating_note =
+        "DIVISION: as A5 — an fdiv mismatch is not evidence about absorption";
+    };
+    {
+      id = "B1";
+      descr = "narrow (narrow (x *. 1.1) +. 1000.)";
+      expr = Nar (Add (Nar (Mul (X, k11)), k1000));
+      discriminating_note = "";
+    };
+    {
+      id = "B2";
+      descr = "narrow (narrow (x *. 1.1) *. 1.1)";
+      expr = Nar (Mul (Nar (Mul (X, k11)), k11));
+      discriminating_note = "";
+    };
+    {
+      id = "B3";
+      descr = "narrow (narrow (x +. 1000.) *. 1.1)";
+      expr = Nar (Mul (Nar (Add (X, k1000)), k11));
+      discriminating_note = "";
+    };
+    {
+      id = "B4";
+      descr = "narrow (narrow (narrow (x *. 1.1) +. 1000.) *. 1.1)";
+      expr = Nar (Mul (Nar (Add (Nar (Mul (X, k11)), k1000)), k11));
+      discriminating_note = "";
+    };
+    {
+      id = "C1";
+      descr = "out.(i) <- inp.(i)   (f16 -> f16 copy, no cast)";
+      expr = X;
+      discriminating_note =
+        "NO NARROWING AT ALL: there is nothing for any policy to elide, so \
+         every model coincides by construction";
+    };
+  ]
+
+let shape_by_id id = List.find (fun s -> s.id = id) shapes
+
+(* ========================================================================= *)
+(* 6. Source emission — the SAME tree the models are evaluated from          *)
+(* ========================================================================= *)
+
+type dialect = Glsl | Opencl
+
+(* Three-address form, one temporary per operation, so that the `precise`
+   variant differs from the plain one by exactly one keyword per declaration —
+   which is what Sarek_ir_glsl.gen_var_decl emits on every float local. *)
+type emitter = {
+  buf : Buffer.t;
+  mutable n : int;
+  dialect : dialect;
+  qual : string;  (** "precise " or "" *)
+  barrier : bool;  (** round-trip every temporary through the volatile store *)
+}
+
+let fresh em =
+  em.n <- em.n + 1 ;
+  Printf.sprintf "t%d" em.n
+
+let line em s = Buffer.add_string em.buf ("  " ^ s ^ "\n")
+
+(* The volatile round-trip. On GLSL it is the SSBO the shader writes; on OpenCL
+   it is a volatile __local slot. Both are the constructions slice 1 measured
+   to restore the discipline on their respective stacks. *)
+let bar_f32 em v =
+  if not em.barrier then v
+  else
+    let t = fresh em in
+    (match em.dialect with
+    | Glsl ->
+        line em (Printf.sprintf "outb[i] = floatBitsToUint(%s);" v) ;
+        line em (Printf.sprintf "float %s = uintBitsToFloat(outb[i]);" t)
+    | Opencl ->
+        line em (Printf.sprintf "s[l] = %s;" v) ;
+        line em (Printf.sprintf "float %s = s[l];" t)) ;
+    t
+
+let decl_f32 em rhs =
+  let t = fresh em in
+  line em (Printf.sprintf "%sfloat %s = %s;" em.qual t rhs) ;
+  bar_f32 em t
+
+let rec emit em e =
+  match e with
+  | X -> "x"
+  | K (_, lit) -> ( match em.dialect with Glsl -> lit | Opencl -> lit ^ "f")
+  | Add (a, b) -> decl_f32 em (Printf.sprintf "%s + %s" (emit em a) (emit em b))
+  | Sub (a, b) -> decl_f32 em (Printf.sprintf "%s - %s" (emit em a) (emit em b))
+  | Mul (a, b) -> decl_f32 em (Printf.sprintf "%s * %s" (emit em a) (emit em b))
+  | Div (a, b) -> decl_f32 em (Printf.sprintf "%s / %s" (emit em a) (emit em b))
+  | Fma (a, b, c) ->
+      let a = emit em a and b = emit em b and c = emit em c in
+      decl_f32 em (Printf.sprintf "fma(%s, %s, %s)" a b c)
+  | Sqrt a -> decl_f32 em (Printf.sprintf "sqrt(%s)" (emit em a))
+  | Floor a -> decl_f32 em (Printf.sprintf "floor(%s)" (emit em a))
+  | Sel (a, b) ->
+      let a = emit em a and b = emit em b in
+      decl_f32
+        em
+        (Printf.sprintf
+           "(x > 0.0%s) ? %s : %s"
+           (match em.dialect with Glsl -> "" | Opencl -> "f")
+           a
+           b)
+  | Nar a ->
+      let v = emit em a in
+      let h = fresh em and t = fresh em in
+      (match (em.dialect, em.barrier) with
+      | Glsl, false ->
+          line em (Printf.sprintf "float16_t %s = float16_t(%s);" h v) ;
+          line em (Printf.sprintf "%sfloat %s = float(%s);" em.qual t h)
+      | Glsl, true ->
+          line em (Printf.sprintf "outb[i] = pack(float16_t(%s));" v) ;
+          line
+            em
+            (Printf.sprintf "float16_t %s = unpackFloat2x16(outb[i]).x;" h) ;
+          line em (Printf.sprintf "float %s = float(%s);" t h)
+      | Opencl, false ->
+          line em (Printf.sprintf "half %s = (half)(%s);" h v) ;
+          line em (Printf.sprintf "%sfloat %s = (float)%s;" em.qual t h)
+      | Opencl, true ->
+          line em (Printf.sprintf "out[i] = as_ushort((half)(%s));" v) ;
+          line em (Printf.sprintf "half %s = as_half(out[i]);" h) ;
+          line em (Printf.sprintf "float %s = (float)%s;" t h)) ;
+      t
+
+let n_local = 256
+
+let source ~dialect ~precise ~barrier shape =
+  let em =
+    {
+      buf = Buffer.create 512;
+      n = 0;
+      dialect;
+      qual = (if precise then "precise " else "");
+      barrier;
+    }
+  in
+  (* C1 has no cast: the f16 bit pattern is copied straight through. *)
+  let body =
+    match shape.expr with
+    | X ->
+        (match dialect with
+        | Glsl -> line em "outb[i] = inb[i] & 0xFFFFu;"
+        | Opencl -> line em "out[i] = in[i];") ;
+        Buffer.contents em.buf
+    | Nar s ->
+        let v = emit em s in
+        (match dialect with
+        | Glsl -> line em (Printf.sprintf "outb[i] = pack(float16_t(%s));" v)
+        | Opencl -> line em (Printf.sprintf "out[i] = as_ushort((half)(%s));" v)) ;
+        Buffer.contents em.buf
+    | _ -> assert false
+  in
+  match dialect with
+  | Glsl ->
+      Printf.sprintf
+        {|#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+layout(local_size_x = %d) in;
+layout(std430, binding = 0) volatile buffer Out { uint outb[]; };
+layout(std430, binding = 1) readonly buffer In { uint inb[]; };
+uint pack(float16_t r) {
+  return packFloat2x16(f16vec2(r, float16_t(0.0))) & 0xFFFFu;
+}
+void main() {
+  uint i = gl_GlobalInvocationID.x;
+  float x = float(unpackFloat2x16(inb[i]).x);
+%s}
+|}
+        n_local
+        body
+  | Opencl ->
+      Printf.sprintf
+        {|#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+/* named `midround` so slice 1's probe can compile it through its existing
+   run_kernel, which looks that entry point up by name.
+
+   `out` is VOLATILE, mirroring the GLSL side where the SSBO is declared
+   volatile. Without it the barrier variant is not a barrier: the f16 round
+   trip goes through `out[i]`, and a non-volatile store is forwardable, so the
+   compiler removes exactly the narrowing the control exists to preserve. That
+   was measured, not feared — shape B2's green control reported
+   S_drop_intermediate_narrowing until this qualifier was added. */
+__kernel void midround(
+    __global volatile ushort *out, __global const ushort *in, int n) {
+  __local volatile float s[%d];
+  int i = get_global_id(0);
+  int l = get_local_id(0);
+  (void)s; (void)l;
+  if (i < n) {
+    float x = (float)as_half(in[i]);
+%s  }
+}
+|}
+        n_local
+        body
+
+(* ========================================================================= *)
+(* 7. Model instantiation and reporting, reusing F16_model_set's classifier   *)
+(* ========================================================================= *)
+
+(* A policy applied to a shape becomes an [F16_model_set.model], so the whole
+   of slice 1's element-wise classifier, separation matrix and §1.3 ceiling
+   machinery is reused unchanged rather than reimplemented. *)
+let model_of_policy shape pol =
+  {
+    M.name = pol.pname;
+    M.descr = pol.pdescr;
+    M.result = result pol shape.expr;
+    M.at_inner_narrowing =
+      (match at_inner_narrowing pol shape.expr with
+      | Some f -> Some f
+      | None -> Some (fun b -> M.dec (result pol shape.expr b)));
+  }
+
+(* Duplicate names are impossible (the five policies have five names), but two
+   policies CAN coincide as functions on a given shape — on A2 the three
+   absorbing policies are the same function, because there is no addition for
+   the cut to bite on and no intermediate narrowing to drop. That is reported,
+   not hidden: [F16_model_set.separation_matrix] prints it and a shape where
+   ALL FIVE coincide measures nothing at all. *)
+let models_of shape = List.map (model_of_policy shape) all_policies
+
+(* The full set actually swept: slice 1's five, plus the two the corrected
+   local rule generates. The corrected pair is NOT a per-shape addition — it is
+   ONE semantics evaluated on whatever tree it is given, which is the whole
+   question backlog-151 was asked. On A2 and B1 it collapses onto slice 1's
+   members and [check_local_rule_matches_slice1] pins that. *)
+let models_with_local shape =
+  models_of shape
+  @ [
+      local_model aco_vulkan_plain shape.expr;
+      local_model aco_vulkan_precise shape.expr;
+      local_model aco_opencl shape.expr;
+    ]
+
+(* The number of DISTINCT functions the five policies induce on a shape. 1 means
+   the shape cannot discriminate between any of them and a device agreeing with
+   S_strict there is not evidence for anything. *)
+let distinct_model_count shape =
+  let ms = models_of shape in
+  let sig_of m = Array.map m.M.result M.finite_bits in
+  let seen = ref [] in
+  List.iter
+    (fun m ->
+      let s = sig_of m in
+      if not (List.exists (fun t -> t = s) !seen) then seen := s :: !seen)
+    ms ;
+  List.length !seen
+
+(* ========================================================================= *)
+(* 8. CALIBRATION — the generator is pinned to slice 1's hand-written models *)
+(* ========================================================================= *)
+
+exception Calibration_failed of string
+
+let failf fmt = Printf.ksprintf (fun s -> raise (Calibration_failed s)) fmt
+
+let agree_on_all name f g =
+  let bad = ref (-1) in
+  Array.iter (fun b -> if !bad < 0 && f b <> g b then bad := b) M.finite_bits ;
+  if !bad >= 0 then
+    failf
+      "GENERATOR MISMATCH: %s disagrees with slice 1's hand-written model at x \
+       = %.9g (0x%04X): generator 0x%04X, slice 1 0x%04X"
+      name
+      (M.dec !bad)
+      !bad
+      (f !bad)
+      (g !bad)
+
+(* THE HINGE. The five generic policies must reproduce F16_model_set's
+   hand-written closed forms, bit-for-bit on all 63488 inputs, on the two shapes
+   slice 1 measured on a device. If they do not, nothing this module says about
+   the other 18 shapes is worth reading, because the generator is then not the
+   thing slice 1 measured. *)
+let check_generator_matches_slice1 () =
+  let a2 = (shape_by_id "A2").expr and b1 = (shape_by_id "B1").expr in
+  let m name ms = List.find (fun m -> m.M.name = name) ms in
+  let s1 = M.shape1_models and s2 = M.shape2_models in
+  agree_on_all "A2 / S_strict" (result p_strict a2) (m "S_strict" s1).M.result ;
+  agree_on_all
+    "A2 / S_fuse_mul_into_narrowing"
+    (result p_fuse_mul a2)
+    (m "S_fuse_mul_into_narrowing" s1).M.result ;
+  agree_on_all "B1 / S_strict" (result p_strict b1) (m "S_strict" s2).M.result ;
+  agree_on_all
+    "B1 / S_fuse_mul_into_narrowing"
+    (result p_fuse_mul b1)
+    (m "S_fuse_mul_into_narrowing" s2).M.result ;
+  agree_on_all
+    "B1 / S_absorb_all_into_final_narrowing"
+    (result p_absorb_all b1)
+    (m "S_absorb_all_into_final_narrowing" s2).M.result ;
+  agree_on_all
+    "B1 / S_f32_mul_then_absorb_add"
+    (result p_cut_mul b1)
+    (m "S_f32_mul_then_absorb_add" s2).M.result ;
+  agree_on_all
+    "B1 / S_drop_intermediate_narrowing"
+    (result p_drop_inner b1)
+    (m "S_drop_intermediate_narrowing" s2).M.result
+
+(* The four separation counts §12.2 records, recomputed from the GENERIC
+   evaluator rather than from the closed forms. Reproducing a known positive is
+   what licenses believing the 18 new columns. *)
+let check_recorded_separations () =
+  let count f g =
+    let n = ref 0 in
+    Array.iter (fun b -> if f b <> g b then incr n) M.finite_bits ;
+    !n
+  in
+  let a2 = (shape_by_id "A2").expr and b1 = (shape_by_id "B1").expr in
+  let expect what got want =
+    if got <> want then
+      failf "CALIBRATION FAILED: %s separates on %d, must be %d" what got want
+  in
+  expect
+    "A2 S_strict vs S_fuse_mul_into_narrowing"
+    (count (result p_strict a2) (result p_fuse_mul a2))
+    2912 ;
+  expect
+    "B1 S_strict vs S_fuse_mul_into_narrowing"
+    (count (result p_strict b1) (result p_fuse_mul b1))
+    620 ;
+  expect
+    "B1 S_strict vs S_absorb_all_into_final_narrowing"
+    (count (result p_strict b1) (result p_absorb_all b1))
+    5075 ;
+  expect
+    "B1 S_strict vs S_f32_mul_then_absorb_add"
+    (count (result p_strict b1) (result p_cut_mul b1))
+    4776 ;
+  expect
+    "B1 S_strict vs S_drop_intermediate_narrowing"
+    (count (result p_strict b1) (result p_drop_inner b1))
+    4774
+
+(* Every shape's every policy must be computable exactly. A shape whose model
+   raises Not_exactly_computable would otherwise be silently absent from the
+   sweep. *)
+let check_all_shapes_computable () =
+  List.iter
+    (fun sh ->
+      List.iter
+        (fun pol ->
+          try ignore (result pol sh.expr M.finite_bits.(31000))
+          with Not_exactly_computable m ->
+            failf "%s / %s is not exactly computable: %s" sh.id pol.pname m)
+        all_policies)
+    shapes
+
+(* The corrected local rule must ALSO reduce to slice 1's named members on the
+   two shapes slice 1 measured — otherwise it is a new semantics dressed up as
+   a correction, and its agreement on the other 18 would say nothing about the
+   contract slice 1 admitted. *)
+let check_local_rule_matches_slice1 () =
+  let a2 = (shape_by_id "A2").expr and b1 = (shape_by_id "B1").expr in
+  let m name ms = (List.find (fun m -> m.M.name = name) ms).M.result in
+  let s1 = M.shape1_models and s2 = M.shape2_models in
+  agree_on_all
+    "A2 / aco_vulkan_plain == S_fuse_mul_into_narrowing"
+    (local_result aco_vulkan_plain a2)
+    (m "S_fuse_mul_into_narrowing" s1) ;
+  agree_on_all
+    "A2 / aco_vulkan_precise == S_fuse_mul_into_narrowing"
+    (local_result aco_vulkan_precise a2)
+    (m "S_fuse_mul_into_narrowing" s1) ;
+  agree_on_all
+    "A2 / aco_opencl == S_fuse_mul_into_narrowing"
+    (local_result aco_opencl a2)
+    (m "S_fuse_mul_into_narrowing" s1) ;
+  agree_on_all
+    "B1 / aco_vulkan_plain == S_absorb_all_into_final_narrowing"
+    (local_result aco_vulkan_plain b1)
+    (m "S_absorb_all_into_final_narrowing" s2) ;
+  agree_on_all
+    "B1 / aco_vulkan_precise == S_f32_mul_then_absorb_add"
+    (local_result aco_vulkan_precise b1)
+    (m "S_f32_mul_then_absorb_add" s2) ;
+  agree_on_all
+    "B1 / aco_opencl == S_fuse_mul_into_narrowing"
+    (local_result aco_opencl b1)
+    (m "S_fuse_mul_into_narrowing" s2)
+
+let calibrate () =
+  M.calibrate () ;
+  check_all_shapes_computable () ;
+  check_generator_matches_slice1 () ;
+  check_recorded_separations () ;
+  check_local_rule_matches_slice1 ()

--- a/tools/f16_shape_catalogue/probe/dune
+++ b/tools/f16_shape_catalogue/probe/dune
@@ -1,0 +1,10 @@
+; backlog-151 — host-only separation analysis for the 20-shape catalogue.
+;
+; An `executable`, not a `test`, for the same reason the slice-1 probes are:
+; it measures whether a contract is deliverable, it does not defend an
+; invariant. The gates defending the f16 refusals are untouched.
+
+(executable
+ (name probe_f16_shape_separation)
+ (modules probe_f16_shape_separation)
+ (libraries f16_model_set f16_shape_catalogue))

--- a/tools/f16_shape_catalogue/probe/probe_f16_shape_separation.ml
+++ b/tools/f16_shape_catalogue/probe/probe_f16_shape_separation.ml
@@ -1,0 +1,99 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-151 — host-only: which of the 20 shapes can discriminate at all.
+ *
+ * WHY THIS RUNS BEFORE ANY DEVICE IS TOUCHED.
+ *
+ * A shape on which all five policies of F16_shape_catalogue are the SAME
+ * FUNCTION over the whole finite binary16 domain cannot produce evidence for or
+ * against the generative rule. A device sweep of such a shape returns "matches
+ * S_strict, 0/63488" and that sentence measures nothing — it is the
+ * coincident-model trap docs/fp-contraction-policy.md §12.2 already guards
+ * against on two shapes, and it is much more dangerous across twenty, because a
+ * table of twenty zeros reads like a strong result.
+ *
+ * So this executable prints, per shape, how many DISTINCT functions the five
+ * policies induce, and the full pairwise separation. A shape with one distinct
+ * function is marked NON-DISCRIMINATING and its device result must be read as
+ * "no information", not as "the rule holds here".
+ *
+ * It also runs the calibration that pins the generic evaluator to slice 1's
+ * hand-written closed forms. Nothing below the calibration line is readable if
+ * the calibration fails, and it exits non-zero in that case.
+ *
+ * Run:
+ *   dune exec tools/f16_shape_catalogue/probe/probe_f16_shape_separation.exe
+ ******************************************************************************)
+
+module M = F16_model_set
+module C = F16_shape_catalogue
+
+let () =
+  Printf.printf
+    "backlog-151 — the 20-shape f16 catalogue, host-only separation analysis\n\n" ;
+  (try C.calibrate () with
+  | C.Calibration_failed s ->
+      Printf.printf "CALIBRATION FAILED — read nothing below it:\n  %s\n" s ;
+      exit 1
+  | M.Calibration_failed s ->
+      Printf.printf
+        "CALIBRATION FAILED (slice 1's own) — read nothing below it:\n  %s\n"
+        s ;
+      exit 1) ;
+  Printf.printf
+    "CALIBRATION PASSED.\n\
+    \  - slice 1's four host checks (63488 round-trip, 620, 2912, x = -907.5);\n\
+    \  - all 20 shapes x 5 policies are exactly computable;\n\
+    \  - the GENERIC evaluator reproduces slice 1's seven hand-written closed\n\
+    \    forms bit-for-bit on A2 and B1, all 63488 inputs;\n\
+    \  - and reproduces the recorded separations 2912 / 620 / 5075 / 4776 /\n\
+    \    4774 from the generic evaluator rather than from those closed forms.\n\n" ;
+
+  Printf.printf
+    "SHAPE DISCRIMINATION — how many DISTINCT functions the five policies\n\
+     induce on each shape over all 63488 finite binary16 inputs.\n\n" ;
+  Printf.printf "  %-4s %-46s %s\n" "id" "shape" "distinct models" ;
+  List.iter
+    (fun sh ->
+      let d = C.distinct_model_count sh in
+      Printf.printf
+        "  %-4s %-46s %d%s\n"
+        sh.C.id
+        sh.C.descr
+        d
+        (if d = 1 then
+           "   <== NON-DISCRIMINATING: a device sweep of this shape measures \
+            nothing"
+         else ""))
+    C.shapes ;
+
+  Printf.printf "\n\nPER-SHAPE PAIRWISE SEPARATION\n" ;
+  List.iter
+    (fun sh ->
+      Printf.printf "\n--- %s : %s ---\n" sh.C.id sh.C.descr ;
+      if sh.C.discriminating_note <> "" then
+        Printf.printf "  NOTE: %s\n" sh.C.discriminating_note ;
+      ignore (M.separation_matrix (C.models_of sh)))
+    C.shapes ;
+
+  Printf.printf "\n\nGENERATED SOURCE — GLSL, plain, one per shape\n" ;
+  List.iter
+    (fun sh ->
+      Printf.printf
+        "\n--- %s ---\n%s"
+        sh.C.id
+        (C.source ~dialect:C.Glsl ~precise:false ~barrier:false sh))
+    C.shapes ;
+
+  Printf.printf "\n\nGENERATED SOURCE — OpenCL C, plain, one per shape\n" ;
+  List.iter
+    (fun sh ->
+      Printf.printf
+        "\n--- %s ---\n%s"
+        sh.C.id
+        (C.source ~dialect:C.Opencl ~precise:false ~barrier:false sh))
+    C.shapes


### PR DESCRIPTION
## The verdict

**Slice 1's generative rule is false.** `docs/fp-contraction-policy.md` §12.4 closed slice 1 with one candidate rule that produced all five of its results —

> *a narrowing absorbs the whole f32 tree feeding it, cut where `NoContraction` binds*

— marked **unverified as a general rule**, and named the other 18 of the 20 emittable f16 shapes as exactly what would settle it. This PR sweeps all 20, on both ACO stacks and all four local devices, element-wise over all 63488 finite binary16 inputs.

Three shapes break it, and the disassembly says the same thing about all three: the absorbing instruction is `v_fma_mixlo_f16`, which takes **one** multiply-add and **one** conversion. It is a peephole. It cannot reach past anything else.

| counterexample | what the rule predicts | what the device does | ISA |
|---|---|---|---|
| **A11** `f16(floor(x*1.1))` | absorption | **`S_strict`, 0/63488** | `v_fma_mix_f32` · `v_floor_f32` · `v_fma_mixlo_f16 1.0, v1, 0` — the multiply is materialised at f32 and the narrowing absorbs an *identity multiply*. Byte-identical plain vs `precise`. |
| **A12** `f16(x>0 ? x*1.1 : x*0.9)` | absorption | **`S_strict`, 0/63488** | three `v_fma_mix_f32` · `v_cmp_lt_f32` · `v_cndmask_b32` · `v_fma_mixlo_f16 1.0, v1, 0` |
| **B4** `f16(f16(f16(x*1.1)+1000)*1.1)` plain | `S_absorb_all_into_final_narrowing` | **matches NO SINGLE MEMBER of the model set** — 63480/63488 against one member, 63486/63488 against another | `v_fma_mix_f32 0xcccd, v1, s1` · `v_fma_mixlo_f16 0xcccd, v1, 0` — **two** single-rounding events at **two** precisions |

B4 is the strongest form of the failure: §1.2 requires bit-identity to *one* member on *every* input, and no member describes it, while every individual input matches some member. The two readings of §1.2 had never come apart before; the harness now reports them differently (`NO SINGLE MODEL (mixture)` vs `NO MODEL (N unmatched)`).

## The corrected rule, and why the contract stays compact

> *Each f32→f16 narrowing absorbs the single f32 operation immediately feeding it — a multiply, an add/sub, or an explicit fma — rounding it once. Independently, a multiply feeding an addition is contracted into a single-rounded **binary32** fma. An intermediate binary16 narrowing consumed only by f32 arithmetic may be elided. **Every other f32 operation keeps its own correctly-rounded binary32 result.** `NoContraction` removes the contraction clause only.*

**It holds on 12 of 12 discriminating shapes on RADV (plain and `precise`) and 11 of 12 on rusticl**, verified on ten shapes it was not fitted to.

So the answer to the question §12.4 said the 18 shapes existed to settle — *does the model set grow per shape?* — is **no, but only after the correction**. §1.2's set is `{S_strict}` plus **one generator with three measured booleans**, for any shape a user writes. The four members §1.2 lists today are that one rule at three settings on the two shapes slice 1 happened to measure. Under the *old* rule the answer would have been yes and badly: B4 would need its own entry, and that entry would tell you nothing about any other shape.

| instance | contract mul+add | elide intermediate narrowings | sink into a select's arms | measured on |
|---|---|---|---|---|
| `R_local_absorb` | yes | yes | no | RADV, plain |
| `R_local_absorb_nocontract` | no | yes | no | RADV, `precise` — what the shipped codegen runs under |
| `R_local_absorb_opencl` | no | no | **yes** | rusticl |

## Three findings the catalogue forced out

- **Only 12 of the 20 shapes can discriminate at all.** On the other eight every model is the same function, so a device sweep of them measures nothing. A table of twenty zeros would have read as twenty confirmations; the host pass labels them `NON-DISCRIMINATING` and the honest denominator is 12.
- **The two ACO front ends are not the same function.** §12.3 concluded "the two ACO front ends behave identically on both shapes" — true of those two shapes, false in general. rusticl keeps the intermediate narrowing where RADV elides it (B1, B3, B4), does not contract multiply-add unasked (A6, A15), and sinks a narrowing into a select's arms where RADV does not (**2863/63488** against RADV's **0**). The allowlist has to be keyed on the front end too.
- **RADV returns `-0` for `0.0 - x` at `x = +0`**, on one input, **through every barrier**. Under §1.2 that is a *failure*, not a relaxation: it is not a rounding. rusticl is correct on it. It shows up as `1 / 63488` in a count-only sweep and was identifiable only because the harness prints the device bit pattern next to each model's.

§1.3's ceiling also needed an evaluation point named: B4 has two intermediate narrowings, and the two candidate points differ by three orders of magnitude — **719 exceedances reaching 1638 ulp** at the outer, **0.500044 ulp with zero exceedances** at the innermost.

## How the instrument is kept honest

- **The models are generators, not entries.** Each of §1.2's named members is restated as a *policy* applied to an expression tree — five policies, twenty shapes — so the answer to "does the set grow?" is not decided by the instrument.
- **Calibration before anything is read.** The generic evaluator must reproduce §12's **seven hand-written closed forms bit-for-bit on all 63488 inputs** on the two shapes slice 1 measured, and reproduce **2912 / 620 / 5075 / 4776 / 4774** from the generic evaluator rather than from those closed forms. The probes exit non-zero and print nothing else if it fails.
- **One source of truth for each shape.** Device source and host model come from the *same* tree, so they cannot drift apart and have a sweep measure the drift.
- **A reporting control**, run before any device number: a host-computed *non-strict* model is fed through the classifier and the harness must **name that model**. Slice 1's re-absorbed control was caught only because the harness reported the wrong model rather than an implausible count — a count-only sweep over twenty shapes would have missed the same thing twenty times.
- **Green control per shape per variant**: every temporary through the volatile store, which must reproduce `S_strict`. It fires exactly twice, both on A10, which is how that defect was localised as *not* the absorption hazard.
- **Exact arithmetic.** Shewchuk expansions plus a sticky flag for division, because three of the models round to binary16 in one step from a sum spanning 65 bits and binary64 would round first — making the model a different function, differing exactly at the ties where §1.3's counterexample lives.
- **The superseded run is committed.** Shape A8 separates two readings of the rule's cut clause; the eager reading was implemented first and refuted, and `vulkan-radv-eager-cut.txt` is kept so the choice reads as a measurement rather than a preference. A8's plain and `precise` disassembly are byte-identical, confirming it at machine-code tier.

## Executed on

- `AMD Radeon RX 7900 XTX (RADV NAVI31)` and `AMD Ryzen 9 7950X (RADV RAPHAEL_MENDOCINO)` — radv, Mesa 26.1.4-arch3.1, Vulkan 1.4.354. Identical results.
- `AMD Radeon RX 7900 XTX (radeonsi, navi31, ACO, DRM 3.64, 7.1.2-3-cachyos)` and its Raphael iGPU equivalent. Identical results.
- ISA: `RADV_DEBUG=asm`, RX 7900 XTX, **one shader per process** via `--shape <id> --variant <plain|precise>`, for eleven shapes.

Test suite unchanged at the baseline: **1612 alcotest / 106 suites + 32 qcheck / 6 suites, 0 FAIL, 23 SKIP** (log 4700 lines, non-empty). `dune build @fmt` clean.

## Not settled

Any driver but ACO; a `precise` equivalent on OpenCL (rusticl was swept plain only, so its `contract = false` is a default rather than a decoration's effect); constant folding across a narrowing — the one residual, where both stacks fold `1.1*1.1` into binary32 `1.21` (`0x3f9ae148` in the ISA) and rusticl's B4 prediction misses as a result; one constant/addend/divisor per shape; the source spelling, which is three-address form as `Sarek_ir_glsl.gen_var_decl` emits; and Sarek-generated shaders, still slice 3.

**No refusal is lifted.** The 18 shapes are measured, not admitted. Slice 3 is still where that decision is taken — and it now has a rule to gate on rather than four measured points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
