### PR TITLE
feat(vulkan): cooperative-matrix capability query and fragment type (backlog-62 slices 2, 4b)

### DIFF
--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -876,7 +876,7 @@ refusal before slice 3.
 |---|---|---|---|---|---|
 | **0** | the contract, as a testable classifier | the gate can tell `S_fuse_mul_into_narrowing` from a dropped narrowing | none (host-only) | no | open — and now also carries §1.3's per-narrowing ceiling |
 | **1** | element-wise model characterisation of ACO scalar f16 | whether the contract of §1.2 is deliverable at all | RX 7900 XTX + Raphael iGPU (local) | no | **DONE — all 20 shapes measured (2 in slice 1, the other 18 in backlog-151). Deliverable, and §1.2's set is generated rather than enumerated. 18 shapes measured but NOT admitted.** |
-| **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | open |
+| **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | **DONE 2026-07-27** — plus the coopmat capability query and the fragment type of slice 4b |
 | **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist | open |
 | **4** | backlog-62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | open |
 | **5** | backlog-63 Metal — **scalar f16 first** | the Metal row of §2 | ladon (M4) | no | **DONE 2026-07-27 — strict, 0/63488** |
@@ -1044,6 +1044,72 @@ was added: 2912/63488, the same figure and the same model as RADV.
 - `Framework_sig.capabilities` gains `supports_fp16` and a coopmat configuration
   list. This is `capability-model.md`'s slice 2 and it breaks the literal-record
   tests in `spoc/framework/test/`, a cost that document already accepts.
+
+> **OUTCOME, 2026-07-27 — done, and it moved two facts this document asserts.**
+> Executed on both local devices (AMD Radeon RX 7900 XTX / RADV NAVI31 and the
+> AMD Ryzen 9 7950X iGPU / RADV RAPHAEL_MENDOCINO), radv, Mesa 26.1.4-arch3.1,
+> Vulkan 1.4.354. Instruments: `sarek-vulkan/test/test_vulkan_coopmat_capability.ml`
+> (device side) and `spoc/ir/test/test_sarek_coopmat.ml` (host side).
+>
+> Delivered: `VkPhysicalDeviceShaderFloat16Int8Features` and
+> `VkPhysicalDevice16BitStorageFeatures` are queried through the
+> `VkPhysicalDeviceFeatures2` chain and **requested** in
+> `VkDeviceCreateInfo.pNext`, alongside `VK_KHR_cooperative_matrix` where
+> advertised; `VkPhysicalDeviceDriverProperties` and
+> `VkPhysicalDeviceSubgroupProperties` are on `Device.t`;
+> `Framework_sig.capabilities` gains `coopmat : Sarek_coopmat.device_support
+> option`; and `Sarek_coopmat` (in `spoc/ir`, beside `Sarek_capability`) carries
+> the configuration vocabulary and **slice 4b's fragment type**, integer
+> component types included.
+>
+> **Two corrections to this document.**
+>
+> 1. **The subgroup size is 64, not 32.** `VkPhysicalDeviceSubgroupProperties.
+>    subgroupSize` reads **64** on *both* local devices. `Vulkan_plugin_base` had
+>    been reporting a hard-coded 32, which was wrong for both. This is ABI, not
+>    a statistic: a 16×16 fragment over 64 invocations is 4 components each, not
+>    8, so any codegen slice written against 32 would have been wrong at the
+>    calling convention. `warp_size` is now the probed value.
+>
+> 2. **The configuration query answers for devices that do not support the
+>    extension, and §4's negative device is only negative if you check the
+>    extension.** `vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR` returns
+>    `VK_SUCCESS` and **all fourteen configurations for the Raphael iGPU** — the
+>    device this document offers as the free negative device, which does not
+>    advertise `VK_KHR_cooperative_matrix` and whose `cooperativeMatrix` feature
+>    reads false. Calling an extension entry point on a device without the
+>    extension is undefined behaviour, and RADV's undefined behaviour here is a
+>    well-formed, plausible, entirely wrong answer. §4's claim is correct as
+>    written — it was measured through the extension list — but a probe that
+>    enumerated configurations first would have contradicted it, and would have
+>    made the `Device_optional` gate unable to refuse anything.
+>
+> **The refusal was observed.** With the extension check in place, the iGPU
+> yields `Unavailable` for 16×16×16 `f16×f16→f32` while the RX 7900 XTX yields
+> `Available`, same driver, same Mesa, same run. Verified falsifiable by
+> mutation: removing the extension check makes the iGPU report all fourteen
+> configurations and both devices permit — and the *gate* test stays green,
+> because it compares the verdict against the same list the verdict reads. Two
+> further checks catch it (`configurations imply the enabled feature`, and a
+> no-drop invariant on the advertised count), and both go red on their
+> respective mutants.
+>
+> **A defect found in the doing, worth recording because it looked like
+> nothing.** A wrong `VkComponentTypeKHR` enumerant table decoded the fourteen
+> advertised configurations into six — including an `f16 × s8 → s32` and a
+> `u8 × u8 → u8` that no hardware advertises — with the other eight silently
+> dropped as unrepresentable. Every number looked plausible and every test
+> passed. The enumerants are now pinned against `vulkan_core.h` by value, and
+> `device_support` carries `ds_advertised_count` so that a dropped configuration
+> is a test failure rather than a smaller list.
+>
+> **`shaderFloat16` enablement did NOT change the f16 measurement.** Controlled
+> A/B, one build, feature request toggled: `test_vulkan_f16_tripwire` reports
+> 2912/63488 on both arms on both devices, same first divergence, all controls
+> green. `fp-contraction-policy.md` §7(b) is closed with the table.
+>
+> **No refusal is lifted.** `Sarek_ir_glsl` still refuses f16; nothing in Sarek
+> emits a cooperative-matrix instruction. Slice 3 and slices 4a/4c are untouched.
 
 ### Slice 3 — lift the GLSL scalar-f16 refusal, on an allowlist (local)
 

--- a/docs/fp-contraction-policy.md
+++ b/docs/fp-contraction-policy.md
@@ -739,14 +739,38 @@ this is where they are collected):
   cross-check, unlike its OpenCL sibling: one data point is thin ground for a
   gate, and §11.5 is a demonstration of what a cross-check built on a
   not-quite-valid oracle does when it meets new hardware.
-  (b) **The `shaderFloat16` device feature is not enabled.** Vulkan requires it
-  before a shader may use the SPIR-V `Float16` capability;
-  `Vulkan_api_device` chains no feature structs beyond core
-  `VkPhysicalDeviceFeatures`, and RADV accepts the shaders anyway. The
-  measurement stands — the defect is visible in the ISA, and the barriered
-  control returns bit-exact results on the same un-enabled path — but that
-  plumbing is real work that enabling f16 here would have to do first, and it
-  is not done.
+  (b) ~~**The `shaderFloat16` device feature is not enabled.**~~ **CLOSED
+  2026-07-27 (backlog-62 slice 2).** Vulkan requires the feature before a shader
+  may use the SPIR-V `Float16` capability; `Vulkan_api_device` used to chain no
+  feature structs beyond core `VkPhysicalDeviceFeatures`, and RADV accepted the
+  shaders anyway. It now queries `VkPhysicalDeviceShaderFloat16Int8Features` and
+  `VkPhysicalDevice16BitStorageFeatures` through the `VkPhysicalDeviceFeatures2`
+  chain and **requests both in `VkDeviceCreateInfo.pNext`**, alongside
+  `VK_KHR_cooperative_matrix` where advertised.
+
+  **The measurement is unchanged by enabling it, and that is itself a result.**
+  Run as a controlled A/B on 2026-07-27 — one build, the feature request
+  toggled, `test_vulkan_f16_tripwire` run on each arm, on the RX 7900 XTX (RADV
+  NAVI31) **and** the Raphael iGPU, radv / Mesa 26.1.4-arch3.1, Vulkan 1.4.354:
+
+  | arm | RX 7900 XTX | Raphael iGPU |
+  |---|---|---|
+  | `shaderFloat16` **not** requested (the pre-slice-2 path) | 2912/63488 | 2912/63488 |
+  | `shaderFloat16` requested | 2912/63488 | 2912/63488 |
+
+  First divergence identical on every arm (`x = 8.94069672e-07`, device
+  `0x0011`, discipline `0x0010`), the `precise` variant identical
+  (2912/63488 from the discipline, 0/63488 from the single-rounding model), and
+  all three calibration controls green throughout. So the caveat named a real
+  gap in the plumbing but **not** a confound in the measurement: ACO's
+  absorption of the f32→f16 narrowing does not depend on whether the feature was
+  requested. Evidence tier: **executed**, both arms, same binary, same devices.
+
+  Only the one-narrowing shape was re-run this way; the 4774/63488
+  two-narrowing figure was not re-measured under the A/B.
+
+  What this does **not** do is lift any refusal — `Sarek_ir_glsl` still refuses
+  f16, and that is slice 3.
   (c) **No Sarek-generated shader was involved.** The tripwire compiles raw
   GLSL, because `Sarek_ir_glsl` refuses f16; it measures the driver, not the
   codegen. If the refusal is ever lifted, the codegen's own output needs its own

