### PR TITLE
fix(codegen): route every public emission entry point through generate_with_types (backlog-155)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,8 +106,13 @@
   `Metal_plugin.generate_source` now take a required `~types`; the OpenCL
   backend's own `generate_source` was two hand-kept copies of "typedefs +
   pragma" and now calls `generate_with_fp64` so the two cannot diverge again.
-  Guarded by `test_typedef_entry_points`, each assertion paired with a control
-  against the typedef-less emitter so it cannot pass vacuously (backlog-155).
+  Guarded by `test_typedef_entry_points` (OpenCL + transpiler) and
+  `test_metal_plugin_entry_points` (the Metal entry point, which is only
+  callable from `sarek-metal/test` because `sarek_metal` is an optional
+  library). Every marker pair is checked for ORDER, not presence — a typedef
+  emitted BELOW the code that uses it satisfies a substring check and no
+  compiler — and each assertion is paired with a control against the
+  typedef-less emitter so it cannot pass vacuously (backlog-155).
 - `Sarek_df64` silently ran at plain float32 precision on real NVIDIA
   hardware (CUDA/PTX and NVIDIA OpenCL): `ptxas` contracted the multiply in
   `two_prod` into the `add`/`sub` of the `quick_two_sum` closing `df64_mul`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,22 @@
 
 ### Fixed
 
+- Three public emission entry points routed to a backend's typedef-less
+  `generate` instead of `generate_with_types`, so a kernel carrying a
+  `[@@sarek.type]` record emitted source naming struct types that were never
+  declared. The one with real reach is `Sarek_transpile.of_source` — the whole
+  public transpiler API, all five backends — which emitted
+  `point p = (point){1.0f, 2.0f};` with no `typedef struct {…} point;` anywhere
+  above it, on CUDA, OpenCL, Metal, GLSL and WGSL alike. The other two are
+  `Sarek_ir_opencl.generate_with_fp64` (re-exported as
+  `Opencl_plugin.generate_with_fp64`) and `Metal_plugin.generate_source`, a
+  top-level alias of `Sarek_ir_metal.generate` under the same name as the
+  runtime path that does use `generate_with_types`. `generate_with_fp64` and
+  `Metal_plugin.generate_source` now take a required `~types`; the OpenCL
+  backend's own `generate_source` was two hand-kept copies of "typedefs +
+  pragma" and now calls `generate_with_fp64` so the two cannot diverge again.
+  Guarded by `test_typedef_entry_points`, each assertion paired with a control
+  against the typedef-less emitter so it cannot pass vacuously (backlog-155).
 - `Sarek_df64` silently ran at plain float32 precision on real NVIDIA
   hardware (CUDA/PTX and NVIDIA OpenCL): `ptxas` contracted the multiply in
   `two_prod` into the `add`/`sub` of the `quick_two_sum` closing `df64_mul`,

--- a/sarek-metal/Metal_plugin.ml
+++ b/sarek-metal/Metal_plugin.ml
@@ -277,5 +277,11 @@ let find_intrinsic = Metal_intrinsics.find
 (** Generate Metal source with custom types *)
 let generate_with_types = Sarek_ir_metal.generate_with_types
 
-(** Generate Metal source for a kernel *)
-let generate_source = Sarek_ir_metal.generate
+(** Generate Metal source for a kernel.
+
+    Takes [~types] (normally [ir.kern_types]) and routes through
+    {!Sarek_ir_metal.generate_with_types}, same as the backend's own
+    [Backend.generate_source]. It used to alias {!Sarek_ir_metal.generate},
+    which emits no record typedefs and no variant definitions — under a name
+    that reads exactly like the runtime path it was NOT (backlog-155). *)
+let generate_source ~types ir = Sarek_ir_metal.generate_with_types ~types ir

--- a/sarek-metal/test/dune
+++ b/sarek-metal/test/dune
@@ -14,3 +14,15 @@
  (name test_metal_compile_options)
  (modules test_metal_compile_options)
  (libraries sarek_metal alcotest))
+
+; backlog-155: Metal_plugin.generate_source used to alias the typedef-less
+; Sarek_ir_metal.generate. It has no caller outside its own file, so this is
+; the only place its signature is type-checked against a use and the only
+; place its routing is executed. sarek_metal is (optional) and only linkable
+; from this directory, which is why the Metal case is not in
+; sarek/tests/unit/test_typedef_entry_points.ml with the others.
+
+(test
+ (name test_metal_plugin_entry_points)
+ (modules test_metal_plugin_entry_points)
+ (libraries sarek_metal sarek_ir alcotest))

--- a/sarek-metal/test/test_metal_plugin_entry_points.ml
+++ b/sarek-metal/test/test_metal_plugin_entry_points.ml
@@ -1,0 +1,146 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** [Metal_plugin.generate_source] must declare the record types it uses
+    (backlog-155).
+
+    This is the Metal half of [sarek/tests/unit/test_typedef_entry_points.ml],
+    and it lives here rather than there for a mechanical reason: [sarek_metal]
+    is an [(optional)] library and the only place in the tree that links it is
+    [sarek-metal/test], so this is the only directory from which the entry point
+    can be CALLED.
+
+    That mattered more than it sounds. [Metal_plugin.ml:287] used to be
+    [let generate_source = Sarek_ir_metal.generate] — a top-level alias of the
+    typedef-less emitter, under the same name as [Backend.generate_source] in
+    the module above it, which does route through [generate_with_types]. When
+    the alias was replaced by a [~types]-taking function, the change compiled
+    with nothing to check it: [generate_source] at that line has ZERO callers
+    outside its own file, so neither the new signature nor the new routing was
+    exercised by anything. A signature change that no call site type-checks
+    against, and a routing change that no test executes, are both free.
+
+    Same shape as the OpenCL/transpiler file: the declaration marker must appear
+    BEFORE the use marker (a typedef emitted below the code that needs it is
+    invalid Metal all the same), and each assertion is paired with a control
+    against [Sarek_ir_metal.generate] so it cannot pass vacuously. *)
+
+open Sarek_metal
+open Sarek_ir_types
+
+let index_of haystack needle =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i =
+    if i + nl > hl then None
+    else if String.sub haystack i nl = needle then Some i
+    else go (i + 1)
+  in
+  if nl = 0 then Some 0 else go 0
+
+let contains haystack needle = index_of haystack needle <> None
+
+let check_declared_before_use ~ctx ~decl ~use src =
+  match (index_of src decl, index_of src use) with
+  | _, None ->
+      Alcotest.failf
+        "%s: the body never uses the type (marker %S), so this case proves \
+         nothing. Emitted source:\n\
+         %s"
+        ctx
+        use
+        src
+  | None, Some _ ->
+      Alcotest.failf
+        "%s: emitted source uses the type but never declares it (missing \
+         marker %S). Emitted source:\n\
+         %s"
+        ctx
+        decl
+        src
+  | Some d, Some u ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s: declaration %S is at offset %d but the use %S is at offset %d \
+            — the declaration must come FIRST, this source is rejected by any \
+            compiler. Emitted source:\n\
+            %s"
+           ctx
+           decl
+           d
+           use
+           u
+           src)
+        true
+        (d < u)
+
+let make_var name ty =
+  {var_id = 0; var_name = name; var_type = ty; var_mutable = false}
+
+let point_types = [("point", [("x", TFloat32); ("y", TFloat32)])]
+
+let point_kernel () =
+  let out = make_var "out" (TVec TFloat32) in
+  let p = make_var "p" (TRecord ("point", List.assoc "point" point_types)) in
+  {
+    kern_name = "k";
+    kern_params = [DParam (out, None)];
+    kern_locals = [DLocal (p, None)];
+    kern_body =
+      SSeq
+        [
+          SAssign
+            ( LArrayElem ("out", EConst (CInt32 0l)),
+              EBinop
+                (Add, ERecordField (EVar p, "x"), ERecordField (EVar p, "y")) );
+        ];
+    kern_types = point_types;
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let typedef_line = "} point;"
+
+let record_use = "point p"
+
+let test_generate_source_declares_records () =
+  let src = Metal_plugin.generate_source ~types:point_types (point_kernel ()) in
+  check_declared_before_use
+    ~ctx:"Metal_plugin.generate_source"
+    ~decl:typedef_line
+    ~use:record_use
+    src
+
+(** POSITIVE CONTROL: [Sarek_ir_metal.generate] is what [generate_source] used
+    to alias. The same declaration check must come out FALSE against it, while
+    the USE marker is still there — that pairing is what shows the emitted
+    source really did name an undeclared struct type. *)
+let test_plain_generate_omits_records () =
+  let src = Sarek_ir_metal.generate (point_kernel ()) in
+  Alcotest.(check bool)
+    "control: bare `generate` uses the record"
+    true
+    (contains src record_use) ;
+  Alcotest.(check bool)
+    "control: bare `generate` emits no typedef, so the check discriminates"
+    false
+    (contains src typedef_line)
+
+let () =
+  Alcotest.run
+    "metal_plugin_entry_points"
+    [
+      ( "generate_source",
+        [
+          Alcotest.test_case
+            "declares record typedefs, above the use"
+            `Quick
+            test_generate_source_declares_records;
+          Alcotest.test_case
+            "control: bare generate does not"
+            `Quick
+            test_plain_generate_omits_records;
+        ] );
+    ]

--- a/sarek-opencl/Opencl_plugin.ml
+++ b/sarek-opencl/Opencl_plugin.ml
@@ -189,13 +189,11 @@ module Backend : Framework_sig.BACKEND = struct
       returning [None]. *)
   let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
       string option =
