### PR TITLE
fix(helper-scoping): tail-recursion id collision and callee vector lookup

### DIFF
--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -269,35 +269,39 @@ and eval_expr state env expr =
   (* Function application *)
   | EApp (fn_expr, args) -> eval_app state env fn_expr args
 
-(* KNOWN GAP — a vector passed as a HELPER FUNCTION PARAMETER is not reachable
-   here. [eval_app] binds arguments with [bind_var], which writes
-   [vars]/[vars_by_name], while this looks only in [arrays]/[shared] — the
-   KERNEL's own parameters. Indexing a vector parameter inside a helper
-   therefore raises "Unbound variable '<param>' in get_array", so a
-   tail-recursive fold over a vector runs on every backend except the
-   interpreter.
+(* Vector lookup, innermost scope first.
 
-   A [vars_by_name] fallback here does make those folds run, and was written and
-   then deliberately REVERTED, because on its own it trades a loud failure for a
-   silent wrong answer. Helper parameter ids come from the typer's [tparam_id]
-   space while body locals come from the kernel-wide [fresh_id] counter
-   (Sarek_lower_ir.ml), the two spaces overlap, and [lookup_var] resolves by id
-   before name — so a tail-recursion temporary can carry the same id as a
-   parameter and clobber it. Observed with the fallback in place: a
-   single-helper [vsum acc v k n] fold over four 1.0s returns 0 on the
-   interpreter where Vulkan and Native both return 4, with no error. Which
-   kernels are affected depends only on id numbering, so a passing test proves
-   nothing about the next kernel.
+   A vector reaches a helper as a PARAMETER, bound by [eval_app] through
+   [bind_var] — so it lives in [vars_by_name], not in [arrays], which holds the
+   KERNEL's own parameters. That table is therefore consulted FIRST: a helper's
+   formal shadows a kernel array of the same name, which is what lexical scoping
+   means and what every GPU backend does. Checking [arrays] first made the
+   shadowing case silently read the wrong buffer — measured: a helper folding
+   over its formal [src] while the kernel also had a vector [src] folded the
+   KERNEL's array, returning 400 instead of 4 on the interpreter while Vulkan and
+   Native both returned 4.
 
-   The repair is to make helper ids unique, and it lands with the fallback and
-   with the lookup-precedence question it raises (a helper's vector formal that
-   shares a name with a kernel array must shadow it, not lose to it). *)
+   The lookup is read-only and must stay so: [arrays] is aliased rather than
+   copied into a callee scope because kernel buffers are shared across threads by
+   design, so registering a binding there would be a cross-thread write.
+
+   This fallback existed briefly on its own and was reverted, because alone it
+   traded a loud [Unbound_variable] for a silently wrong number: the
+   tail-recursion transform allocated its loop scaffolding from a counter
+   starting at 0, colliding with the typer's parameter ids. That is fixed in
+   Sarek_tailrec_elim.ml, and a helper call now gets its own scope
+   ([callee_env]) rather than a copy of the caller's, so the fallback can be
+   reinstated. *)
 and get_array env name =
-  try Hashtbl.find env.arrays name
-  with Not_found -> (
-    try Hashtbl.find env.shared name
-    with Not_found ->
-      Interp_error.raise_error (Unbound_variable {name; context = "get_array"}))
+  match Hashtbl.find_opt env.vars_by_name name with
+  | Some (VArray data) -> data
+  | _ -> (
+      try Hashtbl.find env.arrays name
+      with Not_found -> (
+        try Hashtbl.find env.shared name
+        with Not_found ->
+          Interp_error.raise_error
+            (Unbound_variable {name; context = "get_array"})))
 
 and eval_app state env fn_expr args =
   match fn_expr with
@@ -309,7 +313,7 @@ and eval_app state env fn_expr args =
       | Some hf ->
           (* Call helper function *)
           let arg_vals = List.map (eval_expr state env) args in
