### PR TITLE
fix(execute): gate the interpreter oracle on what its evaluator implements (backlog-154)

### DIFF
--- a/sarek-cuda.opam
+++ b/sarek-cuda.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-hip.opam
+++ b/sarek-hip.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-metal.opam
+++ b/sarek-metal.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-opencl.opam
+++ b/sarek-opencl.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek-vulkan.opam
+++ b/sarek-vulkan.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "sarek" {= version}
   "ctypes" {>= "0.24.0"}
   "ctypes-foreign" {>= "0.24.0"}

--- a/sarek.opam
+++ b/sarek.opam
@@ -15,7 +15,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "spoc" {= version}
   "ppxlib" {>= "0.22.0"}
   "ctypes" {>= "0.24.0"}

--- a/sarek/core_js_exec/dune
+++ b/sarek/core_js_exec/dune
@@ -41,5 +41,10 @@
   Transfer_jsx
   Log_jsx
   Spoc_core
-  Sarek_ir_interp)
+  Sarek_ir_interp
+  ; backlog-154: Execute.ml (copied into jsoo/ verbatim) now applies the
+  ; interpreter's own capability gate, so the jsoo build needs the module that
+  ; states it. Pulled from ../interp/ by the copy_files above, like the rest of
+  ; the interpreter stack — one source, recompiled against the jsoo Spoc_core.
+  Sarek_interp_capability)
  (preprocess no_preprocessing))

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -541,6 +541,24 @@ let check_launch_args ~(kernel : string) (ir : Sarek_ir_types.kernel)
           ())
     args
 
