### PR TITLE
test(width): sweep the third edge — and why bf16 is not a width addition yet

### DIFF
--- a/docs/design/width-addition-cost.md
+++ b/docs/design/width-addition-cost.md
@@ -1,0 +1,250 @@
+# The cost of adding a scalar width — measured, and why bf16 is not landing yet
+
+**Task:** backlog-88 (`bf16-dsl-element-type`) — "bf16 as a DSL element type, and
+make width-addition cheap before a third width is added."
+
+**Date:** 2026-07-27.
+
+**Method:** the cost was not estimated. Each type vocabulary had its constructor
+actually added, the tree built, and the compiler errors counted, round by round,
+until green. The patch used for the measurement is not part of this change; the
+numbers below are what it produced.
+
+**Status of the two halves:**
+
+- **The count and its reduction: delivered.** §1–§4.
+- **bf16 itself: NOT delivered, deliberately.** §5. The blocker is not the count.
+  It is that `docs/design/f16-dsl-element-type.md` §11.1's central premise —
+  "bf16 needs no new machinery … as close to *f16 again, with a different `cvt`*
+  as a new width can be" — is **refuted by execution**. See §5.1.
+
+---
+
+## 1. The headline number
+
+> **A usable scalar width touches 40 production files. The compiler asks for 21
+> of them. The other 20 must be found by reading.**
+
+Not an estimate. Both halves are measured:
+
+| | how it was obtained | count |
+|---|---|---|
+| production files a width actually needs | `git show --name-only` on `c93dbf96`, the f16 slice-1 commit, filtered to non-test `.ml`/`.mli` | **40** |
+| of those, forced by adding the constructors | added `TBFloat16` to `Sarek_ir_types.elttype`, `BFloat16` to `Sarek_ir_analysis.feature`, `TBFloat16` to `Sarek_ir_ppx.elttype` and `BFloat16` to `Sarek_types.registered_type`; built to green | **21** (20 overlap with the 40, plus `Sarek_capability.ml`, which postdates slice 1) |
+| **invisible to the compiler** | set difference | **20** |
+
+And the forced half does not arrive at once. It came in **seven build rounds**,
+because each layer's errors are hidden behind the previous layer's failure:
+
+| round | vocabulary | sites | files |
+|---|---|---|---|
+| 1 | `Sarek_ir_types.elttype` | 7 | 3 (`Sarek_ir_layout` ×5, `Sarek_ir_pp`, `Sarek_ir_analysis`) |
+| 2 | (cascade) | 16 | 9 (`Sarek_capability`, PTX ×4+3, CUDA, Metal, OpenCL ×2, `Sarek_ir_inline_vec`, `Soa`) |
+| 3 | (cascade) | 4 | 3 (OpenCL, WGSL ×2, GLSL) |
+| 4 | (cascade) | 2 | 1 (`test_backend_type_width_totality`) |
+| A | `Sarek_ir_ppx.elttype` + `Sarek_types.registered_type` | 2 | 2 |
+| B | (cascade) | 2 | 2 |
+| C | (cascade) | 5 | 2 (`Sarek_ir_conv`, `test_type_width_totality` ×4) |
+| | **total** | **38 sites** | **21 production files** |
+
+**The blast radius is not visible up front.** You cannot grep it, and you cannot
+see it after one build. This is the mechanical restatement of §9's
+"match-arm counting systematically underestimates a new element type" — except
+that the underestimate is now bounded: match-arm counting is accurate about the
+21, and says nothing at all about the 20.
+
+## 2. The 20 the compiler never asks for
+
+```
+sarek/core_base/Spoc_core_base.ml            sarek/core/Ctypes_ops.ml
+sarek/core_base/Spoc_core_base.mli           sarek/core/Memory.ml
+sarek/core_base/Spoc_core_base_scalar.ml     sarek/core/Vector.ml
+sarek/core_base/Spoc_core_base_scalar.mli    sarek/core/Vector_transfer.ml
+sarek/execute/Execute.ml                     sarek-hip/Hip_api.ml
+sarek/interp/Sarek_float16.ml                sarek/sarek/Sarek_float16.ml
+sarek/interp/Sarek_ir_interp_eval.ml         sarek/interp/Sarek_ir_interp.ml
+sarek/plugins/interpreter/Interpreter_plugin_base.ml
+sarek/plugins/native/Native_plugin_base.ml   sarek/ppx/Sarek_core_primitives.ml
+sarek/ppx/Sarek_native_gen_base.ml           sarek/ppx/Sarek_native_intrinsics.ml
+sarek/codegen/Sarek_ir_ptx_types.mli
+```
+
+This is not a random 20. It is the FFI layer, the host storage layer, the
+exec-arg dispatch, the conversion primitives and the interpreter narrowing —
+**exactly the list of places the f16 post-mortem says its expensive defects
+were** (`f16-dsl-element-type.md` §3.3, §6.4, §9). Restated:
+
+> None of the four round-1 must-fixes and neither of the two soundness bugs
+> were in a match arm.
+
+They were all in the 20.
+
+### 2.1 The asymmetry that explains why
+
+`Execute.ml` contains the two halves of one dispatch, forty lines apart:
+
+- `exec_arg_of_vector`'s **`get`** matches on `Vector.kind v` — total. Adding a
+  host scalar kind **does** force an arm here (measured: it is in the round-1
+  error set of the host-kind experiment).
+- `exec_arg_of_vector`'s **`set`** matches on the `(typed_value, Vector.kind)`
+  **pair**, and ends in a catch-all. Nothing can force an arm into it.
+
+That is why f16 shipped with a `get` arm and no `set` arm, and why "an f16 kernel
+could not run on the Interpreter **device** at all" was discovered by a reviewer
+rather than by the build. A pair-match with a catch-all is
+**gates-that-cannot-fail pattern #4 (no-op arm)** applied to a dispatch table.
+
+## 3. The reduction
+
+Two sweeps already existed, and they cover the ends of the pipeline while
+meeting nowhere:
+
+```
+ source type ──▶ IR element type ──▶ device type string
+ └──── test_type_width_totality ────┘
+                 └──── test_backend_type_width_totality ────┘
+```
+
+Neither says anything about the third edge, which is where the bytes live:
+
+```
+                 IR element type ◀──▶ HOST scalar_kind ──▶ exec-arg dispatch
+```
+
+`sarek/tests/unit/test_host_ir_width_agreement.ml` closes it, with the same
+construction the other two use — a wildcard-free total successor chain over the
+`scalar_kind` GADT, plus pinned exemption sets. It asserts:
+
+1. **width agreement** — `Vector.elem_size k = Sarek_ir_layout.scalar_size t` for
+   every host kind with an IR counterpart. `scalar_size` is the denominator the
+   *backend* sweep already checks device types against, so this is what makes the
+   three segments one chain instead of three self-consistent fragments;
+2. **exec-arg totality** — every host scalar kind either completes a
+   store-and-load round trip through `Execute.exec_arg_of_vector`'s `get`/`set`,
+   or appears in a pinned refusal list. This is the only instrument that can see
+   a missing arm in the catch-all half of §2.1;
+3. **pinned exemptions** — the kinds with no IR counterpart (`Char`, `Complex32`)
+   and the kinds the dispatch refuses (`Char`, `Complex32`) are each pinned
+   exactly.
+
+**What it changes about the count.** It does not shrink the 40. It moves work
+from the invisible 20 into the forced 21: a new host `scalar_kind` now fails to
+**compile** two total matches in the sweep, and `probe_of` cannot be satisfied by
+a stub because each arm must produce a real value *of that kind's own element
+type*. The sweep then *executes* the exec-arg path that no constructor addition
+can reach. The next width still costs 40 files — but the two defects that cost
+f16 the most review time (a missing `set` arm; a host/IR width disagreement) both
+become red instead of silent.
+
+`Char` is in the pinned set as evidence rather than as an excuse: `Vector.char`
+is one byte, the IR has no one-byte element type, and `char` used to lower to
+`Ir.TInt32` and stride the buffer at 4×. That is a width defect this edge would
+have caught, recorded in the file it belongs to.
+
+## 4. Reds observed (prove-a-gate-can-fail)
+
+Every claim below was executed on this worktree, not reasoned.
+
+| # | mutation | result |
+|---|---|---|
+| R1 | add `TBFloat16` to `Sarek_ir_types.elttype` | `test_backend_type_width_totality` **fails to compile**, naming `TBFloat16` as the unmatched case — the backend sweep is genuinely constructor-driven |
+| R2 | add `BFloat16` to `Sarek_types.registered_type` | `test_type_width_totality` **fails to compile** (4 sites), same property for the front half |
+| R3 | f16 `set` arm in `Execute.ml` made to reject floats (the pre-fix state) | new sweep **FAIL**: *"the set of host scalar kinds the exec-arg dispatch REFUSES changed. expected: Char, Complex32 / actual: Char, Complex32, **Float16**"* — the defect is named |
+| R4 | `Sarek_ir_layout.scalar_size TFloat16` 2 → 4 | new sweep **FAIL**: *"**Float16**: the host stores 2 byte(s) per element (Vector.elem_size) but the IR lays the same element out in 4 byte(s)"* |
+| R5 | delete the `Complex32` arm of `probe_of` | **fails to compile**, warning 8 as an error — establishing that the sweep's matches are wildcard-free and that a new `scalar_kind` constructor therefore breaks them |
+| R6 | add an `Int16` constructor to `scalar_kind` | forced arms in `Spoc_core_base`, `Sarek_ir_interp` ×2, and `Execute`'s `get` — but **not** `Execute`'s `set`. This is the §2.1 asymmetry, measured. |
+
+R3 and R4 are the two that matter: they are the f16 defect and the `char` defect,
+reproduced and caught.
+
+## 5. Why bf16 is not in this change
+
+### 5.1 §11.1's premise is refuted by execution
+
+f16's single cheapest property was that **`Bigarray` already had it**. From
+`f16-dsl-element-type.md` §3.1, verified there and re-verified here:
+`Bigarray.Float16` exists, `Array1.create/get/set` round-trips through binary16
+for free, and the host `scalar_kind` arm is
+`Float16 : (float, Bigarray.float16_elt) scalar_kind`.
+
+**There is no `Bigarray.Bfloat16`.** Executed on this switch (OCaml 5.3.0): a
+probe compiles and runs `Bigarray.Float16` (`3.14159 → 3.140625`), and the
+installed `bigarray.mli` enumerates the complete, closed `kind` GADT — 14
+constructors, `Float16` among them, no bfloat16 of any spelling.
+
+`scalar_kind` requires a `Bigarray.*_elt` phantom, so bf16 has **no host storage
+representation available on f16's route**. Both alternatives are redesigns, not
+arms:
+
+- **`Int16_unsigned`** gives `(int, Bigarray.int16_unsigned_elt)`. The host value
+  type becomes `int` — `Vector.get` would hand back a raw bit pattern, and every
+  bf16↔float conversion moves out of the Bigarray store and into Sarek. The
+  storage-genericity of `Vector.get`/`set`/`Soa`/`Execute` is what made f16 cheap,
+  and it is exactly what this gives up.
+- **`Custom_storage`** does reach the transfer layer, but a `Custom` kind is
+  `('a, unit) kind` — **not a `Scalar` kind at all**. It would not flow through
+  `scalar_kind`, so it would not flow through the host width table, the exec-arg
+  scalar dispatch, or the sweep in §3. `Vector.to_bigarray` raises on it, and
+  `(Scalar _, Custom_storage _)` is a refuted case in `Transfer.ml`.
+
+So the correct reading of §11.1 is: bf16 is "f16 again with a different `cvt`"
+*from the IR downward*, and something else entirely *from the IR upward*. The
+lesson generalises the one §3.3 already recorded — a type existing in the stdlib
+says nothing about it existing in every library that mirrors that type's GADT —
+one level further: **f16's cheapness came from a stdlib feature, and a sibling
+width does not inherit it.**
+
+### 5.2 There is nothing to verify bf16 against
+
+The verification bar for a width on this project is bit-exact agreement between
+the interpreter and a real device. For bf16 on this host:
+
+- **CUDA** — `__nv_bfloat16` needs sm_80. There is no NVIDIA device on this box,
+  and echydna is sm_61. `nvrtc` would compile it host-side, but a compile is not
+  the agreement gate.
+- **HIP** — gfx1100 has bf16 in its ISA and `hiprtc` is available, so this is the
+  one plausible backend. But CUDA and HIP **share `Sarek_ir_cuda.ml` verbatim**,
+  and unlike `__half` — a built-in on both toolchains — the bf16 spellings
+  diverge (`__nv_bfloat16` from `cuda_bf16.h` vs ROCm's `__bf16`/`hip_bfloat16`).
+  One arm in the shared emitter cannot serve both.
+- **Metal** — advertises `bfloat` (MSL 3.1+), unmeasured: no Apple device or
+  Metal toolchain here.
+- **OpenCL / GLSL-Vulkan / WGSL** — bf16 support is not established. RADV on the
+  RX 7900 XTX (Mesa 26.1.4-arch3.1) advertises `VK_KHR_shader_float16_int8` and
+  **no bfloat16 extension**, despite RDNA3 having bf16 in its ISA.
+- **PTX** — refuses f16 already, for the `%h` register-class reason.
+
+Under the capability model's own rule — **`Unknown` does not permit** — every one
+of those is a refusal. A bf16 element type that every backend refuses is not a
+feature; it is a constructor that lengthens 38 match sites and delivers nothing.
+
+**And the contraction question is open, not answered.** AMD's two GPU compilers
+fuse an f32 multiply into the f32→**f16** narrowing (620/63488 through
+LLVM/AMDGPU and ACO; 2912/63488 through SPIR-V, where the add is swallowed too).
+Whether the same combine exists for f32→**bf16** is **unmeasured**. It must not
+be assumed either way — assuming *yes* would refuse a backend that works, and
+assuming *no* would ship the §6.2 discipline broken. That measurement is a
+prerequisite for a bf16 backend, and it is not in this change.
+
+### 5.3 What would make bf16 cheap
+
+In order, none of which is bf16 itself:
+
+1. **A host storage decision for widths `Bigarray` does not have** — the real
+   §11.3 question, and it is a *type-level* problem, which is why §11.3's
+   predicted 60% ceiling for a value-level table is if anything optimistic.
+2. **The f32→bf16 narrowing-fusion sweep** on gfx1100 and both RADV devices, the
+   same 65536-input exhaustive shape as the f16 sweeps, with the barriered
+   control that proves it can go green.
+3. **Splitting `Sarek_ir_cuda.ml`'s type mapper for the CUDA/HIP divergence**,
+   which f16 never needed because `__half` happened to be spelled the same.
+
+Until (1) is answered, bf16 is not a width addition. It is a storage-layer design
+task wearing a width addition's clothes.
+
+---
+
+*Every count in this document was produced by building the tree, not by reading
+it. The measurement patch (719 lines) reached a green build with `TBFloat16` and
+`BFloat16` present in all four addable vocabularies, and was reverted; only the
+sweep in §3 is proposed for merge.*

--- a/kb/properties.md
+++ b/kb/properties.md
@@ -160,6 +160,35 @@ holds it, and a weak duplicate gate is worse than none — it produces a second 
   refused statically with no device needed — never a widening and never a quiet
   substitution. Held by the capability model and its tests
   (`spoc/ir/test/test_sarek_capability.ml`), not by the grep.
+- **A width sweep must cover three edges, not two.** `source -> IR` and
+  `IR -> device type` were each swept while the third edge — `IR <-> host scalar_kind
+  -> exec-arg dispatch` — had no sweep, and that is the edge the bytes actually cross.
+  `test_host_ir_width_agreement.ml` closes it by pinning
+  `Vector.elem_size = Sarek_ir_layout.scalar_size` (the same denominator the backend
+  sweep uses, so the three segments form one chain rather than three self-consistent
+  fragments) and by requiring every host scalar kind to complete an exec-arg round trip
+  or appear in a pinned refusal list. `width-addition-cost.md` §3.
+- **Half of a new width is invisible to the compiler, and it is the expensive half.**
+  Measured, not estimated: a usable scalar width touches **40** production files;
+  adding the constructors to all four addable vocabularies forces **21** of them, over
+  **seven** build rounds. The other **20** are the FFI layer, host storage, exec-arg
+  dispatch, the conversion primitives and the interpreter narrowing — and every f16
+  soundness bug lived there, none in a match arm. A blast-radius estimate built by
+  grepping exhaustive matches is accurate about the 21 and says nothing about the 20.
+  `width-addition-cost.md` §1, §2.
+- **A pair-match with a catch-all is a dispatch table no constructor can force.**
+  `Execute.exec_arg_of_vector`'s `get` matches on `Vector.kind` (total, so a new host
+  kind forces an arm) while its `set`, forty lines away, matches on a
+  `(typed_value, kind)` pair ending in a catch-all (so nothing does). f16 shipped with
+  the first and not the second, and could not run on the Interpreter device at all.
+  Only a sweep can see this. `width-addition-cost.md` §2.1.
+- **A stdlib affordance one width enjoys is not inherited by its sibling.**
+  `Bigarray.Float16` exists and gives f16 free 2-byte storage, free round-on-store and a
+  float-typed `Vector.get`/`set`; the `Bigarray.kind` GADT is closed and has **no**
+  bfloat16 (executed, OCaml 5.3.0). So bf16 is "f16 again with a different `cvt`" from
+  the IR downward and a storage-layer redesign from the IR upward — the generalisation,
+  one level up, of the Ctypes-mirror lesson in `f16-dsl-element-type.md` §3.3.
+  `width-addition-cost.md` §5.1.
 - **The capability table and a codegen-correctness sweep are complementary instruments,
   neither subsuming the other.** A defect found by one is not evidence about the other,
   and "we have a capability model now" is not a reason to stop sweeping.

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -26,6 +26,7 @@
   test_kirc_kernel
   test_float16
   test_type_width_totality