--- a/sarek-cuda/Cuda_plugin_base.ml
+++ b/sarek-cuda/Cuda_plugin_base.ml
@@ -58,6 +58,10 @@ module Cuda : Framework_sig.PLUGIN_BASE = struct
            #142, and listing a feature we have not gated would be the
            permissive default this list exists to remove. *)
         device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+        (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+           "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+           refuses; an empty list would be a positive claim nobody measured. *)
+        coopmat = None;
         supports_atomics = true;
         warp_size = d.warp_size;
         max_registers_per_block = 65536;

--- a/sarek-hip/Hip_plugin_base.ml
+++ b/sarek-hip/Hip_plugin_base.ml
@@ -55,6 +55,10 @@ module Hip : Framework_sig.PLUGIN_BASE = struct
         (* As CUDA: fp64 and int64 are core on every HIP target. Float16 is
            omitted for the same reason — unprobed, so not claimed. *)
         device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+        (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+           "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+           refuses; an empty list would be a positive claim nobody measured. *)
+        coopmat = None;
         supports_atomics = true;
         warp_size = d.warp_size;
         max_registers_per_block = 65536;

--- a/sarek-metal/Metal_plugin_base.ml
+++ b/sarek-metal/Metal_plugin_base.ml
@@ -82,6 +82,10 @@ module Metal : Framework_sig.PLUGIN_BASE = struct
           device_features =
             (if d.supports_fp64 then [Sarek_ir_analysis.Float64] else [])
             @ [Sarek_ir_analysis.Int64];
+          (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+             "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+             refuses; an empty list would be a positive claim nobody measured. *)
+          coopmat = None;
           supports_atomics = true;
           warp_size = 32;
           (* SIMD width on Apple GPUs *)

--- a/sarek-opencl/Opencl_plugin_base.ml
+++ b/sarek-opencl/Opencl_plugin_base.ml
@@ -86,6 +86,10 @@ module Opencl : Framework_sig.PLUGIN_BASE = struct
         device_features =
           ((if d.supports_fp64 then [Sarek_ir_analysis.Float64] else [])
           @ if d.supports_int64 then [Sarek_ir_analysis.Int64] else []);
+        (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+           "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+           refuses; an empty list would be a positive claim nobody measured. *)
+        coopmat = None;
         supports_atomics = true;
         (* Most OpenCL devices support atomics *)
         warp_size = 32;

--- a/sarek-vulkan/Vulkan_api_device.ml
+++ b/sarek-vulkan/Vulkan_api_device.ml
@@ -30,6 +30,63 @@ type t = {
           [OpCapability Int64] is legal only against a logical device that
           ENABLED the feature, so querying it without requesting it would still
           be the #142 defect. *)
+  supports_fp16 : bool;
+      (** [VkPhysicalDeviceShaderFloat16Int8Features.shaderFloat16], queried
+          through the [VkPhysicalDeviceFeatures2] chain and REQUESTED in
+          [VkDeviceCreateInfo.pNext] (backlog-62 slice 2). It is not in core
+          [VkPhysicalDeviceFeatures], which is why it could not be plumbed on
+          the #142 path.
+
+          docs/fp-contraction-policy.md §7(b) records that RADV accepts f16
+          shaders today without this feature enabled. That makes the existing
+          f16 tripwire a measurement of an un-enabled path — fine for measuring
+          a driver, not fine for shipping — and it is precisely the "supported
+          but never requested" shape of #332. Enabling it here does NOT lift any
+          f16 refusal; that is slice 3. *)
+  storage_buffer_16bit : bool;
+      (** [VkPhysicalDevice16BitStorageFeatures.storageBuffer16BitAccess],
+          queried and requested on the same chain. Required before a shader may
+          declare 16-bit types in a storage buffer, which every f16 or
+          cooperative-matrix kernel that reads its operands from memory must do.
+      *)
+  driver_id : int;
+      (** [VkPhysicalDeviceDriverProperties.driverID]. 3 is
+          [VK_DRIVER_ID_MESA_RADV]. This is the driver KEY that
+          docs/fp-contraction-policy.md §11.7 and the [is_anv_device] comment in
+          [Test_helpers] both ask for: an allowlist keyed on a device-NAME
+          substring would match a future non-Mesa driver on the same silicon. *)
+  driver_name : string;  (** e.g. ["radv"]. *)
+  driver_info : string;  (** e.g. ["Mesa 26.1.4-arch3.1"]. *)
+  subgroup_size : int;
+      (** [VkPhysicalDeviceSubgroupProperties.subgroupSize] — the real one, not
+          a constant. Measured 64 on the RX 7900 XTX under radv / Mesa
+          26.1.4-arch3.1, where [Vulkan_plugin_base] reported a hard-coded 32. A
+          cooperative-matrix fragment is distributed across exactly this many
+          invocations, so the wrong value is a wrong ABI. *)
+  coopmat_extension_advertised : bool;
+      (** Whether [vkEnumerateDeviceExtensionProperties] listed
+          [VK_KHR_cooperative_matrix] for this physical device. *)
+  coopmat_enabled : bool;
+      (** Whether the extension was advertised AND
+          [VkPhysicalDeviceCooperativeMatrixFeaturesKHR.cooperativeMatrix] was
+          true, so the extension and the feature were both REQUESTED at
+          [vkCreateDevice].
+
+          Recorded separately from {!coopmat} rather than derived from it,
+          because deriving it is exactly the mistake this pair exists to catch:
+          [ds_configs] comes from a query that answers even for devices without
+          the extension, so a non-empty list is NOT evidence that the device
+          supports anything. The implication
+          [ds_configs <> [] ==> coopmat_enabled] is asserted by
+          [test_vulkan_coopmat_capability], and it is what goes red if the
+          extension check in [probe_coopmat] is ever removed — the gate test
+          alone does not, because it compares the verdict against the same list.
+      *)
+  coopmat : Sarek_coopmat.device_support option;
+      (** Cooperative-matrix support, [None] when it could not be probed at all
+          (loader too old to resolve the entry point). See [probe_coopmat] for
+          why an empty list and [None] must stay distinguishable, and for the
+          measurement that makes the extension check load-bearing. *)
 }
 
 let instance_ref : vk_instance structure ptr option ref = ref None
@@ -138,6 +195,302 @@ let count () =
     (vkEnumeratePhysicalDevices inst n (from_voidp vk_physical_device_ptr null)) ;
   Unsigned.UInt32.to_int !@n
 
+(** {1 Extended feature and property probes (backlog-62 slice 2)} *)
+
+(** Read a NUL-terminated fixed-size C char array into an OCaml string. *)
+let string_of_char_array arr =
+  let n = CArray.length arr in
+  let buf = Buffer.create 64 in
+  (try
+     for i = 0 to n - 1 do
+       let c = CArray.get arr i in
+       if c = '\000' then raise Exit else Buffer.add_char buf c
+     done
+   with Exit -> ()) ;
+  Buffer.contents buf
+
+let u32_is_true v = Unsigned.UInt32.to_int v <> 0
+
+(** Zero a struct's bytes before a [pNext] query.
+
+    A driver that does not recognise an [sType] leaves the struct alone, so
+    without this an unrecognised feature struct would be read out of
+    uninitialised memory — and the failure direction is "feature present", on
+    exactly the devices that lack it. [ctypes]' [make] does not zero. *)
+let zero_struct (type a) (typ : a structure typ) (s : a structure) =
+  let bytes = sizeof typ in
+  let p = coerce (ptr typ) (ptr char) (addr s) in
+  for i = 0 to bytes - 1 do
+    p +@ i <-@ '\000'
+  done
+
+(** The device extension names a physical device advertises. *)
+let device_extension_names phys_dev =
+  let count = allocate uint32_t (Unsigned.UInt32.of_int 0) in
+  check
+    "vkEnumerateDeviceExtensionProperties"
+    (vkEnumerateDeviceExtensionProperties
+       phys_dev
+       (from_voidp char null)
+       count
+       (from_voidp vk_extension_properties null)) ;
+  let n = Unsigned.UInt32.to_int !@count in
+  if n = 0 then []
+  else begin
+    let arr = CArray.make vk_extension_properties n in
+    check
+      "vkEnumerateDeviceExtensionProperties"
+      (vkEnumerateDeviceExtensionProperties
+         phys_dev
+         (from_voidp char null)
+         count
+         (CArray.start arr)) ;
+    List.init n (fun i ->
+        string_of_char_array (getf (CArray.get arr i) ext_props_extensionName))
+  end
+
+type extended_features = {
+  ef_shader_float16 : bool;
+  ef_storage_buffer_16bit : bool;
+  ef_cooperative_matrix : bool;
+  ef_coopmat_robust_buffer_access : bool;
+}
+
+(** Query the three extension feature structs in one [VkPhysicalDeviceFeatures2]
+    chain.
+
+    Chaining a struct whose extension the device does not advertise is harmless
+    — the driver skips an [sType] it does not know, and {!zero_struct}
+    guarantees the fields then read false. What is NOT harmless is calling an
+    extension's own entry point on such a device; see {!probe_coopmat}. *)
+let query_extended_features phys_dev =
+  let coopmat_f = make vk_physical_device_cooperative_matrix_features in
+  zero_struct vk_physical_device_cooperative_matrix_features coopmat_f ;
+  setf
+    coopmat_f
+    coopmat_feat_sType
+    (u32 vk_structure_type_physical_device_cooperative_matrix_features_khr) ;
+  setf coopmat_f coopmat_feat_pNext null ;
+
+  let storage16 = make vk_physical_device_16bit_storage_features in
+  zero_struct vk_physical_device_16bit_storage_features storage16 ;
+  setf
+    storage16
+    storage16_sType
+    (u32 vk_structure_type_physical_device_16bit_storage_features) ;
+  setf storage16 storage16_pNext (to_voidp (addr coopmat_f)) ;
+
+  let f16i8 = make vk_physical_device_shader_float16_int8_features in
+  zero_struct vk_physical_device_shader_float16_int8_features f16i8 ;
+  setf
+    f16i8
+    f16i8_sType
+    (u32 vk_structure_type_physical_device_shader_float16_int8_features) ;
+  setf f16i8 f16i8_pNext (to_voidp (addr storage16)) ;
+
+  let features2 = make vk_physical_device_features_2 in
+  zero_struct vk_physical_device_features_2 features2 ;
+  setf
+    features2
+    features2_sType
+    (u32 vk_structure_type_physical_device_features_2) ;
+  setf features2 features2_pNext (to_voidp (addr f16i8)) ;
+
+  vkGetPhysicalDeviceFeatures2 phys_dev (addr features2) ;
+  (* The chain holds bare addresses into all four. *)
+  ignore (Sys.opaque_identity features2) ;
+  ignore (Sys.opaque_identity f16i8) ;
+  ignore (Sys.opaque_identity storage16) ;
+  ignore (Sys.opaque_identity coopmat_f) ;
+  {
+    ef_shader_float16 = u32_is_true (getf f16i8 f16i8_shaderFloat16);
+    ef_storage_buffer_16bit =
+      u32_is_true (getf storage16 storage16_storageBuffer16BitAccess);
+    ef_cooperative_matrix =
+      u32_is_true (getf coopmat_f coopmat_feat_cooperativeMatrix);
+    ef_coopmat_robust_buffer_access =
+      u32_is_true (getf coopmat_f coopmat_feat_robustBufferAccess);
+  }
+
+type extended_properties = {
+  ep_driver_id : int;
+  ep_driver_name : string;
+  ep_driver_info : string;
+  ep_subgroup_size : int;
+}
+
+(** Driver identity and subgroup size, through one [VkPhysicalDeviceProperties2]
+    chain. Both are core Vulkan 1.1 property structs, so no extension gate. *)
+let query_extended_properties phys_dev =
+  let subgroup = make vk_physical_device_subgroup_properties in
+  zero_struct vk_physical_device_subgroup_properties subgroup ;
+  setf
+    subgroup
+    subgroup_props_sType
+    (u32 vk_structure_type_physical_device_subgroup_properties) ;
+  setf subgroup subgroup_props_pNext null ;
+
+  let driver = make vk_physical_device_driver_properties in
+  zero_struct vk_physical_device_driver_properties driver ;
+  setf
+    driver
+    driver_props_sType
+    (u32 vk_structure_type_physical_device_driver_properties) ;
+  setf driver driver_props_pNext (to_voidp (addr subgroup)) ;
+
+  let props2 = make vk_physical_device_properties_2 in
+  zero_struct vk_physical_device_properties_2 props2 ;
+  setf
+    props2
+    properties2_sType
+    (u32 vk_structure_type_physical_device_properties_2) ;
+  setf props2 properties2_pNext (to_voidp (addr driver)) ;
+
+  vkGetPhysicalDeviceProperties2 phys_dev (addr props2) ;
+  ignore (Sys.opaque_identity props2) ;
+  ignore (Sys.opaque_identity driver) ;
+  ignore (Sys.opaque_identity subgroup) ;
+  {
+    ep_driver_id = Unsigned.UInt32.to_int (getf driver driver_props_driverID);
+    ep_driver_name = string_of_char_array (getf driver driver_props_driverName);
+    ep_driver_info = string_of_char_array (getf driver driver_props_driverInfo);
+    ep_subgroup_size =
+      Unsigned.UInt32.to_int (getf subgroup subgroup_props_subgroupSize);
+  }
+
+(** {2 Cooperative-matrix configuration enumeration} *)
+
+let component_type_of_enum (v : int32) : Sarek_coopmat.component_type option =
+  if v = vk_component_type_float16 then Some Sarek_coopmat.Float16
+  else if v = vk_component_type_float32 then Some Sarek_coopmat.Float32
+  else if v = vk_component_type_uint8 then Some Sarek_coopmat.Uint8
+  else if v = vk_component_type_sint8 then Some Sarek_coopmat.Sint8
+  else if v = vk_component_type_uint32 then Some Sarek_coopmat.Uint32
+  else if v = vk_component_type_sint32 then Some Sarek_coopmat.Sint32
+  else None
+
+let scope_of_enum (v : int32) : Sarek_coopmat.scope option =
+  if v = vk_scope_subgroup then Some Sarek_coopmat.Subgroup
+  else if v = vk_scope_workgroup then Some Sarek_coopmat.Workgroup
+  else if v = vk_scope_device then Some Sarek_coopmat.Device_scope
+  else if v = vk_scope_queue_family then Some Sarek_coopmat.Queue_family
+  else None
+
+(** Probe cooperative-matrix support for one physical device.
+
+    {b The extension check is load-bearing and this is measured, not tidy.}
+    [vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR] is an instance-level
+    entry point that dispatches on the physical device handle, and on this
+    workstation RADV answers it for BOTH local devices: the AMD Ryzen 9 7950X
+    iGPU (RADV RAPHAEL_MENDOCINO), which does not advertise
+    [VK_KHR_cooperative_matrix] and reports [cooperativeMatrix = false], still
+    returns [VK_SUCCESS] and fourteen configurations — the same fourteen as the
+    RX 7900 XTX. Calling an extension entry point on a device that does not
+    support the extension is undefined behaviour, and here the undefined
+    behaviour is a plausible, well-formed, entirely wrong answer.
+
+    So a probe that populated the configuration list from the query alone would
+    report the iGPU as fully cooperative-matrix capable, and every gate
+    downstream would say [Available] for a device that cannot execute the
+    instruction. The order below — extension advertised, THEN feature true, THEN
+    query — is what makes the gate able to refuse.
+
+    [None] is returned only when the loader cannot resolve the entry point at
+    all; that is "not probed", and it refuses. A device that is probed and has
+    nothing returns [Some] with an empty list, which is a different fact. *)
+let probe_coopmat ~instance ~phys_dev ~extensions
+    ~(features : extended_features) ~subgroup_size =
+  let advertised =
+    List.mem vk_khr_cooperative_matrix_extension_name extensions
+  in
+  if not (advertised && features.ef_cooperative_matrix) then
+    Some
+      {
+        Sarek_coopmat.ds_configs = [];
+        ds_robust_buffer_access = false;
+        ds_subgroup_size = subgroup_size;
+        ds_advertised_count = 0;
+      }
+  else
+    match get_physical_device_cooperative_matrix_properties instance with
+    | None -> None
+    | Some query ->
+        let count = allocate uint32_t (Unsigned.UInt32.of_int 0) in
+        check
+          "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"
+          (query
+             phys_dev
+             count
+             (from_voidp vk_cooperative_matrix_properties null)) ;
+        let n = Unsigned.UInt32.to_int !@count in
+        let configs =
+          if n = 0 then []
+          else begin
+            let arr = CArray.make vk_cooperative_matrix_properties n in
+            for i = 0 to n - 1 do
+              let e = CArray.get arr i in
+              zero_struct vk_cooperative_matrix_properties e ;
+              setf
+                e
+                coopmat_props_sType
+                (u32 vk_structure_type_cooperative_matrix_properties_khr) ;
+              setf e coopmat_props_pNext null
+            done ;
+            check
+              "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"
+              (query phys_dev count (CArray.start arr)) ;
+            List.filter_map
+              (fun i ->
+                let e = CArray.get arr i in
+                let u f = Unsigned.UInt32.to_int (getf e f) in
+                (* A configuration naming a component type or a scope this
+                   build cannot represent is DROPPED, not approximated. The
+                   list is only ever read to decide what may run, so dropping
+                   an entry can only cause a refusal — the safe direction —
+                   whereas mapping an unknown enumerant onto a neighbouring one
+                   would admit an operation with different semantics. *)
+                match
+                  ( component_type_of_enum (getf e coopmat_props_AType),
+                    component_type_of_enum (getf e coopmat_props_BType),
+                    component_type_of_enum (getf e coopmat_props_CType),
+                    component_type_of_enum (getf e coopmat_props_ResultType),
+                    scope_of_enum (getf e coopmat_props_scope) )
+                with
+                | Some a, Some b, Some c, Some result, Some scope ->
+                    Some
+                      {
+                        Sarek_coopmat.cfg_shape =
+                          {
+                            Sarek_coopmat.m = u coopmat_props_MSize;
+                            n = u coopmat_props_NSize;
+                            k = u coopmat_props_KSize;
+                          };
+                        cfg_a = a;
+                        cfg_b = b;
+                        cfg_c = c;
+                        cfg_result = result;
+                        cfg_saturating =
+                          u coopmat_props_saturatingAccumulation <> 0;
+                        cfg_scope = scope;
+                      }
+                | _ ->
+                    Spoc_core.Log.debugf
+                      Spoc_core.Log.Device
+                      "Vulkan coopmat: dropping configuration %d (component \
+                       type or scope not representable)"
+                      i ;
+                    None)
+              (List.init n (fun i -> i))
+          end
+        in
+        Some
+          {
+            Sarek_coopmat.ds_configs = configs;
+            ds_robust_buffer_access = features.ef_coopmat_robust_buffer_access;
+            ds_subgroup_size = subgroup_size;
+            ds_advertised_count = n;
+          }
+
 (** Find compute queue family index *)
 let find_compute_queue_family phys_dev =
   let count = allocate uint32_t (Unsigned.UInt32.of_int 0) in
@@ -233,6 +586,40 @@ let get idx =
          the physical one. *)
       let supports_int64 = feature_supported shader_int64_field_index in
 
+      (* backlog-62 slice 2. Everything below this line is queried through the
+         Features2 / Properties2 pNext chains, which is the only way to reach
+         shaderFloat16, storageBuffer16BitAccess, cooperativeMatrix, the driver
+         identity and the subgroup size. *)
+      let extensions = device_extension_names phys_dev in
+      let ext = query_extended_features phys_dev in
+      let props2 = query_extended_properties phys_dev in
+      let coopmat =
+        probe_coopmat
+          ~instance:inst
+          ~phys_dev
+          ~extensions
+          ~features:ext
+          ~subgroup_size:props2.ep_subgroup_size
+      in
+      let has_ext name = List.mem name extensions in
+      (* #332's lesson, applied: support is not enablement. Each of these is
+         requested only when the device advertises BOTH the extension and the
+         feature, because vkCreateDevice fails outright on a request the device
+         cannot satisfy — and is not requested at all when unsupported, so the
+         behaviour on such a device is byte-identical to before this change. *)
+      let want_fp16 =
+        ext.ef_shader_float16
+        && has_ext vk_khr_shader_float16_int8_extension_name
+      in
+      let want_storage16 =
+        ext.ef_storage_buffer_16bit
+        && has_ext vk_khr_16bit_storage_extension_name
+      in
+      let want_coopmat =
+        ext.ef_cooperative_matrix
+        && has_ext vk_khr_cooperative_matrix_extension_name
+      in
+
       (* Find compute queue family *)
       let queue_family = find_compute_queue_family phys_dev in
 
@@ -275,14 +662,106 @@ let get idx =
         dev_create_info
         dev_create_ppEnabledLayerNames
         (from_voidp string null) ;
+      (* Device extensions, backlog-62 slice 2. Requested only when advertised;
+         the list is empty on a device that advertises none, which restores the
+         previous (count = 0, names = NULL) call exactly.
+
+         The name buffers are held in [ext_name_arrays] and kept alive past
+         vkCreateDevice explicitly. [CArray.of_string] is used rather than
+         ctypes' [string] view for the same reason the instance's application
+         name is: that view allocates an anonymous buffer rooted only by a fat
+         pointer [setf] discards, so the string would dangle before the loader
+         read it. *)
+      let requested_extensions =
+        List.filter_map
+          (fun (wanted, name) -> if wanted then Some name else None)
+          [
+            (want_fp16, vk_khr_shader_float16_int8_extension_name);
+            (want_storage16, vk_khr_16bit_storage_extension_name);
+            (want_coopmat, vk_khr_cooperative_matrix_extension_name);
+          ]
+      in
+      let ext_name_arrays =
+        List.map (fun n -> CArray.of_string n) requested_extensions
+      in
+      let ext_name_ptrs =
+        CArray.of_list (ptr char) (List.map CArray.start ext_name_arrays)
+      in
       setf
         dev_create_info
         dev_create_enabledExtensionCount
-        (Unsigned.UInt32.of_int 0) ;
+        (Unsigned.UInt32.of_int (List.length requested_extensions)) ;
       setf
         dev_create_info
         dev_create_ppEnabledExtensionNames
-        (from_voidp string null) ;
+        (if requested_extensions = [] then from_voidp string null
+         else coerce (ptr (ptr char)) (ptr string) (CArray.start ext_name_ptrs)) ;
+
+      (* The feature pNext chain. Only structs whose feature is both supported
+         and wanted are chained, and each has exactly the requested field set —
+         cooperativeMatrixRobustBufferAccess is deliberately NOT requested, as
+         it carries a further requirement on core robustBufferAccess; the probe
+         RECORDS whether the device offers it without asking for it.
+
+         pEnabledFeatures below stays non-NULL and keeps carrying the core
+         shaderFloat64 / shaderInt64 request. That is legal: the "pEnabledFeatures
+         must be NULL" rule applies only when VkPhysicalDeviceFeatures2 itself
+         is in the chain, and it is not. *)
+      let coopmat_enable =
+        make vk_physical_device_cooperative_matrix_features
+      in
+      zero_struct vk_physical_device_cooperative_matrix_features coopmat_enable ;
+      setf
+        coopmat_enable
+        coopmat_feat_sType
+        (u32 vk_structure_type_physical_device_cooperative_matrix_features_khr) ;
+      setf coopmat_enable coopmat_feat_pNext null ;
+      setf
+        coopmat_enable
+        coopmat_feat_cooperativeMatrix
+        (Unsigned.UInt32.of_int 1) ;
+
+      let storage16_enable = make vk_physical_device_16bit_storage_features in
+      zero_struct vk_physical_device_16bit_storage_features storage16_enable ;
+      setf
+        storage16_enable
+        storage16_sType
+        (u32 vk_structure_type_physical_device_16bit_storage_features) ;
+      setf
+        storage16_enable
+        storage16_storageBuffer16BitAccess
+        (Unsigned.UInt32.of_int 1) ;
+
+      let f16_enable = make vk_physical_device_shader_float16_int8_features in
+      zero_struct vk_physical_device_shader_float16_int8_features f16_enable ;
+      setf
+        f16_enable
+        f16i8_sType
+        (u32 vk_structure_type_physical_device_shader_float16_int8_features) ;
+      setf f16_enable f16i8_shaderFloat16 (Unsigned.UInt32.of_int 1) ;
+
+      let chain_head =
+        List.fold_left
+          (fun next (wanted, set_pnext, self) ->
+            if wanted then begin
+              set_pnext next ;
+              self
+            end
+            else next)
+          null
+          [
+            ( want_coopmat,
+              (fun p -> setf coopmat_enable coopmat_feat_pNext p),
+              to_voidp (addr coopmat_enable) );
+            ( want_storage16,
+              (fun p -> setf storage16_enable storage16_pNext p),
+              to_voidp (addr storage16_enable) );
+            ( want_fp16,
+              (fun p -> setf f16_enable f16i8_pNext p),
+              to_voidp (addr f16_enable) );
+          ]
+      in
+      setf dev_create_info dev_create_pNext chain_head ;
       (* Request every wide-type feature the physical device actually reports,
          and only those - requesting an unsupported feature fails
          vkCreateDevice outright. All other features are left at their default
@@ -338,10 +817,16 @@ let get idx =
       check
         "vkCreateDevice"
         (vkCreateDevice phys_dev (addr dev_create_info) null device) ;
-      (* [dev_create_info] holds bare addresses into all three. *)
+      (* [dev_create_info] holds bare addresses into all of these, and in OCaml
+         a value dies after its last USE rather than at end of scope. *)
       ignore (Sys.opaque_identity enabled_features) ;
       ignore (Sys.opaque_identity queue_create_info) ;
       ignore (Sys.opaque_identity queue_priority) ;
+      ignore (Sys.opaque_identity ext_name_arrays) ;
+      ignore (Sys.opaque_identity ext_name_ptrs) ;
+      ignore (Sys.opaque_identity coopmat_enable) ;
+      ignore (Sys.opaque_identity storage16_enable) ;
+      ignore (Sys.opaque_identity f16_enable) ;
 
       (* Get compute queue *)
       let queue = allocate vk_queue_ptr (from_voidp vk_queue null) in
@@ -393,6 +878,20 @@ let get idx =
           command_pool = !@pool;
           supports_fp64;
           supports_int64;
+          (* Reported as the ENABLED state, not the supported one. On a device
+             where the extension is absent these are false even if some other
+             path could have reached the feature — which is what makes the
+             value safe to hand to a capability gate. *)
+          supports_fp16 = want_fp16;
+          storage_buffer_16bit = want_storage16;
+          driver_id = props2.ep_driver_id;
+          driver_name = props2.ep_driver_name;
+          driver_info = props2.ep_driver_info;
+          subgroup_size = props2.ep_subgroup_size;
+          coopmat_extension_advertised =
+            has_ext vk_khr_cooperative_matrix_extension_name;
+          coopmat_enabled = want_coopmat;
+          coopmat;
         }
       in
       Hashtbl.add device_cache idx dev ;

--- a/sarek-vulkan/Vulkan_api_device.ml
+++ b/sarek-vulkan/Vulkan_api_device.ml
@@ -62,7 +62,15 @@ type t = {
           a constant. Measured 64 on the RX 7900 XTX under radv / Mesa
           26.1.4-arch3.1, where [Vulkan_plugin_base] reported a hard-coded 32. A
           cooperative-matrix fragment is distributed across exactly this many
-          invocations, so the wrong value is a wrong ABI. *)
+          invocations, so the wrong value is a wrong ABI.
+
+          {b Guaranteed positive}: it is [fallback_subgroup_size] rather than
+          the driver's zero when the query came back unwritten, so a consumer
+          may divide by it. {!subgroup_size_probed} says which it is. *)
+  subgroup_size_probed : bool;
+      (** Whether {!subgroup_size} is a measurement rather than the fallback.
+          Both local devices are probed; a [false] here is a test failure, not a
+          degradation to be tolerated. *)
   coopmat_extension_advertised : bool;
       (** Whether [vkEnumerateDeviceExtensionProperties] listed
           [VK_KHR_cooperative_matrix] for this physical device. *)
@@ -317,7 +325,29 @@ type extended_properties = {
   ep_driver_name : string;
   ep_driver_info : string;
   ep_subgroup_size : int;
+      (** Always positive — see {!fallback_subgroup_size}. *)
+  ep_subgroup_size_probed : bool;
+      (** [false] when the driver left [subgroupSize] at the zero {!zero_struct}
+          wrote, so {!ep_subgroup_size} is the fallback rather than a
+          measurement. *)
 }
+
+(** Used only when [VkPhysicalDeviceSubgroupProperties] came back unwritten.
+
+    [zero_struct] zeroes the struct before the query, so a driver that does not
+    recognise the [sType] leaves [subgroupSize = 0] — and zero flowing into
+    [warp_size] is worse than the wrong-but-usable 32 that preceded this work,
+    because any consumer that divides by it faults instead of merely being
+    wrong. 32 is that historical value, kept as the fallback for continuity and
+    for nothing else.
+
+    It is WRONG on both devices this project measures on, which report 64 (RX
+    7900 XTX / RADV NAVI31 and the Ryzen 9 7950X iGPU / RADV RAPHAEL_MENDOCINO,
+    radv / Mesa 26.1.4-arch3.1). So it must never become the silent normal:
+    [ep_subgroup_size_probed] records which of the two a caller is holding, and
+    [test_vulkan_coopmat_capability] asserts that every local device is PROBED —
+    the fallback going live here is a test failure, not a quiet degradation. *)
+let fallback_subgroup_size = 32
 
 (** Driver identity and subgroup size, through one [VkPhysicalDeviceProperties2]
     chain. Both are core Vulkan 1.1 property structs, so no extension gate. *)
@@ -350,12 +380,17 @@ let query_extended_properties phys_dev =
   ignore (Sys.opaque_identity props2) ;
   ignore (Sys.opaque_identity driver) ;
   ignore (Sys.opaque_identity subgroup) ;
+  let reported_subgroup_size =
+    Unsigned.UInt32.to_int (getf subgroup subgroup_props_subgroupSize)
+  in
   {
     ep_driver_id = Unsigned.UInt32.to_int (getf driver driver_props_driverID);
     ep_driver_name = string_of_char_array (getf driver driver_props_driverName);
     ep_driver_info = string_of_char_array (getf driver driver_props_driverInfo);
     ep_subgroup_size =
-      Unsigned.UInt32.to_int (getf subgroup subgroup_props_subgroupSize);
+      (if reported_subgroup_size > 0 then reported_subgroup_size
+       else fallback_subgroup_size);
+    ep_subgroup_size_probed = reported_subgroup_size > 0;
   }
 
 (** {2 Cooperative-matrix configuration enumeration} *)
@@ -602,18 +637,53 @@ let get idx =
           ~subgroup_size:props2.ep_subgroup_size
       in
       let has_ext name = List.mem name extensions in
-      (* #332's lesson, applied: support is not enablement. Each of these is
-         requested only when the device advertises BOTH the extension and the
-         feature, because vkCreateDevice fails outright on a request the device
-         cannot satisfy — and is not requested at all when unsupported, so the
-         behaviour on such a device is byte-identical to before this change. *)
+      (* #332's lesson, applied — and applied in BOTH directions, which the
+         first draft of this block got wrong.
+
+         A feature must be REQUESTED, not merely supported: that is #332. But
+         requiring an extension STRING for a feature that has since been
+         promoted to core is the same error arriving from the other side, and
+         it silently stops requesting a feature the device does support.
+         [VK_KHR_16bit_storage] is core in Vulkan 1.1 and
+         [VK_KHR_shader_float16_int8] is core in Vulkan 1.2; a device at those
+         versions need not advertise the extension string at all, and on such a
+         device an [advertised && supported] conjunction reads false and the
+         feature is never enabled. Both local devices happen to advertise both
+         strings, so the defect is invisible here on the hardware alone.
+
+         Measured by simulation instead, 2026-07-27: hiding the two PROMOTED
+         extension strings from [has_ext] — i.e. presenting an otherwise
+         identical device that supports them only as core — the previous
+         conjunction reported [shaderFloat16=false storageBuffer16=false] on a
+         device that fully supports both, while the form below reports both
+         true and vkCreateDevice still succeeds. The cooperative-matrix arm is
+         unaffected in either run, which is the control: it is a real extension
+         and its string requirement is correct.
+
+         So each promoted feature is gated on the feature bit plus EITHER the
+         core version that promoted it OR the extension string, and only
+         [VK_KHR_cooperative_matrix] — which is a real extension, promoted to
+         nothing — keeps an unconditional string requirement.
+
+         The version that counts is the EFFECTIVE one: an application may not
+         use a core feature above the [apiVersion] its instance requested, and
+         [get_or_create_instance] above requests 1.2. Both promotions are at or
+         below that, so nothing here is reachable-but-refused; the [min] is
+         there so that lowering the instance version cannot silently start
+         requesting features the application is not entitled to. *)
+      let instance_api_version = (1, 2) in
+      let effective_api_version =
+        min (api_major, api_minor) instance_api_version
+      in
+      let api_at_least v = effective_api_version >= v in
       let want_fp16 =
         ext.ef_shader_float16
-        && has_ext vk_khr_shader_float16_int8_extension_name
+        && (api_at_least (1, 2)
+           || has_ext vk_khr_shader_float16_int8_extension_name)
       in
       let want_storage16 =
         ext.ef_storage_buffer_16bit
-        && has_ext vk_khr_16bit_storage_extension_name
+        && (api_at_least (1, 1) || has_ext vk_khr_16bit_storage_extension_name)
       in
       let want_coopmat =
         ext.ef_cooperative_matrix
@@ -674,7 +744,13 @@ let get idx =
          read it. *)
       let requested_extensions =
         List.filter_map
-          (fun (wanted, name) -> if wanted then Some name else None)
+          (fun (wanted, name) ->
+            (* [has_ext] here and not in [want_*]: a promoted feature may be
+               wanted via its core version on a device that does not advertise
+               the string, and requesting an unadvertised extension fails
+               vkCreateDevice. The feature struct is still chained in either
+               case, which is what actually enables the feature. *)
+            if wanted && has_ext name then Some name else None)
           [
             (want_fp16, vk_khr_shader_float16_int8_extension_name);
             (want_storage16, vk_khr_16bit_storage_extension_name);
@@ -888,6 +964,7 @@ let get idx =
           driver_name = props2.ep_driver_name;
           driver_info = props2.ep_driver_info;
           subgroup_size = props2.ep_subgroup_size;
+          subgroup_size_probed = props2.ep_subgroup_size_probed;
           coopmat_extension_advertised =
             has_ext vk_khr_cooperative_matrix_extension_name;
           coopmat_enabled = want_coopmat;

--- a/sarek-vulkan/Vulkan_bindings.ml
+++ b/sarek-vulkan/Vulkan_bindings.ml
@@ -128,6 +128,80 @@ let vkGetPhysicalDeviceFeatures_lazy =
 let vkGetPhysicalDeviceFeatures dev features =
   Lazy.force vkGetPhysicalDeviceFeatures_lazy dev features
 
+(** {1 Extended feature and property queries (backlog-62 slice 2)} *)
+
+let vkGetPhysicalDeviceFeatures2_lazy =
+  foreign_vk_lazy
+    "vkGetPhysicalDeviceFeatures2"
+    (vk_physical_device_ptr
+    @-> ptr vk_physical_device_features_2
+    @-> returning void)
+
+(** Core Vulkan 1.1, so it resolves by [dlsym] on the loader like any core entry
+    point — unlike the cooperative-matrix query below. *)
+let vkGetPhysicalDeviceFeatures2 dev features2 =
+  Lazy.force vkGetPhysicalDeviceFeatures2_lazy dev features2
+
+let vkGetPhysicalDeviceProperties2_lazy =
+  foreign_vk_lazy
+    "vkGetPhysicalDeviceProperties2"
+    (vk_physical_device_ptr
+    @-> ptr vk_physical_device_properties_2
+    @-> returning void)
+
+let vkGetPhysicalDeviceProperties2 dev properties2 =
+  Lazy.force vkGetPhysicalDeviceProperties2_lazy dev properties2
+
+let vkEnumerateDeviceExtensionProperties_lazy =
+  foreign_vk_lazy
+    "vkEnumerateDeviceExtensionProperties"
+    (vk_physical_device_ptr @-> ptr char @-> ptr uint32_t
+    @-> ptr vk_extension_properties
+    @-> returning vk_result)
+
+let vkEnumerateDeviceExtensionProperties dev layer count props =
+  Lazy.force vkEnumerateDeviceExtensionProperties_lazy dev layer count props
+
+let vkGetInstanceProcAddr_lazy =
+  foreign_vk_lazy
+    "vkGetInstanceProcAddr"
+    (vk_instance_ptr @-> string @-> returning (ptr void))
+
+let vkGetInstanceProcAddr inst name =
+  Lazy.force vkGetInstanceProcAddr_lazy inst name
+
+(** [vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR], resolved through
+    [vkGetInstanceProcAddr] rather than [dlsym].
+
+    Not a stylistic choice. Measured on this workstation: [dlsym] on
+    [libvulkan.so.1] (Arch [vulkan-icd-loader], loader for Mesa 26.1.4-arch3.1)
+    fails with
+    ["undefined symbol: vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"] —
+    the Khronos loader exports core and promoted entry points as symbols but not
+    every extension one, so a [foreign_vk_lazy] binding for this function would
+    raise [Dl.DL_error] the first time it was forced. [vkGetInstanceProcAddr]
+    returns a valid pointer for the same name on the same loader.
+
+    Returns [None] when the loader does not know the name, which is the honest
+    answer for a build against a loader too old to have heard of the extension.
+    A [None] here becomes an unprobed device, hence [Unknown], hence refused. *)
+let get_physical_device_cooperative_matrix_properties inst =
+  let p =
+    vkGetInstanceProcAddr
+      inst
+      "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"
+  in
+  if is_null p then None
+  else
+    Some
+      (coerce
+         (ptr void)
+         (Foreign.funptr
+            (vk_physical_device_ptr @-> ptr uint32_t
+            @-> ptr vk_cooperative_matrix_properties
+            @-> returning vk_result))
+         p)
+
 (** {1 Device Functions} *)
 
 let vkCreateDevice_lazy =

--- a/sarek-vulkan/Vulkan_plugin_base.ml
+++ b/sarek-vulkan/Vulkan_plugin_base.ml
@@ -82,12 +82,24 @@ module Vulkan = struct
         coopmat = dev.Vulkan_api.Device.coopmat;
         supports_atomics = true;
         (* VkPhysicalDeviceSubgroupProperties.subgroupSize, not a constant.
-           This read 32 until backlog-62 slice 2, and 32 is WRONG on the one
-           discrete GPU this project measures on: radv / Mesa 26.1.4-arch3.1
-           reports 64 for the RX 7900 XTX (RADV NAVI31). It reports 64 for the
-           Raphael iGPU too, so the old value was not right for either local
-           device. A cooperative-matrix fragment is distributed across exactly
-           subgroupSize invocations, so this is ABI, not a statistic. *)
+           This read a hard-coded 32 until backlog-62 slice 2, and 32 is WRONG
+           on BOTH local devices: radv / Mesa 26.1.4-arch3.1 reports 64 for the
+           RX 7900 XTX (RADV NAVI31) and 64 for the Ryzen 9 7950X iGPU (RADV
+           RAPHAEL_MENDOCINO). A cooperative-matrix fragment is distributed
+           across exactly subgroupSize invocations, so this is ABI, not a
+           statistic — at 64 a 16x16 fragment is 4 components per invocation,
+           not 8.
+
+           Guaranteed positive. [Vulkan_api_device] clamps at the source: the
+           subgroup properties struct is zeroed before the query, so a driver
+           that ignores its sType would otherwise leave 0 here, and a zero
+           warp_size is worse than the wrong-but-usable 32 it replaced — a
+           consumer that divides by it faults rather than merely being wrong.
+           When the query does come back unwritten the value is
+           [Vulkan_api_device.fallback_subgroup_size] (32, the historical
+           value) and [subgroup_size_probed] is false; both local devices are
+           probed, and test_vulkan_coopmat_capability fails if that stops being
+           true, so the fallback cannot quietly become the normal case. *)
         warp_size = dev.Vulkan_api.Device.subgroup_size;
         max_registers_per_block = 65536;
         clock_rate_khz = 1000000;

--- a/sarek-vulkan/Vulkan_plugin_base.ml
+++ b/sarek-vulkan/Vulkan_plugin_base.ml
@@ -55,10 +55,17 @@ module Vulkan = struct
         (* Both entries come from vkGetPhysicalDeviceFeatures and both are
            mirrored into the logical device's pEnabledFeatures, so this list
            reports what the device will actually ACCEPT, not merely what the
-           physical device advertises (#142). Float16 is absent deliberately:
-           shaderFloat16 is not probed, and f16 is refused on this backend by
-           policy anyway — claiming it here would be the permissive-default
-           error the capability model exists to prevent. *)
+           physical device advertises (#142).
+
+           Float16 joined the list in backlog-62 slice 2, and only because the
+           condition its previous absence was justified by no longer holds:
+           shaderFloat16 is now PROBED (through the VkPhysicalDeviceFeatures2
+           chain) and REQUESTED (in VkDeviceCreateInfo.pNext), so
+           [supports_fp16] is a statement about what this logical device
+           enabled rather than a guess. This does not lift the GLSL f16
+           refusal, which is a Policy/Toolchain_semantic decision at codegen
+           and is slice 3's business: [device_features] says what the DEVICE
+           provides, not what Sarek is willing to emit. *)
         device_features =
           List.concat
             [
@@ -68,10 +75,20 @@ module Vulkan = struct
               (if dev.Vulkan_api.Device.supports_int64 then
                  [Sarek_ir_analysis.Int64]
                else []);
+              (if dev.Vulkan_api.Device.supports_fp16 then
+                 [Sarek_ir_analysis.Float16]
+               else []);
             ];
+        coopmat = dev.Vulkan_api.Device.coopmat;
         supports_atomics = true;
-        warp_size = 32;
-        (* subgroup size varies by vendor *)
+        (* VkPhysicalDeviceSubgroupProperties.subgroupSize, not a constant.
+           This read 32 until backlog-62 slice 2, and 32 is WRONG on the one
+           discrete GPU this project measures on: radv / Mesa 26.1.4-arch3.1
+           reports 64 for the RX 7900 XTX (RADV NAVI31). It reports 64 for the
+           Raphael iGPU too, so the old value was not right for either local
+           device. A cooperative-matrix fragment is distributed across exactly
+           subgroupSize invocations, so this is ABI, not a statistic. *)
+        warp_size = dev.Vulkan_api.Device.subgroup_size;
         max_registers_per_block = 65536;
         clock_rate_khz = 1000000;
         multiprocessor_count = 1;

--- a/sarek-vulkan/Vulkan_types.ml
+++ b/sarek-vulkan/Vulkan_types.ml
@@ -1096,3 +1096,349 @@ let buffer_copy_dstOffset = field vk_buffer_copy "dstOffset" vk_device_size
 let buffer_copy_size = field vk_buffer_copy "size" vk_device_size
 
 let () = seal vk_buffer_copy
+
+(** {1 Extended feature and property queries (backlog-62 slice 2)}
+
+    Everything below is reached through the [pNext] chains of
+    [VkPhysicalDeviceFeatures2] / [VkPhysicalDeviceProperties2], which is the
+    only way to query [shaderFloat16], [storageBuffer16BitAccess],
+    [cooperativeMatrix], the driver identity and the subgroup size. Both entry
+    points are core Vulkan 1.1, and the instance this backend creates requests
+    API 1.2, so neither needs an instance extension.
+
+    Two rules the structs below obey, and both were arrived at the hard way:
+
+    - Every struct is ZEROED and given its [sType] before the query. A driver
+      that does not recognise an [sType] leaves the struct untouched, so an
+      uninitialised struct would be read as "feature present" on exactly the
+      devices that lack it.
+    - A struct chained into a query must be at least as large as the driver
+      believes it to be. [vk_physical_device_properties] above is a TRUNCATED
+      model (it stops after [deviceName] and pads), so it cannot be embedded in
+      [VkPhysicalDeviceProperties2] by value; the properties2 wrapper below
+      carries an opaque blob sized past the real struct instead. *)
+
+let vk_structure_type_physical_device_features_2 = 1000059000
+
+let vk_structure_type_physical_device_properties_2 = 1000059001
+
+let vk_structure_type_physical_device_shader_float16_int8_features = 1000082000
+
+let vk_structure_type_physical_device_16bit_storage_features = 1000083000
+
+let vk_structure_type_physical_device_subgroup_properties = 1000094000
+
+let vk_structure_type_physical_device_driver_properties = 1000196000
+
+let vk_structure_type_physical_device_cooperative_matrix_features_khr =
+  1000506000
+
+let vk_structure_type_cooperative_matrix_properties_khr = 1000506001
+
+(** [VK_KHR_cooperative_matrix]. The extension NAME is what gates the whole
+    path: see [Vulkan_api_device.probe_coopmat] for the measurement that makes
+    checking it mandatory rather than tidy. *)
+let vk_khr_cooperative_matrix_extension_name = "VK_KHR_cooperative_matrix"
+
+let vk_khr_shader_float16_int8_extension_name = "VK_KHR_shader_float16_int8"
+
+let vk_khr_16bit_storage_extension_name = "VK_KHR_16bit_storage"
+
+(** VkExtensionProperties: [char extensionName[256]] then [uint32 specVersion].
+*)
+type vk_extension_properties
+
+let vk_extension_properties : vk_extension_properties structure typ =
+  structure "VkExtensionProperties"
+
+let ext_props_extensionName =
+  field vk_extension_properties "extensionName" (array 256 char)
+
+let ext_props_specVersion = field vk_extension_properties "specVersion" uint32_t
+
+let () = seal vk_extension_properties
+
+(** VkPhysicalDeviceFeatures2. [features] is embedded BY VALUE, and that is safe
+    here only because {!vk_physical_device_features} is modelled exactly — all
+    55 [VkBool32] and nothing omitted — unlike the properties struct. *)
+type vk_physical_device_features_2
+
+let vk_physical_device_features_2 : vk_physical_device_features_2 structure typ
+    =
+  structure "VkPhysicalDeviceFeatures2"
+
+let features2_sType = field vk_physical_device_features_2 "sType" uint32_t
+
+let features2_pNext = field vk_physical_device_features_2 "pNext" (ptr void)
+
+let features2_features =
+  field vk_physical_device_features_2 "features" vk_physical_device_features
+
+let () = seal vk_physical_device_features_2
+
+(** VkPhysicalDeviceProperties2, with the embedded [VkPhysicalDeviceProperties]
+    modelled as an opaque blob.
+
+    The blob must be at least [sizeof(VkPhysicalDeviceProperties)], because the
+    driver writes the whole thing. That is 4 x uint32 + deviceType +
+    deviceName[256] + pipelineCacheUUID[16] + VkPhysicalDeviceLimits (504) +
+    VkPhysicalDeviceSparseProperties (20) ~= 824 bytes; 1024 is comfortably past
+    it and costs nothing, since exactly one of these is made per device query.
+    An [array _ char] has alignment 1, and the blob's offset (16, after a 4-byte
+    [sType] and an 8-aligned [pNext]) is already 8-aligned, so the layout
+    matches the C struct without a named-field model of the limits. *)
+type vk_physical_device_properties_2
+
+let vk_physical_device_properties_2_blob_bytes = 1024
+
+let vk_physical_device_properties_2 :
+    vk_physical_device_properties_2 structure typ =
+  structure "VkPhysicalDeviceProperties2"
+
+let properties2_sType = field vk_physical_device_properties_2 "sType" uint32_t
+
+let properties2_pNext = field vk_physical_device_properties_2 "pNext" (ptr void)
+
+let properties2_properties =
+  field
+    vk_physical_device_properties_2
+    "properties"
+    (array vk_physical_device_properties_2_blob_bytes char)
+
+let () = seal vk_physical_device_properties_2
+
+(** VkPhysicalDeviceShaderFloat16Int8Features *)
+type vk_physical_device_shader_float16_int8_features
+
+let vk_physical_device_shader_float16_int8_features :
+    vk_physical_device_shader_float16_int8_features structure typ =
+  structure "VkPhysicalDeviceShaderFloat16Int8Features"
+
+let f16i8_sType =
+  field vk_physical_device_shader_float16_int8_features "sType" uint32_t
+
+let f16i8_pNext =
+  field vk_physical_device_shader_float16_int8_features "pNext" (ptr void)
+
+let f16i8_shaderFloat16 =
+  field vk_physical_device_shader_float16_int8_features "shaderFloat16" uint32_t
+
+let f16i8_shaderInt8 =
+  field vk_physical_device_shader_float16_int8_features "shaderInt8" uint32_t
+
+let () = seal vk_physical_device_shader_float16_int8_features
+
+(** VkPhysicalDevice16BitStorageFeatures *)
+type vk_physical_device_16bit_storage_features
+
+let vk_physical_device_16bit_storage_features :
+    vk_physical_device_16bit_storage_features structure typ =
+  structure "VkPhysicalDevice16BitStorageFeatures"
+
+let storage16_sType =
+  field vk_physical_device_16bit_storage_features "sType" uint32_t
+
+let storage16_pNext =
+  field vk_physical_device_16bit_storage_features "pNext" (ptr void)
+
+let storage16_storageBuffer16BitAccess =
+  field
+    vk_physical_device_16bit_storage_features
+    "storageBuffer16BitAccess"
+    uint32_t
+
+let storage16_uniformAndStorageBuffer16BitAccess =
+  field
+    vk_physical_device_16bit_storage_features
+    "uniformAndStorageBuffer16BitAccess"
+    uint32_t
+
+let storage16_storagePushConstant16 =
+  field
+    vk_physical_device_16bit_storage_features
+    "storagePushConstant16"
+    uint32_t
+
+let storage16_storageInputOutput16 =
+  field
+    vk_physical_device_16bit_storage_features
+    "storageInputOutput16"
+    uint32_t
+
+let () = seal vk_physical_device_16bit_storage_features
+
+(** VkPhysicalDeviceCooperativeMatrixFeaturesKHR *)
+type vk_physical_device_cooperative_matrix_features
+
+let vk_physical_device_cooperative_matrix_features :
+    vk_physical_device_cooperative_matrix_features structure typ =
+  structure "VkPhysicalDeviceCooperativeMatrixFeaturesKHR"
+
+let coopmat_feat_sType =
+  field vk_physical_device_cooperative_matrix_features "sType" uint32_t
+
+let coopmat_feat_pNext =
+  field vk_physical_device_cooperative_matrix_features "pNext" (ptr void)
+
+let coopmat_feat_cooperativeMatrix =
+  field
+    vk_physical_device_cooperative_matrix_features
+    "cooperativeMatrix"
+    uint32_t
+
+let coopmat_feat_robustBufferAccess =
+  field
+    vk_physical_device_cooperative_matrix_features
+    "cooperativeMatrixRobustBufferAccess"
+    uint32_t
+
+let () = seal vk_physical_device_cooperative_matrix_features
+
+(** VkPhysicalDeviceSubgroupProperties. [subgroupSize] is the one field this
+    backend reads, and it replaces a hard-coded 32 in [Vulkan_plugin_base]. *)
+type vk_physical_device_subgroup_properties
+
+let vk_physical_device_subgroup_properties :
+    vk_physical_device_subgroup_properties structure typ =
+  structure "VkPhysicalDeviceSubgroupProperties"
+
+let subgroup_props_sType =
+  field vk_physical_device_subgroup_properties "sType" uint32_t
+
+let subgroup_props_pNext =
+  field vk_physical_device_subgroup_properties "pNext" (ptr void)
+
+let subgroup_props_subgroupSize =
+  field vk_physical_device_subgroup_properties "subgroupSize" uint32_t
+
+let subgroup_props_supportedStages =
+  field vk_physical_device_subgroup_properties "supportedStages" uint32_t
+
+let subgroup_props_supportedOperations =
+  field vk_physical_device_subgroup_properties "supportedOperations" uint32_t
+
+let subgroup_props_quadOperationsInAllStages =
+  field
+    vk_physical_device_subgroup_properties
+    "quadOperationsInAllStages"
+    uint32_t
+
+let () = seal vk_physical_device_subgroup_properties
+
+(** VkPhysicalDeviceDriverProperties. This is the driver KEY that
+    docs/fp-contraction-policy.md §11.7 asks for: [driverID] is an enumerant (3
+    = [VK_DRIVER_ID_MESA_RADV]), and [driverInfo] carries the Mesa version
+    string, so an allowlist can be keyed on a driver rather than on a substring
+    of a device name. *)
+type vk_physical_device_driver_properties
+
+let vk_physical_device_driver_properties :
+    vk_physical_device_driver_properties structure typ =
+  structure "VkPhysicalDeviceDriverProperties"
+
+let driver_props_sType =
+  field vk_physical_device_driver_properties "sType" uint32_t
+
+let driver_props_pNext =
+  field vk_physical_device_driver_properties "pNext" (ptr void)
+
+let driver_props_driverID =
+  field vk_physical_device_driver_properties "driverID" uint32_t
+
+let driver_props_driverName =
+  field vk_physical_device_driver_properties "driverName" (array 256 char)
+
+let driver_props_driverInfo =
+  field vk_physical_device_driver_properties "driverInfo" (array 256 char)
+
+let driver_props_conformanceVersion =
+  field
+    vk_physical_device_driver_properties
+    "conformanceVersion"
+    (array 4 uint8_t)
+
+let () = seal vk_physical_device_driver_properties
+
+(** VkCooperativeMatrixPropertiesKHR — one advertised configuration.
+
+    [AType]/[BType]/[CType]/[ResultType] are [VkComponentTypeKHR] and [scope] is
+    [VkScopeKHR]; both are C enums, hence [int32_t]. The enumerant values used
+    by {!Vulkan_api_device} are the ones in the probe: f16 = 3, f32 = 4, s8 = 7,
+    s32 = 9, u8 = 0, u32 = 1; subgroup scope = 3. *)
+type vk_cooperative_matrix_properties
+
+let vk_cooperative_matrix_properties :
+    vk_cooperative_matrix_properties structure typ =
+  structure "VkCooperativeMatrixPropertiesKHR"
+
+let coopmat_props_sType =
+  field vk_cooperative_matrix_properties "sType" uint32_t
+
+let coopmat_props_pNext =
+  field vk_cooperative_matrix_properties "pNext" (ptr void)
+
+let coopmat_props_MSize =
+  field vk_cooperative_matrix_properties "MSize" uint32_t
+
+let coopmat_props_NSize =
+  field vk_cooperative_matrix_properties "NSize" uint32_t
+
+let coopmat_props_KSize =
+  field vk_cooperative_matrix_properties "KSize" uint32_t
+
+let coopmat_props_AType = field vk_cooperative_matrix_properties "AType" int32_t
+
+let coopmat_props_BType = field vk_cooperative_matrix_properties "BType" int32_t
+
+let coopmat_props_CType = field vk_cooperative_matrix_properties "CType" int32_t
+
+let coopmat_props_ResultType =
+  field vk_cooperative_matrix_properties "ResultType" int32_t
+
+let coopmat_props_saturatingAccumulation =
+  field vk_cooperative_matrix_properties "saturatingAccumulation" uint32_t
+
+let coopmat_props_scope = field vk_cooperative_matrix_properties "scope" int32_t
+
+let () = seal vk_cooperative_matrix_properties
+
+(** {2 VkComponentTypeKHR and VkScopeKHR enumerants}
+
+    Verbatim from Khronos [vulkan_core.h]. These are NOT in a memorable order —
+    the float types come first and the integer types are interleaved by width
+    rather than by signedness — and an earlier draft of this file guessed them
+    wrong in a way that produced entirely plausible garbage: [f16 * s8 -> s32]
+    and [u8 * u8 -> u8] configurations that no hardware advertises, with eight
+    of the fourteen real ones silently dropped as unrepresentable. Nothing about
+    the resulting values looked malformed. They are pinned by
+    [test_vulkan_coopmat_enumerants] against the same source. *)
+
+let vk_component_type_float16 = 0l
+
+let vk_component_type_float32 = 1l
+
+let vk_component_type_float64 = 2l
+
+let vk_component_type_sint8 = 3l
+
+let vk_component_type_sint16 = 4l
+
+let vk_component_type_sint32 = 5l
+
+let vk_component_type_sint64 = 6l
+
+let vk_component_type_uint8 = 7l
+
+let vk_component_type_uint16 = 8l
+
+let vk_component_type_uint32 = 9l
+
+let vk_component_type_uint64 = 10l
+
+let vk_scope_device = 1l
+
+let vk_scope_workgroup = 2l
+
+let vk_scope_subgroup = 3l
+
+let vk_scope_queue_family = 5l

--- a/sarek-vulkan/Vulkan_types.ml
+++ b/sarek-vulkan/Vulkan_types.ml
@@ -1362,9 +1362,16 @@ let () = seal vk_physical_device_driver_properties
 (** VkCooperativeMatrixPropertiesKHR — one advertised configuration.
 
     [AType]/[BType]/[CType]/[ResultType] are [VkComponentTypeKHR] and [scope] is
-    [VkScopeKHR]; both are C enums, hence [int32_t]. The enumerant values used
-    by {!Vulkan_api_device} are the ones in the probe: f16 = 3, f32 = 4, s8 = 7,
-    s32 = 9, u8 = 0, u32 = 1; subgroup scope = 3. *)
+    [VkScopeKHR]; both are C enums, hence [int32_t]. For the enumerant values,
+    read the constants below — NOT a restatement here.
+
+    There was a restatement here, and it was wrong (f16 = 3, f32 = 4, s8 = 7,
+    s32 = 9, u8 = 0, u32 = 1: the correct values rotated), in the one file whose
+    entire narrative is a wrong enumerant table producing plausible garbage. It
+    survived because [test_vulkan_coopmat_enumerants] pins the CONSTANTS and
+    nothing pins the PROSE — the same asymmetry, one layer up. Hence no second
+    copy of the numbers: a comment that cannot disagree with the code is the
+    only kind worth having here. *)
 type vk_cooperative_matrix_properties
 
 let vk_cooperative_matrix_properties :

--- a/sarek-vulkan/test/dune
+++ b/sarek-vulkan/test/dune
@@ -34,3 +34,8 @@
  (name test_vulkan_f16_tripwire)
  (modules test_vulkan_f16_tripwire)
  (libraries sarek_vulkan spoc_framework alcotest))
+
+(test
+ (name test_vulkan_coopmat_capability)
+ (modules test_vulkan_coopmat_capability)
+ (libraries sarek_vulkan spoc_framework sarek_ir alcotest str))

--- a/sarek-vulkan/test/test_vulkan_coopmat_capability.ml
+++ b/sarek-vulkan/test/test_vulkan_coopmat_capability.ml
@@ -232,6 +232,17 @@ let test_subgroup_size_is_reported () =
             (Printf.sprintf "device %d subgroup size is positive" i)
             true
             (sg > 0) ;
+          (* Positive is not enough: [Vulkan_api_device] guarantees positivity
+             by falling back to 32 when the query comes back unwritten, so a
+             device could pass the check above while reporting nothing. Both
+             local devices DO report, and this is what stops the fallback from
+             becoming the silent normal — see fallback_subgroup_size. *)
+          Alcotest.(check bool)
+            (Printf.sprintf
+               "device %d subgroup size is a measurement, not the fallback"
+               i)
+            true
+            dev.Vulkan_api_device.subgroup_size_probed ;
           Alcotest.(check int)
             (Printf.sprintf
                "device %d: warp_size is the probed subgroupSize, not a constant"

--- a/sarek-vulkan/test/test_vulkan_coopmat_capability.ml
+++ b/sarek-vulkan/test/test_vulkan_coopmat_capability.ml
@@ -1,0 +1,424 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-62 slice 2 — the cooperative-matrix capability gate, on real devices.
+ *
+ * WHAT THIS TEST IS FOR.
+ *
+ * docs/design/capability-model.md classifies cooperative matrices as
+ * [Device_optional]: the backend can spell the instruction, a given device may
+ * not provide it. A capability gate that has never been observed REFUSING is
+ * not known to work — it is indistinguishable from a function that returns
+ * Available unconditionally. This machine has a free negative device: the
+ * Raphael iGPU does not advertise VK_KHR_cooperative_matrix while the RX 7900
+ * XTX does, under the same radv / Mesa build, so both branches are reachable
+ * without a second machine (docs/design/f16-relaxed-accuracy.md §4).
+ *
+ * So this file does not assert "coopmat works". It asserts that the gate
+ * SEPARATES: on a machine with more than one Vulkan device, if the devices
+ * disagree about support then the verdict must disagree with them in the same
+ * direction, and the refusing device must produce a diagnostic that names the
+ * capability and the device.
+ *
+ * WHY IT ALSO CHECKS THE EXTENSION AND NOT ONLY THE CONFIGURATION LIST.
+ *
+ * Measured on this workstation, and it is the reason [probe_coopmat] is shaped
+ * the way it is: vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR returns
+ * VK_SUCCESS and FOURTEEN configurations for the Raphael iGPU — a device that
+ * does not advertise the extension and reports cooperativeMatrix = false.
+ * Calling an extension entry point on a device that lacks the extension is
+ * undefined behaviour, and RADV's undefined behaviour here is a well-formed,
+ * plausible, entirely wrong answer. A probe that trusted the query would have
+ * reported the iGPU as capable and this gate would never refuse anything.
+ *
+ * It skips (does not fail) where there is no Vulkan device, and degrades to the
+ * checks that are still meaningful where every device happens to agree.
+ ******************************************************************************)
+
+open Sarek_vulkan
+
+let device_report i =
+  let dev = Vulkan_api_device.get i in
+  let caps = Vulkan_plugin_base.Vulkan.Device.capabilities dev in
+  (i, dev, caps)
+
+let f16_f32_16x16x16 =
+  {
+    Sarek_coopmat.cfg_shape = {Sarek_coopmat.m = 16; n = 16; k = 16};
+    cfg_a = Sarek_coopmat.Float16;
+    cfg_b = Sarek_coopmat.Float16;
+    cfg_c = Sarek_coopmat.Float32;
+    cfg_result = Sarek_coopmat.Float32;
+    cfg_saturating = false;
+    cfg_scope = Sarek_coopmat.Subgroup;
+  }
+
+let contains needle haystack =
+  let re = Str.regexp_string needle in
+  try
+    ignore (Str.search_forward re haystack 0) ;
+    true
+  with Not_found -> false
+
+let with_devices f =
+  if not (Vulkan_api.is_available ()) then begin
+    Printf.printf "[SKIP] No Vulkan loader available\n%!" ;
+    Alcotest.skip ()
+  end
+  else
+    let n = try Vulkan_api_device.count () with _ -> 0 in
+    if n = 0 then begin
+      Printf.printf "[SKIP] No Vulkan physical device\n%!" ;
+      Alcotest.skip ()
+    end
+    else f (List.init n device_report)
+
+(* The VkComponentTypeKHR / VkScopeKHR enumerants, pinned against Khronos
+   vulkan_core.h.
+
+   This is a value-for-value restatement rather than a derived check, and it
+   earns its place: an earlier draft of Vulkan_types guessed these and produced
+   a completely plausible wrong answer — six configurations instead of fourteen,
+   including an [f16 * s8 -> s32] and a [u8 * u8 -> u8] that no hardware
+   advertises, with the other eight dropped as unrepresentable. Nothing in the
+   output looked malformed, and the gate test below still passed, because it
+   compared the verdict against the SAME mis-decoded list. Two independent
+   checks were needed: this one, and the no-drop invariant in
+   [test_no_configuration_was_dropped]. *)
+let test_enumerant_values () =
+  List.iter
+    (fun (name, actual, expected) ->
+      Alcotest.(check int32) name expected actual)
+    [
+      ( "VK_COMPONENT_TYPE_FLOAT16_KHR",
+        Vulkan_types.vk_component_type_float16,
+        0l );
+      ( "VK_COMPONENT_TYPE_FLOAT32_KHR",
+        Vulkan_types.vk_component_type_float32,
+        1l );
+      ( "VK_COMPONENT_TYPE_FLOAT64_KHR",
+        Vulkan_types.vk_component_type_float64,
+        2l );
+      ("VK_COMPONENT_TYPE_SINT8_KHR", Vulkan_types.vk_component_type_sint8, 3l);
+      ("VK_COMPONENT_TYPE_SINT16_KHR", Vulkan_types.vk_component_type_sint16, 4l);
+      ("VK_COMPONENT_TYPE_SINT32_KHR", Vulkan_types.vk_component_type_sint32, 5l);
+      ("VK_COMPONENT_TYPE_SINT64_KHR", Vulkan_types.vk_component_type_sint64, 6l);
+      ("VK_COMPONENT_TYPE_UINT8_KHR", Vulkan_types.vk_component_type_uint8, 7l);
+      ("VK_COMPONENT_TYPE_UINT16_KHR", Vulkan_types.vk_component_type_uint16, 8l);
+      ("VK_COMPONENT_TYPE_UINT32_KHR", Vulkan_types.vk_component_type_uint32, 9l);
+      ( "VK_COMPONENT_TYPE_UINT64_KHR",
+        Vulkan_types.vk_component_type_uint64,
+        10l );
+      ("VK_SCOPE_DEVICE_KHR", Vulkan_types.vk_scope_device, 1l);
+      ("VK_SCOPE_WORKGROUP_KHR", Vulkan_types.vk_scope_workgroup, 2l);
+      ("VK_SCOPE_SUBGROUP_KHR", Vulkan_types.vk_scope_subgroup, 3l);
+      ("VK_SCOPE_QUEUE_FAMILY_KHR", Vulkan_types.vk_scope_queue_family, 5l);
+    ]
+
+(* The no-drop invariant, and the reason [ds_advertised_count] exists.
+
+   Dropping a configuration whose component type or scope this build cannot
+   represent is the SAFE direction — it can only cause a refusal — but it is
+   silent, and silence is what let a wrong enumerant table look like a working
+   probe. This check is hardware-independent: it makes no claim about which
+   configurations any GPU offers, only that none of the ones it offered was
+   thrown away. It goes red on exactly the defect that the gate test could not
+   see. *)
+let test_no_configuration_was_dropped () =
+  with_devices (fun devs ->
+      List.iter
+        (fun (i, dev, caps) ->
+          match caps.Spoc_framework.Framework_sig.coopmat with
+          | None -> ()
+          | Some s ->
+              let kept = List.length s.Sarek_coopmat.ds_configs in
+              if kept <> s.Sarek_coopmat.ds_advertised_count then
+                Alcotest.failf
+                  "device %d (%s) advertised %d cooperative-matrix \
+                   configurations but only %d were representable: %d were \
+                   dropped, which means the VkComponentTypeKHR/VkScopeKHR \
+                   decoding in Vulkan_types is incomplete or wrong"
+                  i
+                  dev.Vulkan_api_device.name
+                  s.Sarek_coopmat.ds_advertised_count
+                  kept
+                  (s.Sarek_coopmat.ds_advertised_count - kept))
+        devs)
+
+(* The implication that makes the extension check falsifiable:
+     a device reporting cooperative-matrix configurations must have had the
+     extension advertised AND the feature true.
+
+   Without this, removing the extension gate from [probe_coopmat] is INVISIBLE.
+   Verified by mutation on 2026-07-27: replacing the guard with [if false && ...]
+   made the Raphael iGPU report all fourteen configurations, both devices
+   permitted, and the whole file stayed green — because [test_verdict_tracks_support]
+   compares the verdict against the same list the verdict reads, which is a
+   tautology whenever the list is wrong. This test goes red on that mutant, and
+   is the reason [coopmat_enabled] is recorded on the device rather than derived
+   from the configuration list. *)
+let test_configurations_imply_the_enabled_feature () =
+  with_devices (fun devs ->
+      List.iter
+        (fun (i, dev, caps) ->
+          match caps.Spoc_framework.Framework_sig.coopmat with
+          | None -> ()
+          | Some s ->
+              let n = List.length s.Sarek_coopmat.ds_configs in
+              if n > 0 && not dev.Vulkan_api_device.coopmat_enabled then
+                Alcotest.failf
+                  "device %d (%s) reports %d cooperative-matrix configurations \
+                   but the extension/feature were not enabled (advertised=%b): \
+                   the configuration query answers even for devices that lack \
+                   the extension, so this list is not evidence of support"
+                  i
+                  dev.Vulkan_api_device.name
+                  n
+                  dev.Vulkan_api_device.coopmat_extension_advertised ;
+              if dev.Vulkan_api_device.coopmat_enabled && n = 0 then
+                Alcotest.failf
+                  "device %d (%s) enabled cooperative matrices but advertises \
+                   no configuration, which no driver should do"
+                  i
+                  dev.Vulkan_api_device.name)
+        devs)
+
+(* Every device must come back PROBED. [None] means the loader could not
+   resolve the entry point at all, which is a legitimate outcome on an old
+   loader but not on any machine that can run the rest of this backend — and it
+   is the outcome that would make every verdict below vacuously refuse. Failing
+   here is what stops this file from passing green while measuring nothing. *)
+let test_every_device_is_probed () =
+  with_devices (fun devs ->
+      List.iter
+        (fun (i, dev, caps) ->
+          match caps.Spoc_framework.Framework_sig.coopmat with
+          | None ->
+              Alcotest.failf
+                "device %d (%s) reports coopmat = None: the probe did not run, \
+                 so every verdict below would refuse for the wrong reason"
+                i
+                dev.Vulkan_api_device.name
+          | Some support ->
+              Printf.printf
+                "  device %d: %s [driverID=%d %s / %s] subgroupSize=%d \
+                 shaderFloat16=%b storageBuffer16=%b coopmat_configs=%d \
+                 robust=%b\n\
+                 %!"
+                i
+                dev.Vulkan_api_device.name
+                dev.Vulkan_api_device.driver_id
+                dev.Vulkan_api_device.driver_name
+                dev.Vulkan_api_device.driver_info
+                support.Sarek_coopmat.ds_subgroup_size
+                dev.Vulkan_api_device.supports_fp16
+                dev.Vulkan_api_device.storage_buffer_16bit
+                (List.length support.Sarek_coopmat.ds_configs)
+                support.Sarek_coopmat.ds_robust_buffer_access)
+        devs)
+
+(* The subgroup size must be what the device reports, and it must be usable as
+   an ABI number. A zero would divide nothing; a value the plugin invented
+   would silently mis-size every fragment. *)
+let test_subgroup_size_is_reported () =
+  with_devices (fun devs ->
+      List.iter
+        (fun (i, dev, caps) ->
+          let sg = caps.Spoc_framework.Framework_sig.warp_size in
+          Alcotest.(check bool)
+            (Printf.sprintf "device %d subgroup size is positive" i)
+            true
+            (sg > 0) ;
+          Alcotest.(check int)
+            (Printf.sprintf
+               "device %d: warp_size is the probed subgroupSize, not a constant"
+               i)
+            dev.Vulkan_api_device.subgroup_size
+            sg ;
+          match caps.Spoc_framework.Framework_sig.coopmat with
+          | Some s ->
+              Alcotest.(check int)
+                "and the coopmat record carries the same number"
+                sg
+                s.Sarek_coopmat.ds_subgroup_size
+          | None -> ())
+        devs)
+
+(* The driver key of docs/fp-contraction-policy.md §11.7: a non-empty driver
+   name, so an allowlist can be keyed on the driver rather than on a substring
+   of a device name. *)
+let test_driver_identity_is_available () =
+  with_devices (fun devs ->
+      List.iter
+        (fun (i, dev, _) ->
+          Alcotest.(check bool)
+            (Printf.sprintf "device %d has a driver name" i)
+            true
+            (String.length dev.Vulkan_api_device.driver_name > 0))
+        devs)
+
+(* The gate itself. *)
+let test_verdict_tracks_support () =
+  with_devices (fun devs ->
+      let refusing = ref [] and permitting = ref [] in
+      List.iter
+        (fun (i, dev, caps) ->
+          let support = caps.Spoc_framework.Framework_sig.coopmat in
+          let v = Sarek_coopmat.verdict ~support f16_f32_16x16x16 in
+          let advertises =
+            match support with
+            | Some s ->
+                List.exists
+                  (fun c -> c = f16_f32_16x16x16)
+                  s.Sarek_coopmat.ds_configs
+            | None -> false
+          in
+          Alcotest.(check bool)
+            (Printf.sprintf
+               "device %d (%s): verdict agrees with what the device advertises"
+               i
+               dev.Vulkan_api_device.name)
+            advertises
+            (Sarek_capability.permits v) ;
+          if Sarek_capability.permits v then
+            permitting := (i, dev.Vulkan_api_device.name) :: !permitting
+          else begin
+            refusing := (i, dev.Vulkan_api_device.name) :: !refusing ;
+            (* A refusal must be attributable. An unnamed refusal is the
+               failure mode docs/design/capability-model.md exists to remove. *)
+            match v with
+            | Sarek_capability.Unavailable cap ->
+                let msg =
+                  Sarek_capability.explain
+                    ~target:dev.Vulkan_api_device.name
+                    cap
+                in
+                Printf.printf "  REFUSED: %s\n%!" msg ;
+                Alcotest.(check string)
+                  "the refusal names the capability"
+                  "cooperative-matrix"
+                  cap.Sarek_capability.cap_name ;
+                Alcotest.(check string)
+                  "and classifies it as Device_optional"
+                  "device-optional"
+                  (Sarek_capability.kind_name cap.Sarek_capability.cap_kind) ;
+                Alcotest.(check bool)
+                  "and names the device"
+                  true
+                  (contains dev.Vulkan_api_device.name msg)
+            | Sarek_capability.Unknown why ->
+                Alcotest.failf
+                  "device %d was probed, so its verdict must be Unavailable \
+                   rather than Unknown: %s"
+                  i
+                  why
+            | Sarek_capability.Available -> assert false
+          end)
+        devs ;
+      Printf.printf
+        "  gate observed: %d device(s) permitted, %d refused\n%!"
+        (List.length !permitting)
+        (List.length !refusing) ;
+      if !refusing = [] then
+        Printf.printf
+          "  [NOTE] every Vulkan device on this machine advertises the \
+           configuration, so the refusing branch was not exercised here. The \
+           deterministic refusal cases are in \
+           spoc/ir/test/test_sarek_coopmat.ml.\n\
+           %!")
+
+(* The consistency rule that turns the two device reports into one claim: a
+   device advertising configurations must have the extension AND the feature,
+   and a device with neither must advertise none. This is what would go red if
+   [probe_coopmat] ever stopped gating the query on the extension, because the
+   iGPU would then come back with fourteen configurations while its
+   cooperativeMatrix feature still read false. *)
+let test_configurations_imply_the_feature () =
+  with_devices (fun devs ->
+      List.iter
+        (fun (i, dev, caps) ->
+          match caps.Spoc_framework.Framework_sig.coopmat with
+          | None -> ()
+          | Some s ->
+              let n = List.length s.Sarek_coopmat.ds_configs in
+              if n > 0 then begin
+                (* Every advertised configuration must be layout-able over the
+                   subgroup the same device reports, or the pair of numbers is
+                   incoherent and no codegen slice could use them together. *)
+                List.iter
+                  (fun c ->
+                    Alcotest.(check bool)
+                      (Printf.sprintf
+                         "device %d: %s fits a %d-wide subgroup"
+                         i
+                         (Sarek_coopmat.config_name c)
+                         s.Sarek_coopmat.ds_subgroup_size)
+                      true
+                      (Sarek_coopmat.config_fits_subgroup
+                         ~subgroup_size:s.Sarek_coopmat.ds_subgroup_size
+                         c))
+                  s.Sarek_coopmat.ds_configs ;
+                (* And the strict/relaxed split must be computable, with at
+                   least one strict-contract configuration wherever any
+                   configuration exists — that is §8's fallback, and if it ever
+                   becomes false on real hardware the fallback is gone. *)
+                let exact =
+                  List.filter
+                    Sarek_coopmat.accumulation_is_exact
+                    s.Sarek_coopmat.ds_configs
+                in
+                Printf.printf
+                  "  device %d (%s): %d configurations, %d accumulate exactly \
+                   (strict contract)\n\
+                   %!"
+                  i
+                  dev.Vulkan_api_device.name
+                  n
+                  (List.length exact)
+              end)
+        devs)
+
+let () =
+  let open Alcotest in
+  run
+    "Vulkan cooperative-matrix capability"
+    [
+      ( "probe",
+        [
+          test_case "every device is probed" `Quick test_every_device_is_probed;
+          test_case
+            "subgroup size is reported, not assumed"
+            `Quick
+            test_subgroup_size_is_reported;
+          test_case
+            "driver identity is available"
+            `Quick
+            test_driver_identity_is_available;
+          test_case
+            "enumerants match vulkan_core.h"
+            `Quick
+            test_enumerant_values;
+          test_case
+            "no advertised configuration was dropped"
+            `Quick
+            test_no_configuration_was_dropped;
+          test_case
+            "configurations imply the enabled feature"
+            `Quick
+            test_configurations_imply_the_enabled_feature;
+        ] );
+      ( "gate",
+        [
+          test_case
+            "verdict tracks what the device advertises"
+            `Quick
+            test_verdict_tracks_support;
+          test_case
+            "advertised configurations are coherent"
+            `Quick
+            test_configurations_imply_the_feature;
+        ] );
+    ]

--- a/sarek-vulkan/test/test_vulkan_f16_tripwire.ml
+++ b/sarek-vulkan/test/test_vulkan_f16_tripwire.ml
@@ -431,10 +431,11 @@ let obsolete_refusal_message device n =
      re-measure the two-narrowing shapes too — this case covers only the \
      single narrowing, and the two-narrowing shape failed WORSE (5075/63488), \
      (3) record the new measurement in docs/fp-contraction-policy.md, (4) \
-     build the shaderFloat16 device-feature plumbing, which Sarek's Vulkan \
-     device creation still lacks, (5) enable f16 in Sarek_ir_glsl behind the \
-     usual exhaustive interpreter-agreement gate, and (6) delete this test as \
-     part of THAT change, not before it."
+     enable f16 in Sarek_ir_glsl behind the usual exhaustive \
+     interpreter-agreement gate, and (5) delete this test as part of THAT \
+     change, not before it. The shaderFloat16 device-feature plumbing this \
+     step used to call for was built in backlog-62 slice 2 and is no longer \
+     outstanding."
     device
     n
 

--- a/sarek-vulkan/test/test_vulkan_f16_tripwire.ml
+++ b/sarek-vulkan/test/test_vulkan_f16_tripwire.ml
@@ -56,18 +56,26 @@
  *      about ACO and not about a broken buffer layout, a broken pack/unpack, or
  *      the Float16 caveat in the next paragraph.
  *
- * ONE HONEST CAVEAT ABOUT HOW THESE SHADERS RUN.
+ * A CAVEAT THAT WAS HONEST AND HAS NOW BEEN RETIRED BY MEASUREMENT.
  *
  * Vulkan requires the [shaderFloat16] feature to be enabled at device creation
- * before a shader may use the SPIR-V Float16 capability. Sarek's Vulkan device
- * creation chains no feature structs beyond core VkPhysicalDeviceFeatures, so
- * that feature is NOT enabled; RADV accepts these shaders anyway. That plumbing
- * is part of what enabling f16 on this backend would have to build, and it is
- * listed as still-open in docs/fp-contraction-policy.md. It does not weaken the
- * finding: the defect is visible in the emitted ISA (run this executable under
- * RADV_DEBUG=asm to see v_fma_mixlo_f16 for the plain variant and a separate
- * conversion for the barriered one), and control 3 above shows the same
- * un-enabled path producing bit-exact agreement when the fusion is defeated.
+ * before a shader may use the SPIR-V Float16 capability, and until backlog-62
+ * slice 2 Sarek chained no feature structs beyond core
+ * VkPhysicalDeviceFeatures — so these shaders ran on a path where the feature
+ * was never requested, and RADV accepted them anyway. [Vulkan_api_device] now
+ * queries VkPhysicalDeviceShaderFloat16Int8Features through the Features2 chain
+ * and REQUESTS shaderFloat16 (and storageBuffer16BitAccess) at vkCreateDevice.
+ *
+ * The numbers below did not move. Run as a controlled A/B on 2026-07-27 — one
+ * build, the feature request toggled, this executable run on each arm — both
+ * arms report 2912/63488 on the RX 7900 XTX AND on the Raphael iGPU, with the
+ * same first divergence (x = 8.94069672e-07, device 0x0011, discipline 0x0010),
+ * the same `precise` figures, and all three calibration controls green. So the
+ * caveat named a real gap in the plumbing but not a confound in the
+ * measurement: ACO's absorption of the f32->f16 narrowing does not depend on
+ * whether the feature was requested. The defect remains visible in the emitted
+ * ISA too (run this executable under RADV_DEBUG=asm to see v_fma_mixlo_f16 for
+ * the plain variant and a separate conversion for the barriered one).
  ******************************************************************************)
 
 open Sarek_vulkan