+(** Render a non-permitting verdict and raise it as a [Backend_error].
+
+    Shared by {!check_device_capabilities} and {!check_interpreter_capabilities}
+    so the two launch gates cannot drift into describing the same refusal
+    differently — which is a real hazard here, since backlog-154 was two gates
+    disagreeing about the same kernel. *)
+let raise_capability_refusal ~(backend : string) ~(target : string)
+    (verdict : Sarek_capability.verdict) : 'a =
+  let message =
+    match verdict with
+    | Sarek_capability.Unavailable cap -> Sarek_capability.explain ~target cap
+    | Sarek_capability.Unknown why -> Printf.sprintf "%s: %s" target why
+    | Sarek_capability.Available ->
+        (* [first_refusal] returns only non-permitting verdicts. *)
+        assert false
+  in
+  Execute_error.raise_error (Backend_error {backend; message})
+
 (** Refuse a launch whose kernel needs a wide element type the target device
     does not provide (#142).
 
@@ -613,18 +631,40 @@ let check_device_capabilities ~(device : Device.t) (ir : Sarek_ir_types.kernel)
   with
   | None -> ()
   | Some verdict ->
-      let message =
-        match verdict with
-        | Sarek_capability.Unavailable cap ->
-            Sarek_capability.explain ~target:device.Device.name cap
-        | Sarek_capability.Unknown why ->
-            Printf.sprintf "%s: %s" device.Device.name why
-        | Sarek_capability.Available ->
-            (* [first_refusal] returns only non-permitting verdicts. *)
-            assert false
-      in
-      Execute_error.raise_error
-        (Backend_error {backend = device.Device.framework; message})
+      raise_capability_refusal
+        ~backend:device.Device.framework
+        ~target:device.Device.name
+        verdict
+
+(** The launch gate for {!run_interpreter_vectors} (backlog-154).
+
+    [run_interpreter_vectors] applied {!check_launch_args} and NOT
+    {!check_device_capabilities}, so the interpreter — the cross-backend numeric
+    oracle — was the one execution path with no capability gate on it. The
+    asymmetry was observable: in one run of [test_coopmat_integer_e2e] on this
+    workstation, [check_device_capabilities] printed
+    [launch gate refuses on CPU Interpreter (Sequential)] for the same kernel
+    [run_interpreter_vectors] then evaluated to 65536 bit-exact results.
+
+    Note what could NOT be done about that: calling {!check_device_capabilities}
+    here. It needs a [Device.t], this entry point has none by design, and — the
+    substantive half — the interpreter's [Framework_sig.capabilities] says
+    [coopmat = None], which means "not probed", which refuses. Wiring the device
+    gate in would have taken the oracle offline rather than closed a hole. The
+    bypass was load-bearing, which is why the fix is a capability answer for the
+    interpreter and not a call to someone else's.
+
+    {!Sarek_interp_capability} is that answer, and it lives beside the evaluator
+    that justifies it. See its interface for the argument about what an
+    interpreter should advertise. *)
+let check_interpreter_capabilities (ir : Sarek_ir_types.kernel) : unit =
+  match Sarek_interp_capability.first_refusal ir with
+  | None -> ()
+  | Some verdict ->
+      raise_capability_refusal
+        ~backend:"Interpreter"
+        ~target:"CPU Interpreter"
+        verdict
 
 (** Execute a kernel on a device using the unified dispatch mechanism.
 
@@ -894,6 +934,11 @@ let run_interpreter_vectors ~(ir : Sarek_ir_types.kernel)
      renamed or dropped arguments on an arity mismatch (it falls back to
      "param%d") instead of reporting it. *)
   check_launch_args ~kernel:ir.Sarek_ir_types.kern_name ir args ;
+  (* The capability half of the same discipline (backlog-154). Placed next to
+     check_launch_args because the two together are what the three [run]
+     dispatch paths apply, and this entry point had only the first. See
+     {!check_interpreter_capabilities}. *)
+  check_interpreter_capabilities ir ;
   (* Set interpreter parallel mode *)
   Sarek_ir_interp.parallel_mode := parallel ;
   (* Convert vector args to interpreter format, tracking arrays for writeback *)

--- a/sarek/interp/Sarek_interp_capability.ml
+++ b/sarek/interp/Sarek_interp_capability.ml
@@ -1,0 +1,80 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** See Sarek_interp_capability.mli for what this claims and why. *)
+
+let device_features =
+  [
+    Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64; Sarek_ir_analysis.Float16;
+  ]
+
+let float_coopmat_refused (c : Sarek_coopmat.component_type) :
+    Sarek_capability.t =
+  {
+    Sarek_capability.cap_name =
+      "coopmat-" ^ Sarek_coopmat.component_name c ^ "-accumulation";
+    cap_kind = Sarek_capability.Policy;
+    cap_why =
+      "the interpreter is a strict oracle and float cooperative-matrix \
+       accumulation has no single right answer to be strict about: \
+       SPV_KHR_cooperative_matrix leaves the order of the k+1 additions to the \
+       implementation";
+    cap_evidence =
+      Sarek_capability.Quoted
+        "SPV_KHR_cooperative_matrix, cooperative-matrix design document 5.1";
+    cap_remedy =
+      Some
+        "use an integer configuration, whose accumulation the specification \
+         states is exact at the precision of the result type, or compare the \
+         float path across devices without an interpreter oracle";
+  }
+
+(* Not [List.exists] over an enumerated config list: the interpreter holds the
+   whole matrix in every invocation, so the shape is unconstrained and the set
+   is infinite. Only the component types decide. *)
+let coopmat_verdict (cfg : Sarek_coopmat.config) : Sarek_capability.verdict =
+  let components =
+    [
+      cfg.Sarek_coopmat.cfg_a;
+      cfg.Sarek_coopmat.cfg_b;
+      cfg.Sarek_coopmat.cfg_c;
+      cfg.Sarek_coopmat.cfg_result;
+    ]
+  in
+  match
+    List.find_opt
+      (fun c -> not (Sarek_coopmat.component_is_integer c))
+      components
+  with
+  | Some c -> Sarek_capability.Unavailable (float_coopmat_refused c)
+  | None -> Sarek_capability.Available
+
+(* [Coopmat] is a [Sarek_ir_analysis.feature] but it is NOT a width, and
+   judging it by list membership the way the other three are judged is wrong in
+   both directions: absent from [device_features] it refuses every cooperative
+   matrix including the integer ones this evaluator computes, and present it
+   permits the float ones it refuses. It is decided per CONFIGURATION, by
+   {!coopmat_verdict}. [Execute.check_device_capabilities] draws the same line —
+   its [gated] list is widths only and its coopmat verdicts are a separate
+   list — and this partition is written as an exhaustive match rather than a
+   filter so that a fifth feature is a compile error here, not a silently
+   ungated capability. *)
+let is_width_feature = function
+  | Sarek_ir_analysis.Float64 | Sarek_ir_analysis.Float16
+  | Sarek_ir_analysis.Int64 ->
+      true
+  | Sarek_ir_analysis.Coopmat -> false
+
+let first_refusal (ir : Sarek_ir_types.kernel) : Sarek_capability.verdict option
+    =
+  let provided = Some device_features in
+  let required =
+    List.filter
+      (fun f -> is_width_feature f && Sarek_ir_analysis.kernel_uses f ir)
+      Sarek_ir_analysis.all_features
+  in
+  Sarek_capability.first_refusal
+    (List.map (Sarek_capability.device_verdict ~provided) required
+    @ List.map coopmat_verdict (Sarek_ir_analysis.kernel_coopmat_configs ir))

--- a/sarek/interp/Sarek_interp_capability.mli
+++ b/sarek/interp/Sarek_interp_capability.mli
@@ -1,0 +1,147 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** What the INTERPRETER provides, stated by the evaluator that provides it
+    (backlog-154).
+
+    {1 The defect this exists to close}
+
+    [Execute.check_device_capabilities] is applied on all three [Execute.run]
+    dispatch paths. [Execute.run_interpreter_vectors] — the entry point the
+    cross-backend numeric oracle actually goes through — did not apply it. The
+    two answers disagreed, and the disagreement was observed on this
+    workstation, in one run of [test_coopmat_integer_e2e]:
+
+    {v
+      OK  launch gate refuses on CPU Interpreter (Sequential)
+      OK  launch gate refuses on CPU Interpreter (Parallel, 32 cores)
+      ...
+      OK  16 tiles, all 65536 u8 operand pairs, bit-identical to the interpreter
+    v}
+
+    The gate refuses the Interpreter for the very kernel the interpreter then
+    computes 65536 correct results for. The refusal is not wrong on its own
+    terms: [Framework_sig.capabilities.coopmat] is [None] for this backend,
+    {!Sarek_coopmat.verdict} maps [None] to {!Sarek_capability.Unknown}, and
+    [Unknown] does not permit. Every step is the capability model working as
+    designed.
+
+    What that means is worth stating plainly, because it is the actual finding:
+    {b the bypass is load-bearing.} The oracle is reachable only because the
+    second entry point skips the gate. Adding the gate to
+    [run_interpreter_vectors] without first fixing what the interpreter
+    ADVERTISES would not close a hole, it would break the oracle.
+
+    {1 What an interpreter should advertise}
+
+    Neither of the two obvious answers survives.
+
+    [Unknown] — the status quo — is wrong. [Unknown] means "we could not probe".
+    For hardware that is an honest confession, and refusing on it is right. For
+    an interpreter there is nothing to probe: the answer is in the evaluator,
+    and reading the evaluator IS the probe. Reporting [Unknown] for a question
+    whose answer is in the same repository is not conservatism; it is declining
+    to answer, and here it declines on behalf of the one backend every numeric
+    claim in the project is checked against.
+
+    "Supports everything" is wrong too, and not only in principle. It is
+    factually false: {!Sarek_ir_interp_eval.coopmat_refuse_float} refuses float
+    cooperative-matrix accumulation, and refuses it for a reason —
+    [SPV_KHR_cooperative_matrix] leaves the order of the k+1 additions to the
+    implementation, so there is no single value a strict oracle could compare
+    against. An interpreter that claimed everything would validate the backends
+    against shapes it cannot evaluate and configurations no device offers.
+
+    The rule that survives both is:
+    {b an interpreter advertises exactly what its evaluator implements, as a
+       by-construction measurement of that evaluator, and never as "unprobed".}
+    It is falsifiable — every claim below names the code that makes it true — it
+    cannot over-claim, and it never refuses something the oracle can actually
+    do.
+
+    {1 Why this is a predicate and not a [device_support] record}
+
+    {!Framework_sig.capabilities.coopmat} models support as a finite
+    [ds_configs] list, which is the right shape for hardware: a device
+    enumerates what it advertises, and
+    [vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR] hands you the list.
+
+    The interpreter is not enumerable. Every invocation holds the whole matrix
+    ({!Sarek_ir_interp_value.env}.[coopmats]), so it evaluates integer
+    configurations at ANY shape — an infinite set that no [ds_configs] can
+    state. That mismatch, and not an oversight, is why [coopmat = None] was the
+    only available answer at the plugin: the record could not express the truth,
+    so it expressed nothing.
+
+    Hence a predicate. This is a general observation about the capability model
+    rather than a fact about cooperative matrices, and it is written down here
+    because the same wall is waiting for the Native backend and for any future
+    software target. *)
+
+(** The wide element types the interpreter evaluates.
+
+    Every entry is [By_construction] — point at the code:
+
+    - [Float64]: OCaml floats are binary64; [VFloat64] carries them unchanged.
+    - [Int64]: [Int64.t] is native; [VInt64] carries it unchanged.
+    - [Float16]: {!Sarek_float16} implements binary16 round-to-nearest-even, and
+      [Sarek_ir_interp.interp_array_to_vector] rounds the writeback through a
+      [Bigarray.Float16] cell so "cast then store" and "store" agree.
+
+    {b [Float16] is the second instance of the same gap}, and it is already
+    loaded. [Interpreter_plugin_base] and [Native_plugin_base] both report
+    [device_features = [Float64; Int64]], omitting an f16 they both implement.
+    Nothing refuses today only because [Execute.check_device_capabilities]
+    excludes [Float16] from its [gated] list — deliberately, and for an
+    unrelated reason (no backend probes shaderFloat16 yet). The day that list
+    widens with the f16 probe, [run] will refuse an f16 kernel on the
+    Interpreter that [run_interpreter_vectors] runs correctly: coopmat's defect
+    exactly, in a second capability, waiting on a change already planned. *)
+val device_features : Sarek_ir_analysis.feature list
+
+(** [coopmat_verdict cfg] judges a cooperative-matrix configuration against the
+    interpreter's evaluator.
+
+    [Available] for integer component types at any shape:
+    [SPV_KHR_cooperative_matrix] states integer accumulation is exact at the
+    precision of the result type, so a strict oracle has a single right answer
+    to give.
+
+    {!Sarek_capability.Unavailable} for any float component type, with
+    [cap_kind = Policy]: the interpreter could produce a plausible number, and
+    refuses to, because the specification leaves the addition order to the
+    implementation. [Policy] rather than [Backend_structural] is the honest kind
+    — this is a decision about what an oracle may claim, revisable by a
+    decision, not a property of OCaml. It mirrors
+    {!Sarek_ir_interp_eval.coopmat_refuse_float}, which is where a kernel that
+    slips past this gate lands anyway; the difference is that this one fires
+    before any partial writeback, and names the capability. *)
+val coopmat_verdict : Sarek_coopmat.config -> Sarek_capability.verdict
+
+(** [first_refusal ir] is the first capability [ir] requires that the
+    interpreter does not provide, or [None] when it provides all of them.
+
+    Written in terms of {!Sarek_capability.permits} so an [Unknown] cannot leak
+    through as permitted.
+
+    The WIDTH features ([Float64], [Float16], [Int64]) are judged against
+    {!device_features}, all three of them — which is safe HERE, and not in
+    [Execute.check_device_capabilities], precisely because {!device_features} is
+    a by-construction claim about this evaluator rather than an unwritten device
+    probe. That is why the interpreter gate can be stricter than the device gate
+    instead of looser.
+
+    [Coopmat] is a {!Sarek_ir_analysis.feature} too but is deliberately NOT
+    judged that way: it is decided per configuration by {!coopmat_verdict}.
+    Treating it as a boolean is wrong in both directions — absent, it refuses
+    the integer matrices this evaluator computes; present, it permits the float
+    ones it refuses. Both were observed while writing this: gating it by
+    membership made the integer positive control fail with
+    [the device advertises no cooperative-matrix support].
+
+    Returns a verdict rather than raising: the caller renders and raises through
+    its own error type, so the diagnostic reads the same whichever entry point
+    produced it. *)
+val first_refusal : Sarek_ir_types.kernel -> Sarek_capability.verdict option

