### PR TITLE
backlog-62 slice 3: the integer cooperative-matrix path, DSL to executed result

### DIFF
--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -878,7 +878,7 @@ refusal before slice 3.
 | **1** | element-wise model characterisation of ACO scalar f16 | whether the contract of §1.2 is deliverable at all | RX 7900 XTX + Raphael iGPU (local) | no | **DONE — all 20 shapes measured (2 in slice 1, the other 18 in backlog-151). Deliverable, and §1.2's set is generated rather than enumerated. 18 shapes measured but NOT admitted.** |
 | **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | **DONE 2026-07-27** — plus the coopmat capability query and the fragment type of slice 4b |
 | **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist | open |
-| **4** | backlog-62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | open |
+| **4** | backlog-62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | **4a/4c DONE for the INTEGER configurations, 2026-07-27 — see below. The f16 half is untouched and 4a's numeric contract is still unmeasured.** |
 | **5** | backlog-63 Metal — **scalar f16 first** | the Metal row of §2 | ladon (M4) | no | **DONE 2026-07-27 — strict, 0/63488** |
 | **6** | backlog-63 Metal `simdgroup_matrix` | the Apple tensor-core path | ladon (M4) | yes | **DONE 2026-07-27 — availability + numerics; no integer path** |
 
@@ -1131,6 +1131,86 @@ lifting it buys nothing but consistency. **Recommend leaving OpenCL refused** an
 saying why, rather than lifting it for symmetry.
 
 ### Slice 4 — backlog-62, Vulkan cooperative-matrix (local)
+
+> **OUTCOME, 2026-07-27 — the INTEGER path is done end to end, and the order of
+> 4a/4b/4c was deliberately inverted.** Executed on RADV, Mesa 26.1.4-arch3.1,
+> Vulkan 1.4.354, on an `AMD Radeon RX 7900 XTX (RADV NAVI31)`, with the
+> `AMD Ryzen 9 7950X` iGPU (`RADV RAPHAEL_MENDOCINO`) as the negative device.
+> Instruments: `sarek-vulkan/test/test_vulkan_coopmat_integer.ml` (driver side,
+> hand-written GLSL), `sarek/tests/e2e/test_coopmat_integer_e2e.ml` (codegen
+> side, Sarek IR through `Sarek_ir_glsl`), and
+> `sarek-vulkan/probe/probe_vulkan_coopmat_configs.ml` (the advertised table).
+>
+> **Why the inversion.** This slice leads with f16 because f16 scalar is a
+> prerequisite for backlog-63 and for bf16 regardless. But 4a's numeric
+> contract — the γ₁₆ bound of §5.2 and the two positive controls of §5.4 — is
+> entirely unmeasured, whereas `SPV_KHR_cooperative_matrix` states that INTEGER
+> accumulation is exact at the precision of the result type. So the integer
+> configurations land under Sarek's **existing strict contract** with no
+> relaxation, no allowlist, no opt-in and no bound to derive, and they are what
+> got a full DSL-to-executed-result path first. §8's argument, delivered.
+>
+> **The advertised table, measured.** All fourteen are 16×16×16 subgroup scope.
+> Twelve integer: `u8×u8`, `u8×s8`, `s8×u8`, `s8×s8`, each with `→u32`, `→s32`
+> and `→s32 saturating`. Two float: `f16×f16→f16` and `f16×f16→f32`. **Every
+> integer configuration has 8-bit operands with a 32-bit accumulator** — there
+> is no wider integer operand type to fall back on.
+>
+> **Three device features slice 2 did not request, all mandatory.** Read off the
+> SPIR-V rather than guessed: `glslc` on a 16×16×16 u8 `coopMatMulAdd` emits
+> `OpCapability Int8`, `StorageBuffer8BitAccess`, `VulkanMemoryModel` and
+> `CooperativeMatrixKHR`; slice 2 enables only the last. `shaderInt8`,
+> `storageBuffer8BitAccess` and `vulkanMemoryModel` are now queried and
+> **requested** at `vkCreateDevice`. **`vulkanMemoryModel` is required by the
+> FLOAT path too** — glslang makes `GL_KHR_memory_scope_semantics` a
+> prerequisite of `GL_KHR_cooperative_matrix` — so slice 2's coopmat plumbing
+> was incomplete independently of the integer work.
+>
+> **Coverage is exhaustive, not sampled.** The full domain of a 16×16×16 u8
+> multiply-add is 256⁵¹² and cannot be enumerated; the domain that matters for
+> an exactness claim can be. There are exactly 65536 ordered pairs of u8 operand
+> values and one multiply-add performs 4096 multiplications, so
+> `A[i][k] = 16k+i` with `B[k][j] = 16t+j` gives dispatch `t` sixteen disjoint
+> 16×16 blocks of the pair space and `t = 0..15` tiles all 65536 exactly once.
+> Sixteen dispatches, every pair, with a nonzero mixed-sign `C`, bit-identical
+> to the oracle on every output. Wrapping accumulation is exact too, and the
+> case asserts that the reference actually wrapped rather than merely running.
+>
+> **The refusal was observed on both halves.** The iGPU advertises no
+> `VK_KHR_cooperative_matrix`; its verdict refuses while the RX 7900 XTX permits
+> in the same run under the same driver build, and the launch gate refuses on
+> six devices (the Vulkan iGPU, both OpenCL devices, Native, and both
+> Interpreter devices). The gate assertion relates two **independently
+> observed** facts — the extension bit and the verdict — rather than comparing
+> the verdict to the list it reads, which is the tautology slice 2's gate test
+> fell into.
+>
+> **Every claim above was proved falsifiable by mutation.** Seven mutations,
+> each producing the failure it promises: B loaded column-major (driver side and
+> codegen side), the shader dropping C, the interpreter oracle dropping C, the
+> codegen swapping A and B (caught by glslang — `UseA` and `UseB` are not
+> interchangeable types), and the launch gate ignoring the configurations.
+>
+> **One result worth carrying forward, because no results-based test can catch
+> it.** With `storageBuffer8BitAccess` never requested, all three numerics tests
+> stay GREEN and only the feature assertion goes red. That is #142's failure
+> mode reproduced for this feature: RADV computes the right answer from an
+> illegal shader. A capability model is the only instrument that can see it.
+>
+> **What this did NOT do**, and each is a refusal in the code rather than an
+> omission:
+> - **The f16 coopmat path.** `Sarek_ir_glsl` refuses float components, and so
+>   does the interpreter — the latter because §5.1's implementation-defined
+>   addition order means no strict oracle exists to compare against. 4a's
+>   contract is exactly as unmeasured as it was.
+> - **The scalar-f16 refusal of slice 3-as-written is untouched.**
+> - **Saturating accumulation, column-major layout, workgroup scope.** Each is
+>   one enumerant to emit and a second behaviour to verify; none has executed.
+> - **The PPX surface.** A coopmat kernel is built as IR directly. Nothing in
+>   `[%kernel ...]` produces an `SCoopmat`, and the PPX's parallel `stmt` type
+>   deliberately did not gain the constructor.
+> - **Metal, CUDA, OpenCL, WGSL, PTX** refuse rather than emit.
+
 
 Sub-sliced deliberately, because 4a is cheap, is the highest-information step,
 and needs nothing from the DSL:

--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -1166,15 +1166,27 @@ saying why, rather than lifting it for symmetry.
 > prerequisite of `GL_KHR_cooperative_matrix` — so slice 2's coopmat plumbing
 > was incomplete independently of the integer work.
 >
-> **Coverage is exhaustive, not sampled.** The full domain of a 16×16×16 u8
-> multiply-add is 256⁵¹² and cannot be enumerated; the domain that matters for
-> an exactness claim can be. There are exactly 65536 ordered pairs of u8 operand
-> values and one multiply-add performs 4096 multiplications, so
-> `A[i][k] = 16k+i` with `B[k][j] = 16t+j` gives dispatch `t` sixteen disjoint
-> 16×16 blocks of the pair space and `t = 0..15` tiles all 65536 exactly once.
-> Sixteen dispatches, every pair, with a nonzero mixed-sign `C`, bit-identical
-> to the oracle on every output. Wrapping accumulation is exact too, and the
-> case asserts that the reference actually wrapped rather than merely running.
+> **Coverage is exhaustive, not sampled — and the derivation is written out
+> because "exhaustive" is usually sampling in disguise.** The full domain of a
+> 16×16×16 u8 multiply-add is 256⁵¹² and cannot be enumerated. The domain that
+> matters for an EXACTNESS claim can be: there are exactly 65536 ordered pairs
+> `(a, b)` of u8 operand values, and the question is whether every one of them
+> is multiplied at least once.
+>
+> Take `A[i][k] = 16k + i` and `B[k][j] = 16t + j` for dispatch `t`, all indices
+> in `0..15`. One multiply-add forms the 4096 products `A[i][k] · B[k][j]` over
+> the `(i, j, k)` triples. Fix `k`: the A-values are `{16k + i : i}` = the block
+> `[16k, 16k+15]`, and the B-values are `{16t + j : j}` = the block
+> `[16t, 16t+15]`, so the 256 pairs at that `k` are exactly the 16×16 block
+> `[16k, 16k+15] × [16t, 16t+15]`. Ranging `k` over `0..15` gives sixteen blocks
+> that are disjoint (their A-ranges are disjoint), for 4096 pairs per dispatch
+> with no repeat. Ranging `t` over `0..15` moves the B-range through all sixteen
+> of its blocks, so the 256 blocks `(k, t)` tile `[0,255] × [0,255]` exactly.
+>
+> **65536 pairs, each exactly once, in sixteen dispatches.** Every one with a
+> nonzero mixed-sign `C`, and bit-identical to the oracle on every one of the
+> 4096 outputs of every tile. Wrapping accumulation is exact too, and that case
+> asserts the reference ACTUALLY wrapped rather than merely running.
 >
 > **The refusal was observed on both halves.** The iGPU advertises no
 > `VK_KHR_cooperative_matrix`; its verdict refuses while the RX 7900 XTX permits
@@ -1185,17 +1197,66 @@ saying why, rather than lifting it for symmetry.
 > the verdict to the list it reads, which is the tautology slice 2's gate test
 > fell into.
 >
-> **Every claim above was proved falsifiable by mutation.** Seven mutations,
-> each producing the failure it promises: B loaded column-major (driver side and
-> codegen side), the shader dropping C, the interpreter oracle dropping C, the
-> codegen swapping A and B (caught by glslang — `UseA` and `UseB` are not
-> interchangeable types), and the launch gate ignoring the configurations.
+> **Every claim above was proved falsifiable by mutation.** Each row below was
+> applied, run on the hardware named above, and observed to produce the failure
+> it promises. The list is the inventory of what is pinned; nothing is
+> summarised as a count.
 >
-> **One result worth carrying forward, because no results-based test can catch
-> it.** With `storageBuffer8BitAccess` never requested, all three numerics tests
-> stay GREEN and only the feature assertion goes red. That is #142's failure
-> mode reproduced for this feature: RADV computes the right answer from an
-> illegal shader. A capability model is the only instrument that can see it.
+> | # | mutation | observed |
+> |---|---|---|
+> | 1 | driver test: shader loads B column-major | `tile 0 diverges at 0: got 19340 want -500` |
+> | 2 | driver test: shader drops C | exhaustive and wraparound cases both red |
+> | 3 | driver test: `storageBuffer8BitAccess` never requested | **only** the plumbing assertion red — see the finding below |
+> | 4 | e2e: codegen emits `ColumnMajor` in `CM_load` | 16 tiles diverge, first `23780` vs `368140` |
+> | 5 | e2e: codegen swaps the A and B operands | glslang rejects the shader — `UseA` and `UseB` are not interchangeable types |
+> | 6 | e2e: interpreter oracle drops C in `CM_muladd` | 16 tiles diverge, first `-500` vs `0` |
+> | 7 | e2e: launch gate returns no configurations | all six refusing devices report `PERMITTED` |
+> | 8 | e2e: the stride-1-B control made a no-op | `the stride-1-B control was ACCEPTED on 16 of 16 tiles` |
+> | 9 | e2e: the C-dropping control made a no-op | `the C-dropping control was ACCEPTED on 16 of 16 tiles` |
+>
+> Rows 8 and 9 mutate the CONTROLS rather than the code under test, and they are
+> here because a positive control is itself a gate that can rot: if the mutated
+> IR a control builds ever stopped differing from the real one, the control
+> would be accepted every time and its assertion would pass forever while
+> checking nothing. Row 8 exists specifically because that control was
+> MISLABELLED — see the note on the stride-1 read below — and a mislabelled
+> control is the shape a vacuous one arrives in.
+>
+> Mutation 1 leaves the identity case (`D = A × I + 0`) **green**, because `I`
+> is symmetric. That is the reason the identity case and the exhaustive case are
+> two separate tests rather than one.
+>
+> **The stride-1-B control is a Hankel read, not a transposed B.** `CM_load`
+> with stride `s` reads `m[r][c] = buf[base + r·s + c]`, so a stride of 1 gives
+> `buf[r + c]`: every row is the previous row shifted by one, and the whole
+> 16×16 fragment comes from the first 31 elements of the buffer. The transpose
+> would be `buf[c·16 + r]` and is not reachable through a row-major stride at
+> all — it needs `gl_CooperativeMatrixLayoutColumnMajor`, which this slice does
+> not emit. The control is valid either way, since all a control must do is
+> compute a genuinely different function; but it was recorded as "transposed B"
+> in an earlier revision of this section and in the test itself, and that was
+> wrong. Both are corrected. The driver-side test's `transpose_b` IS a genuine
+> transpose — it is a host-side reference, not a stride — and is unchanged.
+>
+> **FINDING — a device feature can be missing with every numeric test green, and
+> only a capability assertion can see it.** This is mutation 3 and it is the most
+> instructive result of the slice, so it is recorded as a finding and not as a
+> table row. With `storageBuffer8BitAccess` never requested, the shader is a
+> specification violation — it declares `OpCapability StorageBuffer8BitAccess`
+> against a logical device that never enabled it — and RADV computes the
+> **correct answer anyway**. All three numerics tests stay green; only the
+> feature assertion goes red. That is backlog-142's failure mode reproduced
+> exactly, one feature over: no results-based test can catch it, however
+> exhaustive its inputs, because the results are right. The instrument that sees
+> it is the capability model, and the reason it exists.
+>
+> **The order reversal paid beyond its intent.** Building the integer path first
+> is what surfaced the three missing device features at all — they were read off
+> the SPIR-V that an integer `coopMatMulAdd` emits. Starting from the float side
+> would have found neither `shaderInt8` nor `storageBuffer8BitAccess`, and would
+> have found `vulkanMemoryModel` only by accident, since a float coopmat shader
+> needs it for the same `GL_KHR_memory_scope_semantics` reason and slice 2 had
+> already shipped without noticing.
 >
 > **What this did NOT do**, and each is a refusal in the code rather than an
 > omission:
@@ -1205,7 +1266,16 @@ saying why, rather than lifting it for symmetry.
 >   contract is exactly as unmeasured as it was.
 > - **The scalar-f16 refusal of slice 3-as-written is untouched.**
 > - **Saturating accumulation, column-major layout, workgroup scope.** Each is
->   one enumerant to emit and a second behaviour to verify; none has executed.
+>   one enumerant to emit and a second behaviour to verify against an oracle,
+>   and none is DELIVERED: the codegen refuses all three.
+>
+>   Stated precisely, because mutations 1 and 4 above did emit column-major
+>   shaders and did run them: column-major has executed only as a MUTATION, to
+>   demonstrate that the comparison goes red. It has never been verified against
+>   the interpreter, so nothing is known about whether Sarek would emit it
+>   correctly — which is exactly why it is refused rather than shipped. "Not
+>   executed" would have been the wrong word and it was the word used here
+>   before.
 > - **The PPX surface.** A coopmat kernel is built as IR directly. Nothing in
 >   `[%kernel ...]` produces an `SCoopmat`, and the PPX's parallel `stmt` type
 >   deliberately did not gain the constructor.

--- a/formal/codegen-ptx/test/test_layout_conformance.ml
+++ b/formal/codegen-ptx/test/test_layout_conformance.ml
@@ -63,8 +63,13 @@ let rec to_lfield (t : elttype) : Model.lfield =
   (* TFloat16 is a 2-byte leaf; the extracted layout model only models L32/L64, and
      f16 aggregate fields are rejected by Sarek_ir_layout.flatten_field anyway
      (#57 slice 1), so f16 is outside the conformance domain. It is likewise
-     absent from [scalar_universe] above, so no generated case reaches here. *)
-  | TFloat16 | TVariant _ | TArray _ | TVec _ | TUnit ->
+     absent from [scalar_universe] above, so no generated case reaches here.
+
+     TUint8 is outside the domain for a different reason: it is a
+     cooperative-matrix operand element type, and the PTX backend this model
+     mirrors refuses it outright, so there is no PTX layout for it to conform
+     to. *)
+  | TFloat16 | TUint8 | TVariant _ | TArray _ | TVec _ | TUnit ->
       invalid_arg "to_lfield: outside the conformance domain"
 
 and to_lfields (ts : elttype list) : Model.lfields =
@@ -77,6 +82,7 @@ let rec pp_elttype = function
   | TInt32 -> "i32"
   | TInt64 -> "i64"
   | TFloat16 -> "f16"
+  | TUint8 -> "u8"
   | TFloat32 -> "f32"
   | TFloat64 -> "f64"
   | TBool -> "bool"

--- a/sarek-vulkan/Vulkan_api_device.ml
+++ b/sarek-vulkan/Vulkan_api_device.ml
@@ -49,6 +49,29 @@ type t = {
           declare 16-bit types in a storage buffer, which every f16 or
           cooperative-matrix kernel that reads its operands from memory must do.
       *)
+  supports_int8 : bool;
+      (** [VkPhysicalDeviceShaderFloat16Int8Features.shaderInt8], on the same
+          chain as {!supports_fp16} (backlog-62 slice 3).
+
+          Every INTEGER cooperative-matrix configuration the local RX 7900 XTX
+          advertises has 8-bit operands — measured, all twelve of them — so a
+          shader that reaches [coopMatMulAdd] on the strict-contract path
+          declares [OpCapability Int8]. Querying without requesting would be
+          #142 verbatim. *)
+  storage_buffer_8bit : bool;
+      (** [VkPhysicalDevice8BitStorageFeatures.storageBuffer8BitAccess]
+          (backlog-62 slice 3). [coopMatLoad] requires the backing array's
+          element type to match the fragment's component type, so an 8-bit
+          fragment loaded from memory declares
+          [OpCapability StorageBuffer8BitAccess]. There is no route to an
+          integer fragment that avoids it: the operand buffer cannot be widened
+          without changing which instruction is emitted. *)
+  vulkan_memory_model : bool;
+      (** [VkPhysicalDeviceVulkanMemoryModelFeatures.vulkanMemoryModel]
+          (backlog-62 slice 3). glslang makes [GL_KHR_memory_scope_semantics] a
+          prerequisite of [GL_KHR_cooperative_matrix], and it lowers to
+          [OpCapability VulkanMemoryModel] — so this is required by the FLOAT
+          coopmat path too, and slice 2 shipped without it. *)
   driver_id : int;
       (** [VkPhysicalDeviceDriverProperties.driverID]. 3 is
           [VK_DRIVER_ID_MESA_RADV]. This is the driver KEY that
@@ -259,12 +282,15 @@ let device_extension_names phys_dev =
 
 type extended_features = {
   ef_shader_float16 : bool;
+  ef_shader_int8 : bool;
   ef_storage_buffer_16bit : bool;
+  ef_storage_buffer_8bit : bool;
+  ef_vulkan_memory_model : bool;
   ef_cooperative_matrix : bool;
   ef_coopmat_robust_buffer_access : bool;
 }
 
-(** Query the three extension feature structs in one [VkPhysicalDeviceFeatures2]
+(** Query the extension feature structs in one [VkPhysicalDeviceFeatures2]
     chain.
 
     Chaining a struct whose extension the device does not advertise is harmless
@@ -272,13 +298,29 @@ type extended_features = {
     guarantees the fields then read false. What is NOT harmless is calling an
     extension's own entry point on such a device; see {!probe_coopmat}. *)
 let query_extended_features phys_dev =
+  let memmodel = make vk_physical_device_vulkan_memory_model_features in
+  zero_struct vk_physical_device_vulkan_memory_model_features memmodel ;
+  setf
+    memmodel
+    memmodel_sType
+    (u32 vk_structure_type_physical_device_vulkan_memory_model_features) ;
+  setf memmodel memmodel_pNext null ;
+
+  let storage8 = make vk_physical_device_8bit_storage_features in
+  zero_struct vk_physical_device_8bit_storage_features storage8 ;
+  setf
+    storage8
+    storage8_sType
+    (u32 vk_structure_type_physical_device_8bit_storage_features) ;
+  setf storage8 storage8_pNext (to_voidp (addr memmodel)) ;
+
   let coopmat_f = make vk_physical_device_cooperative_matrix_features in
   zero_struct vk_physical_device_cooperative_matrix_features coopmat_f ;
   setf
     coopmat_f
     coopmat_feat_sType
     (u32 vk_structure_type_physical_device_cooperative_matrix_features_khr) ;
-  setf coopmat_f coopmat_feat_pNext null ;
+  setf coopmat_f coopmat_feat_pNext (to_voidp (addr storage8)) ;
 
   let storage16 = make vk_physical_device_16bit_storage_features in
   zero_struct vk_physical_device_16bit_storage_features storage16 ;
@@ -305,15 +347,22 @@ let query_extended_features phys_dev =
   setf features2 features2_pNext (to_voidp (addr f16i8)) ;
 
   vkGetPhysicalDeviceFeatures2 phys_dev (addr features2) ;
-  (* The chain holds bare addresses into all four. *)
+  (* The chain holds bare addresses into all six. *)
   ignore (Sys.opaque_identity features2) ;
   ignore (Sys.opaque_identity f16i8) ;
   ignore (Sys.opaque_identity storage16) ;
   ignore (Sys.opaque_identity coopmat_f) ;
+  ignore (Sys.opaque_identity storage8) ;
+  ignore (Sys.opaque_identity memmodel) ;
   {
     ef_shader_float16 = u32_is_true (getf f16i8 f16i8_shaderFloat16);
+    ef_shader_int8 = u32_is_true (getf f16i8 f16i8_shaderInt8);
     ef_storage_buffer_16bit =
       u32_is_true (getf storage16 storage16_storageBuffer16BitAccess);
+    ef_storage_buffer_8bit =
+      u32_is_true (getf storage8 storage8_storageBuffer8BitAccess);
+    ef_vulkan_memory_model =
+      u32_is_true (getf memmodel memmodel_vulkanMemoryModel);
     ef_cooperative_matrix =
       u32_is_true (getf coopmat_f coopmat_feat_cooperativeMatrix);
     ef_coopmat_robust_buffer_access =
@@ -689,6 +738,25 @@ let get idx =
         ext.ef_cooperative_matrix
         && has_ext vk_khr_cooperative_matrix_extension_name
       in
+      (* backlog-62 slice 3, and each follows the same promoted-feature rule as
+         its 16-bit sibling above. VK_KHR_8bit_storage is core in Vulkan 1.2;
+         VK_KHR_shader_float16_int8 (which carries shaderInt8) is core in 1.2;
+         VK_KHR_vulkan_memory_model is core in 1.2. All three are at the
+         effective instance version, so all three are reachable here. *)
+      let want_int8 =
+        ext.ef_shader_int8
+        && (api_at_least (1, 2)
+           || has_ext vk_khr_shader_float16_int8_extension_name)
+      in
+      let want_storage8 =
+        ext.ef_storage_buffer_8bit
+        && (api_at_least (1, 2) || has_ext vk_khr_8bit_storage_extension_name)
+      in
+      let want_memory_model =
+        ext.ef_vulkan_memory_model
+        && (api_at_least (1, 2)
+           || has_ext vk_khr_vulkan_memory_model_extension_name)
+      in
 
       (* Find compute queue family *)
       let queue_family = find_compute_queue_family phys_dev in
@@ -752,8 +820,10 @@ let get idx =
                case, which is what actually enables the feature. *)
             if wanted && has_ext name then Some name else None)
           [
-            (want_fp16, vk_khr_shader_float16_int8_extension_name);
+            (want_fp16 || want_int8, vk_khr_shader_float16_int8_extension_name);
             (want_storage16, vk_khr_16bit_storage_extension_name);
+            (want_storage8, vk_khr_8bit_storage_extension_name);
+            (want_memory_model, vk_khr_vulkan_memory_model_extension_name);
             (want_coopmat, vk_khr_cooperative_matrix_extension_name);
           ]
       in
@@ -808,13 +878,47 @@ let get idx =
         storage16_storageBuffer16BitAccess
         (Unsigned.UInt32.of_int 1) ;
 
+      let storage8_enable = make vk_physical_device_8bit_storage_features in
+      zero_struct vk_physical_device_8bit_storage_features storage8_enable ;
+      setf
+        storage8_enable
+        storage8_sType
+        (u32 vk_structure_type_physical_device_8bit_storage_features) ;
+      setf
+        storage8_enable
+        storage8_storageBuffer8BitAccess
+        (Unsigned.UInt32.of_int 1) ;
+
+      let memmodel_enable =
+        make vk_physical_device_vulkan_memory_model_features
+      in
+      zero_struct
+        vk_physical_device_vulkan_memory_model_features
+        memmodel_enable ;
+      setf
+        memmodel_enable
+        memmodel_sType
+        (u32 vk_structure_type_physical_device_vulkan_memory_model_features) ;
+      setf memmodel_enable memmodel_vulkanMemoryModel (Unsigned.UInt32.of_int 1) ;
+
+      (* ONE VkPhysicalDeviceShaderFloat16Int8Features carries BOTH booleans.
+         Chaining the struct twice — once per feature — is not a way to request
+         two features; the second instance would be a duplicate sType in the
+         pNext chain, which the specification does not permit. *)
       let f16_enable = make vk_physical_device_shader_float16_int8_features in
       zero_struct vk_physical_device_shader_float16_int8_features f16_enable ;
       setf
         f16_enable
         f16i8_sType
         (u32 vk_structure_type_physical_device_shader_float16_int8_features) ;
-      setf f16_enable f16i8_shaderFloat16 (Unsigned.UInt32.of_int 1) ;
+      setf
+        f16_enable
+        f16i8_shaderFloat16
+        (Unsigned.UInt32.of_int (if want_fp16 then 1 else 0)) ;
+      setf
+        f16_enable
+        f16i8_shaderInt8
+        (Unsigned.UInt32.of_int (if want_int8 then 1 else 0)) ;
 
       let chain_head =
         List.fold_left
@@ -832,7 +936,13 @@ let get idx =
             ( want_storage16,
               (fun p -> setf storage16_enable storage16_pNext p),
               to_voidp (addr storage16_enable) );
-            ( want_fp16,
+            ( want_storage8,
+              (fun p -> setf storage8_enable storage8_pNext p),
+              to_voidp (addr storage8_enable) );
+            ( want_memory_model,
+              (fun p -> setf memmodel_enable memmodel_pNext p),
+              to_voidp (addr memmodel_enable) );
+            ( want_fp16 || want_int8,
               (fun p -> setf f16_enable f16i8_pNext p),
               to_voidp (addr f16_enable) );
           ]
@@ -903,6 +1013,8 @@ let get idx =
       ignore (Sys.opaque_identity coopmat_enable) ;
       ignore (Sys.opaque_identity storage16_enable) ;
       ignore (Sys.opaque_identity f16_enable) ;
+      ignore (Sys.opaque_identity storage8_enable) ;
+      ignore (Sys.opaque_identity memmodel_enable) ;
 
       (* Get compute queue *)
       let queue = allocate vk_queue_ptr (from_voidp vk_queue null) in
@@ -960,6 +1072,9 @@ let get idx =
              value safe to hand to a capability gate. *)
           supports_fp16 = want_fp16;
           storage_buffer_16bit = want_storage16;
+          supports_int8 = want_int8;
+          storage_buffer_8bit = want_storage8;
+          vulkan_memory_model = want_memory_model;
           driver_id = props2.ep_driver_id;
           driver_name = props2.ep_driver_name;
           driver_info = props2.ep_driver_info;

--- a/sarek-vulkan/Vulkan_types.ml
+++ b/sarek-vulkan/Vulkan_types.ml
@@ -1126,6 +1126,23 @@ let vk_structure_type_physical_device_shader_float16_int8_features = 1000082000
 
 let vk_structure_type_physical_device_16bit_storage_features = 1000083000
 
+(** backlog-62 slice 3. The three enumerants below are what the INTEGER
+    cooperative-matrix path needs and the f16 path did not.
+
+    Measured, not guessed: [glslc --target-env=vulkan1.3] on a 16x16x16
+    [u8 x u8 -> s32] [coopMatMulAdd] emits exactly [OpCapability Int8],
+    [OpCapability StorageBuffer8BitAccess], [OpCapability VulkanMemoryModel] and
+    [OpCapability CooperativeMatrixKHR]. Slice 2 enables only the last. The
+    first three are conditional on [shaderInt8], [storageBuffer8BitAccess] and
+    [vulkanMemoryModel] being ENABLED on the logical device, exactly as #142's
+    [shaderInt64] was, and with the same failure mode: RADV computes the right
+    answer anyway and the violation is visible only under
+    VK_LAYER_KHRONOS_validation. *)
+
+let vk_structure_type_physical_device_8bit_storage_features = 1000177000
+
+let vk_structure_type_physical_device_vulkan_memory_model_features = 1000211000
+
 let vk_structure_type_physical_device_subgroup_properties = 1000094000
 
 let vk_structure_type_physical_device_driver_properties = 1000196000
@@ -1143,6 +1160,10 @@ let vk_khr_cooperative_matrix_extension_name = "VK_KHR_cooperative_matrix"
 let vk_khr_shader_float16_int8_extension_name = "VK_KHR_shader_float16_int8"
 
 let vk_khr_16bit_storage_extension_name = "VK_KHR_16bit_storage"
+
+let vk_khr_8bit_storage_extension_name = "VK_KHR_8bit_storage"
+
+let vk_khr_vulkan_memory_model_extension_name = "VK_KHR_vulkan_memory_model"
 
 (** VkExtensionProperties: [char extensionName[256]] then [uint32 specVersion].
 *)
@@ -1266,6 +1287,80 @@ let storage16_storageInputOutput16 =
     uint32_t
 
 let () = seal vk_physical_device_16bit_storage_features
+
+(** VkPhysicalDevice8BitStorageFeatures — backlog-62 slice 3.
+
+    Field order and count are pinned against [vulkan_core.h]; the struct is
+    passed by ADDRESS in a pNext chain, so a short or misordered layout is read
+    past its end by the driver rather than diagnosed. Three feature booleans,
+    the last two of which Sarek never requests. *)
+type vk_physical_device_8bit_storage_features
+
+let vk_physical_device_8bit_storage_features :
+    vk_physical_device_8bit_storage_features structure typ =
+  structure "VkPhysicalDevice8BitStorageFeatures"
+
+let storage8_sType =
+  field vk_physical_device_8bit_storage_features "sType" uint32_t
+
+let storage8_pNext =
+  field vk_physical_device_8bit_storage_features "pNext" (ptr void)
+
+let storage8_storageBuffer8BitAccess =
+  field
+    vk_physical_device_8bit_storage_features
+    "storageBuffer8BitAccess"
+    uint32_t
+
+let storage8_uniformAndStorageBuffer8BitAccess =
+  field
+    vk_physical_device_8bit_storage_features
+    "uniformAndStorageBuffer8BitAccess"
+    uint32_t
+
+let storage8_storagePushConstant8 =
+  field vk_physical_device_8bit_storage_features "storagePushConstant8" uint32_t
+
+let () = seal vk_physical_device_8bit_storage_features
+
+(** VkPhysicalDeviceVulkanMemoryModelFeatures — backlog-62 slice 3.
+
+    [GL_KHR_memory_scope_semantics] is a hard prerequisite of
+    [GL_KHR_cooperative_matrix] in glslang, and it lowers to
+    [OpCapability VulkanMemoryModel]. Without [vulkanMemoryModel] enabled on the
+    logical device, a cooperative-matrix shader is a specification violation
+    however correct its results look. *)
+type vk_physical_device_vulkan_memory_model_features
+
+let vk_physical_device_vulkan_memory_model_features :
+    vk_physical_device_vulkan_memory_model_features structure typ =
+  structure "VkPhysicalDeviceVulkanMemoryModelFeatures"
+
+let memmodel_sType =
+  field vk_physical_device_vulkan_memory_model_features "sType" uint32_t
+
+let memmodel_pNext =
+  field vk_physical_device_vulkan_memory_model_features "pNext" (ptr void)
+
+let memmodel_vulkanMemoryModel =
+  field
+    vk_physical_device_vulkan_memory_model_features
+    "vulkanMemoryModel"
+    uint32_t
+
+let memmodel_vulkanMemoryModelDeviceScope =
+  field
+    vk_physical_device_vulkan_memory_model_features
+    "vulkanMemoryModelDeviceScope"
+    uint32_t
+
+let memmodel_vulkanMemoryModelAvailabilityVisibilityChains =
+  field
+    vk_physical_device_vulkan_memory_model_features
+    "vulkanMemoryModelAvailabilityVisibilityChains"
+    uint32_t
+
+let () = seal vk_physical_device_vulkan_memory_model_features
 
 (** VkPhysicalDeviceCooperativeMatrixFeaturesKHR *)
 type vk_physical_device_cooperative_matrix_features

--- a/sarek-vulkan/probe/dune
+++ b/sarek-vulkan/probe/dune
@@ -10,3 +10,11 @@
  (name probe_vulkan_f16_model_agreement)
  (modules probe_vulkan_f16_model_agreement)
  (libraries sarek_vulkan spoc_framework f16_model_set f16_shape_catalogue))
+
+; backlog-62 slice 3 — dumps the advertised coopmat configuration table. Same
+; executable-not-test rationale as above: it measures a driver.
+
+(executable
+ (name probe_vulkan_coopmat_configs)
+ (modules probe_vulkan_coopmat_configs)
+ (libraries sarek_vulkan sarek_ir spoc_framework))

--- a/sarek-vulkan/probe/probe_vulkan_coopmat_configs.ml
+++ b/sarek-vulkan/probe/probe_vulkan_coopmat_configs.ml
@@ -1,0 +1,54 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-62 slice 3 — dump every cooperative-matrix configuration each local
+ * Vulkan device advertises, through Sarek's own probe rather than a C program.
+ *
+ * An executable and not a test, for the reason sarek-vulkan/probe/dune already
+ * gives: this MEASURES a driver. The gate that must stay green on any runner is
+ * sarek-vulkan/test/test_vulkan_coopmat_capability.ml.
+ *
+ * It exists because the C probe in tools/probes/vulkan_coopmat_probe.c needs
+ * Vulkan headers new enough to declare VkComponentTypeKHR, and the newest
+ * headers on this workstation predate the KHR promotion. Sarek's ctypes probe
+ * pins the enumerants by value and does not, so it can answer the question the
+ * C probe cannot be built to ask here.
+ ******************************************************************************)
+
+open Sarek_vulkan
+
+let () =
+  if not (Vulkan_api.is_available ()) then (
+    print_endline "no Vulkan device available" ;
+    exit 0) ;
+  Vulkan_api_device.init () ;
+  let n = Vulkan_api_device.count () in
+  Printf.printf "%d Vulkan device(s)\n\n" n ;
+  for i = 0 to n - 1 do
+    let dev = Vulkan_api_device.get i in
+    let caps = Vulkan_plugin_base.Vulkan.Device.capabilities dev in
+    Printf.printf "device %d: %s\n" i dev.Vulkan_api_device.name ;
+    match caps.Spoc_framework.Framework_sig.coopmat with
+    | None -> Printf.printf "  coopmat: UNPROBED\n\n"
+    | Some ds ->
+        Printf.printf
+          "  subgroup size %d, robustBufferAccess %b, advertised %d, \
+           represented %d\n"
+          ds.Sarek_coopmat.ds_subgroup_size
+          ds.Sarek_coopmat.ds_robust_buffer_access
+          ds.Sarek_coopmat.ds_advertised_count
+          (List.length ds.Sarek_coopmat.ds_configs) ;
+        List.iteri
+          (fun j cfg ->
+            Printf.printf
+              "  [%2d] %-44s exact=%b regime=%s\n"
+              j
+              (Sarek_coopmat.config_name cfg)
+              (Sarek_coopmat.accumulation_is_exact cfg)
+              (Sarek_coopmat.regime_name (Sarek_coopmat.regime cfg)))
+          ds.Sarek_coopmat.ds_configs ;
+        print_newline ()
+  done

--- a/sarek-vulkan/test/dune
+++ b/sarek-vulkan/test/dune
@@ -39,3 +39,14 @@
  (name test_vulkan_coopmat_capability)
  (modules test_vulkan_coopmat_capability)
  (libraries sarek_vulkan spoc_framework sarek_ir alcotest str))