-          let local_env = copy_env env in
+          let local_env = callee_env env in
           List.iter2
             (fun param arg -> bind_var local_env param arg)
             hf.hf_params

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -87,6 +87,59 @@ let copy_env env =
        declared it and is never shared between threads. *)
   }
 
+(** Environment for a HELPER CALL: the callee's own scope, not a copy of the
+    caller's.
+
+    [copy_env] duplicates [vars]/[vars_by_name], which is right for a nested
+    block — a block sees its enclosing locals — and wrong for a function call:
+    carrying the caller's bindings in makes the callee's lookups depend on ids
+    and names not in its scope, and since [lookup_var] resolves by id before
+    name, a caller binding can answer a callee reference.
+
+    "A helper sees only its parameters" would be the clean statement and it is
+    NOT true of this language: a module-level constant ([MConst]) is declared
+    before the helpers and IS lexically visible in their bodies, yet lowering
+    emits it as an [SLet] at the head of the KERNEL body — into [vars], the one
+    table this does not alias. Such a kernel is broken on both sides of this
+    change today (it fails on the base revision too, for an unrelated
+    positional-id reason), so nothing regresses here — but the scope model below
+    is narrower than the surface language, and the two must be reconciled BEFORE
+    the [hf_params] follow-up lands: that fix would turn a masked failure into a
+    hard [Unbound_variable] which [copy_env] was accidentally covering.
+
+    No test distinguishes this from copy semantics: reverting it leaves the
+    whole suite green, measured by two independent review passes. That is not
+    because it is decoration — it is the PRECONDITION that makes [get_array]'s
+    new precedence sound. That lookup consults [vars_by_name] BEFORE [arrays] so
+    a helper's formal shadows a kernel array of the same name; under copy
+    semantics [vars_by_name] also holds the CALLER's locals, so the same
+    precedence would let a caller binding answer a lookup that should reach the
+    kernel's array. The two changes are one change and land together.
+
+    No test separates them because a caller local holding an array value is not
+    expressible today: kernel vectors live in [arrays], and a [let rec] in the
+    kernel body — which could close over one — is rejected at parse time. So the
+    dependency is argued, not measured, and this says which of the two it is.
+
+    [coopmats] is fresh where [copy_env] copied it. A fragment belongs to the
+    block that declared it, which is right for one the helper declares itself;
+    if coopmat ops in helper bodies ever become expressible against a
+    KERNEL-scope fragment, this must alias [coopmats] too.
+
+    [arrays], [shared] and [funcs] stay ALIASED, deliberately: kernel buffers,
+    block-shared memory and the helper table are genuinely global to the
+    invocation, and [arrays] in particular is shared across threads by design,
+    so it must not be copied. *)
+let callee_env env =
+  {
+    vars = Hashtbl.create 8;
+    vars_by_name = Hashtbl.create 8;
+    arrays = env.arrays;
+    shared = env.shared;
+    funcs = env.funcs;
+    coopmats = Hashtbl.create 4;
+  }
+
 (** Bind a variable in the environment (both by id and name) *)
 let bind_var env (v : var) value =
   Hashtbl.replace env.vars v.var_id value ;

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -289,6 +289,13 @@ let create_state fun_map =
     variants = Hashtbl.create 8;
   }
 
