### PR TITLE
fix(fusion): refuse to eliminate an array whose length is still used (backlog-153)

### DIFF
--- a/sarek-cuda.opam
+++ b/sarek-cuda.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-hip.opam
+++ b/sarek-hip.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-metal.opam
+++ b/sarek-metal.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-opencl.opam
+++ b/sarek-opencl.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-vulkan.opam
+++ b/sarek-vulkan.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek.opam
+++ b/sarek.opam
@@ -15,7 +15,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "spoc" {= version}
   "ppxlib" {>= "0.22.0"}
   "ctypes" {>= "0.24.0"}

--- a/sarek/sarek/Sarek_fusion.ml
+++ b/sarek/sarek/Sarek_fusion.ml
@@ -25,6 +25,18 @@ type access_pattern =
 type fusion_info = {
   reads : (string * access_pattern) list;  (** arrays read *)
   writes : (string * access_pattern) list;  (** arrays written *)
+  length_uses : string list;
+      (** Arrays whose LENGTH the kernel takes ([EArrayLen]), sorted and
+          deduplicated.
+
+          Separate from {!reads} on purpose. A length use is not an element
+          access — it has no index and therefore no {!access_pattern} — so
+          folding it into [reads] would either invent a pattern or corrupt the
+          real one: a body doing [temp[tid] + len(temp)] would stop looking
+          [OneToOne] and the element-wise fusion that IS legal there would be
+          lost. But it is still a reference to the array, and fusion's whole job
+          is deleting the array, so it has to be visible somewhere.
+          [backlog-153] is what happens when it is visible nowhere. *)
   has_barriers : bool;  (** contains barriers *)
   has_atomics : bool;  (** contains atomic ops *)
 }
@@ -62,7 +74,19 @@ let rec expr_uses_array arr expr =
   | ERecord (_, fields) ->
       List.exists (fun (_, e) -> expr_uses_array arr e) fields
   | EVariant (_, _, args) -> List.exists (expr_uses_array arr) args
-  | EArrayLen _ | EArrayCreate _ -> false
+  | EArrayLen a ->
+      (* [len(arr)] IS a use of [arr]: it compiles to the companion
+         [sarek_<arr>_length] launch argument, which exists only while [arr] is
+         a parameter. This case said [false] until backlog-153, which made this
+         predicate — the one that answers "may I delete this array?" — return
+         "no reference" for a body whose only surviving reference was a length.
+         Fusion believed it and dropped the parameter. *)
+      a = arr
+  | EArrayCreate (_, size, _) ->
+      (* The size expression is ordinary code and may read or measure [arr].
+         Recursing costs nothing and keeps this predicate CONSERVATIVE, which
+         is the only direction that is safe for a "may I delete this?" test. *)
+      expr_uses_array arr size
   | EConst _ | EVar _ -> false
   | EArrayReadExpr (base, idx) ->
       expr_uses_array arr base || expr_uses_array arr idx
@@ -320,6 +344,86 @@ let rec collect_reads_stmt acc stmt =
       | CM_store {index; stride; _} ->
           collect_reads_expr (collect_reads_expr acc index) stride)
 