+
+; backlog-62 slice 3 — the integer coopmat path, executed against an exact host
+; oracle. A `test` and not a `probe` because the claim it defends (integer
+; accumulation is exact, so this path is under the STRICT contract) is a claim
+; Sarek ships, not a driver measurement: it skips where there is no coopmat
+; device and must be red where there is one and the answer is wrong.
+
+(test
+ (name test_vulkan_coopmat_integer)
+ (modules test_vulkan_coopmat_integer)
+ (libraries sarek_vulkan spoc_framework sarek_ir alcotest astring))

--- a/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
+++ b/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
@@ -1,0 +1,526 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-62 slice 3 — the INTEGER cooperative-matrix path, executed.
+ *
+ * WHY INTEGER AND NOT f16, WHICH IS WHAT THE PLAN LEADS WITH.
+ *
+ * docs/design/f16-relaxed-accuracy.md §7 slice 4a schedules a hand-written
+ * coopmat shader for f16 x f16 -> f32, measured against the gamma_16 bound of
+ * §5.2 with the two positive controls of §5.4. That slice needs a numeric
+ * contract that does not exist yet.
+ *
+ * The integer configurations need none of it. SPV_KHR_cooperative_matrix states
+ * that integer accumulation is performed at the precision of the result type
+ * and is EXACT, so u8 x u8 + s32 -> s32 computes the same function as a host
+ * reference does — bit for bit, no bound, no allowlist, no opt-in, under
+ * Sarek's EXISTING strict contract. Twelve of the fourteen configurations the
+ * local RX 7900 XTX advertises are integer, and all twelve have 8-bit operands
+ * with a 32-bit accumulator (measured; sarek-vulkan/probe/
+ * probe_vulkan_coopmat_configs.ml prints the table).
+ *
+ * So this file is the integer twin of slice 4a: a hand-written GLSL coopmat
+ * shader driven through Sarek's own Vulkan stack, with an exact host oracle.
+ * It measures the DRIVER and the device plumbing, not Sarek's codegen — the
+ * same distinction docs/fp-contraction-policy.md §7(c) draws about the f16
+ * tripwire. The codegen-side gate is test_sarek_ir_glsl's coopmat cases.
+ *
+ * INPUT COVERAGE, AND WHY IT IS EXHAUSTIVE RATHER THAN SAMPLED.
+ *
+ * The full domain of a 16x16x16 u8 multiply-add is 256^512 and cannot be
+ * enumerated. The domain that MATTERS for an exactness claim can be: there are
+ * exactly 65536 ordered pairs (a, b) of u8 operand values, and one 16x16x16
+ * multiply-add performs 4096 multiplications. Choosing
+ *
+ *     A[i][k] = 16*k + i        B[k][j] = 16*t + j
+ *
+ * makes the pair set of dispatch t equal to the union over k of
+ * [16k, 16k+15] x [16t, 16t+15] — sixteen disjoint 16x16 blocks. Over
+ * t = 0..15 those 256 blocks tile the whole 256x256 pair space exactly once.
+ * SIXTEEN dispatches therefore exercise EVERY ordered pair of u8 operand
+ * values exactly once, with no sampling anywhere.
+ *
+ * PROVING THE COMPARISON CAN GO RED.
+ *
+ * A bit-for-bit comparison that has never been observed failing is
+ * indistinguishable from one that returns true. Two positive controls run on
+ * the same measured data, mirroring §5.4's construction for the float path:
+ * a reference that DROPS C, and a reference that TRANSPOSES B. Each must be
+ * REJECTED by the same comparison that accepts the correct one. If either is
+ * accepted, the test fails — the controls are assertions, not printouts.
+ *
+ * THE NEGATIVE DEVICE.
+ *
+ * The Raphael iGPU advertises no VK_KHR_cooperative_matrix. It is not merely
+ * skipped: the test asserts that Sarek's capability verdict REFUSES the
+ * configuration there, in the same run in which the RX 7900 XTX permits it.
+ ******************************************************************************)
+
+open Sarek_vulkan
+module Device = Vulkan_api_device
+module Memory = Vulkan_api_memory
+module Kernel = Vulkan_api_kernel
+
+let mnk = 16
+
+let elems = mnk * mnk
+
+(* u8 x u8 + s32 -> s32, 16x16x16, subgroup scope, non-saturating. Advertised as
+   configuration [1] of 14 on the RX 7900 XTX under radv / Mesa 26.1.4-arch3.1.
+   Non-saturating is the one whose host reference is plain two's-complement
+   arithmetic; the saturating twin computes a different function and is not
+   claimed here. *)
+let cfg_u8_u8_s32 =
+  {
+    Sarek_coopmat.cfg_shape = {Sarek_coopmat.m = mnk; n = mnk; k = mnk};
+    cfg_a = Sarek_coopmat.Uint8;
+    cfg_b = Sarek_coopmat.Uint8;
+    cfg_c = Sarek_coopmat.Sint32;
+    cfg_result = Sarek_coopmat.Sint32;
+    cfg_saturating = false;
+    cfg_scope = Sarek_coopmat.Subgroup;
+  }
+
+(* Hand-written, deliberately: this file measures the driver. It is NOT produced
+   by Sarek_ir_glsl and must not be, or a codegen defect would cancel against a
+   driver defect and the run would still be green. *)
+let coopmat_source ~local_size =
+  Printf.sprintf
+    {|#version 450
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
+
+layout(local_size_x = %d) in;
+layout(std430, binding = 0) readonly buffer BufA { uint8_t a[]; };
+layout(std430, binding = 1) readonly buffer BufB { uint8_t b[]; };
+layout(std430, binding = 2) readonly buffer BufC { int32_t c[]; };
+layout(std430, binding = 3) writeonly buffer BufD { int32_t d[]; };
+
+void main() {
+  coopmat<uint8_t, gl_ScopeSubgroup, %d, %d, gl_MatrixUseA> A;
+  coopmat<uint8_t, gl_ScopeSubgroup, %d, %d, gl_MatrixUseB> B;
+  coopmat<int32_t, gl_ScopeSubgroup, %d, %d, gl_MatrixUseAccumulator> C;
+  coopMatLoad(A, a, 0, %d, gl_CooperativeMatrixLayoutRowMajor);
+  coopMatLoad(B, b, 0, %d, gl_CooperativeMatrixLayoutRowMajor);
+  coopMatLoad(C, c, 0, %d, gl_CooperativeMatrixLayoutRowMajor);
+  C = coopMatMulAdd(A, B, C);
+  coopMatStore(C, d, 0, %d, gl_CooperativeMatrixLayoutRowMajor);
+}
+|}
+    local_size
+    mnk
+    mnk
+    mnk
+    mnk
+    mnk
+    mnk
+    mnk
+    mnk
+    mnk
+    mnk
+
+(** [D = A x B + C] over the integers, exactly, in Int32 two's-complement.
+
+    This is the oracle. It is written in terms of [Int32] operations rather than
+    OCaml's native [int] so that a result which would overflow 32 bits wraps the
+    way the specification says the device wraps, instead of quietly being right
+    for the wrong reason on a 63-bit host int. *)
+let reference ~a ~b ~c ~drop_c ~transpose_b =
+  let d = Array.make elems 0l in
+  for i = 0 to mnk - 1 do
+    for j = 0 to mnk - 1 do
+      let acc = ref (if drop_c then 0l else c.((i * mnk) + j)) in
+      for k = 0 to mnk - 1 do
+        let av = Int32.of_int a.((i * mnk) + k) in
+        let bv =
+          Int32.of_int
+            (if transpose_b then b.((j * mnk) + k) else b.((k * mnk) + j))
+        in
+        acc := Int32.add !acc (Int32.mul av bv)
+      done ;
+      d.((i * mnk) + j) <- !acc
+    done
+  done ;
+  d
+
+let bit_identical (x : int32 array) (y : int32 array) =
+  Array.length x = Array.length y
+  &&
+  let ok = ref true in
+  Array.iteri (fun i v -> if v <> y.(i) then ok := false) x ;
+  !ok
+
+let first_divergence (x : int32 array) (y : int32 array) =
+  let rec go i =
+    if i >= Array.length x then None
+    else if x.(i) <> y.(i) then Some (i, x.(i), y.(i))
+    else go (i + 1)
+  in
+  go 0
+
+(** One dispatch: upload A, B, C, run, read D back. *)
+let dispatch device ~local_size ~a ~b ~c =
+  let compiled =
+    Kernel.compile_cached
+      device
+      ~name:(Printf.sprintf "coopmat_u8_s32_%d" local_size)
+      ~source:(coopmat_source ~local_size)
+  in
+  let buf_a = Memory.alloc device elems Bigarray.int8_unsigned in
+  let buf_b = Memory.alloc device elems Bigarray.int8_unsigned in
+  let buf_c = Memory.alloc device elems Bigarray.int32 in
+  let buf_d = Memory.alloc device elems Bigarray.int32 in
+  let free_all () = List.iter Memory.free [buf_a; buf_b; buf_c; buf_d] in
+  Fun.protect ~finally:free_all (fun () ->
+      let ha =
+        Bigarray.Array1.create Bigarray.int8_unsigned Bigarray.c_layout elems
+      and hb =
+        Bigarray.Array1.create Bigarray.int8_unsigned Bigarray.c_layout elems
+      and hc = Bigarray.Array1.create Bigarray.int32 Bigarray.c_layout elems
+      and hd = Bigarray.Array1.create Bigarray.int32 Bigarray.c_layout elems in
+      for i = 0 to elems - 1 do
+        ha.{i} <- a.(i) ;
+        hb.{i} <- b.(i) ;
+        hc.{i} <- c.(i) ;
+        hd.{i} <- 0l
+      done ;
+      Memory.host_to_device ~src:ha ~dst:buf_a ;
+      Memory.host_to_device ~src:hb ~dst:buf_b ;
+      Memory.host_to_device ~src:hc ~dst:buf_c ;
+      Memory.host_to_device ~src:hd ~dst:buf_d ;
+      let args = Kernel.create_args () in
+      Kernel.set_arg_buffer args 0 buf_a ;
+      Kernel.set_arg_buffer args 1 buf_b ;
+      Kernel.set_arg_buffer args 2 buf_c ;
+      Kernel.set_arg_buffer args 3 buf_d ;
+      let block = Spoc_framework.Framework_sig.dims_1d local_size in
+      let grid = Spoc_framework.Framework_sig.dims_1d 1 in
+      Kernel.launch compiled ~args ~grid ~block ~shared_mem:0 ~stream:None ;
+      Device.synchronize device ;
+      Memory.device_to_host ~src:buf_d ~dst:hd ;
+      Array.init elems (fun i -> hd.{i}))
+
+(* ------------------------------------------------------------------ *)
+(* device selection                                                    *)
+(* ------------------------------------------------------------------ *)
+
+type classified = {
+  dev : Device.t;
+  permits : bool;  (** Sarek's own verdict for [cfg_u8_u8_s32]. *)
+}
+
+let classify () =
+  let n = try Device.count () with _ -> 0 in
+  List.init n (fun i ->
+      let dev = Device.get i in
+      let caps = Vulkan_plugin_base.Vulkan.Device.capabilities dev in
+      let verdict =
+        Sarek_coopmat.verdict
+          ~support:caps.Spoc_framework.Framework_sig.coopmat
+          cfg_u8_u8_s32
+      in
+      {dev; permits = Sarek_capability.permits verdict})
+
+let with_vulkan f =
+  if not (Vulkan_api.is_available ()) then Alcotest.skip ()
+  else begin
+    Device.init () ;
+    f (classify ())
+  end
+
+(* ------------------------------------------------------------------ *)
+(* tests                                                               *)
+(* ------------------------------------------------------------------ *)
+
+(** The device plumbing this path needs, reported as ENABLED rather than merely
+    supported.
+
+    Asserted only on a device whose verdict PERMITS the configuration: on such a
+    device the three features are not optional extras but a precondition, since
+    the shader below cannot be loaded legally without them. Asserting them
+    unconditionally would fail on a device that legitimately has no coopmat at
+    all, which is not the claim. *)
+let test_features_enabled () =
+  with_vulkan (fun devs ->
+      let permitting = List.filter (fun d -> d.permits) devs in
+      if permitting = [] then Alcotest.skip () ;
+      List.iter
+        (fun d ->
+          let name = d.dev.Device.name in
+          Alcotest.(check bool)
+            (name ^ ": shaderInt8 enabled")
+            true
+            d.dev.Device.supports_int8 ;
+          Alcotest.(check bool)
+            (name ^ ": storageBuffer8BitAccess enabled")
+            true
+            d.dev.Device.storage_buffer_8bit ;
+          Alcotest.(check bool)
+            (name ^ ": vulkanMemoryModel enabled")
+            true
+            d.dev.Device.vulkan_memory_model)
+        permitting)
+
+(** The subgroup size is the calling convention, and it is read from the device.
+
+    [Sarek_coopmat.config_fits_subgroup] must accept the configuration at the
+    size this device actually reports, because a fragment that does not divide
+    over the subgroup has no layout at all. Asserting PROBED and not merely
+    positive is deliberate: [fallback_subgroup_size] guarantees positivity, so a
+    positivity assertion cannot fail and is not evidence. *)
+let test_subgroup_convention () =
+  with_vulkan (fun devs ->
+      let permitting = List.filter (fun d -> d.permits) devs in
+      if permitting = [] then Alcotest.skip () ;
+      List.iter
+        (fun d ->
+          let sg = d.dev.Device.subgroup_size in
+          Alcotest.(check bool)
+            (d.dev.Device.name ^ ": subgroup size is probed, not the fallback")
+            true
+            d.dev.Device.subgroup_size_probed ;
+          Alcotest.(check bool)
+            (Printf.sprintf
+               "%s: 16x16x16 fits a subgroup of %d"
+               d.dev.Device.name
+               sg)
+            true
+            (Sarek_coopmat.config_fits_subgroup ~subgroup_size:sg cfg_u8_u8_s32) ;
+          (* The whole point of slice 2's correction: 4 components per
+             invocation at 64, not 8 at the 32 that used to be hard-coded. *)
+          let frag_a, _, _, _ =
+            Sarek_coopmat.fragments_of_config cfg_u8_u8_s32
+          in
+          match
+            Sarek_coopmat.components_per_invocation ~subgroup_size:sg frag_a
+          with
+          | Ok cpi ->
+              Alcotest.(check int)
+                (Printf.sprintf
+                   "%s: components per invocation"
+                   d.dev.Device.name)
+                (elems / sg)
+                cpi
+          | Error e -> Alcotest.fail e)
+        permitting)
+
+(** The gate refuses on a device that does not advertise the extension.
+
+    NOT tautological: it does not ask the configuration list whether the
+    configuration is in the configuration list. It asserts a relation between
+    two INDEPENDENTLY OBSERVED facts — the extension bit that
+    [vkEnumerateDeviceExtensionProperties] reported, and the verdict. A verdict
+    that permitted on a device with no extension, or refused on one that has it
+    and advertises the configuration, fails here. *)
+let test_negative_device_refuses () =
+  with_vulkan (fun devs ->
+      if List.length devs < 2 then Alcotest.skip () ;
+      let refusing =
+        List.filter
+          (fun d -> not d.dev.Device.coopmat_extension_advertised)
+          devs
+      in
+      if refusing = [] then Alcotest.skip () ;
+      List.iter
+        (fun d ->
+          Alcotest.(check bool)
+            (d.dev.Device.name
+           ^ ": no VK_KHR_cooperative_matrix, so the verdict must refuse")
+            false
+            d.permits ;
+          (* And the refusal must be a DIAGNOSTIC, naming the capability. *)
+          let cap = Sarek_coopmat.device_lacks_config cfg_u8_u8_s32 in
+          let msg = Sarek_capability.explain ~target:d.dev.Device.name cap in
+          Alcotest.(check bool)
+            "the refusal names the device"
+            true
+            (String.length msg > 0
+            && Astring.String.is_infix ~affix:d.dev.Device.name msg))
+        refusing ;
+      (* The separation itself: at least one device permits while another
+         refuses, in the same run, under the same driver build. Without this the
+         two arms above could both be vacuous. *)
+      let permits = List.exists (fun d -> d.permits) devs in
+      Alcotest.(check bool)
+        "some device permits, so the refusal above is a separation"
+        true
+        permits)
+
+(** Load, store and operand mapping, isolated from the sum.
+
+    [B = I] and [C = 0] make [D = A]. A wrong row/column layout, a wrong stride,
+    or A and B swapped all survive the exhaustive-product test below (which is
+    symmetric in enough of the wrong ways to be fooled) and die here. *)
+let test_identity_layout () =
+  with_vulkan (fun devs ->
+      let permitting = List.filter (fun d -> d.permits) devs in
+      if permitting = [] then Alcotest.skip () ;
+      List.iter
+        (fun d ->
+          let a = Array.init elems (fun i -> i * 7 land 0xff) in
+          let b =
+            Array.init elems (fun i -> if i / mnk = i mod mnk then 1 else 0)
+          in
+          let c = Array.make elems 0l in
+          let got =
+            dispatch d.dev ~local_size:d.dev.Device.subgroup_size ~a ~b ~c
+          in
+          let want = Array.init elems (fun i -> Int32.of_int a.(i)) in
+          (match first_divergence got want with
+          | None -> ()
+          | Some (i, g, w) ->
+              Alcotest.failf
+                "%s: D = A x I + 0 diverges at %d: got %ld want %ld"
+                d.dev.Device.name
+                i
+                g
+                w) ;
+          Alcotest.(check bool) "D = A x I" true (bit_identical got want))
+        permitting)
+
+(** Every ordered pair of u8 operand values, exactly once, with a nonzero C.
+
+    Sixteen dispatches; see the header for why that is exhaustive rather than a
+    sample. The two positive controls run on the SAME measured output, so a
+    green result here is a claim about a comparison that has been observed to
+    reject two specific wrong answers. *)
+let test_exhaustive_operand_pairs () =
+  with_vulkan (fun devs ->
+      let permitting = List.filter (fun d -> d.permits) devs in
+      if permitting = [] then Alcotest.skip () ;
+      List.iter
+        (fun d ->
+          let controls_fired_drop_c = ref 0 and controls_fired_transp = ref 0 in
+          for t = 0 to mnk - 1 do
+            let a =
+              Array.init elems (fun p ->
+                  ((16 * (p mod mnk)) + (p / mnk)) land 0xff)
+            and b =
+              Array.init elems (fun p -> ((16 * t) + (p mod mnk)) land 0xff)
+            and c =
+              (* Nonzero, mixed sign, and not a constant — a C that is dropped
+                 or added twice must change the answer at every position. *)
+              Array.init elems (fun p -> Int32.of_int ((p * 37 mod 1009) - 500))
+            in
+            let got =
+              dispatch d.dev ~local_size:d.dev.Device.subgroup_size ~a ~b ~c
+            in
+            let want = reference ~a ~b ~c ~drop_c:false ~transpose_b:false in
+            (match first_divergence got want with
+            | None -> ()
+            | Some (i, g, w) ->
+                Alcotest.failf
+                  "%s: tile %d diverges at %d: got %ld want %ld"
+                  d.dev.Device.name
+                  t
+                  i
+                  g
+                  w) ;
+            Alcotest.(check bool)
+              (Printf.sprintf "%s: tile %d exact" d.dev.Device.name t)
+              true
+              (bit_identical got want) ;
+            (* Positive control 1 (§5.4's C-dropping reference). *)
+            let no_c = reference ~a ~b ~c ~drop_c:true ~transpose_b:false in
+            if not (bit_identical got no_c) then incr controls_fired_drop_c ;
+            (* Positive control 2: B transposed. *)
+            let tb = reference ~a ~b ~c ~drop_c:false ~transpose_b:true in
+            if not (bit_identical got tb) then incr controls_fired_transp
+          done ;
+          Alcotest.(check int)
+            (d.dev.Device.name
+           ^ ": the C-dropping reference is rejected on every tile")
+            mnk
+            !controls_fired_drop_c ;
+          Alcotest.(check int)
+            (d.dev.Device.name
+           ^ ": the transposed-B reference is rejected on every tile")
+            mnk
+            !controls_fired_transp)
+        permitting)
+
+(** Integer accumulation is EXACT, which is the whole reason this path lands
+    under the strict contract — so it must also be exact where it wraps.
+
+    A saturating configuration computes a different function; this one is the
+    non-saturating variant and the specification says it wraps at the result
+    precision. Driving C to just below [Int32.max_int] and requiring the
+    two's-complement wrap makes "exact" a testable claim rather than a claim
+    about small numbers only. *)
+let test_wraparound_is_exact () =
+  with_vulkan (fun devs ->
+      let permitting = List.filter (fun d -> d.permits) devs in
+      if permitting = [] then Alcotest.skip () ;
+      List.iter
+        (fun d ->
+          let a = Array.init elems (fun _ -> 255)
+          and b = Array.init elems (fun _ -> 255)
+          and c = Array.make elems (Int32.sub Int32.max_int 1000l) in
+          let got =
+            dispatch d.dev ~local_size:d.dev.Device.subgroup_size ~a ~b ~c
+          in
+          let want = reference ~a ~b ~c ~drop_c:false ~transpose_b:false in
+          (* The reference must actually be exercising the wrap, or this test
+             proves nothing about wrapping. 16 * 255 * 255 = 1040400 >> 1000. *)
+          Alcotest.(check bool)
+            "the reference wrapped, so the case is not vacuous"
+            true
+            (Int32.compare want.(0) 0l < 0) ;
+          (match first_divergence got want with
+          | None -> ()
+          | Some (i, g, w) ->
+              Alcotest.failf
+                "%s: wrap diverges at %d: got %ld want %ld"
+                d.dev.Device.name
+                i
+                g
+                w) ;
+          Alcotest.(check bool)
+            (d.dev.Device.name ^ ": wrapping accumulation is exact")
+            true
+            (bit_identical got want))
+        permitting)
+
+let () =
+  Alcotest.run
+    "Vulkan integer cooperative matrix"
+    [
+      ( "plumbing",
+        [
+          Alcotest.test_case
+            "the device features the path needs are enabled"
+            `Quick
+            test_features_enabled;
+          Alcotest.test_case
+            "the subgroup calling convention is probed and divides"
+            `Quick
+            test_subgroup_convention;
+        ] );
+      ( "gate",
+        [
+          Alcotest.test_case
+            "a device without the extension is refused"
+            `Quick
+            test_negative_device_refuses;
+        ] );
+      ( "numerics",
+        [
+          Alcotest.test_case
+            "D = A x I + 0 recovers A"
+            `Quick
+            test_identity_layout;
+          Alcotest.test_case
+            "every u8 operand pair, exact, controls rejected"
+            `Quick
+            test_exhaustive_operand_pairs;
+          Alcotest.test_case
+            "wrapping accumulation is exact"
+            `Quick
+            test_wraparound_is_exact;
+        ] );
+    ]

--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -49,6 +49,20 @@ let rec cuda_type_of_elttype = function
   | TFloat16 -> "__half"
   | TFloat32 -> "float"
   | TFloat64 -> "double"
+  | TUint8 ->
+      (* Not "CUDA has no 8-bit integer" — it has several. The refusal is that
+         [TUint8] carries a promise this backend cannot keep: it exists only as
+         the element type of a cooperative-matrix operand buffer, and mapping it
+         to `unsigned char` here would let a kernel written for the tensor-core
+         path compile into scalar CUDA that silently computes something else.
+         Mapping it becomes correct the day CUDA grows a wmma lowering, not
+         before. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "uint8"
+           "CUDA: uint8 is a cooperative-matrix operand element type, emitted \
+            only by the Vulkan backend, and CUDA has no cooperative-matrix \
+            path")
   | TBool -> "int"
   | TUnit -> "void"
   | TRecord (name, _) -> mangle_name name
@@ -516,6 +530,18 @@ let rec gen_stmt buf indent = function
       gen_stmt buf (indent ^ "  ") body ;
       Buffer.add_string buf indent ;
       Buffer.add_string buf "}\n"
+  | SCoopmat _ ->
+      (* CUDA does have tensor cores, but reaching them means the wmma
+         fragment API, whose fragment types, ldmatrix layouts and per-shape
+         constraints are a lowering nobody has written or measured here. An
+         approximation emitted from this arm would be a scalar loop wearing a
+         tensor-core name, so the statement is refused outright. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "cooperative matrix"
+           "CUDA: the CUDA backend has no cooperative-matrix path; \
+            cooperative-matrix statements are emitted only by the Vulkan \
+            backend")
 
 (** Helper: Generate record field assignment *)
 and gen_record_assign buf indent lv fields =

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -285,6 +285,17 @@ let rec glsl_type_of_elttype = function
         (Codegen_error.unsupported_construct
            "f16"
            Sarek_ir_codegen.glsl_float16_refusal)
+  | TUint8 ->
+      (* Spelled under GL_EXT_shader_explicit_arithmetic_types_int8, which
+         {!glsl_header} emits whenever the kernel mentions this type at all. The
+         extension is not optional in the way the fp64 one is: [uint8_t] does
+         not parse under plain [#version 450].
+
+         Unlike every other arm of this function, nothing arithmetic is ever
+         generated at this type — see {!Sarek_ir_types.TUint8}. It appears in
+         exactly two positions: the element type of a storage buffer, and the
+         component type of a cooperative-matrix fragment. *)
+      "uint8_t"
   | TFloat32 -> "float"
   | TFloat64 -> "double" (* Requires GL_ARB_gpu_shader_fp64 *)
   | TBool -> "bool"
@@ -936,6 +947,147 @@ and gen_array_decl buf indent v_name elem_ty size =
   gen_expr buf size ;
   Buffer.add_string buf "];\n"
 
+(** {1 Cooperative matrix — backlog-62 slice 3}
+
+    The GLSL surface is [GL_KHR_cooperative_matrix]: a
+    [coopmat<T, scope, rows, cols, use>] type, [coopMatLoad] / [coopMatStore]
+    against a storage buffer, and [coopMatMulAdd]. Every one of these functions
+    is total on the IR it is given and raises where the IR admits something this
+    extension cannot spell, rather than emitting text that glslang would reject
+    with a message about a line the user never wrote. *)
+
+(** The GLSL scalar type of a fragment component.
+
+    Deliberately NOT routed through {!glsl_type_of_elttype}: the IR element
+    types and the cooperative-matrix component types are different alphabets
+    that happen to overlap, and there is no [elttype] at all for [s8], [u32] or
+    [f16]-as-a-coopmat-component. Mapping them through a shared function would
+    force one of the two to grow constructors it has no other use for. *)
+let glsl_coopmat_component (c : Sarek_coopmat_types.component_type) =
+  match c with
+  | Sarek_coopmat_types.Uint8 -> "uint8_t"
+  | Sarek_coopmat_types.Sint8 -> "int8_t"
+  | Sarek_coopmat_types.Uint32 -> "uint32_t"
+  | Sarek_coopmat_types.Sint32 -> "int32_t"
+  | Sarek_coopmat_types.Float16 ->
+      (* The f16 REFUSAL is not lifted by this slice, and this is where it is
+         enforced for the coopmat path specifically. Slice 4a's numeric contract
+         — the gamma_16 bound of docs/design/f16-relaxed-accuracy.md §5.2 and
+         its two positive controls — is entirely unmeasured, and §7 is explicit
+         that slice 3 must not lift a refusal past what a model has been
+         measured for. The integer configurations need none of it:
+         SPV_KHR_cooperative_matrix states integer accumulation is exact, so
+         they land under the EXISTING strict contract. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "f16 cooperative matrix"
+           "the numeric contract for float cooperative-matrix accumulation is \
+            unmeasured (docs/design/f16-relaxed-accuracy.md §5, slice 4a). The \
+            INTEGER configurations are available and are under the strict \
+            contract.")
+  | Sarek_coopmat_types.Float32 ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "f32 cooperative matrix"
+           "the numeric contract for float cooperative-matrix accumulation is \
+            unmeasured (docs/design/f16-relaxed-accuracy.md §5, slice 4a). The \
+            INTEGER configurations are available and are under the strict \
+            contract.")
+
+let glsl_coopmat_scope (sc : Sarek_coopmat_types.scope) =
+  match sc with
+  | Sarek_coopmat_types.Subgroup -> "gl_ScopeSubgroup"
+  | Sarek_coopmat_types.Workgroup ->
+      (* Modelled in the IR because an unrepresentable scope must not be
+         silently rewritten to Subgroup (see Sarek_coopmat's interface), and
+         refused here because nothing has executed one: every configuration
+         measured on the local device is subgroup scope, and an emitted scope no
+         hardware has run is a claim without evidence. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "workgroup-scope cooperative matrix"
+           "no local device advertises a workgroup-scope configuration, so \
+            none has been measured")
+  | Sarek_coopmat_types.Device_scope | Sarek_coopmat_types.Queue_family ->
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "cooperative-matrix scope"
+           "device and queue-family scopes have no GL_KHR_cooperative_matrix \
+            spelling")
+
+let glsl_coopmat_use (u : Sarek_coopmat_types.use) =
+  match u with
+  | Sarek_coopmat_types.Matrix_a -> "gl_MatrixUseA"
+  | Sarek_coopmat_types.Matrix_b -> "gl_MatrixUseB"
+  | Sarek_coopmat_types.Accumulator -> "gl_MatrixUseAccumulator"
+
+(** The full [coopmat<...>] type of a fragment.
+
+    Rows and columns come from {!Sarek_coopmat_types.fragment_dims}, which
+    DERIVES them from the use and the shape (A is m x k, B is k x n, an
+    accumulator is m x n). Emitting [m] and [n] here regardless of use — the
+    obvious wrong version — produces a shader that compiles and computes
+    nonsense on any non-square shape, which is exactly the class of defect the
+    derived dimensions exist to make unspellable. *)
+let glsl_coopmat_type (f : Sarek_coopmat_types.fragment) =
+  let rows, cols = Sarek_coopmat_types.fragment_dims f in
+  Printf.sprintf
+    "coopmat<%s, %s, %d, %d, %s>"
+    (glsl_coopmat_component f.Sarek_coopmat_types.frag_component)
+    (glsl_coopmat_scope f.Sarek_coopmat_types.frag_scope)
+    rows
+    cols
+    (glsl_coopmat_use f.Sarek_coopmat_types.frag_use)
+
+let gen_coopmat_op op =
+  let expr_str e =
+    let b = Buffer.create 32 in
+    gen_expr b e ;
+    Buffer.contents b
+  in
+  match op with
+  | CM_decl {name; frag} ->
+      Printf.sprintf "%s %s;" (glsl_coopmat_type frag) (escape_glsl_name name)
+  | CM_load {dst; frag; src; index; stride} ->
+      (* Row-major only, and only because that is the layout this slice
+         executed. gl_CooperativeMatrixLayoutColumnMajor is one more enumerant
+         and a second layout to verify on hardware. *)
+      ignore frag ;
+      Printf.sprintf
+        "coopMatLoad(%s, %s, %s, %s, gl_CooperativeMatrixLayoutRowMajor);"
+        (escape_glsl_name dst)
+        (escape_glsl_name src)
+        (expr_str index)
+        (expr_str stride)
+  | CM_store {src; frag; dst; index; stride} ->
+      ignore frag ;
+      Printf.sprintf
+        "coopMatStore(%s, %s, %s, %s, gl_CooperativeMatrixLayoutRowMajor);"
+        (escape_glsl_name src)
+        (escape_glsl_name dst)
+        (expr_str index)
+        (expr_str stride)
+  | CM_muladd {dst; a; b; c; cfg} ->
+      (* [coopMatMulAdd]'s optional fourth argument is the operand-saturation
+         flag. It is emitted from the CONFIGURATION rather than left to a
+         default because saturating and non-saturating are two distinct
+         advertised configurations computing two different functions, and the
+         device gate is keyed on which one the kernel asked for — a codegen that
+         dropped the flag would run the wrong one of the two while the gate
+         reported the right one available. *)
+      let sat =
+        if cfg.Sarek_coopmat_types.cfg_saturating then
+          ", gl_CooperativeMatrixOperandsSaturatingAccumulationKHR"
+        else ""
+      in
+      Printf.sprintf
+        "%s = coopMatMulAdd(%s, %s, %s%s);"
+        (escape_glsl_name dst)
+        (escape_glsl_name a)
+        (escape_glsl_name b)
+        (escape_glsl_name c)
+        sat
+
 let rec gen_stmt buf indent = function
   | SEmpty -> ()
   | SSeq stmts -> List.iter (gen_stmt buf indent) stmts
@@ -1068,6 +1220,10 @@ let rec gen_stmt buf indent = function
       gen_stmt buf (indent_nested indent) body ;
       Buffer.add_string buf indent ;
       Buffer.add_string buf "}\n"
+  | SCoopmat op ->
+      Buffer.add_string buf indent ;
+      Buffer.add_string buf (gen_coopmat_op op) ;
+      Buffer.add_char buf '\n'
 
 (** {1 Helper Function Generation} *)
 
@@ -1148,7 +1304,7 @@ let gen_helper_func ~pc_names buf (hf : helper_func) =
       Defaults to [false] on the same byte-identity grounds as [uses_float64].
 *)
 let glsl_header ~kernel_name ?(block = (256, 1, 1)) ?(uses_float64 = false)
-    ?(uses_int64 = false) () =
+    ?(uses_int64 = false) ?(uses_coopmat = false) ?(uses_uint8 = false) () =
   let bx, by, bz = block in
   let fp64_extension =
     if uses_float64 then "#extension GL_ARB_gpu_shader_fp64 : require\n" else ""
@@ -1175,15 +1331,42 @@ let glsl_header ~kernel_name ?(block = (256, 1, 1)) ?(uses_float64 = false)
   let int64_extension =
     if uses_int64 then "#extension GL_ARB_gpu_shader_int64 : require\n" else ""
   in
+  (* backlog-62 slice 3. Each of these is REQUIRED rather than declared for
+     tidiness, and the set was read off the SPIR-V rather than guessed: glslc on
+     a 16x16x16 u8 coopMatMulAdd emits OpCapability Int8,
+     StorageBuffer8BitAccess, VulkanMemoryModel and CooperativeMatrixKHR.
+     GL_KHR_memory_scope_semantics is what produces the third, and glslang makes
+     it a prerequisite of GL_KHR_cooperative_matrix — so it belongs to the
+     coopmat line and not to the int8 one, and a float coopmat kernel would need
+     it too.
+
+     The two are separate conditions rather than one, because they are separate
+     facts: a kernel may declare a uint8 buffer without reaching a multiply-add.
+     Emitting the coopmat extension for such a kernel would put a requirement in
+     the shader that the device gate was never asked about. *)
+  let coopmat_extension =
+    if uses_coopmat then
+      "#extension GL_KHR_cooperative_matrix : require\n\
+       #extension GL_KHR_memory_scope_semantics : require\n"
+    else ""
+  in
+  let uint8_extension =
+    if uses_uint8 then
+      "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n\
+       #extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n"
+    else ""
+  in
   Printf.sprintf
     {|#version 450
-%s%s
+%s%s%s%s
 // Sarek-generated compute shader: %s
 layout(local_size_x = %d, local_size_y = %d, local_size_z = %d) in;
 
 |}
     fp64_extension
     int64_extension
+    coopmat_extension
+    uint8_extension
     kernel_name
     bx
     by
@@ -1272,6 +1455,12 @@ let rec collect_shared_decls (s : stmt) : (string * elttype * expr) list =
       List.concat_map (fun (_, body) -> collect_shared_decls body) cases
   | SEmpty | SBarrier | SWarpBarrier | SMemFence | SNative _ | SExpr _
   | SAssign _ | SReturn _ ->
+      []
+  | SCoopmat _ ->
+      (* A cooperative-matrix statement never introduces a shared array: a
+         fragment is a subgroup-cooperative value with no storage this pass can
+         hoist, and the buffers it loads from are parameters, already declared.
+         This is the final answer, not a slice-3 placeholder. *)
       []
 
 (** Generate shared declarations at module scope *)
@@ -1675,6 +1864,8 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
        ?block
        ~uses_float64:(Sarek_ir_analysis.kernel_uses_float64 k)
        ~uses_int64:!current_needs_int64
+       ~uses_coopmat:(Sarek_ir_analysis.kernel_has_coopmat_op k)
+       ~uses_uint8:(Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k)
        ()) ;
 
   (* Generate buffer bindings *)
@@ -1802,6 +1993,8 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
        ?block
        ~uses_float64:(Sarek_ir_analysis.kernel_uses_float64 k)
        ~uses_int64:!current_needs_int64
+       ~uses_coopmat:(Sarek_ir_analysis.kernel_has_coopmat_op k)
+       ~uses_uint8:(Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k)
        ()) ;
 
   (* Generate record type definitions (simple structs without tag) *)

