### PR TITLE
fix(glsl): one name for an array's length, and a check that both halves use it (backlog-156)

### DIFF
--- a/benchmarks/descriptions/generated/dot_product_generated.md
+++ b/benchmarks/descriptions/generated/dot_product_generated.md
@@ -161,15 +161,15 @@ layout(std430, set=0, binding = 2) buffer Buffer_outputv {
   float outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
-  int outputv_len;
+  int sarek_a_length;
+  int sarek_b_length;
+  int sarek_outputv_length;
   int n;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
-#define outputv_len pc.outputv_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
+#define sarek_outputv_length pc.sarek_outputv_length
 #define n pc.n
 
 // Shared memory

--- a/benchmarks/descriptions/generated/gather_generated.md
+++ b/benchmarks/descriptions/generated/gather_generated.md
@@ -47,15 +47,15 @@ layout(std430, set=0, binding = 2) buffer Buffer_outputv {
   int outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int indices_len;
-  int outputv_len;
+  int sarek_inputv_length;
+  int sarek_indices_length;
+  int sarek_outputv_length;
   int n;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define indices_len pc.indices_len
-#define outputv_len pc.outputv_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_indices_length pc.sarek_indices_length
+#define sarek_outputv_length pc.sarek_outputv_length
 #define n pc.n
 
 void main() {

--- a/benchmarks/descriptions/generated/mandelbrot_generated.md
+++ b/benchmarks/descriptions/generated/mandelbrot_generated.md
@@ -63,13 +63,13 @@ layout(std430, set=0, binding = 0) buffer Buffer_outputv {
   int outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int outputv_len;
+  int sarek_outputv_length;
   int width;
   int height;
   int max_iter;
 } pc;
 
-#define outputv_len pc.outputv_len
+#define sarek_outputv_length pc.sarek_outputv_length
 #define width pc.width
 #define height pc.height
 #define max_iter pc.max_iter

--- a/benchmarks/descriptions/generated/matrix_mul_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_generated.md
@@ -57,17 +57,17 @@ layout(std430, set=0, binding = 2) buffer Buffer_c {
   float c[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
-  int c_len;
+  int sarek_a_length;
+  int sarek_b_length;
+  int sarek_c_length;
   int m;
   int n;
   int k;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
-#define c_len pc.c_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
+#define sarek_c_length pc.sarek_c_length
 #define m pc.m
 #define n pc.n
 #define k pc.k

--- a/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
+++ b/benchmarks/descriptions/generated/matrix_mul_tiled_generated.md
@@ -113,17 +113,17 @@ layout(std430, set=0, binding = 2) buffer Buffer_c {
   float c[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
-  int c_len;
+  int sarek_a_length;
+  int sarek_b_length;
+  int sarek_c_length;
   int m;
   int n;
   int k;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
-#define c_len pc.c_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
+#define sarek_c_length pc.sarek_c_length
 #define m pc.m
 #define n pc.n
 #define k pc.k

--- a/benchmarks/descriptions/generated/radix_sort_histogram_generated.md
+++ b/benchmarks/descriptions/generated/radix_sort_histogram_generated.md
@@ -82,15 +82,15 @@ layout(std430, set=0, binding = 1) buffer Buffer_histogram {
   int histogram[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int histogram_len;
+  int sarek_inputv_length;
+  int sarek_histogram_length;
   int n;
   int shift;
   int mask;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define histogram_len pc.histogram_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_histogram_length pc.sarek_histogram_length
 #define n pc.n
 #define shift pc.shift
 #define mask pc.mask

--- a/benchmarks/descriptions/generated/radix_sort_scatter_generated.md
+++ b/benchmarks/descriptions/generated/radix_sort_scatter_generated.md
@@ -51,17 +51,17 @@ layout(std430, set=0, binding = 2) buffer Buffer_counters {
   int counters[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int outputv_len;
-  int counters_len;
+  int sarek_inputv_length;
+  int sarek_outputv_length;
+  int sarek_counters_length;
   int n;
   int shift;
   int mask;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define outputv_len pc.outputv_len
-#define counters_len pc.counters_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_outputv_length pc.sarek_outputv_length
+#define sarek_counters_length pc.sarek_counters_length
 #define n pc.n
 #define shift pc.shift
 #define mask pc.mask

--- a/benchmarks/descriptions/generated/reduction_generated.md
+++ b/benchmarks/descriptions/generated/reduction_generated.md
@@ -164,13 +164,13 @@ layout(std430, set=0, binding = 1) buffer Buffer_outputv {
   float outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int outputv_len;
+  int sarek_inputv_length;
+  int sarek_outputv_length;
   int n;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define outputv_len pc.outputv_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_outputv_length pc.sarek_outputv_length
 #define n pc.n
 
 // Shared memory

--- a/benchmarks/descriptions/generated/reduction_max_generated.md
+++ b/benchmarks/descriptions/generated/reduction_max_generated.md
@@ -228,13 +228,13 @@ layout(std430, set=0, binding = 1) buffer Buffer_outputv {
   float outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int outputv_len;
+  int sarek_inputv_length;
+  int sarek_outputv_length;
   int n;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define outputv_len pc.outputv_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_outputv_length pc.sarek_outputv_length
 #define n pc.n
 
 // Shared memory

--- a/benchmarks/descriptions/generated/scatter_generated.md
+++ b/benchmarks/descriptions/generated/scatter_generated.md
@@ -47,15 +47,15 @@ layout(std430, set=0, binding = 2) buffer Buffer_outputv {
   int outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int indices_len;
-  int outputv_len;
+  int sarek_inputv_length;
+  int sarek_indices_length;
+  int sarek_outputv_length;
   int n;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define indices_len pc.indices_len
-#define outputv_len pc.outputv_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_indices_length pc.sarek_indices_length
+#define sarek_outputv_length pc.sarek_outputv_length
 #define n pc.n
 
 void main() {

--- a/benchmarks/descriptions/generated/stream_triad_generated.md
+++ b/benchmarks/descriptions/generated/stream_triad_generated.md
@@ -45,16 +45,16 @@ layout(std430, set=0, binding = 2) buffer Buffer_c {
   float c[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
-  int c_len;
+  int sarek_a_length;
+  int sarek_b_length;
+  int sarek_c_length;
   float scalar;
   int n;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
-#define c_len pc.c_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
+#define sarek_c_length pc.sarek_c_length
 #define scalar pc.scalar
 #define n pc.n
 

--- a/benchmarks/descriptions/generated/transpose_naive_generated.md
+++ b/benchmarks/descriptions/generated/transpose_naive_generated.md
@@ -52,14 +52,14 @@ layout(std430, set=0, binding = 1) buffer Buffer_outputv {
   float outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int outputv_len;
+  int sarek_inputv_length;
+  int sarek_outputv_length;
   int width;
   int height;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define outputv_len pc.outputv_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_outputv_length pc.sarek_outputv_length
 #define width pc.width
 #define height pc.height
 

--- a/benchmarks/descriptions/generated/transpose_tiled_generated.md
+++ b/benchmarks/descriptions/generated/transpose_tiled_generated.md
@@ -86,14 +86,14 @@ layout(std430, set=0, binding = 1) buffer Buffer_outputv {
   float outputv[];
 };
 layout(push_constant) uniform PushConstants {
-  int inputv_len;
-  int outputv_len;
+  int sarek_inputv_length;
+  int sarek_outputv_length;
   int width;
   int height;
 } pc;
 
-#define inputv_len pc.inputv_len
-#define outputv_len pc.outputv_len
+#define sarek_inputv_length pc.sarek_inputv_length
+#define sarek_outputv_length pc.sarek_outputv_length
 #define width pc.width
 #define height pc.height
 

--- a/benchmarks/descriptions/generated/vector_add_generated.md
+++ b/benchmarks/descriptions/generated/vector_add_generated.md
@@ -45,15 +45,15 @@ layout(std430, set=0, binding = 2) buffer Buffer_c {
   float c[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
-  int c_len;
+  int sarek_a_length;
+  int sarek_b_length;
+  int sarek_c_length;
   int n;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
-#define c_len pc.c_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
+#define sarek_c_length pc.sarek_c_length
 #define n pc.n
 
 void main() {

--- a/benchmarks/descriptions/generated/vector_copy_generated.md
+++ b/benchmarks/descriptions/generated/vector_copy_generated.md
@@ -42,13 +42,13 @@ layout(std430, set=0, binding = 1) buffer Buffer_b {
   float b[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
+  int sarek_a_length;
+  int sarek_b_length;
   int n;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
 #define n pc.n
 
 void main() {

--- a/kb/properties.md
+++ b/kb/properties.md
@@ -41,6 +41,7 @@ each of which actually happened here:
 | A calibration is pinned at one hand-computed input, and a broken oracle passes the pin | `test_opencl_f16_tripwire`'s oracle pinned at `x = 1.0` (§11.5) |
 | A count-only sweep reports `1 / 63488` and nothing else, hiding *which* value was wrong | RADV returning `-0` for `0.0 - x` at `x = +0` (§13.6) |
 | An empty declared set turns a strict check into a permissive one | any `exempt`/roots list that no longer names anything |
+| An emitter names one concept twice — declaring it under one spelling and using it under another — and nothing compares its two halves | `Sarek_ir_glsl` declared `<v>_len` and used `sarek_<v>_length` for `EArrayLen`; unreachable from surface Sarek (no `len` primitive exists), so no test, example or user could observe it (backlog-156) |
 
 The operative rule, and the reason `scripts/check-kb-properties.sh` exists at all:
 

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -230,9 +230,13 @@ let escape_glsl_name name =
     backlog-156 those were two separate string constructions in this same file —
     [<name>_len] on the declaring side, [sarek_<name>_length] on the using side
     — and nothing compared them, so every kernel taking a length emitted GLSL
-    naming an identifier the shader never declared. Route both halves (and the
-    shadowing sets in {!generate_with_types}) through here so the disagreement
-    is not expressible.
+    naming an identifier the shader never declared. Both halves go through here
+    so the disagreement is not expressible.
+
+    The shadowing sets that {!rename_pc_shadowing_locals} matches against are
+    the same name and would be a third place to spell it, so they do not spell
+    it either: {!param_macro_names} calls this, and {!generate} and
+    {!generate_with_types} both call {!param_macro_names}.
 
     The spelling is the cross-backend one: CUDA, OpenCL, Metal and WGSL all call
     this [sarek_<name>_length], and so does PTX, via
@@ -1793,6 +1797,51 @@ let gen_f64_softmath_helpers ~pc_names buf =
       Buffer.add_char buf '\n' ;
       List.iter (gen_helper_func ~pc_names buf) helpers
 
+(** The two macro-name sets a kernel's parameter list induces, as one value:
+    [(pc_names, len_names)].
+
+    {b One construction, deliberately.} {!gen_push_constants} emits a
+    [#define <s> pc.<s>] for every scalar parameter and a
+    [#define sarek_<v>_length pc.sarek_<v>_length] for every vector parameter;
+    {!rename_pc_shadowing_locals} needs both sets to know which body locals
+    those macros would rewrite. Both {!generate} and {!generate_with_types} need
+    them, and until backlog-156's close-out each built them by its own copy of
+    this [filter_map] pair. That is the same two-halves-one-concept shape
+    {!glsl_array_length_name} exists to close, one level up: reverting either
+    copy alone left the whole tree green while the other entry point emitted
+    GLSL glslangValidator rejects with "unexpected DOT". So there is one
+    construction and both entry points call it — the copies cannot drift because
+    there are no copies.
+
+    Note which entry point production uses: [Vulkan_plugin] calls
+    {!generate_with_types}; {!generate} is reached only from the transpiler and
+    the benchmark generator. A check that exercises only one of them is checking
+    the other one's twin. *)
+let param_macro_names params =
+  let pc_names =
+    List.filter_map
+      (fun decl ->
+        match decl with
+        | DParam (v, _) -> (
+            match v.var_type with
+            | TVec _ -> None (* vectors don't get macros, only their length *)
+            | _ -> Some (escape_glsl_name v.var_name))
+        | _ -> None)
+      params
+  in
+  let len_names =
+    List.filter_map
+      (fun decl ->
+        match decl with
+        | DParam (v, _) -> (
+            match v.var_type with
+            | TVec _ -> Some (glsl_array_length_name v.var_name)
+            | _ -> None)
+        | _ -> None)
+      params
+  in
+  (pc_names, len_names)
+
 (** Alpha-rename kernel-body binders whose name collides with a push-constant
     macro.
 
@@ -1902,31 +1951,9 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
 
   (* Generate push constants and collect scalar names for macro collision handling *)
   gen_push_constants buf k.kern_params ;
-  let pc_names =
-    List.filter_map
-      (fun decl ->
-        match decl with
-        | DParam (v, _) -> (
-            match v.var_type with
-            | TVec _ -> None (* vectors don't get macros, only their length *)
-            | _ -> Some (escape_glsl_name v.var_name))
-        | _ -> None)
-      k.kern_params
-  in
-  (* Vector params emit a length macro
-     [#define sarek_<vec>_length pc.sarek_<vec>_length]; a local named
-     [sarek_<vec>_length] collides with it (see rename_pc_shadowing_locals). *)
-  let len_names =
-    List.filter_map
-      (fun decl ->
-        match decl with
-        | DParam (v, _) -> (
-            match v.var_type with
-            | TVec _ -> Some (glsl_array_length_name v.var_name)
-            | _ -> None)
-        | _ -> None)
-      k.kern_params
-  in
+  (* Scalar-param macros and vector-length macros, from the single
+     construction both entry points share (see [param_macro_names]). *)
+  let pc_names, len_names = param_macro_names k.kern_params in
 
   (* Generate shared declarations at module scope (GLSL requirement) *)
   let shared_decls = collect_shared_decls k.kern_body in
@@ -2038,31 +2065,9 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
 
   (* Generate push constants and collect scalar names for macro collision handling *)
   gen_push_constants buf k.kern_params ;
-  let pc_names =
-    List.filter_map
-      (fun decl ->
-        match decl with
-        | DParam (v, _) -> (
-            match v.var_type with
-            | TVec _ -> None (* vectors don't get macros, only their length *)
-            | _ -> Some (escape_glsl_name v.var_name))
-        | _ -> None)
-      k.kern_params
-  in
-  (* Vector params emit a length macro
-     [#define sarek_<vec>_length pc.sarek_<vec>_length]; a local named
-     [sarek_<vec>_length] collides with it (see rename_pc_shadowing_locals). *)
-  let len_names =
-    List.filter_map
-      (fun decl ->
-        match decl with
-        | DParam (v, _) -> (
-            match v.var_type with
-            | TVec _ -> Some (glsl_array_length_name v.var_name)
-            | _ -> None)
-        | _ -> None)
-      k.kern_params
-  in
+  (* Scalar-param macros and vector-length macros, from the single
+     construction both entry points share (see [param_macro_names]). *)
+  let pc_names, len_names = param_macro_names k.kern_params in
 
   (* Generate shared declarations at module scope (GLSL requirement) *)
   let shared_decls = collect_shared_decls k.kern_body in

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -216,11 +216,30 @@ let mangle_softmath_ident name =
   else name
 
 (** Escape reserved GLSL keywords by adding 'v' suffix (avoids double underscore
-    with _len), and re-spell software-transcendental helper names
-    ({!mangle_softmath_ident}). *)
+    with the [_length] suffix of {!glsl_array_length_name}), and re-spell
+    software-transcendental helper names ({!mangle_softmath_ident}). *)
 let escape_glsl_name name =
   let name = mangle_softmath_ident name in
   if List.mem name glsl_reserved_keywords then name ^ "v" else name
+
+(** The GLSL identifier carrying the length of vector parameter [name].
+
+    {b One definition, deliberately.} This name has two halves that must agree:
+    {!gen_push_constants} {e declares} it (a push-constant field plus a
+    [#define] alias), and {!gen_expr} {e uses} it for [EArrayLen]. Before
+    backlog-156 those were two separate string constructions in this same file —
+    [<name>_len] on the declaring side, [sarek_<name>_length] on the using side
+    — and nothing compared them, so every kernel taking a length emitted GLSL
+    naming an identifier the shader never declared. Route both halves (and the
+    shadowing sets in {!generate_with_types}) through here so the disagreement
+    is not expressible.
+
+    The spelling is the cross-backend one: CUDA, OpenCL, Metal and WGSL all call
+    this [sarek_<name>_length], and so does PTX, via
+    {!Sarek_ir_ptx_types.length_param_name} — five of the six emitters, with
+    GLSL the odd one out until now. The [sarek_] prefix also keeps the
+    identifier out of the user namespace, unlike the old bare [<name>_len]. *)
+let glsl_array_length_name name = "sarek_" ^ escape_glsl_name name ^ "_length"
 
 (** Map Sarek IR element type to GLSL type string *)
 let rec glsl_type_of_elttype = function
@@ -494,8 +513,7 @@ let rec gen_expr buf = function
           gen_expr buf e)
         args ;
       Buffer.add_char buf ')'
-  | EArrayLen arr ->
-      Buffer.add_string buf ("sarek_" ^ escape_glsl_name arr ^ "_length")
+  | EArrayLen arr -> Buffer.add_string buf (glsl_array_length_name arr)
   | EArrayCreate _ ->
       Codegen_error.raise_error
         (Codegen_error.unsupported_construct
@@ -1406,8 +1424,8 @@ let gen_push_constants buf params =
     (* Add length parameter for each vector *)
     List.iter
       (fun v ->
-        let name = escape_glsl_name v.var_name in
-        Buffer.add_string buf (Printf.sprintf "  int %s_len;\n" name))
+        let name = glsl_array_length_name v.var_name in
+        Buffer.add_string buf (Printf.sprintf "  int %s;\n" name))
       vectors ;
     (* Add user-defined scalar parameters *)
     List.iter
@@ -1421,10 +1439,8 @@ let gen_push_constants buf params =
     (* Define convenience aliases for push constants *)
     List.iter
       (fun v ->
-        let name = escape_glsl_name v.var_name in
-        Buffer.add_string
-          buf
-          (Printf.sprintf "#define %s_len pc.%s_len\n" name name))
+        let name = glsl_array_length_name v.var_name in
+        Buffer.add_string buf (Printf.sprintf "#define %s pc.%s\n" name name))
       vectors ;
     List.iter
       (fun v ->
@@ -1782,13 +1798,14 @@ let gen_f64_softmath_helpers ~pc_names buf =
 
     Scalar params are exposed to the body as preprocessor macros
     ([#define width pc.width]), and each vector param exposes a length macro
-    ([#define v_len pc.v_len]); a macro rewrites {e every} matching token in
-    [main] — including the declared name of a local. A helper inlined at its
-    call site (e.g. a [[@sarek.module]] function whose formal is named like a
-    kernel scalar) emits a self-binding [int width = width;], which the macro
-    turns into [int pc.width = pc.width;] — a syntax error ("unexpected DOT").
-    Helper {e functions} already dodge this via the [#undef]/[#define] guards in
-    {!gen_helper_func}, but a body-inlined binder has no such guard.
+    ([#define sarek_v_length pc.sarek_v_length]); a macro rewrites {e every}
+    matching token in [main] — including the declared name of a local. A helper
+    inlined at its call site (e.g. a [[@sarek.module]] function whose formal is
+    named like a kernel scalar) emits a self-binding [int width = width;], which
+    the macro turns into [int pc.width = pc.width;] — a syntax error
+    ("unexpected DOT"). Helper {e functions} already dodge this via the
+    [#undef]/[#define] guards in {!gen_helper_func}, but a body-inlined binder
+    has no such guard.
 
     Both scalar-param macros ([pc_names]) and vector-length macros ([len_names])
     are treated as collisions; a colliding binder is rewritten to a fresh
@@ -1801,8 +1818,9 @@ let rename_pc_shadowing_locals ~pc_names ~len_names body =
   Sarek_ir_codegen.rename_shadowing_locals
     ~collides:(fun name ->
       (* A local collides if its escaped name matches a scalar-param macro
-         ([#define name pc.name]) or a vector-length macro ([#define vec_len
-         pc.vec_len]); either would rewrite the declared identifier to [pc....]. *)
+         ([#define name pc.name]) or a vector-length macro
+         ([#define sarek_vec_length pc.sarek_vec_length]); either would rewrite
+         the declared identifier to [pc....]. *)
       let n = escape_glsl_name name in
       List.mem n pc_names || List.mem n len_names)
     ~fresh_name:(fun orig n ->
@@ -1890,20 +1908,21 @@ let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
         match decl with
         | DParam (v, _) -> (
             match v.var_type with
-            | TVec _ -> None (* vectors don't get macros, only their _len *)
+            | TVec _ -> None (* vectors don't get macros, only their length *)
             | _ -> Some (escape_glsl_name v.var_name))
         | _ -> None)
       k.kern_params
   in
-  (* Vector params emit a length macro [#define <vec>_len pc.<vec>_len]; a local
-     named [<vec>_len] collides with it (see rename_pc_shadowing_locals). *)
+  (* Vector params emit a length macro
+     [#define sarek_<vec>_length pc.sarek_<vec>_length]; a local named
+     [sarek_<vec>_length] collides with it (see rename_pc_shadowing_locals). *)
   let len_names =
     List.filter_map
       (fun decl ->
         match decl with
         | DParam (v, _) -> (
             match v.var_type with
-            | TVec _ -> Some (escape_glsl_name v.var_name ^ "_len")
+            | TVec _ -> Some (glsl_array_length_name v.var_name)
             | _ -> None)
         | _ -> None)
       k.kern_params
@@ -2025,20 +2044,21 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
         match decl with
         | DParam (v, _) -> (
             match v.var_type with
-            | TVec _ -> None (* vectors don't get macros, only their _len *)
+            | TVec _ -> None (* vectors don't get macros, only their length *)
             | _ -> Some (escape_glsl_name v.var_name))
         | _ -> None)
       k.kern_params
   in
-  (* Vector params emit a length macro [#define <vec>_len pc.<vec>_len]; a local
-     named [<vec>_len] collides with it (see rename_pc_shadowing_locals). *)
+  (* Vector params emit a length macro
+     [#define sarek_<vec>_length pc.sarek_<vec>_length]; a local named
+     [sarek_<vec>_length] collides with it (see rename_pc_shadowing_locals). *)
   let len_names =
     List.filter_map
       (fun decl ->
         match decl with
         | DParam (v, _) -> (
             match v.var_type with
-            | TVec _ -> Some (escape_glsl_name v.var_name ^ "_len")
+            | TVec _ -> Some (glsl_array_length_name v.var_name)
             | _ -> None)
         | _ -> None)
       k.kern_params

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -1360,10 +1360,11 @@ let gen_bindings buf params =
     that is not a scalar param, so [gen_expr]'s [scalar_param_names] check never
     matches it. The initializer is evaluated in the outer scope, so it still
     expands to [params.<name>], preserving semantics. Unlike GLSL there is no
-    vector-length ([_len]) collision: WGSL emits vector length as the field
-    access [params.sarek_<arr>_length] ({!EArrayLen}), hardcoded with a
-    [params.] prefix independent of any local, so a local cannot alias it — the
-    collision set is scalar params only. WGSL-only. *)
+    vector-length collision: both spell the length [sarek_<arr>_length]
+    ({!EArrayLen}), but WGSL emits it as the field access
+    [params.sarek_<arr>_length], hardcoded with a [params.] prefix independent
+    of any local, so a local cannot alias it — the collision set is scalar
+    params only. WGSL-only. *)
 let rename_scalar_shadowing_locals ~scalar_names body =
   Sarek_ir_codegen.rename_shadowing_locals
     ~collides:(fun name ->

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -973,13 +973,13 @@ let () =
     \  float c[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
-    \  int c_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
+    \  int sarek_c_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\
-     #define c_len pc.c_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\
+     #define sarek_c_length pc.sarek_c_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  c[idx] = (a[idx] + b[idx]);\n\
@@ -999,9 +999,9 @@ let () =
     \  Point2 pts[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int pts_len;\n\
+    \  int sarek_pts_length;\n\
      } pc;\n\n\
-     #define pts_len pc.pts_len\n\n\
+     #define sarek_pts_length pc.sarek_pts_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  Point2 p = pts[idx];\n\
@@ -1038,11 +1038,11 @@ let () =
     \  Opt outv[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int flags_len;\n\
-    \  int outv_len;\n\
+    \  int sarek_flags_length;\n\
+    \  int sarek_outv_length;\n\
      } pc;\n\n\
-     #define flags_len pc.flags_len\n\
-     #define outv_len pc.outv_len\n\n\
+     #define sarek_flags_length pc.sarek_flags_length\n\
+     #define sarek_outv_length pc.sarek_outv_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  int flag = flags[idx];\n\
@@ -1066,11 +1066,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = sin(a[idx]);\n\
@@ -1133,11 +1133,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = sin(a[idx]);\n\
@@ -1423,11 +1423,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = inversesqrt(a[idx]);\n\
@@ -1446,11 +1446,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = abs(a[idx]);\n\
@@ -1470,11 +1470,11 @@ let () =
     \  double b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = abs(a[idx]);\n\
@@ -1497,13 +1497,13 @@ let () =
     \  double c[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
-    \  int c_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
+    \  int sarek_c_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\
-     #define c_len pc.c_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\
+     #define sarek_c_length pc.sarek_c_length\n\n\
      float sarek_copysign(float x, float y) { return \
      uintBitsToFloat((floatBitsToUint(x) & 0x7FFFFFFFu) | (floatBitsToUint(y) \
      & 0x80000000u)); }\n\n\
@@ -1531,13 +1531,13 @@ let () =
     \  float c[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
-    \  int c_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
+    \  int sarek_c_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\
-     #define c_len pc.c_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\
+     #define sarek_c_length pc.sarek_c_length\n\n\
      float sarek_copysign(float x, float y) { return \
      uintBitsToFloat((floatBitsToUint(x) & 0x7FFFFFFFu) | (floatBitsToUint(y) \
      & 0x80000000u)); }\n\n\
@@ -1563,13 +1563,13 @@ let () =
     \  double c[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
-    \  int c_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
+    \  int sarek_c_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\
-     #define c_len pc.c_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\
+     #define sarek_c_length pc.sarek_c_length\n\n\
      float sarek_fmod(float x, float y) {\n\
     \  float ay = abs(y);\n\
     \  if (isnan(x) || isnan(y) || isinf(x) || ay == 0.0) return \
@@ -1618,13 +1618,13 @@ let () =
     \  float c[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
-    \  int c_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
+    \  int sarek_c_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\
-     #define c_len pc.c_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\
+     #define sarek_c_length pc.sarek_c_length\n\n\
      float sarek_fmod(float x, float y) {\n\
     \  float ay = abs(y);\n\
     \  if (isnan(x) || isnan(y) || isinf(x) || ay == 0.0) return \
@@ -1659,13 +1659,13 @@ let () =
     \  float c[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
-    \  int c_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
+    \  int sarek_c_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\
-     #define c_len pc.c_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\
+     #define sarek_c_length pc.sarek_c_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  c[idx] = atan(a[idx], b[idx]);\n\
@@ -1684,11 +1684,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = (sign(a[idx]) * pow(abs(a[idx]), 1.0 / 3.0));\n\
@@ -1710,13 +1710,13 @@ let () =
     \  float c[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
-    \  int c_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
+    \  int sarek_c_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\
-     #define c_len pc.c_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\
+     #define sarek_c_length pc.sarek_c_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  c[idx] = sqrt((a[idx]) * (a[idx]) + (b[idx]) * (b[idx]));\n\
@@ -1735,11 +1735,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = (exp(a[idx]) - 1.0);\n\
@@ -1758,11 +1758,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = log(1.0 + (a[idx]));\n\
@@ -1781,11 +1781,11 @@ let () =
     \  float b[];\n\
      };\n\
      layout(push_constant) uniform PushConstants {\n\
-    \  int a_len;\n\
-    \  int b_len;\n\
+    \  int sarek_a_length;\n\
+    \  int sarek_b_length;\n\
      } pc;\n\n\
-     #define a_len pc.a_len\n\
-     #define b_len pc.b_len\n\n\
+     #define sarek_a_length pc.sarek_a_length\n\
+     #define sarek_b_length pc.sarek_b_length\n\n\
      void main() {\n\
     \  int idx = int(gl_GlobalInvocationID.x);\n\
     \  b[idx] = (log(a[idx]) / log(10.0));\n\
@@ -1808,12 +1808,12 @@ layout(std430, set=0, binding = 1) buffer Buffer_b {
   double b[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
+  int sarek_a_length;
+  int sarek_b_length;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
 
 double sarek_f64_log(double);
 double sarek_f64_log10(double);
@@ -1859,12 +1859,12 @@ layout(std430, set=0, binding = 1) buffer Buffer_b {
   double b[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
+  int sarek_a_length;
+  int sarek_b_length;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
 
 double sarek_f64_exp(double);
 double sarek_f64_log(double);
@@ -1928,12 +1928,12 @@ layout(std430, set=0, binding = 1) buffer Buffer_b {
   double b[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
+  int sarek_a_length;
+  int sarek_b_length;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
 
 double sarek_f64_exp(double);
 
@@ -1977,12 +1977,12 @@ layout(std430, set=0, binding = 1) buffer Buffer_b {
   double b[];
 };
 layout(push_constant) uniform PushConstants {
-  int a_len;
-  int b_len;
+  int sarek_a_length;
+  int sarek_b_length;
 } pc;
 
-#define a_len pc.a_len
-#define b_len pc.b_len
+#define sarek_a_length pc.sarek_a_length
+#define sarek_b_length pc.sarek_b_length
 
 double sarek_f64_log(double);
 

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -218,6 +218,15 @@
  (modules test_backend_arm_parity)
  (libraries sarek.codegen sarek_ir alcotest))
 
+; An emitter must declare every name it uses (backlog-156). Within ONE backend,
+; between the half that declares a generated identifier and the half that uses
+; it — the axis the cross-backend arm-parity matrix cannot see.
+
+(test
+ (name test_emitted_name_declared)
+ (modules test_emitted_name_declared)
+ (libraries sarek.codegen sarek_ir alcotest unix))
+
 ; Intrinsic-surface reconciliation: derives its expectation from
 ; Sarek_registry's link-time record of every let%sarek_intrinsic, and checks it
 ; against Sarek_pure_registry (GPU codegen) and Sarek_cpu_runtime (native).

--- a/sarek/tests/unit/test_emitted_name_declared.ml
+++ b/sarek/tests/unit/test_emitted_name_declared.ml
@@ -1,0 +1,338 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * An emitter must declare every name it uses (backlog-156).
+ *
+ * WHAT THIS IS FOR
+ *
+ * A backend emitter has two halves that never meet in the type system: the part
+ * that DECLARES a generated identifier (a kernel parameter, a push-constant
+ * field, a struct member) and the part that USES it (an expression arm). Each
+ * half builds the identifier by string concatenation, at its own site, and
+ * nothing in OCaml relates the two. Two spellings of one concept is therefore a
+ * shape the compiler cannot see, and the only witness is a device compiler
+ * rejecting the output.
+ *
+ * backlog-156 is exactly that: `Sarek_ir_glsl` declared the length of a vector
+ * parameter as `<name>_len` (push-constant field plus `#define` alias) and used
+ * it, for `EArrayLen`, as `sarek_<name>_length`. Any kernel taking a length
+ * emitted GLSL naming an identifier the shader never declared; glslangValidator
+ * exits 2 with "'sarek_a_length' : undeclared identifier". It survived because
+ * nothing reaches `EArrayLen` on a GLSL path: no test, no example, and no
+ * surface syntax — the Sarek frontend has no `len` primitive at all, so the
+ * constructor is reachable only by hand-written IR. An unreachable feature
+ * cannot be observed to be broken.
+ *
+ * HOW IT CHECKS, AND WHY THIS WAY
+ *
+ * The property "every identifier used is declared" needs a parser to state
+ * directly, and a per-backend list of language builtins to approximate — and a
+ * hand-maintained builtin list is the same unowned-list shape that produced the
+ * bug. So this checks a corollary that needs neither:
+ *
+ *   Generate the SAME kernel twice, differing only in the construct under test.
+ *   In each output, collect the identifiers occurring EXACTLY ONCE. An identifier
+ *   used once and declared nowhere is a singleton; an identifier that is declared
+ *   is not. Builtins, keywords and the kernel's own scaffolding appear in both
+ *   outputs and cancel in the difference.
+ *
+ * What remains — a singleton the construct introduced — is a name the emitter
+ * wrote and never bound. No allowlist, and it applies to any construct on any
+ * backend, which is why the probe table below is a list rather than one case.
+ *
+ * WHY NOT EXTEND THE ARM-PARITY MATRIX (#94)
+ *
+ * test_backend_arm_parity.ml compares FIVE BACKENDS against each other on one
+ * axis (does each know this intrinsic name). The defect here is within ONE
+ * backend, between two of its own halves, and is invisible to a cross-backend
+ * comparison: all five agree on `sarek_<a>_length` at the use site, which is
+ * precisely why the arm-parity matrix was green throughout — five of the six
+ * emitters spell it that way, GLSL having been the odd one out. Its lexical
+ * companion, scripts/check-arm-parity-coverage.sh, extracts `arm` match-arm
+ * literals and cannot see push-constant emission either. Different axis, so a
+ * different instrument rather than a widened one.
+ *
+ * WHAT IT DOES NOT COVER
+ *
+ * Only the constructs listed in [probes], and only for the parameter shapes
+ * those probes use. It sees a name that is used and never declared; it does not
+ * see a name declared with the wrong type, wrong layout, or wrong offset.
+ *
+ * EXACTLY ONCE IS A CONDITION, NOT A DETAIL. The corollary above detects a free
+ * name only while that name occurs EXACTLY ONCE in the output. A name the
+ * emitter writes TWICE and binds nowhere has count 2, is not a singleton, and is
+ * invisible here — the check reads green on a shader the device compiler
+ * rejects. Measured, on this file: emitting `(sarek_a_undeclared_len -
+ * sarek_a_undeclared_len)` for [EArrayLen] on GLSL leaves both `singleton-free`
+ * GLSL cases green and is caught only by the `device-compiler` case below. So
+ * this instrument covers single-use identifiers; a repeated one needs the
+ * validator.
+ *
+ * AND THE VALIDATOR SKIPS AS PASS. [check_probe_validator] returns unit when
+ * glslangValidator is not on PATH: the `device-compiler` cases then report [OK],
+ * not a skip, and the suite exits 0. The "[skipped]" line it prints goes to the
+ * per-case log alcotest does not surface on success. On a runner without the
+ * tool the GLSL row is therefore SINGLETON-ONLY, and the two limits compose —
+ * measured: with the mutation above and glslangValidator off PATH, all 12 cases
+ * report [OK] and the suite exits 0 on a shader that does not compile.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Wgsl = Sarek_codegen.Sarek_ir_wgsl
+module Metal = Sarek_codegen.Sarek_ir_metal
+module Cuda = Sarek_codegen.Sarek_ir_cuda
+module Opencl = Sarek_codegen.Sarek_ir_opencl
+module Glsl = Sarek_codegen.Sarek_ir_glsl
+module SS = Set.Make (String)
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* Two float32 vector params, [a] read and [c] written; the body is a single
+   assignment whose right-hand side is the only thing that varies. Keeping the
+   body to one statement keeps the singleton sets small and the diff sharp. *)
+let kernel_with rhs =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  {
+    kern_name = "emitted_name_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_locals = [];
+    kern_body = SAssign (LArrayElem ("c", EConst (CInt32 0l)), rhs);
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(* ------------------------------------------------------------------------ *)
+(* Identifier tokenising                                                     *)
+
+let is_id_char ch =
+  (ch >= 'a' && ch <= 'z')
+  || (ch >= 'A' && ch <= 'Z')
+  || (ch >= '0' && ch <= '9')
+  || ch = '_'
+
+(** Identifiers in [src], in order, with duplicates.
+
+    Numeric literals are consumed whole — including any type suffix and any
+    fractional part — rather than skipped a character at a time. Without that,
+    WGSL's suffixed integers ([0i], [2u]) each contribute a bare [i]/[u]
+    "identifier", whose singleton status then flips with the literal count and
+    reports a free name on WGSL that is not there. Measured: it did. *)
+let identifiers src =
+  let n = String.length src in
+  let out = ref [] and i = ref 0 in
+  while !i < n do
+    let ch = src.[!i] in
+    if ch >= '0' && ch <= '9' then
+      while !i < n && (is_id_char src.[!i] || src.[!i] = '.') do
+        incr i
+      done
+    else if is_id_char ch then begin
+      let s = !i in
+      while !i < n && is_id_char src.[!i] do
+        incr i
+      done ;
+      out := String.sub src s (!i - s) :: !out
+    end
+    else incr i
+  done ;
+  List.rev !out
+
+(** Identifiers occurring exactly once in [src]. *)
+let singletons src =
+  let tbl = Hashtbl.create 64 in
+  List.iter
+    (fun id ->
+      Hashtbl.replace tbl id (1 + try Hashtbl.find tbl id with Not_found -> 0))
+    (identifiers src) ;
+  Hashtbl.fold (fun k v acc -> if v = 1 then SS.add k acc else acc) tbl SS.empty
+
+(* ------------------------------------------------------------------------ *)
+(* The matrix                                                                *)
+
+type backend = {
+  label : string;
+  gen : kernel -> string;
+  validate : (string -> (unit, string) result) option;
+      (** External compiler for this backend's output, when one exists and is
+          the real oracle for "undeclared identifier". *)
+}
+
+let read_file path =
+  let ic = open_in_bin path in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic ;
+  s
+
+let run_validator ~exe ~ext ~args src =
+  let base = Filename.temp_file "sarek_name_decl_" "" in
+  let file = base ^ ext in
+  let err = base ^ ".err" in
+  let oc = open_out file in
+  output_string oc src ;
+  close_out oc ;
+  let cmd =
+    Printf.sprintf
+      "%s %s %s >%s 2>&1"
+      exe
+      args
+      (Filename.quote file)
+      (Filename.quote err)
+  in
+  let rc = Unix.system cmd in
+  let out = read_file err in
+  List.iter (fun f -> try Sys.remove f with _ -> ()) [file; err; base] ;
+  match rc with Unix.WEXITED 0 -> Ok () | _ -> Error out
+
+let tool_available exe =
+  lazy
+    (Unix.system (Printf.sprintf "command -v %s >/dev/null 2>&1" exe)
+    = Unix.WEXITED 0)
+
+let glslang_available = tool_available "glslangValidator"
+
+let glslang_ok src =
+  run_validator
+    ~exe:"glslangValidator"
+    ~ext:".comp"
+    ~args:"-V -S comp -o /dev/null"
+    src
+
+let plain label gen = {label; gen; validate = None}
+
+(* Five of the six emitters. PTX is deliberately absent, on two grounds.
+
+   The class is not expressible there: both halves already go through the one
+   {!Sarek_ir_ptx_types.length_param_name} definition — Sarek_ir_ptx_kernel
+   declares the length param with it, Sarek_ir_ptx_expr looks [EArrayLen] up with
+   it — and anything it cannot name that way it refuses, raising [unsupported]
+   ("only parameter arrays have a length") rather than emitting a guessed
+   spelling. There is no second string construction to disagree with the first.
+
+   And the instrument does not transfer: PTX is an assembly, where the singleton
+   corollary's premise (an identifier is either declared or free) does not hold.
+   Measured — adding PTX to this table makes the [EArrayLen] case fail with "PTX
+   emits mov but declares no such name": a once-used INSTRUCTION MNEMONIC, not a
+   free name. Covering PTX needs a different oracle, not this table. *)
+let backends =
+  [
+    plain "CUDA" (fun k -> Cuda.generate_with_types ~types:[] k);
+    plain "OpenCL" (fun k -> Opencl.generate_with_types ~types:[] k);
+    plain "Metal" (fun k -> Metal.generate_with_types ~types:[] k);
+    plain "WGSL" (fun k -> Wgsl.generate_with_types ~types:[] k);
+    {
+      label = "GLSL";
+      gen = (fun k -> Glsl.generate_with_types ~types:[] k);
+      validate = Some glslang_ok;
+    };
+  ]
+
+(** A construct under test: [rhs] uses it, [baseline] does not, and the two are
+    otherwise the same kernel. Anything [rhs] introduces that is used once and
+    bound nowhere is a free identifier the emitter wrote. *)
+type probe = {name : string; rhs : expr; baseline : expr}
+
+let probes =
+  [
+    {
+      (* backlog-156: GLSL declared [a_len] and used [sarek_a_length]. *)
+      name = "EArrayLen of a vector parameter";
+      rhs = ECast (TFloat32, EArrayLen "a");
+      baseline = ECast (TFloat32, EConst (CInt32 0l));
+    };
+    {
+      (* Control: a construct whose name IS declared on all five, so a red here
+         means the instrument itself started reporting names that are bound. *)
+      name = "EArrayRead of a vector parameter";
+      rhs = EArrayRead ("a", EConst (CInt32 0l));
+      baseline = EConst (CFloat32 0.0);
+    };
+  ]
+
+let check_probe b p () =
+  let src = b.gen (kernel_with p.rhs) in
+  let base = b.gen (kernel_with p.baseline) in
+  let free = SS.diff (singletons src) (singletons base) in
+  if not (SS.is_empty free) then
+    Alcotest.failf
+      "%s emits %s but declares no such name.\n\n\
+       Free identifier(s): %s\n\n\
+       The emitter wrote %s into its output for %S and bound it nowhere: it is \
+       used exactly once in the whole shader. Two spellings of one concept in \
+       one emitter — declare it and use it through a single definition rather \
+       than concatenating the name twice.\n\n\
+       Generated source:\n\
+       %s"
+      b.label
+      (String.concat ", " (SS.elements free))
+      (String.concat ", " (SS.elements free))
+      (String.concat ", " (SS.elements free))
+      p.name
+      src
+
+(* The real oracle, where one is installed: the device compiler. The singleton
+   check exists because it runs everywhere; this exists because it is the thing
+   the singleton check is a proxy for. Skips (rather than passes) when the tool
+   is absent, and says so. *)
+let check_probe_validator b p () =
+  match b.validate with
+  | None -> ()
+  | Some validate ->
+      if not (Lazy.force glslang_available) then
+        Printf.printf
+          "  [skipped] glslangValidator not installed — %s/%S not compiled\n"
+          b.label
+          p.name
+      else begin
+        let src = b.gen (kernel_with p.rhs) in
+        match validate src with
+        | Ok () -> ()
+        | Error out ->
+            Alcotest.failf
+              "%s output for %S does not compile.\n\n%s\nGenerated source:\n%s"
+              b.label
+              p.name
+              out
+              src
+      end
+
+let () =
+  Alcotest.run
+    "emitted names are declared"
+    [
+      ( "singleton-free",
+        List.concat_map
+          (fun b ->
+            List.map
+              (fun p ->
+                Alcotest.test_case
+                  (b.label ^ ": " ^ p.name)
+                  `Quick
+                  (check_probe b p))
+              probes)
+          backends );
+      ( "device-compiler",
+        List.concat_map
+          (fun b ->
+            if b.validate = None then []
+            else
+              List.map
+                (fun p ->
+                  Alcotest.test_case
+                    (b.label ^ ": " ^ p.name)
+                    `Quick
+                    (check_probe_validator b p))
+                probes)
+          backends );
+    ]

--- a/sarek/tests/unit/test_emitted_name_declared.ml
+++ b/sarek/tests/unit/test_emitted_name_declared.ml
@@ -78,6 +78,24 @@
  * tool the GLSL row is therefore SINGLETON-ONLY, and the two limits compose —
  * measured: with the mutation above and glslangValidator off PATH, all 12 cases
  * report [OK] and the suite exits 0 on a shader that does not compile.
+ *
+ * And it sees only ONE POLARITY of the disagreement. The difference is
+ * `free = SS.diff (singletons src) (singletons base)`, so every identifier the
+ * parameter-declaration machinery emits appears in BOTH outputs and cancels
+ * regardless of whether it is spelled correctly. The declaring half is
+ * baseline-invariant and hence outside the difference: this check's witness is
+ * always a USE-side singleton, and it can see a declaring-side defect only
+ * indirectly, when that defect happens to strand a use. A declaration that is
+ * wrong but strands nothing cancels and is invisible — measured, not assumed:
+ * spelling the push-constant FIELD `a_len` while the `#define` alias and the
+ * `EArrayLen` use site both keep `sarek_a_length` leaves all ten
+ * [singleton-free] cases green and is caught only by [device-compiler] below.
+ * Since backlog-156 was itself a declaring/using disagreement, the half this
+ * instrument caught was its using half. For the declaring half the validator,
+ * not the singleton set, is the only oracle — which is why the device-compiler
+ * cases are part of the check rather than a bonus — and, per the preceding
+ * paragraph, why a runner without glslangValidator has no oracle for the
+ * declaring half at all.
  ******************************************************************************)
 
 open Sarek_ir_types

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -299,16 +299,29 @@ let match_pc_shadow_kernel () =
   {k with kern_variants = [("Opt", opt_constrs)]}
 
 (** Vector-length-macro shadow (#71, Minor): each vector param [v] emits a
-    length macro [#define v_len pc.v_len]. A local named [<vec>_len] collides
-    with it: [int data_len = ...;] → [int pc.data_len = ...;] → "unexpected
-    DOT". [pc_names] excludes vectors, so the pre-pass must additionally treat
-    the [_len] macro names as collisions. *)
+    length macro [#define sarek_v_length pc.sarek_v_length]. A local named like
+    that macro collides with it: [int sarek_data_length = ...;] →
+    [int pc.sarek_data_length = ...;] → "unexpected DOT". [pc_names] excludes
+    vectors, so the pre-pass must additionally treat the length macro names as
+    collisions.
+
+    The colliding local is spelled [sarek_data_length], not [data_len]:
+    backlog-156 renamed the macro to the cross-backend [sarek_<v>_length]
+    spelling, so [data_len] now names no macro and this case must follow the
+    rename to keep probing a real collision.
+
+    It does {e not} go quietly green if left un-retargeted — measured: with the
+    local back at [data_len] the case fails at the first assertion below,
+    "expected the vector-_len-shadowing local to be alpha-renamed
+    (sarek_pc_shadow_*)", because nothing collides so nothing is renamed. The
+    retarget keeps the case testing what it is named for; it is not repairing a
+    vacuous check. *)
 let vec_len_shadow_kernel () =
   let data = make_var "data" (TVec TFloat32) in
   let out = make_var "out" (TVec TFloat32) in
   let tid = make_var "tid" TInt32 in
   (* local named EXACTLY like the [data] vector's length macro *)
-  let data_len_l = make_var "data_len" TInt32 in
+  let data_len_l = make_var "sarek_data_length" TInt32 in
   let body =
     SLet
       ( tid,
@@ -318,7 +331,8 @@ let vec_len_shadow_kernel () =
             EConst (CInt32 0l),
             SAssign
               ( LArrayElem ("out", EVar tid),
-                EArrayRead ("data", EVar (make_var "data_len" TInt32)) ) ) )
+                EArrayRead ("data", EVar (make_var "sarek_data_length" TInt32))
+              ) ) )
   in
   base_kernel
     "vec_len_shadow"
@@ -776,10 +790,10 @@ let test_glsl_match_pattern_pc_shadow_validates () =
           e
           k
 
-(* #71 gap #3: a local named like a vector-length macro (`data_len`) must be
-   alpha-renamed. Red-on-mutation: drop the `_len` names from the pre-pass
-   collision set and glslangValidator fails with "unexpected DOT" on
-   `int pc.data_len = ...`. *)
+(* #71 gap #3: a local named like a vector-length macro (`sarek_data_length`)
+   must be alpha-renamed. Red-on-mutation: drop the length names from the
+   pre-pass collision set and glslangValidator fails with "unexpected DOT" on
+   `int pc.sarek_data_length = ...`. *)
 let test_glsl_vec_len_shadow_validates () =
   let k = Sarek_ir_glsl.generate (vec_len_shadow_kernel ()) in
   if not (contains k "sarek_pc_shadow_") then
@@ -788,7 +802,7 @@ let test_glsl_vec_len_shadow_validates () =
        (sarek_pc_shadow_*):\n\
        %s"
       k ;
-  if contains k "int data_len =" then
+  if contains k "int sarek_data_length =" then
     Alcotest.failf
       "a vector-_len-shadowing local declaration survived unrenamed:\n%s"
       k ;
@@ -921,7 +935,7 @@ let () =
             `Quick
             test_glsl_match_pattern_pc_shadow_validates;
           Alcotest.test_case
-            "GLSL local shadows vector _len macro (unexpected DOT)"
+            "GLSL local shadows vector length macro (unexpected DOT)"
             `Quick
             test_glsl_vec_len_shadow_validates;
           Alcotest.test_case

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -793,18 +793,36 @@ let test_glsl_match_pattern_pc_shadow_validates () =
 (* #71 gap #3: a local named like a vector-length macro (`sarek_data_length`)
    must be alpha-renamed. Red-on-mutation: drop the length names from the
    pre-pass collision set and glslangValidator fails with "unexpected DOT" on
-   `int pc.sarek_data_length = ...`. *)
-let test_glsl_vec_len_shadow_validates () =
-  let k = Sarek_ir_glsl.generate (vec_len_shadow_kernel ()) in
+   `int pc.sarek_data_length = ...`.
+
+   RUN ON BOTH ENTRY POINTS, and that is not redundancy. Sarek_ir_glsl exposes
+   two: [generate] and [generate_with_types]. They are separate functions with
+   separate bodies, and the one PRODUCTION uses is the second —
+   sarek-vulkan/Vulkan_plugin.ml calls [generate_with_types]; [generate] is
+   reached only from Sarek_transpile and the benchmark generator. While each
+   built its own copy of the length-macro collision set, this case exercising
+   only [generate] left the shipped path unchecked: reverting the
+   [generate_with_types] copy alone kept the whole tree green while the Vulkan
+   backend emitted GLSL glslangValidator rejects with "unexpected DOT". The
+   copies are now one function ([Sarek_ir_glsl.param_macro_names]); this
+   parameterised pair is what would have caught the drift, and is what fails if
+   the two bodies are ever allowed to diverge again. *)
+let vec_len_shadow_validates ~entry ~gen () =
+  let k = gen (vec_len_shadow_kernel ()) in
   if not (contains k "sarek_pc_shadow_") then
     Alcotest.failf
-      "expected the vector-_len-shadowing local to be alpha-renamed \
+      "[%s] expected the vector-_len-shadowing local to be alpha-renamed \
        (sarek_pc_shadow_*):\n\
        %s"
+      entry
       k ;
   if contains k "int sarek_data_length =" then
     Alcotest.failf
-      "a vector-_len-shadowing local declaration survived unrenamed:\n%s"
+      "[%s] a vector-_len-shadowing local declaration survived unrenamed — the \
+       length-macro collision set this entry point uses does not contain \
+       sarek_data_length:\n\
+       %s"
+      entry
       k ;
   if not (Lazy.force glslang_available) then begin
     Printf.printf "  SKIP: glslangValidator not on PATH\n%!" ;
@@ -816,15 +834,26 @@ let test_glsl_vec_len_shadow_validates () =
   end
   else
     match glslang_ok k with
-    | Ok () -> Printf.printf "  glslangValidator OK: vec_len_shadow\n%!"
+    | Ok () ->
+        Printf.printf "  glslangValidator OK: vec_len_shadow [%s]\n%!" entry
     | Error e ->
         Alcotest.failf
-          "glslangValidator rejected vec_len_shadow GLSL (unexpected DOT?):\n\
+          "[%s] glslangValidator rejected vec_len_shadow GLSL (unexpected DOT?):\n\
            %s\n\
            --- shader ---\n\
            %s"
+          entry
           e
           k
+
+let test_glsl_vec_len_shadow_validates =
+  vec_len_shadow_validates ~entry:"generate" ~gen:Sarek_ir_glsl.generate
+
+(* The entry point sarek-vulkan/Vulkan_plugin.ml actually calls. *)
+let test_glsl_vec_len_shadow_with_types_validates =
+  vec_len_shadow_validates
+    ~entry:"generate_with_types"
+    ~gen:(Sarek_ir_glsl.generate_with_types ~types:[])
 
 (* #71 gap #2 (silent wrong-var read) + #75 (payload binding), on one kernel.
 
@@ -935,9 +964,14 @@ let () =
             `Quick
             test_glsl_match_pattern_pc_shadow_validates;
           Alcotest.test_case
-            "GLSL local shadows vector length macro (unexpected DOT)"
+            "GLSL local shadows vector length macro (unexpected DOT) [generate]"
             `Quick
             test_glsl_vec_len_shadow_validates;
+          Alcotest.test_case
+            "GLSL local shadows vector length macro (unexpected DOT) \
+             [generate_with_types — the Vulkan path]"
+            `Quick
+            test_glsl_vec_len_shadow_with_types_validates;
           Alcotest.test_case
             "GLSL EMatch payload binding validates (#75)"
             `Quick


### PR DESCRIPTION
`Sarek_ir_glsl` declared the length of a vector parameter as `<v>_len` — a push-constant field plus a `#define` alias — and used it, for `EArrayLen`, as `sarek_<v>_length`. Two string concatenations at two sites in one file, never compared. Any kernel taking a length emitted GLSL naming an identifier the shader never declares; `glslangValidator` exits 2 with `'sarek_a_length' : undeclared identifier`.

**Blast radius: nil, and that is the finding.** Nothing reaches `EArrayLen` on a GLSL path — no test, no example, and no surface syntax, because the Sarek frontend has no `len` primitive at all. The constructor is reachable only from hand-written IR. An unreachable feature cannot be observed to be broken, which is the whole explanation for how a `len()` on GLSL has never compiled.

## The name

Both halves now go through `glsl_array_length_name`, so the disagreement is no longer expressible. The spelling is `sarek_<v>_length` — the one CUDA, OpenCL, Metal, WGSL **and PTX** already use, five of the six emitters, GLSL the odd one out. Push constants are bound by byte offset, not by name, so the Vulkan host side is unaffected; field order is unchanged.

## The check

`sarek/tests/unit/test_emitted_name_declared.ml`, over five of the six emitters: generate the same kernel twice differing only in the construct under test, and take the identifiers occurring exactly once in each output. A name used once and declared nowhere is a singleton; a declared name is not; builtins and scaffolding appear in both and cancel in the difference. No allowlist. Where a device compiler exists (`glslangValidator`) the suite also compiles the output, which is the oracle the singleton check stands in for.

This is a different axis from the #94 arm-parity matrix rather than an extension of it: that compares backends against each other, and they all agree on `sarek_<v>_length` at the use site — which is exactly why it stayed green. The defect is inside one backend, between two of its own halves.

## What the check does not cover — measured, and now stated in the file

A review pass measured three claims in this PR's prose that were wider than what the code actually checks. The code is unchanged; the prose is narrowed to it.

**1. "Exactly once" is a condition, not a detail.** The corollary detects a free name only while that name occurs exactly once. A name the emitter writes **twice** and binds nowhere has count 2, is not a singleton, and is invisible.

> Mutation: emit `(sarek_a_undeclared_len - sarek_a_undeclared_len)` for `EArrayLen` on GLSL.
> RED observed: `1 failure! in 0.197s. 12 tests run.`, rc 1 — and the failure is `device-compiler.000`, **not** either GLSL `singleton-free` case. Both of those stayed `[OK]` on a shader that does not compile.

**2. And the device-compiler arm skips as pass.** `check_probe_validator` returns unit when `glslangValidator` is off `PATH`. The cases then report `[OK]`, not a skip; the `[skipped]` line it prints lands in a per-case log alcotest does not surface on success.

> Measured with `PATH` stripped: `Test Successful in 0.005s. 12 tests run.`, rc 0, with `  [skipped] glslangValidator not installed` present only in `device-compiler.000.output`.
> The two limits **compose**: with mutation 1 in force *and* the tool absent, all 12 cases read `[OK]` at exit 0 on a broken shader. On such a runner the GLSL row is singleton-only.

Both limits are now in the file's `WHAT IT DOES NOT COVER` block.

**3. The vacuity claim on the #71 shadow case was wrong, and is dropped.** The retarget of the vector-length-macro shadow case (`data_len` → `sarek_data_length`) is still right — after the rename `data_len` names no macro — but the justification given for it was not the one doing the work. It does *not* go quietly green if left un-retargeted.

> Un-retargeted case, RED observed: `FAIL expected the vector-_len-shadowing local to be alpha-renamed (sarek_pc_shadow_*)` at `test_shader_recursion_vector.ml:794-798`; `1 failure! in 0.495s. 10 tests run.`, rc 1. With nothing colliding, nothing is renamed, so the case's own first assertion fires.

**PTX is out of scope, on two grounds, now recorded beside the backend table.** Its two halves already share the one `length_param_name` definition (`Sarek_ir_ptx_kernel` declares with it, `Sarek_ir_ptx_expr` looks up with it) and anything else raises `unsupported` ("only parameter arrays have a length") — the disagreement is not expressible. And the instrument does not transfer to an assembly:

> Measured, adding PTX to the table: `FAIL PTX emits mov but declares no such name` — a once-used instruction mnemonic, not a free name. Covering PTX needs a different oracle.

## Close-out round: the thesis, one level up

The docstring on `glsl_array_length_name` claimed it routed "both halves (and the shadowing sets in `generate_with_types`)" through one definition so the disagreement was not expressible. **The parenthesis was not true, and nothing checked it.**

`generate` and `generate_with_types` each built `pc_names`/`len_names` from their own copy of the same `filter_map` pair, and nothing compared the copies — the same two-spellings-of-one-concept shape this PR exists to close, one level up from the name itself.

> Mutation, before the fix: revert the `generate_with_types` copy alone to `<v>_len`.
> **Tree-wide `dune test --force` rc 0** on a 4811-line log — fully green — while the emitter produced GLSL `glslangValidator` rejects with **exit 2, `syntax error, unexpected DOT, expecting COMMA or SEMICOLON`**.

**And the tested path was the one production does not use.** `sarek-vulkan/Vulkan_plugin.ml:198` calls `generate_with_types`; `generate` is reached only from `Sarek_transpile.ml:240` and `benchmarks/generate_backend_code.ml:495`. The only test of the vector-length-macro collision called `generate`.

### One construction

Both copies are now `Sarek_ir_glsl.param_macro_names` (`sarek/codegen/Sarek_ir_glsl.ml:1820`), called by `generate` (`:1956`) and `generate_with_types` (`:2070`). The drift is not expressible rather than merely untested — the hoisted body is the two copies verbatim, so there is no behaviour change. The docstring's parenthesis is replaced by a claim that is now structurally true.

### And the check that would have caught it

`test_shader_recursion_vector.ml:810` parameterises the vector-length-macro shadow case over the entry point; it is registered twice, the second on `generate_with_types` — the Vulkan path.

> **M2** — reintroduce the `generate_with_types` divergence by hand:
> RED, rc 1, `1 failure! in 0.578s. 11 tests run.`
> `FAIL [generate_with_types] expected the vector-_len-shadowing local to be alpha-renamed (sarek_pc_shadow_*)`, and case 8 (`[generate]`) stays `[OK]` — precisely the asymmetry that was invisible.
> The shader it prints, fed to the validator directly: **exit 2**, `ERROR: 21: '' : syntax error, unexpected DOT, expecting COMMA or SEMICOLON`.

> **M1′** — mutate the single shared construction:
> RED, rc 1, `2 failures! in 0.487s. 11 tests run.` — both entry-point cases fail. One construction, both sides covered.

Both cases report `[OK]`, not `[SKIP]`, on this host, so the validator arm genuinely ran.

## The disclosed limit understated itself by a whole polarity

`WHAT IT DOES NOT COVER` framed the hole as *a name the emitter writes twice and binds nowhere*. The mechanism is broader. The witness is `free = SS.diff (singletons src) (singletons base)`, so **every** identifier the parameter-declaration machinery emits appears in both outputs and cancels regardless of whether it is spelled correctly. The check's witness is therefore always a **use**-side singleton; it sees a declaring-side defect only indirectly, when that defect happens to strand a use.

> **M4** — corrupt only the push-constant **field** name (`a_len`) while the `#define` alias and the `EArrayLen` use site both keep `sarek_a_length`, so no use is stranded:
> all **ten** `singleton-free` cases `[OK]`; caught only by `device-compiler.000`, `FAIL GLSL output for "EArrayLen of a vector parameter" does not compile.` rc 1.

> Contrast **M3** — move the whole declaring half, which *does* strand a use: caught, but the witness is `FAIL GLSL emits sarek_a_length but declares no such name` — the **use**-side name, confirming the polarity rather than contradicting it.

Since backlog-156 was itself a declaring/using disagreement, the half this instrument caught was its **using** half. For the declaring half the validator, not the singleton set, is the only oracle — which composes with the previously-recorded skip-as-pass limit: on a runner without `glslangValidator` the declaring half has no oracle at all. Stated in the file.

## Verification

- `dune build @check` — rc 0. `dune build @fmt` — rc 0.
- `test_emitted_name_declared` — rc 0, `Test Successful in 0.201s. 12 tests run.`
- `test_shader_recursion_vector` — rc 0, `Test Successful in 0.725s. 11 tests run.` (was 10; the new case is the `generate_with_types` twin.)
- `dune test --force` — rc 0, log **4812** lines (non-empty, not a cached no-op).
- `scripts/test-suite-counts.sh` on that log — rc **0**: `TOTAL: 1710 cases across 118 suites / FAIL 0 / SKIP 23 / zero-case suites 4`. (1709 → 1710: the one added case.)
- The counter's own gate proven able to fail before trusting it (backlog-157): empty log → rc **2** (`no test-suite output recognised`), missing file → rc **2**, `--min-suites 500` → rc **3**.
- Every mutation above re-run on the final rebased tree, not only pre-rebase.

Earlier rounds' text-only narrowing is retained above; this round additionally changes code (the hoist) and adds one test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
