### PR TITLE
feat(ci): prove-red.sh — mutate each gate and require the failure it promises

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,18 @@ jobs:
       - name: KB properties (code-intel) gate
         run: ./scripts/check-kb-properties.sh
 
+      # backlog-151. The step above enforces that every gate DECLARES whether
+      # it has a red-path test. This one executes the declaration: it copies
+      # each subject into a scratch tree, applies the mutations declared beside
+      # it, and requires the exact exit code and the exact message each one
+      # promises -- with a mandatory positive control first, because "went red"
+      # and "is always red" are otherwise the same observation. It is its own
+      # subject (scripts/prove-red-fixtures/), so a version of it that credited
+      # an immune checker would fail here rather than print a second green.
+      # ~0.5s for 4 subjects and 13 mutations; it never runs the test suite.
+      - name: Prove-red (gates are mutated and observed to fail)
+        run: ./scripts/prove-red.sh
+
       # The harness's own guards. They gate everything else, so they are the
       # last place a silent regression is acceptable.
       - name: Harness self-tests
@@ -169,6 +181,14 @@ jobs:
           # source -- and case 0 is the positive control without which every
           # red below it proves nothing.
           ./scripts/check-kb-properties.test.sh
+          # backlog-151. prove-red.sh exists to catch checkers that cannot
+          # fail, so "prove-red.sh cannot fail" is the most expensive thing
+          # that could go wrong in this repository. Nineteen cases, exact exit
+          # codes throughout (its contract separates 1 = the subject did not
+          # fail from 2 = the mechanism produced no evidence, and an assertion
+          # accepting "non-zero" would not notice those being swapped), and
+          # case 0 is the positive control.
+          ./scripts/prove-red.test.sh
 
       - name: Formal proofs admit gate
         run: |

--- a/kb/properties.md
+++ b/kb/properties.md
@@ -48,17 +48,24 @@ The operative rule, and the reason `scripts/check-kb-properties.sh` exists at al
 > mutated and observed to fail *with the message it promises*. A positive control is not
 > optional — without it, "went red" and "is always red" are the same observation.
 