--- a/sarek/codegen/Sarek_ir_inline_vec.ml
+++ b/sarek/codegen/Sarek_ir_inline_vec.ml
@@ -172,6 +172,37 @@ let rec subst_stmt ~rename_binders subst s =
   | SLetMut (v, e, b) -> SLetMut (sb v, se e, ss b)
   | SPragma (h, b) -> SPragma (h, ss b)
   | SBlock b -> SBlock (ss b)
+  | SCoopmat op ->
+      (* [src] and [dst] here name a BUFFER, in the same namespace as
+         [EArrayRead]'s string, so they take [sub] exactly as that case does —
+         a coopmat load from a helper's vector parameter has to be redirected to
+         the caller's buffer like any other access, and an alpha-renamed local
+         has to follow its binder.
+
+         The fragment names are the ones left alone: they live in their own
+         namespace, [subst] never contains one, and passing them through [sub]
+         would let a fragment that happens to share a name with a substituted
+         variable be silently redirected. *)
+      SCoopmat
+        (match op with
+        | CM_decl _ -> op
+        | CM_load r ->
+            CM_load
+              {
+                r with
+                src = sub subst r.src;
+                index = se r.index;
+                stride = se r.stride;
+              }
+        | CM_store r ->
+            CM_store
+              {
+                r with
+                dst = sub subst r.dst;
+                index = se r.index;
+                stride = se r.stride;
+              }
+        | CM_muladd _ -> op)
 
 (* ------------------------------------------------------------------ *)
 (* Binder collection (for alpha-renaming)                              *)
@@ -207,6 +238,13 @@ let collect_binders s =
           cases
     | SAssign _ | SReturn _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence
     | SEmpty | SNative _ ->
+        ()
+    | SCoopmat _ ->
+        (* A [CM_decl] introduces a FRAGMENT name, not a local variable, and
+           this list exists to find names that could capture a substituted-in
+           buffer reference. Fragments are in a namespace of their own where no
+           such collision is expressible, so contributing one here would only
+           trigger spurious alpha-renaming of unrelated locals. *)
         ()
   in
   go s ;
@@ -247,7 +285,9 @@ let rec rewrite_returns ctx sink s =
       assert_no_return ctx s ;
       s
   | ( SAssign _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence | SEmpty
-    | SNative _ ) as s ->
+    | SNative _ | SCoopmat _ ) as s ->
+      (* An [SCoopmat] is not a return and holds no statement to descend into,
+         so it passes through untouched like the other effect-only forms. *)
       s
 
 (** Verify [s] contains no [SReturn] anywhere (used for non-tail sub-statements
@@ -268,7 +308,9 @@ and assert_no_return ctx s =
     | SMatch (_, cases) -> List.iter (fun (_, b) -> chk b) cases
     | SLet (_, _, b) | SLetMut (_, _, b) -> chk b
     | SAssign _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence | SEmpty
-    | SNative _ ->
+    | SNative _ | SCoopmat _ ->
+        (* No [SReturn] can hide inside an [SCoopmat]: it carries expressions
+           and names, never a nested statement. *)
         ()
   in
   chk s
@@ -284,13 +326,18 @@ let default_expr ctx = function
   | TFloat64 -> EConst (CFloat64 0.0)
   | TBool -> EConst (CBool false)
   | TUnit -> EConst CUnit
-  | (TFloat16 | TRecord _ | TVariant _ | TArray _ | TVec _) as t ->
+  | (TFloat16 | TUint8 | TRecord _ | TVariant _ | TArray _ | TVec _) as t ->
       (* TFloat16 has no default initializer here because f16 has no IR
          constant (no literal, by design — see Sarek_ir_types.elttype): there is
          no [CFloat16 0.0] to return. An f16-returning helper would need an
          [ECast (TFloat16, EConst (CFloat32 0.0))] temporary; that is only
          reachable once f16 helper inlining is actually exercised, so reject
-         with the existing diagnostic rather than guess. *)
+         with the existing diagnostic rather than guess.
+
+         TUint8 joins it for a stronger reason: a cooperative-matrix operand
+         element cannot be a helper's return type at all — no expression
+         produces or consumes one — so this arm is a shape the front end cannot
+         build, and inventing a zero for it would only hide that. *)
       fail
         ctx
         "recursion+vector helper"
@@ -302,6 +349,7 @@ let default_expr ctx = function
            | TVariant (n, _) -> "variant " ^ n
            | TArray _ -> "an array"
            | TFloat16 -> "float16"
+           | TUint8 -> "uint8 (a Vulkan cooperative-matrix operand element)"
            | _ -> "a vector"))
 
 (* ------------------------------------------------------------------ *)
@@ -529,6 +577,24 @@ and inline_stmt ctx s : stmt =
   | SBlock b -> SBlock (inline_stmt ctx b)
   | SPragma (hints, b) -> SPragma (hints, inline_stmt ctx b)
   | (SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _) as s -> s