-    let source = Sarek_ir_opencl.generate_with_types ~types:ir.kern_types ir in
-    (* Add FP64 pragma if kernel uses double precision *)
-    let source =
-      if Sarek_ir_analysis.kernel_uses_float64 ir then
-        "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\n" ^ source
-      else source
-    in
+    (* The runtime path and the public [generate_with_fp64] re-export below are
+       now the SAME function. They used to be two hand-kept copies of "typedefs
+       + pragma", and the copy behind the re-export had lost the typedefs
+       (backlog-155). One emitter means the divergence cannot recur. *)
+    let source = Sarek_ir_opencl.generate_with_fp64 ~types:ir.kern_types ir in
     Spoc_core.Log.debug Kernel ("OpenCL source:\n" ^ source) ;
     Some source
 
@@ -300,5 +298,9 @@ let find_intrinsic = Opencl_intrinsics.find
 (** Generate OpenCL source with custom types *)
 let generate_with_types = Sarek_ir_opencl.generate_with_types
 
-(** Generate OpenCL source with FP64 extension if needed *)
+(** Generate OpenCL source with the FP64 extension pragma if needed. Takes
+    [~types] (normally [ir.kern_types]) — see
+    {!Sarek_ir_opencl.generate_with_fp64} for why the label is required rather
+    than optional. This is the exact function the backend's own
+    [generate_source] runs. *)
 let generate_with_fp64 = Sarek_ir_opencl.generate_with_fp64

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -1202,9 +1202,24 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
 
   Buffer.contents buf
 
-(** Generate OpenCL source with double precision extension if needed *)
-let generate_with_fp64 (k : kernel) : string =
-  let source = generate k in
+(** Generate OpenCL source with the double-precision extension pragma if the
+    kernel needs it.
+
+    [types] is REQUIRED and not defaulted on purpose. This function used to
+    delegate to {!generate}, which emits no record typedefs and no variant
+    definitions, so a kernel carrying a [[@@sarek.type]] record produced OpenCL
+    C referring to struct types that were never declared (backlog-155). An
+    optional [?types] defaulting to [[]] would have reproduced that silent drop
+    at every call site that forgot it; a required label makes the caller name
+    what it is emitting. Pass [~types:k.kern_types] unless you have a reason not
+    to.
+
+    The pragma is orthogonal to type emission: this is exactly
+    {!generate_with_types} with a prefix, and it is the single OpenCL emission
+    entry point that composes the two. *)
+let generate_with_fp64 ~(types : (string * (string * elttype) list) list)
+    (k : kernel) : string =
+  let source = generate_with_types ~types k in
   if Sarek_ir_analysis.kernel_uses_float64 k then
     "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\n" ^ source
   else source

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -563,18 +563,20 @@ let test_deferred_backends_reject_f16 () =
       ~expected_reason:reason_opencl
       (label ^ "/opencl generate_with_types")
       (fun () -> Sarek_ir_opencl.generate_with_types ~types:k.kern_types k) ;
-    (* OpenCL has a THIRD public entry point. It delegates to [generate], so it
-       is covered transitively today — but "covered transitively" is exactly how
-       this repo's previous guard holes were argued, and THIS refusal is what
-       keeps Sarek's f16 narrowing away from IGC, where the ACO barrier is
-       measured to BREAK a correct narrowing (4774/63488, Intel Arc /
-       Meteor Lake-P, docs/fp-contraction-policy.md §11.4). Asserted directly so
-       a future non-delegating implementation cannot reopen it. *)
+    (* OpenCL has a THIRD public entry point. It delegates to
+       [generate_with_types] (it delegated to [generate] until backlog-155, and
+       so emitted no record typedefs), so it is covered transitively today — but
+       "covered transitively" is exactly how this repo's previous guard holes
+       were argued, and THIS refusal is what keeps Sarek's f16 narrowing away
+       from IGC, where the ACO barrier is measured to BREAK a correct narrowing
+       (4774/63488, Intel Arc / Meteor Lake-P,
+       docs/fp-contraction-policy.md §11.4). Asserted directly so a future
+       non-delegating implementation cannot reopen it. *)
     expect_f16_rejected
       ~backend:"OpenCL"
       ~expected_reason:reason_opencl
       (label ^ "/opencl generate_with_fp64")
-      (fun () -> Sarek_ir_opencl.generate_with_fp64 k) ;
+      (fun () -> Sarek_ir_opencl.generate_with_fp64 ~types:k.kern_types k) ;
     (* GLSL's Backend_error tag is "Vulkan" (that is the framework name). *)
     expect_f16_rejected
       ~tag:"Vulkan"

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -189,6 +189,24 @@
  (modules test_opencl_gate)
  (libraries sarek.codegen spoc.ir opencl_gate alcotest str unix))
 
+; backlog-155: every public emission entry point that accepts a kernel carrying
+; kern_types must declare those records, not silently route to the typedef-less
+; `generate`. Covers OpenCL's third entry point (generate_with_fp64) and the
+; whole public transpiler surface (all five backends). Each assertion is paired
+; with a control against the typedef-less emitter so it cannot pass vacuously.
+; CPU-only, no device.
+
+(test
+ (name test_typedef_entry_points)
+ (modules test_typedef_entry_points)
+ (libraries
+  sarek.codegen
+  sarek.transpile
+  sarek_stdlib
+  sarek_stdlib_meta
+  spoc.ir
+  alcotest))
+
 ; Negative controls for the Metal validation gate (#139). Layer 2 (xcrun metal)
 ; cannot run outside macOS, so layer 1 (address-space text check) is the only
 ; cover on the machines this code is written on — these cases are the proof it

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -190,11 +190,16 @@
  (libraries sarek.codegen spoc.ir opencl_gate alcotest str unix))
 
 ; backlog-155: every public emission entry point that accepts a kernel carrying
