### PR TITLE
feat(soa): carry the record field list on custom_type (backlog-54 slice 2)

### DIFF
--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -103,6 +103,25 @@ module Make (Ops : CUSTOM_OPS) = struct
     get : Ops.handle -> int -> 'a;
     set : Ops.handle -> int -> 'a -> unit;
     name : string;
+    ir_fields : (string * Sarek_ir_types.elttype) list option;
+        (** Immediate fields of the element type, in declaration order, when the
+            element is a flat scalar record whose byte layout is derivable by
+            {!Sarek_ir_layout.record_layout}. [None] means "layout not derivable
+            here" — variants, hand-written descriptors, and any record with a
+            field type outside the six the host marshaller can read/write.
+            Consumers must treat [None] as "no SoA", never as "no fields".
+
+            Trust contract: [ir_fields] carries exactly the same trust as
+            [elem_size] — it is metadata *about* ['a], not a witness *of* it,
+            and the type system does not relate the two. What makes it sound is
+            that the producer derives [ir_fields], [elem_size] and [get]/[set]
+            from one source. Concretely, for a PPX-generated record all four
+            come from [Sarek_ppx.aligned_record_offsets]; for {!Sarek_tuple_vec}
+            all four come from one [Sarek_ir_layout.record_layout] call. A
+            producer that derives them separately can desynchronize them
+            silently, which is wrong data rather than a type error — see
+            [test_ir_fields.ml], which pins the agreement by probing the bytes
+            [set] actually writes. *)
   }
 
   and (_, _) kind =

--- a/sarek/core_base/Spoc_core_base.mli
+++ b/sarek/core_base/Spoc_core_base.mli
@@ -100,6 +100,17 @@ module Make (Ops : CUSTOM_OPS) : sig
     get : Ops.handle -> int -> 'a;
     set : Ops.handle -> int -> 'a -> unit;
     name : string;
+    ir_fields : (string * Sarek_ir_types.elttype) list option;
+        (** Immediate fields of the element type in declaration order, when the
+            element is a flat scalar record whose byte layout is derivable by
+            {!Sarek_ir_layout.record_layout}; [None] when it is not (variants,
+            hand-written descriptors, unsupported field types). [None] means "no
+            SoA plan derivable", never "no fields".
+
+            Carries the same trust as [elem_size]: it is untyped metadata about
+            ['a] that the type system does not relate to [get]/[set]. It is
+            sound only because each producer derives the field list, the size
+            and the accessors from a single layout computation. *)
   }
 
   and (_, _) kind =

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -344,6 +344,10 @@ end = struct
               Interpreter_error.(
                 raise_error (feature_not_supported "custom type set accessor")));
           name = "custom";
+          (* Placeholder descriptor: [alloc_custom] is given only [elem_size],
+             no element type, and its accessors raise. There is no field list
+             to state. *)
+          ir_fields = None;
         }
       in
       {

--- a/sarek/plugins/native/Native_plugin_base.ml
+++ b/sarek/plugins/native/Native_plugin_base.ml
@@ -363,6 +363,10 @@ end = struct
               Native_error.(
                 raise_error (feature_not_supported "custom type set accessor")));
           name = "custom";