+  | SCoopmat op ->
+      (* The index and the stride are ordinary expressions and may contain a
+         call to a vector-parameter helper, so they get the same hoist-then-
+         rebuild treatment as every other expression-carrying statement. The
+         fragment and buffer names hold no calls to hoist. *)
+      let h, op' =
+        match op with
+        | CM_decl _ | CM_muladd _ -> ([], op)
+        | CM_load r ->
+            let h1, index = hoist_expr ctx r.index in
+            let h2, stride = hoist_expr ctx r.stride in
+            (h1 @ h2, CM_load {r with index; stride})
+        | CM_store r ->
+            let h1, index = hoist_expr ctx r.index in
+            let h2, stride = hoist_expr ctx r.stride in
+            (h1 @ h2, CM_store {r with index; stride})
+      in
+      with_hoisted ctx h (SCoopmat op')
 
 (* ------------------------------------------------------------------ *)
 (* Entry point                                                         *)

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -54,6 +54,18 @@ let rec metal_type_of_elttype = function
         (Codegen_error.unsupported_construct
            "f16"
            "Metal: float16 not yet supported (#57 slice 2)")
+  | TUint8 ->
+      (* Unlike the f16 arm above this is not a deferral. MSL has `uchar` and
+         even has simdgroup matrices, but [TUint8] is not a general 8-bit
+         integer in this IR: it marks a cooperative-matrix operand buffer, and
+         emitting `uchar` for it would produce a buffer no Metal statement can
+         consume, because the [SCoopmat] that gives it meaning is refused. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "uint8"
+           "Metal: uint8 is a cooperative-matrix operand element type, emitted \
+            only by the Vulkan backend, and Metal has no cooperative-matrix \
+            path")
   | TFloat32 -> "float"
   | TFloat64 ->
       (* Until #64 slice 1 this arm was `"float"`, with a comment saying Metal
@@ -726,6 +738,18 @@ let rec gen_stmt buf indent = function
       gen_stmt buf (indent_nested indent) body ;
       Buffer.add_string buf indent ;
       Buffer.add_string buf "}\n"
+  | SCoopmat _ ->
+      (* MSL's simdgroup_matrix is a plausible future home for this, but it has
+         its own shapes, its own load/store convention and no measurement here;
+         until one exists the statement has no lowering, and a silent skip would
+         leave the accumulator buffer untouched rather than wrong-by-a-little,
+         which is the failure mode hardest to notice. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "cooperative matrix"
+           "Metal: the Metal backend has no cooperative-matrix path; \
+            cooperative-matrix statements are emitted only by the Vulkan \
+            backend")
 
 (** {1 Declaration Generation} *)
 
@@ -1108,6 +1132,21 @@ let reject_float64_kernel =
     Sarek_capability.float64_absent_metal
     Sarek_ir_analysis.Float64
 
+(* Whole-kernel cooperative-matrix gate, for the reason spelled out at
+   {!Sarek_ir_codegen.reject_feature}: the per-node arms above see only what the
+   emitter reaches, and a kernel can carry the feature in a [TUint8] parameter
+   it never loads from. Like the f64 gate and unlike the f16 one this does NOT
+   go through [reject_feature], whose composed sentence hardcodes "#57 slice
+   2" — the wrong issue to send a reader to for a cooperative-matrix refusal. *)
+let reject_coopmat_kernel (k : kernel) : unit =
+  if Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k then
+    Codegen_error.raise_error
+      (Codegen_error.unsupported_construct
+         "cooperative matrix"
+         "Metal: the Metal backend has no cooperative-matrix path; cooperative \
+          matrices and their uint8 operand buffers are emitted only by the \
+          Vulkan backend (backlog-62)")
+
 (** The ONLY thing measured to stop Metal contracting [a*b+c].
 
     Metal's compile options do NOT do it. Measured on Apple M4 / macOS 15.6.1
@@ -1145,6 +1184,7 @@ let metal_fp_contract_pragma = "#pragma METAL fp contract(off)\n"
 let generate (k : kernel) : string =
   reject_float16_kernel k ;
   reject_float64_kernel k ;
+  reject_coopmat_kernel k ;
   let buf = Buffer.create 4096 in
 
   (* Collect variables used with atomic operations *)
@@ -1210,6 +1250,7 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
     (k : kernel) : string =
   reject_float16_kernel k ;
   reject_float64_kernel k ;
+  reject_coopmat_kernel k ;
   (* Set current_variants for SMatch binding extraction *)
   current_variants := k.kern_variants ;
   let buf = Buffer.create 4096 in

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -101,6 +101,19 @@ let rec opencl_type_of_elttype = function
         (Codegen_error.unsupported_construct
            "f16"
            Sarek_ir_codegen.opencl_float16_refusal)
+  | TUint8 ->
+      (* OpenCL C spells an 8-bit unsigned integer `uchar` perfectly well; that
+         is not what is being refused. [TUint8] reaches the IR only as the
+         element type of a cooperative-matrix operand buffer, and OpenCL has no
+         cooperative-matrix path to load it into. Mapping the type would let the
+         buffer through while the matching [SCoopmat] statement is refused, i.e.
+         it would move the diagnostic away from the construct that caused it. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "uint8"
+           "OpenCL: uint8 is a cooperative-matrix operand element type, \
+            emitted only by the Vulkan backend, and OpenCL has no \
+            cooperative-matrix path")
   | TFloat32 -> "float"
   | TFloat64 -> "double"
   | TBool -> "int"
@@ -558,6 +571,17 @@ let rec gen_stmt buf indent = function
       gen_stmt buf (indent ^ "  ") body ;
       Buffer.add_string buf indent ;
       Buffer.add_string buf "}\n"
+  | SCoopmat _ ->
+      (* Reached only if a kernel slipped past [reject_coopmat_kernel] — a
+         helper body compiled outside [generate], say. The arm is kept a hard
+         refusal rather than a no-op so that the failure mode is a diagnostic
+         and not a kernel that quietly omits its matrix multiply. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "cooperative matrix"
+           "OpenCL: the OpenCL backend has no cooperative-matrix path; \
+            cooperative-matrix statements are emitted only by the Vulkan \
+            backend")
 
 (** Generate a pattern match case (extracted helper) *)
 and gen_match_case buf indent scrutinee pattern body =
@@ -774,6 +798,25 @@ let reject_float16_kernel (k : kernel) : unit =
          "f16"
          Sarek_ir_codegen.opencl_float16_refusal)
 
+(* The cooperative-matrix counterpart, at the same whole-kernel choke point and
+   for the same reason the f16 gate is there: a refusal that only fires from
+   inside the statement walk names whichever node happened to be reached first,
+   while the thing the user has to change is a property of the KERNEL. Note this
+   also catches a kernel that merely declares a [TUint8] buffer without ever
+   reaching a multiply-add, which the per-statement arm cannot see.
+
+   Deliberately not {!Sarek_ir_codegen.reject_feature}: that composer hardcodes
+   "not yet supported (#57 slice 2)", and citing the f16 slice for a
+   cooperative-matrix refusal would send a reader to the wrong history. *)
+let reject_coopmat_kernel (k : kernel) : unit =
+  if Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k then
+    Codegen_error.raise_error
+      (Codegen_error.unsupported_construct
+         "cooperative matrix"
+         "OpenCL: the OpenCL backend has no cooperative-matrix path; \
+          cooperative matrices and their uint8 operand buffers are emitted \
+          only by the Vulkan backend (backlog-62)")
+
 (** {1 Recursion Resolution}
 
     OpenCL C forbids recursion outright (OpenCL C 1.2 §6.9.e, 3.0 §6.9.5: "the
@@ -840,6 +883,18 @@ let rec zero_expr (t : elttype) : expr =
            "recursion"
            "OpenCL: a recursive helper returning an array, vector or f16 \
             cannot have its residual call elided; rewrite it without recursion")
+  | TUint8 ->
+      (* A zero of this type would be spellable — but a helper cannot return a
+         cooperative-matrix operand element in the first place, since nothing
+         but [CM_load]/[CM_store] ever touches one. Reaching here means the type
+         escaped its intended scope, which is worth a diagnostic rather than a
+         plausible-looking literal. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "uint8"
+           "OpenCL: uint8 is a cooperative-matrix operand element type, \
+            emitted only by the Vulkan backend, and cannot be the return type \
+            of a helper")
 
 (** Inline budget declared by [hf], parsed from an [SPragma] at its body root.
 
@@ -920,6 +975,17 @@ let rec map_stmt (f : expr -> expr) (s : stmt) : stmt =
   | SLetMut (v, x, b) -> SLetMut (v, e x, r b)
   | SPragma (h, b) -> SPragma (h, r b)
   | SBlock b -> SBlock (r b)
+  | SCoopmat op ->
+      (* This walk is used both to SCAN for helper calls and to REWRITE residual
+         ones, so it must descend into every expression a statement holds — the
+         index and the stride here. Fragment and buffer names are not
+         expressions and stay as they are; substituting one would replace a
+         named buffer with a term [CM_load] has no field to hold. *)
+      SCoopmat
+        (match op with
+        | CM_decl _ | CM_muladd _ -> op
+        | CM_load r -> CM_load {r with index = e r.index; stride = e r.stride}
+        | CM_store r -> CM_store {r with index = e r.index; stride = e r.stride})
 
 (** Names of helper functions called (directly) from [s]. *)
 let called_helpers (helpers : string list) (s : stmt) : string list =
@@ -1049,6 +1115,7 @@ let resolve_recursive_helpers (k : kernel) : kernel =
 (** Generate complete OpenCL source for a kernel *)
 let generate (k : kernel) : string =
   reject_float16_kernel k ;
+  reject_coopmat_kernel k ;
   let k = resolve_recursive_helpers k in
   let buf = Buffer.create large_buffer_size in
 
@@ -1092,6 +1159,7 @@ let gen_variant_def buf v =
 let generate_with_types ~(types : (string * (string * elttype) list) list)
     (k : kernel) : string =
   reject_float16_kernel k ;
+  reject_coopmat_kernel k ;
   let k = resolve_recursive_helpers k in
   (* Set current_variants for SMatch binding extraction *)
   current_variants := k.kern_variants ;

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1241,6 +1241,13 @@ and emit_cast buf alloc r_src dst_ty : string =
          "cvt.rn.f32.s32" integer path and produce garbage. f16 registers must
          not exist until those guards are made class-aware. *)
       unsupported_elttype TFloat16 "ECast to float16"
+  | TUint8 ->
+      (* Unreachable through any front end — no cast to or from a
+         cooperative-matrix operand element type is producible from the surface
+         syntax, by design. Kept a refusal rather than a truncating u32 path so
+         that if some rewrite ever synthesizes one, it is a diagnostic instead
+         of a silent narrowing. *)
+      unsupported_coopmat_elttype "ECast to uint8"
   | TFloat32 ->
       if is_f32 r_src then r_src
       else

--- a/sarek/codegen/Sarek_ir_ptx_kernel.ml
+++ b/sarek/codegen/Sarek_ir_ptx_kernel.ml
@@ -34,6 +34,18 @@ let soa_leaves_of_param param_name (elt : elttype) : (string * elttype) list =
                     unsupported (#57 slice 2)"
                    param_name
                    fname)
+          | TUint8 ->
+              (* Not a width limitation: a uint8 field is a cooperative-matrix
+                 operand element, and the statements that give it meaning are
+                 refused by this backend, so splitting it into its own SoA leaf
+                 would manufacture a buffer nothing can read. *)
+              fail
+                (Printf.sprintf
+                   "PTX codegen: SoA parameter '%s': uint8 field '%s' is a \
+                    cooperative-matrix operand element type, emitted only by \
+                    the Vulkan backend"
+                   param_name
+                   fname)
           | TRecord _ ->
               fail
                 (Printf.sprintf
@@ -227,6 +239,18 @@ let emit_params buf alloc (env : env) ~(soa_params : string list)
                     the PTX backend does not support (#57 slice 2 — needs a \
                     %%h register class)"
                    v.var_name)
+          | TUint8 ->
+              (* A scalar uint8 parameter is not something the surface language
+                 can build; the type exists only as a cooperative-matrix operand
+                 buffer element, so seeing one here means the kernel targeted
+                 the wrong backend rather than that PTX is missing a width. *)
+              fail
+                (Printf.sprintf
+                   "PTX codegen: kernel parameter '%s' has type uint8, a \
+                    cooperative-matrix operand element type emitted only by \
+                    the Vulkan backend; the PTX backend has no \
+                    cooperative-matrix path"
+                   v.var_name)
           | TRecord (tname, _) | TVariant (tname, _) ->
               (* C-17 / FR-030: by-value aggregate params have no host
                  marshalling; a TVec of the same type IS accepted (EC-11). *)
@@ -378,6 +402,18 @@ let reject_float16_kernel (k : kernel) : unit =
   if Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Float16 k then
     Sarek_ir_ptx_types.unsupported_elttype TFloat16 "kernel-level float16 usage"
 
+(* The cooperative-matrix gate, sharing the f16 gate's placement and its reason
+   for existing: a per-node refusal names whichever node the emitter happened to
+   reach, and a [TUint8] operand buffer that is only ever stored to reaches
+   none. It also covers helper bodies, which [emit_stmt] visits through a
+   different entry. *)
+let reject_coopmat_kernel (k : kernel) : unit =
+  if Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k then
+    Sarek_ir_ptx_types.unsupported
+      "kernel-level cooperative-matrix usage: cooperative matrices and their \
+       uint8 operand buffers are emitted only by the Vulkan backend \
+       (backlog-62)"
+
 (** Generate PTX for a single kernel. Three-phase: (1) emit body to count
     registers, (2) build header with correct register counts, (3) concatenate.
     @param sm_target Override the default [sm_86] target for older hardware.
@@ -389,6 +425,7 @@ let reject_float16_kernel (k : kernel) : unit =
       to before. *)
 let generate ?(sm_target = "sm_86") ?(soa_params = []) (k : kernel) : string =
   reject_float16_kernel k ;
+  reject_coopmat_kernel k ;
   let alloc = make_alloc () in
   List.iter
     (fun hf ->

--- a/sarek/codegen/Sarek_ir_ptx_stmt.ml
+++ b/sarek/codegen/Sarek_ir_ptx_stmt.ml
@@ -210,6 +210,16 @@ let rec emit_stmt buf alloc (env : env) (stmt : stmt) : unit =
       Buffer.add_string buf code ;
       if String.length code > 0 && code.[String.length code - 1] <> '\n' then
         Buffer.add_char buf '\n'
+  | SCoopmat _ ->
+      (* PTX does reach tensor cores, through wmma/mma — but with its own
+         fragment register layout, its own per-shape instruction names and a
+         warp-level convention this emitter's scalar register model knows
+         nothing about. There is no partial lowering worth emitting, and
+         [reject_coopmat_kernel] normally refuses such a kernel before the walk
+         starts; this arm covers the paths that enter the emitter directly. *)
+      unsupported
+        "cooperative matrix: the PTX backend has no cooperative-matrix path; \
+         cooperative-matrix statements are emitted only by the Vulkan backend"
 
 and emit_assign buf alloc (env : env) (lv : lvalue) (e : expr) : unit =
   match lv with

--- a/sarek/codegen/Sarek_ir_ptx_types.ml
+++ b/sarek/codegen/Sarek_ir_ptx_types.ml
@@ -189,10 +189,27 @@ let unsupported_elttype (ty : elttype) what =
        what
        (Sarek_ir_pp.string_of_elttype ty))
 
+(* The cooperative-matrix counterpart of {!unsupported_elttype}, kept separate
+   because the two refusals have nothing in common but their shape. f16 is
+   blocked by an internal invariant of THIS emitter (the prefix-sniffed register
+   classes) and cites the slice that will lift it; [TUint8] is blocked because
+   it is not a general 8-bit integer at all — it is the element type of a
+   cooperative-matrix operand buffer, meaningful only alongside the [SCoopmat]
+   statements the Vulkan backend emits. Sharing one message would attach the %h
+   register-class explanation to a refusal it does not explain. *)
+let unsupported_coopmat_elttype what =
+  unsupported
+    (Printf.sprintf
+       "%s: uint8 is a cooperative-matrix operand element type, emitted only \
+        by the Vulkan backend, and the PTX backend has no cooperative-matrix \
+        path"
+       what)
+
 let ptx_reg_type_of = function
   | TInt32 | TBool -> ".u32"
   | TInt64 -> ".u64"
   | TFloat16 -> unsupported_elttype TFloat16 "TFloat16 register type"
+  | TUint8 -> unsupported_coopmat_elttype "TUint8 register type"
   | TFloat32 -> ".f32"
   | TFloat64 -> ".f64"
   | TUnit -> ".u32"
@@ -205,6 +222,7 @@ let new_reg_for_type alloc = function
   | TInt32 | TBool | TUnit -> new_u32 alloc
   | TInt64 -> new_u64 alloc
   | TFloat16 -> unsupported_elttype TFloat16 "TFloat16 new_reg"
+  | TUint8 -> unsupported_coopmat_elttype "TUint8 new_reg"
   | TFloat32 -> new_f32 alloc
   | TFloat64 -> new_f64 alloc
   | TVec _ | TArray _ -> new_u64 alloc
@@ -400,6 +418,7 @@ let rec mov_binding buf ~src ~dst =
 
 let ptx_align_of_elttype = function
   | TFloat16 -> unsupported_elttype TFloat16 "align of float16"
+  | TUint8 -> unsupported_coopmat_elttype "align of uint8"
   | TFloat32 | TInt32 | TBool -> 4
   | TFloat64 | TInt64 -> 8
   | TUnit -> 4
@@ -408,6 +427,7 @@ let ptx_align_of_elttype = function
 
 let ptx_btype_of_elttype = function
   | TFloat16 -> unsupported_elttype TFloat16 "btype of float16"
+  | TUint8 -> unsupported_coopmat_elttype "btype of uint8"
   | TFloat32 | TInt32 | TBool | TUnit -> "b32"
   | TFloat64 | TInt64 -> "b64"
   | TVec _ | TArray _ -> "b64"

--- a/sarek/codegen/Sarek_ir_ptx_types.mli
+++ b/sarek/codegen/Sarek_ir_ptx_types.mli
@@ -32,6 +32,19 @@ val unsupported : string -> 'a
     feature-specific export next to {!fail}. *)
 val unsupported_elttype : Sarek_ir_types.elttype -> string -> 'a
 
+(** [unsupported_coopmat_elttype what] raises {!Ptx_codegen_error} for a
+    [TUint8] reaching the site named [what].
+
+    Kept apart from {!unsupported_elttype} because the two refusals rest on
+    different facts. f16 is blocked by an internal invariant of this emitter,
+    and its message points at the register-class audit that will lift it.
+    [TUint8] is not a general 8-bit integer at all: it is the element type of a
+    cooperative-matrix operand buffer, meaningful only with the [SCoopmat]
+    statements the Vulkan backend emits, so no amount of PTX register work makes
+    it representable here. Merging the two would attach the [%h] explanation to
+    a refusal it does not explain. *)
+val unsupported_coopmat_elttype : string -> 'a
+
 (** {1 Value bindings} *)
 
 (** SROA-decomposed aggregate value: a record is one binding per field (in

--- a/sarek/codegen/Sarek_ir_softmath.ml
+++ b/sarek/codegen/Sarek_ir_softmath.ml
@@ -849,6 +849,15 @@ let rec fold_stmt_exprs f acc s =
   | SLet (_, e, body) | SLetMut (_, e, body) ->
       fold_stmt_exprs f (fold_expr f acc e) body
   | SPragma (_, body) | SBlock body -> fold_stmt_exprs f acc body
+  | SCoopmat op -> (
+      (* The index and the stride are ordinary expressions and can perfectly
+         well hold an f64 intrinsic call, which is what this fold is looking
+         for. The fragment and buffer names are not expressions and have no
+         sub-terms to visit. *)
+      match op with
+      | CM_decl _ | CM_muladd _ -> acc
+      | CM_load {index; stride; _} | CM_store {index; stride; _} ->
+          fold_expr f (fold_expr f acc index) stride)
 
 let is_softmath_helper_name name =
   let p = "__sarek_f64_" in

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -424,6 +424,17 @@ let rec wgsl_type_of_elttype = function
            "f16"
            "WGSL: float16 not yet supported (#57 slice 2 — needs a module-top \
             `enable f16;` directive)")
+  | TUint8 ->
+      (* Core WebGPU has no 8-bit scalar at all, but even if it did this arm
+         would refuse: [TUint8] is not a general integer type here, it is the
+         element type of a cooperative-matrix operand buffer, and WGSL has no
+         cooperative-matrix construct to consume one. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "uint8"
+           "WGSL: uint8 is a cooperative-matrix operand element type, emitted \
+            only by the Vulkan backend, and WGSL has no cooperative-matrix \
+            path")
   | TFloat32 -> "f32"
   | TFloat64 ->
       Codegen_error.raise_error
@@ -444,7 +455,7 @@ let rec has_float64 = function
   | TRecord (_, fields) -> List.exists (fun (_, t) -> has_float64 t) fields
   | TVariant (_, constrs) ->
       List.exists (fun (_, ts) -> List.exists has_float64 ts) constrs
-  | TInt32 | TInt64 | TFloat16 | TFloat32 | TBool | TUnit -> false
+  | TInt32 | TInt64 | TFloat16 | TFloat32 | TBool | TUnit | TUint8 -> false
 
 (** {1 Thread Intrinsics}
 
@@ -1051,6 +1062,17 @@ let rec gen_stmt buf indent = function
       gen_stmt buf (indent_nested indent) body ;
       Buffer.add_string buf indent ;
       Buffer.add_string buf "}\n"
+  | SCoopmat _ ->
+      (* Core WebGPU has no cooperative-matrix construct — the subgroup-matrix
+         proposal is not in the shipped specification — so unlike the [SNative]
+         arm above there is no comment-and-continue that would still produce a
+         module computing what the kernel asked for. *)
+      Codegen_error.raise_error
+        (Codegen_error.unsupported_construct
+           "cooperative matrix"
+           "WGSL: the WGSL backend has no cooperative-matrix path; \
+            cooperative-matrix statements are emitted only by the Vulkan \
+            backend")
 
 (** {1 Helper Function Generation} *)
 
@@ -1230,6 +1252,12 @@ let rec collect_workgroup_decls (s : stmt) : (string * elttype * expr) list =
   | SEmpty | SBarrier | SWarpBarrier | SMemFence | SNative _ | SExpr _
   | SAssign _ | SReturn _ ->
       []
+  | SCoopmat _ ->
+      (* No workgroup storage to hoist: a fragment is a subgroup-cooperative
+         value, not an array, and the buffers a load names are parameters. The
+         statement itself is refused later by [gen_stmt]; returning [] here
+         keeps that refusal the one the user sees. *)
+      []
 
 let gen_workgroup_module_decls buf (decls : (string * elttype * expr) list) =
   if decls <> [] then begin
@@ -1386,10 +1414,26 @@ let reject_float16_kernel =
     ~hint:"needs a module-top `enable f16;` directive"
     Sarek_ir_analysis.Float16
 
+(* Whole-kernel cooperative-matrix gate, at the same choke point and for the
+   reason given at {!Sarek_ir_codegen.reject_feature}: the per-node arms see
+   only what the emitter reaches, and a [TUint8] parameter that is never loaded
+   from carries the feature without reaching any of them. Not routed through
+   [reject_feature] because its composed sentence hardcodes "#57 slice 2", which
+   is the f16 history and not this one. *)
+let reject_coopmat_kernel (k : kernel) : unit =
+  if Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k then
+    Codegen_error.raise_error
+      (Codegen_error.unsupported_construct
+         "cooperative matrix"
+         "WGSL: the WGSL backend has no cooperative-matrix path; cooperative \
+          matrices and their uint8 operand buffers are emitted only by the \
+          Vulkan backend (backlog-62)")
+
 (** Generate complete WGSL source for a kernel. *)
 let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
     =
   reject_float16_kernel k ;
+  reject_coopmat_kernel k ;
   if params_have_float64 k.kern_params then
     Codegen_error.raise_error
       (Codegen_error.unsupported_construct
@@ -1423,6 +1467,7 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
 let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
     ~(types : (string * (string * elttype) list) list) (k : kernel) : string =
   reject_float16_kernel k ;
+  reject_coopmat_kernel k ;
   if params_have_float64 k.kern_params then
     Codegen_error.raise_error
       (Codegen_error.unsupported_construct

--- a/sarek/core/Soa.ml
+++ b/sarek/core/Soa.ml
@@ -36,6 +36,19 @@ let reject_non_flat name fields =
                    slice 1 supports f16 vectors, not aggregate fields)"
                   fname
                   name))
+      | TUint8 ->
+          (* Not a missing marshaller like the f16 case above: a uint8 field is
+             a cooperative-matrix operand element, which no host record can hold
+             because nothing outside CM_load/CM_store ever reads or writes one.
+             A field of this type in a [@@sarek.type] record means the type
+             escaped the Vulkan coopmat path, not that SoA needs extending. *)
+          raise
+            (Unsupported
+               (Printf.sprintf
+                  "uint8 field %S in %S: uint8 is a cooperative-matrix operand \
+                   element type (Vulkan only), not a record field type"
+                  fname
+                  name))
       | TRecord _ ->
           raise
             (Unsupported

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -581,9 +581,35 @@ let check_device_capabilities ~(device : Device.t) (ir : Sarek_ir_types.kernel)
   let required =
     List.filter (fun f -> Sarek_ir_analysis.kernel_uses f ir) gated
   in
+  (* backlog-62 slice 3. Cooperative matrices are gated HERE and not in
+     [gated] above, because they are not a [device_features] flag: they are
+     decided per CONFIGURATION. The same RX 7900 XTX that permits
+     [u8 x u8 + s32 -> s32] refuses [f16 x f16 -> f16 saturating], so a boolean
+     "this device has coopmat" would be [Available] for a request the device
+     cannot run — which is the #142 defect in a new place.
+
+     WHY IT IS WIDENED NOW AND WAS NOT AT SLICE 2. Gating at slice 2 would have
+     been a refusal with nothing to refuse: no kernel could reach a
+     cooperative-matrix instruction, so the branch was unreachable and an
+     unreachable gate is not a gate. After this slice a kernel CAN require one.
+
+     [capabilities.coopmat = None] means the backend never probed, which
+     {!Sarek_coopmat.verdict} turns into [Unknown] and
+     {!Sarek_capability.permits} refuses. That is the safe direction and it is
+     load-bearing: every backend other than Vulkan leaves it [None], so a
+     coopmat kernel aimed at CUDA is refused here by the capability model even
+     before the CUDA backend's own codegen refusal — and the diagnostic names
+     the device rather than the emitter. *)
+  let coopmat_verdicts =
+    List.map
+      (Sarek_coopmat.verdict
+         ~support:device.Device.capabilities.Framework_sig.coopmat)
+      (Sarek_ir_analysis.kernel_coopmat_configs ir)
+  in
   match
     Sarek_capability.first_refusal
-      (List.map (Sarek_capability.device_verdict ~provided) required)
+      (List.map (Sarek_capability.device_verdict ~provided) required
+      @ coopmat_verdicts)
   with
   | None -> ()
   | Some verdict ->

--- a/sarek/interp/Sarek_ir_interp.ml
+++ b/sarek/interp/Sarek_ir_interp.ml
@@ -55,6 +55,7 @@ type env = Sarek_ir_interp_value.env = {
   arrays : (string, value array) Hashtbl.t;
   shared : (string, value array) Hashtbl.t;
   funcs : (string, Sarek_ir_types.helper_func) Hashtbl.t;
+  coopmats : (string, value array) Hashtbl.t;
 }
 
 let create_env = Sarek_ir_interp_value.create_env

--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -405,6 +405,153 @@ and exec_stmt state env stmt =
   | SNative {ocaml; _} ->
       (* Call the typed OCaml fallback *)
       ocaml.run ~block:state.block_dim ~grid:state.grid_dim [||]
+  | SCoopmat op -> exec_coopmat state env op
+
+(** {1 Cooperative matrix — backlog-62 slice 3}
+
+    The interpreter is the ORACLE every backend is checked against, so this is
+    not a courtesy implementation: [test_vulkan_coopmat_ir_e2e] compares the
+    GLSL backend's output against these numbers bit for bit, and a skip here
+    would let a coopmat kernel "agree" with an interpreter that never computed
+    the product.
+
+    Every invocation holds the whole matrix and performs the whole operation;
+    see {!Sarek_ir_interp_value.env}.[coopmats] for why that is exact rather
+    than approximate.
+
+    {b Only the INTEGER configurations are evaluated.} Float accumulation is
+    refused, and refused HERE rather than left to produce a plausible number,
+    because the interpreter cannot honestly model it: SPV_KHR_cooperative_matrix
+    leaves the ORDER of the k+1 additions to the implementation, so there is no
+    single value a strict oracle could compare against (design document §5.1).
+    Integer accumulation has no such freedom — the specification states it is
+    exact at the precision of the result type — which is the entire reason the
+    integer path lands under Sarek's existing strict contract. *)
+
+and coopmat_zero (c : Sarek_coopmat_types.component_type) =
+  match c with
+  | Sarek_coopmat_types.Uint8 | Sarek_coopmat_types.Sint8
+  | Sarek_coopmat_types.Uint32 | Sarek_coopmat_types.Sint32 ->
+      VInt32 0l
+  | Sarek_coopmat_types.Float16 | Sarek_coopmat_types.Float32 ->
+      coopmat_refuse_float c
+
+and coopmat_refuse_float : 'a. Sarek_coopmat_types.component_type -> 'a =
+ fun c ->
+  Interp_error.raise_error
+    (Unsupported_operation
+       {
+         operation =
+           "cooperative matrix with "
+           ^ Sarek_coopmat_types.component_name c
+           ^ " components";
+         reason =
+           "float cooperative-matrix accumulation has no single correct value \
+            to be an oracle for: SPV_KHR_cooperative_matrix leaves the order \
+            of the additions to the implementation. The INTEGER configurations \
+            are evaluated, and are exact.";
+       })
+
+(** Narrow an accumulated Int32 to the declared component type.
+
+    This is what makes the interpreter a faithful oracle for the 8-bit operand
+    types rather than merely a plausible one: a value loaded into a [u8]
+    fragment from a buffer holding 300 is 44 on the device, and an oracle that
+    kept 300 would disagree with correct hardware. *)
+and coopmat_narrow (c : Sarek_coopmat_types.component_type) (n : int32) =
+  match c with
+  | Sarek_coopmat_types.Uint8 -> Int32.logand n 0xffl
+  | Sarek_coopmat_types.Sint8 ->
+      let b = Int32.logand n 0xffl in
+      if Int32.compare b 0x80l >= 0 then Int32.sub b 0x100l else b
+  | Sarek_coopmat_types.Uint32 | Sarek_coopmat_types.Sint32 -> n
+  | Sarek_coopmat_types.Float16 | Sarek_coopmat_types.Float32 ->
+      coopmat_refuse_float c
+
+and get_coopmat env name =
+  match Hashtbl.find_opt env.coopmats name with
+  | Some m -> m
+  | None ->
+      Interp_error.raise_error
+        (Unbound_variable {name; context = "cooperative-matrix fragment"})
+
+and exec_coopmat state env op =
+  let open Sarek_coopmat_types in
+  match op with
+  | CM_decl {name; frag} ->
+      Hashtbl.replace
+        env.coopmats
+        name
+        (Array.make
+           (fragment_components frag)
+           (coopmat_zero frag.frag_component))
+  | CM_load {dst; frag; src; index; stride} ->
+      let buf = get_array env src in
+      let base = to_int (eval_expr state env index) in
+      let stride = to_int (eval_expr state env stride) in
+      let rows, cols = fragment_dims frag in
+      let m = Array.make (rows * cols) (coopmat_zero frag.frag_component) in
+      for r = 0 to rows - 1 do
+        for c = 0 to cols - 1 do
+          let i = base + (r * stride) + c in
+          if i < 0 || i >= Array.length buf then
+            Interp_error.raise_error
+              (Array_bounds_error
+                 {array_name = src; index = i; length = Array.length buf})
+          else
+            m.((r * cols) + c) <-
+              VInt32 (coopmat_narrow frag.frag_component (to_int32 buf.(i)))
+        done
+      done ;
+      Hashtbl.replace env.coopmats dst m
+  | CM_store {src; frag; dst; index; stride} ->
+      let m = get_coopmat env src in
+      let buf = get_array env dst in
+      let base = to_int (eval_expr state env index) in
+      let stride = to_int (eval_expr state env stride) in
+      let rows, cols = fragment_dims frag in
+      for r = 0 to rows - 1 do
+        for c = 0 to cols - 1 do
+          let i = base + (r * stride) + c in
+          if i < 0 || i >= Array.length buf then
+            Interp_error.raise_error
+              (Array_bounds_error
+                 {array_name = dst; index = i; length = Array.length buf})
+          else buf.(i) <- m.((r * cols) + c)
+        done
+      done
+  | CM_muladd {dst; a; b; c; cfg} ->
+      if cfg.cfg_saturating then
+        Interp_error.raise_error
+          (Unsupported_operation
+             {
+               operation = "saturating cooperative-matrix accumulation";
+               reason =
+                 "the saturating variant computes a different function from \
+                  the plain one and nothing has executed it, so there is \
+                  nothing for an oracle to be faithful to";
+             }) ;
+      let ma = get_coopmat env a
+      and mb = get_coopmat env b
+      and mc = get_coopmat env c in
+      let sh = cfg.cfg_shape in
+      let out = Array.make (sh.m * sh.n) (coopmat_zero cfg.cfg_result) in
+      for i = 0 to sh.m - 1 do
+        for j = 0 to sh.n - 1 do
+          (* Int32 throughout, so that a result exceeding 32 bits WRAPS exactly
+             as the device wraps, rather than being accidentally right on a
+             63-bit host int. This is the claim the whole integer path rests
+             on. *)
+          let acc = ref (to_int32 mc.((i * sh.n) + j)) in
+          for kk = 0 to sh.k - 1 do
+            let av = to_int32 ma.((i * sh.k) + kk) in
+            let bv = to_int32 mb.((kk * sh.n) + j) in
+            acc := Int32.add !acc (Int32.mul av bv)
+          done ;
+          out.((i * sh.n) + j) <- VInt32 (coopmat_narrow cfg.cfg_result !acc)
+        done
+      done ;
+      Hashtbl.replace env.coopmats dst out
 
 and assign_lvalue state env lv value =
   (* Store values directly - VRecord is handled by ERecordField *)

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -41,6 +41,25 @@ type env = {
   arrays : (string, value array) Hashtbl.t;  (** array_name -> data *)
   shared : (string, value array) Hashtbl.t;  (** shared arrays for block *)
   funcs : (string, helper_func) Hashtbl.t;  (** helper functions *)
+  coopmats : (string, value array) Hashtbl.t;
+      (** Cooperative-matrix fragments, by fragment name — backlog-62 slice 3.
+
+          A SEPARATE table from {!vars} and {!arrays} because fragment names are
+          a separate namespace in the IR: a fragment is not a variable and not
+          an array, and merging it into either would make a name collision
+          between a fragment and a variable silently resolve to one of them.
+
+          {b The model.} A subgroup-scope fragment is held collectively by the
+          whole subgroup, with each invocation holding a few components at an
+          implementation-defined position. The interpreter has no subgroup, so
+          it holds the WHOLE matrix redundantly in every invocation and has
+          every invocation perform the whole operation. That is observationally
+          equivalent to the device — a [coopMatStore] then writes the same value
+          to the same location once per invocation instead of once per subgroup
+          — precisely BECAUSE GL_KHR_cooperative_matrix requires the buffer,
+          index and stride arguments to be dynamically uniform across the scope.
+          The redundancy is not an approximation; it is the same function
+          computed the only way a scalar interpreter can compute it. *)
 }
 
 let create_env () =
@@ -50,6 +69,7 @@ let create_env () =
     arrays = Hashtbl.create 16;
     shared = Hashtbl.create 8;
     funcs = Hashtbl.create 8;
+    coopmats = Hashtbl.create 4;
   }
 
 let copy_env env =
@@ -62,6 +82,9 @@ let copy_env env =
     (* shared within block *)
     funcs = env.funcs;
     (* shared *)
+    coopmats = Hashtbl.copy env.coopmats;
+    (* per-invocation, like [vars]: a fragment does not outlive the block that
+       declared it and is never shared between threads. *)
   }
 
 (** Bind a variable in the environment (both by id and name) *)

--- a/sarek/sarek/Sarek_fusion.ml
+++ b/sarek/sarek/Sarek_fusion.ml
@@ -168,6 +168,32 @@ let rec subst_array_read_stmt arr idx_var replacement stmt =
       SPragma (hints, subst_array_read_stmt arr idx_var replacement body)
   | SBlock body -> SBlock (subst_array_read_stmt arr idx_var replacement body)
   | SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _ -> stmt
+  | SCoopmat op ->
+      (* The index and the stride are ordinary expressions and are rewritten.
+         The buffer name is NOT: [replacement] is an expression, and a
+         cooperative-matrix load has no field that can hold one — its source
+         must stay a named buffer. So when this statement is the very access
+         being fused away, the statement is left exactly as it was rather than
+         half-rewritten. That is safe only because [can_fuse] refuses any
+         kernel carrying a cooperative-matrix statement in the first place; the
+         bail-out here is the second half of that pair, not a lone hope. *)
+      let names_arr =
+        match op with
+        | CM_load {src; _} -> src = arr
+        | CM_store {dst; _} -> dst = arr
+        | CM_decl _ | CM_muladd _ -> false
+      in
+      if names_arr then stmt
+      else
+        SCoopmat
+          (match op with
+          | CM_decl _ | CM_muladd _ -> op
+          | CM_load r ->
+              CM_load
+                {r with index = subst_e r.index; stride = subst_e r.stride}
+          | CM_store r ->
+              CM_store
+                {r with index = subst_e r.index; stride = subst_e r.stride})
 
 (** Check if statement uses an array *)
 let rec stmt_uses_array arr stmt =
@@ -191,6 +217,16 @@ let rec stmt_uses_array arr stmt =
       expr_uses_array arr e || stmt_uses_array arr body
   | SPragma (_, body) | SBlock body -> stmt_uses_array arr body
   | SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _ -> false
+  | SCoopmat op -> (
+      (* [src]/[dst] name a buffer in the same namespace this predicate is
+         asking about, so a coopmat load counts as a use of its source just as
+         an [EArrayRead] would. Missing it would let a pass conclude an array
+         is dead while a cooperative-matrix load still reads it. *)
+      match op with
+      | CM_decl _ | CM_muladd _ -> false
+      | CM_load {src = name; index; stride; _}
+      | CM_store {dst = name; index; stride; _} ->
+          name = arr || expr_uses_array arr index || expr_uses_array arr stride)
 
 (** {1 Analysis} *)
 
@@ -240,6 +276,14 @@ let rec collect_writes_stmt acc stmt =
   | SReturn _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence | SEmpty
   | SNative _ ->
       acc
+  | SCoopmat op -> (
+      (* A store is the only cooperative-matrix operation that writes memory,
+         and it writes [dst] at [index]. A load writes nothing addressable: its
+         destination is a fragment, which lives in no buffer this analysis can
+         name. *)
+      match op with
+      | CM_store {dst; index; _} -> (dst, index) :: acc
+      | CM_decl _ | CM_load _ | CM_muladd _ -> acc)
 
 (** Collect all array reads from a statement *)
 let rec collect_reads_stmt acc stmt =
@@ -264,6 +308,17 @@ let rec collect_reads_stmt acc stmt =
       collect_reads_stmt (collect_reads_expr acc e) body
   | SPragma (_, body) | SBlock body -> collect_reads_stmt acc body
   | SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _ -> acc
+  | SCoopmat op -> (
+      (* A load reads [src] at [index]; both forms additionally read whatever
+         their index and stride expressions read. A store's own buffer access is
+         a write and is reported by [collect_writes_stmt] instead. *)
+      match op with
+      | CM_decl _ | CM_muladd _ -> acc
+      | CM_load {src; index; stride; _} ->
+          let acc = collect_reads_expr (collect_reads_expr acc index) stride in
+          (src, index) :: acc
+      | CM_store {index; stride; _} ->
+          collect_reads_expr (collect_reads_expr acc index) stride)
 
 (** Check if statement contains barriers *)
 let rec has_barrier stmt =
@@ -278,6 +333,13 @@ let rec has_barrier stmt =
     ->
       has_barrier body
   | SAssign _ | SReturn _ | SExpr _ | SMemFence | SEmpty | SNative _ -> false
+  | SCoopmat _ ->
+      (* Not a barrier. A cooperative-matrix operation IS subgroup-collective,
+         but that is a convergence requirement on the invocations reaching it,
+         not an ordering point this predicate's callers care about — they use it
+         to decide whether two kernels can be merged across a synchronisation
+         edge, and there is none here. *)
+      false
 
 (** Extract constant offset from index expression. Returns Some (base, offset)
     if idx = base + const or base - const. *)
@@ -375,6 +437,12 @@ let rec find_write_expr stmt arr idx =
   | SAssign _ | SReturn _ | SExpr _ | SBarrier | SWarpBarrier | SMemFence
   | SEmpty | SNative _ ->
       None
+  | SCoopmat _ ->
+      (* A cooperative-matrix store writes a whole tile through a fragment, not
+         a single element as an expression, so there is no [expr] to hand back
+         that would reproduce it. [None] is the honest answer and stops the
+         fusion attempt. *)
+      None
 
 (** Check if two kernels can be fused via an intermediate array.
 
@@ -433,8 +501,20 @@ let can_fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
      kernel would silently change its semantics. *)
   let no_atomics = (not prod_info.has_atomics) && not cons_info.has_atomics in
 
+  (* No cooperative matrices in either. Fusion works by replacing an
+     [EArrayRead] of the intermediate with the producer's expression and then
+     DROPPING the intermediate parameter; a [CM_load] names its source buffer
+     rather than reading it through an expression, so there is nothing to
+     substitute and the load would be left pointing at a parameter that no
+     longer exists. Refusing the whole kernel pair is the conservative reading
+     and matches how atomics are handled just above. *)
+  let no_coopmat =
+    (not (Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat producer))
+    && not (Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat consumer)
+  in
+
   prod_writes_inter && cons_reads_inter && patterns_ok && no_barriers
-  && no_atomics
+  && no_atomics && no_coopmat
 
 (** Fuse producer into consumer, eliminating intermediate array.
 

--- a/sarek/tests/codegen_golden/opencl_gate/ir_uniquify.ml
+++ b/sarek/tests/codegen_golden/opencl_gate/ir_uniquify.ml
@@ -146,6 +146,18 @@ let rec ustmt (env : env) (s : stmt) : stmt =
       SLetMut (v', x, ustmt env' b)
   | SPragma (h, b) -> SPragma (h, r b)
   | SBlock b -> SBlock (r b)
+  | SCoopmat op ->
+      (* Mirrors [Sarek_ir_codegen.rename_shadowing_locals]: fragment names are
+         not [var]s, are never in [env], and must not be looked up there — only
+         the index and stride expressions can mention a renamed variable. *)
+      SCoopmat
+        (match op with
+        | CM_decl _ -> op
+        | CM_load req ->
+            CM_load {req with index = e req.index; stride = e req.stride}
+        | CM_store req ->
+            CM_store {req with index = e req.index; stride = e req.stride}
+        | CM_muladd _ -> op)
 
 and ucase_stmt env p b =
   match p with

--- a/sarek/tests/codegen_golden/test_backend_type_width_totality.ml
+++ b/sarek/tests/codegen_golden/test_backend_type_width_totality.ml
@@ -68,7 +68,8 @@ open Sarek_codegen
 
 let next_elt : elttype -> elttype option = function
   | TInt32 -> Some TInt64
-  | TInt64 -> Some TFloat16
+  | TInt64 -> Some TUint8
+  | TUint8 -> Some TFloat16
   | TFloat16 -> Some TFloat32
   | TFloat32 -> Some TFloat64
   | TFloat64 -> Some TBool
@@ -93,6 +94,7 @@ let name_of_elt = function
   | TInt32 -> "TInt32"
   | TInt64 -> "TInt64"
   | TFloat16 -> "TFloat16"
+  | TUint8 -> "TUint8"
   | TFloat32 -> "TFloat32"
   | TFloat64 -> "TFloat64"
   | TBool -> "TBool"
@@ -160,6 +162,19 @@ let metal_width = function
    i.e. the same 4-byte slot the host writes. *)
 let glsl_width = function
   | "int" -> Some (Bytes 4)
+  (* backlog-62 slice 3, and MEASURED like the `bool` row above rather than
+     assumed from the name. glslc --target-env=vulkan1.3 on a u8 cooperative-
+     matrix shader whose operands are `uint8_t a[]` in an std430 storage buffer,
+     then spirv-dis:
+
+       %uchar = OpTypeInt 8 0
+       OpDecorate %_runtimearr_uchar ArrayStride 1
+
+     i.e. the 1-byte slot the host writes, and NOT padded to 4 the way `bool`
+     is. That distinction is the whole reason this validator exists: an 8-bit
+     element silently occupying 4 bytes on the device would make every
+     cooperative-matrix operand load read one value in four. *)
+  | "uint8_t" -> Some (Bytes 1)
   | "int64_t" -> Some (Bytes 8)
   | "float16_t" -> Some (Bytes 2)
   | "float" -> Some (Bytes 4)
@@ -274,7 +289,7 @@ let run_mapper b t =
 let test_enumeration_is_complete () =
   Alcotest.(check int)
     "scalar elttype constructors swept"
-    7
+    8
     (List.length all_scalar_elts) ;
   Alcotest.(check int) "backends swept" 6 (List.length backends) ;
   (* A count alone does not prove the chain was walked correctly — see the

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1378,3 +1378,27 @@
  (alias e2e-gpu)
  (action
   (run %{dep:test_vulkan_int64.exe})))
+
+; backlog-62 slice 3 — the integer coopmat path end to end: hand-built IR with
+; SCoopmat statements, emitted by Sarek_ir_glsl, executed on the GPU, compared
+; bit-for-bit against the interpreter. e2e-gpu: it needs a device advertising an
+; integer cooperative-matrix configuration, and skips (does not fail) otherwise.
+
+(executable
+ (name test_coopmat_integer_e2e)
+ (modules test_coopmat_integer_e2e)
+ (libraries
+  sarek
+  sarek_ir
+  sarek_codegen
+  sarek_vulkan
+  spoc_core
+  spoc_framework
+  test_helpers
+  unix)
+ (preprocess no_preprocessing))
+
+(rule
+ (alias e2e-gpu)
+ (action
+  (run %{dep:test_coopmat_integer_e2e.exe})))

--- a/sarek/tests/e2e/test_coopmat_integer_e2e.ml
+++ b/sarek/tests/e2e/test_coopmat_integer_e2e.ml
@@ -32,7 +32,7 @@
  *
  * Bit-identity against an oracle is worth nothing if the oracle is the same
  * code path. Two positive controls run on the SAME measured GPU output: a
- * C-dropping reference and a transposed-B reference, each computed by the
+ * C-dropping reference and a stride-1-B reference, each computed by the
  * interpreter from a MUTATED IR kernel, and each must be REJECTED. If either
  * is accepted the test fails.
  *
@@ -73,19 +73,18 @@ let frag_a, frag_b, frag_c, frag_d = Sarek_coopmat.fragments_of_config cfg
 
 (** [D = A x B + C], as a Sarek IR kernel.
 
-    [transpose_b] and [drop_c] are the two positive controls, built into the IR
+    [stride1_b] and [drop_c] are the two positive controls, built into the IR
     generator rather than into a separate host reference: a control that takes a
     different path through the code than the thing it controls does not control
-    it. Transposing B is expressed by swapping the load's stride and the
-    within-row step — see below — and dropping C by never loading it, leaving
-    the [CM_decl]'s zero.
+    it. Dropping C is expressed by never loading it, leaving the [CM_decl]'s
+    zero; [stride1_b] loads B with a stride of 1 — see below.
 
     No [global_thread_id] anywhere. One subgroup performs one 16x16x16
     multiply-add cooperatively, and the buffer, index and stride arguments of a
     [coopMatLoad] must be dynamically uniform across that subgroup. A kernel
     that indexed them by thread id would be undefined behaviour on the device
     and would silently differ from the interpreter, which has no subgroup. *)
-let make_ir ?(drop_c = false) ?(transpose_b = false) () : kernel =
+let make_ir ?(drop_c = false) ?(stride1_b = false) () : kernel =
   let v id name ty =
     {var_name = name; var_id = id; var_type = ty; var_mutable = false}
   in
@@ -104,11 +103,24 @@ let make_ir ?(drop_c = false) ?(transpose_b = false) () : kernel =
       SCoopmat (CM_decl {name = "fc"; frag = frag_c});
       SCoopmat (CM_decl {name = "fd"; frag = frag_d});
       load "fa" frag_a "a" mnk;
-      (* A stride of 1 walks the buffer down columns instead of along rows, so
-         the fragment receives B-transposed. It is a real, emittable IR kernel
-         computing a genuinely different function — which is what makes it a
-         control rather than a host-side fudge. *)
-      load "fb" frag_b "b" (if transpose_b then 1 else mnk);
+      (* [CM_load] with stride [s] reads [m.(r).(c) = buf.(base + r*s + c)], so
+         a stride of 1 gives [buf.(r + c)]: every row is the previous row
+         shifted by one, and the whole 16x16 fragment is drawn from the first 31
+         elements of the buffer.
+
+         That is a Hankel read and NOT the transpose, which would be
+         [buf.(c*16 + r)] and is not expressible through the row-major stride at
+         all — reaching it needs gl_CooperativeMatrixLayoutColumnMajor, which
+         this slice deliberately does not emit. An earlier revision of this
+         comment called it "B-transposed"; it was wrong, and a mislabelled
+         control is worse than none because the label is what a later reader
+         audits against.
+
+         What matters for a control is only that it is a real, emittable IR
+         kernel computing a genuinely DIFFERENT function from [D = A*B + C], so
+         that a comparison accepting it would be a comparison accepting
+         anything. A Hankel read is that. *)
+      load "fb" frag_b "b" (if stride1_b then 1 else mnk);
     ]
     @ (if drop_c then [] else [load "fc" frag_c "c" mnk])
     @ [
@@ -324,7 +336,7 @@ let () =
           (* Positive controls, computed by the interpreter from MUTATED IR. *)
           if not (equal gpu (run_interp (make_ir ~drop_c:true ()) ~t)) then
             incr controls_c ;
-          if not (equal gpu (run_interp (make_ir ~transpose_b:true ()) ~t)) then
+          if not (equal gpu (run_interp (make_ir ~stride1_b:true ()) ~t)) then
             incr controls_t
         done ;
         if !controls_c <> mnk then
@@ -335,7 +347,7 @@ let () =
             mnk ;
         if !controls_t <> mnk then
           fail
-            "%s: the transposed-B control was ACCEPTED on %d of %d tiles"
+            "%s: the stride-1-B control was ACCEPTED on %d of %d tiles"
             dev.Device.name
             (mnk - !controls_t)
             mnk ;

--- a/sarek/tests/e2e/test_coopmat_integer_e2e.ml
+++ b/sarek/tests/e2e/test_coopmat_integer_e2e.ml
@@ -1,0 +1,353 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-62 slice 3 — the integer cooperative-matrix path END TO END.
+ *
+ * WHAT THIS ADDS OVER sarek-vulkan/test/test_vulkan_coopmat_integer.ml.
+ *
+ * That test compiles a HAND-WRITTEN GLSL coopmat shader and measures the
+ * driver. This one builds a Sarek IR kernel containing SCoopmat statements,
+ * hands it to Execute, and lets Sarek_ir_glsl EMIT the shader — so what is
+ * under test here is the codegen, the launch gate and the calling convention,
+ * not RADV. docs/fp-contraction-policy.md §7(c) is explicit that a hand-written
+ * shader does not substitute for a codegen gate, and the two halves are kept
+ * separate for exactly that reason: if the codegen were wrong in a way the
+ * driver happened to cancel, a single combined test would still be green.
+ *
+ * THE ORACLE IS THE INTERPRETER, AND THE COMPARISON IS BIT FOR BIT.
+ *
+ * SPV_KHR_cooperative_matrix states that integer accumulation is performed at
+ * the precision of the result type and is EXACT. So there is no tolerance, no
+ * ulp band and no allowlist here: the SAME IR value is executed on the
+ * interpreter and on the GPU, and the two int32 arrays must be equal. That is
+ * only a legitimate demand because the configuration is integer; the float
+ * configurations are refused by both the codegen and the interpreter, and
+ * deliberately (design document §5.1 — the order of the k+1 additions is
+ * implementation-defined, so no oracle exists).
+ *
+ * PROVING THE COMPARISON CAN FAIL.
+ *
+ * Bit-identity against an oracle is worth nothing if the oracle is the same
+ * code path. Two positive controls run on the SAME measured GPU output: a
+ * C-dropping reference and a transposed-B reference, each computed by the
+ * interpreter from a MUTATED IR kernel, and each must be REJECTED. If either
+ * is accepted the test fails.
+ *
+ * Run with:
+ *   dune exec sarek/tests/e2e/test_coopmat_integer_e2e.exe -- --vulkan
+ ******************************************************************************)
+
+open Sarek_ir_types
+open Sarek
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Test_helpers.Benchmarks.init_backends ()
+
+let mnk = 16
+
+let elems = mnk * mnk
+
+let shape = {Sarek_coopmat.m = mnk; n = mnk; k = mnk}
+
+(* u8 x u8 + s32 -> s32, non-saturating: advertised as configuration [1] of 14
+   on the RX 7900 XTX. The accumulator is s32 rather than u32 because s32 is
+   what Sarek's TInt32 vector already is — no new host element type is needed on
+   the accumulator side, only on the 8-bit operand side. *)
+let cfg =
+  {
+    Sarek_coopmat.cfg_shape = shape;
+    cfg_a = Sarek_coopmat.Uint8;
+    cfg_b = Sarek_coopmat.Uint8;
+    cfg_c = Sarek_coopmat.Sint32;
+    cfg_result = Sarek_coopmat.Sint32;
+    cfg_saturating = false;
+    cfg_scope = Sarek_coopmat.Subgroup;
+  }
+
+let frag_a, frag_b, frag_c, frag_d = Sarek_coopmat.fragments_of_config cfg
+
+(** [D = A x B + C], as a Sarek IR kernel.
+
+    [transpose_b] and [drop_c] are the two positive controls, built into the IR
+    generator rather than into a separate host reference: a control that takes a
+    different path through the code than the thing it controls does not control
+    it. Transposing B is expressed by swapping the load's stride and the
+    within-row step — see below — and dropping C by never loading it, leaving
+    the [CM_decl]'s zero.
+
+    No [global_thread_id] anywhere. One subgroup performs one 16x16x16
+    multiply-add cooperatively, and the buffer, index and stride arguments of a
+    [coopMatLoad] must be dynamically uniform across that subgroup. A kernel
+    that indexed them by thread id would be undefined behaviour on the device
+    and would silently differ from the interpreter, which has no subgroup. *)
+let make_ir ?(drop_c = false) ?(transpose_b = false) () : kernel =
+  let v id name ty =
+    {var_name = name; var_id = id; var_type = ty; var_mutable = false}
+  in
+  let a = v 0 "a" (TVec TUint8) in
+  let b = v 1 "b" (TVec TUint8) in
+  let c = v 2 "c" (TVec TInt32) in
+  let d = v 3 "d" (TVec TInt32) in
+  let k n = EConst (CInt32 (Int32.of_int n)) in
+  let load name frag src stride =
+    SCoopmat (CM_load {dst = name; frag; src; index = k 0; stride = k stride})
+  in
+  let stmts =
+    [
+      SCoopmat (CM_decl {name = "fa"; frag = frag_a});
+      SCoopmat (CM_decl {name = "fb"; frag = frag_b});
+      SCoopmat (CM_decl {name = "fc"; frag = frag_c});
+      SCoopmat (CM_decl {name = "fd"; frag = frag_d});
+      load "fa" frag_a "a" mnk;
+      (* A stride of 1 walks the buffer down columns instead of along rows, so
+         the fragment receives B-transposed. It is a real, emittable IR kernel
+         computing a genuinely different function — which is what makes it a
+         control rather than a host-side fudge. *)
+      load "fb" frag_b "b" (if transpose_b then 1 else mnk);
+    ]
+    @ (if drop_c then [] else [load "fc" frag_c "c" mnk])
+    @ [
+        SCoopmat (CM_muladd {dst = "fd"; a = "fa"; b = "fb"; c = "fc"; cfg});
+        SCoopmat
+          (CM_store
+             {src = "fd"; frag = frag_d; dst = "d"; index = k 0; stride = k mnk});
+      ]
+  in
+  {
+    kern_name = "coopmat_u8_s32";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TUint8; arr_memspace = Global});
+        DParam (b, Some {arr_elttype = TUint8; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TInt32; arr_memspace = Global});
+        DParam (d, Some {arr_elttype = TInt32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body = SSeq stmts;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* inputs                                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* The same tiling as the driver-side test, so the two halves exercise the same
+   arithmetic: A[i][k] = 16k+i and B[k][j] = 16t+j make dispatch t cover sixteen
+   disjoint 16x16 blocks of the 256x256 u8 operand-pair space, and t = 0..15
+   tiles all 65536 pairs exactly once. *)
+let input_a =
+  Array.init elems (fun p -> ((16 * (p mod mnk)) + (p / mnk)) land 0xff)
+
+let input_b t = Array.init elems (fun p -> ((16 * t) + (p mod mnk)) land 0xff)
+
+let input_c = Array.init elems (fun p -> Int32.of_int ((p * 37 mod 1009) - 500))
+
+let fill_u8 arr =
+  let v = Vector.create Vector.char elems in
+  Array.iteri (fun i x -> Vector.set v i (Char.chr x)) arr ;
+  v
+
+let fill_i32 arr =
+  let v = Vector.create Vector.int32 elems in
+  Array.iteri (fun i x -> Vector.set v i x) arr ;
+  v
+
+let zeros_i32 () =
+  let v = Vector.create Vector.int32 elems in
+  for i = 0 to elems - 1 do
+    Vector.set v i 0l
+  done ;
+  v
+
+let args_for ~t =
+  let a = fill_u8 input_a
+  and b = fill_u8 (input_b t)
+  and c = fill_i32 input_c
+  and d = zeros_i32 () in
+  ([Execute.Vec a; Execute.Vec b; Execute.Vec c; Execute.Vec d], d)
+
+(* ------------------------------------------------------------------ *)
+(* runners                                                             *)
+(* ------------------------------------------------------------------ *)
+
+(** The device dispatch. One workgroup of exactly one subgroup.
+
+    The block size is the device's PROBED subgroup size, not a constant: a 16x16
+    fragment over 64 invocations is 4 components each and over 32 is 8, and
+    slice 2 measured 64 on both local devices where the code had been
+    hard-coding 32. *)
+let run_gpu dev ir ~t =
+  let args, d = args_for ~t in
+  let sg = dev.Device.capabilities.Spoc_framework.Framework_sig.warp_size in
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args
+    ~block:(Execute.dims1d sg)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  Vector.to_array d
+
+let run_interp ir ~t =
+  let args, d = args_for ~t in
+  Execute.run_interpreter_vectors
+    ~ir
+    ~args
+    ~block:(Execute.dims1d 64)
+    ~grid:(Execute.dims1d 1)
+    ~parallel:false ;
+  Vector.to_array d
+
+let equal x y =
+  Array.length x = Array.length y
+  &&
+  let ok = ref true in
+  Array.iteri (fun i v -> if v <> y.(i) then ok := false) x ;
+  !ok
+
+let first_divergence x y =
+  let rec go i =
+    if i >= Array.length x then None
+    else if x.(i) <> y.(i) then Some (i, x.(i), y.(i))
+    else go (i + 1)
+  in
+  go 0
+
+(* ------------------------------------------------------------------ *)
+
+let failures = ref 0
+
+let fail fmt =
+  Printf.ksprintf
+    (fun s ->
+      incr failures ;
+      print_endline ("  FAIL " ^ s))
+    fmt
+
+let () =
+  let devices = Array.to_list (Device.init ()) in
+  let coopmat_devices =
+    List.filter
+      (fun dev ->
+        Sarek_capability.permits
+          (Sarek_coopmat.verdict
+             ~support:
+               dev.Device.capabilities.Spoc_framework.Framework_sig.coopmat
+             cfg))
+      devices
+  in
+  let ir = make_ir () in
+
+  (* The emitted shader, printed unconditionally and asserted on. A codegen test
+     whose output nobody can read is a test of a black box, and these four
+     substrings are the ones a wrong emission drops silently: without the
+     extension lines the shader does not parse, and without the derived
+     coopmat type the wrong fragment dimensions compile and compute nonsense. *)
+  (match Sarek_codegen.Sarek_ir_glsl.generate ~block:(64, 1, 1) ir with
+  | src ->
+      print_endline "--- emitted GLSL ---" ;
+      print_string src ;
+      print_endline "--- end ---" ;
+      List.iter
+        (fun needle ->
+          if not (Test_helpers.string_contains ~needle src) then
+            fail "the emitted GLSL does not contain %S" needle)
+        [
+          "#extension GL_KHR_cooperative_matrix : require";
+          "#extension GL_KHR_memory_scope_semantics : require";
+          "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require";
+          "coopmat<uint8_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA>";
+          "coopmat<int32_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator>";
+          "coopMatLoad(";
+          "coopMatMulAdd(";
+          "coopMatStore(";
+        ]
+  | exception e -> fail "GLSL generation raised: %s" (Printexc.to_string e)) ;
+
+  (* The launch gate, on every device that does NOT advertise the
+     configuration — checked whether or not any device does, because that is the
+     half that can be vacuous. A gate observed only permitting is
+     indistinguishable from one that returns Available unconditionally, and this
+     workstation has a free negative device (the Raphael iGPU) under the same
+     driver build as the positive one. *)
+  let refusing =
+    List.filter (fun d -> not (List.memq d coopmat_devices)) devices
+  in
+  if refusing = [] then
+    print_endline
+      "  note: every device advertises the configuration, so the refusal arm \
+       is not exercised on this machine"
+  else
+    List.iter
+      (fun dev ->
+        match Execute.check_device_capabilities ~device:dev ir with
+        | () ->
+            fail
+              "%s advertises no such cooperative-matrix configuration, yet the \
+               launch gate PERMITTED the kernel"
+              dev.Device.name
+        | exception _ ->
+            Printf.printf "  OK  launch gate refuses on %s\n%!" dev.Device.name)
+      refusing ;
+
+  if coopmat_devices = [] then
+    print_endline
+      "[SKIP] no device advertises the u8*u8+s32->s32 cooperative-matrix \
+       configuration; the numeric comparison did not run"
+  else
+    List.iter
+      (fun dev ->
+        Printf.printf "device: %s\n%!" dev.Device.name ;
+        let controls_c = ref 0 and controls_t = ref 0 in
+        for t = 0 to mnk - 1 do
+          let gpu = run_gpu dev ir ~t in
+          let oracle = run_interp ir ~t in
+          (match first_divergence gpu oracle with
+          | None -> ()
+          | Some (i, g, o) ->
+              fail
+                "%s tile %d: GPU and interpreter diverge at %d: %ld vs %ld"
+                dev.Device.name
+                t
+                i
+                g
+                o) ;
+          (* Positive controls, computed by the interpreter from MUTATED IR. *)
+          if not (equal gpu (run_interp (make_ir ~drop_c:true ()) ~t)) then
+            incr controls_c ;
+          if not (equal gpu (run_interp (make_ir ~transpose_b:true ()) ~t)) then
+            incr controls_t
+        done ;
+        if !controls_c <> mnk then
+          fail
+            "%s: the C-dropping control was ACCEPTED on %d of %d tiles"
+            dev.Device.name
+            (mnk - !controls_c)
+            mnk ;
+        if !controls_t <> mnk then
+          fail
+            "%s: the transposed-B control was ACCEPTED on %d of %d tiles"
+            dev.Device.name
+            (mnk - !controls_t)
+            mnk ;
+        if !failures = 0 then
+          Printf.printf
+            "  OK  16 tiles, all 65536 u8 operand pairs, bit-identical to the \
+             interpreter; both controls rejected\n\
+             %!")
+      coopmat_devices ;
+
+  if !failures > 0 then begin
+    Printf.printf "%d failure(s)\n" !failures ;
+    exit 1
+  end
+  else print_endline "PASS"

--- a/sarek/tests/unit/test_float16.ml
+++ b/sarek/tests/unit/test_float16.ml
@@ -244,6 +244,7 @@ let interp_env () =
     arrays = Hashtbl.create 4;
     shared = Hashtbl.create 4;
     funcs = Hashtbl.create 4;
+    coopmats = Hashtbl.create 4;
   }
 
 let interp_state () =

--- a/sarek/tests/unit/test_ir_interp.ml
+++ b/sarek/tests/unit/test_ir_interp.ml
@@ -17,6 +17,7 @@ let make_env () =
     arrays = Hashtbl.create 8;
     shared = Hashtbl.create 8;
     funcs = Hashtbl.create 8;
+    coopmats = Hashtbl.create 4;
   }
 
 (** Helper to create a test thread state *)

--- a/spoc/ir/Sarek_capability.ml
+++ b/spoc/ir/Sarek_capability.ml
@@ -126,6 +126,24 @@ let device_lacks_feature (f : Sarek_ir_analysis.feature) =
              VkPhysicalDeviceFeatures2; OpenCL: cl_khr_fp16 is an optional \
              extension",
           Some "Use float32." )