--- a/sarek/interp/dune
+++ b/sarek/interp/dune
@@ -16,6 +16,7 @@
   Sarek_ir_interp_intrinsics
   Sarek_ir_interp_eval
   Sarek_ir_interp
+  Sarek_interp_capability
   Sarek_type_helpers
   Interp_error)
  (preprocess no_preprocessing)

--- a/sarek/plugins/interpreter/Interpreter_plugin_base.ml
+++ b/sarek/plugins/interpreter/Interpreter_plugin_base.ml
@@ -216,8 +216,14 @@ end = struct
         shared_mem_per_block = 1024 * 1024;
         total_global_mem = Int64.of_int (16 * 1024 * 1024 * 1024);
         compute_capability = (0, 0);
-        (* Host execution: OCaml floats are binary64 and Int64.t is native. *)
-        device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+        (* Read from the evaluator's own declaration rather than restated here
+           (backlog-154). It said [Float64; Int64], omitting the [Float16] that
+           Sarek_float16 implements and that interp_array_to_vector rounds
+           through a Bigarray.Float16 cell on writeback — an under-claim that
+           was harmless only because check_device_capabilities excludes Float16
+           from its gated list, for an unrelated reason. Sharing the list is
+           what stops a declaration and its evaluator drifting again. *)
+        device_features = Sarek_interp.Sarek_interp_capability.device_features;
         (* backlog-62: no cooperative-matrix probe on this backend. [None] is
            "not probed", which Sarek_coopmat.verdict maps to Unknown and therefore
            refuses; an empty list would be a positive claim nobody measured. *)