+          (* Placeholder descriptor: [alloc_custom] is given only [elem_size],
+             no element type, and its accessors raise. There is no field list
+             to state. *)
+          ir_fields = None;
         }
       in
       {

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -683,6 +683,80 @@ let field_element_count (ct : core_type) : int =
 (** Get field size in bytes for V2 custom types *)
 let field_byte_size (ct : core_type) : int = get_type_size_from_core_type ct
 
+(* IR element type of a record field, for [custom_type.ir_fields].
+
+   This mapping is the SoA wrong-data hazard, so it is deliberately narrow: it
+   answers [Some] for exactly the six field types [gen_field_read] /
+   [gen_field_write] can marshal, and [None] for everything else. Anything
+   [None] makes the WHOLE record's [ir_fields] [None] (see
+   [ir_fields_of_labels]), because a partial field list would describe a
+   different type than the one [get]/[set] actually read.
+
+   The widths must agree with BOTH neighbours or SoA transposes the wrong bytes:
+
+     field type | get_type_size_from_core_type | accessor          | elttype  | scalar_size
+     -----------+-----------------------------+-------------------+----------+------------
+     int32      | 4                           | read_int32        | TInt32   | 4
+     int        | 4                           | read_int (int32!) | TInt32   | 4
+     int64      | 8                           | read_int64        | TInt64   | 8
+     float32    | 4                           | read_float32      | TFloat32 | 4
+     float      | 4  (* GPU float32 *)        | read_float32      | TFloat32 | 4
+     float64    | 8                           | read_float64      | TFloat64 | 8
+
+   Two arms are traps and are the reason this table is written out. OCaml
+   [float] is 8 bytes in OCaml but this framework marshals it as a 32-bit GPU
+   float (Sarek_ppx.get_type_size_from_core_type = 4, accessor = read_float32),
+   so it maps to [TFloat32]; mapping it to [TFloat64] on the strength of the
+   OCaml type would double every stride below it. [int] likewise marshals
+   through [read_int], which is [Int32.to_int (read_int32 ...)] — 4 bytes, not
+   an OCaml 63-bit int — so it maps to [TInt32].
+
+   [bool] and [unit] are NOT here on purpose. [get_type_size_from_core_type]
+   gives them 4 bytes, but [gen_field_read] has no arm for either: they fall to
+   its nested-custom-type branch and emit [bool_custom.get], which does not
+   compile. They are unusable as record fields today, so claiming a layout for
+   them would be describing a type that cannot exist. If they are ever given
+   accessors, add them here as TBool/TUnit (scalar_size 4) at the same time.
+
+   test_ir_fields.ml pins every row of this table against the bytes [set]
+   actually writes, so a wrong arm is a red test rather than silent bad data. *)
+let ir_elttype_of_core_type ~loc (ct : core_type) : expression option =
+  let ident name =
+    Some
+      (Ast_builder.Default.pexp_construct
+         ~loc
+         {txt = Ldot (Lident "Sarek_ir_types", name); loc}
+         None)
+  in
+  match ct.ptyp_desc with
+  | Ptyp_constr ({txt = Lident "int32"; _}, _) -> ident "TInt32"
+  | Ptyp_constr ({txt = Lident "int"; _}, _) -> ident "TInt32"
+  | Ptyp_constr ({txt = Lident "int64"; _}, _) -> ident "TInt64"
+  | Ptyp_constr ({txt = Lident "float32"; _}, _) -> ident "TFloat32"
+  | Ptyp_constr ({txt = Lident "float"; _}, _) -> ident "TFloat32"
+  | Ptyp_constr ({txt = Lident "float64"; _}, _) -> ident "TFloat64"
+  | _ -> None
+
+(* [Some fields] when every field maps, [None] otherwise — all-or-nothing, see
+   above. Field order is declaration order, which is what
+   Sarek_ir_layout.record_layout consumes. *)
+let ir_fields_of_labels ~loc (labels : label_declaration list) : expression =
+  let mapped =
+    List.map
+      (fun ld ->
+        Option.map
+          (fun ty ->
+            Ast_builder.Default.pexp_tuple
+              ~loc
+              [Ast_builder.Default.estring ~loc ld.pld_name.txt; ty])
+          (ir_elttype_of_core_type ~loc ld.pld_type))
+      labels
+  in
+  if List.exists Option.is_none mapped then [%expr None]
+  else
+    let items = List.filter_map Fun.id mapped in
+    [%expr Some [%e Ast_builder.Default.elist ~loc items]]
+
 (** Generate a <name>_custom value for Vector.Custom. For a record type like
     float4 with float32 fields, generates get/set functions using
     Spoc.Tools.float32get/set *)
@@ -929,6 +1003,10 @@ let generate_custom_value ~loc (td : type_declaration) : structure_item list =
                name = [%e name_expr];
                get = [%e get_fn];
                set = [%e set_fn];
+               (* Same [labels] the offsets, [size_expr] and [get]/[set] above
+                  are derived from — one source, per the [ir_fields] trust
+                  contract in Spoc_core_base.mli. *)
+               ir_fields = [%e ir_fields_of_labels ~loc labels];
              }
               : [%t type_annot])];
         (* Generate: let point_custom = point_make_custom () *)
@@ -1242,6 +1320,11 @@ let generate_custom_value ~loc (td : type_declaration) : structure_item list =
                name = [%e name_expr];
                get = [%e get_fn];
                set = [%e set_fn];
+               (* Variant deriver: a variant is a tagged union, not a flat
+                  scalar record, so it has no SoA field list.
+                  Sarek_ir_layout.flatten_field rejects it below top level
+                  anyway. *)
+               ir_fields = None;
              }
               : [%t type_annot])];
         [%stri let [%p custom_pat] = [%e make_fn_call]];