+    | Sarek_ir_analysis.Coopmat ->
+        (* Reached only through [device_lacks_feature], i.e. by a caller that
+           knows a kernel wants cooperative matrices but has no CONFIGURATION to
+           name. {!Sarek_coopmat.device_lacks_config} is the richer refusal and
+           is what the launch gate uses; this is the one a backend emits when it
+           cannot spell the instruction at all, where naming a configuration
+           would suggest that a different one might work. *)
+        ( "the device advertises no cooperative-matrix support \
+           (VK_KHR_cooperative_matrix and its cooperativeMatrix feature, or \
+           the backend equivalent)",
+          Quoted
+            "Vulkan specification, VK_KHR_cooperative_matrix: cooperative \
+             matrices are an optional device feature, and \
+             SPV_KHR_cooperative_matrix states that INTEGER accumulation is \
+             exact at the precision of the result type",
+          Some
+            "Use an ordinary multiply-accumulate kernel, or select a device \
+             that advertises the cooperative-matrix configuration you need." )
   in
   {
     cap_name = Sarek_ir_analysis.feature_name f;

--- a/spoc/ir/Sarek_coopmat.ml
+++ b/spoc/ir/Sarek_coopmat.ml
@@ -3,91 +3,14 @@
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 
-(** Cooperative-matrix vocabulary and fragment type (backlog-62, slices 2 and
-    4b). See the .mli for why integers are admitted from the start and why the
-    device gate cannot be keyed on the configuration list. *)
+(** Cooperative matrix: the DEVICE-facing half (backlog-62 slice 2).
 
-type component_type = Float16 | Float32 | Uint8 | Sint8 | Uint32 | Sint32
+    The vocabulary lives in {!Sarek_coopmat_types}, which this module re-exports
+    wholesale — see there for why the split exists. What is left here is exactly
+    the part that consults {!Sarek_capability}: given a device's probed support,
+    is a requested configuration permitted? *)
 
-let component_name = function
-  | Float16 -> "f16"
-  | Float32 -> "f32"
-  | Uint8 -> "u8"
-  | Sint8 -> "s8"
-  | Uint32 -> "u32"
-  | Sint32 -> "s32"
-
-let component_bits = function
-  | Uint8 | Sint8 -> 8
-  | Float16 -> 16
-  | Float32 | Uint32 | Sint32 -> 32
-
-(* An explicit match on every constructor rather than [<> Float16 && <>
-   Float32]. A new float component type (bf16, fp8) added to the variant must
-   be a compile error here, because the one thing this predicate decides is
-   whether a configuration escapes the accuracy relaxation — and a new float
-   type defaulting to "integer, therefore exact" is the permissive-default
-   failure the capability model exists to prevent. *)
-let component_is_integer = function
-  | Uint8 | Sint8 | Uint32 | Sint32 -> true
-  | Float16 | Float32 -> false
-
-type scope = Subgroup | Workgroup | Device_scope | Queue_family
-
-let scope_name = function
-  | Subgroup -> "subgroup"
-  | Workgroup -> "workgroup"
-  | Device_scope -> "device"
-  | Queue_family -> "queuefamily"
-
-type shape = {m : int; n : int; k : int}
-
-let shape_name s = Printf.sprintf "%dx%dx%d" s.m s.n s.k
-
-type config = {
-  cfg_shape : shape;
-  cfg_a : component_type;
-  cfg_b : component_type;
-  cfg_c : component_type;
-  cfg_result : component_type;
-  cfg_saturating : bool;
-  cfg_scope : scope;
-}
-
-let config_name c =
-  Printf.sprintf
-    "%s %s*%s+%s->%s%s %s"
-    (shape_name c.cfg_shape)
-    (component_name c.cfg_a)
-    (component_name c.cfg_b)
-    (component_name c.cfg_c)
-    (component_name c.cfg_result)
-    (if c.cfg_saturating then " saturating" else "")
-    (scope_name c.cfg_scope)
-
-(* Exactness is a property of the ACCUMULATION, so it is decided by the addend
-   and result types, not by the operand types. The distinction is not academic
-   on this hardware: every configuration the local device advertises has
-   integer operands paired with integer accumulate, but f16*f16 pairs with BOTH
-   f16 and f32 accumulate, and reading the operand types would have called both
-   of those the same thing. *)
-let accumulation_is_exact c =
-  component_is_integer c.cfg_c && component_is_integer c.cfg_result
-
-type accuracy_regime = Strict | Relaxed_bounded
-
-let regime c = if accumulation_is_exact c then Strict else Relaxed_bounded
-
-let regime_name = function
-  | Strict -> "strict"
-  | Relaxed_bounded -> "relaxed-bounded"
-
-type device_support = {
-  ds_configs : config list;
-  ds_robust_buffer_access : bool;
-  ds_subgroup_size : int;
-  ds_advertised_count : int;
-}
+include Sarek_coopmat_types
 
 let device_lacks_config cfg =
   {
@@ -118,26 +41,6 @@ let device_lacks_config cfg =
          advertises this cooperative-matrix configuration.";
   }
 
-let config_matches ~shape ~a ~b ~c ~result cfg =
-  cfg.cfg_shape = shape && cfg.cfg_a = a && cfg.cfg_b = b && cfg.cfg_c = c
-  && cfg.cfg_result = result
-
-let find_config ~support ~shape ~a ~b ~c ~result =
-  match support with
-  | None -> None
-  | Some s -> (
-      let candidates =
-        List.filter (config_matches ~shape ~a ~b ~c ~result) s.ds_configs
-      in
-      (* Prefer the non-saturating variant: it is the one that computes the
-         same function as a plain accumulate, so it is what an unqualified
-         request means. A caller that wants saturation must ask for it, which
-         it cannot do through this function — deliberately, until a slice
-         exists that can emit either. *)
-      match List.find_opt (fun cfg -> not cfg.cfg_saturating) candidates with
-      | Some cfg -> Some cfg
-      | None -> List.nth_opt candidates 0)
-
 let verdict ~support cfg =
   match support with
   | None ->
@@ -160,73 +63,3 @@ let verdict ~support cfg =
           s.ds_configs
       then Sarek_capability.Available
       else Sarek_capability.Unavailable (device_lacks_config cfg)
-
-type use = Matrix_a | Matrix_b | Accumulator
-
-let use_name = function
-  | Matrix_a -> "A"
-  | Matrix_b -> "B"
-  | Accumulator -> "accumulator"
-
-type fragment = {
-  frag_use : use;
-  frag_shape : shape;
-  frag_component : component_type;
-  frag_scope : scope;
-}
-
-let fragment_dims f =
-  let s = f.frag_shape in
-  match f.frag_use with
-  | Matrix_a -> (s.m, s.k)
-  | Matrix_b -> (s.k, s.n)
-  | Accumulator -> (s.m, s.n)
-
-let fragment_components f =
-  let rows, cols = fragment_dims f in
-  rows * cols
-
-let fragments_of_config c =
-  let frag frag_use frag_component =
-    {
-      frag_use;
-      frag_shape = c.cfg_shape;
-      frag_component;
-      frag_scope = c.cfg_scope;
-    }
-  in
-  ( frag Matrix_a c.cfg_a,
-    frag Matrix_b c.cfg_b,
-    frag Accumulator c.cfg_c,
-    frag Accumulator c.cfg_result )
-
-let components_per_invocation ~subgroup_size f =
-  let total = fragment_components f in
-  if subgroup_size <= 0 then
-    Error
-      (Printf.sprintf
-         "subgroup size %d is not positive, so a %s fragment cannot be \
-          distributed"
-         subgroup_size
-         (use_name f.frag_use))
-  else if total mod subgroup_size <> 0 then
-    Error
-      (Printf.sprintf
-         "a %s fragment of %s (%d components) cannot be distributed over a \
-          subgroup of %d invocations: %d does not divide %d"
-         (use_name f.frag_use)
-         (shape_name f.frag_shape)
-         total
-         subgroup_size
-         subgroup_size
-         total)
-  else Ok (total / subgroup_size)
-
-let config_fits_subgroup ~subgroup_size c =
-  let a, b, cc, r = fragments_of_config c in
-  List.for_all
-    (fun f ->
-      match components_per_invocation ~subgroup_size f with
-      | Ok _ -> true
-      | Error _ -> false)
-    [a; b; cc; r]

--- a/spoc/ir/Sarek_coopmat.mli
+++ b/spoc/ir/Sarek_coopmat.mli
@@ -3,176 +3,29 @@
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 
-(** Cooperative-matrix (tensor-core) vocabulary and fragment type.
+(** Cooperative matrix: the DEVICE-facing half.
 
-    backlog-62, slices 2 and 4b of docs/design/f16-relaxed-accuracy.md §7. This
-    module is the backend-neutral half: what a cooperative-matrix configuration
-    IS, what a device provides, and what a matrix fragment looks like. It holds
-    no Vulkan types and no Metal types — the Vulkan probe lives in
-    [sarek-vulkan/Vulkan_api_device.ml] and lowers into these values.
+    Every type and value of {!Sarek_coopmat_types} is re-exported here by
+    [include module type of], with its type equalities intact, so
+    [Sarek_coopmat.fragment], [Sarek_coopmat.Uint8] and the rest mean exactly
+    what they meant before slice 3 split the module. Read
+    {!Sarek_coopmat_types}'s interface for the vocabulary and the design
+    rationale behind it.
 
-    It sits in [spoc/ir] beside {!Sarek_capability} for the same reason that one
-    does: {!Framework_sig.capabilities} must be able to report what a device
-    provides, and [spoc/framework] may not depend on any backend.
+    What is defined HERE is the part that consults {!Sarek_capability}, and it
+    is separated for a mechanical reason as much as a conceptual one: the IR
+    names a fragment, {!Sarek_capability} depends on the IR, and a vocabulary
+    that also depended on {!Sarek_capability} would close a module cycle. *)
 
-    {1 What this module deliberately does NOT do}
-
-    It does not emit code, and it does not decide accuracy. {!regime} classifies
-    a configuration into the two acceptance regimes of the design document's
-    §1.6, but it does not admit anything: nothing in Sarek generates a
-    cooperative-matrix instruction yet, so every configuration here is queryable
-    and none is reachable from the DSL. Slices 4a and 4c are where that changes.
-
-    {1 Why the type admits integers}
-
-    §8 of the design document, adopted as binding by §7 slice 4b. Twelve of the
-    fourteen configurations the local RX 7900 XTX advertises are integer;
-    [SPV_KHR_cooperative_matrix] states that integer accumulation is exact at
-    the precision of the result type; so those configurations are deliverable
-    under Sarek's EXISTING strict accuracy contract, with no relaxation, no
-    allowlist and no opt-in. {!accumulation_is_exact} is where that distinction
-    is computed rather than asserted in prose. Retrofitting integer component
-    types after an f16-only fragment type had shipped would be a wide, invasive
-    change; admitting them now costs one variant group and one predicate. *)
-
-(** {1 Component types} *)
-
-(** The element type of one matrix operand or result.
-
-    The float half is the two configurations that need the relaxed contract; the
-    integer half is the twelve that do not. Closed on what has been MEASURED to
-    exist on a device this project can reach — the Vulkan set of
-    docs/design/f16-relaxed-accuracy.md §4 — plus nothing. In particular
-    [bfloat16] is absent: Metal advertises an 8x8 [bfloat] [simdgroup_matrix]
-    (§7 slice 6) but nothing has been swept about what it computes, and a
-    component type nothing can lower is a claim without evidence. Adding it is a
-    one-line change when a measurement exists. *)
-type component_type = Float16 | Float32 | Uint8 | Sint8 | Uint32 | Sint32
-
-(** Stable lowercase rendering: ["f16"], ["f32"], ["u8"], ["s8"], ["u32"],
-    ["s32"]. Matches the column headings of the design document's §4 table and
-    the [ctype] function of [tools/probes/vulkan_coopmat_probe.c], so a probe
-    line and a Sarek diagnostic can be compared by eye. *)
-val component_name : component_type -> string
-
-(** Width in bits. *)
-val component_bits : component_type -> int
-
-(** Whether the component type is an integer type.
-
-    Load-bearing rather than cosmetic: it is what {!accumulation_is_exact}
-    reads, and therefore what decides whether a configuration falls under the
-    strict contract or needs the relaxation. *)
-val component_is_integer : component_type -> bool
-
-(** {1 Scope} *)
-
-(** The set of invocations that cooperate to hold one matrix.
-
-    All fourteen configurations measured locally are [Subgroup] scope, and
-    Metal's [simdgroup_matrix] is a SIMD-group (i.e. subgroup) construct too, so
-    [Subgroup] is the only scope any planned backend can currently produce. The
-    other three are modelled because {!Sarek_capability}'s lesson is that a
-    value you cannot represent becomes a value you silently permit: a device
-    reporting [Workgroup] scope must come back as an unrecognised-but-named
-    scope, not be quietly rewritten to [Subgroup]. *)
-type scope = Subgroup | Workgroup | Device_scope | Queue_family
-
-val scope_name : scope -> string
-
-(** {1 Shapes} *)
-
-(** A [m x n x k] multiply-add shape: [A] is [m x k], [B] is [k x n], and [C]
-    and the result are [m x n].
-
-    A record of three ints rather than a closed variant of the shapes seen so
-    far, because §7 slice 4b makes non-hard-coded dimensions binding: Vulkan
-    measured 16x16x16 and Metal measured 8x8x8, and 8x8 is the ONLY size MSL
-    offers, so a type that could only spell 16x16x16 would already be wrong for
-    a backend whose numbers are in the same document. *)
-type shape = {m : int; n : int; k : int}
-
-val shape_name : shape -> string
-
-(** {1 Configurations} *)
-
-(** One multiply-add configuration a device advertises: [D = A x B + C].
-
-    [cfg_saturating] is Vulkan's [saturatingAccumulation] — integer accumulation
-    that clamps instead of wrapping. It is a separate field rather than a
-    component type because it is a property of the OPERATION, not of any
-    operand: the local device advertises the same [s8 x s8 -> s32] element types
-    both with it and without it, and those are two distinct configurations that
-    compute different functions. *)
-type config = {
-  cfg_shape : shape;
-  cfg_a : component_type;
-  cfg_b : component_type;
-  cfg_c : component_type;
-  cfg_result : component_type;
-  cfg_saturating : bool;
-  cfg_scope : scope;
-}
-
-(** A one-line rendering, e.g. ["16x16x16 f16*f16+f32->f32 subgroup"]. Appears
-    in diagnostics. *)
-val config_name : config -> string
-
-(** {1 Accuracy regime — the §8 discriminator} *)
-
-(** Is the accumulation of this configuration exact?
-
-    True exactly when the addend and result component types are both integer.
-    [SPV_KHR_cooperative_matrix] states that integer accumulation is performed
-    at the precision of the result type and is exact, so such a configuration
-    computes the same function as the interpreter and lands under Sarek's
-    existing strict contract. Every float configuration is false: the
-    specification leaves the ORDER of the [k + 1] additions to the
-    implementation, which is a freedom no closed-form model can pin down (design
-    document §5.1). *)
-val accumulation_is_exact : config -> bool
-
-(** The two acceptance regimes of docs/design/f16-relaxed-accuracy.md §1.6.
-
-    [Strict] means bit-identity with the interpreter is still promised.
-    [Relaxed_bounded] means only the derived error bound of §5.2 holds, which
-    §6.1 makes an explicit opt-in rather than a diagnostic. *)
-type accuracy_regime = Strict | Relaxed_bounded
-
-val regime : config -> accuracy_regime
-
-val regime_name : accuracy_regime -> string
-
-(** {1 What a device provides} *)
-
-(** A device's cooperative-matrix support, as probed.
-
-    [ds_subgroup_size] is here rather than left to the caller because a
-    subgroup-scope fragment's storage is distributed across exactly that many
-    invocations, so it is part of the calling convention and not an unrelated
-    device statistic. See {!components_per_invocation}. *)
-type device_support = {
-  ds_configs : config list;
-  ds_robust_buffer_access : bool;
-      (** Vulkan [cooperativeMatrixRobustBufferAccess]: whether out-of-bounds
-          cooperative-matrix loads and stores are bounds-checked. *)
-  ds_subgroup_size : int;
-      (** Invocations per subgroup, as the device reports it — NOT a constant.
-          Measured 64 on the RX 7900 XTX under radv / Mesa 26.1.4-arch3.1, where
-          [Vulkan_plugin_base] had been hard-coding 32. *)
-  ds_advertised_count : int;
-      (** How many configurations the DEVICE reported, including any this build
-          could not represent and therefore dropped from {!ds_configs}.
-
-          Kept because dropping an unrepresentable configuration is the safe
-          direction (it can only cause a refusal) but it is also SILENT, and a
-          silent drop hid a real defect once: a wrong [VkComponentTypeKHR]
-          enumerant table turned fourteen advertised configurations into six
-          plausible-looking wrong ones. The equality
-          [ds_advertised_count = List.length ds_configs] is the check that
-          catches it, and it is hardware-independent — unlike any assertion
-          about which configurations a particular GPU offers. *)
-}
+(* [struct include ... end] and not the bare module path: the bare form
+   re-declares each type ABSTRACTLY, so [Sarek_coopmat.config] would be a
+   distinct type from [Sarek_coopmat_types.config] and every value crossing
+   between the IR and the capability layer would need a conversion that does
+   nothing. This form preserves the type equalities, which is the whole point of
+   the re-export. *)
+include module type of struct
+  include Sarek_coopmat_types
+end
 
 (** [verdict ~support cfg] judges a requested configuration against a device.
 
@@ -199,78 +52,3 @@ val verdict :
 (** The {!Sarek_capability.Device_optional} record for a device that provides no
     cooperative-matrix support at all, or none matching the request. *)
 val device_lacks_config : config -> Sarek_capability.t
-
-(** [find_config ~support ~a ~b ~c ~result ~shape] returns the first advertised
-    configuration matching those component types and that shape, preferring a
-    non-saturating one. [None] when the device was not probed or advertises no
-    such configuration. *)
-val find_config :
-  support:device_support option ->
-  shape:shape ->
-  a:component_type ->
-  b:component_type ->
-  c:component_type ->
-  result:component_type ->
-  config option
-
-(** {1 The fragment type (slice 4b)} *)
-
-(** Which operand of [D = A x B + C] a fragment holds.
-
-    [Accumulator] covers both [C] and the result [D], which are the same shape
-    and the same component type in every configuration measured, and which
-    SPIR-V and MSL both give a single fragment role. *)
-type use = Matrix_a | Matrix_b | Accumulator
-
-val use_name : use -> string
-
-(** A cooperative-matrix fragment: the DSL-side value one invocation holds a
-    slice of.
-
-    It is NOT a per-invocation array. A fragment is a subgroup-cooperative
-    value: the whole subgroup collectively holds [rows x columns] components,
-    each invocation holding {!components_per_invocation} of them at an
-    implementation-defined position. That indeterminate position is why a
-    fragment must not be indexable from the DSL, and it is the reason this type
-    exists at all rather than the DSL using an array. *)
-type fragment = {
-  frag_use : use;
-  frag_shape : shape;
-  frag_component : component_type;
-  frag_scope : scope;
-}
-
-(** [fragment_dims f] is [(rows, columns)], derived from {!use} and the shape:
-    [A] is [m x k], [B] is [k x n], and an accumulator is [m x n]. Derived
-    rather than stored so a fragment cannot be built claiming a size its shape
-    does not have. *)
-val fragment_dims : fragment -> int * int
-
-(** Total components in the whole fragment, i.e. [rows * columns]. *)
-val fragment_components : fragment -> int
-
-(** The fragments a configuration operates on: [(a, b, c, result)]. *)
-val fragments_of_config : config -> fragment * fragment * fragment * fragment
-
-(** {2 The subgroup calling convention} *)
-
-(** [components_per_invocation ~subgroup_size f] is how many components of [f]
-    each invocation of the cooperating subgroup holds.
-
-    [Error] when [subgroup_size] does not divide {!fragment_components}, which
-    is a real constraint and not a defensive check: a 16x16 fragment over a
-    64-wide subgroup is 4 components per invocation, and the same fragment over
-    a 24-wide subgroup has no distribution at all. It returns a result rather
-    than raising because it is the check a codegen slice must perform BEFORE
-    emitting anything, and it is the check a device query must survive when a
-    driver reports a subgroup size the configuration cannot be laid out over.
-
-    The value itself is deliberately NOT a promise about WHICH components an
-    invocation holds. That mapping is implementation-defined in both SPIR-V and
-    MSL; only the count is portable. *)
-val components_per_invocation :
-  subgroup_size:int -> fragment -> (int, string) result
-
-(** [config_fits_subgroup ~subgroup_size cfg] is true when every one of the four
-    fragments of [cfg] can be distributed over a subgroup of that size. *)
-val config_fits_subgroup : subgroup_size:int -> config -> bool

--- a/spoc/ir/Sarek_coopmat_types.ml
+++ b/spoc/ir/Sarek_coopmat_types.ml
@@ -1,0 +1,199 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Cooperative-matrix vocabulary, fragment type and subgroup calling convention
+    — the half with NO dependencies (backlog-62, slices 2, 4b and 3).
+
+    Split out of {!Sarek_coopmat} in slice 3 and for one reason only: the IR
+    must be able to name a fragment. [Sarek_ir_types.coopmat_op] carries a
+    {!fragment} and a {!config}, and [Sarek_capability] depends on
+    [Sarek_ir_types] — so leaving the vocabulary in a module that also depends
+    on [Sarek_capability] closes a cycle
+    [Sarek_ir_types -> Sarek_coopmat -> Sarek_capability -> Sarek_ir_analysis ->
+     Sarek_ir_types] that dune rejects outright.
+
+    The cut is at the capability boundary, which is also where it belongs
+    conceptually: WHAT a cooperative-matrix configuration is has no opinion
+    about whether a device provides it. {!Sarek_coopmat} [include]s this module,
+    so every existing [Sarek_coopmat.fragment] / [Sarek_coopmat.Uint8] reference
+    keeps its meaning and its type equality; nothing outside needs to know the
+    module was split.
+
+    The .mli of {!Sarek_coopmat} carries the design rationale for every type
+    here — why integers are admitted from the start, why the shape is a record
+    rather than a closed variant, why an unrepresentable scope must not be
+    rewritten. It is not repeated. *)
+
+type component_type = Float16 | Float32 | Uint8 | Sint8 | Uint32 | Sint32
+
+let component_name = function
+  | Float16 -> "f16"
+  | Float32 -> "f32"
+  | Uint8 -> "u8"
+  | Sint8 -> "s8"
+  | Uint32 -> "u32"
+  | Sint32 -> "s32"
+
+let component_bits = function
+  | Uint8 | Sint8 -> 8
+  | Float16 -> 16
+  | Float32 | Uint32 | Sint32 -> 32
+
+(* An explicit match on every constructor rather than [<> Float16 && <>
+   Float32]. A new float component type (bf16, fp8) added to the variant must
+   be a compile error here, because the one thing this predicate decides is
+   whether a configuration escapes the accuracy relaxation — and a new float
+   type defaulting to "integer, therefore exact" is the permissive-default
+   failure the capability model exists to prevent. *)
+let component_is_integer = function
+  | Uint8 | Sint8 | Uint32 | Sint32 -> true
+  | Float16 | Float32 -> false
+
+type scope = Subgroup | Workgroup | Device_scope | Queue_family
+
+let scope_name = function
+  | Subgroup -> "subgroup"
+  | Workgroup -> "workgroup"
+  | Device_scope -> "device"
+  | Queue_family -> "queuefamily"
+
+type shape = {m : int; n : int; k : int}
+
+let shape_name s = Printf.sprintf "%dx%dx%d" s.m s.n s.k
+
+type config = {
+  cfg_shape : shape;
+  cfg_a : component_type;
+  cfg_b : component_type;
+  cfg_c : component_type;
+  cfg_result : component_type;
+  cfg_saturating : bool;
+  cfg_scope : scope;
+}
+
+let config_name c =
+  Printf.sprintf
+    "%s %s*%s+%s->%s%s %s"
+    (shape_name c.cfg_shape)
+    (component_name c.cfg_a)
+    (component_name c.cfg_b)
+    (component_name c.cfg_c)
+    (component_name c.cfg_result)
+    (if c.cfg_saturating then " saturating" else "")
+    (scope_name c.cfg_scope)
+
+(* Exactness is a property of the ACCUMULATION, so it is decided by the addend
+   and result types, not by the operand types. The distinction is not academic
+   on this hardware: every configuration the local device advertises has
+   integer operands paired with integer accumulate, but f16*f16 pairs with BOTH
+   f16 and f32 accumulate, and reading the operand types would have called both
+   of those the same thing. *)
+let accumulation_is_exact c =
+  component_is_integer c.cfg_c && component_is_integer c.cfg_result
+
+type accuracy_regime = Strict | Relaxed_bounded
+
+let regime c = if accumulation_is_exact c then Strict else Relaxed_bounded
+
+let regime_name = function
+  | Strict -> "strict"
+  | Relaxed_bounded -> "relaxed-bounded"
+
+type device_support = {
+  ds_configs : config list;
+  ds_robust_buffer_access : bool;
+  ds_subgroup_size : int;
+  ds_advertised_count : int;
+}
+
+let config_matches ~shape ~a ~b ~c ~result cfg =
+  cfg.cfg_shape = shape && cfg.cfg_a = a && cfg.cfg_b = b && cfg.cfg_c = c
+  && cfg.cfg_result = result
+
+let find_config ~support ~shape ~a ~b ~c ~result =
+  match support with
+  | None -> None
+  | Some s -> (
+      let candidates =
+        List.filter (config_matches ~shape ~a ~b ~c ~result) s.ds_configs
+      in
+      (* Prefer the non-saturating variant: it is the one that computes the
+         same function as a plain accumulate, so it is what an unqualified
+         request means. A caller that wants saturation must ask for it, which
+         it cannot do through this function — deliberately, until a slice
+         exists that can emit either. *)
+      match List.find_opt (fun cfg -> not cfg.cfg_saturating) candidates with
+      | Some cfg -> Some cfg
+      | None -> List.nth_opt candidates 0)
+
+type use = Matrix_a | Matrix_b | Accumulator
+
+let use_name = function
+  | Matrix_a -> "A"
+  | Matrix_b -> "B"
+  | Accumulator -> "accumulator"
+
+type fragment = {
+  frag_use : use;
+  frag_shape : shape;
+  frag_component : component_type;
+  frag_scope : scope;
+}
+
+let fragment_dims f =
+  let s = f.frag_shape in
+  match f.frag_use with
+  | Matrix_a -> (s.m, s.k)
+  | Matrix_b -> (s.k, s.n)
+  | Accumulator -> (s.m, s.n)
+
+let fragment_components f =
+  let rows, cols = fragment_dims f in
+  rows * cols
+
+let fragments_of_config c =
+  let frag frag_use frag_component =
+    {
+      frag_use;
+      frag_shape = c.cfg_shape;
+      frag_component;
+      frag_scope = c.cfg_scope;
+    }
+  in
+  ( frag Matrix_a c.cfg_a,
+    frag Matrix_b c.cfg_b,
+    frag Accumulator c.cfg_c,
+    frag Accumulator c.cfg_result )
+
+let components_per_invocation ~subgroup_size f =
+  let total = fragment_components f in
+  if subgroup_size <= 0 then
+    Error
+      (Printf.sprintf
+         "subgroup size %d is not positive, so a %s fragment cannot be \
+          distributed"
+         subgroup_size
+         (use_name f.frag_use))
+  else if total mod subgroup_size <> 0 then
+    Error
+      (Printf.sprintf
+         "a %s fragment of %s (%d components) cannot be distributed over a \
+          subgroup of %d invocations: %d does not divide %d"
+         (use_name f.frag_use)
+         (shape_name f.frag_shape)
+         total
+         subgroup_size
+         subgroup_size
+         total)
+  else Ok (total / subgroup_size)
+
+let config_fits_subgroup ~subgroup_size c =
+  let a, b, cc, r = fragments_of_config c in
+  List.for_all
+    (fun f ->
+      match components_per_invocation ~subgroup_size f with
+      | Ok _ -> true
+      | Error _ -> false)
+    [a; b; cc; r]

--- a/spoc/ir/Sarek_coopmat_types.mli
+++ b/spoc/ir/Sarek_coopmat_types.mli
@@ -1,0 +1,268 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Cooperative-matrix (tensor-core) vocabulary and fragment type.
+
+    backlog-62, slices 2 and 4b of docs/design/f16-relaxed-accuracy.md §7. This
+    module is the backend-neutral half: what a cooperative-matrix configuration
+    IS, what a device provides, and what a matrix fragment looks like. It holds
+    no Vulkan types and no Metal types — the Vulkan probe lives in
+    [sarek-vulkan/Vulkan_api_device.ml] and lowers into these values.
+
+    It sits in [spoc/ir] beside {!Sarek_capability} for the same reason that one
+    does: {!Framework_sig.capabilities} must be able to report what a device
+    provides, and [spoc/framework] may not depend on any backend.
+
+    {1 What this module deliberately does NOT do}
+
+    It does not emit code, and it does not decide accuracy. {!regime} classifies
+    a configuration into the two acceptance regimes of the design document's
+    §1.6, but it does not admit anything: nothing in Sarek generates a
+    cooperative-matrix instruction yet, so every configuration here is queryable
+    and none is reachable from the DSL. Slices 4a and 4c are where that changes.
+
+    {1 Why the type admits integers}
+
+    §8 of the design document, adopted as binding by §7 slice 4b. Twelve of the
+    fourteen configurations the local RX 7900 XTX advertises are integer;
+    [SPV_KHR_cooperative_matrix] states that integer accumulation is exact at
+    the precision of the result type; so those configurations are deliverable
+    under Sarek's EXISTING strict accuracy contract, with no relaxation, no
+    allowlist and no opt-in. {!accumulation_is_exact} is where that distinction
+    is computed rather than asserted in prose. Retrofitting integer component
+    types after an f16-only fragment type had shipped would be a wide, invasive
+    change; admitting them now costs one variant group and one predicate. *)
+
+(** {1 Component types} *)
+
+(** The element type of one matrix operand or result.
+
+    The float half is the two configurations that need the relaxed contract; the
+    integer half is the twelve that do not. Closed on what has been MEASURED to
+    exist on a device this project can reach — the Vulkan set of
+    docs/design/f16-relaxed-accuracy.md §4 — plus nothing. In particular
+    [bfloat16] is absent: Metal advertises an 8x8 [bfloat] [simdgroup_matrix]
+    (§7 slice 6) but nothing has been swept about what it computes, and a
+    component type nothing can lower is a claim without evidence. Adding it is a
+    one-line change when a measurement exists. *)
+type component_type = Float16 | Float32 | Uint8 | Sint8 | Uint32 | Sint32
+
+(** Stable lowercase rendering: ["f16"], ["f32"], ["u8"], ["s8"], ["u32"],
+    ["s32"]. Matches the column headings of the design document's §4 table and
+    the [ctype] function of [tools/probes/vulkan_coopmat_probe.c], so a probe
+    line and a Sarek diagnostic can be compared by eye. *)
+val component_name : component_type -> string
+
+(** Width in bits. *)
+val component_bits : component_type -> int
+
+(** Whether the component type is an integer type.
+
+    Load-bearing rather than cosmetic: it is what {!accumulation_is_exact}
+    reads, and therefore what decides whether a configuration falls under the
+    strict contract or needs the relaxation. *)
+val component_is_integer : component_type -> bool
+
+(** {1 Scope} *)
+
+(** The set of invocations that cooperate to hold one matrix.
+
+    All fourteen configurations measured locally are [Subgroup] scope, and
+    Metal's [simdgroup_matrix] is a SIMD-group (i.e. subgroup) construct too, so
+    [Subgroup] is the only scope any planned backend can currently produce. The
+    other three are modelled because {!Sarek_capability}'s lesson is that a
+    value you cannot represent becomes a value you silently permit: a device
+    reporting [Workgroup] scope must come back as an unrecognised-but-named
+    scope, not be quietly rewritten to [Subgroup]. *)
+type scope = Subgroup | Workgroup | Device_scope | Queue_family
+
+val scope_name : scope -> string
+
+(** {1 Shapes} *)
+
+(** A [m x n x k] multiply-add shape: [A] is [m x k], [B] is [k x n], and [C]
+    and the result are [m x n].
+
+    A record of three ints rather than a closed variant of the shapes seen so
+    far, because §7 slice 4b makes non-hard-coded dimensions binding: Vulkan
+    measured 16x16x16 and Metal measured 8x8x8, and 8x8 is the ONLY size MSL
+    offers, so a type that could only spell 16x16x16 would already be wrong for
+    a backend whose numbers are in the same document. *)
+type shape = {m : int; n : int; k : int}
+
+val shape_name : shape -> string
+
+(** {1 Configurations} *)
+
+(** One multiply-add configuration a device advertises: [D = A x B + C].
+
+    [cfg_saturating] is Vulkan's [saturatingAccumulation] — integer accumulation
+    that clamps instead of wrapping. It is a separate field rather than a
+    component type because it is a property of the OPERATION, not of any
+    operand: the local device advertises the same [s8 x s8 -> s32] element types
+    both with it and without it, and those are two distinct configurations that
+    compute different functions. *)
+type config = {
+  cfg_shape : shape;
+  cfg_a : component_type;
+  cfg_b : component_type;
+  cfg_c : component_type;
+  cfg_result : component_type;
+  cfg_saturating : bool;
+  cfg_scope : scope;
+}
+
+(** A one-line rendering, e.g. ["16x16x16 f16*f16+f32->f32 subgroup"]. Appears
+    in diagnostics. *)
+val config_name : config -> string
+
+(** {1 Accuracy regime — the §8 discriminator} *)
+
+(** Is the accumulation of this configuration exact?
+
+    True exactly when the addend and result component types are both integer.
+    [SPV_KHR_cooperative_matrix] states that integer accumulation is performed
+    at the precision of the result type and is exact, so such a configuration
+    computes the same function as the interpreter and lands under Sarek's
+    existing strict contract. Every float configuration is false: the
+    specification leaves the ORDER of the [k + 1] additions to the
+    implementation, which is a freedom no closed-form model can pin down (design
+    document §5.1). *)
+val accumulation_is_exact : config -> bool
+
+(** The two acceptance regimes of docs/design/f16-relaxed-accuracy.md §1.6.
+
+    [Strict] means bit-identity with the interpreter is still promised.
+    [Relaxed_bounded] means only the derived error bound of §5.2 holds, which
+    §6.1 makes an explicit opt-in rather than a diagnostic. *)
+type accuracy_regime = Strict | Relaxed_bounded
+
+val regime : config -> accuracy_regime
+
+val regime_name : accuracy_regime -> string
+
+(** {1 What a device provides} *)
+
+(** A device's cooperative-matrix support, as probed.
+
+    [ds_subgroup_size] is here rather than left to the caller because a
+    subgroup-scope fragment's storage is distributed across exactly that many
+    invocations, so it is part of the calling convention and not an unrelated
+    device statistic. See {!components_per_invocation}. *)
+type device_support = {
+  ds_configs : config list;
+  ds_robust_buffer_access : bool;
+      (** Vulkan [cooperativeMatrixRobustBufferAccess]: whether out-of-bounds
+          cooperative-matrix loads and stores are bounds-checked. *)
+  ds_subgroup_size : int;
+      (** Invocations per subgroup, as the device reports it — NOT a constant.
+          Measured 64 on the RX 7900 XTX under radv / Mesa 26.1.4-arch3.1, where
+          [Vulkan_plugin_base] had been hard-coding 32. *)
+  ds_advertised_count : int;
+      (** How many configurations the DEVICE reported, including any this build
+          could not represent and therefore dropped from {!ds_configs}.
+
+          Kept because dropping an unrepresentable configuration is the safe
+          direction (it can only cause a refusal) but it is also SILENT, and a
+          silent drop hid a real defect once: a wrong [VkComponentTypeKHR]
+          enumerant table turned fourteen advertised configurations into six
+          plausible-looking wrong ones. The equality
+          [ds_advertised_count = List.length ds_configs] is the check that
+          catches it, and it is hardware-independent — unlike any assertion
+          about which configurations a particular GPU offers. *)
+}
+
+(** [config_matches ~shape ~a ~b ~c ~result cfg] compares the DIMENSIONS and the
+    four component types, and deliberately NOT [cfg_saturating] or [cfg_scope].
+
+    Those two are what separates configurations that this predicate is used to
+    group: the local device advertises the same [s8 x s8 -> s32] element types
+    both saturating and not, and they compute different functions. Callers that
+    need an exact match ({!verdict}) test them explicitly on top; callers that
+    are searching ({!find_config}) rank them. Folding them in here would make
+    the two behaviours indistinguishable at the call site. *)
+val config_matches :
+  shape:shape ->
+  a:component_type ->
+  b:component_type ->
+  c:component_type ->
+  result:component_type ->
+  config ->
+  bool
+
+(** [find_config ~support ~a ~b ~c ~result ~shape] returns the first advertised
+    configuration matching those component types and that shape, preferring a
+    non-saturating one. [None] when the device was not probed or advertises no
+    such configuration. *)
+val find_config :
+  support:device_support option ->
+  shape:shape ->
+  a:component_type ->
+  b:component_type ->
+  c:component_type ->
+  result:component_type ->
+  config option
+
+(** {1 The fragment type (slice 4b)} *)
+
+(** Which operand of [D = A x B + C] a fragment holds.
+
+    [Accumulator] covers both [C] and the result [D], which are the same shape
+    and the same component type in every configuration measured, and which
+    SPIR-V and MSL both give a single fragment role. *)
+type use = Matrix_a | Matrix_b | Accumulator
+
+val use_name : use -> string
+
+(** A cooperative-matrix fragment: the DSL-side value one invocation holds a
+    slice of.
+
+    It is NOT a per-invocation array. A fragment is a subgroup-cooperative
+    value: the whole subgroup collectively holds [rows x columns] components,
+    each invocation holding {!components_per_invocation} of them at an
+    implementation-defined position. That indeterminate position is why a
+    fragment must not be indexable from the DSL, and it is the reason this type
+    exists at all rather than the DSL using an array. *)
+type fragment = {
+  frag_use : use;
+  frag_shape : shape;
+  frag_component : component_type;
+  frag_scope : scope;
+}
+
+(** [fragment_dims f] is [(rows, columns)], derived from {!use} and the shape:
+    [A] is [m x k], [B] is [k x n], and an accumulator is [m x n]. Derived
+    rather than stored so a fragment cannot be built claiming a size its shape
+    does not have. *)
+val fragment_dims : fragment -> int * int
+
+(** Total components in the whole fragment, i.e. [rows * columns]. *)
+val fragment_components : fragment -> int
+
+(** The fragments a configuration operates on: [(a, b, c, result)]. *)
+val fragments_of_config : config -> fragment * fragment * fragment * fragment
+
+(** {2 The subgroup calling convention} *)
+
+(** [components_per_invocation ~subgroup_size f] is how many components of [f]
+    each invocation of the cooperating subgroup holds.
+
+    [Error] when [subgroup_size] does not divide {!fragment_components}, which
+    is a real constraint and not a defensive check: a 16x16 fragment over a
+    64-wide subgroup is 4 components per invocation, and the same fragment over
+    a 24-wide subgroup has no distribution at all. It returns a result rather
+    than raising because it is the check a codegen slice must perform BEFORE
+    emitting anything, and it is the check a device query must survive when a
+    driver reports a subgroup size the configuration cannot be laid out over.
+
+    The value itself is deliberately NOT a promise about WHICH components an
+    invocation holds. That mapping is implementation-defined in both SPIR-V and
+    MSL; only the count is portable. *)
+val components_per_invocation :
+  subgroup_size:int -> fragment -> (int, string) result
+
+(** [config_fits_subgroup ~subgroup_size cfg] is true when every one of the four
+    fragments of [cfg] can be distributed over a subgroup of that size. *)
+val config_fits_subgroup : subgroup_size:int -> config -> bool