+  test_host_ir_width_agreement
   test_diagnostic_locations)
  (modules
   test_types
@@ -54,6 +55,7 @@
   test_kirc_kernel
   test_float16
   test_type_width_totality
+  test_host_ir_width_agreement
   test_diagnostic_locations)
  ; Link sarek_stdlib to trigger auto-registration of intrinsics
  ; ctypes is listed explicitly (not relied on transitively via sarek): the

--- a/sarek/tests/unit/test_host_ir_width_agreement.ml
+++ b/sarek/tests/unit/test_host_ir_width_agreement.ml
@@ -1,0 +1,406 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * CLASS VALIDATOR for the HOST side of the element-type surface — the third
+ * and last segment of the pipeline, and the one that had no sweep.
+ *
+ * The two existing sweeps cover the ends and meet nowhere:
+ *
+ *   sarek/tests/unit/test_type_width_totality.ml
+ *       source type  ->  IR element type          (stops AT the IR)
+ *   sarek/tests/codegen_golden/test_backend_type_width_totality.ml
+ *       IR element type  ->  device type string   (starts AT the IR)
+ *
+ * Neither says anything about the third edge:
+ *
+ *       IR element type  <->  HOST scalar_kind  ->  exec-arg dispatch
+ *
+ * That edge is where the bytes actually live. It is also where measurement
+ * says the expensive defects are. Adding a constructor to
+ * [Sarek_ir_types.elttype] and to [Sarek_types.registered_type] makes 21
+ * production files fail to compile; the f16 width needed 40, and the other
+ * half — [Spoc_core_base_scalar], [Vector], [Memory], [Ctypes_ops],
+ * [Execute], the interpreter narrowing, the plugin bases — is invisible to
+ * the compiler, because none of it matches on the IR type. Two of the three
+ * f16 soundness bugs lived in that invisible half:
+ *
+ *   - [Execute]'s exec-arg [get]/[set] had no [Float16] arm, so an f16 kernel
+ *     could not run on the Interpreter DEVICE at all. The dispatch is a match
+ *     on a (typed_value, kind) PAIR with a catch-all, so no constructor
+ *     addition anywhere can force that arm to exist. Nothing failed to
+ *     compile; the feature was simply absent.
+ *   - the host width and the IR width can disagree with no diagnostic — the
+ *     [char] case (Bigarray char is ONE byte, [Ir.TInt32] declares four) is
+ *     the recorded instance.
+ *
+ * This file closes that edge by the same discipline the other two use: a
+ * total successor chain with NO wildcard, so a new host scalar kind fails to
+ * COMPILE here (warning 8 is an error in this test's flags), and a pinned
+ * refusal set, so a kind that stops round-tripping is a deliberate edit
+ * rather than a quiet narrowing.
+ *
+ * WHY THIS GATE CANNOT SILENTLY PASS (see the "gates that cannot fail" list):
+ *
+ *  - the kind enumeration is unfolded from [next_scalar], a total match on
+ *    the [scalar_kind] GADT with no wildcard, and its length is pinned;
+ *  - the labels are checked for DISTINCTNESS, so an off-by-one walk that
+ *    omits one kind while duplicating another cannot pass on the count;
+ *  - every probe carries a value that is NOT the zero/default of its type, so
+ *    a round trip that silently returns a fresh cell fails;
+ *  - the set of kinds with no IR counterpart, and the set whose exec-arg
+ *    dispatch refuses, are each pinned EXACTLY — growing either is an edit to
+ *    a list, not a smaller sweep;
+ *  - [test_sweep_is_not_vacuous] requires a floor of kinds that actually
+ *    complete a round trip, so a change that made everything refuse would
+ *    fail here rather than pass trivially.
+ ******************************************************************************)
+
+module Ir = Sarek_ir_types
+module Vector = Spoc_core.Vector
+module Execute = Sarek.Execute
+module Framework_sig = Spoc_framework.Framework_sig
+
+(* ------------------------------------------------------------------ *)
+(* Compiler-enforced enumeration of the HOST scalar kinds              *)
+(* ------------------------------------------------------------------ *)
+
+type packed = Pack : ('a, 'b) Vector.scalar_kind -> packed
+
+(** Total match, NO wildcard: adding a constructor to
+    [Spoc_core_base_scalar.scalar_kind] fails to compile here. *)
+let next_scalar : type a b. (a, b) Vector.scalar_kind -> packed option =
+  function
+  | Vector.Float16 -> Some (Pack Vector.Float32)
+  | Vector.Float32 -> Some (Pack Vector.Float64)
+  | Vector.Float64 -> Some (Pack Vector.Int32)
+  | Vector.Int32 -> Some (Pack Vector.Int64)
+  | Vector.Int64 -> Some (Pack Vector.Char)
+  | Vector.Char -> Some (Pack Vector.Complex32)
+  | Vector.Complex32 -> None
+
+let unfold_kinds () =
+  let rec go acc (Pack k as p) =
+    match next_scalar k with
+    | Some q -> go (p :: acc) q
+    | None -> List.rev (p :: acc)
+  in
+  go [] (Pack Vector.Float16)
+
+let all_kinds = unfold_kinds ()
+
+(* ------------------------------------------------------------------ *)
+(* What each host kind must satisfy                                    *)
+(* ------------------------------------------------------------------ *)
+
+(** A probe carries a host kind together with a representative value, so the
+    exec-arg round trip below can be run without knowing the element type
+    statically.
+
+    [ir] is the IR element type this host kind stores. [None] means the host
+    kind has no IR counterpart at all, which is a real state and is pinned below
+    — it must never be reached by forgetting to add one. *)
+type probe =
+  | Probe : {
+      kind : ('a, 'b) Vector.kind;
+      label : string;
+      ir : Ir.elttype option;
+      sample : 'a;
+          (** deliberately not the zero value of the type: a round trip that
+              returns a fresh, untouched cell must not be able to pass *)
+      expect : 'a;  (** [sample] after a store-and-load through this kind *)
+      equal : 'a -> 'a -> bool;
+      show : 'a -> string;
+    }
+      -> probe
+
+let cx_equal (a : Complex.t) (b : Complex.t) = a.re = b.re && a.im = b.im
+
+let cx_show (c : Complex.t) = Printf.sprintf "%g+%gi" c.re c.im
+
+(** Total match, NO wildcard: a new host scalar kind fails to compile here too,
+    and — unlike a table keyed by name — it cannot be satisfied by a stub,
+    because the arm has to produce a value of the kind's own element type. *)
+let probe_of : type a b. (a, b) Vector.scalar_kind -> probe = function
+  | Vector.Float16 ->
+      Probe
+        {
+          kind = Vector.float16;
+          label = "Float16";
+          ir = Some Ir.TFloat16;
+          sample = 3.14159;
+          (* Nearest binary16 to 3.14159. Reading back 3.14159 would prove the
+             store is not actually 2-byte, which is the width claim this file
+             checks from the other direction. *)
+          expect = 3.140625;
+          equal = Float.equal;
+          show = string_of_float;
+        }
+  | Vector.Float32 ->
+      Probe
+        {
+          kind = Vector.float32;
+          label = "Float32";
+          ir = Some Ir.TFloat32;
+          sample = 2.5;
+          expect = 2.5;
+          equal = Float.equal;
+          show = string_of_float;
+        }
+  | Vector.Float64 ->
+      Probe
+        {
+          kind = Vector.float64;
+          label = "Float64";
+          ir = Some Ir.TFloat64;
+          sample = 2.5;
+          expect = 2.5;
+          equal = Float.equal;
+          show = string_of_float;
+        }
+  | Vector.Int32 ->
+      Probe
+        {
+          kind = Vector.int32;
+          label = "Int32";
+          ir = Some Ir.TInt32;
+          sample = 7l;
+          expect = 7l;
+          equal = Int32.equal;
+          show = Int32.to_string;
+        }
+  | Vector.Int64 ->
+      Probe
+        {
+          kind = Vector.int64;
+          label = "Int64";
+          ir = Some Ir.TInt64;
+          sample = 9L;
+          expect = 9L;
+          equal = Int64.equal;
+          show = Int64.to_string;
+        }
+  | Vector.Char ->
+      Probe
+        {
+          kind = Vector.char;
+          label = "Char";
+          (* No IR counterpart, and this is the recorded wrong-width defect:
+             [Spoc_core.Vector.char] is a Bigarray of OCaml chars, ONE byte per
+             element, and the IR has no 1-byte element type. [char] used to
+             lower to [Ir.TInt32] — declaring `int*` on the device, four bytes
+             — so a `char vector` kernel strode the buffer at 4x the host's
+             element size with no diagnostic. [Sarek_lower_ir] now rejects it
+             rather than mapping it, which is why this is [None] and not a
+             width this sweep could check. *)
+          ir = None;
+          sample = 'A';
+          expect = 'A';
+          equal = Char.equal;
+          show = (fun c -> String.make 1 c);
+        }
+  | Vector.Complex32 ->
+      Probe
+        {
+          kind = Vector.complex32;
+          label = "Complex32";
+          (* No IR counterpart: the IR has no complex element type at all. *)
+          ir = None;
+          sample = {Complex.re = 1.5; im = -2.5};
+          expect = {Complex.re = 1.5; im = -2.5};
+          equal = cx_equal;
+          show = cx_show;
+        }
+
+let all_probes = List.map (fun (Pack k) -> probe_of k) all_kinds
+
+let label_of (Probe p) = p.label
+
+(* ------------------------------------------------------------------ *)
+(* Anti-vacuity                                                        *)
+(* ------------------------------------------------------------------ *)
+
+let test_enumeration_is_complete () =
+  Alcotest.(check int) "host scalar kinds swept" 7 (List.length all_kinds) ;
+  (* A count alone does not prove the chain was walked correctly: an off-by-one
+     walk that omits one kind and duplicates another keeps the count. *)
+  let labels = List.map label_of all_probes in
+  if List.length (List.sort_uniq compare labels) <> List.length labels then
+    Alcotest.failf
+      "the host-kind enumeration contains duplicates, so some kind is going \
+       unswept: %s"
+      (String.concat ", " labels)
+
+(** Pinned exactly. A host scalar kind with no IR element type cannot be used as
+    a kernel element type at all, so growing this set silently is how a width
+    would get dropped from the DSL without anything going red. *)
+let expected_no_ir_counterpart = ["Char"; "Complex32"]
+
+let test_no_ir_counterpart_set_is_exactly_as_recorded () =
+  let actual =
+    List.filter_map
+      (fun (Probe p) -> if p.ir = None then Some p.label else None)
+      all_probes
+  in
+  if List.sort compare actual <> List.sort compare expected_no_ir_counterpart
+  then
+    Alcotest.failf
+      "the set of host scalar kinds with NO IR element type changed.\n\
+       expected: %s\n\
+       actual:   %s\n\
+       A kind in this set cannot be a kernel element type. Adding one must be \
+       a deliberate edit backed by a reason, not a consequence of forgetting \
+       to map it."
+      (String.concat ", " (List.sort compare expected_no_ir_counterpart))
+      (String.concat ", " (List.sort compare actual))
+
+(* ------------------------------------------------------------------ *)
+(* INVARIANT 1 — the host width IS the IR width                        *)
+(* ------------------------------------------------------------------ *)
+
+(** [Sarek_ir_layout.scalar_size] is what the device-side sweep uses as its
+    denominator, and [Vector.elem_size] is what the host allocator and every
+    transfer actually stride by. If they disagree, the two sweeps are each
+    internally consistent and the pipeline is still wrong — which is precisely
+    the shape of the [char] defect. *)
+let test_host_width_equals_ir_width () =
+  List.iter
+    (fun (Probe p) ->
+      match p.ir with
+      | None -> ()
+      | Some t ->
+          let host = Vector.elem_size p.kind in
+          let ir = Sarek_ir_layout.scalar_size t in
+          if host <> ir then
+            Alcotest.failf
+              "%s: the host stores %d byte(s) per element (Vector.elem_size) \
+               but the IR lays the same element out in %d byte(s) \
+               (Sarek_ir_layout.scalar_size, which is the denominator the \
+               backend width sweep checks device types against). A kernel \
+               using it would compile, run, and stride the buffer wrong with \
+               no diagnostic."
+              p.label
+              host
+              ir)
+    all_probes
+
+(* ------------------------------------------------------------------ *)
+(* INVARIANT 2 — every host kind survives the exec-arg dispatch        *)
+(* ------------------------------------------------------------------ *)
+
+(* The dispatch this exercises is [Execute.exec_arg_of_vector]'s [get]/[set],
+    which is a match on a (typed_value, Vector.kind) PAIR ending in a
+    catch-all. No constructor addition can force an arm into it, so nothing
+    but a sweep can tell you an arm is missing — and a missing arm is not a
+    compile error, it is a feature that silently does not exist on the
+    Interpreter device.
+
+    Run as a store-through-the-framework / load-through-the-framework round
+   trip so that a [set] arm that accepts a value and drops it fails here too. *)
+
+(** Outcome of one round trip. The element type is existential inside [Probe],
+    so the comparison must happen in the scope that unpacks it — hence a verdict
+    rather than a returned value. *)
+type outcome = Completed | Lost of string | Refused
+
+let roundtrip_through_exec_arg (Probe p) : outcome =
+  let v = Vector.create p.kind 4 in
+  Vector.set v 0 p.sample ;
+  match Execute.exec_arg_of_vector v with
+  | Framework_sig.EA_Vec (module EV) -> (
+      match
+        let tv = EV.get 0 in
+        EV.set 1 tv ;
+        Vector.get v 1
+      with
+      | got ->
+          if p.equal got p.expect then Completed
+          else Lost (Printf.sprintf "%s, not %s" (p.show got) (p.show p.expect))
+      | exception _ -> Refused)
+  | EA_Int32 _ | EA_Int64 _ | EA_Float32 _ | EA_Float64 _ | EA_Scalar _
+  | EA_Composite _ ->
+      Alcotest.failf "%s: exec_arg_of_vector did not produce an EA_Vec" p.label
+
+(** Pinned exactly, and every entry is a kind with no IR counterpart — i.e. one
+    that cannot be a kernel element type anyway. A kind that CAN be a kernel
+    element type appearing here would mean that element type does not work on
+    the Interpreter device, which is exactly the f16 hole. *)
+let expected_exec_arg_refusals = ["Char"; "Complex32"]
+
+let test_exec_arg_roundtrip_totality () =
+  let refused = ref [] in
+  List.iter
+    (fun (Probe p as probe) ->
+      match roundtrip_through_exec_arg probe with
+      | Completed -> ()
+      | Refused -> refused := p.label :: !refused
+      | Lost detail ->
+          Alcotest.failf
+            "%s: a value written and read back through the exec-arg interface \
+             came out as %s. The dispatch accepted the element and lost it."
+            p.label
+            detail)
+    all_probes ;
+  if List.sort compare !refused <> List.sort compare expected_exec_arg_refusals
+  then
+    Alcotest.failf
+      "the set of host scalar kinds the exec-arg dispatch REFUSES changed.\n\
+       expected: %s\n\
+       actual:   %s\n\
+       A kind that is a legal kernel element type but is refused here cannot \
+       run on the Interpreter device — the framework's get/set dispatch ends \
+       in a catch-all, so this sweep is the only thing that can notice."
+      (String.concat ", " (List.sort compare expected_exec_arg_refusals))
+      (String.concat ", " (List.sort compare !refused))
+
+(** A change that made every kind refuse would satisfy a pinned-set check that
+    was written loosely. Require a floor of kinds that actually complete. *)
+let test_sweep_is_not_vacuous () =
+  let n =
+    List.length
+      (List.filter
+         (fun probe -> roundtrip_through_exec_arg probe = Completed)
+         all_probes)
+  in
+  if n < 5 then
+    Alcotest.failf
+      "only %d host scalar kind(s) complete an exec-arg round trip; every \
+       assertion in this file about the rest is vacuous"
+      n
+
+let () =
+  Alcotest.run
+    "host_ir_width_agreement"
+    [
+      ( "gate is not vacuous",
+        [
+          Alcotest.test_case
+            "the host-kind enumeration is complete and distinct"
+            `Quick
+            test_enumeration_is_complete;
+          Alcotest.test_case
+            "the no-IR-counterpart set is exactly as recorded"
+            `Quick
+            test_no_ir_counterpart_set_is_exactly_as_recorded;
+          Alcotest.test_case
+            "enough kinds complete a round trip for the sweep to mean something"
+            `Quick
+            test_sweep_is_not_vacuous;
+        ] );
+      ( "host/IR width agreement",
+        [
+          Alcotest.test_case
+            "the host element size equals Sarek_ir_layout.scalar_size"
+            `Quick
+            test_host_width_equals_ir_width;
+        ] );
+      ( "exec-arg dispatch totality",
+        [
+          Alcotest.test_case
+            "every host scalar kind round-trips, or is a pinned refusal"
+            `Quick
+            test_exec_arg_roundtrip_totality;
+        ] );
+    ]


### PR DESCRIPTION
## What this is

backlog-88 asked for two things: bf16 as a DSL element type, **and** making
width-addition cheap before a third width lands. The second half is delivered.
**bf16 is not, deliberately** — and the measurement is the argument.

## The number

Not an estimate. Each type vocabulary had its constructor actually added and the
tree built to green, counting compiler errors round by round.

> **A usable scalar width touches 40 production files. The compiler asks for 21.
> The other 20 must be found by reading.**

| | how obtained | count |
|---|---|---|
| files a width actually needs | `git show --name-only c93dbf96` (f16 slice 1), non-test `.ml`/`.mli` | **40** |
| forced by the constructors | added `TBFloat16`/`BFloat16` to all four addable vocabularies, built to green | **21** |
| **invisible to the compiler** | difference | **20** |

The forced half arrives in **seven build rounds**, not one — each layer's errors
hide behind the previous layer's failure. You cannot grep the blast radius, and
one build does not show it.

The 20 are the FFI layer, host storage, the exec-arg dispatch, the conversion
primitives and the interpreter narrowing — **exactly where every f16 soundness
bug lived**. None was in a match arm.

### Why: one file, two halves, one catch-all

`Execute.exec_arg_of_vector`'s `get` matches on `Vector.kind` — total, so a new
host kind forces an arm. Its `set`, forty lines away, matches on a
`(typed_value, kind)` **pair** ending in a catch-all — so nothing does. f16
shipped with the first and not the second, and could not run on the Interpreter
device at all. Measured directly (red R6 below): adding an `Int16` scalar kind
forces `get` and not `set`.

## The reduction

Two sweeps existed and meet nowhere:

```
 source type ──▶ IR element type ──▶ device type string
 └── test_type_width_totality ──┘
              └── test_backend_type_width_totality ──┘
```

`test_host_ir_width_agreement.ml` adds the third edge, where the bytes cross:

```
              IR element type ◀──▶ HOST scalar_kind ──▶ exec-arg dispatch
```

- `Vector.elem_size = Sarek_ir_layout.scalar_size` — the *same denominator* the
  backend sweep checks device types against, so the three segments become one
  chain rather than three self-consistent fragments;
- every host scalar kind completes a store-and-load round trip through the
  exec-arg `get`/`set`, or appears in a pinned refusal list — the only
  instrument that can see a missing arm in the catch-all half;
- exemption sets pinned exactly. `Char` is in them as *evidence*: 1-byte host,
  no 1-byte IR type, and it used to lower to `TInt32` and stride the buffer 4×.

This does not shrink the 40. It moves the two defects that cost f16 the most
review time out of the invisible 20 and into red.

## Reds observed — all executed

| # | mutation | result |
|---|---|---|
| R1 | add `TBFloat16` to `elttype` | backend sweep **fails to compile**, naming `TBFloat16` |
| R2 | add `BFloat16` to `registered_type` | front sweep **fails to compile** (4 sites) |
| R3 | f16 `set` arm reverted to pre-fix state | **FAIL**: *"expected: Char, Complex32 / actual: Char, Complex32, **Float16**"* |
| R4 | `scalar_size TFloat16` 2→4 | **FAIL**: *"**Float16**: the host stores 2 byte(s) … but the IR lays the same element out in 4"* |
| R5 | delete an arm of `probe_of` | **fails to compile** — warning 8 is fatal here and the matches are wildcard-free |
| R6 | add an `Int16` `scalar_kind` | forces `Execute`'s `get`, **not** its `set` |

R3 and R4 are the f16 defect and the `char` defect, reproduced and caught.

## Why bf16 is not here

`f16-dsl-element-type.md` §11.1 said bf16 "needs no new machinery … as close to
*f16 again, with a different `cvt`* as a new width can be." **Refuted by
execution.**

OCaml 5.3.0's `Bigarray.kind` GADT is closed: 14 constructors, `Float16` among
them, **no bfloat16 of any spelling** (probe run; `bigarray.mli` read).
`scalar_kind` requires a `Bigarray.*_elt` phantom, so bf16 has no host storage on
f16's route. f16's cheapness came from a stdlib affordance its sibling does not
inherit — the Ctypes-mirror lesson of §3.3, one level up. Both alternatives are
redesigns, not arms: `Int16_unsigned` makes `Vector.get` return raw bits instead
of a float; `Custom_storage` is `('a, unit) kind`, **not a `Scalar` kind at
all**, so it bypasses the host width table and the exec-arg scalar dispatch.

**And there is nothing to verify it against here.** No NVIDIA device for the
sm_80 `__nv_bfloat16` path (echydna is sm_61); RADV on the RX 7900 XTX
(Mesa 26.1.4-arch3.1) advertises `VK_KHR_shader_float16_int8` and no bfloat16
extension; Metal's `bfloat` is unmeasurable on this host; CUDA and HIP share one
emitter while their bf16 spellings diverge (`__nv_bfloat16` vs `__bf16`), unlike
`__half`. Under **`Unknown` does not permit**, every backend refuses — and a
width every backend refuses is a constructor lengthening 38 match sites for zero
capability.

**The f32→bf16 narrowing-fusion question is open.** AMD's two GPU compilers fuse
the f32 multiply into the f32→**f16** narrowing (620/63488; 2912/63488 through
SPIR-V). Whether the same combine exists for bf16 is **unmeasured**, and is
stated as open rather than answered by analogy.

## What I did not do

- Did not add bf16 to any vocabulary — the measurement patch (719 lines, green)
  was reverted; only the sweep is proposed.
- Did not measure the f32→bf16 narrowing on gfx1100 or RADV.
- Did not touch `.harness/`, `skills/`, `roster/`, `Sarek_fusion.ml`,
  `Execute.check_device_capabilities`, `Sarek_coopmat*`, or the two owned docs.
- Did not build a table-driven width descriptor. §11.3 says wait for the second
  instance; the second instance turned out not to be a width addition at all.
- Did not split `Sarek_ir_cuda.ml`'s mapper for the CUDA/HIP divergence.

## Verification

- `dune build @fmt` clean.
- Full suite via `scripts/test-suite-counts.sh` on a **verified non-empty**
  4758-line log: **1676 cases / 116 suites, 0 FAIL, 23 SKIP**. Baseline was
  1665/114; the delta is this suite's 5 cases plus 6 cases and one suite from
  backlog-62 slice 3, which landed on `main` during this work. Rebased onto
  `a9706432`.
- Devices named where claimed: RX 7900 XTX (RADV NAVI31) and Raphael iGPU
  (RADV RAPHAEL_MENDOCINO), Mesa 26.1.4-arch3.1. No bf16 execution claim is made
  on any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