-; kern_types must declare those records, not silently route to the typedef-less
-; `generate`. Covers OpenCL's third entry point (generate_with_fp64) and the
-; whole public transpiler surface (all five backends). Each assertion is paired
-; with a control against the typedef-less emitter so it cannot pass vacuously.
-; CPU-only, no device.
+; kern_types/kern_variants must declare those types ABOVE the code using them,
+; not silently route to the typedef-less `generate`. Covers OpenCL's third
+; entry point (generate_with_fp64, records AND variants) and the whole public
+; transpiler surface — of_source on all five backends plus of_source_with_abi,
+; which is a second emission path and not a wrapper over the first. Every
+; marker pair is checked for ORDER, not presence: a typedef emitted below its
+; use passes a `contains` check and no compiler. Each assertion is paired with
+; a control against the typedef-less emitter so it cannot pass vacuously.
+; Metal's entry point is covered in sarek-metal/test — sarek_metal is
+; (optional) and not linkable from here. CPU-only, no device.
 
 (test
  (name test_typedef_entry_points)

--- a/sarek/tests/unit/test_typedef_entry_points.ml
+++ b/sarek/tests/unit/test_typedef_entry_points.ml
@@ -322,6 +322,81 @@ let test_transpile_declares_records () =
         src)
     transpile_cases
 
+(* ------------------------------------------------------------------ *)
+(* The transpiler's OpenCL arm: the fp64 pragma, not just the typedefs *)
+(* ------------------------------------------------------------------ *)
+
+(** [Sarek_transpile.emit_backend]'s OpenCL arm was fixed to
+    [generate_with_types] along with the other four, which restored the typedefs
+    and left the fp64 pragma still missing — [generate_with_fp64] is the entry
+    point that composes both, and nothing on the transpile path added the pragma
+    anywhere (grep for `cl_khr` over Sarek_transpile.ml returned nothing).
+
+    That a float64 kernel REACHES that arm is the thing this pair pins. It is
+    not obvious: the transpiler could plausibly have refused fp64 upstream, at
+    the typer or the lowering, in which case the pragma would be dead code and
+    the arm's choice would not matter. It does not refuse — the first case here
+    fails at [transpile_ocl] rather than at an assertion if that ever changes,
+    and the message says so.
+
+    The float32 control is the falsifier. Without it, "the output contains the
+    pragma" is also satisfied by prefixing every OpenCL kernel unconditionally,
+    which would be a different bug (a pragma naming an extension the program
+    does not use, on every float32 kernel the transpiler emits). *)
+
+let fp64_kernel_src =
+  "fun (a : float64 vector) (b : float64 vector) ->\n\
+  \  let i = global_thread_id in\n\
+  \  b.(i) <- a.(i) +. a.(i)"
+
+let f32_kernel_src =
+  "fun (a : float32 vector) (b : float32 vector) ->\n\
+  \  let i = global_thread_id in\n\
+  \  b.(i) <- a.(i) +. a.(i)"
+
+let fp64_pragma = "#pragma OPENCL EXTENSION cl_khr_fp64 : enable"
+
+let transpile_ocl ~ctx src =
+  match Sarek_transpile.of_source Sarek_transpile.OpenCL src with
+  | Ok s -> s
+  | Error e ->
+      Alcotest.failf
+        "%s: transpile failed, so this case proves nothing: %s"
+        ctx
+        (Sarek_transpile.string_of_error e)
+
+let test_transpile_opencl_fp64_emits_pragma () =
+  let src = transpile_ocl ~ctx:"transpiler/OpenCL fp64" fp64_kernel_src in
+  (* Vacuity guard: if the emitted kernel does not actually use `double`, the
+     pragma assertion below is about a kernel that never needed it. *)
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "the fp64 kernel really does emit `double` — otherwise the pragma check \
+        is vacuous. Emitted source:\n\
+        %s"
+       src)
+    true
+    (contains src "double") ;
+  (* Order matters as much as presence: an extension pragma below the code that
+     uses the extension enables nothing. *)
+  check_declared_before_use
+    ~ctx:"transpiler/OpenCL fp64"
+    ~decl:fp64_pragma
+    ~use:"double"
+    src
+
+let test_transpile_opencl_float32_omits_pragma () =
+  let src = transpile_ocl ~ctx:"transpiler/OpenCL float32" f32_kernel_src in
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "control: a float32 kernel must NOT carry the fp64 pragma — the prefix \
+        is conditional on the kernel using float64, not unconditional. Emitted \
+        source:\n\
+        %s"
+       src)
+    false
+    (contains src fp64_pragma)
+
 let () =
   Alcotest.run
     "typedef_entry_points"