--- a/spoc/ir/Sarek_ir_analysis.ml
+++ b/spoc/ir/Sarek_ir_analysis.ml
@@ -44,6 +44,19 @@ open Sarek_ir_types
 type 'a folder = {
   fe : 'a -> expr -> 'a;
   ft : 'a -> elttype -> 'a;
+  fs : 'a -> stmt -> 'a;
+      (** Combine the accumulator with a STATEMENT node, before the traversal
+          descends into it. The counterpart of {!fe} for the imperative half,
+          added in backlog-62 slice 3 because [SCoopmat] is the first IR node
+          whose feature content is neither an expression nor an element type: a
+          cooperative-matrix multiply-add carries a
+          {!Sarek_coopmat_types.config}, and a config is what the device gate is
+          keyed on.
+
+          Families that do not inspect statements leave this at the identity,
+          which reproduces the pre-slice-3 behaviour exactly — the hook fires at
+          every statement, so a non-identity value here is a deliberate
+          statement-level detector and never an accident of traversal order. *)
   fnative : 'a -> 'a;
   visit_lvalue : bool;
 }
@@ -76,7 +89,9 @@ let rec lvalue_fold f acc = function
   | LArrayElemExpr (base, idx) -> expr_fold f (expr_fold f acc base) idx
   | LRecordField (lv, _) -> lvalue_fold f acc lv
 