+(** Collect the arrays whose LENGTH an expression takes.
+
+    Deliberately a separate traversal from {!collect_reads_expr} rather than an
+    extra case in it: that one returns [(array, index)] pairs feeding
+    {!analyze_pattern}, and a length use has no index. Giving it a fake one is
+    how a legal element-wise fusion would get misclassified as a gather. *)
+let rec collect_length_uses_expr acc expr =
+  match expr with
+  | EArrayLen arr -> arr :: acc
+  | EArrayRead (_, idx) -> collect_length_uses_expr acc idx
+  | EBinop (_, e1, e2) ->
+      collect_length_uses_expr (collect_length_uses_expr acc e1) e2
+  | EUnop (_, e) | ERecordField (e, _) | ECast (_, e) ->
+      collect_length_uses_expr acc e
+  | EIntrinsic (_, _, args) | EVariant (_, _, args) | ETuple args ->
+      List.fold_left collect_length_uses_expr acc args
+  | EApp (fn, args) ->
+      List.fold_left
+        collect_length_uses_expr
+        (collect_length_uses_expr acc fn)
+        args
+  | ERecord (_, fields) ->
+      List.fold_left
+        (fun acc (_, e) -> collect_length_uses_expr acc e)
+        acc
+        fields
+  | EArrayCreate (_, size, _) -> collect_length_uses_expr acc size
+  | EArrayReadExpr (base, idx) ->
+      collect_length_uses_expr (collect_length_uses_expr acc base) idx
+  | EIf (cond, then_, else_) ->
+      collect_length_uses_expr
+        (collect_length_uses_expr (collect_length_uses_expr acc cond) then_)
+        else_
+  | EMatch (e, cases) ->
+      List.fold_left
+        (fun acc (_, body) -> collect_length_uses_expr acc body)
+        (collect_length_uses_expr acc e)
+        cases
+  | EConst _ | EVar _ -> acc
+
+(** Collect the arrays whose length a statement takes. *)
+let rec collect_length_uses_stmt acc stmt =
+  match stmt with
+  | SAssign (LArrayElem (_, idx), e) ->
+      collect_length_uses_expr (collect_length_uses_expr acc idx) e
+  | SAssign (_, e) | SReturn e | SExpr e -> collect_length_uses_expr acc e
+  | SSeq stmts -> List.fold_left collect_length_uses_stmt acc stmts
+  | SIf (cond, s1, s2) ->
+      let acc =
+        collect_length_uses_stmt (collect_length_uses_expr acc cond) s1
+      in
+      Option.fold ~none:acc ~some:(collect_length_uses_stmt acc) s2
+  | SWhile (cond, body) ->
+      collect_length_uses_stmt (collect_length_uses_expr acc cond) body
+  | SFor (_, start, stop, _, body) ->
+      let acc =
+        collect_length_uses_expr (collect_length_uses_expr acc start) stop
+      in
+      collect_length_uses_stmt acc body
+  | SMatch (e, cases) ->
+      let acc = collect_length_uses_expr acc e in
+      List.fold_left
+        (fun acc (_, s) -> collect_length_uses_stmt acc s)
+        acc
+        cases
+  | SLet (_, e, body) | SLetMut (_, e, body) ->
+      collect_length_uses_stmt (collect_length_uses_expr acc e) body
+  | SPragma (_, body) | SBlock body -> collect_length_uses_stmt acc body
+  | SBarrier | SWarpBarrier | SMemFence | SEmpty | SNative _ -> acc
+  | SCoopmat op -> (
+      (* A coopmat load or store addresses its buffer through [index] and
+         [stride], which are ordinary expressions and may therefore take a
+         length. The buffer NAME is a use of the array rather than of its
+         length, so it belongs to [stmt_uses_array] and not here — the same
+         split [collect_reads_stmt] makes just above. *)
+      match op with
+      | CM_decl _ | CM_muladd _ -> acc
+      | CM_load {index; stride; _} | CM_store {index; stride; _} ->
+          collect_length_uses_expr (collect_length_uses_expr acc index) stride)
+
 (** Check if statement contains barriers *)
 let rec has_barrier stmt =
   match stmt with
@@ -410,6 +514,8 @@ let analyze (k : kernel) : fusion_info =
   {
     reads = List.map (fun arr -> (arr, analyze_pattern reads arr)) read_arrs;
     writes = List.map (fun arr -> (arr, analyze_pattern writes arr)) write_arrs;
+    length_uses =
+      List.sort_uniq compare (collect_length_uses_stmt [] k.kern_body);
     has_barriers = has_barrier k.kern_body;
     has_atomics = Sarek_ir_analysis.kernel_uses_atomics k;
   }
@@ -443,6 +549,65 @@ let rec find_write_expr stmt arr idx =
          that would reproduce it. [None] is the honest answer and stops the
          fusion attempt. *)
       None