--- a/sarek/core/test/test_device.ml
+++ b/sarek/core/test/test_device.ml
@@ -31,6 +31,10 @@ let make_fake_caps ?(is_cpu = false) ?(supports_fp64 = true)
     device_features =
       ((if supports_fp64 then [Sarek_ir_analysis.Float64] else [])
       @ if supports_int64 then [Sarek_ir_analysis.Int64] else []);
+    (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+       "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+       refuses; an empty list would be a positive claim nobody measured. *)
+    coopmat = None;
     supports_atomics;
     warp_size;
     max_registers_per_block = 16384;

--- a/sarek/core/test/test_kernel.ml
+++ b/sarek/core/test/test_kernel.ml
@@ -20,6 +20,10 @@ let make_fake_caps () : Spoc_framework.Framework_sig.capabilities =
     total_global_mem = 1073741824L;
     compute_capability = (0, 0);
     device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+    (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+       "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+       refuses; an empty list would be a positive claim nobody measured. *)
+    coopmat = None;
     supports_atomics = true;
     warp_size = 32;
     max_registers_per_block = 16384;

--- a/sarek/core/test/test_memory.ml
+++ b/sarek/core/test/test_memory.ml
@@ -22,6 +22,10 @@ let make_fake_caps () : Spoc_framework.Framework_sig.capabilities =
     total_global_mem = 1073741824L;
     compute_capability = (0, 0);
     device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+    (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+       "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+       refuses; an empty list would be a positive claim nobody measured. *)
+    coopmat = None;
     supports_atomics = true;
     warp_size = 32;
     max_registers_per_block = 16384;

--- a/sarek/core/test/test_vector_transfer.ml
+++ b/sarek/core/test/test_vector_transfer.ml
@@ -20,6 +20,10 @@ let make_caps () : Spoc_framework.Framework_sig.capabilities =
     total_global_mem = 1073741824L;
     compute_capability = (0, 0);
     device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+    (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+       "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+       refuses; an empty list would be a positive claim nobody measured. *)
+    coopmat = None;
     supports_atomics = true;
     warp_size = 32;
     max_registers_per_block = 16384;

--- a/sarek/execute/jsoo/smoke.ml
+++ b/sarek/execute/jsoo/smoke.ml
@@ -32,6 +32,10 @@ let () =
         {
           is_cpu = true;
           device_features = [];
+          (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+             "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+             refuses; an empty list would be a positive claim nobody measured. *)
+          coopmat = None;
           supports_atomics = false;
           compute_capability = (0, 0);
           max_threads_per_block = 1;

--- a/sarek/framework/test/dummy_backend.ml
+++ b/sarek/framework/test/dummy_backend.ml
@@ -86,6 +86,10 @@ module Dummy_backend : BACKEND = struct
         (* 1GB *)
         compute_capability = (0, 0);
         device_features = [];
+        (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+           "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+           refuses; an empty list would be a positive claim nobody measured. *)
+        coopmat = None;
         supports_atomics = false;
         warp_size = 1;
         max_registers_per_block = 0;

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -218,6 +218,10 @@ end = struct
         compute_capability = (0, 0);
         (* Host execution: OCaml floats are binary64 and Int64.t is native. *)
         device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+        (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+           "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+           refuses; an empty list would be a positive claim nobody measured. *)
+        coopmat = None;
         supports_atomics = true;
         warp_size = (if d.parallel then 32 else 1);
         max_registers_per_block = 0;

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -227,6 +227,10 @@ end = struct
         (* Native has no compute capability *)
         (* Host execution: OCaml floats are binary64 and Int64.t is native. *)
         device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+        (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+           "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+           refuses; an empty list would be a positive claim nobody measured. *)
+        coopmat = None;
         supports_atomics = true;
         warp_size = 1;
         max_registers_per_block = 0;

--- a/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
+++ b/sarek/tests/e2e/test_cpu_opencl_known_issue.ml
@@ -38,6 +38,10 @@ let caps ~is_cpu : Spoc_framework.Framework_sig.capabilities =
     total_global_mem = 1073741824L;
     compute_capability = (0, 0);
     device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+    (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+       "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+       refuses; an empty list would be a positive claim nobody measured. *)
+    coopmat = None;
     supports_atomics = true;
     warp_size = 32;
     max_registers_per_block = 0;

--- a/sarek/tests/unit/test_execute.ml
+++ b/sarek/tests/unit/test_execute.ml
@@ -180,6 +180,10 @@ let caps_with (features : Sarek_ir_analysis.feature list) :
     total_global_mem = 1073741824L;
     compute_capability = (0, 0);
     device_features = features;
+    (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+       "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+       refuses; an empty list would be a positive claim nobody measured. *)
+    coopmat = None;
     supports_atomics = true;
     warp_size = 32;
     max_registers_per_block = 16384;

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -50,8 +50,31 @@ type capabilities = {
           [Spoc_core.Device.allows_fp64] and [allows_int64] are the derived
           accessors, so this stays the single source and the two cannot drift.
       *)
+  coopmat : Sarek_coopmat.device_support option;
+      (** The cooperative-matrix (tensor-core) configurations this DEVICE
+          advertises, or [None] when the backend does not probe for them
+          (backlog-62 slice 2).
+
+          An OPTION rather than a plain list, for the same reason
+          {!Sarek_capability.device_verdict} takes one: an empty list and an
+          unprobed device are different facts, and collapsing them makes
+          "advertises nothing" indistinguishable from "nobody asked". Only the
+          first is evidence. {!Sarek_coopmat.verdict} maps [None] to
+          {!Sarek_capability.Unknown}, which does not permit.
+
+          Read it through {!Sarek_coopmat.verdict} or
+          {!Sarek_coopmat.find_config}, never by matching on the list directly.
+      *)
   supports_atomics : bool;
   warp_size : int;
+      (** Invocations that execute in lockstep — CUDA warp, AMD wavefront,
+          Vulkan/Metal subgroup. Load-bearing for cooperative matrices, whose
+          fragments are distributed across exactly this many invocations
+          ({!Sarek_coopmat.components_per_invocation}), so a wrong value here is
+          a wrong ABI rather than a wrong statistic. The Vulkan backend now
+          reports [VkPhysicalDeviceSubgroupProperties.subgroupSize] instead of a
+          hard-coded 32; on the RX 7900 XTX under radv / Mesa 26.1.4-arch3.1
+          that is 64. *)
   max_registers_per_block : int;
   clock_rate_khz : int;
   multiprocessor_count : int;

--- a/spoc/framework/test/test_device_type.ml
+++ b/spoc/framework/test/test_device_type.ml
@@ -22,6 +22,10 @@ let test_device_type_alias () =
       total_global_mem = Int64.of_int (4 * 1024 * 1024 * 1024);
       compute_capability = (6, 1);
       device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+      (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+         "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+         refuses; an empty list would be a positive claim nobody measured. *)
+      coopmat = None;
       supports_atomics = true;
       warp_size = 32;
       max_registers_per_block = 65536;
@@ -56,6 +60,10 @@ let test_device_type_fields () =
       total_global_mem = Int64.of_int (11 * 1024 * 1024 * 1024);
       compute_capability = (8, 6);
       device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+      (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+         "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+         refuses; an empty list would be a positive claim nobody measured. *)
+      coopmat = None;
       supports_atomics = true;
       warp_size = 32;
       max_registers_per_block = 65536;
@@ -92,6 +100,10 @@ let test_device_type_cpu () =
       total_global_mem = Int64.of_int (32 * 1024 * 1024 * 1024);
       compute_capability = (0, 0);
       device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+      (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+         "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+         refuses; an empty list would be a positive claim nobody measured. *)
+      coopmat = None;
       supports_atomics = true;
       warp_size = 1;
       max_registers_per_block = 0;
@@ -127,6 +139,10 @@ let test_cross_module_compatibility () =
       total_global_mem = Int64.of_int (2 * 1024 * 1024 * 1024);
       compute_capability = (0, 0);
       device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+      (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+         "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+         refuses; an empty list would be a positive claim nobody measured. *)
+      coopmat = None;
       supports_atomics = true;
       warp_size = 64;
       max_registers_per_block = 16384;

--- a/spoc/framework/test/test_framework_sig.ml
+++ b/spoc/framework/test/test_framework_sig.ml
@@ -53,6 +53,10 @@ let test_capabilities () =
       total_global_mem = Int64.of_int (8 * 1024 * 1024 * 1024);
       compute_capability = (7, 5);
       device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+      (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+         "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+         refuses; an empty list would be a positive claim nobody measured. *)
+      coopmat = None;
       supports_atomics = true;
       warp_size = 32;
       max_registers_per_block = 65536;
@@ -80,6 +84,10 @@ let test_device () =
       total_global_mem = Int64.of_int (2 * 1024 * 1024 * 1024);
       compute_capability = (0, 0);
       device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+      (* backlog-62: no cooperative-matrix probe on this backend. [None] is
+         "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
+         refuses; an empty list would be a positive claim nobody measured. *)
+      coopmat = None;
       supports_atomics = true;
       warp_size = 64;
       max_registers_per_block = 16384;

--- a/spoc/ir/Sarek_coopmat.ml
+++ b/spoc/ir/Sarek_coopmat.ml
@@ -1,0 +1,232 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Cooperative-matrix vocabulary and fragment type (backlog-62, slices 2 and
+    4b). See the .mli for why integers are admitted from the start and why the
+    device gate cannot be keyed on the configuration list. *)
+
+type component_type = Float16 | Float32 | Uint8 | Sint8 | Uint32 | Sint32
+
+let component_name = function
+  | Float16 -> "f16"
+  | Float32 -> "f32"
+  | Uint8 -> "u8"
+  | Sint8 -> "s8"
+  | Uint32 -> "u32"
+  | Sint32 -> "s32"
+
+let component_bits = function
+  | Uint8 | Sint8 -> 8
+  | Float16 -> 16
+  | Float32 | Uint32 | Sint32 -> 32
+
+(* An explicit match on every constructor rather than [<> Float16 && <>
+   Float32]. A new float component type (bf16, fp8) added to the variant must
+   be a compile error here, because the one thing this predicate decides is
+   whether a configuration escapes the accuracy relaxation — and a new float
+   type defaulting to "integer, therefore exact" is the permissive-default
+   failure the capability model exists to prevent. *)
+let component_is_integer = function
+  | Uint8 | Sint8 | Uint32 | Sint32 -> true
+  | Float16 | Float32 -> false
+
+type scope = Subgroup | Workgroup | Device_scope | Queue_family
+
+let scope_name = function
+  | Subgroup -> "subgroup"
+  | Workgroup -> "workgroup"
+  | Device_scope -> "device"
+  | Queue_family -> "queuefamily"
+
+type shape = {m : int; n : int; k : int}
+
+let shape_name s = Printf.sprintf "%dx%dx%d" s.m s.n s.k
+
+type config = {
+  cfg_shape : shape;
+  cfg_a : component_type;
+  cfg_b : component_type;
+  cfg_c : component_type;
+  cfg_result : component_type;
+  cfg_saturating : bool;
+  cfg_scope : scope;
+}
+
+let config_name c =
+  Printf.sprintf
+    "%s %s*%s+%s->%s%s %s"
+    (shape_name c.cfg_shape)
+    (component_name c.cfg_a)
+    (component_name c.cfg_b)
+    (component_name c.cfg_c)
+    (component_name c.cfg_result)
+    (if c.cfg_saturating then " saturating" else "")
+    (scope_name c.cfg_scope)
+
+(* Exactness is a property of the ACCUMULATION, so it is decided by the addend
+   and result types, not by the operand types. The distinction is not academic
+   on this hardware: every configuration the local device advertises has
+   integer operands paired with integer accumulate, but f16*f16 pairs with BOTH
+   f16 and f32 accumulate, and reading the operand types would have called both
+   of those the same thing. *)
+let accumulation_is_exact c =
+  component_is_integer c.cfg_c && component_is_integer c.cfg_result
+
+type accuracy_regime = Strict | Relaxed_bounded
+
+let regime c = if accumulation_is_exact c then Strict else Relaxed_bounded
+
+let regime_name = function
+  | Strict -> "strict"
+  | Relaxed_bounded -> "relaxed-bounded"
+
+type device_support = {
+  ds_configs : config list;
+  ds_robust_buffer_access : bool;
+  ds_subgroup_size : int;
+  ds_advertised_count : int;
+}
+
+let device_lacks_config cfg =
+  {
+    Sarek_capability.cap_name = "cooperative-matrix";
+    (* Device_optional, per docs/design/capability-model.md §2: the backend can
+       spell the instruction, a given device may not provide it. The local box
+       has one device that does and one that does not under the SAME driver,
+       which is why a driver-keyed or backend-keyed refusal would be wrong
+       here. *)
+    cap_kind = Sarek_capability.Device_optional;
+    cap_why =
+      Printf.sprintf
+        "the device advertises no cooperative-matrix configuration matching %s \
+         (VK_KHR_cooperative_matrix absent, its cooperativeMatrix feature \
+         false, or no advertised configuration with these dimensions and \
+         component types)"
+        (config_name cfg);
+    cap_evidence =
+      Sarek_capability.Measured
+        "AMD Radeon RX 7900 XTX (RADV NAVI31) advertises \
+         VK_KHR_cooperative_matrix revision 2 with 14 configurations; the AMD \
+         Ryzen 9 7950X iGPU (RADV RAPHAEL_MENDOCINO) does not advertise the \
+         extension and reports cooperativeMatrix = false, under the same radv \
+         / Mesa 26.1.4-arch3.1 / Vulkan 1.4.354";
+    cap_remedy =
+      Some
+        "Use an ordinary multiply-accumulate kernel, or select a device that \
+         advertises this cooperative-matrix configuration.";
+  }
+
+let config_matches ~shape ~a ~b ~c ~result cfg =
+  cfg.cfg_shape = shape && cfg.cfg_a = a && cfg.cfg_b = b && cfg.cfg_c = c
+  && cfg.cfg_result = result
+
+let find_config ~support ~shape ~a ~b ~c ~result =
+  match support with
+  | None -> None
+  | Some s -> (
+      let candidates =
+        List.filter (config_matches ~shape ~a ~b ~c ~result) s.ds_configs
+      in
+      (* Prefer the non-saturating variant: it is the one that computes the
+         same function as a plain accumulate, so it is what an unqualified
+         request means. A caller that wants saturation must ask for it, which
+         it cannot do through this function — deliberately, until a slice
+         exists that can emit either. *)
+      match List.find_opt (fun cfg -> not cfg.cfg_saturating) candidates with
+      | Some cfg -> Some cfg
+      | None -> List.nth_opt candidates 0)
+
+let verdict ~support cfg =
+  match support with
+  | None ->
+      Sarek_capability.Unknown
+        "device cooperative-matrix support was not probed, so no configuration \
+         can be confirmed"
+  | Some s ->
+      if
+        List.exists
+          (fun advertised ->
+            config_matches
+              ~shape:cfg.cfg_shape
+              ~a:cfg.cfg_a
+              ~b:cfg.cfg_b
+              ~c:cfg.cfg_c
+              ~result:cfg.cfg_result
+              advertised
+            && advertised.cfg_saturating = cfg.cfg_saturating
+            && advertised.cfg_scope = cfg.cfg_scope)
+          s.ds_configs
+      then Sarek_capability.Available
+      else Sarek_capability.Unavailable (device_lacks_config cfg)
+
+type use = Matrix_a | Matrix_b | Accumulator
+
+let use_name = function
+  | Matrix_a -> "A"
+  | Matrix_b -> "B"
+  | Accumulator -> "accumulator"
+
+type fragment = {
+  frag_use : use;
+  frag_shape : shape;
+  frag_component : component_type;
+  frag_scope : scope;
+}
+
+let fragment_dims f =
+  let s = f.frag_shape in
+  match f.frag_use with
+  | Matrix_a -> (s.m, s.k)
+  | Matrix_b -> (s.k, s.n)
+  | Accumulator -> (s.m, s.n)
+
+let fragment_components f =
+  let rows, cols = fragment_dims f in
+  rows * cols
+
+let fragments_of_config c =
+  let frag frag_use frag_component =
+    {
+      frag_use;
+      frag_shape = c.cfg_shape;
+      frag_component;
+      frag_scope = c.cfg_scope;
+    }
+  in
+  ( frag Matrix_a c.cfg_a,
+    frag Matrix_b c.cfg_b,
+    frag Accumulator c.cfg_c,
+    frag Accumulator c.cfg_result )
+
+let components_per_invocation ~subgroup_size f =
+  let total = fragment_components f in
+  if subgroup_size <= 0 then
+    Error
+      (Printf.sprintf
+         "subgroup size %d is not positive, so a %s fragment cannot be \
+          distributed"
+         subgroup_size
+         (use_name f.frag_use))
+  else if total mod subgroup_size <> 0 then
+    Error
+      (Printf.sprintf
+         "a %s fragment of %s (%d components) cannot be distributed over a \
+          subgroup of %d invocations: %d does not divide %d"
+         (use_name f.frag_use)
+         (shape_name f.frag_shape)
+         total
+         subgroup_size
+         subgroup_size
+         total)
+  else Ok (total / subgroup_size)
+
+let config_fits_subgroup ~subgroup_size c =
+  let a, b, cc, r = fragments_of_config c in
+  List.for_all
+    (fun f ->
+      match components_per_invocation ~subgroup_size f with
+      | Ok _ -> true
+      | Error _ -> false)
+    [a; b; cc; r]

--- a/spoc/ir/Sarek_coopmat.mli
+++ b/spoc/ir/Sarek_coopmat.mli
@@ -1,0 +1,276 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Cooperative-matrix (tensor-core) vocabulary and fragment type.
+
+    backlog-62, slices 2 and 4b of docs/design/f16-relaxed-accuracy.md §7. This
+    module is the backend-neutral half: what a cooperative-matrix configuration
+    IS, what a device provides, and what a matrix fragment looks like. It holds
+    no Vulkan types and no Metal types — the Vulkan probe lives in
+    [sarek-vulkan/Vulkan_api_device.ml] and lowers into these values.
+
+    It sits in [spoc/ir] beside {!Sarek_capability} for the same reason that one
+    does: {!Framework_sig.capabilities} must be able to report what a device
+    provides, and [spoc/framework] may not depend on any backend.
+
+    {1 What this module deliberately does NOT do}
+
+    It does not emit code, and it does not decide accuracy. {!regime} classifies
+    a configuration into the two acceptance regimes of the design document's
+    §1.6, but it does not admit anything: nothing in Sarek generates a
+    cooperative-matrix instruction yet, so every configuration here is queryable
+    and none is reachable from the DSL. Slices 4a and 4c are where that changes.
+
+    {1 Why the type admits integers}
+
+    §8 of the design document, adopted as binding by §7 slice 4b. Twelve of the
+    fourteen configurations the local RX 7900 XTX advertises are integer;
+    [SPV_KHR_cooperative_matrix] states that integer accumulation is exact at
+    the precision of the result type; so those configurations are deliverable
+    under Sarek's EXISTING strict accuracy contract, with no relaxation, no
+    allowlist and no opt-in. {!accumulation_is_exact} is where that distinction
+    is computed rather than asserted in prose. Retrofitting integer component
+    types after an f16-only fragment type had shipped would be a wide, invasive
+    change; admitting them now costs one variant group and one predicate. *)
+
+(** {1 Component types} *)
+
+(** The element type of one matrix operand or result.
+
+    The float half is the two configurations that need the relaxed contract; the
+    integer half is the twelve that do not. Closed on what has been MEASURED to
+    exist on a device this project can reach — the Vulkan set of
+    docs/design/f16-relaxed-accuracy.md §4 — plus nothing. In particular
+    [bfloat16] is absent: Metal advertises an 8x8 [bfloat] [simdgroup_matrix]
+    (§7 slice 6) but nothing has been swept about what it computes, and a
+    component type nothing can lower is a claim without evidence. Adding it is a
+    one-line change when a measurement exists. *)
+type component_type = Float16 | Float32 | Uint8 | Sint8 | Uint32 | Sint32
+
+(** Stable lowercase rendering: ["f16"], ["f32"], ["u8"], ["s8"], ["u32"],
+    ["s32"]. Matches the column headings of the design document's §4 table and
+    the [ctype] function of [tools/probes/vulkan_coopmat_probe.c], so a probe
+    line and a Sarek diagnostic can be compared by eye. *)
+val component_name : component_type -> string
+
+(** Width in bits. *)
+val component_bits : component_type -> int
+
+(** Whether the component type is an integer type.
+
+    Load-bearing rather than cosmetic: it is what {!accumulation_is_exact}
+    reads, and therefore what decides whether a configuration falls under the
+    strict contract or needs the relaxation. *)
+val component_is_integer : component_type -> bool
+
+(** {1 Scope} *)
+
+(** The set of invocations that cooperate to hold one matrix.
+
+    All fourteen configurations measured locally are [Subgroup] scope, and
+    Metal's [simdgroup_matrix] is a SIMD-group (i.e. subgroup) construct too, so
+    [Subgroup] is the only scope any planned backend can currently produce. The
+    other three are modelled because {!Sarek_capability}'s lesson is that a
+    value you cannot represent becomes a value you silently permit: a device
+    reporting [Workgroup] scope must come back as an unrecognised-but-named
+    scope, not be quietly rewritten to [Subgroup]. *)
+type scope = Subgroup | Workgroup | Device_scope | Queue_family
+
+val scope_name : scope -> string
+
+(** {1 Shapes} *)
+
+(** A [m x n x k] multiply-add shape: [A] is [m x k], [B] is [k x n], and [C]
+    and the result are [m x n].
+
+    A record of three ints rather than a closed variant of the shapes seen so
+    far, because §7 slice 4b makes non-hard-coded dimensions binding: Vulkan
+    measured 16x16x16 and Metal measured 8x8x8, and 8x8 is the ONLY size MSL
+    offers, so a type that could only spell 16x16x16 would already be wrong for
+    a backend whose numbers are in the same document. *)
+type shape = {m : int; n : int; k : int}
+
+val shape_name : shape -> string
+
+(** {1 Configurations} *)
+
+(** One multiply-add configuration a device advertises: [D = A x B + C].
+
+    [cfg_saturating] is Vulkan's [saturatingAccumulation] — integer accumulation
+    that clamps instead of wrapping. It is a separate field rather than a
+    component type because it is a property of the OPERATION, not of any
+    operand: the local device advertises the same [s8 x s8 -> s32] element types
+    both with it and without it, and those are two distinct configurations that
+    compute different functions. *)
+type config = {
+  cfg_shape : shape;
+  cfg_a : component_type;
+  cfg_b : component_type;
+  cfg_c : component_type;
+  cfg_result : component_type;
+  cfg_saturating : bool;
+  cfg_scope : scope;
+}
+
+(** A one-line rendering, e.g. ["16x16x16 f16*f16+f32->f32 subgroup"]. Appears
+    in diagnostics. *)
+val config_name : config -> string
+
+(** {1 Accuracy regime — the §8 discriminator} *)
+
+(** Is the accumulation of this configuration exact?
+
+    True exactly when the addend and result component types are both integer.
+    [SPV_KHR_cooperative_matrix] states that integer accumulation is performed
+    at the precision of the result type and is exact, so such a configuration
+    computes the same function as the interpreter and lands under Sarek's
+    existing strict contract. Every float configuration is false: the
+    specification leaves the ORDER of the [k + 1] additions to the
+    implementation, which is a freedom no closed-form model can pin down (design
+    document §5.1). *)
+val accumulation_is_exact : config -> bool
+
+(** The two acceptance regimes of docs/design/f16-relaxed-accuracy.md §1.6.
+
+    [Strict] means bit-identity with the interpreter is still promised.
+    [Relaxed_bounded] means only the derived error bound of §5.2 holds, which
+    §6.1 makes an explicit opt-in rather than a diagnostic. *)
+type accuracy_regime = Strict | Relaxed_bounded
+
+val regime : config -> accuracy_regime
+
+val regime_name : accuracy_regime -> string
+
+(** {1 What a device provides} *)
+
+(** A device's cooperative-matrix support, as probed.
+
+    [ds_subgroup_size] is here rather than left to the caller because a
+    subgroup-scope fragment's storage is distributed across exactly that many
+    invocations, so it is part of the calling convention and not an unrelated
+    device statistic. See {!components_per_invocation}. *)
+type device_support = {
+  ds_configs : config list;
+  ds_robust_buffer_access : bool;
+      (** Vulkan [cooperativeMatrixRobustBufferAccess]: whether out-of-bounds
+          cooperative-matrix loads and stores are bounds-checked. *)
+  ds_subgroup_size : int;
+      (** Invocations per subgroup, as the device reports it — NOT a constant.
+          Measured 64 on the RX 7900 XTX under radv / Mesa 26.1.4-arch3.1, where
+          [Vulkan_plugin_base] had been hard-coding 32. *)
+  ds_advertised_count : int;
+      (** How many configurations the DEVICE reported, including any this build
+          could not represent and therefore dropped from {!ds_configs}.
+
+          Kept because dropping an unrepresentable configuration is the safe
+          direction (it can only cause a refusal) but it is also SILENT, and a
+          silent drop hid a real defect once: a wrong [VkComponentTypeKHR]
+          enumerant table turned fourteen advertised configurations into six
+          plausible-looking wrong ones. The equality
+          [ds_advertised_count = List.length ds_configs] is the check that
+          catches it, and it is hardware-independent — unlike any assertion
+          about which configurations a particular GPU offers. *)
+}
+
+(** [verdict ~support cfg] judges a requested configuration against a device.
+
+    [support = None] yields {!Sarek_capability.Unknown}, which
+    {!Sarek_capability.permits} refuses. That is the reason this takes an option
+    and the reason {!Framework_sig.capabilities} stores an option: an empty
+    configuration list and an unprobed device are different facts, and only one
+    of them is evidence.
+
+    {b The gate must be keyed on the feature, not on the configuration list},
+    and this is measured rather than argued. On this workstation
+    [vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR] returns [VK_SUCCESS] and
+    FOURTEEN configurations for the Raphael iGPU — a device that does not
+    advertise [VK_KHR_cooperative_matrix] and whose [cooperativeMatrix] feature
+    reads false. A probe that populated [ds_configs] from that call without
+    first checking the extension would report the iGPU as fully capable, and
+    this verdict would say [Available] for a device that cannot run the
+    instruction. The Vulkan probe therefore leaves [ds_configs] empty unless the
+    extension is advertised AND the feature is true; see
+    [sarek-vulkan/Vulkan_api_device.ml]. *)
+val verdict :
+  support:device_support option -> config -> Sarek_capability.verdict
+
+(** The {!Sarek_capability.Device_optional} record for a device that provides no
+    cooperative-matrix support at all, or none matching the request. *)
+val device_lacks_config : config -> Sarek_capability.t
+
+(** [find_config ~support ~a ~b ~c ~result ~shape] returns the first advertised
+    configuration matching those component types and that shape, preferring a
+    non-saturating one. [None] when the device was not probed or advertises no
+    such configuration. *)
+val find_config :
+  support:device_support option ->
+  shape:shape ->
+  a:component_type ->
+  b:component_type ->
+  c:component_type ->
+  result:component_type ->
+  config option
+
+(** {1 The fragment type (slice 4b)} *)
+
+(** Which operand of [D = A x B + C] a fragment holds.
+
+    [Accumulator] covers both [C] and the result [D], which are the same shape
+    and the same component type in every configuration measured, and which
+    SPIR-V and MSL both give a single fragment role. *)
+type use = Matrix_a | Matrix_b | Accumulator
+
+val use_name : use -> string
+
+(** A cooperative-matrix fragment: the DSL-side value one invocation holds a
+    slice of.
+
+    It is NOT a per-invocation array. A fragment is a subgroup-cooperative
+    value: the whole subgroup collectively holds [rows x columns] components,
+    each invocation holding {!components_per_invocation} of them at an
+    implementation-defined position. That indeterminate position is why a
+    fragment must not be indexable from the DSL, and it is the reason this type
+    exists at all rather than the DSL using an array. *)
+type fragment = {
+  frag_use : use;
+  frag_shape : shape;
+  frag_component : component_type;
+  frag_scope : scope;
+}
+
+(** [fragment_dims f] is [(rows, columns)], derived from {!use} and the shape:
+    [A] is [m x k], [B] is [k x n], and an accumulator is [m x n]. Derived
+    rather than stored so a fragment cannot be built claiming a size its shape
+    does not have. *)
+val fragment_dims : fragment -> int * int
+
+(** Total components in the whole fragment, i.e. [rows * columns]. *)
+val fragment_components : fragment -> int
+
+(** The fragments a configuration operates on: [(a, b, c, result)]. *)
+val fragments_of_config : config -> fragment * fragment * fragment * fragment
+
+(** {2 The subgroup calling convention} *)
+
+(** [components_per_invocation ~subgroup_size f] is how many components of [f]
+    each invocation of the cooperating subgroup holds.
+
+    [Error] when [subgroup_size] does not divide {!fragment_components}, which
+    is a real constraint and not a defensive check: a 16x16 fragment over a
+    64-wide subgroup is 4 components per invocation, and the same fragment over
+    a 24-wide subgroup has no distribution at all. It returns a result rather
+    than raising because it is the check a codegen slice must perform BEFORE
+    emitting anything, and it is the check a device query must survive when a
+    driver reports a subgroup size the configuration cannot be laid out over.
+
+    The value itself is deliberately NOT a promise about WHICH components an
+    invocation holds. That mapping is implementation-defined in both SPIR-V and
+    MSL; only the count is portable. *)
+val components_per_invocation :
+  subgroup_size:int -> fragment -> (int, string) result
+
+(** [config_fits_subgroup ~subgroup_size cfg] is true when every one of the four
+    fragments of [cfg] can be distributed over a subgroup of that size. *)
+val config_fits_subgroup : subgroup_size:int -> config -> bool

--- a/spoc/ir/dune
+++ b/spoc/ir/dune
@@ -11,6 +11,7 @@
   Sarek_ir_pp
   Sarek_ir_analysis
   Sarek_capability
+  Sarek_coopmat
   Sarek_ir_codegen
   Sarek_pure_registry)
  (preprocess no_preprocessing)

--- a/spoc/ir/test/dune
+++ b/spoc/ir/test/dune
@@ -4,5 +4,6 @@
   test_sarek_ir_pp
   test_sarek_ir_analysis
   test_sarek_capability
+  test_sarek_coopmat
   test_sarek_pure_registry)
- (libraries sarek_ir))
+ (libraries sarek_ir alcotest str))

--- a/spoc/ir/test/test_sarek_coopmat.ml
+++ b/spoc/ir/test/test_sarek_coopmat.ml
@@ -1,0 +1,552 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Host-only tests for {!Sarek_coopmat} (backlog-62, slices 2 and 4b).
+
+    No device, no Vulkan, no GPU. The device-side observation lives in
+    [sarek-vulkan/test/test_vulkan_coopmat_capability.ml], which can only run
+    where there is a Vulkan device; these are the cases that must hold
+    everywhere, and in particular they are where the REFUSAL branches are
+    exercised deterministically rather than at the mercy of whichever hardware
+    the runner happens to have. *)
+
+open Sarek_coopmat
+
+let shape16 = {m = 16; n = 16; k = 16}
+
+let shape8 = {m = 8; n = 8; k = 8}
+
+let f16_f32_config =
+  {
+    cfg_shape = shape16;
+    cfg_a = Float16;
+    cfg_b = Float16;
+    cfg_c = Float32;
+    cfg_result = Float32;
+    cfg_saturating = false;
+    cfg_scope = Subgroup;
+  }
+
+let f16_f16_config = {f16_f32_config with cfg_c = Float16; cfg_result = Float16}
+
+let s8_s32_config =
+  {
+    cfg_shape = shape16;
+    cfg_a = Sint8;
+    cfg_b = Sint8;
+    cfg_c = Sint32;
+    cfg_result = Sint32;
+    cfg_saturating = false;
+    cfg_scope = Subgroup;
+  }
+
+let u8_u32_config =
+  {
+    s8_s32_config with
+    cfg_a = Uint8;
+    cfg_b = Uint8;
+    cfg_c = Uint32;
+    cfg_result = Uint32;
+  }
+
+let s8_s32_saturating = {s8_s32_config with cfg_saturating = true}
+
+(* The fourteen configurations measured on the RX 7900 XTX (RADV NAVI31), radv
+   / Mesa 26.1.4-arch3.1, in docs/design/f16-relaxed-accuracy.md §4. Written out
+   rather than generated so that a change to the local hardware record is a
+   visible diff here. *)
+let navi31_configs =
+  let int_cfg a b c saturating =
+    {
+      cfg_shape = shape16;
+      cfg_a = a;
+      cfg_b = b;
+      cfg_c = c;
+      cfg_result = c;
+      cfg_saturating = saturating;
+      cfg_scope = Subgroup;
+    }
+  in
+  let operand_pairs =
+    [(Uint8, Uint8); (Uint8, Sint8); (Sint8, Uint8); (Sint8, Sint8)]
+  in
+  List.concat_map
+    (fun (a, b) ->
+      [
+        int_cfg a b Uint32 false;
+        int_cfg a b Sint32 false;
+        int_cfg a b Sint32 true;
+      ])
+    operand_pairs
+  @ [f16_f16_config; f16_f32_config]
+
+let navi31_support =
+  {
+    ds_configs = navi31_configs;
+    ds_robust_buffer_access = true;
+    ds_subgroup_size = 64;
+    ds_advertised_count = List.length navi31_configs;
+  }
+
+(* The Raphael iGPU, same driver, same Mesa: extension not advertised,
+   cooperativeMatrix feature false, therefore an empty PROBED list. *)
+let raphael_support =
+  {
+    ds_configs = [];
+    ds_robust_buffer_access = false;
+    ds_subgroup_size = 64;
+    ds_advertised_count = 0;
+  }
+
+(** {1 The local hardware record} *)
+
+let test_navi31_record_shape () =
+  Alcotest.(check int) "14 configurations" 14 (List.length navi31_configs) ;
+  let integer_configs = List.filter accumulation_is_exact navi31_configs in
+  (* §4 and §8: twelve of the fourteen are integer, and it is exactly those
+     twelve that land under the existing strict contract. If this number ever
+     moves, §8's whole argument — that a tensor-core path is reachable with no
+     accuracy relaxation at all — has to be re-derived rather than assumed. *)
+  Alcotest.(check int)
+    "12 of 14 accumulate exactly"
+    12
+    (List.length integer_configs) ;
+  Alcotest.(check int)
+    "2 of 14 need the relaxed contract"
+    2
+    (List.length
+       (List.filter (fun c -> regime c = Relaxed_bounded) navi31_configs)) ;
+  List.iter
+    (fun c ->
+      Alcotest.(check string)
+        ("all local configurations are 16x16x16: " ^ config_name c)
+        "16x16x16"
+        (shape_name c.cfg_shape) ;
+      Alcotest.(check string)
+        ("all local configurations are subgroup scope: " ^ config_name c)
+        "subgroup"
+        (scope_name c.cfg_scope))
+    navi31_configs
+
+(** {1 Exactness — the §8 discriminator} *)
+
+let test_accumulation_exactness () =
+  (* SPV_KHR_cooperative_matrix: integer accumulation is exact at the precision
+     of the result type, so an integer configuration computes the same function
+     as the interpreter and needs no relaxation. *)
+  Alcotest.(check bool)
+    "s8*s8+s32 is exact"
+    true
+    (accumulation_is_exact s8_s32_config) ;
+  Alcotest.(check bool)
+    "u8*u8+u32 is exact"
+    true
+    (accumulation_is_exact u8_u32_config) ;
+  Alcotest.(check bool)
+    "saturating s8*s8+s32 is still exact"
+    true
+    (accumulation_is_exact s8_s32_saturating) ;
+  (* Both float configurations are inexact, and for the same reason: the
+     specification leaves the ORDER of the k + 1 additions to the
+     implementation (§5.1). The f32-accumulate one is inexact even though every
+     f16 x f16 PRODUCT is exact in binary32 — reading the operand types would
+     have got this wrong, which is why accumulation_is_exact reads cfg_c and
+     cfg_result. *)
+  Alcotest.(check bool)
+    "f16*f16+f32 is NOT exact despite exact products"
+    false
+    (accumulation_is_exact f16_f32_config) ;
+  Alcotest.(check bool)
+    "f16*f16+f16 is not exact"
+    false
+    (accumulation_is_exact f16_f16_config) ;
+  Alcotest.(check string)
+    "integer regime is strict"
+    "strict"
+    (regime_name (regime s8_s32_config)) ;
+  Alcotest.(check string)
+    "float regime is relaxed-bounded"
+    "relaxed-bounded"
+    (regime_name (regime f16_f32_config))
+
+let test_component_classification () =
+  List.iter
+    (fun (c, expect_int, name, bits) ->
+      Alcotest.(check bool)
+        (name ^ " integer?")
+        expect_int
+        (component_is_integer c) ;
+      Alcotest.(check string) (name ^ " name") name (component_name c) ;
+      Alcotest.(check int) (name ^ " bits") bits (component_bits c))
+    [
+      (Float16, false, "f16", 16);
+      (Float32, false, "f32", 32);
+      (Uint8, true, "u8", 8);
+      (Sint8, true, "s8", 8);
+      (Uint32, true, "u32", 32);
+      (Sint32, true, "s32", 32);
+    ]
+
+(** {1 The verdict — and that it can refuse} *)
+
+let non_permitting name v =
+  Alcotest.(check bool)
+    (name ^ ": does not permit")
+    false
+    (Sarek_capability.permits v)
+
+let test_unprobed_device_refuses () =
+  (* The safety property, inherited from Sarek_capability: an unprobed device
+     is refused, not admitted. Positive control below. *)
+  let v = verdict ~support:None f16_f32_config in
+  non_permitting "unprobed device" v ;
+  match v with
+  | Sarek_capability.Unknown why ->
+      Alcotest.(check bool)
+        "the Unknown reason says it was not probed"
+        true
+        (let re = Str.regexp_string "not probed" in
+         try
+           ignore (Str.search_forward re why 0) ;
+           true
+         with Not_found -> false)
+  | _ -> Alcotest.fail "an unprobed device must yield Unknown, not Unavailable"
+
+let test_capable_device_permits () =
+  (* The positive control for every refusal below: the SAME call on a device
+     that does advertise the configuration must permit, or the refusals prove
+     nothing about the gate and only that this function always says no. *)
+  Alcotest.(check bool)
+    "NAVI31 permits f16*f16+f32"
+    true
+    (Sarek_capability.permits
+       (verdict ~support:(Some navi31_support) f16_f32_config)) ;
+  Alcotest.(check bool)
+    "NAVI31 permits s8*s8+s32"
+    true
+    (Sarek_capability.permits
+       (verdict ~support:(Some navi31_support) s8_s32_config))
+
+let test_device_without_support_refuses () =
+  (* The Raphael iGPU shape: probed, and advertises nothing. *)
+  let v = verdict ~support:(Some raphael_support) f16_f32_config in
+  non_permitting "probed device with no configurations" v ;
+  match v with
+  | Sarek_capability.Unavailable cap ->
+      Alcotest.(check string)
+        "capability is named"
+        "cooperative-matrix"
+        cap.Sarek_capability.cap_name ;
+      Alcotest.(check string)
+        "and it is Device_optional, not a backend or policy refusal"
+        "device-optional"
+        (Sarek_capability.kind_name cap.Sarek_capability.cap_kind) ;
+      let msg = Sarek_capability.explain ~target:"AMD Ryzen 9 7950X iGPU" cap in
+      Alcotest.(check bool)
+        "the diagnostic names the target"
+        true
+        (let re = Str.regexp_string "AMD Ryzen 9 7950X iGPU" in
+         try
+           ignore (Str.search_forward re msg 0) ;
+           true
+         with Not_found -> false) ;
+      Alcotest.(check bool)
+        "the diagnostic names the requested configuration"
+        true
+        (let re = Str.regexp_string "16x16x16" in
+         try
+           ignore (Str.search_forward re msg 0) ;
+           true
+         with Not_found -> false)
+  | _ ->
+      Alcotest.fail "a probed device advertising nothing must yield Unavailable"
+
+let test_unadvertised_configuration_refuses () =
+  (* A capable device still refuses a configuration it does not advertise. This
+     is the case that separates "has tensor cores" from "has THIS operation",
+     and it is the one a boolean capability model gets wrong. *)
+  let f32_operands = {f16_f32_config with cfg_a = Float32; cfg_b = Float32} in
+  non_permitting
+    "f32*f32 operands on NAVI31"
+    (verdict ~support:(Some navi31_support) f32_operands) ;
+  non_permitting
+    "8x8x8 shape on a 16x16x16-only device"
+    (verdict
+       ~support:(Some navi31_support)
+       {f16_f32_config with cfg_shape = shape8}) ;
+  non_permitting
+    "workgroup scope on a subgroup-only device"
+    (verdict
+       ~support:(Some navi31_support)
+       {f16_f32_config with cfg_scope = Workgroup}) ;
+  (* Saturation is part of the operation, not decoration: NAVI31 advertises
+     saturating s8 accumulate but not saturating u8 accumulate. *)
+  non_permitting
+    "saturating u8*u8+u32 is not advertised"
+    (verdict
+       ~support:(Some navi31_support)
+       {u8_u32_config with cfg_saturating = true}) ;
+  Alcotest.(check bool)
+    "but saturating s8*s8+s32 is"
+    true
+    (Sarek_capability.permits
+       (verdict ~support:(Some navi31_support) s8_s32_saturating))
+
+let test_find_config () =
+  Alcotest.(check bool)
+    "unprobed device finds nothing"
+    true
+    (find_config
+       ~support:None
+       ~shape:shape16
+       ~a:Float16
+       ~b:Float16
+       ~c:Float32
+       ~result:Float32
+    = None) ;
+  (match
+     find_config
+       ~support:(Some navi31_support)
+       ~shape:shape16
+       ~a:Float16
+       ~b:Float16
+       ~c:Float32
+       ~result:Float32
+   with
+  | Some c ->
+      Alcotest.(check string)
+        "found the f32-accumulate configuration"
+        "16x16x16 f16*f16+f32->f32 subgroup"
+        (config_name c)
+  | None -> Alcotest.fail "NAVI31 advertises f16*f16+f32") ;
+  (* Both a saturating and a non-saturating s8 configuration exist; the
+     unqualified request must resolve to the non-saturating one, because that
+     is the one that computes an ordinary accumulate. *)
+  match
+    find_config
+      ~support:(Some navi31_support)
+      ~shape:shape16
+      ~a:Sint8
+      ~b:Sint8
+      ~c:Sint32
+      ~result:Sint32
+  with
+  | Some c ->
+      Alcotest.(check bool)
+        "prefers the non-saturating variant"
+        false
+        c.cfg_saturating
+  | None -> Alcotest.fail "NAVI31 advertises s8*s8+s32"
+
+(** {1 The fragment type (slice 4b)} *)
+
+let test_fragment_dims_are_derived () =
+  let a, b, c, r = fragments_of_config f16_f32_config in
+  Alcotest.(check (pair int int)) "A is m x k" (16, 16) (fragment_dims a) ;
+  Alcotest.(check (pair int int)) "B is k x n" (16, 16) (fragment_dims b) ;
+  Alcotest.(check (pair int int)) "C is m x n" (16, 16) (fragment_dims c) ;
+  Alcotest.(check (pair int int)) "D is m x n" (16, 16) (fragment_dims r) ;
+  (* A square shape cannot tell the three roles apart, so the discriminating
+     case is a rectangular one. Nothing advertises it locally; that is the
+     point — §7 slice 4b makes non-hard-coded dimensions binding precisely
+     because the two backends in the plan measured different sizes. *)
+  let rect = {f16_f32_config with cfg_shape = {m = 8; n = 32; k = 4}} in
+  let a, b, c, _ = fragments_of_config rect in
+  Alcotest.(check (pair int int)) "A is 8 x 4" (8, 4) (fragment_dims a) ;
+  Alcotest.(check (pair int int)) "B is 4 x 32" (4, 32) (fragment_dims b) ;
+  Alcotest.(check (pair int int)) "C is 8 x 32" (8, 32) (fragment_dims c) ;
+  Alcotest.(check int) "A has 32 components" 32 (fragment_components a) ;
+  Alcotest.(check int) "B has 128 components" 128 (fragment_components b)
+
+let test_fragment_admits_integer_components () =
+  (* Slice 4b's binding requirement: the fragment type must carry integer
+     component types, not only f16/f32. This is the whole of §8's fallback —
+     if the f16 accuracy story stalls, an integer path still lands under the
+     strict contract, and only if the type was built for it. *)
+  let a, b, c, r = fragments_of_config s8_s32_saturating in
+  Alcotest.(check string)
+    "A fragment is s8"
+    "s8"
+    (component_name a.frag_component) ;
+  Alcotest.(check string)
+    "B fragment is s8"
+    "s8"
+    (component_name b.frag_component) ;
+  Alcotest.(check string)
+    "C fragment is s32"
+    "s32"
+    (component_name c.frag_component) ;
+  Alcotest.(check string)
+    "D fragment is s32"
+    "s32"
+    (component_name r.frag_component) ;
+  List.iter
+    (fun f ->
+      Alcotest.(check bool)
+        "every fragment of an integer configuration has an integer component"
+        true
+        (component_is_integer f.frag_component))
+    [a; b; c; r] ;
+  (* And the mixed-signedness configurations really are distinct values, not
+     one configuration seen twice. *)
+  let mixed = {s8_s32_config with cfg_a = Uint8} in
+  let ma, mb, _, _ = fragments_of_config mixed in
+  Alcotest.(check string)
+    "mixed A is u8"
+    "u8"
+    (component_name ma.frag_component) ;
+  Alcotest.(check string)
+    "mixed B is s8"
+    "s8"
+    (component_name mb.frag_component)
+
+let test_metal_shape_is_expressible () =
+  (* §7 slice 6: 8x8 is the ONLY size MSL offers, so a fragment type that could
+     not spell it would already be wrong for a backend whose measurements are
+     in the same document. No Metal code exists here; the claim under test is
+     only that the TYPE does not exclude it. *)
+  let metal_like =
+    {
+      f16_f32_config with
+      cfg_shape = shape8;
+      cfg_c = Float32;
+      cfg_result = Float32;
+    }
+  in
+  let a, _, _, _ = fragments_of_config metal_like in
+  Alcotest.(check (pair int int)) "8x8 A fragment" (8, 8) (fragment_dims a) ;
+  Alcotest.(check int) "64 components" 64 (fragment_components a)
+
+(** {2 The subgroup calling convention} *)
+
+let test_components_per_invocation () =
+  let a, _, _, _ = fragments_of_config f16_f32_config in
+  (* Measured subgroup size on the RX 7900 XTX is 64, not 32. A 16x16 fragment
+     over 64 invocations is 4 components each. *)
+  (match components_per_invocation ~subgroup_size:64 a with
+  | Ok n -> Alcotest.(check int) "16x16 over a 64-wide subgroup" 4 n
+  | Error e -> Alcotest.fail e) ;
+  (match components_per_invocation ~subgroup_size:32 a with
+  | Ok n -> Alcotest.(check int) "16x16 over a 32-wide subgroup" 8 n
+  | Error e -> Alcotest.fail e) ;
+  (* The failure case is real, not defensive: 256 components have no
+     distribution over 24 invocations, and a codegen slice must find that out
+     before emitting rather than after. *)
+  (match components_per_invocation ~subgroup_size:24 a with
+  | Ok n -> Alcotest.failf "24 must not divide 256, got %d per invocation" n
+  | Error e ->
+      Alcotest.(check bool)
+        "the error names both numbers"
+        true
+        (let has s =
+           let re = Str.regexp_string s in
+           try
+             ignore (Str.search_forward re e 0) ;
+             true
+           with Not_found -> false
+         in
+         has "24" && has "256")) ;
+  match components_per_invocation ~subgroup_size:0 a with
+  | Ok _ -> Alcotest.fail "a zero-wide subgroup must not divide anything"
+  | Error _ -> ()
+
+let test_config_fits_subgroup () =
+  Alcotest.(check bool)
+    "16x16x16 fits a 64-wide subgroup"
+    true
+    (config_fits_subgroup ~subgroup_size:64 f16_f32_config) ;
+  Alcotest.(check bool)
+    "8x8x8 fits a 64-wide subgroup exactly once per invocation"
+    true
+    (config_fits_subgroup
+       ~subgroup_size:64
+       {f16_f32_config with cfg_shape = shape8}) ;
+  Alcotest.(check bool)
+    "8x8x8 does NOT fit a 128-wide subgroup"
+    false
+    (config_fits_subgroup
+       ~subgroup_size:128
+       {f16_f32_config with cfg_shape = shape8}) ;
+  (* A rectangular shape can fit some fragments and not others, which is why
+     this checks all four rather than one. A = 8x4 = 32 components divides 32;
+     B = 4x32 = 128 divides 32; C = 8x32 = 256 divides 32 — all fit. Widen the
+     subgroup to 64 and A (32 components) no longer does. *)
+  let rect = {f16_f32_config with cfg_shape = {m = 8; n = 32; k = 4}} in
+  Alcotest.(check bool)
+    "rectangular fits 32"
+    true
+    (config_fits_subgroup ~subgroup_size:32 rect) ;
+  Alcotest.(check bool)
+    "rectangular does not fit 64 — its A fragment is too small"
+    false
+    (config_fits_subgroup ~subgroup_size:64 rect)
+
+let () =
+  let open Alcotest in
+  run
+    "Sarek_coopmat"
+    [
+      ( "local hardware record",
+        [
+          test_case
+            "NAVI31: 14 configurations, 12 exact"
+            `Quick
+            test_navi31_record_shape;
+        ] );
+      ( "accuracy regime",
+        [
+          test_case
+            "integer accumulate is exact, float is not"
+            `Quick
+            test_accumulation_exactness;
+          test_case
+            "component classification"
+            `Quick
+            test_component_classification;
+        ] );
+      ( "device verdict",
+        [
+          test_case
+            "unprobed device is refused"
+            `Quick
+            test_unprobed_device_refuses;
+          test_case
+            "capable device permits (positive control)"
+            `Quick
+            test_capable_device_permits;
+          test_case
+            "probed device with no support is refused"
+            `Quick
+            test_device_without_support_refuses;
+          test_case
+            "unadvertised configurations are refused"
+            `Quick
+            test_unadvertised_configuration_refuses;
+          test_case "find_config" `Quick test_find_config;
+        ] );
+      ( "fragment type",
+        [
+          test_case
+            "dimensions are derived from use and shape"
+            `Quick
+            test_fragment_dims_are_derived;
+          test_case
+            "integer component types are admitted"
+            `Quick
+            test_fragment_admits_integer_components;
+          test_case
+            "Metal's 8x8 is expressible"
+            `Quick
+            test_metal_shape_is_expressible;
+        ] );
+      ( "subgroup ABI",
+        [
+          test_case
+            "components per invocation"
+            `Quick
+            test_components_per_invocation;
+          test_case "config fits subgroup" `Quick test_config_fits_subgroup;
+        ] );
+    ]


### PR DESCRIPTION
Slice 2 of `docs/design/f16-relaxed-accuracy.md` §7, plus the fragment type that §7 slice 4b makes binding. **No refusal is lifted, and nothing in Sarek emits a cooperative-matrix instruction.** This is the query, the enablement, and the vocabulary.

## What lands

**`Sarek_coopmat`** (`spoc/ir`, beside `Sarek_capability`) — the backend-neutral half: component types, scope, shape, `config`, `device_support`, and the fragment type with its subgroup calling convention.

- **Integer component types are admitted from the start**, per §8 adopted as binding by slice 4b. 12 of the 14 configurations the local RX 7900 XTX advertises are integer, and `SPV_KHR_cooperative_matrix` makes integer accumulation exact at the result precision, so those land under Sarek's **existing strict contract** — no relaxation, no allowlist, no opt-in. `accumulation_is_exact` *computes* that split (from `cfg_c`/`cfg_result`, not the operand types) rather than asserting it in prose.
- **Dimensions are a record, not a closed variant**, so Vulkan's measured 16×16×16 and Metal's measured 8×8×8 both fit.
- `components_per_invocation` encodes the subgroup ABI as a `result`: a fragment's components must divide the subgroup size, and that is a check codegen must do *before* emitting.

**Vulkan plumbing** (`Vulkan_types` / `Vulkan_bindings` / `Vulkan_api_device`) — `VkPhysicalDeviceFeatures2` chain for `shaderFloat16`, `storageBuffer16BitAccess` and `cooperativeMatrix`; `VkPhysicalDeviceProperties2` chain for `driverID`/`driverName`/`driverInfo` and `subgroupSize`; configuration enumeration via `vkGetInstanceProcAddr`. All three features and `VK_KHR_cooperative_matrix` are **requested** at `vkCreateDevice`, following #332: support is not enablement, and the previous code queried `shaderFloat16` nowhere and requested it never.

**`Framework_sig.capabilities`** gains `coopmat : Sarek_coopmat.device_support option`. An *option*, not a list — an empty list and an unprobed device are different facts, and `Sarek_coopmat.verdict` maps `None` to `Unknown`, which does not permit.

## The refusal, observed

Executed on **AMD Radeon RX 7900 XTX (RADV NAVI31)** and **AMD Ryzen 9 7950X iGPU (RADV RAPHAEL_MENDOCINO)**, radv, Mesa 26.1.4-arch3.1, Vulkan 1.4.354.

```
device 0: AMD Radeon RX 7900 XTX (RADV NAVI31)  [driverID=3 radv / Mesa 26.1.4-arch3.1]
          subgroupSize=64 shaderFloat16=true storageBuffer16=true coopmat_configs=14 robust=true
device 1: AMD Ryzen 9 7950X (RADV RAPHAEL_MENDOCINO) [driverID=3 radv / Mesa 26.1.4-arch3.1]
          subgroupSize=64 shaderFloat16=true storageBuffer16=true coopmat_configs=0  robust=false

REFUSED: AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO): cooperative-matrix
unavailable — the device advertises no cooperative-matrix configuration matching
16x16x16 f16*f16+f32->f32 subgroup [device-optional; measured: ...]

gate observed: 1 device(s) permitted, 1 refused
device 0: 14 configurations, 12 accumulate exactly (strict contract)
```

That reproduces §4's table through the Sarek path, on the same box, with one device permitting and one refusing under the same driver.

## Three things the measurement corrected

1. **`subgroupSize` is 64 on both local devices.** `Vulkan_plugin_base` hard-coded `warp_size = 32`, which was wrong for *both*. This is ABI, not a statistic: a 16×16 fragment over 64 invocations is 4 components per invocation, not 8, so codegen written against 32 would have been wrong at the calling convention. `warp_size` is now the probed value.

2. **`vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR` answers for devices that do not support the extension.** It returns `VK_SUCCESS` and **all fourteen configurations for the iGPU** — the device the design document offers as the free negative device, which does not advertise `VK_KHR_cooperative_matrix` and whose `cooperativeMatrix` feature reads false. Calling an extension entry point on such a device is UB, and RADV's UB here is a plausible, well-formed, entirely wrong answer. §4's claim is correct as written (it was measured through the extension list), but a probe that enumerated configurations first would have contradicted it and left the gate unable to refuse anything. The probe gates on extension **and** feature before querying.

3. **A wrong `VkComponentTypeKHR` enumerant table looked like a working probe.** It decoded the 14 advertised configurations into 6 plausible-looking wrong ones (`f16*s8->s32`, `u8*u8->u8`) and silently dropped the other 8. Every number looked reasonable and every test passed. Enumerants are now pinned against `vulkan_core.h` by value, and `device_support` carries `ds_advertised_count` so a dropped configuration is a failure rather than a shorter list.

## Proving the gates can fail

The device gate test alone is **tautological** — it compares the verdict against the same list the verdict reads — and this was found by mutation, not by inspection:

| mutant | `verdict tracks support` | `configurations imply enabled feature` | `no configuration dropped` | `enumerants match vulkan_core.h` |
|---|---|---|---|---|
| extension check removed (`if false && …`) | green (iGPU reports 14, both permit) | **RED** | green | green |
| one enumerant wrong (`f16 = 3`) | green | green | **RED** | **RED** |

Both mutants are caught, each by at least one check that does not read the polluted data. `coopmat_enabled` is recorded on the device rather than derived from the configuration list precisely so the first implication is expressible.

## `shaderFloat16` enablement does not move the f16 measurement

Controlled A/B, one build, feature request toggled, `test_vulkan_f16_tripwire` run on each arm:

| arm | RX 7900 XTX | Raphael iGPU |
|---|---|---|
| `shaderFloat16` **not** requested (pre-slice-2 path) | 2912/63488 | 2912/63488 |
| `shaderFloat16` requested | 2912/63488 | 2912/63488 |

Same first divergence on every arm, same `precise` figures, all three calibration controls green. So `fp-contraction-policy.md` §7(b)'s caveat named a real gap in the plumbing but **not** a confound in the measurement — ACO's absorption of the f32→f16 narrowing does not depend on whether the feature was requested. §7(b) is closed with the table; the tripwire's header comment is updated in place.

## What this does NOT do

- **Slice 3** — `Sarek_ir_glsl.reject_float16_kernel` still refuses f16 unconditionally. Untouched.
- **Slice 4a** — the coopmat numeric contract of §5 is still **entirely unmeasured on every implementation**. No `OpCooperativeMatrixMulAddKHR` was executed; neither of §5.4's two mandatory positive controls exists; §5.3's binary64 exactness invariant is not asserted anywhere, because no reference exists to assert it in.
- **Slice 4c** — no codegen. `Sarek_coopmat` values are queryable and none is reachable from the DSL.
- `Execute.check_device_capabilities` is **not** widened. Its gated list stays `[Float64; Int64]`, and cooperative matrices are not added because no kernel can require them yet — a gate on a requirement nothing can express would be a refusal with nothing to refuse.
- `bfloat16` is deliberately absent from `component_type`: Metal advertises an 8×8 `bfloat` `simdgroup_matrix`, but nothing has been swept about what it computes.

Vulkan's backend now reports `Float16` in `device_features` (probed and enabled, so honest); the GLSL policy refusal is unaffected, and no other backend's `device_features` changes.

## Verification

- `dune build @fmt` clean; full build clean.
- Suite: **1633 alcotest / 108 suites + 32 qcheck / 6, 0 FAIL, 23 SKIP** (baseline 1612/106 + 32/6; +21 cases, +2 suites = exactly the two new files). Log confirmed non-empty (4733 lines) before counting, per backlog-150.
- The 4 zero-case suites are pre-existing CUDA/PTX hardware gates (`ptx_stride_spike`, `ptx_atomics_probe`, `ptx_mma_probe`, `cuda_f16_sass`), none introduced here.
- Rebased on current `origin/main` (`1f174523`), rebuilt and re-tested after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cooperative-matrix capability modeling and device-level availability checks.
  * Vulkan now reports supported cooperative-matrix configurations, subgroup size, driver details, and relevant numeric feature support.
  * Capability checks now distinguish supported, unavailable, and unprobed hardware.
* **Bug Fixes**
  * Corrected Vulkan configuration decoding and detect dropped advertised configurations.
* **Tests**
  * Added coverage for cooperative-matrix support, configuration matching, subgroup compatibility, and Vulkan capability reporting.
* **Documentation**
  * Updated accuracy and feature-plumbing documentation with latest measurements and clarifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->