-let rec stmt_fold f acc = function
+let rec stmt_fold f acc stmt =
+  let acc = f.fs acc stmt in
+  match stmt with
   | SAssign (lv, e) ->
       let acc = if f.visit_lvalue then lvalue_fold f acc lv else acc in
       expr_fold f acc e
@@ -101,6 +116,15 @@ let rec stmt_fold f acc = function
       stmt_fold f (expr_fold f acc e) body
   | SPragma (_, body) | SBlock body -> stmt_fold f acc body
   | SNative _ -> f.fnative acc
+  | SCoopmat op -> (
+      (* The fragment's own component type is NOT routed through [ft]. [ft] is
+         the elttype hook, and a fragment is not an elttype — that is the whole
+         reason [SCoopmat] exists rather than a [TCoopmat] constructor. A family
+         that wants to see fragments uses [fs]. *)
+      match op with
+      | CM_decl _ | CM_muladd _ -> acc
+      | CM_load {index; stride; _} | CM_store {index; stride; _} ->
+          expr_fold f (expr_fold f acc index) stride)
 
 let decl_fold f acc = function
   | DParam (v, arr_info) ->
@@ -143,11 +167,12 @@ let kernel_fold f acc k =
     node (and may inspect embedded types); [type_leaf] fires per binder/decl
     type; [native] is the [SNative] verdict; [visit_lvalue] controls whether
     [SAssign] descends into its l-value. *)
-let exists_folder ~leaf ?(type_leaf = fun _ -> false) ~native
-    ?(visit_lvalue = true) () =
+let exists_folder ~leaf ?(type_leaf = fun _ -> false)
+    ?(stmt_leaf = fun _ -> false) ~native ?(visit_lvalue = true) () =
   {
     fe = (fun acc e -> acc || leaf e);
     ft = (fun acc t -> acc || type_leaf t);
+    fs = (fun acc s -> acc || stmt_leaf s);
     fnative = (if native then fun _ -> true else fun acc -> acc);
     visit_lvalue;
   }
@@ -188,14 +213,15 @@ let exists_folder ~leaf ?(type_leaf = fun _ -> false) ~native
     [Kernel.requirements] capability field reduces to, and it lives in the right
     layer already ([spoc/ir], no backend dependencies). *)
 
-type feature = Float64 | Float16 | Int64
+type feature = Float64 | Float16 | Int64 | Coopmat
 
-let all_features = [Float64; Float16; Int64]
+let all_features = [Float64; Float16; Int64; Coopmat]
 
 let feature_name = function
   | Float64 -> "float64"
   | Float16 -> "float16"
   | Int64 -> "int64"
+  | Coopmat -> "cooperative-matrix"
 
 (** Does element type [t] mention the width [f], transitively through records,
     variants, arrays and vectors? *)
@@ -207,6 +233,14 @@ let rec elttype_uses (f : feature) = function
   | TVariant (_, constrs) ->
       List.exists (fun (_, args) -> List.exists (elttype_uses f) args) constrs
   | TArray (elt, _) | TVec elt -> elttype_uses f elt
+  (* [TUint8] counts as Coopmat, and this is load-bearing rather than tidy. It
+     is the element type of a cooperative-matrix OPERAND BUFFER and exists for
+     nothing else, so a kernel that declares one already needs shaderInt8 and
+     storageBuffer8BitAccess on the device and the int8 extension in the shader
+     — whether or not it also reaches a multiply-add. Reporting it as
+     feature-free would let a kernel acquire the 8-bit requirement without
+     passing the gate that checks for it. *)
+  | TUint8 -> f = Coopmat
   | TInt32 | TFloat32 | TBool | TUnit -> false
 
 (** Is constant [c] a literal of width [f]? [Float64] and [Int64] each have one
@@ -224,10 +258,22 @@ let feature_leaf f = function
   | ECast (ty, _) | EArrayCreate (ty, _, _) -> elttype_uses f ty
   | _ -> false
 
+(** A statement mentions [f] when it is an [SCoopmat] and [f] is [Coopmat].
+
+    Written as an explicit match on the feature rather than
+    [f = Coopmat && is_coopmat s] so that a future statement-level feature (a
+    barrier class, a printf) is a compile error here rather than a silent false.
+*)
+let feature_stmt_leaf f s =
+  match (f, s) with
+  | Coopmat, SCoopmat _ -> true
+  | (Coopmat | Float64 | Float16 | Int64), _ -> false
+
 let folder_of f =
   exists_folder
     ~leaf:(feature_leaf f)
     ~type_leaf:(elttype_uses f)
+    ~stmt_leaf:(feature_stmt_leaf f)
     ~native:false
     ~visit_lvalue:false
     ()
@@ -240,10 +286,13 @@ let float16_folder = folder_of Float16
 
 let int64_folder = folder_of Int64
 
+let coopmat_folder = folder_of Coopmat
+
 let folder = function
   | Float64 -> float64_folder
   | Float16 -> float16_folder
   | Int64 -> int64_folder
+  | Coopmat -> coopmat_folder
 
 (** Does expression [e] use width [f]? *)
 let expr_uses f e = expr_fold (folder f) false e
@@ -437,6 +486,7 @@ let kernel_float64_intrinsics k =
           | EIntrinsic (path, name, _) when path_is_float64 path -> name :: acc
           | _ -> acc);
       ft = (fun acc _ -> acc);
+      fs = (fun acc _ -> acc);
       fnative = (fun acc -> acc);
       visit_lvalue = true;
     }
@@ -483,3 +533,58 @@ let kernel_uses_intrinsic name k =
     | _ -> false
   in
   kernel_fold (exists_folder ~leaf ~native:true ()) false k
+
+(** {1 Cooperative-matrix extraction — backlog-62 slice 3}
+
+    {!kernel_uses} [Coopmat] answers a yes/no question, and a yes/no answer is
+    not enough for the launch gate. [Device_optional] capabilities are decided
+    per CONFIGURATION: the RX 7900 XTX advertises fourteen and the same device
+    that permits [u8 x u8 + s32 -> s32] refuses [f16 x f16 -> f16 saturating].
+    So the gate needs the configurations a kernel actually asks for, and this is
+    where they are collected — in [spoc/ir], with no backend dependency, on the
+    same traversal skeleton as every other detector rather than a bespoke walk.
+*)
+
+(** Every cooperative-matrix operation in the kernel, in traversal order.
+
+    Uses the {!folder.fs} hook, which is why that hook exists: a coopmat
+    operation is neither an expression nor an element type, so no pre-slice-3
+    hook could see one. *)
+let kernel_coopmat_ops k =
+  let folder =
+    {
+      fe = (fun acc _ -> acc);
+      ft = (fun acc _ -> acc);
+      fs = (fun acc -> function SCoopmat op -> op :: acc | _ -> acc);
+      fnative = (fun acc -> acc);
+      visit_lvalue = false;
+    }
+  in
+  List.rev (kernel_fold folder [] k)
+
+(** Whether the kernel contains a cooperative-matrix OPERATION.
+
+    Strictly stronger than [kernel_uses Coopmat], which is also true for a
+    kernel that merely declares a [TUint8] buffer. The distinction is what lets
+    the GLSL backend emit the 8-bit extension without the cooperative-matrix
+    one: a kernel that never reaches a multiply-add must not carry a shader
+    requirement the device gate was never asked about. *)
+let kernel_has_coopmat_op k = kernel_coopmat_ops k <> []
+
+(** The distinct configurations a kernel's multiply-adds require.
+
+    Only {!Sarek_ir_types.CM_muladd} carries a configuration, and deliberately:
+    a load or a store constrains the fragment's component type and shape but
+    says nothing about which multiply-add the device must provide, and it is the
+    multiply-add that [VK_KHR_cooperative_matrix] enumerates. A kernel that
+    loads and stores a fragment without ever multiplying needs no advertised
+    configuration at all, and reporting one would refuse it on a device that can
+    run it perfectly well. *)
+let kernel_coopmat_configs k =
+  List.sort_uniq
+    compare
+    (List.filter_map
+       (function
+         | CM_muladd {cfg; _} -> Some cfg
+         | CM_decl _ | CM_load _ | CM_store _ -> None)
+       (kernel_coopmat_ops k))

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -263,6 +263,31 @@ let rename_shadowing_locals ~collides ~fresh_name body =
     | SPragma (ss, b) -> SPragma (ss, re_stmt env b)
     | SBlock b -> SBlock (re_stmt env b)
     | SNative _ as s -> s
+    | SCoopmat op ->
+        (* Fragment names are NOT [var]s and are not in [env], so they are not
+           renamed. Only the index and stride EXPRESSIONS can mention a renamed
+           variable, and they are rewritten. Renaming a fragment here would be
+           wrong in the direction that matters: [env] maps variable names, and a
+           fragment that happened to share a name with a shadowed variable would
+           be silently redirected. *)
+        SCoopmat
+          (match op with
+          | CM_decl _ -> op
+          | CM_load r ->
+              CM_load
+                {
+                  r with
+                  index = re_expr env r.index;
+                  stride = re_expr env r.stride;
+                }
+          | CM_store r ->
+              CM_store
+                {
+                  r with
+                  index = re_expr env r.index;
+                  stride = re_expr env r.stride;
+                }
+          | CM_muladd _ -> op)
   in
   re_stmt SM.empty body
 

--- a/spoc/ir/Sarek_ir_layout.ml
+++ b/spoc/ir/Sarek_ir_layout.ml
@@ -94,6 +94,7 @@ let layout_error_message = function
    host PPX (via read_float64/write_float64) and placed on their natural 8-byte
    boundary by the aligned layout. *)
 let scalar_size = function
+  | TUint8 -> 1
   | TFloat16 -> 2
   | TInt32 | TFloat32 | TBool | TUnit -> 4
   | TInt64 | TFloat64 -> 8
@@ -108,6 +109,7 @@ let scalar_size = function
   | TVec _ -> invalid_arg "Sarek_ir_layout.scalar_size: not a scalar type: TVec"
 
 let scalar_align = function