+Nine of those twelve were caught by a manual habit that nothing required, so as of
+backlog-151 the rule is mechanical for the checkers that opt in:
+`scripts/prove-red.sh` applies each declared mutation to a scratch copy and asserts the
+exact exit code and the exact message. What it does *not* do is claim to cover every
+checker — see "Reading the block" below.
+
 ## The machine-checked block
 
 ```code-intel
 {"id": "KB-GATE-INVENTORY", "type": "gate-inventory-complete", "description": "Every scripts/* and ci/* a fresh clone executes from CI or the Makefile is declared below, or exempted with a stated reason. Adding a gate to CI without a row here fails. Both directories are scanned because gates do land outside scripts/ — the pocl runner probe and its covering test are under ci/ — and an inventory that knows one directory is complete about a set it chose rather than about what CI runs.", "check": {"carriers": [".github/workflows/ci.yml", "Makefile"], "exempt_manifest": "scripts/review-bundle.manifest.json", "exempt": ["scripts/coverage-unit.sh", "scripts/gpu-bench-check.sh", "ci/Dockerfile"]}}
 {"id": "KB-GATE-SELF", "type": "gate-red-path", "description": "This checker itself. A gate that validates other gates and is not itself proven able to fail is the joke version of this file.", "check": {"tool": "scripts/check-kb-properties.sh", "red_path": "scripts/check-kb-properties.test.sh"}}
+{"id": "KB-GATE-PROVE-RED", "type": "gate-red-path", "description": "Executes the mutation declared beside each subject checker and requires the exact exit code and message it promises, with a mandatory positive control first. This is the step KB-GATE-SELF cannot take: `gate-red-path` above enforces that a red-path test is DECLARED, and a declared red-path test that asserts nothing satisfies it perfectly. Its own spec block breaks a committed fixture gate in the four ways it could lie, so a version of it that credited an immune checker fails rather than printing a second green.", "check": {"tool": "scripts/prove-red.sh", "red_path": "scripts/prove-red.test.sh"}}
 {"id": "KB-GATE-ALCOTEST", "type": "gate-red-path", "description": "An unregistered Alcotest case compiles and the suite reports green having not run it.", "check": {"tool": "scripts/check-alcotest-registration.js", "red_path": "scripts/check-alcotest-registration.test.js"}}
 {"id": "KB-GATE-DUNE-VISIBILITY", "type": "gate-red-path", "description": "A (dirs ...) stanza can put a whole directory outside dune's traversal; to dune there is then nothing there to fail.", "check": {"tool": "scripts/check-dune-dir-visibility.sh", "red_path": "scripts/check-dune-dir-visibility.test.sh"}}
 {"id": "KB-GATE-LICENSE", "type": "gate-red-path", "description": "The pre-backlog-137 finder ended in 2>/dev/null, so a deleted root produced 'All license headers are up-to-date!' about a tree it had not read.", "check": {"tool": "scripts/check-license-headers.sh", "red_path": "scripts/check-license-headers.test.sh"}}
 {"id": "KB-GATE-BUNDLE-TRACKED", "type": "gate-red-path", "description": "An untracked review-tool bundle verifies perfectly on the workstation that has it; only a fresh-clone check notices.", "check": {"tool": "scripts/check-review-bundle-tracked.sh", "red_path": "scripts/check-review-bundle-tracked.test.sh"}}
-{"id": "KB-GATE-ARM-PARITY", "type": "gate-red-path", "description": "Lexical companion to test_backend_arm_parity.ml: a name added to one backend's arm and to no list is invisible to the behavioural test.", "check": {"tool": "scripts/check-arm-parity-coverage.sh", "red_path": null, "reason": "No red-path test yet. Its internal refusals (zero rows parsed, unlocatable arm table, fewer backends scanned than declared) are the anti-vacuity controls, but none of them has been observed firing. Backlog item: give it a .test.sh on the shape of check-dune-dir-visibility.test.sh."}}
-{"id": "KB-GATE-ALIAS-COVERAGE", "type": "gate-red-path", "description": "Guards that every test dune file is reachable from a runtest alias.", "check": {"tool": "scripts/check-test-alias-coverage.sh", "red_path": null, "reason": "No red-path test yet. It is also the gate that check-dune-dir-visibility.sh was added to backstop, because alias coverage assumes dune can see the file it audits — so its failure mode is partly covered by another gate's red path, and partly not."}}
+{"id": "KB-GATE-ARM-PARITY", "type": "gate-red-path", "description": "Lexical companion to test_backend_arm_parity.ml: a name added to one backend's arm and to no list is invisible to the behavioural test. Its red path is a prove-red-spec block beside it rather than a .test.sh, because the three mutations that matter are edits to a scratch copy of the five backend sources and of the matrix — which is what prove-red.sh does — and not a harness. Two of its three internal refusals are now observed firing; the third (scanned != len(backends)) is unreachable while the loop body ends in `scanned += 1`, so mutating it would mutate a tautology.", "check": {"tool": "scripts/check-arm-parity-coverage.sh", "red_path": "scripts/prove-red.sh"}}
+{"id": "KB-GATE-ALIAS-COVERAGE", "type": "gate-red-path", "description": "Guards that every test dune file is reachable from a runtest alias. Its red path is a prove-red-spec block beside it (backlog-151): an unwired executable is exit 1, and both anti-vacuity refusals — a missing dune file and a file that parses to zero declared executables — are exit 2, observed. It remains true that alias coverage assumes dune can see the file it audits, which is what check-dune-dir-visibility.sh backstops.", "check": {"tool": "scripts/check-test-alias-coverage.sh", "red_path": "scripts/prove-red.sh"}}
 {"id": "KB-GATE-FORMAL-ADMIT", "type": "gate-red-path", "description": "Fast lexical tripwire for `Admitted.` in the Rocq sources.", "check": {"tool": "scripts/check-formal-proofs.sh", "red_path": null, "reason": "Deliberately uncovered at this layer: a grep is not a proof and this script does not claim to be the guarantee. The machine-checked guarantee is the formal-proofs job, which rebuilds every .v from scratch, and the ledger/axiom-allowlist gate beside it does have a red-path test (KB-GATE-PROOF-LEDGER)."}}
 {"id": "KB-GATE-OPAM-CLEAN", "type": "gate-red-path", "description": "Guards against a `make opam` regression that dirties the tree.", "check": {"tool": "scripts/check-opam-clean.sh", "red_path": null, "reason": "No red-path test yet. Lowest-value of the uncovered four: it compares a generated file against the tree, so it fails loudly and locally rather than silently, and it has no declared-coverage set that could empty out."}}
 {"id": "KB-GATE-TOOLCHAIN-ASSERT", "type": "gate-red-path", "description": "Every codegen gate self-skips when its tool is absent (ptxas, glslangValidator, naga), so a SKIP is how the whole codegen-validation story silently disappears. This asserts the tools are present AND runnable, and carries an fp64 positive control so the skip cannot become CI's normal outcome.", "check": {"tool": "ci/assert-toolchain.sh", "red_path": null, "reason": "No red-path test yet, and it is the highest-value of the uncovered gates: its subject is exactly the shape this file is about. It does hard-fail rather than warn (nvdisasm section), and it carries its own positive control, but neither has been observed firing. Best candidate for the first application of the approved scripts/prove-red.sh."}}
@@ -89,9 +96,19 @@ The operative rule, and the reason `scripts/check-kb-properties.sh` exists at al
 - `gate-red-path` enforces **declaration** completeness, not **coverage** completeness. A
   gate with no red-path test passes — but only by saying so, here, with a reason. That is
   a deliberately weaker contract than "every gate is proven able to fail"; the strong
-  version fails today on five gates, and a gate that is red on arrival gets disabled
-  rather than fixed. The strong part is `KB-GATE-INVENTORY`: a gate cannot reach CI
-  without a row saying which of the two it is.
+  version fails today on three gates (`check-formal-proofs.sh`, `check-opam-clean.sh`,
+  `ci/assert-toolchain.sh`), and a gate that is red on arrival gets disabled rather than
+  fixed. The strong part is `KB-GATE-INVENTORY`: a gate cannot reach CI without a row
+  saying which of the two it is.
+- **A declared red path is not an executed one.** A `red_path` naming a test that asserts
+  nothing satisfies the row above perfectly, which is why `scripts/prove-red.sh`
+  (backlog-151) exists: it applies the mutation declared *beside* a subject checker and
+  requires the exact exit code and the exact message that checker promises, after a
+  mandatory positive control. Coverage is opt-in, one deliberate edit at a time, and
+  pinned by `EXPECTED_SUBJECTS` so it cannot shrink in silence — the same
+  declaration-over-coverage trade as the bullet above, and for the same reason. A
+  `red_path` of `scripts/prove-red.sh` means the evidence is a spec block beside the gate
+  rather than a `.test.sh` beside it.
 - `invocation: "manual"` says CI runs the covering test but not the tool. It is a real
   weakening and it always carries a reason.
 - Review-bundle members are exempt by **delegation**, not by opinion:

--- a/scripts/check-arm-parity-coverage.sh
+++ b/scripts/check-arm-parity-coverage.sh
@@ -99,3 +99,54 @@ if missing:
 print("OK: %d backends scanned, every arm name covered by %d matrix rows."
       % (scanned, len(covered)))
 PY
+
+# ---------------------------------------------------------------------------
+# Red-path evidence for this gate, executed by scripts/prove-red.sh
+# (backlog-151). kb/properties.md recorded this one as `red_path: null` with the
+# note that its three internal refusals -- zero rows parsed, an unlocatable arm
+# table, fewer backends scanned than declared -- "are the anti-vacuity controls,
+# but none of them has been observed firing". Two of the three are observed
+# below; the third (`scanned != len(backends)`) is unreachable while the loop
+# body ends in `scanned += 1`, so mutating it would be mutating a tautology
+# rather than the gate.
+#
+# The mutations edit a scratch copy of the five backend sources and of the
+# matrix. They never touch the working tree.
+#
+# BEGIN prove-red-spec
+# copy: scripts/check-arm-parity-coverage.sh
+# copy: sarek/tests/unit/test_backend_arm_parity.ml
+# copy: sarek/codegen/Sarek_ir_cuda.ml
+# copy: sarek/codegen/Sarek_ir_opencl.ml
+# copy: sarek/codegen/Sarek_ir_metal.ml
+# copy: sarek/codegen/Sarek_ir_wgsl.ml
+# copy: sarek/codegen/Sarek_ir_glsl.ml
+# invoke: scripts/check-arm-parity-coverage.sh
+# baseline-exit: 0
+# baseline-message: 5 backends scanned, every arm name covered
+#
+# mutation: uncovered-arm
+#   desc: a name is added to one backend's arm table and to no list. This is the whole point of the gate: test_backend_arm_parity.ml can only probe names it was told about, so this name would otherwise be invisible to it and the suite would stay green having verified nothing about it.
+#   apply: python3 - <<'PYEOF'
+#   apply: p = "sarek/codegen/Sarek_ir_glsl.ml"
+#   apply: s = open(p, encoding="utf-8").read()
+#   apply: i = s.index("arm =")
+#   apply: j = s.index("| _ -> None)", i)
+#   apply: open(p, "w", encoding="utf-8").write(s[:j] + '| "zz_prove_red_probe" -> Some "zz"\n        ' + s[j:])
+#   apply: PYEOF
+#   expect-exit: 1
+#   expect-message: zz_prove_red_probe
+#
+# mutation: matrix-emptied
+#   desc: the matrix parses to zero rows. An empty `covered` set makes every arm name trivially absent OR trivially present depending on the comparison; the gate must refuse rather than answer from nothing.
+#   apply: printf 'let names = []\n' > sarek/tests/unit/test_backend_arm_parity.ml
+#   expect-exit: 1
+#   expect-message: no rows parsed out of
+#
+# mutation: matrix-deleted
+#   desc: the file this gate compares against is gone -- an environment mutation. Without the explicit refusal it would compare against nothing and pass.
+#   apply: rm -f sarek/tests/unit/test_backend_arm_parity.ml
+#   expect-exit: 1
+#   expect-message: is missing
+# END prove-red-spec
+# ---------------------------------------------------------------------------

--- a/scripts/check-test-alias-coverage.sh
+++ b/scripts/check-test-alias-coverage.sh
@@ -71,3 +71,38 @@ if missing:
 
 print(f"OK: all {len(declared)} e2e test executables are wired to an alias")
 PYEOF
+
+# ---------------------------------------------------------------------------
+# Red-path evidence for this gate, executed by scripts/prove-red.sh. Until
+# backlog-151 this was one of the four gates kb/properties.md recorded as
+# `red_path: null` -- its refusals (missing file, nothing parsed) were written
+# and never observed firing. The `empty-declared-set` mutation below is the one
+# that matters: this gate's whole job is to notice unwired executables, and a
+# parse that finds zero of them would otherwise report "OK: all 0 ... wired".
+#
+# BEGIN prove-red-spec
+# copy: scripts/check-test-alias-coverage.sh
+# copy: sarek/tests/e2e/dune
+# invoke: scripts/check-test-alias-coverage.sh
+# baseline-exit: 0
+# baseline-message: e2e test executables are wired to an alias
+#
+# mutation: unwired-executable
+#   desc: an executable is declared and attached to no alias or run rule -- the "builds green, never executes" shape the gate exists for.
+#   apply: printf '\n(executable (name zz_prove_red_probe))\n' >> sarek/tests/e2e/dune
+#   expect-exit: 1
+#   expect-message: UNWIRED: zz_prove_red_probe
+#
+# mutation: missing-input
+#   desc: the dune file the gate reads is gone. An environment mutation: the gate must refuse rather than pass having read nothing.
+#   apply: rm -f sarek/tests/e2e/dune
+#   expect-exit: 2
+#   expect-message: not found
+#
+# mutation: empty-declared-set
+#   desc: the file parses cleanly but declares no executables. An empty declared set turns this strict check into a permissive one, so it must be exit 2 and not "OK: all 0".
+#   apply: printf '(rule (alias runtest))\n' > sarek/tests/e2e/dune
+#   expect-exit: 2
+#   expect-message: no executables parsed
+# END prove-red-spec
+# ---------------------------------------------------------------------------

--- a/scripts/prove-red-fixtures/dune-test-sample-log.txt
+++ b/scripts/prove-red-fixtures/dune-test-sample-log.txt
@@ -1,0 +1,25 @@
+Testing `spoc_basic'.
+This run has ID `4F2A0C11-0000-0000-0000-000000000000'.
+
+  [OK]          basic                  0   allocation.
+  [OK]          basic                  1   transfer.
+Test Successful in 0.004s. 12 tests run.
+
+Testing `sarek_ir_singular'.
+This run has ID `4F2A0C11-0000-0000-0000-000000000001'.
+
+  [OK]          lowering               0   one case only.
+Test Successful in 0.010s. 1 test run.
+
+Testing `sarek_codegen'.
+This run has ID `4F2A0C11-0000-0000-0000-000000000002'.
+
+  [SKIP]        codegen                0   ptx snapshot (no ptxas).
+Test Successful in 0.001s. 7 tests run.
+
+random seed: 271828
+generated error fail pass / total     time test name
+[ ]    0    0    0    0 /    4     0.0s roundtrip
+[✓]    4    0    0    4 /    4     0.0s roundtrip
+================================================================================
+success (ran 4 tests)

--- a/scripts/prove-red-fixtures/root/data/input.txt
+++ b/scripts/prove-red-fixtures/root/data/input.txt
@@ -1,0 +1,1 @@
+MARKER-OK

--- a/scripts/prove-red-fixtures/root/scripts/fixture-gate.sh
+++ b/scripts/prove-red-fixtures/root/scripts/fixture-gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+# ---------------------------------------------------------------------------
+# The subject scripts/prove-red.sh proves ITSELF against.
+#
+# It is a real gate in miniature: it reads a declared input, refuses when the
+# input is absent (exit 2, a broken world), and fails when the input is wrong
+# (exit 1, a real violation). It is committed rather than synthesised so that
+# prove-red.sh's own spec block can break it in the four ways prove-red.sh can
+# lie -- see that block. Nothing else in the repository reads it, and it is not
+# discovered by prove-red.sh's own scan: the scan walks `scripts/` and `ci/`
+# non-recursively, and this lives one level down.
+#
+# Exit codes:
+#   0  the input carries the marker
+#   1  the input does not carry the marker
+#   2  the input is not there at all
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+IN="data/input.txt"
+
+if [ ! -f "$IN" ]; then
+  echo "::error::$IN not found -- there is nothing to check and a pass would" \
+       "mean nothing."
+  exit 2
+fi
+
+if ! grep -q 'MARKER-OK' "$IN"; then
+  echo "::error::$IN does not carry MARKER-OK."
+  exit 1
+fi
+
+echo "OK: input.txt is well-formed"
+
+# ---------------------------------------------------------------------------
+# BEGIN prove-red-spec
+# copy: scripts/fixture-gate.sh
+# copy: data/input.txt
+# invoke: scripts/fixture-gate.sh
+# baseline-exit: 0
+# baseline-message: OK: input.txt is well-formed
+#
+# mutation: marker-removed
+#   desc: the input is present but wrong -- a real violation, exit 1.
+#   apply: printf 'nothing here\n' > data/input.txt
+#   expect-exit: 1
+#   expect-message: does not carry MARKER-OK
+#
+# mutation: input-deleted
+#   desc: the declared input is gone -- an environment mutation, not a source edit; the shape that made add-license-headers.sh report success about a tree it had never read.
+#   apply: rm -f data/input.txt
+#   expect-exit: 2
+#   expect-message: not found
+# END prove-red-spec
+# ---------------------------------------------------------------------------

--- a/scripts/prove-red.sh
+++ b/scripts/prove-red.sh
@@ -1,0 +1,662 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+# ---------------------------------------------------------------------------
+# Mechanise "prove red before trusting green" (backlog-151, health-2026-07-27 P3).
+#
+# WHY THIS EXISTS
+#
+# kb/properties.md states the rule this repository learned the expensive way:
+#
+#   > A checker is not evidence until it has been mutated and observed to fail
+#   > WITH THE MESSAGE IT PROMISES. A positive control is not optional --
+#   > without it, "went red" and "is always red" are the same observation.
+#
+# That rule is currently held by a habit. The 2026-07-27 skill-health report
+# counted 12 new `gate-vacuous` instances in one session and 9 of them were
+# caught only because somebody happened to remember. `check-kb-properties.sh`
+# enforces that every gate DECLARES whether it has a red-path test, which is a
+# real and load-bearing check -- but a declared red-path test that asserts
+# nothing satisfies it perfectly. This script closes that last step: it applies
+# a declared mutation and watches the gate fail.
+#
+# WHAT A SUBJECT DECLARES, AND WHERE
+#
+# Beside itself, in a comment block delimited by two marker lines whose stripped
+# text is exactly `BEGIN prove-red-spec` and `END prove-red-spec`. Leading `#` or
+# `//` and indentation are stripped, so the block is a comment in shell, JS and
+# Python alike. Keys, one per line, `key: value`, values single-line. There is no
+# continuation syntax on purpose: a continuation line and a mistyped key are the
+# same two tokens, and treating an unrecognised key as prose is how a
+# declaration ends up not executed while looking like it is. Repeat the key
+# instead (`apply:` and `copy:` are repeatable) or write one long line.
+#
+#   HEADER (before the first `mutation:`)
+#     copy:              path relative to the repo root, file or directory,
+#                        copied into the scratch tree at the same relative
+#                        path. Repeatable; at least one required. This is the
+#                        subject's declared world -- if the checker reads
+#                        something not listed here it will not find it.
+#     invoke:            argv, whitespace-split, run with cwd = scratch root.
+#                        Exactly one.
+#     baseline-argv:     appended to `invoke` for the positive control.
+#     baseline-stdin:    `empty` or `file:PATH` (PATH inside the scratch).
+#                        Default: an empty pipe (never a terminal, never
+#                        inherited).
+#     baseline-exit:     exact exit code of the UNMUTATED run. Exactly one.
+#     baseline-message:  substring the unmutated run must print. Exactly one.
+#
+#   PER MUTATION (a `mutation: <id>` line opens one)
+#     desc:              one line saying which real shape this mutation is.
+#     apply:             shell, run with `bash -euo pipefail` and cwd = scratch
+#                        root. Repeatable; the lines are joined into one script,
+#                        so variables set on one line are visible on the next.
+#     stdin:             overrides baseline-stdin for this run.
+#     argv:              REPLACES baseline-argv for this run.
+#     expect-exit:       exact exit code. Not "non-zero" -- a contract that
+#                        names 2 for a broken declaration and 1 for a real
+#                        violation is not satisfied by "something failed", and
+#                        an assertion that accepts either is a weakened
+#                        assertion (health-2026-07-27, P3's own sub-case).
+#     expect-message:    substring the mutated run must print.
+#
+# A mutation is therefore NOT limited to editing a source file, and that is the
+# point: the defects that motivated this were a deleted root directory
+# (`add-license-headers.sh`), an absent tool, and an empty stdin
+# (`test-suite-counts.sh`). `apply:` is arbitrary shell over the whole scratch
+# tree, and `stdin:`/`argv:` mutate the invocation, so the environment is as
+# mutable as the source. There is no example block in this header on purpose:
+# two blocks in one file is exit 2 (see below), and a format documented by a
+# live instance cannot rot. Read `scripts/check-test-alias-coverage.sh`.
+#
+# WHAT STOPS THIS FROM BEING A SECOND GREEN
+#
+# A tool that runs mutations and prints "all checkers went red" is itself a
+# checker, and the obvious implementation of it is exactly the shape it exists
+# to police. Four things, none optional:
+#
+#   1. THE BASELINE IS MANDATORY AND MUST CARRY ITS MESSAGE. Before any
+#      mutation, the subject runs unmutated and must exit `baseline-exit` AND
+#      print `baseline-message`. A subject that is red on arrival, or that
+#      passes silently, is exit 2 here -- because for such a subject "went red
+#      under mutation" and "is always red" are indistinguishable, which is the
+#      sentence at the top of this file.
+#   2. A MUTATION MUST ACTUALLY MUTATE. After `apply:` runs, the scratch tree
+#      is re-fingerprinted (path, mode, sha256, symlink-ness). If nothing
+#      changed and the mutation overrides neither stdin nor argv, that is exit 2
+#      -- a no-op mutation would let a subject collect a red it did not earn.
+#      An `apply:` that itself fails is exit 2 for the same reason.
+#   3. DECLARED == EXECUTED, AND FOUND == EXPECTED. Refusing to report success
+#      over a spec this script did not fully run is copied from
+#      check-kb-properties.sh; the subject-count pin is the `EXPECTED_PROJECTS`
+#      / `EXPECTED_CHECKS` idiom already used by check-formal-proofs.sh and
+#      ci/assert-toolchain.sh. A subject silently dropping out of the scan is
+#      how a strict check becomes a permissive one.
+#   4. IT IS ITS OWN SUBJECT. This script carries a prove-red-spec block whose
+#      mutations break a committed fixture gate in the four ways this tool can
+#      lie -- an immune checker, a checker red on arrival, a subject that
+#      vanishes, and a declared message the gate never prints -- and require
+#      this script to report each one. `scripts/prove-red.test.sh` is the
+#      covering test that asserts those same four shapes with exact exit codes.
+#
+# The recursion stops there, and it is worth saying where: prove-red.test.sh has
+# no red-path of its own. It is a test with exact assertions rather than a gate
+# with a coverage set, its failures are its output, and one more turtle would be
+# a test asserting that a test can fail. That is the same line kb/properties.md
+# draws with KB-GATE-SELF.
+#
+# WHAT IT COVERS, AND WHAT IT DELIBERATELY DOES NOT
+#
+# Subjects are discovered by the presence of the block, so coverage is opt-in
+# and grows one deliberate edit at a time; `EXPECTED_SUBJECTS` below is what
+# stops it shrinking. This is declaration-completeness over
+# coverage-completeness, the same trade kb/properties.md argues for
+# `gate-red-path`: the strong version ("every checker with no declared mutation
+# is a failure") would be red on arrival across a dozen gates today, and a gate
+# that is red on arrival gets disabled rather than fixed. The uncovered ones and
+# the reason for each are recorded in kb/properties.md, not in folklore.
+#
+# `*.test.sh` and `*.test.js` are never subjects: a covering test IS a red path,
+# not a gate with one, and the fixture blocks inside prove-red.test.sh would
+# otherwise be discovered as real declarations.
+#
+# Exit codes:
+#   0  every declared mutation produced its declared failure
+#   1  at least one mutation did NOT -- a checker that cannot fail, or that
+#      fails with a different code or a different message than it promises
+#   2  the mechanism could not produce evidence: a malformed or missing spec, a
+#      subject red on arrival, a mutation that changed nothing or failed to
+#      apply, a subject count that does not match the pin, a `copy:` target git
+#      does not track (present here, absent on a fresh clone), a timed-out run.
+#      Never a skip -- an unusable declaration reporting 0 would be this file's
+#      own failure mode.
+#
+# Usage:
+#   scripts/prove-red.sh [--root DIR] [--expect-subjects N] [-v]
+#
+# MEASURED COST: see the `prove-red` step in .github/workflows/ci.yml.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+# How many subjects the scan must find. Pinned, not counted: a scan that
+# reports what it happened to find is complete about a set it chose. Raise it
+# in the same commit that adds a block.
+EXPECTED_SUBJECTS=4
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPECT=""
+VERBOSE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ $# -ge 2 ] || { echo "ERROR: --root needs a value" >&2; exit 2; }
+      ROOT="$2"; shift 2 ;;
+    --root=*) ROOT="${1#--root=}"; shift ;;
+    --expect-subjects)
+      [ $# -ge 2 ] || { echo "ERROR: --expect-subjects needs a value" >&2; exit 2; }
+      EXPECT="$2"; shift 2 ;;
+    --expect-subjects=*) EXPECT="${1#--expect-subjects=}"; shift ;;
+    -v|--verbose) VERBOSE=1; shift ;;
+    -h|--help)
+      cat <<'USAGE'
+usage: scripts/prove-red.sh [--root DIR] [--expect-subjects N] [-v]
+
+  --root DIR            tree to scan (default: this repository)
+  --expect-subjects N   override the pinned subject count; used when running
+                        against a fixture root
+
+exit 0  every declared mutation produced its declared failure
+exit 1  a checker did not fail as declared
+exit 2  the mechanism could not produce evidence (malformed spec, subject red
+        on arrival, no-op mutation, subject count mismatch)
+USAGE
+      exit 0 ;;
+    -*) echo "ERROR: unknown option: $1" >&2; exit 2 ;;
+    *)  echo "ERROR: unexpected argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$EXPECT" ] || EXPECT="$EXPECTED_SUBJECTS"
+case "$EXPECT" in
+  ''|*[!0-9]*) echo "ERROR: --expect-subjects must be a non-negative integer, got: $EXPECT" >&2; exit 2 ;;
+esac
+
+[ -d "$ROOT" ] || { echo "::error::--root $ROOT is not a directory."; exit 2; }
+ROOT="$(cd "$ROOT" && pwd)"
+
+# The parser lives in a variable rather than on python's stdin. Same reason
+# test-suite-counts.sh does it: `python3 - <<EOF` hands python its program on
+# stdin, and this script hands stdin to the subjects it runs.
+PYPROG=$(cat <<'PYEOF'
+import hashlib
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = sys.argv[1]
+EXPECT_SUBJECTS = int(sys.argv[2])
+VERBOSE = sys.argv[3] == "1"
+
+SCAN_DIRS = ["scripts", "ci"]
+BEGIN = "BEGIN prove-red-spec"
+END = "END prove-red-spec"
+TIMEOUT = 300
+
+HEADER_KEYS = {"copy", "invoke", "baseline-argv", "baseline-stdin",
+               "baseline-exit", "baseline-message"}
+MUT_KEYS = {"desc", "apply", "stdin", "argv", "expect-exit", "expect-message"}
+
+
+def die(msg):
+    """Exit 2. The mechanism could not produce evidence; this is never a skip."""
+    print("::error::%s" % msg)
+    sys.exit(2)
+
+
+def strip_comment(line):
+    s = line.strip()
+    for marker in ("#", "//"):
+        if s.startswith(marker):
+            s = s[len(marker):]
+            if s.startswith(" "):
+                s = s[1:]
+            return s
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+def discover():
+    found, roots_present = [], 0
+    for d in SCAN_DIRS:
+        full = os.path.join(ROOT, d)
+        if not os.path.isdir(full):
+            continue
+        roots_present += 1
+        for name in sorted(os.listdir(full)):
+            path = os.path.join(full, name)
+            if not os.path.isfile(path):
+                continue
+            # A covering test is a red path, not a gate that has one.
+            if name.endswith(".test.sh") or name.endswith(".test.js"):
+                continue
+            try:
+                with open(path, encoding="utf-8", errors="replace") as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            if any(strip_comment(l) == BEGIN for l in text.split("\n")):
+                found.append((os.path.join(d, name), text))
+    if roots_present == 0:
+        die("none of %s exists under %s, so the scan read nothing. An empty "
+            "scan set turns this into a check that always passes."
+            % (", ".join(SCAN_DIRS), ROOT))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Spec parsing
+# ---------------------------------------------------------------------------
+def parse(rel, text):
+    lines = text.split("\n")
+    starts = [i for i, l in enumerate(lines) if strip_comment(l) == BEGIN]
+    ends = [i for i, l in enumerate(lines) if strip_comment(l) == END]
+    if len(starts) != 1 or len(ends) != 1:
+        die("%s carries %d `%s` and %d `%s` marker(s); exactly one of each is "
+            "allowed. With two blocks, which one is authoritative is undefined "
+            "and a declaration can hide in the one nothing reads."
+            % (rel, len(starts), BEGIN, len(ends), END))
+    if ends[0] < starts[0]:
+        die("%s: `%s` appears before `%s`." % (rel, END, BEGIN))
+
+    header, muts = {}, []
+    cur = None
+    for n in range(starts[0] + 1, ends[0]):
+        raw = strip_comment(lines[n])
+        if not raw.strip():
+            continue
+        if ":" not in raw:
+            die("%s line %d: `%s` is not `key: value`." % (rel, n + 1, raw))
+        key, _, val = raw.partition(":")
+        key, val = key.strip(), val.strip()
+        if key == "mutation":
+            if not val:
+                die("%s line %d: `mutation:` needs an id." % (rel, n + 1))
+            if any(m["id"] == val for m in muts):
+                die("%s line %d: duplicate mutation id `%s`. The id names the "
+                    "mutation in the report, so two sharing one make it "
+                    "ambiguous." % (rel, n + 1, val))
+            cur = {"id": val, "apply": [], "line": n + 1}
+            muts.append(cur)
+            continue
+        target, allowed = (header, HEADER_KEYS) if cur is None else (cur, MUT_KEYS)
+        if key not in allowed:
+            die("%s line %d: unknown key `%s` in the %s section. Known: %s. A "
+                "typo'd key that was ignored would be a declaration nothing "
+                "executes wearing the badge of one that passed."
+                % (rel, n + 1, key, "header" if cur is None else "mutation",
+                   ", ".join(sorted(allowed))))
+        if key in ("copy", "apply"):
+            target.setdefault(key, []).append(val)
+        elif key in target and key != "id":
+            die("%s line %d: `%s` given twice." % (rel, n + 1, key))
+        else:
+            target[key] = val
+
+    for k in ("invoke", "baseline-exit", "baseline-message"):
+        if not header.get(k):
+            die("%s: spec block is missing required header key `%s`." % (rel, k))
+    if not header.get("copy"):
+        die("%s: spec block declares no `copy:`. A subject with no declared "
+            "world would be run against an empty scratch tree and fail for the "
+            "wrong reason." % rel)
+    if not muts:
+        die("%s: spec block declares no mutation. A checker with no declared "
+            "mutation is not evidence -- it is an assertion about itself." % rel)
+
+    for k in ("baseline-exit",):
+        try:
+            header[k] = int(header[k])
+        except ValueError:
+            die("%s: `%s` must be an integer, got %r." % (rel, k, header[k]))
+
+    for m in muts:
+        for k in ("desc", "expect-exit", "expect-message"):
+            if not m.get(k):
+                die("%s mutation `%s` (line %d): missing required key `%s`."
+                    % (rel, m["id"], m["line"], k))
+        try:
+            m["expect-exit"] = int(m["expect-exit"])
+        except ValueError:
+            die("%s mutation `%s`: `expect-exit` must be an integer, got %r. "
+                "\"non-zero\" is not a contract." % (rel, m["id"], m["expect-exit"]))
+        if not m["apply"] and "stdin" not in m and "argv" not in m:
+            die("%s mutation `%s`: declares no `apply:`, no `stdin:` and no "
+                "`argv:`, so it changes nothing. A mutation that mutates "
+                "nothing collects a red the subject did not earn."
+                % (rel, m["id"]))
+        if m["expect-exit"] == header["baseline-exit"] and m["expect-message"] \
+                == header["baseline-message"]:
+            die("%s mutation `%s`: expects the baseline's exit code AND the "
+                "baseline's message, so it asserts the subject did not "
+                "notice." % (rel, m["id"]))
+
+    for k in ("baseline-stdin",):
+        v = header.get(k)
+        if v is not None and v != "empty" and not v.startswith("file:"):
+            die("%s: `%s` must be `empty` or `file:PATH`, got %r." % (rel, k, v))
+    for m in muts:
+        v = m.get("stdin")
+        if v is not None and v != "empty" and not v.startswith("file:"):
+            die("%s mutation `%s`: `stdin` must be `empty` or `file:PATH`, got "
+                "%r." % (rel, m["id"], v))
+
+    return header, muts
+
+
+# ---------------------------------------------------------------------------
+# Scratch trees
+# ---------------------------------------------------------------------------
+def git_tracked():
+    """The set of paths git tracks under ROOT, or None if ROOT is not a work
+    tree (a synthetic root under test, for instance).
+
+    An untracked `copy:` target verifies perfectly on the workstation that has
+    it and is missing on a fresh clone -- the defect KB-GATE-BUNDLE-TRACKED
+    exists for, and one this file walked straight into: the first
+    test-suite-counts fixture was named `*.log` and .gitignore swallowed it."""
+    try:
+        inside = subprocess.run(["git", "-C", ROOT, "rev-parse",
+                                 "--is-inside-work-tree"],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if inside.returncode != 0 or inside.stdout.strip() != b"true":
+        return None
+    ls = subprocess.run(["git", "-C", ROOT, "ls-files", "-z"],
+                        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                        timeout=120)
+    if ls.returncode != 0:
+        return None
+    return {p.decode("utf-8", "replace")
+            for p in ls.stdout.split(b"\0") if p}
+
+
+TRACKED = git_tracked()
+
+
+def build_scratch(rel, header, tmp):
+    scratch = tempfile.mkdtemp(dir=tmp)
+    for p in header["copy"]:
+        src = os.path.join(ROOT, p)
+        dst = os.path.join(scratch, p)
+        if not os.path.exists(src):
+            die("%s: declared `copy: %s` does not exist under %s. The subject "
+                "would run against a world it did not ask for."
+                % (rel, p, ROOT))
+        if TRACKED is not None:
+            norm = p.rstrip("/")
+            if norm not in TRACKED and not any(
+                    t.startswith(norm + "/") for t in TRACKED):
+                die("%s: declared `copy: %s` is not tracked by git. It exists "
+                    "here and would be absent on a fresh clone, so this "
+                    "subject would be exit 2 in CI while passing on the "
+                    "workstation that has the file. Commit it -- and check "
+                    ".gitignore, which is how this usually happens."
+                    % (rel, p))
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        if os.path.isdir(src):
+            shutil.copytree(src, dst, symlinks=True)
+        else:
+            shutil.copy2(src, dst, follow_symlinks=False)
+    return scratch
+
+
+def fingerprint(d):
+    """Path, mode, symlink-ness and content of every file. A mutation that
+    leaves this unchanged mutated nothing."""
+    out = []
+    for dirpath, dirnames, filenames in os.walk(d):
+        dirnames.sort()
+        for name in sorted(filenames):
+            p = os.path.join(dirpath, name)
+            rel = os.path.relpath(p, d)
+            if os.path.islink(p):
+                out.append((rel, "link", os.readlink(p)))
+                continue
+            try:
+                with open(p, "rb") as fh:
+                    digest = hashlib.sha256(fh.read()).hexdigest()
+                mode = oct(os.stat(p).st_mode & 0o777)
+            except OSError as exc:
+                digest, mode = "unreadable:%s" % exc, "?"
+            out.append((rel, mode, digest))
+        for name in sorted(dirnames):
+            out.append((os.path.relpath(os.path.join(dirpath, name), d), "dir", ""))
+    return out
+
+
+def stdin_bytes(spec, scratch, rel, what):
+    if spec is None or spec == "empty":
+        return b""
+    path = os.path.join(scratch, spec[len("file:"):])
+    if not os.path.isfile(path):
+        die("%s: %s names `%s`, which is not in the scratch tree. Add it to "
+            "`copy:` or create it in `apply:`." % (rel, what, spec))
+    with open(path, "rb") as fh:
+        return fh.read()
+
+
+def run(argv, scratch, data, rel, what):
+    try:
+        p = subprocess.run(argv, cwd=scratch, input=data,
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                           timeout=TIMEOUT)
+    except OSError as exc:
+        # PermissionError as well as FileNotFoundError: a subject copied
+        # without its executable bit would otherwise leave a traceback and
+        # python's exit 1, which is this script's code for "a checker did not
+        # fail as declared" -- a mechanism failure wearing a finding's badge.
+        die("%s: cannot execute `%s` in the scratch tree (%s): %s. Is it listed "
+            "in `copy:`, and is the committed file +x?"
+            % (rel, argv[0], " ".join(argv), exc))
+    except subprocess.TimeoutExpired:
+        die("%s: %s did not finish within %ds. A checker that hangs is not "
+            "evidence either." % (rel, what, TIMEOUT))
+    return p.returncode, p.stdout.decode("utf-8", "replace")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+subjects = discover()
+
+if len(subjects) != EXPECT_SUBJECTS:
+    names = "\n        ".join(s[0] for s in subjects) or "(none)"
+    die("expected %d subject(s) carrying a prove-red-spec block under %s, "
+        "found %d:\n        %s\n        A subject dropping out of the scan is "
+        "how a strict check becomes a permissive one. If this is deliberate, "
+        "change EXPECTED_SUBJECTS in scripts/prove-red.sh in the same commit."
+        % (EXPECT_SUBJECTS, ", ".join(SCAN_DIRS), len(subjects), names))
+
+violations = []
+executed = 0
+declared = 0
+tmp = tempfile.mkdtemp(prefix="prove-red.")
+try:
+    for rel, text in subjects:
+        header, muts = parse(rel, text)
+        declared += len(muts)
+        invoke = shlex.split(header["invoke"])
+        base_argv = shlex.split(header.get("baseline-argv", ""))
+
+        print("== %s" % rel)
+
+        # -- positive control ------------------------------------------------
+        scratch = build_scratch(rel, header, tmp)
+        code, out = run(invoke + base_argv, scratch,
+                        stdin_bytes(header.get("baseline-stdin"), scratch, rel,
+                                    "baseline-stdin"),
+                        rel, "the baseline run")
+        if code != header["baseline-exit"]:
+            print(out)
+            die("%s: BASELINE is not green. The unmutated subject exited %d, "
+                "declared %d. Every red below it would prove nothing -- \"went "
+                "red\" and \"is always red\" are the same observation. Fix the "
+                "subject, or its `copy:` set if the scratch world is wrong."
+                % (rel, code, header["baseline-exit"]))
+        if header["baseline-message"] not in out:
+            print(out)
+            die("%s: BASELINE exited %d as declared but never printed %r. A "
+                "positive control that only checks an exit code passes for a "
+                "subject that did nothing and said nothing."
+                % (rel, code, header["baseline-message"]))
+        print("   baseline: exit %d, says %r" % (code, header["baseline-message"]))
+        shutil.rmtree(scratch)
+
+        # -- mutations -------------------------------------------------------
+        for m in muts:
+            scratch = build_scratch(rel, header, tmp)
+            before = fingerprint(scratch)
+            if m["apply"]:
+                script = "\n".join(m["apply"])
+                try:
+                    p = subprocess.run(["bash", "-euo", "pipefail", "-c", script],
+                                       cwd=scratch, stdout=subprocess.PIPE,
+                                       stderr=subprocess.STDOUT, timeout=TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    die("%s mutation `%s`: the `apply:` script did not finish "
+                        "within %ds." % (rel, m["id"], TIMEOUT))
+                if p.returncode != 0:
+                    print(p.stdout.decode("utf-8", "replace"))
+                    die("%s mutation `%s`: the `apply:` script exited %d. A "
+                        "mutation that failed to apply proves nothing about "
+                        "the subject." % (rel, m["id"], p.returncode))
+                if fingerprint(scratch) == before and "stdin" not in m \
+                        and "argv" not in m:
+                    die("%s mutation `%s`: `apply:` ran successfully and "
+                        "changed no file in the scratch tree. The subject "
+                        "would be about to collect a red it did not earn."
+                        % (rel, m["id"]))
+            argv = invoke + (shlex.split(m["argv"]) if "argv" in m else base_argv)
+            data = stdin_bytes(m.get("stdin", header.get("baseline-stdin")),
+                               scratch, rel, "mutation `%s` stdin" % m["id"])
+            code, out = run(argv, scratch, data, rel,
+                            "mutation `%s`" % m["id"])
+            executed += 1
+            if code != m["expect-exit"]:
+                if code == header["baseline-exit"]:
+                    why = ("the subject DID NOT FAIL: it exited %d, exactly as "
+                           "it does unmutated" % code)
+                else:
+                    why = ("the subject exited %d, declared %d. \"It failed\" "
+                           "is not the contract; the code is"
+                           % (code, m["expect-exit"]))
+                violations.append((rel, m["id"], m["desc"], why, out))
+                print("   [%s] FAIL -- %s" % (m["id"], why))
+                shutil.rmtree(scratch)
+                continue
+            if m["expect-message"] not in out:
+                why = ("the subject exited %d as declared, but its output never "
+                       "mentioned %r -- so the failure it reports is not the "
+                       "one declared here"
+                       % (code, m["expect-message"]))
+                violations.append((rel, m["id"], m["desc"], why, out))
+                print("   [%s] FAIL -- %s" % (m["id"], why))
+                shutil.rmtree(scratch)
+                continue
+            print("   [%s] red: exit %d, says %r"
+                  % (m["id"], code, m["expect-message"]))
+            if VERBOSE:
+                print("        %s" % m["desc"])
+                for line in out.rstrip("\n").split("\n"):
+                    print("        | %s" % line)
+            shutil.rmtree(scratch)
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+print("")
+if executed != declared:
+    die("%d mutation(s) declared but %d executed. Refusing to report on a set "
+        "this script did not fully run." % (declared, executed))
+if executed == 0:
+    die("0 mutations executed. A prover that proved nothing must not exit 0.")
+
+if violations:
+    print("::error::%d declared mutation(s) did not produce their declared "
+          "failure." % len(violations))
+    for rel, mid, desc, why, out in violations:
+        print("    - %s [%s]: %s" % (rel, mid, why))
+        print("      the mutation: %s" % desc)
+        for line in out.rstrip("\n").split("\n")[-12:]:
+            print("      | %s" % line)
+    print("")
+    print("A checker that survives its own declared mutation is not evidence. "
+          "Either the checker cannot fail, or the declaration beside it "
+          "describes a checker that no longer exists.")
+    sys.exit(1)
+
+print("OK: %d subject(s), %d mutation(s); every declared mutation produced its "
+      "declared exit code and message, and every baseline was green."
+      % (len(subjects), executed))
+PYEOF
+)
+
+python3 -c "$PYPROG" "$ROOT" "$EXPECT" "$VERBOSE"
+
+# ---------------------------------------------------------------------------
+# BEGIN prove-red-spec
+# copy: scripts/prove-red.sh
+# copy: scripts/prove-red-fixtures
+# invoke: scripts/prove-red.sh
+# baseline-argv: --root scripts/prove-red-fixtures/root --expect-subjects 1
+# baseline-exit: 0
+# baseline-message: every declared mutation produced its declared exit code
+#
+# mutation: immune-checker
+#   desc: the fixture gate is replaced by one that always exits 0 while still printing its success message -- the "gate that cannot fail" shape itself. This must be a finding (1), not an error (2).
+#   apply: G=scripts/prove-red-fixtures/root/scripts/fixture-gate.sh
+#   apply: sed -n "/BEGIN prove-red-spec/,/END prove-red-spec/p" "$G" > .blk
+#   apply: printf '#!/usr/bin/env bash\necho "OK: input.txt is well-formed"\nexit 0\n' > "$G"
+#   apply: cat .blk >> "$G"
+#   apply: rm -f .blk
+#   apply: chmod +x "$G"
+#   argv: --root scripts/prove-red-fixtures/root --expect-subjects 1
+#   expect-exit: 1
+#   expect-message: DID NOT FAIL
+#
+# mutation: subject-red-on-arrival
+#   desc: the fixture gate always fails, so every mutation would "go red" and none of those reds would mean anything. The positive control must stop the run before any of them is credited -- and as an error, not a finding.
+#   apply: G=scripts/prove-red-fixtures/root/scripts/fixture-gate.sh
+#   apply: sed -n "/BEGIN prove-red-spec/,/END prove-red-spec/p" "$G" > .blk
+#   apply: printf '#!/usr/bin/env bash\necho "::error::input.txt is malformed"\nexit 1\n' > "$G"
+#   apply: cat .blk >> "$G"
+#   apply: rm -f .blk
+#   apply: chmod +x "$G"
+#   argv: --root scripts/prove-red-fixtures/root --expect-subjects 1
+#   expect-exit: 2
+#   expect-message: BASELINE is not green
+#
+# mutation: subject-vanishes
+#   desc: the only subject in the fixture root is deleted. A scan that reports what it happens to find would say "0 subjects, 0 failures" and exit 0.
+#   apply: rm -f scripts/prove-red-fixtures/root/scripts/fixture-gate.sh
+#   argv: --root scripts/prove-red-fixtures/root --expect-subjects 1
+#   expect-exit: 2
+#   expect-message: found 0
+#
+# mutation: message-half-is-live
+#   desc: the fixture's declared expect-message is changed to something its gate never prints, with the exit code left alone. Without this, expect-message would be decorative and a gate could satisfy its declaration by failing for an unrelated reason.
+#   apply: G=scripts/prove-red-fixtures/root/scripts/fixture-gate.sh
+#   apply: sed -i "s/^#   expect-message: does not carry MARKER-OK$/#   expect-message: a string this gate never prints/" "$G"
+#   apply: grep -q "a string this gate never prints" "$G"
+#   argv: --root scripts/prove-red-fixtures/root --expect-subjects 1
+#   expect-exit: 1
+#   expect-message: never mentioned
+# END prove-red-spec
+# ---------------------------------------------------------------------------

--- a/scripts/prove-red.test.sh
+++ b/scripts/prove-red.test.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CECILL-B
+# SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
+# ---------------------------------------------------------------------------
+# Covering test for scripts/prove-red.sh (backlog-151).
+#
+# prove-red.sh exists to catch checkers that cannot fail, which makes "prove-red
+# itself cannot fail" the single most expensive thing that could go wrong here.
+# So this asserts the four ways it could lie -- crediting an immune checker,
+# crediting a checker that is red on arrival, reporting on a set it did not
+# find, and treating `expect-message` as decoration -- plus every refusal in its
+# spec parser.
+#
+# EXACT EXIT CODES, NOT `! cmd`. prove-red.sh's contract distinguishes 1 (a
+# checker did not fail as declared -- a finding about the subject) from 2 (the
+# mechanism could not produce evidence -- a finding about the declaration).
+# An assertion that accepted "non-zero" would not notice the two being swapped,
+# and that is not hypothetical: accepting non-zero where a code was specified is
+# itself on the 2026-07-27 gate-vacuous list.
+#
+# Case 0 is the positive control. Without it every red below proves nothing --
+# a prove-red.sh that exited 2 unconditionally would pass cases 1-17.
+#
+# Each case builds a synthetic root under a temp dir and points the REAL
+# scripts/prove-red.sh at it with --root. Nothing here touches the working tree,
+# and no case depends on the repository's own four subjects.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOL="$SCRIPT_DIR/prove-red.sh"
+[ -x "$TOOL" ] || { echo "FAIL: $TOOL not found or not executable"; exit 2; }
+
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/prove-red-test.XXXXXX")"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass=0
+fail=0
+
+# newroot <name> -- an empty synthetic root with a scripts/ and a data/ input.
+newroot() {
+  local d="$TMPROOT/$1"
+  mkdir -p "$d/scripts" "$d/data"
+  printf 'MARKER-OK\n' > "$d/data/input.txt"
+  echo "$d"
+}
+
+# gate_body <path> -- an honest little gate: exit 2 with "not found" when its
+# input is absent, exit 1 with "does not carry MARKER-OK" when it is wrong,
+# exit 0 with "OK: input is well-formed" otherwise.
+gate_body() {
+  cat > "$1" <<'GATE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ ! -f data/input.txt ]; then
+  echo "::error::data/input.txt not found"
+  exit 2
+fi
+if ! grep -q MARKER-OK data/input.txt; then
+  echo "::error::data/input.txt does not carry MARKER-OK"
+  exit 1
+fi
+echo "OK: input is well-formed"
+GATE
+  chmod +x "$1"
+}
+
+# good_spec <path> -- the spec a correct subject carries. Appended as comments.
+good_spec() {
+  cat >> "$1" <<'SPEC'
+# BEGIN prove-red-spec
+# copy: scripts/gate.sh
+# copy: data/input.txt
+# invoke: scripts/gate.sh
+# baseline-exit: 0
+# baseline-message: OK: input is well-formed
+#
+# mutation: marker-removed
+#   desc: input present but wrong
+#   apply: printf 'nothing\n' > data/input.txt
+#   expect-exit: 1
+#   expect-message: does not carry MARKER-OK
+#
+# mutation: input-deleted
+#   desc: input absent -- an environment mutation, not a source edit
+#   apply: rm -f data/input.txt
+#   expect-exit: 2
+#   expect-message: not found
+# END prove-red-spec
+SPEC
+}
+
+# expect <desc> <root> <expect-subjects> <wanted-exit> [needle]
+expect() {
+  local desc="$1" root="$2" n="$3" want="$4" needle="${5:-}"
+  local out got
+  out="$("$TOOL" --root "$root" --expect-subjects "$n" 2>&1)"
+  got=$?
+  if [ "$got" != "$want" ]; then
+    echo "  FAIL: $desc -- expected exit $want, got $got"
+    printf '%s\n' "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+    return
+  fi
+  if [ -n "$needle" ] && ! printf '%s' "$out" | grep -qF -- "$needle"; then
+    echo "  FAIL: $desc -- exit $got as expected, but output never mentioned '$needle'"
+    printf '%s\n' "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+    return
+  fi
+  echo "  PASS: $desc (exit $got)"
+  pass=$((pass + 1))
+}
+
+echo "prove-red.sh covering test"
+
+# --- Case 0: positive control ------------------------------------------------
+# A correct subject with two honest mutations. Without this, every red below is
+# indistinguishable from a tool that always fails.
+d="$(newroot case0)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+expect "case0: an honest subject with working mutations is GREEN" \
+  "$d" 1 0 "2 mutation(s)"
+
+# --- Case 1: the immune checker ----------------------------------------------
+# The whole point. A gate that prints its success message and exits 0 whatever
+# happens to its world must be a FINDING (1), not an error (2) -- the tool
+# worked perfectly, the subject is the problem.
+d="$(newroot case1)"
+cat > "$d/scripts/gate.sh" <<'GATE'
+#!/usr/bin/env bash
+echo "OK: input is well-formed"
+exit 0
+GATE
+chmod +x "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+expect "case1: a checker immune to its own declared mutation is exit 1" \
+  "$d" 1 1 "DID NOT FAIL"
+
+# --- Case 2: red on arrival --------------------------------------------------
+# Every mutation below such a subject "goes red" and none of those reds means
+# anything. The positive control must stop the run before any is credited, and
+# report it as a broken mechanism (2) rather than a finding (1).
+d="$(newroot case2)"
+cat > "$d/scripts/gate.sh" <<'GATE'
+#!/usr/bin/env bash
+echo "::error::data/input.txt does not carry MARKER-OK"
+exit 1
+GATE
+chmod +x "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+expect "case2: a subject that is red on arrival is exit 2, and no mutation is credited" \
+  "$d" 1 2 "BASELINE is not green"
+
+# --- Case 3: a silent baseline -----------------------------------------------
+# Exit 0 and nothing else. A positive control that checks only the exit code
+# passes for a subject that did nothing and said nothing -- which is the shape
+# of every gate on the vacuous list.
+d="$(newroot case3)"
+cat > "$d/scripts/gate.sh" <<'GATE'
+#!/usr/bin/env bash
+if [ ! -f data/input.txt ]; then exit 2; fi
+grep -q MARKER-OK data/input.txt || exit 1
+exit 0
+GATE
+chmod +x "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+expect "case3: baseline exits 0 but prints nothing -- exit 2" \
+  "$d" 1 2 "never printed"
+
+# --- Case 4: right failure, wrong code ---------------------------------------
+# The gate does fail, with the promised words, under the wrong exit code. This
+# is the sub-case P3 names: "non-zero" is not the contract.
+d="$(newroot case4)"
+cat > "$d/scripts/gate.sh" <<'GATE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ ! -f data/input.txt ]; then
+  echo "::error::data/input.txt not found"
+  exit 1
+fi
+if ! grep -q MARKER-OK data/input.txt; then
+  echo "::error::data/input.txt does not carry MARKER-OK"
+  exit 1
+fi
+echo "OK: input is well-formed"
+GATE
+chmod +x "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+expect "case4: fails with the right message under the wrong exit code -- exit 1" \
+  "$d" 1 1 "declared 2"
+
+# --- Case 5: right code, wrong reason ----------------------------------------
+# The gate exits 1 as declared, for something else entirely. Without the message
+# half, `expect-message` is decoration and a subject can satisfy its declaration
+# by failing for an unrelated reason.
+d="$(newroot case5)"
+gate_body "$d/scripts/gate.sh"
+cat >> "$d/scripts/gate.sh" <<'SPEC'
+# BEGIN prove-red-spec
+# copy: scripts/gate.sh
+# copy: data/input.txt
+# invoke: scripts/gate.sh
+# baseline-exit: 0
+# baseline-message: OK: input is well-formed
+#
+# mutation: marker-removed
+#   desc: input present but wrong
+#   apply: printf 'nothing\n' > data/input.txt
+#   expect-exit: 1
+#   expect-message: a sentence this gate never prints
+# END prove-red-spec
+SPEC
+expect "case5: exits as declared but with a different failure -- exit 1" \
+  "$d" 1 1 "never mentioned"
+
+# --- Case 6: a subject with no declared mutation -----------------------------
+d="$(newroot case6)"
+gate_body "$d/scripts/gate.sh"
+cat >> "$d/scripts/gate.sh" <<'SPEC'
+# BEGIN prove-red-spec
+# copy: scripts/gate.sh
+# copy: data/input.txt
+# invoke: scripts/gate.sh
+# baseline-exit: 0
+# baseline-message: OK: input is well-formed
+# END prove-red-spec
+SPEC
+expect "case6: a block declaring no mutation is exit 2" \
+  "$d" 1 2 "declares no mutation"
+
+# --- Case 7: a mistyped key --------------------------------------------------
+# Silently ignoring it would leave a declaration that reads as executed and is
+# not -- this file's entire subject, one level up.
+d="$(newroot case7)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+sed -i 's/^#   expect-message: not found$/#   expect-mesage: not found/' \
+  "$d/scripts/gate.sh"
+expect "case7: an unknown key is exit 2, not ignored" \
+  "$d" 1 2 "unknown key"
+
+# --- Case 8: duplicate mutation ids ------------------------------------------
+d="$(newroot case8)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+sed -i 's/^# mutation: input-deleted$/# mutation: marker-removed/' \
+  "$d/scripts/gate.sh"
+expect "case8: duplicate mutation ids are exit 2" \
+  "$d" 1 2 "duplicate mutation id"
+
+# --- Case 9: two blocks in one file ------------------------------------------
+# Whichever one is authoritative is undefined, and a declaration can hide in the
+# one nothing reads.
+d="$(newroot case9)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+expect "case9: two spec blocks in one subject is exit 2" \
+  "$d" 1 2 "exactly one of each is allowed"
+
+# --- Case 10: a mutation that mutates nothing --------------------------------
+# The most dangerous shape available to this mechanism: the subject collects a
+# red it did not earn, from a mutation that never happened.
+d="$(newroot case10)"
+gate_body "$d/scripts/gate.sh"
+cat >> "$d/scripts/gate.sh" <<'SPEC'
+# BEGIN prove-red-spec
+# copy: scripts/gate.sh
+# copy: data/input.txt
+# invoke: scripts/gate.sh
+# baseline-exit: 0
+# baseline-message: OK: input is well-formed
+#
+# mutation: does-nothing
+#   desc: an apply that succeeds and changes no file
+#   apply: true
+#   expect-exit: 1
+#   expect-message: does not carry MARKER-OK
+# END prove-red-spec
+SPEC
+expect "case10: an apply that changes no file is exit 2" \
+  "$d" 1 2 "changed no file"
+
+# --- Case 11: an apply that fails --------------------------------------------
+d="$(newroot case11)"
+gate_body "$d/scripts/gate.sh"
+cat >> "$d/scripts/gate.sh" <<'SPEC'
+# BEGIN prove-red-spec
+# copy: scripts/gate.sh
+# copy: data/input.txt
+# invoke: scripts/gate.sh
+# baseline-exit: 0
+# baseline-message: OK: input is well-formed
+#
+# mutation: broken-apply
+#   desc: the mutation itself does not run
+#   apply: sed -i 's/x/y/' data/no-such-file.txt
+#   expect-exit: 1
+#   expect-message: does not carry MARKER-OK
+# END prove-red-spec
+SPEC
+expect "case11: an apply that exits non-zero is exit 2" \
+  "$d" 1 2 "script exited"
+
+# --- Case 12: a copy path that does not exist --------------------------------
+d="$(newroot case12)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+sed -i 's|^# copy: data/input.txt$|# copy: data/absent.txt|' "$d/scripts/gate.sh"
+expect "case12: a declared copy path that does not exist is exit 2" \
+  "$d" 1 2 "does not exist under"
+
+# --- Case 13: the subject count pin ------------------------------------------
+# A scan that reports what it happened to find is complete about a set it chose.
+d="$(newroot case13)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+expect "case13: one subject found where two are pinned is exit 2" \
+  "$d" 2 2 "found 1"
+
+# --- Case 14: a mutation that asserts the subject did not notice -------------
+d="$(newroot case14)"
+gate_body "$d/scripts/gate.sh"
+cat >> "$d/scripts/gate.sh" <<'SPEC'
+# BEGIN prove-red-spec
+# copy: scripts/gate.sh
+# copy: data/input.txt
+# invoke: scripts/gate.sh
+# baseline-exit: 0
+# baseline-message: OK: input is well-formed
+#
+# mutation: expects-green
+#   desc: declares the baseline's exit code and the baseline's message
+#   apply: printf 'nothing\n' > data/input.txt
+#   expect-exit: 0
+#   expect-message: OK: input is well-formed
+# END prove-red-spec
+SPEC
+expect "case14: a mutation expecting the baseline verdict is exit 2" \
+  "$d" 1 2 "did not notice"
+
+# --- Case 15: expect-exit must be a number -----------------------------------
+d="$(newroot case15)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+sed -i 's/^#   expect-exit: 2$/#   expect-exit: nonzero/' "$d/scripts/gate.sh"
+expect "case15: a non-integer expect-exit is exit 2" \
+  "$d" 1 2 "not a contract"
+
+# --- Case 16: covering tests are not subjects --------------------------------
+# The exclusion is live, not merely intended: the fixture blocks inside THIS
+# file would otherwise be discovered as real declarations.
+d="$(newroot case16)"
+gate_body "$d/scripts/gate.test.sh"
+good_spec "$d/scripts/gate.test.sh"
+expect "case16: a *.test.sh carrying a block is not discovered as a subject" \
+  "$d" 1 2 "found 0"
+
+# --- Case 18: an untracked copy target ---------------------------------------
+# It exists here and is absent on a fresh clone, so the subject would be exit 2
+# in CI while passing on the workstation that has the file. This is not a
+# hypothetical: the first fixture log for scripts/test-suite-counts.sh was named
+# `*.log`, which .gitignore swallows. The refusal only applies inside a git work
+# tree, so this case makes one.
+d="$(newroot case18)"
+gate_body "$d/scripts/gate.sh"
+good_spec "$d/scripts/gate.sh"
+( cd "$d" && git init -q . && git config user.email t@t.t \
+    && git config user.name t && printf 'data/\n' > .gitignore \
+    && git add scripts/gate.sh .gitignore \
+    && git commit -qm init ) >/dev/null 2>&1
+expect "case18: a copy target git does not track is exit 2" \
+  "$d" 1 2 "not tracked by git"
+
+# --- Case 17: nothing to scan ------------------------------------------------
+# An empty scan set turns this into a check that always passes.
+d="$TMPROOT/case17"
+mkdir -p "$d"
+expect "case17: a root with no scripts/ and no ci/ is exit 2" \
+  "$d" 0 2 "scan read nothing"
+
+echo ""
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/test-suite-counts.sh
+++ b/scripts/test-suite-counts.sh
@@ -251,3 +251,47 @@ if suites < min_suites:
 PYEOF
 )
 python3 -c "$PYPROG" "$SRC" "$MIN_SUITES"
+
+# ---------------------------------------------------------------------------
+# Red-path evidence, executed by scripts/prove-red.sh (backlog-151).
+#
+# This tool already has a covering test. It is a subject here anyway, and only
+# for one reason: two of its three failure modes are mutations of the
+# ENVIRONMENT rather than of any file -- an empty stdin and a missing
+# --min-suites -- and if the mechanism that is supposed to police the
+# gate-vacuous class could only edit source files it would miss the shape it
+# was built for. `empty-stdin` is the literal backlog-150 defect: the advertised
+# pipe form returned "0 cases / 0 FAIL", exit 0, for a genuine 1644-case log.
+#
+# `below-floor` pins exit 3 specifically. This script's contract distinguishes
+# 2 (not a result) from 3 (a result below the plausibility floor), and an
+# assertion that accepted "non-zero" would not notice the two being confused.
+#
+# BEGIN prove-red-spec
+# copy: scripts/test-suite-counts.sh
+# copy: scripts/prove-red-fixtures/dune-test-sample-log.txt
+# invoke: scripts/test-suite-counts.sh
+# baseline-argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
+# baseline-exit: 0
+# baseline-message: TOTAL    :    24 cases across   4 suites
+#
+# mutation: empty-stdin
+#   desc: the pipe form with nothing on stdin -- a fully-cached `dune test` prints exactly this. The absence of a measurement must not share an output shape with a result.
+#   stdin: empty
+#   argv: --min-suites 0
+#   expect-exit: 2
+#   expect-message: no test-suite output recognised
+#
+# mutation: truncated-epilogue
+#   desc: every suite epilogue loses its case count, as a log cut mid-write does. Three "Test Successful" markers and zero parsed counts must be a refusal, not a confident total of 0.
+#   apply: sed -i 's/ [0-9]* tests\? run\.//' scripts/prove-red-fixtures/dune-test-sample-log.txt
+#   expect-exit: 2
+#   expect-message: the log is truncated or the format has drifted
+#
+# mutation: below-floor
+#   desc: the same log counted without --min-suites 0. Four suites is a plausible-looking number and a partially-cached run produces exactly that, so it is exit 3 -- neither a pass nor the same failure as an unreadable log.
+#   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt
+#   expect-exit: 3
+#   expect-message: below the plausibility floor
+# END prove-red-spec
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements **P3** from `skills-meta/health-2026-07-27.md`: every checker declares a mutation beside itself, and a tool applies it and requires the failure the checker promises.

`scripts/check-kb-properties.sh` already enforces that every gate **declares** whether it has a red-path test. A declared red-path test that asserts nothing satisfies that perfectly. `scripts/prove-red.sh` takes the last step: it applies the declared mutation and watches the gate fail, with the exact exit code and the exact message.

**4 subjects, 13 mutations, ~0.5s.** Two gates that `kb/properties.md` recorded as `red_path: null` now have observed red paths.

---

## The design decisions, and why

### Where the declarations live: beside the checker

A `BEGIN prove-red-spec` / `END prove-red-spec` comment block in the checker's own file. Leading `#` or `//` is stripped, so the same block is a comment in shell, JS and Python.

The argument for central (one registry) is discoverability; the argument against is that a mutation spec needs a shell snippet, a path, an exit code and a message, and cramming that into the single-line JSON of the `code-intel` block would make it unreadable — and unreadable is how a declaration stops being read. The risk of "beside itself" — a declaration nobody reads — is handled the way this repo already handles it: the *content* lives with the thing, and *completeness* is enforced centrally. `EXPECTED_SUBJECTS` is pinned in the tool (the `EXPECTED_PROJECTS` / `EXPECTED_CHECKS` idiom from `check-formal-proofs.sh` and `ci/assert-toolchain.sh`), and `KB-GATE-PROVE-RED` in `kb/properties.md` puts the tool itself under the existing inventory gate.

Two consequences worth stating. **There is no example block in `prove-red.sh`'s header** — two blocks in one file is exit 2, and the format is documented by a live instance (`check-test-alias-coverage.sh`) that cannot rot. And **there is no continuation syntax**: a continuation line and a mistyped key are the same two tokens, and reading an unrecognised key as prose is exactly how a declaration ends up not executed while looking like it is. Unknown key → exit 2.

### What a mutation is: the environment, not just the source

`apply:` is arbitrary shell run in the scratch root, plus `stdin:` and `argv:` overrides. If the mechanism could only edit source files it would miss the class it was built for — as the report notes, `check-license-headers.sh`'s bug was a **deleted root** and `test-suite-counts.sh`'s was **empty stdin**. Both shapes are in the covered set:

| mutation | what it changes | expects |
| --- | --- | --- |
| `test-suite-counts.sh` / `empty-stdin` | nothing on stdin — a fully-cached `dune test` prints exactly this | exit **2** |
| `test-suite-counts.sh` / `below-floor` | the invocation only (no `--min-suites 0`) | exit **3** |
| `check-test-alias-coverage.sh` / `missing-input` | the file the gate reads is deleted | exit **2** |
| `check-arm-parity-coverage.sh` / `matrix-deleted` | the matrix it compares against is deleted | exit **1** |

`below-floor` is the one that pins exit **3** specifically: that script's contract separates 2 (not a result) from 3 (a result below the plausibility floor), and an assertion accepting "non-zero" would not notice the two being swapped. That sub-case is P3's own, and it is asserted throughout — `prove-red.test.sh` uses exact exit codes in all 19 cases, never `! cmd`.

### A checker with no declared mutation: **not** a failure. Declaration-completeness, again.

The report says it should be. I did not do that, and the argument is the one `kb/properties.md` already made for `gate-red-path` and I think it holds here more strongly, not less:

> the strong version fails today on \[N] gates, and **a gate that is red on arrival gets disabled rather than fixed**.

A tool whose first CI run is red across a dozen pre-existing checkers does not get those checkers fixed; it gets itself commented out, and then the repository has one more inert gate — in the instrument whose whole job is inert gates. So subjects are discovered by the presence of a block, coverage is opt-in and grows one deliberate edit at a time, and what is enforced is that it **cannot shrink**: `EXPECTED_SUBJECTS` is pinned, and a subject silently dropping out of the scan is exit 2 with the count that was found.

This is a real weakening and it is stated in the script header and in `kb/properties.md` rather than left for a reader to discover. If the operator wants the strong version, the honest sequence is: raise coverage first, flip the default second.

### Why this is not just a second green

A tool that runs mutations and reports "all checkers went red" is itself a checker, and the obvious implementation of it is the next thing on the `gate-vacuous` list. Four mechanisms, none optional:

1. **The baseline is mandatory and must carry its message.** Before any mutation the subject runs unmutated and must exit `baseline-exit` **and print `baseline-message`**. A subject red on arrival is exit 2 and no mutation below it is credited — because for such a subject "went red under mutation" and "is always red" are the same observation. A baseline that only checked the exit code would pass for a subject that did nothing and said nothing, which is the shape of every gate on the vacuous list; `prove-red.test.sh` case 3 asserts that.
2. **A mutation must actually mutate.** After `apply:`, the scratch tree is re-fingerprinted (path, mode, symlink-ness, sha256). Unchanged, with no `stdin:`/`argv:` override → exit 2. An `apply:` that fails → exit 2. Without this, a no-op mutation lets a subject collect a red it did not earn.
3. **Declared == executed, found == expected**, and 0 mutations executed is never exit 0.
4. **It is its own subject.** `prove-red.sh` carries a spec block whose four mutations break a committed fixture gate in the four ways this tool can lie: an immune checker (must be **1**, a finding), a checker red on arrival (must be **2**, a mechanism failure), a subject that vanishes (**2**), and an `expect-message` the gate never prints (**1**, so the message half is provably not decoration).

**Where the recursion stops, and why:** `prove-red.test.sh` has no red path of its own. It is a test with exact assertions rather than a gate with a coverage set, its failures are its output, and one more turtle would be a test asserting that a test can fail. That is the same line `kb/properties.md` draws with `KB-GATE-SELF`. What replaces it is the mutation testing below — I broke the tool four ways and confirmed the test noticed each one.

---

## The reds I observed

**Four mutants of `prove-red.sh` itself** (scratch copies, run against the covering test):

| mutant | covering test result |
| --- | --- |
| A — baseline-message assertion removed | `FAIL: case3 ... expected exit 2, got 1` → **17 passed, 1 failed** |
| B — exit-code comparison neutered | `FAIL: case1 ... never mentioned 'DID NOT FAIL'`, `FAIL: case4 ... expected exit 1, got 0` → **16 passed, 2 failed** |
| C — no-op-mutation detection removed | `FAIL: case10 ... expected exit 2, got 1` → **17 passed, 1 failed** |
| D — untracked-`copy:` refusal removed | `FAIL: case18 ... expected exit 2, got 0` → **18 passed, 1 failed** |

**On a real checker**, as the verification bar requires. I made `check-test-alias-coverage.sh` immune to its own declared mutation (`if missing:` → `if False:`) and ran the real tool against the real tree:

```
== scripts/check-test-alias-coverage.sh
   baseline: exit 0, says 'e2e test executables are wired to an alias'
   [unwired-executable] FAIL -- the subject DID NOT FAIL: it exited 0, exactly as it does unmutated
   [missing-input] red: exit 2, says 'not found'
   [empty-declared-set] red: exit 2, says 'no executables parsed'
...
::error::1 declared mutation(s) did not produce their declared failure.
    - scripts/check-test-alias-coverage.sh [unwired-executable]: the subject DID NOT FAIL: it exited 0, exactly as it does unmutated
      the mutation: an executable is declared and attached to no alias or run rule -- the "builds green, never executes" shape the gate exists for.
      | OK: all 84 e2e test executables are wired to an alias
```

exit **1**, and the other two mutations still red — the tool reports the one immune mutation rather than the whole subject. Reverted immediately; the working tree is clean.

**One real red found by the tool during development, not planted.** The first fixture log for `test-suite-counts.sh` was named `dune-test-sample.log`, and `.gitignore:25` is `*.log`. It would have verified perfectly here and been absent on a fresh clone — `KB-GATE-BUNDLE-TRACKED`'s exact defect. Fixed by renaming, and then closed as a class: `prove-red.sh` now refuses a `copy:` target git does not track (exit 2), with case 18 covering it and mutant D proving that case can fail.

---

## Coverage: what is in, what is deliberately out

**In (4 subjects, 13 mutations).** Chosen for value rather than ease — three of the four are gates whose red path was `null` or whose failure mode is environmental:

- `scripts/check-test-alias-coverage.sh` — was `red_path: null`. Unwired executable (1), missing input (2), a file that parses to zero declared executables (2). That last one is the point: a gate whose job is to notice unwired executables would otherwise report `OK: all 0 ... wired`.
- `scripts/check-arm-parity-coverage.sh` — was `red_path: null`, with the KB note that its refusals "are the anti-vacuity controls, but none of them has been observed firing". Two of the three now are. The third (`scanned != len(backends)`) is unreachable while the loop body ends in `scanned += 1`; mutating it would be mutating a tautology, and I have said so in the KB row rather than faking coverage of it.
- `scripts/test-suite-counts.sh` — has a `.test.sh` already. Included anyway, and only because two of its three failure modes are mutations of the *environment*: it is the proof that the mechanism handles the class it was built for, and it pins exit 3.
- `scripts/prove-red.sh` — itself.

**Out, with a reason each:**

- `ci/assert-toolchain.sh` — named in `kb/properties.md` as the best first candidate, and I agree with that judgement but cannot act on it here. Its baseline is green only inside `ci/Dockerfile`'s image (it asserts `ptxas`, `glslangValidator`, `naga` are present *and runnable*). A subject whose baseline is red is exit 2 by design, so adding it would make `prove-red.sh` red on every workstation and in the fast job. It needs to run in the `codegen-validation` job instead — a follow-up, and the mutation is obvious once it is there (strip `PATH`).
- `scripts/check-opam-clean.sh` — runs `make opam` twice and diffs against git. Its declared world is the whole repository plus a working `make`, so the "scratch copy" would be the repository itself; that contradicts the isolation the mechanism depends on.
- `scripts/check-formal-proofs.sh` — needs a Rocq toolchain and ~50s of CPU. `kb/properties.md` already argues it is deliberately uncovered at this layer (a grep is not a proof; the guarantee is the `formal-proofs` job).
- Everything with an existing `.test.sh` — `check-license-headers.sh`, `check-dune-dir-visibility.sh`, `check-kb-properties.sh`, `check-review-bundle-tracked.sh`, the JS harness tools. Their red paths are covered and re-covering them would buy a second green, not a second check. `*.test.sh` / `*.test.js` are excluded from discovery entirely: a covering test **is** a red path, not a gate with one (case 16 asserts the exclusion is live).

## Cost

**~0.48 s** for 4 subjects / 13 mutations / 17 process runs, measured on this branch. Each mutation is one scratch copy of the subject's declared world (never the repository) and one run of the checker. It never runs the test suite; the heaviest copy is the five `Sarek_ir_*.ml` backend sources for the arm-parity subject. `prove-red.test.sh` adds ~2 s. This is cheap enough that there is no argument for running it on a subset.

## Wiring

Both are in the fast `checks` job, following the house pattern: `prove-red.sh` as its own step next to the KB properties gate (they are the pair — one enforces the declaration, the other executes it), and `prove-red.test.sh` in the *Harness self-tests* block.

## Verification

- `dune build @fmt` clean (exit 0; the doc-comment warnings are pre-existing).
- `dune test --force`: **1633 alcotest / 108 suites + 32 qcheck / 6 = 1665 across 114, 0 FAIL, 23 SKIP** via `scripts/test-suite-counts.sh` on a 4734-line log (checked non-empty first). Higher than the stated 1612/106 baseline, which is upstream drift, not this branch: `git diff --stat origin/main` touches only `scripts/`, `kb/` and `.github/` — no OCaml, no dune file. 0 FAIL / 23 SKIP match.
- Every fast-job gate re-run by hand, all exit 0. `*.opam` dune-3.24 churn reverted, not committed.

## What I could not verify

- **The CI run.** Everything here was executed locally; the steps are wired but have not run on a GitHub runner.
- **`scanned != len(backends)`** in `check-arm-parity-coverage.sh` — unreachable, argued above rather than covered.
- **Non-Linux.** `apply:` snippets use GNU `sed -i`; CI is Linux-only, but a macOS developer running `prove-red.sh` locally would see the `uncovered-arm` mutation fail to apply (exit 2, loudly — not a false green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