+
+(** Does eliminating [intermediate] destroy a length either kernel still needs?
+
+    [len(arr)] lowers to the companion [sarek_<arr>_length] launch argument
+    ({!Sarek_ir_codegen.gen_param}), which every backend emits from the
+    PARAMETER list. Delete the parameter and the length is gone with it — there
+    is nothing left to substitute the expression with, because the value was
+    never in the IR, only in the launch. So a length use is not a fusion this
+    pass can perform more carefully; it is a fusion it must decline.
+
+    Both kernels are asked. The consumer is the obvious side, but the producer's
+    write expression is spliced verbatim into the consumer body, so a
+    [len(intermediate)] inside it lands in the fused kernel just the same.
+
+    [backlog-153]: before this, [analyze] could not see a length use at all, the
+    three [can_fuse*] guards therefore said yes, and the fused kernel named a
+    parameter that no longer existed. *)
+let length_of_intermediate_needed (producer : kernel) (consumer : kernel)
+    (intermediate : string) : bool =
+  let uses k =
+    List.mem
+      intermediate
+      (List.sort_uniq compare (collect_length_uses_stmt [] k.kern_body))
+  in
+  uses producer || uses consumer
+
+(** Reject a fused kernel that still names the array it was supposed to
+    eliminate.
+
+    A BACKSTOP, not the primary defence — {!length_of_intermediate_needed} and
+    the {!access_pattern} checks are what should keep us out of here. It exists
+    because the primary defence is a set of positive rules about shapes we
+    understand, and this is the negative statement of the actual contract: after
+    [fuse], [intermediate] is not a parameter, so no reference to it may remain
+    anywhere in the body.
+
+    It raises rather than returning the unfused consumer because reaching it
+    means an invariant the guards claim to enforce did not hold, and the
+    alternative to raising is what backlog-153 did: hand the caller a kernel
+    whose only remaining diagnosis is
+    [error: use of undeclared identifier 'sarek_temp_length'] from clang,
+    glslangValidator or naga — a name the author never wrote, in generated
+    source they never saw. *)
+let reject_if_intermediate_survives ~(fn : string) ~(intermediate : string)
+    (fused : kernel) : kernel =
+  if stmt_uses_array intermediate fused.kern_body then
+    Fusion_error.raise_error
+      (Fusion_error.Invalid_fusion
+         {
+           kernel = fused.kern_name;
+           reason =
+             Printf.sprintf
+               "%s eliminated the parameter '%s' but the fused body still \
+                references it; emitting this kernel would produce backend \
+                source naming a parameter that does not exist"
+               fn
+               intermediate;
+         })
+  else fused
 
 (** Check if two kernels can be fused via an intermediate array.
 
@@ -515,6 +680,7 @@ let can_fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
 
   prod_writes_inter && cons_reads_inter && patterns_ok && no_barriers
   && no_atomics && no_coopmat
+  && not (length_of_intermediate_needed producer consumer intermediate)
 
 (** Fuse producer into consumer, eliminating intermediate array.
 
@@ -621,16 +787,19 @@ let fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
               producer.kern_params
           in
 
-          {
-            kern_name = consumer.kern_name ^ "_fused";
-            kern_params = fused_params @ new_params;
-            kern_locals = consumer.kern_locals @ producer.kern_locals;
-            kern_body = fused_body;
-            kern_types = consumer.kern_types @ producer.kern_types;
-            kern_variants = consumer.kern_variants @ producer.kern_variants;
-            kern_funcs = consumer.kern_funcs @ producer.kern_funcs;
-            kern_native_fn = None;
-          })
+          reject_if_intermediate_survives
+            ~fn:"fuse"
+            ~intermediate
+            {
+              kern_name = consumer.kern_name ^ "_fused";
+              kern_params = fused_params @ new_params;
+              kern_locals = consumer.kern_locals @ producer.kern_locals;
+              kern_body = fused_body;
+              kern_types = consumer.kern_types @ producer.kern_types;
+              kern_variants = consumer.kern_variants @ producer.kern_variants;
+              kern_funcs = consumer.kern_funcs @ producer.kern_funcs;
+              kern_native_fn = None;
+            })
 
 (** {1 High-level interface} *)
 
@@ -783,6 +952,7 @@ let can_fuse_reduction (map_kernel : kernel) (reduce_kernel : kernel)
   map_writes_inter
   && Option.is_some reduce_reads_inter
   && no_barriers && no_atomics