--- a/sarek/plugins/interpreter/dune
+++ b/sarek/plugins/interpreter/dune
@@ -9,6 +9,9 @@
   spoc_framework
   spoc_framework_registry
   sarek
+  ; backlog-154: the capability list this plugin reports is the evaluator's own
+  ; declaration, not a restatement of it.
+  sarek_interp
   (re_export spoc_core))
  (modules Interpreter_error Interpreter_plugin_base Interpreter_plugin)
  (preprocess no_preprocessing))

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -61,7 +61,18 @@
  ; ctypes is listed explicitly (not relied on transitively via sarek): the
  ; GC-root canary in test_float16 asserts the managed-vs-unmanaged asymmetry
  ; of the f16 host pointer directly, so it names Ctypes/Ctypes_bigarray.
- (libraries sarek_ppx_lib sarek_stdlib sarek alcotest ppxlib str ctypes)
+ ; sarek.interp: test_execute drives Sarek_interp_capability directly — the
+ ; interpreter's own launch gate (backlog-154), which is not reachable through
+ ; the Sarek.Execute surface.
+ (libraries
+  sarek_ppx_lib
+  sarek_stdlib
+  sarek
+  sarek.interp
+  alcotest
+  ppxlib
+  str
+  ctypes)
  (preprocess
   (pps ppxlib.metaquot)))
 