--- a/sarek/tests/unit/ir_fields/dune
+++ b/sarek/tests/unit/ir_fields/dune
@@ -1,0 +1,13 @@
+; ir-fields: the SoA field list [@@sarek.type] puts on custom_type, checked
+; against the bytes the generated get/set actually touch. Isolated in its own
+; directory so the sarek_ppx preprocessing does not collide with the metaquot
+; test group in the parent unit/ directory (same reason as
+; ktype_variant_field/).
+
+(test
+ (name test_ir_fields)
+ (libraries sarek spoc_core spoc.ir ctypes alcotest)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))

--- a/sarek/tests/unit/ir_fields/test_ir_fields.ml
+++ b/sarek/tests/unit/ir_fields/test_ir_fields.ml
@@ -1,0 +1,446 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** [custom_type.ir_fields] — the SoA field list, checked against the bytes the
+    generated accessors actually touch (backlog-54 slice 2).
+
+    {1 What this file is defending}
+
+    [ir_fields] is untyped metadata sitting next to [elem_size], [get] and
+    [set] in a plain record. Nothing in the type system relates them. If the
+    PPX's [ir_elttype_of_core_type] maps a field to the wrong [elttype], the
+    result is not a type error and not a crash: [Soa.plan] computes a different
+    offset or a different width than [set] wrote to, the SoA transposition moves
+    the wrong bytes, and the kernel reads plausible garbage. That is the
+    wrong-width failure family (backlog-85/-96/-139/-141/-142), and prose
+    review does not catch it.
+
+    Two arms of the mapping are traps and are the reason this file exists:
+
+    - OCaml [float] is 8 bytes {i in OCaml} but this framework marshals a
+      [float] record field as a 32-bit GPU float ([read_float32], size 4). It
+      maps to [TFloat32]. Reading the OCaml type and answering [TFloat64] is
+      the natural mistake and doubles every stride below it.
+    - [int] marshals through [read_int], which is
+      [Int32.to_int (read_int32 ...)] — 4 bytes, not an OCaml 63-bit int. It
+      maps to [TInt32].
+
+    {1 The gate}
+
+    [check_layout] does not compare the mapping against a second copy of the
+    mapping — that would be a tautology, and two copies of a wrong table agree
+    perfectly. It compares against the {b observable behaviour of the generated
+    [set]}: write one field with an all-[0x7F] bit pattern into a zeroed
+    element and record which byte indices became nonzero. The set of dirtied
+    bytes must be exactly the half-open range [[aos_offset, aos_offset + size)]
+    that [Soa.plan] derived from [ir_fields]. Field {i order} is pinned the same
+    way, because a swapped pair dirties the other field's byte range.
+
+    So the assertion chain is
+
+    [ir_fields] -> [Soa.plan] -> predicted (offset, size) per leaf
+    vs. bytes [set] really wrote, and [aos_stride] vs. [elem_size].
+
+    Both ends are independently derived; agreement is evidence, not restatement.
+
+    {1 Coverage}
+
+    Enumerated, not sampled, over the mapping's domain: all six field types the
+    marshaller supports appear as the sole field of a record, which pins each
+    width in isolation ({!singleton_cases}). On top of that, {!pair_cases}
+    covers every ordered 4-byte/8-byte alignment-class pair, which is where
+    padding is inserted and where an offset error shows up; plus a three-field
+    record for the general case. [bool] and [unit] are absent because
+    [gen_field_read] has no arm for them — they are unusable as record fields
+    today (see the note in [Sarek_ppx.ir_elttype_of_core_type]).
+
+    Not covered here: any device. This is a pure host-layout test. *)
+
+module Soa = Spoc_core.Soa
+module Vector = Spoc_core.Vector
+module Helpers = Spoc_core.Vector_types.Custom_helpers
+open Sarek_ir_types
+
+type float32 = float
+
+type float64 = float
+
+(** {1 Element types} *)
+
+(* One field each: pins the width of every arm of the mapping in isolation. *)
+
+type r_i32 = {i32_f : int32} [@@sarek.type]
+
+type r_int = {int_f : int} [@@sarek.type]
+
+type r_i64 = {i64_f : int64} [@@sarek.type]
+
+type r_f32 = {f32_f : float32} [@@sarek.type]
+
+type r_flt = {flt_f : float} [@@sarek.type]
+
+type r_f64 = {f64_f : float64} [@@sarek.type]
+
+(* Ordered 4/8-byte pairs: padding is inserted only when an 8-byte field
+   follows a 4-byte one, and the struct tail is padded only when an 8-byte
+   member is present, so both orders of each pair are distinct layouts. *)
+
+type p_i32_i64 = {a_i32 : int32; b_i64 : int64} [@@sarek.type]
+
+type p_i64_i32 = {a_i64 : int64; b_i32 : int32} [@@sarek.type]
+
+type p_f32_f64 = {a_f32 : float32; b_f64 : float64} [@@sarek.type]
+
+type p_f64_f32 = {a_f64 : float64; b_f32 : float32} [@@sarek.type]
+
+type p_int_f64 = {a_int : int; b_f64d : float64} [@@sarek.type]
+
+type p_flt_i64 = {a_flt : float; b_i64d : int64} [@@sarek.type]
+
+(* Three fields, mixed alignment: the general case. *)
+type t_mixed = {m_i32 : int32; m_f64 : float64; m_f32 : float32} [@@sarek.type]
+
+(* All-4-byte: the historically common shape, where aligned == packed. *)
+type t_flat3 = {v_x : float32; v_y : float32; v_z : float32} [@@sarek.type]
+
+(* Not SoA-derivable: a nested custom-type field. [gen_field_read] handles it
+   (via the nested-descriptor branch) so it compiles, but Sarek_ir_layout
+   rejects nested records for v1 SoA, so the field list must be withheld. *)
+type nested_outer = {n_head : float32; n_body : t_flat3} [@@sarek.type]
+
+(* Not SoA-derivable: a variant is a tagged union, not a flat scalar record. *)
+type v_tag = VA | VB of float32 [@@sarek.type]
+
+(** {1 Byte probing} *)
+
+(* All bytes 0x7F: nonzero in every byte, and a finite (non-NaN) float in both
+   widths, so nothing normalises it away on the way through [set]. *)
+let hot_i32 = 0x7F7F7F7Fl
+
+let hot_i64 = 0x7F7F7F7F7F7F7F7FL
+
+let hot_int = 0x7F7F7F7F
+
+let hot_f32 = Int32.float_of_bits hot_i32
+
+let hot_f64 = Int64.float_of_bits hot_i64
+
+let alloc_zeroed n =
+  let p = Ctypes.allocate_n Ctypes.uint8_t ~count:n in
+  for i = 0 to n - 1 do
+    Ctypes.(p +@ i <-@ Unsigned.UInt8.zero)
+  done ;
+  Ctypes.to_voidp p
+
+(* Byte indices of [ptr.(0 .. n-1)] that are nonzero. *)
+let dirty_bytes ptr n =
+  let bp = Ctypes.from_voidp Ctypes.uint8_t ptr in
+  let acc = ref [] in
+  for i = n - 1 downto 0 do
+    if Unsigned.UInt8.compare Ctypes.(!@(bp +@ i)) Unsigned.UInt8.zero <> 0 then
+      acc := i :: !acc
+  done ;
+  !acc
+
+let range_list off size = List.init size (fun k -> off + k)
+
+(* Every constructor spelled out, no wildcard: a new elttype must be considered
+   here (is it a legal record field? does the PPX map it?) rather than silently
+   absorbed into a catch-all. TUint8 arriving with backlog-62 slice 3 made this
+   file fail to compile, which is the intended behaviour. *)
+let string_of_elttype = function
+  | TInt32 -> "TInt32"
+  | TInt64 -> "TInt64"
+  | TFloat16 -> "TFloat16"
+  | TUint8 -> "TUint8"
+  | TFloat32 -> "TFloat32"
+  | TFloat64 -> "TFloat64"
+  | TBool -> "TBool"
+  | TUnit -> "TUnit"
+  | TRecord (n, _) -> "TRecord " ^ n
+  | TVariant (n, _) -> "TVariant " ^ n
+  | TArray _ -> "TArray"
+  | TVec _ -> "TVec"
+
+(** [check_layout ~custom ~expected ~probes] is the whole gate.
+
+    [probes] must be in the same order as the type's fields: [probes.(k)] writes
+    element 0 with field [k] hot and every other field zero. *)
+let check_layout ~name ~custom ~expected ~probes () =
+  (* 1. The PPX emitted a field list at all, and it is the expected one. *)
+  let fields =
+    match custom.Vector.ir_fields with
+    | Some f -> f
+    | None ->
+        Alcotest.failf "%s: ir_fields is None, expected a derivable record" name
+  in
+  let show = List.map (fun (n, t) -> (n, string_of_elttype t)) in
+  Alcotest.(check (list (pair string string)))
+    (name ^ ": ir_fields")
+    (show expected)
+    (show fields) ;
+
+  (* 2. The plan derived from that list must agree with the element size the
+     accessors index by. A stride disagreement corrupts every element past the
+     first, so it is checked separately from the per-field offsets. *)
+  let plan = Soa.plan ~name:custom.Vector.name fields in
+  Alcotest.(check int)
+    (name ^ ": aos_stride = elem_size")
+    custom.Vector.elem_size
+    plan.Soa.aos_stride ;
+
+  let leaves = Array.of_list plan.Soa.leaves in
+  Alcotest.(check int)
+    (name ^ ": one leaf per field")
+    (List.length fields)
+    (Array.length leaves) ;
+  Alcotest.(check int)
+    (name ^ ": one probe per field")
+    (List.length fields)
+    (Array.length probes) ;
+
+  (* 3. The bytes [set] actually writes must be exactly the bytes the plan
+     predicted. This is the part that cannot be satisfied by a second copy of a
+     wrong mapping table. *)
+  Array.iteri
+    (fun k (leaf : Soa.leaf) ->
+      let ptr = alloc_zeroed custom.Vector.elem_size in
+      probes.(k) ptr ;
+      let got = dirty_bytes ptr custom.Vector.elem_size in
+      let want = range_list leaf.Soa.aos_offset leaf.Soa.size in
+      Alcotest.(check (list int))
+        (Printf.sprintf
+           "%s: field %d (%s) dirties bytes [%d,%d)"
+           name
+           k
+           leaf.Soa.path
+           leaf.Soa.aos_offset
+           (leaf.Soa.aos_offset + leaf.Soa.size))
+        want
+        got)
+    leaves
+
+(** {1 Cases} *)
+
+let singleton_cases =
+  [
+    ( "r_i32",
+      check_layout
+        ~name:"r_i32"
+        ~custom:r_i32_custom
+        ~expected:[("i32_f", TInt32)]
+        ~probes:[|(fun p -> r_i32_custom.Vector.set p 0 {i32_f = hot_i32})|] );
+    ( "r_int",
+      check_layout
+        ~name:"r_int"
+        ~custom:r_int_custom
+        ~expected:[("int_f", TInt32)]
+        ~probes:[|(fun p -> r_int_custom.Vector.set p 0 {int_f = hot_int})|] );
+    ( "r_i64",
+      check_layout
+        ~name:"r_i64"
+        ~custom:r_i64_custom
+        ~expected:[("i64_f", TInt64)]
+        ~probes:[|(fun p -> r_i64_custom.Vector.set p 0 {i64_f = hot_i64})|] );
+    ( "r_f32",
+      check_layout
+        ~name:"r_f32"
+        ~custom:r_f32_custom
+        ~expected:[("f32_f", TFloat32)]
+        ~probes:[|(fun p -> r_f32_custom.Vector.set p 0 {f32_f = hot_f32})|] );
+    ( "r_flt (OCaml float marshals as GPU float32)",
+      check_layout
+        ~name:"r_flt"
+        ~custom:r_flt_custom
+        ~expected:[("flt_f", TFloat32)]
+        ~probes:[|(fun p -> r_flt_custom.Vector.set p 0 {flt_f = hot_f32})|] );
+    ( "r_f64",
+      check_layout
+        ~name:"r_f64"
+        ~custom:r_f64_custom
+        ~expected:[("f64_f", TFloat64)]
+        ~probes:[|(fun p -> r_f64_custom.Vector.set p 0 {f64_f = hot_f64})|] );
+  ]
+
+let pair_cases =
+  [
+    ( "p_i32_i64",
+      check_layout
+        ~name:"p_i32_i64"
+        ~custom:p_i32_i64_custom
+        ~expected:[("a_i32", TInt32); ("b_i64", TInt64)]
+        ~probes:
+          [|
+            (fun p ->
+              p_i32_i64_custom.Vector.set p 0 {a_i32 = hot_i32; b_i64 = 0L});
+            (fun p ->
+              p_i32_i64_custom.Vector.set p 0 {a_i32 = 0l; b_i64 = hot_i64});
+          |] );
+    ( "p_i64_i32",
+      check_layout
+        ~name:"p_i64_i32"
+        ~custom:p_i64_i32_custom
+        ~expected:[("a_i64", TInt64); ("b_i32", TInt32)]
+        ~probes:
+          [|
+            (fun p ->
+              p_i64_i32_custom.Vector.set p 0 {a_i64 = hot_i64; b_i32 = 0l});
+            (fun p ->
+              p_i64_i32_custom.Vector.set p 0 {a_i64 = 0L; b_i32 = hot_i32});
+          |] );
+    ( "p_f32_f64",
+      check_layout
+        ~name:"p_f32_f64"
+        ~custom:p_f32_f64_custom
+        ~expected:[("a_f32", TFloat32); ("b_f64", TFloat64)]
+        ~probes:
+          [|
+            (fun p ->
+              p_f32_f64_custom.Vector.set p 0 {a_f32 = hot_f32; b_f64 = 0.0});
+            (fun p ->
+              p_f32_f64_custom.Vector.set p 0 {a_f32 = 0.0; b_f64 = hot_f64});
+          |] );
+    ( "p_f64_f32",
+      check_layout
+        ~name:"p_f64_f32"
+        ~custom:p_f64_f32_custom
+        ~expected:[("a_f64", TFloat64); ("b_f32", TFloat32)]
+        ~probes:
+          [|
+            (fun p ->
+              p_f64_f32_custom.Vector.set p 0 {a_f64 = hot_f64; b_f32 = 0.0});
+            (fun p ->
+              p_f64_f32_custom.Vector.set p 0 {a_f64 = 0.0; b_f32 = hot_f32});
+          |] );
+    ( "p_int_f64",
+      check_layout
+        ~name:"p_int_f64"
+        ~custom:p_int_f64_custom
+        ~expected:[("a_int", TInt32); ("b_f64d", TFloat64)]
+        ~probes:
+          [|
+            (fun p ->
+              p_int_f64_custom.Vector.set p 0 {a_int = hot_int; b_f64d = 0.0});
+            (fun p ->
+              p_int_f64_custom.Vector.set p 0 {a_int = 0; b_f64d = hot_f64});
+          |] );
+    ( "p_flt_i64",
+      check_layout
+        ~name:"p_flt_i64"
+        ~custom:p_flt_i64_custom
+        ~expected:[("a_flt", TFloat32); ("b_i64d", TInt64)]
+        ~probes:
+          [|
+            (fun p ->
+              p_flt_i64_custom.Vector.set p 0 {a_flt = hot_f32; b_i64d = 0L});
+            (fun p ->
+              p_flt_i64_custom.Vector.set p 0 {a_flt = 0.0; b_i64d = hot_i64});
+          |] );
+  ]
+
+let wide_cases =
+  [
+    ( "t_mixed",
+      check_layout
+        ~name:"t_mixed"
+        ~custom:t_mixed_custom
+        ~expected:[("m_i32", TInt32); ("m_f64", TFloat64); ("m_f32", TFloat32)]
+        ~probes:
+          [|
+            (fun p ->
+              t_mixed_custom.Vector.set
+                p
+                0
+                {m_i32 = hot_i32; m_f64 = 0.0; m_f32 = 0.0});
+            (fun p ->
+              t_mixed_custom.Vector.set
+                p
+                0
+                {m_i32 = 0l; m_f64 = hot_f64; m_f32 = 0.0});
+            (fun p ->
+              t_mixed_custom.Vector.set
+                p
+                0
+                {m_i32 = 0l; m_f64 = 0.0; m_f32 = hot_f32});
+          |] );
+    ( "t_flat3",
+      check_layout
+        ~name:"t_flat3"
+        ~custom:t_flat3_custom
+        ~expected:[("v_x", TFloat32); ("v_y", TFloat32); ("v_z", TFloat32)]
+        ~probes:
+          [|
+            (fun p ->
+              t_flat3_custom.Vector.set
+                p
+                0
+                {v_x = hot_f32; v_y = 0.0; v_z = 0.0});
+            (fun p ->
+              t_flat3_custom.Vector.set
+                p
+                0
+                {v_x = 0.0; v_y = hot_f32; v_z = 0.0});
+            (fun p ->
+              t_flat3_custom.Vector.set
+                p
+                0
+                {v_x = 0.0; v_y = 0.0; v_z = hot_f32});
+          |] );
+  ]
+
+(** {1 Withholding} *)
+
+(* [None] must mean "no SoA plan derivable", and a consumer must never read it
+   as "a record with no fields" — the difference between falling back to AoS and
+   transposing a zero-leaf plan over real data. *)
+
+let test_nested_withheld () =
+  Alcotest.(check bool)
+    "nested-record field: ir_fields withheld"
+    true
+    (nested_outer_custom.Vector.ir_fields = None) ;
+  (* And the withholding is not over-cautious noise: Sarek_ir_layout would in
+     fact refuse this type, so [None] is the truthful answer rather than a
+     missed opportunity. *)
+  Alcotest.check_raises
+    "and Soa.plan would have rejected it"
+    (Soa.Unsupported
+       "nested-record field \"n_body\" in \"nested_outer\": v1 SoA supports \
+        flat records only")
+    (fun () ->
+      ignore
+        (Soa.plan
+           ~name:"nested_outer"
+           [
+             ("n_head", TFloat32);
+             ( "n_body",
+               TRecord
+                 ( "t_flat3",
+                   [("v_x", TFloat32); ("v_y", TFloat32); ("v_z", TFloat32)] )
+             );
+           ]))
+
+let test_variant_withheld () =
+  Alcotest.(check bool)
+    "variant: ir_fields withheld"
+    true
+    (v_tag_custom.Vector.ir_fields = None)
+
+(** {1 Runner} *)
+
+let () =
+  let case (n, f) = Alcotest.test_case n `Quick f in
+  Alcotest.run
+    "ir_fields"
+    [
+      ("width-per-type (enumerated)", List.map case singleton_cases);
+      ("alignment pairs", List.map case pair_cases);
+      ("multi-field", List.map case wide_cases);
+      ( "not derivable",
+        [
+          Alcotest.test_case "nested record" `Quick test_nested_withheld;
+          Alcotest.test_case "variant" `Quick test_variant_withheld;
+        ] );
+    ]

--- a/sarek/tests/unit/test_execute.ml
+++ b/sarek/tests/unit/test_execute.ml
@@ -38,6 +38,11 @@ let point_custom : point Vector.custom_type =
     get;
     set;
     name = "point";
+    (* Hand-written descriptor: [get]/[set] above are written by hand, not
+       derived from a layout, so nothing keeps a field list in step with them.
+       [None] is the correct answer for that shape even though this particular
+       layout happens to be SoA-derivable. *)
+    ir_fields = None;
   }
 
 (** {1 Tests for vector argument types} *)

--- a/sarek/tuple_vec/Sarek_tuple_vec.ml
+++ b/sarek/tuple_vec/Sarek_tuple_vec.ml
@@ -205,6 +205,8 @@ let pair (a : 'a component) (b : 'b component) : ('a * 'b) Vector.custom_type =
         let base = idx * size in
         a.c_write ptr (base + o0) x ;
         b.c_write ptr (base + o1) y);
+    (* Same [fields] that produced [rl], hence [size] and [o0]/[o1] above. *)
+    ir_fields = Some fields;
   }
 
 (** [triple a b c] is the [custom_type] for a [(a, b, c)] tuple vector element.
@@ -243,4 +245,6 @@ let triple (a : 'a component) (b : 'b component) (c : 'c component) :
         a.c_write ptr (base + o0) x ;
         b.c_write ptr (base + o1) y ;
         c.c_write ptr (base + o2) z);
+    (* Same [fields] that produced [rl], hence [size] and [o0]/[o1]/[o2]. *)
+    ir_fields = Some fields;
   }


### PR DESCRIPTION
## What this is

Slice 2 of the tier-1c transparent SoA plan
(`docs/optimization/tier1c-transparent-dispatch-design.md` §1 blocker 1,
§4 PR 2), tracked as backlog-54.

Transparent SoA dispatch has to derive a `Soa.plan` from a vector's element
type at *create* time. Today the field list is supplied externally
(`Soa_vector.create custom ~fields`), which is why `run_soa` has to be an
explicit API. This puts the list on the descriptor the runtime already holds:

```ocaml
ir_fields : (string * Sarek_ir_types.elttype) list option
```

`Some fields` = flat scalar record, SoA-derivable, declaration order.
`None` = not derivable. **`None` means "no SoA plan", never "a record with no
fields"** — that is the difference between falling back to AoS and transposing
a zero-leaf plan over live data, so it is stated in the mli.

Nothing reads `ir_fields` yet. No behaviour change.

## Why this needed a real test rather than a review

`ir_fields` sits in a plain record beside `elem_size`, `get` and `set` with
nothing in the type system relating them. A mis-mapped field is not a type
error and not a crash: `Soa.plan` computes an offset or a width that `set`
never wrote to, the transposition moves the wrong bytes, and the kernel reads
plausible garbage. That is the wrong-width family (backlog-85/-96/-139/-141/-142).

Two arms of the mapping are traps, and they are why it is written narrowly:

| field type | PPX size | accessor | elttype |
|---|---|---|---|
| `int32` | 4 | `read_int32` | `TInt32` |
| `int` | 4 | `read_int` = `Int32.to_int (read_int32 …)` | **`TInt32`** |
| `int64` | 8 | `read_int64` | `TInt64` |
| `float32` | 4 | `read_float32` | `TFloat32` |
| `float` | 4 *(GPU float32)* | `read_float32` | **`TFloat32`** |
| `float64` | 8 | `read_float64` | `TFloat64` |

OCaml `float` is 8 bytes *in OCaml* but marshals as a 32-bit GPU float;
answering `TFloat64` from the OCaml type doubles every stride below it. `int`
goes through a 32-bit round trip, not a 63-bit one.

`bool` and `unit` are deliberately absent. `get_type_size_from_core_type`
accepts them at 4 bytes, but `gen_field_read` has no arm for either — they
fall to its nested-custom-type branch and emit `bool_custom.get`, which does
not compile. They are unusable as record fields today, so claiming a layout
for them would describe a type that cannot exist. (Pre-existing inconsistency,
not touched here; noted in the code comment.)

## The gate

`sarek/tests/unit/ir_fields/test_ir_fields.ml` does **not** compare the mapping
against a second copy of the mapping — two copies of a wrong table agree
perfectly. It compares against the observable behaviour of the generated
`set`: write one field with an all-`0x7F` pattern into a zeroed element, and
require the dirtied byte indices to equal exactly
`[aos_offset, aos_offset + size)` as derived from `ir_fields` through
`Soa.plan`, plus `aos_stride = elem_size`. Both ends are independently derived.

Coverage is enumerated over the mapping's domain, not sampled: all six field
types as the sole field of a record (pins each width in isolation), every
ordered 4-byte/8-byte alignment pair (pins padding and offsets), two
multi-field records, and two withholding cases (nested record, variant).
16 cases.

## Proven red before trusted green

Four mutations, each restored afterwards:

| mutation | result | caught by |
|---|---|---|
| reverse `ir_fields` order | 8 FAIL — names the swapped pair (`Expected [("a_i32","TInt32");("b_i64","TInt64")]` / `Received` reversed) | the `ir_fields` equality |
| `scalar_size TFloat32 = 8` | 7 FAIL — **only** f32-bearing types, on `aos_stride = elem_size expected 4 got 8` | the stride check |
| drop field `align_up` padding | 5 FAIL | the layout module's own misalignment guard, **not** the byte probe |
| reverse `rl_leaves` only | 8 FAIL — `field 0 (b_i64) dirties bytes [8,16) / Expected [8..15] / Received [0;1;2;3]` | **the byte probe alone** |

The fourth is the one that matters. It has a correct stride, correct
alignment and a correct `ir_fields` — a pure transposition swap, exactly the
shape that produces silent wrong data — and only the byte probe sees it. The
third is recorded honestly: it goes red, but the credit belongs to
`Sarek_ir_layout`'s existing defensive guard, not to anything this PR adds.

Not added to `scripts/prove-red.sh`: every subject there is a standalone shell
script that runs in a copied scratch tree via `copy:`/`invoke:`. This subject
is a dune-built alcotest binary needing `_opam` and a full build, which that
harness cannot express.

## Construction sites

All seven were forced by the compiler (OCaml records have no field defaults):

| site | value |
|---|---|
| `Sarek_ppx.ml` record deriver | mapped list, or `None` if any field is unmappable |
| `Sarek_ppx.ml` variant deriver | `None` — a tagged union is not a flat record |
| `Sarek_tuple_vec.ml` `pair` | `Some fields` (already in scope) |
| `Sarek_tuple_vec.ml` `triple` | `Some fields` (already in scope) |
| `Native_plugin_base.ml` `alloc_custom` | `None` — placeholder, accessors raise |
| `Interpreter_plugin_base.ml` `alloc_custom` | `None` — placeholder, accessors raise |
| `test_execute.ml` hand-written `point` | `None` — hand-written `get`/`set` are not derived from a layout |

The design doc's §1 table named five and asserted the plugin sites were
unaffected ("`Kirc_kernel.ml:258` and `Native_plugin.ml:272` are `NA_Vec`/`NV`
literals, not `custom_type`"). It checked the wrong modules: the real
`custom_type` literals are in `Native_plugin_Base.ml` and
`Interpreter_plugin_Base.ml`, inside `alloc_custom`. Both are placeholder
descriptors whose accessors raise, so `None` is correct — but they are forced
sites the doc did not predict.

## Verification

- `dune build` clean; `dune build @fmt` clean.
- `test_ir_fields`: 16/16, executed on this host (CPU only — no device is
  involved in a host-layout test).
- Rebased on current `origin/main`. The rebase picked up `TUint8`
  (backlog-62 slice 3), which made this file fail to compile — the match is
  spelled out with no wildcard precisely so a new element type has to be
  considered rather than silently absorbed. Arm added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added layout metadata for custom, record, and tuple vector elements.
  * Supported record fields now expose their names and IR types in declaration order.
  * Unsupported layouts, such as nested records and variants, are clearly marked as unavailable.

* **Bug Fixes**
  * Improved consistency between reported element layouts and custom access behavior.

* **Tests**
  * Added coverage validating field metadata, alignment, element sizes, and generated data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->