+  && not (length_of_intermediate_needed map_kernel reduce_kernel intermediate)
 
 (** Fuse a map kernel into a reduction kernel, eliminating intermediate array.
 
@@ -868,17 +1038,20 @@ let fuse_reduction (map_kernel : kernel) (reduce_kernel : kernel)
               map_kernel.kern_params
           in
 
-          {
-            kern_name = reduce_kernel.kern_name ^ "_fused";
-            kern_params = fused_params @ new_params;
-            kern_locals = reduce_kernel.kern_locals @ map_kernel.kern_locals;
-            kern_body = fused_body;
-            kern_types = reduce_kernel.kern_types @ map_kernel.kern_types;
-            kern_variants =
-              reduce_kernel.kern_variants @ map_kernel.kern_variants;
-            kern_funcs = reduce_kernel.kern_funcs @ map_kernel.kern_funcs;
-            kern_native_fn = None;
-          })
+          reject_if_intermediate_survives
+            ~fn:"fuse_reduction"
+            ~intermediate
+            {
+              kern_name = reduce_kernel.kern_name ^ "_fused";
+              kern_params = fused_params @ new_params;
+              kern_locals = reduce_kernel.kern_locals @ map_kernel.kern_locals;
+              kern_body = fused_body;
+              kern_types = reduce_kernel.kern_types @ map_kernel.kern_types;
+              kern_variants =
+                reduce_kernel.kern_variants @ map_kernel.kern_variants;
+              kern_funcs = reduce_kernel.kern_funcs @ map_kernel.kern_funcs;
+              kern_native_fn = None;
+            })
 
 (** Try to fuse map+reduce, falling back to regular fusion if not applicable *)
 let try_fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
@@ -943,6 +1116,7 @@ let can_fuse_stencil (producer : kernel) (consumer : kernel)
   let no_atomics = (not prod_info.has_atomics) && not cons_info.has_atomics in
 
   prod_writes_inter && cons_stencil && no_barriers && no_atomics
+  && not (length_of_intermediate_needed producer consumer intermediate)
 
 (** Information about fused stencil *)
 type stencil_fusion_info = {
@@ -1134,16 +1308,19 @@ let fuse_stencil (producer : kernel) (consumer : kernel) (intermediate : string)
               producer.kern_params
           in
 
-          {
-            kern_name = consumer.kern_name ^ "_stencil_fused";
-            kern_params = fused_params @ new_params;
-            kern_locals = consumer.kern_locals @ producer.kern_locals;
-            kern_body = fused_body;
-            kern_types = consumer.kern_types @ producer.kern_types;
-            kern_variants = consumer.kern_variants @ producer.kern_variants;
-            kern_funcs = consumer.kern_funcs @ producer.kern_funcs;
-            kern_native_fn = None;
-          })
+          reject_if_intermediate_survives
+            ~fn:"fuse_stencil"
+            ~intermediate
+            {
+              kern_name = consumer.kern_name ^ "_stencil_fused";
+              kern_params = fused_params @ new_params;
+              kern_locals = consumer.kern_locals @ producer.kern_locals;
+              kern_body = fused_body;
+              kern_types = consumer.kern_types @ producer.kern_types;
+              kern_variants = consumer.kern_variants @ producer.kern_variants;
+              kern_funcs = consumer.kern_funcs @ producer.kern_funcs;
+              kern_native_fn = None;
+            })
 
 (** Enhanced try_fuse that includes stencil fusion *)
 let try_fuse_all (producer : kernel) (consumer : kernel) (intermediate : string)
@@ -1204,7 +1381,23 @@ let should_fuse (producer : kernel) (consumer : kernel) (intermediate : string)
      reason). *)
   if prod_info.has_atomics || cons_info.has_atomics then
     {decision = DontFuse; reason = "Atomic operation prevents fusion"}