+(* DEAD as of this writing: [fresh_id] has no caller, and [next_var_id] is
+   touched only by it. Flagged rather than deleted (pre-existing dead code
+   outside this change's scope) but flagged deliberately, because a commit
+   message on this branch described it as one of three LIVE id allocators and
+   that was wrong — the live ones are the typer's [fresh_var_id] and, until it
+   was unified with it, the tail-recursion transform's. The only other live id
+   convention is the NEGATIVE range for tuple temporaries below. *)
 let fresh_id state =
   let id = state.next_var_id in
   state.next_var_id <- id + 1 ;

--- a/sarek/ppx/Sarek_tailrec_elim.ml
+++ b/sarek/ppx/Sarek_tailrec_elim.ml
@@ -15,10 +15,37 @@ open Sarek_types
 
 (** {1 Tail Recursion Elimination} *)
 
-(** Fresh variable ID generator for transformation (thread-safe) *)
-let transform_var_counter = Atomic.make 0
+(** Fresh variable id for the loop scaffolding — drawn from THE typer's
+    allocator, not a second one.
 
-let fresh_transform_id () = Atomic.fetch_and_add transform_var_counter 1
+    There used to be a private [Atomic.make 0] here, and starting at 0 put the
+    scaffolding in the same range as the [tparam_id]s it was scaffolding. On
+    [vsum acc v k n] the [_result] temporary took id 3 and so did the parameter
+    [n]; the interpreter's [lookup_var] resolves by id before name, so the
+    temporary answered every reference to [n], the loop bound became 0, and a
+    fold over four 1.0s returned 0 while Vulkan and Native returned 4 —
+    silently, on the cross-backend oracle. With one body-local [let] added the
+    same kernel either returned 0 or did not terminate, depending on how many
+    kernels the process had already compiled, because the counter was global and
+    persisted across them.
+
+    Two intermediate fixes were tried and both were worse than this one. Seeding
+    a private counter above the PARAMETER ids relocated the collision onto the
+    first body-local (max(param_id)+1 is exactly its id, since the typer types a
+    body straight after its parameters). Seeding above the typer's whole counter
+    worked but coupled two files through a counter read, and left a second
+    allocator alive to drift.
+
+    Drawing from the typer removes the class rather than the instance: there is
+    one monotonic source of variable ids, so a transform id cannot equal a typer
+    id by construction and nothing has to be kept in sync. The only other id
+    convention in the pipeline is the NEGATIVE range used for tuple temporaries
+    (Sarek_lower_ir.ml), which is disjoint by construction and untouched.
+
+    Nothing pins these ids: codegen emits [var_name] and never [var_id], no
+    golden or snapshot depends on them, and test_tailrec_elim asserts only
+    relative ordering. Verified before making the change, not after. *)
+let fresh_transform_id () = Sarek_typed_ast.fresh_var_id ()
 
 (** Transform a tail-recursive function into a loop.
 

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1455,3 +1455,30 @@
  (alias runtest)
  (action
   (run %{dep:test_tailrec_vector_param.exe})))
+
+; Helper-function scoping in the interpreter, checked against the GPU backends.
+; Three defects that each produced a silently wrong number on the oracle:
+; positional helper param ids, a callee inheriting the caller's scope, and
+; get_array preferring the kernel's vectors over the callee's own bindings.
+; Run with: dune exec sarek/tests/e2e/test_helper_scoping.exe
+
+(executable
+ (name test_helper_scoping)
+ (modules test_helper_scoping)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek.float64
+  sarek_ir
+  sarek_interpreter
+  spoc_core
+  test_helpers
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_helper_scoping.exe})))