--- a/sarek/tests/unit/test_execute.ml
+++ b/sarek/tests/unit/test_execute.ml
@@ -267,12 +267,196 @@ let test_float64_refused_without_device_support () =
   | Some msg ->
       check bool "diagnostic names float64" true (contains_sub msg "float64")
 
+(** {1 The interpreter's own capability gate (backlog-154)}
+
+    [run_interpreter_vectors] applied [check_launch_args] and no capability
+    gate, so the cross-backend numeric ORACLE was the one execution path with
+    none. The asymmetry was visible in a single run of
+    [test_coopmat_integer_e2e] on this workstation: [check_device_capabilities]
+    refused the Interpreter device for a kernel that [run_interpreter_vectors]
+    then evaluated to 65536 bit-exact results.
+
+    These cases drive [Sarek_interp_capability] directly rather than through
+    [run_interpreter_vectors], which needs live vectors; the property under test
+    is entirely the kernel/capability pair. The e2e coopmat suite covers the
+    wired path.
+
+    Read {!Sarek_interp_capability} for the argument about what an interpreter
+    should advertise. In one line: what its evaluator implements, stated by
+    construction — never "unprobed", and never everything. *)
+
+let interp_refusal ir =
+  Option.map
+    (fun v ->
+      match v with
+      | Sarek_capability.Unavailable cap ->
+          Sarek_capability.explain ~target:"CPU Interpreter" cap
+      | Sarek_capability.Unknown why -> why
+      | Sarek_capability.Available -> fail "first_refusal returned Available")
+    (Sarek_interp.Sarek_interp_capability.first_refusal ir)
+
+let coopmat_kernel (comp : Sarek_coopmat.component_type) : Sarek_ir_types.kernel
+    =
+  let open Sarek_ir_types in
+  let shape = {Sarek_coopmat.m = 16; n = 16; k = 16} in
+  let cfg =
+    {
+      Sarek_coopmat.cfg_shape = shape;
+      cfg_a = comp;
+      cfg_b = comp;
+      cfg_c = Sarek_coopmat.Sint32;
+      cfg_result = Sarek_coopmat.Sint32;
+      cfg_saturating = false;
+      cfg_scope = Sarek_coopmat.Subgroup;
+    }
+  in
+  {
+    kern_name = "interp_coopmat_probe";
+    kern_params = [];
+    kern_locals = [];
+    kern_body =
+      SCoopmat (CM_muladd {dst = "fd"; a = "fa"; b = "fb"; c = "fc"; cfg});
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(* THE POSITIVE CONTROL, and it is the load-bearing one. A gate observed only
+   refusing is indistinguishable from one that refuses unconditionally — and
+   refusing unconditionally is exactly what the DEVICE gate does to the
+   interpreter (coopmat = None -> Unknown), which is the defect. This case is
+   the assertion that the new gate did not simply reproduce it. *)
+let test_interp_permits_integer_coopmat () =
+  match interp_refusal (coopmat_kernel Sarek_coopmat.Uint8) with
+  | None -> ()
+  | Some msg ->
+      fail
+        (Printf.sprintf
+           "the interpreter evaluates integer cooperative matrices \
+            (Sarek_ir_interp_eval.exec_coopmat) and is the oracle the GPU \
+            backends are compared against, yet its own gate refused: %s"
+           msg)
+
+(* And it still refuses what the evaluator refuses — at the launch gate now,
+   rather than from inside exec_coopmat after a partial writeback. *)
+let test_interp_refuses_float_coopmat () =
+  match interp_refusal (coopmat_kernel Sarek_coopmat.Float16) with
+  | None ->
+      fail
+        "float cooperative-matrix accumulation has no single right answer \
+         (SPV_KHR_cooperative_matrix leaves the addition order to the \
+         implementation), so a strict oracle must refuse it"
+  | Some msg ->
+      check bool "diagnostic names f16" true (contains_sub msg "f16") ;
+      check
+        bool
+        "diagnostic names the interpreter"
+        true
+        (contains_sub msg "CPU Interpreter")
+
+(* The second instance of the same gap, and the reason this is not a
+   coopmat-specific fix. Both plugins reported [Float64; Int64], omitting an
+   f16 they implement; nothing refused only because check_device_capabilities
+   excludes Float16 from its gated list for an unrelated reason. The
+   interpreter gate DOES gate f16, against its own by-construction claim, so
+   this assertion has teeth: drop Float16 from device_features and it goes
+   red. *)
+let test_interp_declares_float16 () =
+  check
+    bool
+    "the interpreter advertises the f16 that Sarek_float16 implements"
+    true
+    (List.mem
+       Sarek_ir_analysis.Float16
+       Sarek_interp.Sarek_interp_capability.device_features) ;
+  match interp_refusal (kernel_over Sarek_ir_types.TFloat16) with
+  | None -> ()
+  | Some msg -> fail ("an f16 kernel must reach the interpreter: " ^ msg)
+
+(* THE GATE MUST BE WIRED, not merely correct.
+
+   Every case above drives Sarek_interp_capability directly, and every one of
+   them stays green if the call in run_interpreter_vectors is deleted — which
+   is the whole defect restored. That is the "unwired declaration" shape: a
+   checker that is right about everything and consulted by nobody. This case is
+   the only one that goes red on that deletion, so it is the one that actually
+   pins backlog-154.
+
+   It also pins WHICH error: before the gate, this kernel reached
+   Sarek_ir_interp_eval.coopmat_refuse_float from inside the evaluation, after
+   the run had begun and could have written back. Now it is refused at the
+   launch gate, as an Execute Backend_error, before anything runs. *)
+let test_run_interpreter_vectors_is_gated () =
+  match
+    run_interpreter_vectors
+      ~ir:(coopmat_kernel Sarek_coopmat.Float16)
+      ~args:[]
+      ~block:(dims1d 1)
+      ~grid:(dims1d 1)
+      ~parallel:false
+  with
+  | () ->
+      fail
+        "run_interpreter_vectors ran a float cooperative-matrix kernel: the \
+         interpreter capability gate is not wired into the oracle entry point \
+         (backlog-154)"
+  | exception
+      Sarek.Execute_error.Execution_error
+        (Sarek.Execute_error.Backend_error {backend; message}) ->
+      check string "refused as the Interpreter backend" "Interpreter" backend ;
+      check
+        bool
+        "diagnostic names the capability"
+        true
+        (contains_sub message "coopmat")
+  | exception e ->
+      fail
+        ("expected the launch gate's Backend_error, got a deeper failure — \
+          which means the kernel started running: " ^ Printexc.to_string e)
+
+(* The gate is not vacuous on the feature axis either: a feature the
+   interpreter does NOT provide is refused. Uses a deliberately-emptied
+   provided-list through the same code path the real one uses. *)
+let test_interp_feature_gate_can_refuse () =
+  match
+    Sarek_capability.device_verdict
+      ~provided:(Some [Sarek_ir_analysis.Int64])
+      Sarek_ir_analysis.Float64
+  with
+  | Sarek_capability.Available ->
+      fail "device_verdict permitted a feature absent from the provided list"
+  | _ -> ()
+
 (** {1 Test suite} *)
 
 let () =
   run
     "Execute"
     [
+      ( "interpreter_capability_gate",
+        [
+          test_case
+            "integer coopmat permitted (positive control)"
+            `Quick
+            test_interp_permits_integer_coopmat;
+          test_case
+            "float coopmat refused at the launch gate"
+            `Quick
+            test_interp_refuses_float_coopmat;
+          test_case
+            "f16 declared and permitted"
+            `Quick
+            test_interp_declares_float16;
+          test_case
+            "feature gate can refuse"
+            `Quick
+            test_interp_feature_gate_can_refuse;
+          test_case
+            "run_interpreter_vectors is gated (the wiring)"
+            `Quick
+            test_run_interpreter_vectors_is_gated;
+        ] );
       ( "device_capability_gate",
         [
           test_case

--- a/spoc.opam
+++ b/spoc.opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/mathiasbourgoin/Sarek"
 bug-reports: "https://github.com/mathiasbourgoin/Sarek/issues"
 depends: [
   "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.15"}
+  "dune" {>= "3.15" & >= "3.15"}
   "ctypes" {>= "0.24.0"}
   "bisect_ppx" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
`Execute.check_device_capabilities` runs on all three `Execute.run` dispatch paths. `Execute.run_interpreter_vectors` — the entry point the cross-backend numeric oracle goes through — applied `check_launch_args` and no capability gate at all.

## The asymmetry, observed

One run of `test_coopmat_integer_e2e` on this workstation prints both halves:

```
OK  launch gate refuses on CPU Interpreter (Sequential)
OK  launch gate refuses on CPU Interpreter (Parallel, 32 cores)
...
OK  16 tiles, all 65536 u8 operand pairs, bit-identical to the interpreter
```

The gate refuses the Interpreter for the very kernel the interpreter then computes 65536 correct results for. Every step of that refusal is the capability model working as designed: `capabilities.coopmat = None`, `Sarek_coopmat.verdict` maps `None` to `Unknown`, and `Unknown` does not permit.

Which makes the finding sharper than "a gate was missing":

> **The bypass is load-bearing.** The oracle is reachable *only* because the second entry point skips the gate. Wiring `check_device_capabilities` into `run_interpreter_vectors` would not have closed a hole — it would have taken the oracle offline.

So the interpreter had to be given an honest capability answer first.

## What an interpreter should advertise

Neither obvious answer survives.

**`Unknown` — the status quo — is wrong.** `Unknown` means *"we could not probe"*. For hardware that is an honest confession and refusing on it is right. For an interpreter there is nothing to probe: the answer is in the evaluator, and reading the evaluator *is* the probe. Reporting `Unknown` for a question whose answer is in the same repository is not conservatism, it is declining to answer — on behalf of the one backend every numeric claim in the project is checked against.

**"Supports everything" is wrong too, and not merely unwise — it is factually false.** `Sarek_ir_interp_eval.coopmat_refuse_float` refuses float cooperative-matrix accumulation, and refuses it *for a reason*: `SPV_KHR_cooperative_matrix` leaves the order of the k+1 additions to the implementation, so there is no single value a strict oracle could compare against. An interpreter claiming everything would validate the backends against shapes it cannot evaluate and configurations no device offers.

**The rule that survives both:**

> An interpreter advertises **exactly what its evaluator implements**, as a by-construction measurement of that evaluator, and never as "unprobed".

Falsifiable — every claim names the code that makes it true — it cannot over-claim, and it never refuses something the oracle can actually do.

`Sarek_interp_capability` states it, beside the evaluator that justifies it: `Float64`, `Int64` and `Float16` as widths, and cooperative matrices **per configuration** — integer permitted at any shape, float refused as `Policy` with the specification citation. `run_interpreter_vectors` consults it next to `check_launch_args`, and the Interpreter plugin now reads `device_features` from it so a declaration and its evaluator cannot drift apart again.

`Coopmat` is a `Sarek_ir_analysis.feature` but is deliberately **not** judged as one: as a boolean it is wrong in both directions, and both were observed while writing this. The partition is an exhaustive match, so a fifth feature is a compile error rather than a silently ungated capability.

## Yes, the gap is broader than coopmat — and the second instance is already loaded

`Interpreter_plugin_base` and `Native_plugin_base` both reported `device_features = [Float64; Int64]`, omitting an f16 they both implement (`Sarek_float16` does binary16 round-to-nearest-even; the writeback rounds through a `Bigarray.Float16` cell).

Nothing refuses today **only** because `check_device_capabilities` excludes `Float16` from its `gated` list — deliberately, and for an unrelated reason (no backend probes `shaderFloat16` yet). The day that list widens with the f16 probe, `run` will refuse an f16 kernel on the Interpreter that `run_interpreter_vectors` runs correctly: coopmat's defect exactly, in a second capability, waiting on a change that is already planned.

This PR corrects the Interpreter's declaration. Native's is named, not touched.

There is a third, already documented in `Execute.ml`: an f16 kernel could not run on the Interpreter *device* at all, "even though `test_hip_f16` passes: that test uses `run_interpreter_vectors`, which bypasses this path". Same bypass, third capability.

## What is deliberately NOT closed

As a **device**, the Interpreter still reports `coopmat = None`, so `run ~device:interpreter` still refuses an integer coopmat kernel that the oracle path now permits.

`Framework_sig` models support as a finite `ds_configs` list — the right shape for hardware, which enumerates. The interpreter holds the whole matrix per invocation, so it accepts **any** shape: an infinite set no list can state. That mismatch, not an oversight, is why `coopmat = None` was the only available answer at the plugin — the record could not express the truth, so it expressed nothing.

Closing that half needs predicate-valued device support, a capability-model change rather than a plugin edit, and it collides with in-flight coopmat work. Named here rather than left in folklore.

## Reds observed

Each mutation applied, rebuilt, run:

- **delete the `check_interpreter_capabilities` call** from `run_interpreter_vectors` → `"run_interpreter_vectors is gated"`: `expected the launch gate's Backend_error, got a deeper failure — which means the kernel started running: Sarek_interp.Interp_error.Interpreter_error(_)` (which also records the pre-fix behaviour: the refusal came from *inside* the evaluation, after the run had begun)
- **drop `Float16`** from `device_features` → `"f16 declared and permitted"` FAIL
- **make `coopmat_verdict` always `Available`** → `"float coopmat refused at the launch gate"` FAIL and the wiring case FAIL
- **judge `Coopmat` by list membership** (the first implementation) → `"integer coopmat permitted"` FAIL: `...yet its own gate refused: CPU Interpreter: cooperative-matrix unavailable...`

The **positive control** is the load-bearing case: a gate seen only refusing is indistinguishable from one that refuses unconditionally — which is precisely what the device gate does to the interpreter. And the **wiring** case is the only one of the five that goes red when the call is deleted; the other four stay green, which is the "unwired declaration" shape.

## Notes for the reviewer

- **Suite, rebased onto `eaf9d878`: 1681 / 116, 0 FAIL, 23 SKIP.** Baseline measured on that same commit: **1676 / 116**, 0 FAIL, 23 SKIP. The difference is exactly the five new cases.
- **`scripts/prove-red.sh`: no new subject, and coverage does not shrink.** Its subjects are standalone checker scripts invoked by argv over a copied scratch tree; these gates are Alcotest cases inside the dune build, which that mechanism cannot invoke. `prove-red.sh` still reports 4 subjects / 13 mutations / exit 0 on this branch.
- `sarek/core_js_exec/dune` gains the new module because `Execute.ml` is copied into the jsoo build verbatim; it is pulled from `../interp/` by the existing `copy_files`, so there is still one source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