-    (* Rule 1: Can't fuse if barriers present *)
+    (* Rule 0b: Can't fuse if either kernel takes len(intermediate) — the
+       length lives in the launch arguments, not the IR, so eliminating the
+       parameter destroys it (backlog-153). Checked up here for the same
+       reason Rule 0 is: [try_fuse] would decline anyway now that [can_fuse]
+       knows, but auto_fuse_pipeline_list would then record the reason from
+       whichever later rule matched — "Element-wise producer/consumer" for the
+       type case, which names the property that HELD rather than the one that
+       failed. *)
+  else if length_of_intermediate_needed producer consumer intermediate then
+    {
+      decision = DontFuse;
+      reason =
+        Printf.sprintf
+          "len(%s) is used, and the length of an eliminated array cannot be \
+           recovered"
+          intermediate;
+    } (* Rule 1: Can't fuse if barriers present *)
   else if prod_info.has_barriers || cons_info.has_barriers then
     {decision = DontFuse; reason = "Barrier prevents fusion"}
   else

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -70,12 +70,17 @@
  (modules test_cpu_runtime)
  (libraries sarek alcotest))
 
-; Fusion tests use sarek library directly (no ppx needed)
+; Fusion tests use sarek library directly (no ppx needed).
+;
+; sarek.codegen and str are for the backlog-153 cases: the defect there was
+; only OBSERVABLE in emitted backend source (a bare `sarek_temp_length` for a
+; parameter fusion had deleted), so the regression test asserts on generated
+; CUDA/OpenCL/Metal rather than on the IR alone.
 
 (test
  (name test_fusion)
  (modules test_fusion)
- (libraries sarek))
+ (libraries sarek sarek.codegen str))
 
 ; Interpreter tests removed - Sarek_interp was legacy SPOC-dependent
 

--- a/sarek/tests/unit/test_fusion.ml
+++ b/sarek/tests/unit/test_fusion.ml
@@ -1332,6 +1332,209 @@ let test_auto_fuse_pipeline_list_preserves_mismatched_indices () =
   Printf.printf
     "test_auto_fuse_pipeline_list_preserves_mismatched_indices: PASSED\n"
 