--- a/sarek/tests/e2e/test_helper_scoping.ml
+++ b/sarek/tests/e2e/test_helper_scoping.ml
@@ -1,0 +1,312 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Helper-function scoping in the interpreter, against the GPU backends as the
+ * reference.
+ *
+ * Three defects, all of which produced a SILENTLY WRONG NUMBER on the
+ * interpreter — the cross-backend oracle — while Vulkan and Native computed the
+ * right one:
+ *
+ *   A. the tail-recursion transform allocated its loop scaffolding from a
+ *      counter starting at 0, the same range the typer uses for parameter ids.
+ *      On `vsum acc v k n` the `_result` temporary took id 3 and so did the
+ *      parameter `n`; since lookup_var resolves by id before name, the temporary
+ *      answered every reference to `n`, the loop bound became 0, and the fold
+ *      returned 0 instead of 4.
+ *   B. a helper call inherited a COPY of the caller's scope (copy_env), so a
+ *      caller binding could answer a callee reference. NOT covered here and NOT
+ *      claimed as a repaired defect: reverting that change leaves this whole
+ *      file green, so it is hardening whose absence nothing would notice. Said
+ *      plainly rather than counted as a third fix.
+ *   E. the same id collision as A, but with a body-local [let] in the helper.
+ *      Seeding the transform above the PARAMETER ids alone did not fix it —
+ *      max(param_id)+1 is exactly the first body-local's id — and the earlier
+ *      appeal to case D as evidence was void, since case D is non-recursive and
+ *      the transform never runs for it.
+ *   C. get_array consulted `arrays` (the kernel's vectors) before the callee's
+ *      own bindings, so a helper formal named like a kernel vector read the
+ *      KERNEL's buffer. Folding `other` returned 400 — the contents of `src`.
+ *
+ * A FOURTH suspicion was probed and NOT confirmed, so nothing was changed for
+ * it: `hf_params` gives each helper parameter the POSITIONAL INDEX as its id
+ * while every use site inside the body carries the typer's id, which means the
+ * same parameter has two ids and the name fallback in lookup_var is silently
+ * load-bearing. Case D below was written to expose that (four parameters, two
+ * body bindings, no tail recursion) and it passes identically with and without a
+ * fix, on all five devices. Filed rather than fixed: an unobservable change is
+ * not shippable on the strength of looking more correct.
+ *
+ * Each case asserts BOTH an exact expected value per device AND agreement
+ * across devices, and reports which backend deviates. An earlier version of this
+ * header claimed the cross-device comparison while the code only compared each
+ * device to a hardcoded constant — the claim is now implemented rather than
+ * deleted, because it is the useful half: a constant says a run is wrong, the
+ * comparison says which side is.
+ *
+ * Values are exact — small integers in binary64 — so there is no tolerance to
+ * hide behind, and NaN would fail rather than pass.
+ *
+ * Case E carries a WALL-CLOCK guard. Its failure mode on the base revision is
+ * not a wrong number but non-termination: the loop scaffolding overwrote the
+ * counter it was testing, so `_continue` never cleared. Which of the two symptoms
+ * appears — 0, or a hang — depends on how many kernels the process compiled
+ * first, because the transform's id counter is global and persists. A test whose
+ * red is a hang reads as a stuck CI job rather than a failure, so it must time
+ * out on its own.
+ *
+ * Run with: dune exec sarek/tests/e2e/test_helper_scoping.exe
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Test_helpers.Benchmarks.init_backends ()
+
+(* A — single helper, tail-recursive fold over a vector parameter. One helper is
+   deliberate: the three-helper shape in test_tailrec_vector_param happened to
+   get a non-colliding numbering and passed while this one returned 0. *)
+let single_helper_kernel =
+  [%kernel
+    let open Std in
+    let open Sarek_float64 in
+    let rec vsum (acc : float64) (v : float64 vector) (k : int32) (n : int32) :
+        float64 =
+      if k >= n then acc else vsum (acc +. v.(k)) v (k + 1l) n
+    in
+    fun (out : float64 vector) (src : float64 vector) (n : int32) ->
+      let t = global_thread_id in
+      if t < 1l then out.(0l) <- vsum 0.0G src 0l n]
+
+(* C — the helper's formal is named like a DIFFERENT kernel vector. The call
+   passes `other`; a lookup that prefers the kernel's `arrays` folds `src`. *)
+let shadowing_kernel =
+  [%kernel
+    let open Std in
+    let open Sarek_float64 in
+    let rec fold_src (acc : float64) (src : float64 vector) (k : int32)
+        (n : int32) : float64 =
+      if k >= n then acc else fold_src (acc +. src.(k)) src (k + 1l) n
+    in
+    fun (out : float64 vector)
+        (src : float64 vector)
+        (other : float64 vector)
+        (n : int32)
+      ->
+      let t = global_thread_id in
+      if t < 1l then out.(0l) <- fold_src 0.0G other 0l n]
+
+(* D — a NON-recursive helper with several parameters and a body binding. The
+   positional-index scheme gave the parameters ids 0..n-1; a body [let] carries a
+   typer id from an independent space, so it can land on one of them. No tail
+   recursion here on purpose: this probes the id scheme itself, not the loop
+   scaffolding. *)
+let multi_param_kernel =
+  [%kernel
+    let open Std in
+    let open Sarek_float64 in
+    let combine (a : float64) (b : float64) (c : float64) (d : float64) :
+        float64 =
+      let z = a +. b in
+      let w = z +. c in
+      w +. d
+    in
+    fun (out : float64 vector) (src : float64 vector) (n : int32) ->
+      let t = global_thread_id in
+      if t < 1l then out.(0l) <- combine src.(0l) src.(1l) src.(2l) src.(3l)]
+
+(* E — the case that seeding above the parameter ids alone did NOT fix. *)
+let body_local_kernel =
+  [%kernel
+    let open Std in
+    let open Sarek_float64 in
+    let rec vsum2 (acc : float64) (v : float64 vector) (k : int32) (n : int32) :
+        float64 =
+      if k >= n then acc
+      else
+        let x = v.(k) in
+        vsum2 (acc +. x) v (k + 1l) n
+    in
+    fun (out : float64 vector) (src : float64 vector) (n : int32) ->
+      let t = global_thread_id in
+      if t < 1l then out.(0l) <- vsum2 0.0G src 0l n]
+
+let n = 4
+
+let describe = function
+  | Sarek_interp.Interp_error.Interpreter_error e ->
+      Sarek_interp.Interp_error.error_to_string e
+  | e -> Printexc.to_string e
+
+let ir_of k =
+  let _, kirc = k in
+  match kirc.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let fp64_devices () =
+  Array.to_list (Device.init ())
+  |> List.filter (fun (d : Device.t) ->
+      let f = d.Device.framework in
+      f = "Native" || f = "Interpreter" || Device.allows_fp64 d)
+
+(* [fills] gives each input vector its constant value, in argument order after
+   [out]. Returns out.(0) or an error string. *)
+let run (dev : Device.t) ir ~fills =
+  try
+    let out = Vector.create Vector.float64 1 in
+    Vector.set out 0 0.0 ;
+    let vecs =
+      List.map
+        (fun v ->
+          let a = Vector.create Vector.float64 n in
+          for i = 0 to n - 1 do
+            Vector.set a i v
+          done ;
+          a)
+        fills
+    in
+    Execute.run_vectors
+      ~device:dev
+      ~ir
+      ~args:
+        ((Execute.Vec out :: List.map (fun a -> Execute.Vec a) vecs)
+        @ [Execute.Int n])
+      ~block:(Execute.dims1d 1)
+      ~grid:(Execute.dims1d 1)
+      () ;
+    Transfer.flush dev ;
+    Ok (Vector.to_array out).(0)
+  with e -> Error (describe e)
+
+let failures = ref 0
+
+let case ?(timeout_s = 30) label ir ~fills ~expected =
+  Printf.printf "  %s (expect %g on every device)\n%!" label expected ;
+  let devs = fp64_devices () in
+  if devs = [] then begin
+    print_endline "    no fp64-capable device — proves nothing" ;
+    incr failures
+  end ;
+  let results =
+    List.map
+      (fun (dev : Device.t) ->
+        (* Wall-clock guard: the pre-fix failure mode of case E is
+           non-termination, and a hung run is not a reported failure. *)
+        let alarm_fired = ref false in
+        let prev =
+          Sys.signal
+            Sys.sigalrm
+            (Sys.Signal_handle
+               (fun _ ->
+                 alarm_fired := true ;
+                 Printf.printf
+                   "    %-11s %-40s TIMEOUT after %ds\n%!"
+                   dev.Device.framework
+                   dev.Device.name
+                   timeout_s ;
+                 exit 1))
+        in
+        ignore (Unix.alarm timeout_s) ;
+        let r = run dev ir ~fills in
+        ignore (Unix.alarm 0) ;
+        Sys.set_signal Sys.sigalrm prev ;
+        ignore !alarm_fired ;
+        (dev, r))
+      devs
+  in
+  List.iter
+    (fun ((dev : Device.t), r) ->
+      match r with
+      | Ok got ->
+          Printf.printf
+            "    %-11s %-40s got=%g %s\n%!"
+            dev.Device.framework
+            dev.Device.name
+            got
+            (if got = expected then "" else "<-- WRONG") ;
+          if got <> expected then incr failures
+      | Error msg ->
+          Printf.printf
+            "    %-11s %-40s ERROR %s\n%!"
+            dev.Device.framework
+            dev.Device.name
+            msg ;
+          incr failures)
+    results ;
+  (* Cross-device agreement, reported separately: it says WHICH backend deviates,
+     which the per-device constant check cannot. *)
+  let oks =
+    List.filter_map
+      (fun (d, r) -> match r with Ok v -> Some (d, v) | _ -> None)
+      results
+  in
+  let values = List.sort_uniq compare (List.map snd oks) in
+  if List.length values > 1 then begin
+    let tally =
+      List.map
+        (fun v ->
+          ( v,
+            List.filter_map
+              (fun ((d : Device.t), w) ->
+                if w = v then Some d.Device.framework else None)
+              oks ))
+        values
+    in
+    let majority, _ =
+      List.fold_left
+        (fun (bv, bn) (v, ds) ->
+          let n = List.length ds in
+          if n > bn then (v, n) else (bv, bn))
+        (expected, 0)
+        tally
+    in
+    Printf.printf
+      "    DISAGREEMENT — majority %g, deviating: %s\n%!"
+      majority
+      (String.concat
+         ", "
+         (List.concat_map
+            (fun (v, ds) ->
+              if v = majority then []
+              else List.map (fun f -> Printf.sprintf "%s(%g)" f v) ds)
+            tally)) ;
+    incr failures
+  end
+
+let () =
+  print_endline "=== helper-function scoping in the interpreter ===" ;
+  (* src = four 1.0s, so the fold is 4. *)
+  case
+    "A: single-helper tail-recursive fold over a vector parameter"
+    (ir_of single_helper_kernel)
+    ~fills:[1.0]
+    ~expected:4.0 ;
+  (* src = 100.0 each, other = 1.0 each. Folding `other` is 4; folding the
+     kernel's `src` instead is 400, which is what the wrong precedence gave. *)
+  case
+    "C: helper formal named like a DIFFERENT kernel vector"
+    (ir_of shadowing_kernel)
+    ~fills:[100.0; 1.0]
+    ~expected:4.0 ;
+  (* src = four 1.0s, so a + b + c + d = 4. *)
+  case
+    "D: non-recursive helper, four params and two body bindings"
+    (ir_of multi_param_kernel)
+    ~fills:[1.0]
+    ~expected:4.0 ;
+  (* E — same as A plus one body-local `let`. src = four 1.0s, fold = 4. *)
+  case
+    "E: tail-recursive helper with a body-local let"
+    (ir_of body_local_kernel)
+    ~fills:[1.0]
+    ~expected:4.0 ;
+  if !failures > 0 then exit 1

--- a/sarek/tests/e2e/test_tailrec_vector_param.ml
+++ b/sarek/tests/e2e/test_tailrec_vector_param.ml
@@ -90,8 +90,6 @@ let labels =
 
 let slots = Array.length labels
 
-let is_interpreter framework = framework = "Interpreter"
-
 let describe = function
   | Sarek_interp.Interp_error.Interpreter_error e ->
       Sarek_interp.Interp_error.error_to_string e
@@ -157,8 +155,6 @@ let () =
   let devs = Device.init () in
   let ran = ref 0 in
   let failures = ref 0 in
-  let interpreters_run = ref 0 in
-  let gap_seen = ref 0 in
   Array.iter
     (fun (dev : Device.t) ->
       let framework = dev.Device.framework in
@@ -167,7 +163,6 @@ let () =
          kernel at all - skipping it is correct, not a silent pass. *)
       if native || Device.allows_fp64 dev then begin
         incr ran ;
-        if is_interpreter framework then incr interpreters_run ;
         try
           let got = run_on_device dev ir in
           let bad = ref 0 in
@@ -189,52 +184,14 @@ let () =
             (if !bad = 0 then "PASS" else "FAIL") ;
           if !bad <> 0 then incr failures
         with e ->
-          (* DOCUMENTED GAP, not a failure. Helper C passes a vector as a helper
-             PARAMETER; the interpreter binds arguments into [vars] while
-             [get_array] looks only in [arrays]/[shared], so it refuses. That is
-             the LOUD behaviour, and it is deliberately still in place: the
-             one-line fallback that makes it run is not sufficient on its own,
-             because helper parameter ids and body-local ids come from two
-             overlapping numbering spaces and a tail-recursion temporary can
-             clobber a parameter — a single-helper fold then returns 0 on the
-             interpreter where Vulkan and Native return 4, silently. Trading a
-             loud refusal for a sometimes-wrong number is a regression, so the
-             repair lands with the id fix rather than ahead of it.
-
-             When that lands this branch stops being taken and the test goes
-             RED — on purpose. That is the reminder to delete this arm and let
-             helper C be asserted on every device like A and B. *)
-          let expected_gap =
-            (* Match the CONSTRUCTOR, not the rendered text: a reworded
-               error_to_string would otherwise silently reclassify this
-               documented gap as a generic ERROR and fail for an unrelated
-               reason. *)
-            is_interpreter framework
-            &&
-            match e with
-            | Sarek_interp.Interp_error.Interpreter_error
-                (Sarek_interp.Interp_error.Unbound_variable
-                   {name = "v"; context = "get_array"}) ->
-                true
-            | _ -> false
-          in
-          if expected_gap then incr gap_seen ;
           Printf.printf
-            "  %-11s %-40s %s (%s)\n%!"
+            "  %-11s %-40s ERROR (%s)\n%!"
             framework
             dev.Device.name
-            (if expected_gap then "KNOWN-GAP" else "ERROR")
             (describe e) ;
-          if not expected_gap then incr failures
+          incr failures
       end)
     devs ;
-  if !gap_seen = 0 && !interpreters_run > 0 then begin
-    print_endline
-      "test_tailrec_vector_param: the interpreter no longer refuses a vector \
-       helper parameter — the id-allocation fix has landed. Delete the \
-       KNOWN-GAP arm and assert helper C on every device." ;
-    exit 1
-  end ;
   (* A run that reached no device proves nothing; report it as a failure rather
      than exiting 0 on an empty device list. *)
   if !ran = 0 then begin


### PR DESCRIPTION
The follow-up #354 promised. #354 shipped a test whose KNOWN-GAP arm was built to go
RED the moment this landed, with an instruction to delete it. It fired, and this is
that deletion.

## Two defects, both silent, both on the cross-backend oracle

**The tail-recursion transform collided with ids the typer had handed out.** Its
counter started at 0 — the same range as `tparam_id`. On `vsum acc v k n` the
`_result` temporary took id 3 and so did the parameter `n`; `lookup_var` resolves by
id before name, so the temporary answered every reference to `n`, the loop bound
became 0, and a fold over four `1.0`s returned **0** where Vulkan and Native
returned **4**.

**`get_array` consulted the kernel's vectors before the callee's own bindings.** A
helper formal named like a kernel vector read the KERNEL's buffer — **400 instead
of 4**. `vars_by_name` first now, which is what lexical scoping means. That
precedence is only sound because `callee_env` makes `vars_by_name` hold the
callee's parameters and nothing else; the two are one change and the source says so.

## The id fix is the structural one, after two worse attempts

**Attempt 1 made things worse.** It seeded the counter from `max(param_id)+1`, which
does not shrink the collision surface: the typer allocates parameters and body locals
from one counter and types a body immediately after its parameters, so
`max(param_id)+1` is *exactly* the first body-local's id. The fix relocated the
collision and made it deterministic. Measured on a fold with one `let x = v.(k) in`:
4 on Vulkan and Native; on the Interpreter either **0** or **non-termination**,
depending on how many kernels the process had already compiled — the counter is
global and persists, so the symptom moved between runs of the same file. One review
pass saw the hang, I saw the 0; both were right.

**Attempt 2 seeded above the typer's whole counter.** Correct, and it is what the
first pushed version of this branch contained. But it keeps two allocators and makes
one read the other's high-water mark — a coupling that holds only as long as nobody
allocates between the read and the use.

**What is shipped draws the ids from the typer itself:**

```ocaml
let fresh_transform_id () = Sarek_typed_ast.fresh_var_id ()
```

`reserve_above` and its call site are deleted. One monotone source, so a transform id
**cannot** equal a typer id by construction — the class is gone, not narrowed, and
there is no longer anything to keep synchronised.

I had deferred this as "a refactor, not a bug fix". That was an **unmeasured cost
estimate**, and measuring refuted it: **net −20 lines** (27 insertions, 47
deletions), 6 call sites, one definition changed, no golden touched —
`check-generated-code` green confirms no generated artifact depends on var ids.
The structural fix is *smaller* than the workaround it replaces.

Measuring also refuted the premise of my own earlier commit message: there were
never three live allocators. The lowering allocator (`Sarek_lower_ir.fresh_id` /
`next_var_id`) is **dead** — defined, never called — and tuple temporaries use
**negative** ids, disjoint by construction. The dead one is flagged in place rather
than deleted, since removing it is out of scope for a bug-fix branch, but flagged
deliberately: I had claimed it was live.

## What review changed, and it was a lot

Round 1 was a **NO-GO**. Two passes ran — `reviewer` and an **unscoped** pass with
no checklist — and they converged on attempt 1 being a relocation rather than a fix.

**Four claims of mine were refuted**, all the same mistake — a negative result
generalised past its evidence:

| claimed | actual |
| --- | --- |
| the body-local case was probed by test case D | **D is non-recursive**; the transform never runs for it, so the probe could not fire either way |
| correcting `hf_params` changes nothing observable | **false** — with a module constant ahead of the helper, a body reference resolves to the WRONG parameter: Native 6.0, Interpreter 9.0 |
| each shipped fix reverted individually goes red | **false for `callee_env`** — reverting it leaves the suite green |
| each case is checked against the other backends | the code only compared to a constant — **now implemented**, not deleted |

Also corrected: "a helper sees only its parameters" is **false** for this language —
module-level constants are lexically visible in helper bodies but land in `vars`,
the one table `callee_env` does not alias. Broken on both sides today, so no
regression, but the ordering constraint on the `hf_params` follow-up is recorded.
And #354's superseded `KNOWN GAP` comment above `get_array` is deleted; it asserted
the opposite of the code.

## Verification

`dune test --force`: 4865-line log, zero `[FAIL]`. `test_helper_scoping` — 4 cases
(A, C, D, E) × 5 devices, exact per-device value **and** cross-device agreement,
reporting which backend deviates. Case E carries a **wall-clock guard**: its pre-fix
symptom can be non-termination, and a hung test reads as a stuck CI job rather than
a failure. `test_helper_scoping` green on three consecutive runs, since the defect it
covers was order-dependent.

Prove-red per fix, not as a blanket claim: the id fix reverted → A=0, C=3, E red;
`get_array` reverted → C=400; `callee_env` reverted alone → **green**, which is why
its commit argues a dependency instead of claiming a proof.

Verified from a **checkpoint commit**, not from HEAD. On a branch with nothing
committed HEAD is the base, so `checkout HEAD -- <path>` discards the work instead
of restoring it — that destroyed two fixes mid-session and they were rewritten.

## Not shipped, filed with repros

`hf_params` positional ids (observable, gated behind the module-constant
reconciliation); the dead lowering allocator; `default_for_type` missing float arms;
a tautological assertion in `test_tailrec_elim`; Vulkan/GLSL cannot compile a helper
referencing a module constant. Everything filed from #354's review remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