@@ -355,5 +430,13 @@ let () =
             "of_source and of_source_with_abi declare records before using them"
             `Quick
             test_transpile_declares_records;
+          Alcotest.test_case
+            "of_source OpenCL enables cl_khr_fp64 above the first `double`"
+            `Quick
+            test_transpile_opencl_fp64_emits_pragma;
+          Alcotest.test_case
+            "control: a float32 kernel gets no fp64 pragma"
+            `Quick
+            test_transpile_opencl_float32_omits_pragma;
         ] );
     ]

--- a/sarek/tests/unit/test_typedef_entry_points.ml
+++ b/sarek/tests/unit/test_typedef_entry_points.ml
@@ -3,40 +3,118 @@
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 
-(** Every public emission entry point must declare the record types it uses
-    (backlog-155).
+(** Every public emission entry point must declare the record types and variant
+    types it uses, ABOVE the code that uses them (backlog-155).
 
     Each backend has a [generate] that emits the kernel body but NO record
     typedefs and no variant definitions, and a [generate_with_types] that emits
     both. [generate] is not wrong — it is the "I have no custom types" emitter.
     What is wrong is a PUBLIC entry point that accepts a kernel carrying
-    [kern_types] and quietly routes to [generate], because the result is source
-    that names struct types nobody declared. That had happened in three places:
+    [kern_types]/[kern_variants] and quietly routes to [generate], because the
+    result is source that names struct types nobody declared. That had happened
+    in three places:
 
     - [Sarek_ir_opencl.generate_with_fp64] (re-exported as
       [Opencl_plugin.generate_with_fp64]) delegated to [generate];
     - [Metal_plugin.generate_source] aliased [Sarek_ir_metal.generate], under a
-      name identical to the runtime path that does use [generate_with_types];
-    - [Sarek_transpile.of_source] — the whole public transpiler API — emitted
-      through [generate] for all five backends, even though [conv_kernel]
-      faithfully carries [kern_types] across.
+      name identical to the runtime path that does use [generate_with_types] —
+      covered by [sarek-metal/test/test_metal_plugin_entry_points.ml], which is
+      where the [sarek_metal] library is linkable;
+    - [Sarek_transpile.of_source] AND [of_source_with_abi] — the whole public
+      transpiler API — emitted through [generate], even though [conv_kernel]
+      faithfully carries [kern_types]/[kern_variants] across.
 
-    Each case below asserts the typedef IS emitted, and is paired with a
-    positive control asserting the typedef-less emitter does NOT emit it. The
-    control is what makes the assertion falsifiable: without it, a check for a
-    substring in a large generated blob could be passing for any reason. *)
+    THREE THINGS THIS FILE DOES THAT THE FIRST VERSION OF IT DID NOT, each added
+    because a mutation of the fixed code left the first version GREEN:
+
+    1. ORDER, NOT PRESENCE. Every marker pair is checked with
+    [check_declared_before_use], which fails unless the DECLARATION's offset is
+    strictly below the USE's. Presence alone is not a gate: moving the typedef
+    block of [Sarek_ir_opencl.generate_with_types] from the prologue to the
+    epilogue — emitting [point p = (point){…}] above [} point;], which no OpenCL
+    C compiler accepts — left the presence-only version of this file green, exit
+    0, 4 cases OK.
+
+    2. [of_source_with_abi] HAS ITS OWN ROW. Starving its [~types] argument
+    ([~types:[]] rather than [ir_kernel.kern_types]) changed nothing in the
+    whole 1701-case suite: the ABI entry point was reached by no test at all, so
+    making the label required bought coverage nowhere.
+
+    3. A VARIANT-CARRYING FIXTURE. Every fixture here used to have
+    [kern_variants = []], so the "and no variant definitions" half of the
+    sentence above was not falsifiable by anything in this file — the
+    [grep-absent] shape, where a test's prose is wider than its assertions.
+    [Sarek_ir_opencl.generate_with_types] also sets [current_variants] from
+    [k.kern_variants], which is the binding source for [SMatch], so a variant
+    fixture is cheap and load-bearing.
+
+    Each positive assertion is paired with a control asserting the typedef-less
+    emitter does NOT emit the declaration. The control is what makes the
+    assertion falsifiable: without it, a check for a substring in a large
+    generated blob could be passing for any reason. *)
 
 open Sarek_ir_types
 module Ocl = Sarek_codegen.Sarek_ir_opencl
 
 let () = Sarek_stdlib_meta.force_init ()
 
-let contains haystack needle =
+(** Offset of the first occurrence of [needle], or [None]. Offsets — not a
+    boolean — because the defect this file exists to catch is an ORDERING one
+    and [contains] cannot see it. *)
+let index_of haystack needle =
   let nl = String.length needle and hl = String.length haystack in
   let rec go i =
-    i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1))
+    if i + nl > hl then None
+    else if String.sub haystack i nl = needle then Some i
+    else go (i + 1)
   in
-  nl = 0 || go 0
+  if nl = 0 then Some 0 else go 0
+
+let contains haystack needle = index_of haystack needle <> None
+
+(** The assertion this whole file is built on: [decl] must be present, [use]
+    must be present, and [decl] must come FIRST.
+
+    All three legs are load-bearing and each fails with its own message.
+    - no [use]: the body never mentions the type, so declaring it would prove
+      nothing and the [decl] leg would be vacuous;
+    - no [decl]: the entry point routed to the typedef-less emitter — the
+      original backlog-155 defect;
+    - [use] before [decl]: the declaration is emitted, but below the code that
+      needs it, which is invalid source just the same. *)
+let check_declared_before_use ~ctx ~decl ~use src =
+  match (index_of src decl, index_of src use) with
+  | _, None ->
+      Alcotest.failf
+        "%s: the body never uses the type (marker %S), so this case proves \
+         nothing. Emitted source:\n\
+         %s"
+        ctx
+        use
+        src
+  | None, Some _ ->
+      Alcotest.failf
+        "%s: emitted source uses the type but never declares it (missing \
+         marker %S). Emitted source:\n\
+         %s"
+        ctx
+        decl
+        src
+  | Some d, Some u ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s: declaration %S is at offset %d but the use %S is at offset %d \
+            — the declaration must come FIRST, this source is rejected by any \
+            compiler. Emitted source:\n\
+            %s"
+           ctx
+           decl
+           d
+           use
+           u
+           src)
+        true
+        (d < u)
 
 let make_var name ty =
   {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
@@ -66,7 +144,39 @@ let point_kernel () =
     kern_native_fn = None;
   }
 
+(** The variant counterpart. [kern_types] is empty here on purpose: this fixture
+    exercises the [kern_variants] arm of [generate_with_types] on its own, so
+    deleting only that arm is red here and the record cases stay green. *)
+let shape_constrs = [("Circle", [TFloat32]); ("Square", [])]
+
+let variant_kernel () =
+  let out = make_var "out" (TVec (TVariant ("shape", shape_constrs))) in
+  {
+    kern_name = "kv";
+    kern_params = [DParam (out, None)];
+    kern_locals = [];
+    kern_body =
+      SAssign
+        ( LArrayElem ("out", EConst (CInt32 0l)),
+          EVariant ("shape", "Circle", [EConst (CFloat32 1.0)]) );
+    kern_types = [];
+    kern_variants = [("shape", shape_constrs)];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
 let typedef_line = "} point;"
+
+let record_use = "point p"
+
+let variant_typedef_line = "} shape;"
+
+(* Deliberately NOT the bare constructor name: [gen_variant_def] emits the
+   constructor's DEFINITION (`static inline shape make_shape_Circle(`) as part
+   of the declaration block, so a bare `make_shape_Circle` would be found
+   inside the declaration itself and the ordering check would hold vacuously.
+   The `= ` prefix pins the CALL in the kernel body. *)
+let variant_use = "= make_shape_Circle("
 
 (* ------------------------------------------------------------------ *)
 (* OpenCL: the third entry point                                       *)
@@ -75,10 +185,11 @@ let typedef_line = "} point;"
 let test_opencl_fp64_emits_typedefs () =
   Ocl.current_variants := [] ;
   let src = Ocl.generate_with_fp64 ~types:point_types (point_kernel ()) in
-  Alcotest.(check bool)
-    "generate_with_fp64 must declare the record it uses"
-    true
-    (contains src typedef_line)
+  check_declared_before_use
+    ~ctx:"generate_with_fp64, record"
+    ~decl:typedef_line
+    ~use:record_use
+    src
 
 (** POSITIVE CONTROL for the assertion above: [generate] is the typedef-less
     emitter, so the same check must come out FALSE against it. If this ever
@@ -88,9 +199,40 @@ let test_opencl_plain_generate_omits_typedefs () =
   Ocl.current_variants := [] ;
   let src = Ocl.generate (point_kernel ()) in
   Alcotest.(check bool)
+    "control: bare `generate` uses the record"
+    true
+    (contains src record_use) ;
+  Alcotest.(check bool)
     "control: bare `generate` emits no typedef, so the check discriminates"
     false
     (contains src typedef_line)
+
+(** The other half of the sentence at the top of this file: [generate] emits no
+    VARIANT definitions either, and [generate_with_fp64] must. Without this
+    case, deleting the [kern_variants] arm of [generate_with_types] left every
+    assertion in this file green, because every other fixture has
+    [kern_variants = []]. *)
+let test_opencl_fp64_emits_variant_defs () =
+  Ocl.current_variants := [] ;
+  let src = Ocl.generate_with_fp64 ~types:[] (variant_kernel ()) in
+  check_declared_before_use
+    ~ctx:"generate_with_fp64, variant"
+    ~decl:variant_typedef_line
+    ~use:variant_use
+    src
+
+(** Control for the variant case, same shape as the record one. *)
+let test_opencl_plain_generate_omits_variant_defs () =
+  Ocl.current_variants := [] ;
+  let src = Ocl.generate (variant_kernel ()) in
+  Alcotest.(check bool)
+    "control: bare `generate` calls the variant constructor"
+    true
+    (contains src variant_use) ;
+  Alcotest.(check bool)
+    "control: bare `generate` emits no variant definition"
+    false
+    (contains src variant_typedef_line)
 
 (** The pragma is the other half of what [generate_with_fp64] is for; assert it
     is still composed on top of the type-aware body, not lost in the rewiring.
@@ -118,7 +260,7 @@ let test_opencl_fp64_still_emits_the_pragma () =
     (contains src typedef_line)
 
 (* ------------------------------------------------------------------ *)
-(* The transpiler: same gap, five backends, no plugin involved         *)
+(* The transpiler: same gap, five backends + the ABI entry point       *)
 (* ------------------------------------------------------------------ *)
 
 let record_kernel_src =
@@ -130,7 +272,7 @@ let record_kernel_src =
   \  let p = {x = 1.0; y = 2.0} in\n\
   \  out.(i) <- p.x +. p.y"
 
-let transpile backend =
+let transpile backend () =
   match Sarek_transpile.of_source backend record_kernel_src with
   | Ok s -> s
   | Error e ->
@@ -138,41 +280,46 @@ let transpile backend =
         "transpile failed, so this test proves nothing: %s"
         (Sarek_transpile.string_of_error e)
 
-(* [(backend, declaration marker, use marker)]. The C-family backends close the
-   typedef with "} point;" and spell the use "point p"; GLSL and WGSL have no
-   typedef and emit "struct point" / "let p : point". Keyed per backend so a
-   backend that emits nothing cannot pass on another backend's marker. *)
+(** [of_source_with_abi] is a SEPARATE emission entry point, not a wrapper over
+    [of_source]: it re-runs the pipeline and calls [Sarek_ir_wgsl] itself
+    (Sarek_transpile.ml:344-352). Nothing exercised it, so starving its [~types]
+    argument was invisible to the entire suite. *)
+let transpile_with_abi backend () =
+  match Sarek_transpile.of_source_with_abi backend record_kernel_src with
+  | Ok (code, _abi) -> code
+  | Error e ->
+      Alcotest.failf
+        "transpile-with-abi failed, so this test proves nothing: %s"
+        (Sarek_transpile.string_of_error e)
+
+(* [(label, emit, declaration marker, use marker)]. The C-family backends close
+   the typedef with "} point;" and spell the use "point p"; GLSL and WGSL have
+   no typedef and emit "struct point" / "let p : point". Keyed per row so a
+   backend that emits nothing cannot pass on another backend's marker, and
+   carrying the emitter as a closure rather than a backend tag so the ABI entry
+   point gets a row of its own. *)
 let transpile_cases =
   [
-    ("CUDA", Sarek_transpile.CUDA, typedef_line, "point p");
-    ("OpenCL", Sarek_transpile.OpenCL, typedef_line, "point p");
-    ("Metal", Sarek_transpile.Metal, typedef_line, "point p");
-    ("GLSL", Sarek_transpile.GLSL, "struct point", "point p");
-    ("WGSL", Sarek_transpile.WGSL, "struct point", "p : point");
+    ("CUDA", transpile Sarek_transpile.CUDA, typedef_line, record_use);
+    ("OpenCL", transpile Sarek_transpile.OpenCL, typedef_line, record_use);
+    ("Metal", transpile Sarek_transpile.Metal, typedef_line, record_use);
+    ("GLSL", transpile Sarek_transpile.GLSL, "struct point", record_use);
+    ("WGSL", transpile Sarek_transpile.WGSL, "struct point", "p : point");
+    ( "WGSL/of_source_with_abi",
+      transpile_with_abi Sarek_transpile.WGSL,
+      "struct point",
+      "p : point" );
   ]
 
 let test_transpile_declares_records () =
   List.iter
-    (fun (name, backend, decl_marker, use_marker) ->
-      let src = transpile backend in
-      (* Check the USE first: if the body does not mention the type, declaring
-         it proves nothing and the assertion below would be vacuous. *)
-      Alcotest.(check bool)
-        (Printf.sprintf
-           "%s: body must actually use `point` (marker %S), got:\n%s"
-           name
-           use_marker
-           src)
-        true
-        (contains src use_marker) ;
-      Alcotest.(check bool)
-        (Printf.sprintf
-           "%s: transpiled source must declare `point` (marker %S), got:\n%s"
-           name
-           decl_marker
-           src)
-        true
-        (contains src decl_marker))
+    (fun (name, emit, decl_marker, use_marker) ->
+      let src = emit () in
+      check_declared_before_use
+        ~ctx:(Printf.sprintf "transpiler/%s" name)
+        ~decl:decl_marker
+        ~use:use_marker
+        src)
     transpile_cases
 
 let () =
@@ -182,13 +329,21 @@ let () =
       ( "opencl_generate_with_fp64",
         [
           Alcotest.test_case
-            "emits record typedefs"
+            "emits record typedefs, above the use"
             `Quick
             test_opencl_fp64_emits_typedefs;
           Alcotest.test_case
             "control: bare generate does not"
             `Quick
             test_opencl_plain_generate_omits_typedefs;
+          Alcotest.test_case
+            "emits variant definitions, above the use"
+            `Quick
+            test_opencl_fp64_emits_variant_defs;
+          Alcotest.test_case
+            "control: bare generate does not"
+            `Quick
+            test_opencl_plain_generate_omits_variant_defs;
           Alcotest.test_case
             "still emits the fp64 pragma"
             `Quick
@@ -197,7 +352,7 @@ let () =
       ( "transpiler",
         [
           Alcotest.test_case
-            "of_source declares records on all five backends"
+            "of_source and of_source_with_abi declare records before using them"
             `Quick
             test_transpile_declares_records;
         ] );

--- a/sarek/tests/unit/test_typedef_entry_points.ml
+++ b/sarek/tests/unit/test_typedef_entry_points.ml
@@ -1,0 +1,204 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** Every public emission entry point must declare the record types it uses
+    (backlog-155).
+
+    Each backend has a [generate] that emits the kernel body but NO record
+    typedefs and no variant definitions, and a [generate_with_types] that emits
+    both. [generate] is not wrong — it is the "I have no custom types" emitter.
+    What is wrong is a PUBLIC entry point that accepts a kernel carrying
+    [kern_types] and quietly routes to [generate], because the result is source
+    that names struct types nobody declared. That had happened in three places:
+
+    - [Sarek_ir_opencl.generate_with_fp64] (re-exported as
+      [Opencl_plugin.generate_with_fp64]) delegated to [generate];
+    - [Metal_plugin.generate_source] aliased [Sarek_ir_metal.generate], under a
+      name identical to the runtime path that does use [generate_with_types];
+    - [Sarek_transpile.of_source] — the whole public transpiler API — emitted
+      through [generate] for all five backends, even though [conv_kernel]
+      faithfully carries [kern_types] across.
+
+    Each case below asserts the typedef IS emitted, and is paired with a
+    positive control asserting the typedef-less emitter does NOT emit it. The
+    control is what makes the assertion falsifiable: without it, a check for a
+    substring in a large generated blob could be passing for any reason. *)
+
+open Sarek_ir_types
+module Ocl = Sarek_codegen.Sarek_ir_opencl
+
+let () = Sarek_stdlib_meta.force_init ()
+
+let contains haystack needle =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i =
+    i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1))
+  in
+  nl = 0 || go 0
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(** A kernel whose body mentions a [point] record, with the record declared in
+    [kern_types] exactly as the frontend would leave it. *)
+let point_types = [("point", [("x", TFloat32); ("y", TFloat32)])]
+
+let point_kernel () =
+  let out = make_var "out" (TVec TFloat32) in
+  let p = make_var "p" (TRecord ("point", List.assoc "point" point_types)) in
+  {
+    kern_name = "k";
+    kern_params = [DParam (out, None)];
+    kern_locals = [DLocal (p, None)];
+    kern_body =
+      SSeq
+        [
+          SAssign
+            ( LArrayElem ("out", EConst (CInt32 0l)),
+              EBinop
+                (Add, ERecordField (EVar p, "x"), ERecordField (EVar p, "y")) );
+        ];
+    kern_types = point_types;
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+let typedef_line = "} point;"
+
+(* ------------------------------------------------------------------ *)
+(* OpenCL: the third entry point                                       *)
+(* ------------------------------------------------------------------ *)
+
+let test_opencl_fp64_emits_typedefs () =
+  Ocl.current_variants := [] ;
+  let src = Ocl.generate_with_fp64 ~types:point_types (point_kernel ()) in
+  Alcotest.(check bool)
+    "generate_with_fp64 must declare the record it uses"
+    true
+    (contains src typedef_line)
+
+(** POSITIVE CONTROL for the assertion above: [generate] is the typedef-less
+    emitter, so the same check must come out FALSE against it. If this ever
+    passes, [typedef_line] has stopped discriminating and the test above is
+    vacuous. *)
+let test_opencl_plain_generate_omits_typedefs () =
+  Ocl.current_variants := [] ;
+  let src = Ocl.generate (point_kernel ()) in
+  Alcotest.(check bool)
+    "control: bare `generate` emits no typedef, so the check discriminates"
+    false
+    (contains src typedef_line)
+
+(** The pragma is the other half of what [generate_with_fp64] is for; assert it
+    is still composed on top of the type-aware body, not lost in the rewiring.
+*)
+let test_opencl_fp64_still_emits_the_pragma () =
+  Ocl.current_variants := [] ;
+  let out = make_var "out" (TVec TFloat64) in
+  let k =
+    {
+      (point_kernel ()) with
+      kern_params = [DParam (out, None)];
+      kern_locals = [];
+      kern_body =
+        SAssign (LArrayElem ("out", EConst (CInt32 0l)), EConst (CFloat64 1.0));
+    }
+  in
+  let src = Ocl.generate_with_fp64 ~types:point_types k in
+  Alcotest.(check bool)
+    "fp64 kernel keeps the cl_khr_fp64 pragma"
+    true
+    (contains src "#pragma OPENCL EXTENSION cl_khr_fp64 : enable") ;
+  Alcotest.(check bool)
+    "...and the typedef is still there alongside it"
+    true
+    (contains src typedef_line)
+
+(* ------------------------------------------------------------------ *)
+(* The transpiler: same gap, five backends, no plugin involved         *)
+(* ------------------------------------------------------------------ *)
+
+let record_kernel_src =
+  "let module M = struct\n\
+  \  type point = {x : float32; y : float32} [@@sarek.type]\n\
+   end in\n\
+   fun (out : float32 vector) ->\n\
+  \  let i = global_thread_id in\n\
+  \  let p = {x = 1.0; y = 2.0} in\n\
+  \  out.(i) <- p.x +. p.y"
+
+let transpile backend =
+  match Sarek_transpile.of_source backend record_kernel_src with
+  | Ok s -> s
+  | Error e ->
+      Alcotest.failf
+        "transpile failed, so this test proves nothing: %s"
+        (Sarek_transpile.string_of_error e)
+
+(* [(backend, declaration marker, use marker)]. The C-family backends close the
+   typedef with "} point;" and spell the use "point p"; GLSL and WGSL have no
+   typedef and emit "struct point" / "let p : point". Keyed per backend so a
+   backend that emits nothing cannot pass on another backend's marker. *)
+let transpile_cases =
+  [
+    ("CUDA", Sarek_transpile.CUDA, typedef_line, "point p");
+    ("OpenCL", Sarek_transpile.OpenCL, typedef_line, "point p");
+    ("Metal", Sarek_transpile.Metal, typedef_line, "point p");
+    ("GLSL", Sarek_transpile.GLSL, "struct point", "point p");
+    ("WGSL", Sarek_transpile.WGSL, "struct point", "p : point");
+  ]
+
+let test_transpile_declares_records () =
+  List.iter
+    (fun (name, backend, decl_marker, use_marker) ->
+      let src = transpile backend in
+      (* Check the USE first: if the body does not mention the type, declaring
+         it proves nothing and the assertion below would be vacuous. *)
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s: body must actually use `point` (marker %S), got:\n%s"
+           name
+           use_marker
+           src)
+        true
+        (contains src use_marker) ;
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s: transpiled source must declare `point` (marker %S), got:\n%s"
+           name
+           decl_marker
+           src)
+        true
+        (contains src decl_marker))
+    transpile_cases
+
+let () =
+  Alcotest.run
+    "typedef_entry_points"
+    [
+      ( "opencl_generate_with_fp64",
+        [
+          Alcotest.test_case
+            "emits record typedefs"
+            `Quick
+            test_opencl_fp64_emits_typedefs;
+          Alcotest.test_case
+            "control: bare generate does not"
+            `Quick
+            test_opencl_plain_generate_omits_typedefs;
+          Alcotest.test_case
+            "still emits the fp64 pragma"
+            `Quick
+            test_opencl_fp64_still_emits_the_pragma;
+        ] );
+      ( "transpiler",
+        [
+          Alcotest.test_case
+            "of_source declares records on all five backends"
+            `Quick
+            test_transpile_declares_records;
+        ] );
+    ]

--- a/sarek/transpile/Sarek_transpile.ml
+++ b/sarek/transpile/Sarek_transpile.ml
@@ -231,14 +231,21 @@ let set_framework backend =
   Sarek_ir_metal.current_framework := Some name ;
   Sarek_ir_wgsl.current_framework := Some name
 
+(* Each backend's [generate] emits the kernel body but NO record typedefs and no
+   variant definitions; only [generate_with_types] does. [conv_kernel] faithfully
+   carries [kern_types]/[kern_variants] across from the frontend, so calling
+   [generate] here silently discarded them and a transpiled kernel using a
+   `[@@sarek.type]` record emitted e.g. `point p = (point){...};` with `point`
+   never declared — invalid C on every one of the five backends (backlog-155). *)
 let emit_backend backend (k : Sarek_ir_ppx.kernel) =
   let k_types = Sarek_ir_conv.conv_kernel k in
+  let types = k_types.Sarek_ir_types.kern_types in
   match backend with
-  | CUDA -> Sarek_ir_cuda.generate k_types
-  | OpenCL -> Sarek_ir_opencl.generate k_types
-  | Metal -> Sarek_ir_metal.generate k_types
-  | GLSL -> Sarek_ir_glsl.generate k_types
-  | WGSL -> Sarek_ir_wgsl.generate k_types
+  | CUDA -> Sarek_ir_cuda.generate_with_types ~types k_types
+  | OpenCL -> Sarek_ir_opencl.generate_with_types ~types k_types
+  | Metal -> Sarek_ir_metal.generate_with_types ~types k_types
+  | GLSL -> Sarek_ir_glsl.generate_with_types ~types k_types
+  | WGSL -> Sarek_ir_wgsl.generate_with_types ~types k_types
 
 (******************************************************************************)
 (* Main pipeline                                                              *)
@@ -337,7 +344,12 @@ let of_source_with_abi (backend : backend) (src : string) :
       | Ok ppx_kernel -> (
           try
             let ir_kernel = Sarek_ir_conv.conv_kernel ppx_kernel in
-            let code = Sarek_ir_wgsl.generate ir_kernel in
+            (* Same typedef-dropping trap as [emit_backend] above (backlog-155). *)
+            let code =
+              Sarek_ir_wgsl.generate_with_types
+                ~types:ir_kernel.Sarek_ir_types.kern_types
+                ir_kernel
+            in
             let abi_t = Sarek_ir_wgsl.abi ir_kernel in
             let abi_json = Sarek_wgsl_abi.to_json abi_t in
             Ok (code, abi_json)

--- a/sarek/transpile/Sarek_transpile.ml
+++ b/sarek/transpile/Sarek_transpile.ml
@@ -236,13 +236,35 @@ let set_framework backend =
    carries [kern_types]/[kern_variants] across from the frontend, so calling
    [generate] here silently discarded them and a transpiled kernel using a
    `[@@sarek.type]` record emitted e.g. `point p = (point){...};` with `point`
-   never declared — invalid C on every one of the five backends (backlog-155). *)
+   never declared — invalid C on every one of the five backends (backlog-155).
+
+   OpenCL takes [generate_with_fp64], which is [generate_with_types] plus a
+   conditional `#pragma OPENCL EXTENSION cl_khr_fp64 : enable`, because a
+   float64 kernel DOES reach here — measured, not assumed: transpiling
+   `fun (a : float64 vector) (b : float64 vector) -> b.(i) <- a.(i) +. a.(i)`
+   through [of_source OpenCL] emitted `__global double* restrict a` and, before
+   this line changed, no pragma anywhere in the output.
+
+   Whether that omission is FATAL is implementation-dependent, and the honest
+   answer measured here is "not on the implementation this box has": Mesa
+   rusticl 3.0 (clang 22) on an RX 7900 XTX, on the radeonsi CPU device and on
+   llvmpipe, built the pragma-less source with clBuildProgram = CL_SUCCESS,
+   including under `-cl-std=CL1.2`, with an invalid-source control correctly
+   refused. clang enables cl_khr_fp64 by default for every target that has
+   fp64, so no clang-based ICD will care. The reasons to emit it anyway are
+   that the OpenCL C spec makes the pragma the way an application enables the
+   extension (so a non-clang ICD may demand it and none is reachable here to
+   ask), and that {!Opencl_plugin.generate_source} — the RUNTIME path for the
+   same IR — already calls [generate_with_fp64]. Two emission paths for one
+   backend that disagree on the prologue is the divergence backlog-155 was
+   about. It costs nothing: [kernel_uses_float64] is false for every float32
+   kernel, so their output is byte-identical. *)
 let emit_backend backend (k : Sarek_ir_ppx.kernel) =
   let k_types = Sarek_ir_conv.conv_kernel k in
   let types = k_types.Sarek_ir_types.kern_types in
   match backend with
   | CUDA -> Sarek_ir_cuda.generate_with_types ~types k_types
-  | OpenCL -> Sarek_ir_opencl.generate_with_types ~types k_types
+  | OpenCL -> Sarek_ir_opencl.generate_with_fp64 ~types k_types
   | Metal -> Sarek_ir_metal.generate_with_types ~types k_types
   | GLSL -> Sarek_ir_glsl.generate_with_types ~types k_types
   | WGSL -> Sarek_ir_wgsl.generate_with_types ~types k_types


### PR DESCRIPTION
## The decision

`Sarek_ir_opencl.generate_with_fp64` (`sarek/codegen/Sarek_ir_opencl.ml:1206`) called `generate` (`:1116`) rather than `generate_with_types` (`:1159`), and is re-exported at `sarek-opencl/Opencl_plugin.ml:304`. The premise holds.

**Chosen: change the signature.** `generate_with_fp64` now takes a required `~types` and delegates to `generate_with_types`. The fp64 pragma is orthogonal to type emission, so the honest composition is pragma ∘ `generate_with_types`.

**Rejected: withdraw the public re-export.** It closes one of two doors. `Sarek_ir_opencl` has no `.mli`, `sarek_codegen` is a public library, and `benchmarks/generate_backend_code.ml:481` already reaches `Sarek_opencl.Sarek_ir_opencl.*` directly — so hiding the plugin alias would leave the broken function reachable under its original name. That is how the delegation asymmetry survived backlog-142.

`~types` is **required**, not `?types` defaulting to `[]`. An optional label would reproduce the exact silent drop at every call site that forgot it.

The OpenCL backend's own `generate_source` (`Opencl_plugin.ml:190`) was a second hand-kept copy of "typedefs + fp64 pragma"; it now calls `generate_with_fp64`, so the runtime path and the public re-export are one function.

## The gap is broader, and the reported instance is not the worst one

`generate_with_fp64` is the only *third* entry point in `sarek/codegen/` — every other backend has exactly `generate` + `generate_with_types`. So the three-entry-point **shape** is OpenCL-specific. The underlying **gap** is not: *a public surface that accepts a kernel carrying `kern_types` and calls the emitter that ignores them*. Two more instances:

**1. `Sarek_transpile.of_source` — the whole public transpiler API, all five backends.** No plugin, no device. `Sarek_ir_conv.conv_kernel` faithfully carries `kern_types`/`kern_variants` across (`sarek/transpile/Sarek_ir_conv.ml:197`) and `emit_backend` (`Sarek_transpile.ml:234-241`) threw them away. Measured before the fix on a record kernel, CUDA came out as

```c
__global__ void sarek_kern(float* __restrict__ out, int sarek_out_length) {
  int i = (threadIdx.x + blockIdx.x * blockDim.x);
  point p = (point){1.0f, 2.0f};
  out[i] = (p.x + p.y);
}
```

with no `typedef struct {…} point;` above it; OpenCL identically. `of_source_with_abi` (WGSL, `:340`) had the same call.

**2. `Metal_plugin.ml:281`** was `let generate_source = Sarek_ir_metal.generate` — a top-level alias of the typedef-less emitter under the *same name* as `Backend.generate_source` in the module above it, which does use `generate_with_types`.

Both now take `~types` and route through `generate_with_types`.

## The RED I observed

New suite `sarek/tests/unit/test_typedef_entry_points.ml` (4 cases). Every "typedef IS emitted" assertion is paired with a control asserting the typedef-less emitter does NOT emit it, so the substring check cannot pass for an unrelated reason. The transpiler cases check the *use* marker before the *declaration* marker: if the body did not mention the type, declaring it would prove nothing.

Reverted one fix at a time and re-ran:

| mutation | observed |
|---|---|
| `generate_with_fp64` back to `generate` | `FAIL opencl_generate_with_fp64 0` — *"generate_with_fp64 must declare the record it uses"*, `Expected: true / Received: false`; case 2 (pragma + typedef) also red; **control case 1 stayed green**. `2 failures!`, exit **1** |
| `emit_backend` CUDA arm back to `generate` | `FAIL transpiler 0` — *"CUDA: transpiled source must declare `point`"*, with the typedef-less CUDA source printed in the message. `1 failure!`, exit **1** |

Green after restore: `Test Successful … 4 tests run`, exit **0**.

## Suite

`scripts/test-suite-counts.sh`, log checked non-empty **and** `dune test`'s own exit code checked (backlog-157):

| | dune test exit | log lines | cases / suites | FAIL | SKIP | zero-case |
|---|---|---|---|---|---|---|
| `origin/main` (stashed) | 0 | 4793 | 1697 / 117 | 0 | 23 | 4 |
| this branch | 0 | 4803 | 1701 / 118 | 0 | 23 | 4 |

Delta is exactly the new suite. No golden regressed — expected, since no committed golden covers a record kernel through the transpiler. `dune build @fmt` clean; no `*.opam` churn.

## Not verified

No OpenCL or Metal device was used. The claim that the pre-fix source is invalid rests on it naming an undeclared struct type, not on a vendor compiler having rejected it on this machine. `Metal_plugin.ml` *is* compiled on this Linux host (`sarek_metal__Metal_plugin.cmo` exists), so the signature change is type-checked, but no Metal toolchain ran. `Metal_plugin.generate_source` and `Opencl_plugin.generate_with_fp64` have no in-repo callers, so both signature changes are breaking for out-of-repo consumers.

---

# Follow-up: the gate itself was tested, and it failed (41418fd)

An independent red-prover mutated the *fixed* code three ways and the suite above stayed green for all three. Every item below was reproduced here first, then fixed, then re-measured red. **Baseline reproduced exactly**: `dune test` exit **0**, log **4803** lines, **1701 / 118**, 0 FAIL, 23 SKIP, 4 zero-case — every digit matching the table above.

## 1. Both markers were unordered, so the gate could not see a use-before-declaration

Moving the typedef block of `Sarek_ir_opencl.generate_with_types` (`sarek/codegen/Sarek_ir_opencl.ml:1168-1177`) from the prologue to the epilogue — the same bytes — emits

```c
__kernel void k(__global float* restrict out, int sarek_out_length) {
  point p;
  out[0] = (p.x + p.y);
}
typedef struct {
  float x;
  float y;
} point;
```

That is a use above its declaration, rejected by every OpenCL C compiler. **The gate stayed GREEN, exit 0, 4 cases OK** — both checks were unordered `contains`.

Fixed at `sarek/tests/unit/test_typedef_entry_points.ml:85` (`check_declared_before_use`): markers are compared by OFFSET, and the check fails unless the declaration's is strictly lower. Three legs, three distinct messages — no use marker (the case would be vacuous), no declaration marker (the original defect), declaration below the use.

**RED, exit 1, 3 failures:**

```
FAIL generate_with_fp64, record: declaration "} point;" is at offset 146 but the use
"point p" is at offset 72 — the declaration must come FIRST, this source is rejected
by any compiler.
FAIL generate_with_fp64, variant: declaration "} shape;" is at offset 210 but the use
"= make_shape_Circle(" is at offset 80 — …
FAIL transpiler/OpenCL: declaration "} point;" is at offset 215 but the use "point p"
is at offset 109 — …
```

**One correction to the prover.** It reported the six full-suite failures under this mutation as *all* device-backed OpenCL suites, hence uncovered on a runner with no OpenCL device. Measured here on a host with rusticl: two of the six are `codegen_golden` `opencl/record_kernel` and `opencl/variant_kernel` — string comparisons against committed goldens, needing no device. So ordering was not uncovered repo-wide. It was uncovered in the gate that claimed to cover it.

## 2. `of_source_with_abi`'s `~types` was read by nothing

Starving it — `sarek/transpile/Sarek_transpile.ml:349`, `~types:[]` in place of `~types:ir_kernel.kern_types` — left the **full suite identical in every digit**: exit 0, 4803 lines, 1701 / 118, 0 FAIL, 23 SKIP, 4 zero-case. Making the label required bought nothing, because nothing called it.

`transpile_cases` (`test_typedef_entry_points.ml:290`) now carries an emitter closure per row instead of a backend tag, and has a sixth row for `of_source_with_abi` — a second emission path, not a wrapper: it re-runs the pipeline and calls `Sarek_ir_wgsl` itself.

**RED, exit 1:**

```
FAIL transpiler/WGSL/of_source_with_abi: emitted source uses the type but never
declares it (missing marker "struct point").
```

`Metal_plugin.generate_source` (`sarek-metal/Metal_plugin.ml:287`) was worse: **zero callers outside its own file**, so the signature change was not type-checked against a single use. New suite `sarek-metal/test/test_metal_plugin_entry_points.ml` — that directory and not `sarek/tests/unit` because `sarek_metal` is `(optional)` and `sarek-metal/test` is the only place in the tree that links it. Reverted to `Sarek_ir_metal.generate`, **RED, exit 1:**

```
FAIL Metal_plugin.generate_source: emitted source uses the type but never declares it
(missing marker "} point;").
```

## 3. The "and no variant definitions" half was not falsifiable here

Every fixture had `kern_variants = []`, so the file's prose was wider than its assertions. Added a variant-carrying fixture + control (`test_typedef_entry_points.ml:152`). Deleting the `List.iter (gen_variant_def buf) k.kern_variants` line — **RED, exit 1:**

```
FAIL generate_with_fp64, variant: emitted source uses the type but never declares it
(missing marker "} shape;").
```

The use marker is `= make_shape_Circle(`, not the bare constructor name: `gen_variant_def` emits the constructor's *definition* inside the declaration block, so a bare name would be found within the declaration and the ordering check would hold vacuously.

**Two corrections to the prover.** Its mutation C was `List.iter (…)` → `ignore (List.iter (…))`, which still evaluates the iteration — a no-op, so its greenness was not evidence. And *"covered by nothing"* is too strong: a mutation that genuinely deletes the emission takes the full suite to **exit 1, FAIL: 6** — `codegen_golden opencl/variant_kernel`, `opencl_validation_sweep 2` and `22`, and a `whole-module-search-is-vacuous OpenCL` case. What holds is that *this* gate, whose docstring names variant definitions, could not tell.

## Suite after

`scripts/test-suite-counts.sh`, log checked non-empty and `dune test`'s own exit code captured (backlog-157):

| | dune test exit | log lines | cases / suites | FAIL | SKIP | zero-case | counter exit |
|---|---|---|---|---|---|---|---|
| branch before (166fb05e) | 0 | 4803 | 1701 / 118 | 0 | 23 | 4 | 0 |
| this commit (41418fd) | 0 | 4813 | 1705 / 119 | 0 | 23 | 4 | 0 |

Delta is exactly +2 cases in `typedef_entry_points` (variant case + control) and the new 2-case Metal suite. `dune build @fmt` clean; no `*.opam` churn. **No production code changed in this commit** — the four reds were produced by mutating it and reverting.

Also re-checked the original defect against the reworked gate: `generate_with_fp64` back to `generate` → 3 failures, exit 1, controls green.

## Round 3 (04320a6b) — bounded close-out

Three more mutations were measured green against the version above. All three are now red. **No production code changed in this commit either**; the reds below were produced by mutating it and reverting.

### 1. The variant half covered one entry point out of seven

The file's opening sentence claims every public emission entry point declares the record types **and variant types** it uses. The variant fixture added in round 2 covers only `Ocl.generate_with_fp64`. All six `transpile_cases` rows share `record_kernel_src`, which declares `type point = {x; y}` and no variant — so for `of_source` on CUDA/OpenCL/Metal/GLSL/WGSL and for `of_source_with_abi`, the variant half was exactly as unfalsifiable as before, **inside `emit_backend`, the function 166fb05e rewrote**.

`variant_transpile_cases` (`test_typedef_entry_points.ml:439-459`) is `transpile_cases` with a variant source and the variant markers, reusing `check_declared_before_use` unchanged. Per-row keying as before: `} shape;` for the C family, `struct shape` for GLSL/WGSL, `= make_shape_Circle(` for the use everywhere — the bare constructor name matches inside its own definition, which is part of the declaration block.

### 2. The fp64 pragma had no negative control

Lines 51-54 state the file's own discipline: each positive assertion is paired with a control asserting the typedef-less emitter does *not* emit the declaration. Every typedef assertion honoured it; `test_opencl_fp64_still_emits_the_pragma` did not. `generate_with_fp64` is what this PR made the OpenCL runtime path, so the blast radius of an unconditional pragma — a compile error on a device without `cl_khr_fp64`, not a no-op — grew in the same commit that left the direction untested.

### 3. "record type**s**" was checked with one record

`Sarek_ir_codegen.gen_record_typedefs` is shared by CUDA/OpenCL/Metal; both fixtures carried a single record, so a head-only walk was green repo-wide. `point_types` now carries `box` behind `point`, asserted separately in both files. That file is untouched by this PR, so this one is pre-existing — but the gate's prose claimed it.

### Reds observed

| # | mutation | site | result |
|---|---|---|---|
| M1 | `let k_types = {k_types with kern_variants = []}` | `Sarek_transpile.ml:242` (`emit_backend`) | exit 1 — `FAIL transpiler/CUDA, variant: emitted source uses the type but never declares it (missing marker "} shape;")` |
| M1b | same, on the ABI path | `Sarek_transpile.ml:347` | exit 1 — `FAIL transpiler/WGSL/of_source_with_abi, variant: … (missing marker "struct shape")` |
| M2 | `if true then` in place of `if Sarek_ir_analysis.kernel_uses_float64 k` | `Sarek_ir_opencl.ml:1223` | exit 1 — `FAIL control: a float32-only kernel must NOT get the cl_khr_fp64 pragma, so the positive assertion above is not passing for any reason` |
| M3 | `let types = match types with [] -> [] \| t :: _ -> [t]` | `Sarek_ir_codegen.ml:693` (`gen_record_typedefs`) | exit 1 in both files — `FAIL generate_with_fp64, second record: … (missing marker "} box;")` and `FAIL Metal_plugin.generate_source, second record: … (missing marker "} box;")` |

M1 alone left the suite at **exit 0** before this commit, as did M2 and M3.

### Suite

`dune test --force` (forced — the shared dune cache on this host can return exit 0 on a zero-line log): **exit 0**, 4816-line log, 1675 `[OK]` lines. `typedef_entry_points` 8 cases, `metal_plugin_entry_points` 2 cases, both green. `dune build @sarek/tests/unit/fmt @sarek-metal/test/fmt` clean; no `*.opam` churn.

## Still not verified

No OpenCL or Metal device compiler is invoked by either of these two suites; they assert on emitted text. The rusticl-backed suites that *do* compile OpenCL are what ran the ordering claim end to end, and they are not portable — which is the reason these exist.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated GPU code for kernels using custom record and variant types by ensuring required type declarations are emitted (or included) across supported OpenCL, Metal, and transpilation paths.
  - Centralized OpenCL FP64 pragma handling so the FP64 extension line is included only when needed.
  - Corrected ABI-based WGSL output to include required type declarations.

- **API Changes**
  - OpenCL and Metal code-generation entry points now require an explicit `~types` type-definition collection.

- **Tests**
  - Added coverage to validate typedef/variant declarations across public code-generation and transpilation entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