+(** {1 backlog-153: eliminating an array whose LENGTH is still used}
+
+    [len(arr)] does not live in the IR. It lowers to the companion
+    [sarek_<arr>_length] launch argument, which every backend emits from the
+    PARAMETER list, so deleting the parameter deletes the length with it and
+    there is no expression to substitute in its place.
+
+    Before the fix, [analyze] could not see a length use at all ([EArrayLen]
+    contributed to neither [reads] nor anything else), so a consumer body of the
+    form [output[tid] = temp[tid] + len(temp)] still looked purely [OneToOne] in
+    [temp]. [can_fuse] said yes, [fuse] dropped the [temp] parameter,
+    [subst_array_read] rewrote the element read and walked straight past the
+    [EArrayLen], and the fused kernel named a parameter that no longer existed.
+
+    The consequence was measured on this shape, on every backend:
+
+    - CUDA / OpenCL / Metal emitted the bare identifier [sarek_temp_length].
+      clang's OpenCL front end:
+      [error: use of undeclared identifier 'sarek_temp_length'].
+    - GLSL emitted it too; glslangValidator:
+      ['sarek_temp_length' : undeclared identifier].
+    - WGSL emitted [params.sarek_temp_length] against a [Params] struct with no
+      such field; naga: [invalid field accessor `sarek_temp_length`].
+    - PTX raised its own [unsupported construct: EArrayLen] refusal.
+    - The interpreter raised [Unbound_variable] from [get_array].
+
+    So the failure was LOUD on every path — a broken build, not a wrong answer,
+    and specifically not the silent wrong-width family. It is still worth
+    refusing at the fusion pass rather than at the vendor compiler: the name in
+    every one of those diagnostics is one the author never wrote, in generated
+    source they never saw, for an array the optimiser deleted. *)
+
+let len_producer =
+  mk_kernel
+    "producer"
+    (SAssign
+       ( LArrayElem ("temp", thread_idx_x),
+         EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l)) ))
+
+(* output[tid] = temp[tid] + len(temp) — an element read AND a length use of
+   the same array. The element read is what makes this fusable-looking; the
+   length use is what makes it unfusable. *)
+let len_consumer =
+  mk_kernel
+    "consumer"
+    (SAssign
+       ( LArrayElem ("output", thread_idx_x),
+         EBinop (Add, EArrayRead ("temp", thread_idx_x), EArrayLen "temp") ))
+
+(** [expr_uses_array] is the predicate that answers "may I delete this array?".
+    It returned [false] for [EArrayLen] — the root of backlog-153. *)
+let test_expr_uses_array_sees_length () =
+  assert (expr_uses_array "temp" (EArrayLen "temp")) ;
+  (* Still discriminating: a length of a DIFFERENT array is not a use. *)
+  assert (not (expr_uses_array "temp" (EArrayLen "other"))) ;
+  (* And it reaches a length nested in ordinary expression structure. *)
+  assert (
+    expr_uses_array "temp" (EBinop (Add, EConst (CInt32 1l), EArrayLen "temp"))) ;
+  assert (stmt_uses_array "temp" len_consumer.kern_body) ;
+  Printf.printf "test_expr_uses_array_sees_length: PASSED\n"
+
+(** [analyze] reports the length use, and does NOT let it corrupt the access
+    pattern — [temp] must still read as [OneToOne], because the reason to refuse
+    is the length, not a pretended gather. *)
+let test_analyze_reports_length_uses () =
+  let info = analyze len_consumer in
+  assert (info.length_uses = ["temp"]) ;
+  assert (
+    match List.assoc_opt "temp" info.reads with
+    | Some (OneToOne _) -> true
+    | _ -> false) ;
+  (* A kernel that takes no length reports none. *)
+  assert ((analyze len_producer).length_uses = []) ;
+  Printf.printf "test_analyze_reports_length_uses: PASSED\n"
+
+(** The three [can_fuse*] guards all refuse the shape. *)
+let test_can_fuse_refuses_length_use () =
+  assert (not (can_fuse len_producer len_consumer "temp")) ;
+  assert (not (can_fuse_stencil len_producer len_consumer "temp")) ;
+  (* And the producer side counts too: its write expression is spliced into
+     the consumer body verbatim, so a length there lands in the fused kernel
+     just the same. *)
+  let producer_takes_len =
+    mk_kernel
+      "producer_len"
+      (SAssign (LArrayElem ("temp", thread_idx_x), EArrayLen "temp"))
+  in
+  let plain_consumer =
+    mk_kernel
+      "consumer"
+      (SAssign
+         (LArrayElem ("output", thread_idx_x), EArrayRead ("temp", thread_idx_x)))
+  in
+  assert (not (can_fuse producer_takes_len plain_consumer "temp")) ;
+  (* Positive control: the same pair WITHOUT the length use still fuses, so
+     the guard is refusing the length and not the shape. *)
+  assert (can_fuse len_producer plain_consumer "temp") ;
+  Printf.printf "test_can_fuse_refuses_length_use: PASSED\n"
+
+(** [auto_fuse_pipeline_list] preserves both stages and names the real reason.
+*)
+let test_auto_fuse_preserves_length_user () =
+  let hint = should_fuse len_producer len_consumer "temp" in
+  assert (hint.decision = DontFuse) ;
+  assert (
+    hint.reason
+    = "len(temp) is used, and the length of an eliminated array cannot be \
+       recovered") ;
+  let pipeline, eliminated, skipped =
+    auto_fuse_pipeline_list [len_producer; len_consumer]
+  in
+  assert (kernel_names pipeline = ["producer"; "consumer"]) ;
+  assert (eliminated = []) ;
+  assert (skipped = [hint.reason]) ;
+  (* fuse_pipeline_list, which does not consult should_fuse, must refuse via
+     can_fuse alone. *)
+  let pipeline', eliminated' =
+    fuse_pipeline_list [len_producer; len_consumer]
+  in
+  assert (kernel_names pipeline' = ["producer"; "consumer"]) ;
+  assert (eliminated' = []) ;
+  Printf.printf "test_auto_fuse_preserves_length_user: PASSED\n"
+
+(** The backstop. [fuse] is public and documented as callable directly, so the
+    guards are not the only way in. Reaching it means an invariant the guards
+    claim to enforce did not hold, and the only alternative to raising is
+    handing back the kernel that produced those five vendor diagnostics. *)
+let test_fuse_rejects_surviving_intermediate () =
+  match fuse len_producer len_consumer "temp" with
+  | exception
+      Sarek.Fusion_error.Fusion_error
+        (Sarek.Fusion_error.Invalid_fusion {kernel; reason}) ->
+      assert (kernel = "consumer_fused") ;
+      (* The message must name the parameter, or it cannot be acted on. *)
+      assert (
+        let re = Str.regexp_string "'temp'" in
+        try
+          ignore (Str.search_forward re reason 0) ;
+          true
+        with Not_found -> false) ;
+      Printf.printf "test_fuse_rejects_surviving_intermediate: PASSED\n"
+  | _ ->
+      Printf.printf
+        "test_fuse_rejects_surviving_intermediate: FAILED (fuse returned a \
+         kernel that still references 'temp')\n" ;
+      assert false
+
+(** End-to-end, on the artefact that actually broke: no backend source may
+    mention [sarek_temp_length]. This is the assertion that pins the observable
+    defect rather than the internal predicate — it goes red on the unfixed pass
+    whatever route the regression takes back in. *)
+let test_no_backend_names_eliminated_length () =
+  let arr name id =
+    DParam
+      ( {
+          var_name = name;
+          var_id = id;
+          var_type = TVec TInt32;
+          var_mutable = true;
+        },
+        Some {arr_elttype = TInt32; arr_memspace = Global} )
+  in
+  let with_params k params = {k with kern_params = params} in
+  let producer = with_params len_producer [arr "input" 1; arr "temp" 2] in
+  let consumer = with_params len_consumer [arr "temp" 2; arr "output" 3] in
+  let pipeline, _, _ = auto_fuse_pipeline_list [producer; consumer] in
+  let mentions_dead_length src =
+    let re = Str.regexp_string "sarek_temp_length" in
+    try
+      ignore (Str.search_forward re src 0) ;
+      true
+    with Not_found -> false
+  in
+  List.iter
+    (fun k ->
+      let declares_temp =
+        List.exists
+          (function
+            | DParam (v, _) -> v.var_name = "temp"
+            | DShared (n, _, _) -> n = "temp"
+            | _ -> false)
+          k.kern_params
+      in
+      List.iter
+        (fun (label, src) ->
+          (* A kernel that still DECLARES temp may of course name its length;
+             a kernel that does not declare it must never do so. *)
+          if (not declares_temp) && mentions_dead_length src then begin
+            Printf.printf
+              "test_no_backend_names_eliminated_length: FAILED (%s source for \
+               %s names sarek_temp_length with no temp parameter)\n"
+              label
+              k.kern_name ;
+            assert false
+          end)
+        [
+          ("CUDA", Sarek_codegen.Sarek_ir_cuda.generate k);
+          ("OpenCL", Sarek_codegen.Sarek_ir_opencl.generate k);
+          ("Metal", Sarek_codegen.Sarek_ir_metal.generate k);
+        ])
+    pipeline ;
+  Printf.printf "test_no_backend_names_eliminated_length: PASSED\n"
+
 let () =
   Printf.printf "=== Fusion Unit Tests ===\n" ;
   test_expr_equal () ;
@@ -1370,4 +1573,11 @@ let () =
   test_auto_fuse_pipeline_list_preserves_dont_fuse () ;
   test_auto_fuse_pipeline_list_mixed_order () ;
   test_auto_fuse_pipeline_list_preserves_mismatched_indices () ;
+  Printf.printf "\n=== backlog-153: length of an eliminated array ===\n" ;
+  test_expr_uses_array_sees_length () ;
+  test_analyze_reports_length_uses () ;
+  test_can_fuse_refuses_length_use () ;
+  test_auto_fuse_preserves_length_user () ;
+  test_fuse_rejects_surviving_intermediate () ;
+  test_no_backend_names_eliminated_length () ;
   Printf.printf "=== All tests passed! ===\n"

--- a/spoc.opam
+++ b/spoc.opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "ctypes" {>= "0.24.0"}
   "bisect_ppx" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
`Sarek_fusion.fuse` removed the intermediate array from `kern_params` while leaving an `EArrayLen` naming it in the body, producing an IR node that referred to a parameter which no longer existed.

## What it actually emits, and therefore how serious it is

`len(arr)` does not live in the IR. It lowers to the companion `sarek_<arr>_length` launch argument that `Sarek_ir_codegen.gen_param` emits beside every vector parameter, so deleting the parameter deletes the length and there is nothing to substitute the expression with.

Reached through the fully-guarded public path — `auto_fuse_pipeline_list` on

```
producer: temp[tid]   = input[tid] * 2
consumer: output[tid] = temp[tid] + len(temp)
```

`can_fuse` returned `true`, `should_fuse` returned `Fuse ("Element-wise producer/consumer")`, and the fused kernel dropped `temp`. Measured on every backend:

| Backend | Emitted | Diagnostic |
|---|---|---|
| CUDA / OpenCL / Metal | bare `sarek_temp_length` | `clang -x cl`: `error: use of undeclared identifier 'sarek_temp_length'` |
| GLSL | same identifier | `glslangValidator`: `'sarek_temp_length' : undeclared identifier` |
| WGSL | `params.sarek_temp_length` against a `Params` struct with no such field | `naga`: ``invalid field accessor `sarek_temp_length` `` |
| PTX | — | its own `unsupported construct: EArrayLen` refusal |
| Interpreter | — | `Unbound_variable` from `get_array` |

**So the failure is LOUD on every path — a broken build, not a wrong answer, and specifically not the silent wrong-width family this campaign has hit before.** That lowers the severity from what was feared.

It is still worth refusing at the fusion pass: every one of those diagnostics names an identifier the author never wrote, in generated source they never saw, for an array the optimiser deleted.

## Root cause

`expr_uses_array` — the predicate that answers *"may I delete this array?"* — returned `false` for `EArrayLen`, and `analyze` collected length uses nowhere. A body whose only surviving reference was a length looked like no reference at all.

## The fix, at three levels

- **`expr_uses_array`** now reports `EArrayLen a` when `a = arr`, and recurses into an `EArrayCreate` size expression. It is a *may-I-delete* test, so it is conservative in the only safe direction.
- **`fusion_info.length_uses`**, collected by its own traversal rather than folded into `reads`: a length use has no index, and inventing one would make the legal element-wise fusion of `temp[tid] + len(temp)` misclassify as a gather. All three `can_fuse*` guards consult it, on **both** kernels — the producer's write expression is spliced into the consumer verbatim, so a length there lands in the fused kernel just the same. `should_fuse` gains Rule 0b so `auto_fuse_pipeline_list` reports the property that *failed* rather than the one that held, matching the existing Rule 0 precedent.
- **A backstop** in `fuse` / `fuse_reduction` / `fuse_stencil` that raises `Invalid_fusion` if the intermediate survives in the fused body. `fuse` is public and documented as callable directly, so the guards are not the only way in; and the backstop states the contract negatively, where the guards are positive rules about shapes we understand.

## Reds observed

Each mutation applied, rebuilt, and run:

- `expr_uses_array`'s `EArrayLen` case back to `false` → `test_expr_uses_array_sees_length`, `Assertion failed` at line 1388
- `analyze` stops collecting `length_uses` → `test_analyze_reports_length_uses`, `Assertion failed` at line 1404
- **both defences neutered**, so the pass behaves exactly as before this PR → `test_can_fuse_refuses_length_use`, `Assertion failed` at line 1415; and with the earlier cases removed so the assertion is reached, `test_no_backend_names_eliminated_length: FAILED (CUDA source for consumer_fused names sarek_temp_length with no temp parameter)`

The last is the load-bearing one: it asserts on generated CUDA/OpenCL/Metal, pinning the observable artefact rather than an internal predicate.

## Notes for the reviewer

- **Suite unchanged at 1676 / 116, 0 FAIL, 23 SKIP** — identical to the baseline measured on `eaf9d878`. Unchanged rather than +6 because `test_fusion` is a plain `(test ...)` executable, not an Alcotest suite, so `scripts/test-suite-counts.sh` has never counted its cases, old or new. It is still a real gate (dune fails on non-zero exit), just invisible to that counter.
- **`scripts/prove-red.sh`: no new subject, and coverage does not shrink.** Its subjects are standalone checker scripts invoked by argv over a copied scratch tree; these gates are test cases inside the dune build, which that mechanism cannot invoke. `prove-red.sh` still reports 4 subjects / 13 mutations / exit 0 on this branch.
- The rebase crossed a coopmat guard that landed on `can_fuse` in the meantime, for a neighbouring shape of the same defect (a `CM_load` left pointing at a dropped parameter). Both conjuncts are kept.

## Found while here, not fixed

**`Sarek_ir_glsl`'s `EArrayLen` is broken unconditionally, fusion or not.** It emits `sarek_<arr>_length` while the GLSL backend's own push constant is named `<arr>_len`. On an ordinary, unfused kernel with a live parameter:

```glsl
layout(push_constant) uniform PushConstants { int inputv_len; ... } pc;
#define inputv_len pc.inputv_len
void main() {
  outputv[int(gl_LocalInvocationID.x)] = sarek_inputv_length;   // undeclared
}
```

Same family — emitting a reference to a name that does not exist — but a separate backend defect with its own fix. Filing separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