+  | TUint8 -> 1
   | TFloat16 -> 2
   | TInt32 | TFloat32 | TBool | TUnit -> 4
   | TInt64 | TFloat64 -> 8
@@ -125,7 +127,8 @@ let align_up off a = if a <= 1 then off else (off + a - 1) / a * a
     rejected below top level, so their value here is a harmless placeholder used
     only before {!flatten_field} produces the typed rejection. *)
 let rec elttype_align = function
-  | (TInt32 | TFloat32 | TBool | TUnit | TInt64 | TFloat64 | TFloat16) as t ->
+  | (TInt32 | TFloat32 | TBool | TUnit | TInt64 | TFloat64 | TFloat16 | TUint8)
+    as t ->
       scalar_align t
   | TRecord (_, fields) -> record_align fields
   | TVariant _ -> 4 (* rejected below top level; placeholder *)
@@ -184,7 +187,7 @@ let ( let* ) = Result.bind
 let rec flatten_field ~type_name ~path ~offset (t : elttype) :
     (leaf list * int, layout_error) result =
   match t with
-  | TInt32 | TInt64 | TFloat32 | TFloat64 | TBool | TUnit ->
+  | TInt32 | TInt64 | TFloat32 | TFloat64 | TBool | TUnit | TUint8 ->
       let size = scalar_size t in
       let align = scalar_align t in
       if offset mod align <> 0 then
@@ -319,7 +322,7 @@ let variant_layout ~type_name (ctors : (string * elttype list) list) :
 
 let elttype_layout (t : elttype) : (layout, layout_error) result =
   match t with
-  | TInt32 | TInt64 | TFloat16 | TFloat32 | TFloat64 | TBool | TUnit ->
+  | TInt32 | TInt64 | TFloat16 | TFloat32 | TFloat64 | TBool | TUnit | TUint8 ->
       Ok (LScalar {size = scalar_size t; align = scalar_align t})
   | TRecord (name, fields) ->
       let* rl = record_layout ~type_name:name fields in

--- a/spoc/ir/Sarek_ir_pp.ml
+++ b/spoc/ir/Sarek_ir_pp.ml
@@ -13,6 +13,7 @@ let rec string_of_elttype = function
   | TFloat16 -> "float16"
   | TFloat32 -> "float32"
   | TFloat64 -> "float64"
+  | TUint8 -> "uint8"
   | TBool -> "bool"
   | TUnit -> "unit"
   | TRecord (name, _) -> name
@@ -196,6 +197,47 @@ let rec pp_stmt fmt = function
   | SMemFence -> Format.fprintf fmt "__threadfence();"
   | SBlock body -> Format.fprintf fmt "@[<v 2>{@ %a@]@ }" pp_stmt body
   | SNative _ -> Format.fprintf fmt "/* native code */"
+  | SCoopmat op -> pp_coopmat_op fmt op
+
+and pp_coopmat_op fmt = function
+  | CM_decl {name; frag} ->
+      Format.fprintf
+        fmt
+        "coopmat %s : %s %s %s;"
+        name
+        (Sarek_coopmat_types.use_name frag.Sarek_coopmat_types.frag_use)
+        (Sarek_coopmat_types.shape_name frag.Sarek_coopmat_types.frag_shape)
+        (Sarek_coopmat_types.component_name
+           frag.Sarek_coopmat_types.frag_component)
+  | CM_load {dst; src; index; stride; _} ->
+      Format.fprintf
+        fmt
+        "coopmat_load %s <- %s[%a] stride %a;"
+        dst
+        src
+        pp_expr
+        index
+        pp_expr
+        stride
+  | CM_store {src; dst; index; stride; _} ->
+      Format.fprintf
+        fmt
+        "coopmat_store %s -> %s[%a] stride %a;"
+        src
+        dst
+        pp_expr
+        index
+        pp_expr
+        stride
+  | CM_muladd {dst; a; b; c; cfg} ->
+      Format.fprintf
+        fmt
+        "%s = coopmat_muladd(%s, %s, %s) : %s;"
+        dst
+        a
+        b
+        c
+        (Sarek_coopmat_types.config_name cfg)
 
 and pp_pattern fmt = function
   | PConstr (name, vars) ->

--- a/spoc/ir/Sarek_ir_types.ml
+++ b/spoc/ir/Sarek_ir_types.ml
@@ -53,6 +53,25 @@ type elttype =
           produced by conversion ([ECast (TFloat16, _)]), never by a literal. *)
   | TFloat32
   | TFloat64
+  | TUint8
+      (** Unsigned 8-bit integer {e storage} type (backlog-62 slice 3).
+
+          It exists for one reason and its scope is deliberately that narrow: it
+          is the element type of a cooperative-matrix OPERAND BUFFER. Every one
+          of the twelve integer configurations the local RX 7900 XTX advertises
+          has 8-bit operands with a 32-bit accumulator, and [coopMatLoad]
+          requires the backing array's element type to MATCH the fragment's
+          component type — so there is no route to an integer fragment through a
+          wider buffer, and no way to reach the strict-contract tensor-core path
+          without an 8-bit element type in the IR.
+
+          There is no arithmetic on it. No binop, no literal, no cast to or from
+          it is emitted by any backend; a [TUint8] value reaches a kernel only
+          by being read by {!Sarek_ir_types.CM_load} and leaves only by
+          {!Sarek_ir_types.CM_store}. That is not an oversight to be filled in
+          later — widening it into a general arithmetic type is a separate
+          decision with its own promotion and overflow questions, and this slice
+          measured none of them. *)
   | TBool
   | TUnit
   | TRecord of string * (string * elttype) list
@@ -166,6 +185,89 @@ type stmt =
       gpu : framework:string -> string;  (** Generate GPU code for framework *)
       ocaml : ocaml_closure;  (** Typed OCaml fallback *)
     }  (** Inline native GPU code with OCaml fallback *)
+  | SCoopmat of coopmat_op
+      (** A cooperative-matrix (tensor-core) operation — backlog-62 slice 3.
+
+          {b Why ONE statement constructor carrying an operation family, rather
+             than four constructors.} Seventeen places in this repository match
+          exhaustively on {!stmt}, and most of them are backends whose only
+          correct response to any of these operations is the same refusal. Four
+          constructors would be sixty-eight arms to write and to keep in
+          agreement; one is seventeen, and a backend that handles [SCoopmat] at
+          all is then forced by the compiler to consider every member of
+          {!coopmat_op} in one place where the four cases sit next to each
+          other.
+
+          {b Why fragments are NOT [var]s and NOT an [elttype].} A fragment is a
+          subgroup-cooperative value: the whole subgroup collectively holds
+          [rows * columns] components and each invocation holds a few of them at
+          an implementation-defined position. It cannot be indexed, assigned to,
+          added, cast, passed to a helper, or stored in an array. Giving it an
+          {!elttype} would make every one of those spellable in the IR and would
+          oblige ~36 exhaustive [elttype] matches to invent an answer for a type
+          none of them can represent. Fragments therefore live in their own
+          namespace, addressed by name, and the only things that can be done to
+          one are the four below. *)
+
+(** The four things that can be done with a cooperative-matrix fragment.
+
+    Fragment names live in a namespace of their own, separate from {!var}. They
+    are plain strings for the same reason an [SShared] array name is: a fragment
+    is not an l-value, cannot be captured, and cannot escape the kernel body, so
+    there is nothing for a [var]'s mutability or type field to carry that
+    {!Sarek_coopmat_types.fragment} does not already say. *)
+and coopmat_op =
+  | CM_decl of {name : string; frag : Sarek_coopmat_types.fragment}
+      (** Bring a fragment into scope for the rest of the enclosing block.
+
+          Statement-level rather than a scoping form like {!SLet}, because GLSL,
+          MSL and C all admit a declaration in the middle of a block and because
+          [D = A * B + C] wants four fragments live at once — nesting four
+          [SLet]-shaped binders to express that is noise with no invariant
+          behind it. *)
+  | CM_load of {
+      dst : string;
+      frag : Sarek_coopmat_types.fragment;
+      src : string;
+      index : expr;
+      stride : expr;
+    }
+      (** Fill [dst] from the buffer [src], row-major, starting at element
+          [index], with [stride] elements between consecutive rows.
+
+          [frag] is repeated here rather than looked up from the [CM_decl]: a
+          codegen backend must be able to emit this statement without carrying a
+          fragment environment, and an interpreter must be able to CHECK the two
+          agree. A single source of truth that every consumer has to reconstruct
+          is not a single source of truth.
+
+          Column-major is deliberately absent. It is one more enumerant in GLSL,
+          but it is a second layout to verify on hardware and this slice
+          measured only row-major — an emitted layout nothing has executed is a
+          claim without evidence. *)
+  | CM_store of {
+      src : string;
+      frag : Sarek_coopmat_types.fragment;
+      dst : string;
+      index : expr;
+      stride : expr;
+    }  (** The inverse of {!CM_load}. *)
+  | CM_muladd of {
+      dst : string;
+      a : string;
+      b : string;
+      c : string;
+      cfg : Sarek_coopmat_types.config;
+    }
+      (** [dst = a * b + c], the tensor-core instruction itself.
+
+          [cfg] is the whole point of carrying a configuration rather than four
+          fragments: it is what the device gate is keyed on, it is what says
+          whether the accumulation SATURATES (a property of the operation and
+          not of any operand), and it is what
+          {!Sarek_coopmat_types.accumulation_is_exact} reads to decide whether
+          this statement is under the strict contract or needs the relaxation of
+          docs/design/f16-relaxed-accuracy.md §1.6. *)
 
 (** Declarations *)
 and decl =

--- a/spoc/ir/dune
+++ b/spoc/ir/dune
@@ -11,6 +11,7 @@
   Sarek_ir_pp
   Sarek_ir_analysis
   Sarek_capability
+  Sarek_coopmat_types
   Sarek_coopmat
   Sarek_ir_codegen
   Sarek_pure_registry)

--- a/spoc/ir/test/test_sarek_ir_analysis.ml
+++ b/spoc/ir/test/test_sarek_ir_analysis.ml
@@ -1092,8 +1092,10 @@ let test_kernel_requirements () =
     = [Float64; Float16]) ;
   (* Every feature must be reachable from [all_features]; a new constructor that
      is not added there would silently never be required. *)
-  assert (List.length all_features = 3) ;
-  assert (List.map feature_name all_features = ["float64"; "float16"; "int64"]) ;
+  assert (List.length all_features = 4) ;
+  assert (
+    List.map feature_name all_features
+    = ["float64"; "float16"; "int64"; "cooperative-matrix"]) ;
   (* [Int64], added in #141 so the GLSL backend can gate
      `#extension GL_ARB_gpu_shader_int64` on the user's own int64 and not only
      on the software-f64 helpers that bit-cast a double. *)
@@ -1248,6 +1250,112 @@ let test_kernel_float64_intrinsics () =
 
 (** {1 Main} *)
 
+(* ------------------------------------------------------------------ *)
+(* Cooperative matrix — backlog-62 slice 3                             *)
+(* ------------------------------------------------------------------ *)
+
+let cm_shape = {Sarek_coopmat_types.m = 16; n = 16; k = 16}
+
+let cm_cfg =
+  {
+    Sarek_coopmat_types.cfg_shape = cm_shape;
+    cfg_a = Sarek_coopmat_types.Uint8;
+    cfg_b = Sarek_coopmat_types.Uint8;
+    cfg_c = Sarek_coopmat_types.Sint32;
+    cfg_result = Sarek_coopmat_types.Sint32;
+    cfg_saturating = false;
+    cfg_scope = Sarek_coopmat_types.Subgroup;
+  }
+
+let cm_frag_a, cm_frag_b, cm_frag_c, cm_frag_d =
+  Sarek_coopmat_types.fragments_of_config cm_cfg
+
+let test_coopmat_detection () =
+  let u8_param =
+    {var_name = "a"; var_id = 0; var_type = TVec TUint8; var_mutable = false}
+  in
+  let muladd =
+    SCoopmat (CM_muladd {dst = "d"; a = "a"; b = "b"; c = "c"; cfg = cm_cfg})
+  in
+  (* An SCoopmat statement alone is enough. Nothing about it is an expression or
+     an element type, so before the [fs] hook existed no folder could see it. *)
+  assert (kernel_uses Coopmat (empty_kernel muladd)) ;
+  assert (kernel_has_coopmat_op (empty_kernel muladd)) ;
+  (* A TUint8 buffer alone reports the FEATURE but not an OPERATION. That
+     distinction is what lets the GLSL backend emit the int8 extension without
+     the cooperative-matrix one, and it is asserted in BOTH directions because
+     collapsing the two is the easy mistake. *)
+  let k_u8 =
+    feature_kern
+      [DParam (u8_param, Some {arr_elttype = TUint8; arr_memspace = Global})]
+      SEmpty
+  in
+  assert (kernel_uses Coopmat k_u8) ;
+  assert (not (kernel_has_coopmat_op k_u8)) ;
+  (* And an ordinary kernel trips neither. *)
+  assert (not (kernel_uses Coopmat (empty_kernel SEmpty))) ;
+  assert (not (kernel_has_coopmat_op (empty_kernel SEmpty))) ;
+  (* Coopmat must not be triggered by, nor trigger, the numeric widths. *)
+  assert (not (kernel_uses Float16 (empty_kernel muladd))) ;
+  assert (not (kernel_uses Int64 (empty_kernel muladd))) ;
+  assert (not (kernel_uses Float64 k_u8)) ;
+  print_endline "  coopmat detection: OK"
+
+let test_coopmat_configs () =
+  (* Only CM_muladd carries a configuration. A kernel that loads and stores a
+     fragment without multiplying needs no ADVERTISED configuration at all, and
+     reporting one would refuse it on a device that can run it. *)
+  let idx = EConst (CInt32 0l) in
+  let load_store =
+    SSeq
+      [
+        SCoopmat (CM_decl {name = "f"; frag = cm_frag_a});
+        SCoopmat
+          (CM_load
+             {dst = "f"; frag = cm_frag_a; src = "a"; index = idx; stride = idx});
+        SCoopmat
+          (CM_store
+             {src = "f"; frag = cm_frag_a; dst = "b"; index = idx; stride = idx});
+      ]
+  in
+  assert (kernel_coopmat_configs (empty_kernel load_store) = []) ;
+  assert (kernel_has_coopmat_op (empty_kernel load_store)) ;
+  (* One multiply-add, one configuration. *)
+  let one =
+    SCoopmat (CM_muladd {dst = "d"; a = "a"; b = "b"; c = "c"; cfg = cm_cfg})
+  in
+  assert (kernel_coopmat_configs (empty_kernel one) = [cm_cfg]) ;
+  (* Two multiply-adds with the SAME configuration deduplicate; the launch gate
+     asks the device once, not once per statement. *)
+  assert (kernel_coopmat_configs (empty_kernel (SSeq [one; one])) = [cm_cfg]) ;
+  (* Two DIFFERENT configurations are both reported — including two that differ
+     only in [cfg_saturating], which compute different functions and are two
+     distinct advertised configurations on the local device. *)
+  let sat_cfg = {cm_cfg with Sarek_coopmat_types.cfg_saturating = true} in
+  let two =
+    SSeq
+      [
+        one;
+        SCoopmat
+          (CM_muladd {dst = "d"; a = "a"; b = "b"; c = "c"; cfg = sat_cfg});
+      ]
+  in
+  assert (List.length (kernel_coopmat_configs (empty_kernel two)) = 2) ;
+  (* Nested inside control flow, which is where a hand-written walk would have
+     missed it. *)
+  let nested = SIf (EConst (CBool true), SBlock (SSeq [one]), None) in
+  assert (kernel_coopmat_configs (empty_kernel nested) = [cm_cfg]) ;
+  (* And inside a HELPER function, which [kernel_fold] also visits. *)
+  let hf =
+    {hf_name = "h"; hf_params = []; hf_ret_type = TUnit; hf_body = one}
+  in
+  let k = empty_kernel SEmpty in
+  assert (kernel_coopmat_configs {k with kern_funcs = [hf]} = [cm_cfg]) ;
+  ignore cm_frag_b ;
+  ignore cm_frag_c ;
+  ignore cm_frag_d ;
+  print_endline "  coopmat configs: OK"
+
 let () =
   print_endline "Sarek_ir_analysis tests:" ;
   test_elttype_float64 () ;
@@ -1302,4 +1410,6 @@ let () =
   test_kernel_uses_nonfinite_float64 () ;
   test_kernel_uses_intrinsic () ;
   test_kernel_float64_intrinsics () ;
+  test_coopmat_detection () ;
+  test_coopmat_configs () ;
   print_endline "All Sarek_ir_analysis tests passed!"


### PR DESCRIPTION
backlog-62 slice 3: the cooperative-matrix path made reachable from a kernel, and executed. Before this, no `Sarek_coopmat` value could be reached from a kernel at all — slice 2 could report what a device provides and nothing could ask for it.

**The integer path is delivered end to end. The f16 path is not, and that is deliberate.** `SPV_KHR_cooperative_matrix` states integer accumulation is exact at the precision of the result type, so `u8 × u8 + s32 → s32` lands under Sarek's **existing strict contract** — no relaxation, no allowlist, no opt-in, no §5 bound to derive. Slice 4a's numeric contract for floats is entirely unmeasured, and `docs/design/f16-relaxed-accuracy.md` §7 is explicit that slice 3 must not lift a refusal past what a model has been measured for. Float components are refused in the codegen *and* in the interpreter, and the scalar-f16 refusal in `Sarek_ir_glsl` is untouched.

Twelve of the fourteen configurations the local RX 7900 XTX advertises are integer, and **all twelve have 8-bit operands with a 32-bit accumulator** — there is no wider integer operand type to fall back on.

## What landed

- **`Sarek_coopmat` is split.** `Sarek_coopmat_types` holds the vocabulary with no dependencies; `Sarek_coopmat` includes it and keeps the capability half. The cut is forced rather than tidy: the IR must name a fragment, `Sarek_capability` depends on the IR, so a vocabulary that also depended on `Sarek_capability` closes a module cycle dune rejects. The `.mli` uses `include module type of struct include ... end` — the bare path re-declares each type *abstractly*, which would have made `Sarek_coopmat.config` a distinct type from `Sarek_coopmat_types.config`. No call site outside changed.
- **One IR statement constructor**, `SCoopmat`, carrying a four-member operation family. Seventeen places match exhaustively on `stmt` and most are backends whose only correct answer is one refusal; four constructors would have been sixty-eight arms.
- **Fragments are not `var`s and not an `elttype`.** A fragment cannot be indexed, assigned, added, cast or stored in an array. Giving it an `elttype` would make all of those spellable and oblige ~36 exhaustive `elttype` matches to invent an answer for a type none of them can represent.
- **`TUint8`**, deliberately narrow: the element type of a coopmat operand buffer and nothing else. No arithmetic, no literal, no cast. Not avoidable — `coopMatLoad` requires the backing array's element type to match the fragment's component type.
- **Three device features slice 2 did not request.** Read off the SPIR-V rather than guessed: `glslc` on a 16×16×16 u8 `coopMatMulAdd` emits `OpCapability Int8`, `StorageBuffer8BitAccess`, `VulkanMemoryModel` and `CooperativeMatrixKHR`; slice 2 enables only the last. **`vulkanMemoryModel` is required by the float path too** — glslang makes `GL_KHR_memory_scope_semantics` a prerequisite of `GL_KHR_cooperative_matrix` — so slice 2's coopmat plumbing was incomplete independently of the integer work.
- **`Sarek_ir_analysis` grows an `fs` statement hook** (the counterpart of `fe`/`ft`, needed because a coopmat op is neither an expression nor an element type) and `kernel_coopmat_configs`. The launch gate needs the *configurations*, not a boolean: the same device that permits `u8×u8+s32→s32` refuses `f16×f16+f16→f16 saturating`.
- **`Execute.check_device_capabilities` is widened.** Gating at slice 2 would have been a refusal with nothing to refuse. `capabilities.coopmat = None` — every backend but Vulkan — becomes `Unknown` and is refused, so a coopmat kernel aimed at CUDA is stopped by the capability model with a diagnostic naming the *device*, before any codegen refusal.
- **The interpreter evaluates the integer configurations.** It is the oracle, so a skip would have let a coopmat kernel "agree" with an interpreter that never computed the product.

## Evidence

Executed on RADV, Mesa 26.1.4-arch3.1, Vulkan 1.4.354, on an **AMD Radeon RX 7900 XTX (RADV NAVI31)**, with the **AMD Ryzen 9 7950X iGPU (RADV RAPHAEL_MENDOCINO)** as the negative device.

**Coverage is exhaustive, not sampled — derivation written out, because "exhaustive" is usually sampling in disguise.** The full domain of a 16×16×16 u8 multiply-add is 256⁵¹² and cannot be enumerated. The domain that matters for an *exactness* claim can be: there are exactly 65536 ordered pairs `(a, b)` of u8 operand values.

Take `A[i][k] = 16k + i` and `B[k][j] = 16t + j` for dispatch `t`, indices in `0..15`. One multiply-add forms the 4096 products `A[i][k] · B[k][j]`. Fix `k`: the A-values are `{16k + i : i}` = block `[16k, 16k+15]`, the B-values are `{16t + j : j}` = block `[16t, 16t+15]`, so the 256 pairs at that `k` are exactly the 16×16 block `[16k, 16k+15] × [16t, 16t+15]`. Ranging `k` over `0..15` gives sixteen blocks disjoint in their A-range — 4096 pairs per dispatch, no repeat. Ranging `t` over `0..15` moves the B-range through all sixteen of its blocks, so the 256 `(k, t)` blocks tile `[0,255] × [0,255]` exactly.

**65536 pairs, each exactly once, in sixteen dispatches** — with a nonzero mixed-sign `C`, bit-identical on every one of the 4096 outputs of every tile. No tolerance anywhere. Wrapping accumulation is exact too, and that case asserts the reference actually wrapped rather than merely running.

Two halves, kept separate on purpose (`fp-contraction-policy.md` §7(c)): a hand-written GLSL shader measures the *driver*, and a Sarek IR kernel through `Sarek_ir_glsl` measures the *codegen*. A single combined test would stay green if a codegen defect happened to cancel a driver defect.

**The refusal was observed.** The iGPU advertises no `VK_KHR_cooperative_matrix`; its verdict refuses while the RX 7900 XTX permits in the same run under the same driver build, and the launch gate refuses on six devices (the Vulkan iGPU, both OpenCL devices, Native, and both Interpreter devices). The gate assertion relates two **independently observed** facts — the extension bit and the verdict — rather than comparing the verdict to the list it reads, which is the tautology the slice-2 gate test fell into.

## Proved red

Each row was applied, run on the hardware named above, and observed to produce the failure it promises. No summary count — the table is the inventory.

| # | mutation | observed |
|---|---|---|
| 1 | driver test: shader loads B column-major | `tile 0 diverges at 0: got 19340 want -500` |
| 2 | driver test: shader drops C | exhaustive and wraparound both red |
| 3 | driver test: `storageBuffer8BitAccess` never requested | **only** the plumbing assertion red — see the finding below |
| 4 | e2e: codegen emits `ColumnMajor` in `CM_load` | 16 tiles diverge, first `23780` vs `368140` |
| 5 | e2e: codegen swaps the A and B operands | glslang rejects — `UseA` and `UseB` are not interchangeable types |
| 6 | e2e: interpreter oracle drops C in `CM_muladd` | 16 tiles diverge, first `-500` vs `0` |
| 7 | e2e: launch gate returns no configurations | all six refusing devices report `PERMITTED` |
| 8 | e2e: the stride-1-B control made a no-op | `the stride-1-B control was ACCEPTED on 16 of 16 tiles` |
| 9 | e2e: the C-dropping control made a no-op | `the C-dropping control was ACCEPTED on 16 of 16 tiles` |

Rows 8 and 9 mutate the **controls**, not the code under test: a positive control is itself a gate that can rot, and if the mutated IR a control builds ever stopped differing from the real one, its assertion would pass forever while checking nothing.

Mutation 1 leaves the identity case (`D = A × I + 0`) **green**, because `I` is symmetric. That is why the identity case and the exhaustive case are two separate tests.

## FINDING: a device feature can be missing with every numeric test green

This is mutation 3 and it is the most instructive result in the PR, so it is stated as a finding rather than a table row. With `storageBuffer8BitAccess` never requested the shader is a **specification violation** — it declares `OpCapability StorageBuffer8BitAccess` against a logical device that never enabled it — and RADV computes the **correct answer anyway**. All three numerics tests stay green; only the feature assertion goes red. That is backlog-142's failure mode reproduced exactly, one feature over: no results-based test can catch it however exhaustive its inputs, *because the results are right*. The capability model is the only instrument that sees it, and the reason it exists.

**The order reversal paid beyond its intent.** Building the integer path first is what surfaced the three missing features at all — they were read off the SPIR-V an integer `coopMatMulAdd` emits. Starting from the float side would have found neither `shaderInt8` nor `storageBuffer8BitAccess`, and `vulkanMemoryModel` only by accident.

Two existing gates went red on arrival and were right to. The backend type-width validator refused `TUint8` until its byte width was **recorded**, and it is now measured rather than assumed (`spirv-dis`: `%uchar = OpTypeInt 8 0`, `ArrayStride 1` — 1 byte, not padded to 4 the way `bool` is). The analysis suite's `all_features` pin refused a fourth feature until updated.

## What this did NOT do

Each is a refusal in the code, not an omission:

- **The f16 coopmat path.** Refused in `Sarek_ir_glsl` *and* in the interpreter — the latter because §5.1's implementation-defined addition order means no strict oracle exists to compare against. 4a's contract is exactly as unmeasured as before.
- **The scalar-f16 refusal** of slice-3-as-written in `Sarek_ir_glsl` is untouched.
- **Saturating accumulation, column-major layout, workgroup scope.** Each is one enumerant to emit and a second behaviour to verify against an oracle; the codegen refuses all three, so none is *delivered*. Stated precisely, because mutations 1 and 4 above did emit column-major shaders and run them: column-major has executed only as a **mutation**, to show the comparison goes red, and has never been verified against the interpreter — which is exactly why it is refused rather than shipped.
- **The PPX surface.** A coopmat kernel is built as IR directly (the `test_float32_sin_pure` pattern). Nothing in `[%kernel ...]` produces an `SCoopmat`, and the PPX's parallel `stmt` type deliberately did not gain the constructor.
- **Metal, CUDA, OpenCL, WGSL, PTX** refuse rather than emit.

## Known asymmetry, recorded rather than papered over

The Interpreter **device** is refused by the launch gate — its `capabilities.coopmat` is `None`, i.e. unprobed — while `Execute.run_interpreter_vectors` evaluates the same kernel fine. That is the safe direction, but it means the oracle is reachable by one entry point and not the other. Deciding what configuration list an interpreter should advertise is a separate question this slice did not measure.

## Suite

`dune test --force` exit 0. **1671 cases across 115 suites, 0 FAIL, 23 SKIP** (baseline after today's merges: 1665/114 — the delta is the new Vulkan suite). `dune build @fmt` clean. `scripts/prove-red.sh` exit 0, 4 subjects / 13 mutations (that script covers the CI gates; the nine rows above are this slice's own mutations, run by hand). `dune build @sarek/tests/e2e/e2e-gpu` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vulkan integer cooperative-matrix support and a new GPU end-to-end integer validation path.
  * Added a Vulkan probing tool to enumerate cooperative-matrix device configurations.
  * Extended the IR/interpreter to execute cooperative-matrix operations for validation.
* **Bug Fixes**
  * Improved handling and diagnostics for unsupported uint8/cooperative-matrix usage across non-Vulkan backends.
  * Updated capability gating to include cooperative-matrix requirements derived from the kernel.
* **Tests**
  * Added extensive backend, analysis, and integer coopmat conformance tests.
* **Documentation**
  * Updated the cooperative-matrix design/validation write-up with new outcomes and clarified exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->