### PR TITLE
fix(codegen): the plain generate was a lossy copy of generate_with_types, in all five backends

### DIFF
--- a/sarek/codegen/Sarek_ir_cuda.ml
+++ b/sarek/codegen/Sarek_ir_cuda.ml
@@ -903,44 +903,6 @@ let cuda_header_for (k : kernel) =
     cuda_fp16_include ^ sarek_f32_barrier_decl ^ cuda_header
   else cuda_header
 
-(** Generate complete CUDA source for a kernel *)
-let generate (k : kernel) : string =
-  let buf = Buffer.create 4096 in
-
-  (* Header *)
-  Buffer.add_string buf (cuda_header_for k) ;
-
-  (* Generate helper functions before kernel *)
-  List.iter (gen_helper_func buf) k.kern_funcs ;
-
-  (* Kernel signature *)
-  Buffer.add_string buf "__global__ void " ;
-  Buffer.add_string buf k.kern_name ;
-  Buffer.add_char buf '(' ;
-
-  (* Parameters *)
-  List.iteri
-    (fun i p ->
-      if i > 0 then Buffer.add_string buf ", " ;
-      gen_param buf p)
-    k.kern_params ;
-
-  Buffer.add_string buf ") {\n" ;
-
-  (* Local declarations *)
-  List.iter (gen_local buf "  ") k.kern_locals ;
-
-  (* Body *)
-  gen_stmt buf "  " k.kern_body ;
-
-  (* Close kernel *)
-  Buffer.add_string buf "}\n" ;
-
-  (* Close extern "C" *)
-  Buffer.add_string buf "}\n" ;
-
-  Buffer.contents buf
-
 (** Generate CUDA variant type definition *)
 let gen_variant_def buf v =
   Sarek_ir_codegen.gen_variant_def
@@ -998,3 +960,15 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
   Buffer.add_string buf "}\n" ;
 
   Buffer.contents buf
+
+(** Generate complete CUDA source for a kernel.
+
+    A special case of {!generate_with_types} with the kernel's OWN type
+    declarations, which is the only thing every production caller ever passed:
+    [~types] has exactly the type of the [kern_types] field
+    ([Sarek_ir_types.kernel]), so the parameter was redundant with the record it
+    travels in. This used to be a separate 30-80 line copy of the emit sequence
+    that silently omitted record typedefs, variant typedefs and
+    [current_variants] — source referencing an undeclared struct, with no error.
+    Delegating keeps one emit path per backend. *)
+let generate (k : kernel) : string = generate_with_types ~types:k.kern_types k

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -1970,90 +1970,6 @@ let reject_float16_kernel (k : kernel) : unit =
          "f16"
          Sarek_ir_codegen.glsl_float16_refusal)
 
-(** Generate complete GLSL source for a kernel.
-    @param block Optional workgroup dimensions (x, y, z). Defaults to 256x1x1.
-*)
-let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
-    =
-  reject_float16_kernel k ;
-  (* Inline vector-parameter helpers (buffers cannot be passed as GLSL function
-     arguments — see Sarek_ir_inline_vec). *)
-  let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"Vulkan" k in
-  (* Clear per-kernel state *)
-  Hashtbl.clear helper_vec_param_indices ;
-  current_smod_name := compute_smod_name k ;
-  current_copysign_name := compute_copysign_name k ;
-  current_fmod_name := compute_fmod_name k ;
-  compute_f64_softmath k ;
-  let buf = Buffer.create 1024 in
-  Buffer.add_string
-    buf
-    (glsl_header
-       ~kernel_name:k.kern_name
-       ?block
-       ~uses_float64:(Sarek_ir_analysis.kernel_uses_float64 k)
-       ~uses_int64:!current_needs_int64
-       ~uses_coopmat:(Sarek_ir_analysis.kernel_has_coopmat_op k)
-       ~uses_uint8:(Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k)
-       ()) ;
-
-  (* Generate buffer bindings *)
-  let binding_idx = ref 0 in
-  List.iter
-    (fun decl ->
-      match decl with
-      | DParam (v, _) -> (
-          match v.var_type with
-          | TVec elem_type ->
-              gen_buffer_binding buf !binding_idx v elem_type ;
-              incr binding_idx
-          | _ -> ())
-      | _ -> ())
-    k.kern_params ;
-
-  (* Generate push constants and collect scalar names for macro collision handling *)
-  gen_push_constants buf k.kern_params ;
-  (* Scalar-param macros and vector-length macros, from the single
-     construction both entry points share (see [param_macro_names]). *)
-  let pc_names, len_names = param_macro_names k.kern_params in
-
-  (* Generate shared declarations at module scope (GLSL requirement) *)
-  let shared_decls = collect_shared_decls k.kern_body in
-  gen_shared_decls buf shared_decls ;
-
-  (* Emit the integer-remainder helper (before user helpers, which may call
-     it) when the kernel uses [mod]. *)
-  gen_smod_helper buf k ;
-
-  (* Emit the sign-copy helper (before user helpers, which may call it) when
-     the kernel uses [copysign]. *)
-  gen_copysign_helper buf k ;
-
-  (* Emit the C-fmod helper (before user helpers, which may call it) when the
-     kernel uses [fmod]. *)
-  gen_fmod_helper buf k ;
-
-  (* Emit the software f64-transcendental helper family (forward-declared,
-     after copysign which they may call, before user helpers which may call
-     them) when the kernel invokes a [Float64] transcendental. *)
-  gen_f64_softmath_helpers ~pc_names ~len_names buf ;
-
-  (* Generate helper functions *)
-  List.iter (gen_helper_func ~pc_names ~len_names buf) k.kern_funcs ;
-
-  (* Generate main function. Alpha-rename any body local that shadows a scalar
-     push-constant macro first (see rename_pc_shadowing_locals). *)
-  Buffer.add_string buf "void main() {\n" ;
-  gen_stmt
-    buf
-    "  "
-    (rename_pc_shadowing_locals ~pc_names ~len_names k.kern_body) ;
-  Buffer.add_string buf "}\n" ;
-
-  let shader = Buffer.contents buf in
-  log (Printf.sprintf "[GLSL] Generated shader:\n%s" shader) ;
-  shader
-
 (** Generate GLSL record type definition - simple struct without tag *)
 let gen_record_def buf (name, fields) =
   let mangled = mangle_name name in
@@ -2167,3 +2083,16 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   let shader = Buffer.contents buf in
   log (Printf.sprintf "[GLSL] Generated shader:\n%s" shader) ;
   shader
+
+(** Generate complete GLSL source for a kernel.
+
+    A special case of {!generate_with_types} with the kernel's OWN type
+    declarations, which is the only thing every production caller ever passed:
+    [~types] has exactly the type of the [kern_types] field
+    ([Sarek_ir_types.kernel]), so the parameter was redundant with the record it
+    travels in. This used to be a separate 30-80 line copy of the emit sequence
+    that silently omitted record typedefs, variant typedefs and
+    [current_variants] — source referencing an undeclared struct, with no error.
+    Delegating keeps one emit path per backend. *)
+let generate ?block ?log (k : kernel) : string =
+  generate_with_types ?block ?log ~types:k.kern_types k

--- a/sarek/codegen/Sarek_ir_metal.ml
+++ b/sarek/codegen/Sarek_ir_metal.ml
@@ -1180,63 +1180,6 @@ let reject_coopmat_kernel (k : kernel) : unit =
     not a tuning choice. *)
 let metal_fp_contract_pragma = "#pragma METAL fp contract(off)\n"
 
-(** Generate complete Metal source for a kernel *)
-let generate (k : kernel) : string =
-  reject_float16_kernel k ;
-  reject_float64_kernel k ;
-  reject_coopmat_kernel k ;
-  let buf = Buffer.create 4096 in
-
-  (* Collect variables used with atomic operations *)
-  let atomic_vars = collect_atomic_vars_stmt k.kern_body in
-
-  (* Metal header *)
-  Buffer.add_string buf "#include <metal_stdlib>\n" ;
-  Buffer.add_string buf "using namespace metal;\n" ;
-  Buffer.add_string buf metal_fp_contract_pragma ;
-  Buffer.add_string buf "\n" ;
-
-  (* Generate helper functions before kernel *)
-  List.iter (gen_helper_func buf) k.kern_funcs ;
-
-  (* Kernel signature *)
-  Buffer.add_string buf "kernel void " ;
-  Buffer.add_string buf k.kern_name ;
-  Buffer.add_char buf '(' ;
-
-  (* Parameters with buffer attributes *)
-  let buffer_idx = ref 0 in
-  List.iteri
-    (fun i p ->
-      if i > 0 then Buffer.add_string buf ", " ;
-      buffer_idx := gen_param_metal buf atomic_vars !buffer_idx p)
-    k.kern_params ;
-
-  (* Add thread position parameters *)
-  if !buffer_idx > 0 then Buffer.add_string buf ", " ;
-  Buffer.add_string buf "\n  uint3 __metal_gid [[thread_position_in_grid]],\n" ;
-  Buffer.add_string
-    buf
-    "  uint3 __metal_tid [[thread_position_in_threadgroup]],\n" ;
-  Buffer.add_string
-    buf
-    "  uint3 __metal_bid [[threadgroup_position_in_grid]],\n" ;
-  Buffer.add_string buf "  uint3 __metal_tpg [[threads_per_threadgroup]],\n" ;
-  Buffer.add_string buf "  uint3 __metal_num_groups [[threadgroups_per_grid]]" ;
-
-  Buffer.add_string buf ") {\n" ;
-
-  (* Local declarations *)
-  List.iter (gen_local buf "  " atomic_vars) k.kern_locals ;
-
-  (* Body *)
-  gen_stmt buf "  " k.kern_body ;
-
-  (* Close kernel *)
-  Buffer.add_string buf "}\n" ;
-
-  pretty_print_metal (Buffer.contents buf)
-
 (** Generate variant type definition for Metal *)
 let gen_variant_def buf v =
   Sarek_ir_codegen.gen_variant_def
@@ -1317,3 +1260,15 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
 
   (* Pretty-print the generated code *)
   pretty_print_metal (Buffer.contents buf)
+
+(** Generate complete Metal source for a kernel.
+
+    A special case of {!generate_with_types} with the kernel's OWN type
+    declarations, which is the only thing every production caller ever passed:
+    [~types] has exactly the type of the [kern_types] field
+    ([Sarek_ir_types.kernel]), so the parameter was redundant with the record it
+    travels in. This used to be a separate 30-80 line copy of the emit sequence
+    that silently omitted record typedefs, variant typedefs and
+    [current_variants] — source referencing an undeclared struct, with no error.
+    Delegating keeps one emit path per backend. *)
+let generate (k : kernel) : string = generate_with_types ~types:k.kern_types k

--- a/sarek/codegen/Sarek_ir_opencl.ml
+++ b/sarek/codegen/Sarek_ir_opencl.ml
@@ -1112,41 +1112,6 @@ let resolve_recursive_helpers (k : kernel) : kernel =
     funcs ;
   k
 
-(** Generate complete OpenCL source for a kernel *)
-let generate (k : kernel) : string =
-  reject_float16_kernel k ;
-  reject_coopmat_kernel k ;
-  let k = resolve_recursive_helpers k in
-  let buf = Buffer.create large_buffer_size in
-
-  (* Generate helper functions before kernel *)
-  gen_helpers buf k.kern_funcs ;
-
-  (* Kernel signature *)
-  Buffer.add_string buf "__kernel void " ;
-  Buffer.add_string buf k.kern_name ;
-  Buffer.add_char buf '(' ;
-
-  (* Parameters *)
-  List.iteri
-    (fun i p ->
-      if i > 0 then Buffer.add_string buf ", " ;
-      gen_param buf p)
-    k.kern_params ;
-
-  Buffer.add_string buf ") {\n" ;
-
-  (* Local declarations *)
-  List.iter (gen_local buf "  ") k.kern_locals ;
-
-  (* Body *)
-  gen_stmt buf "  " k.kern_body ;
-
-  (* Close kernel *)
-  Buffer.add_string buf "}\n" ;
-
-  Buffer.contents buf
-
 (** Generate variant type definition for OpenCL *)
 let gen_variant_def buf v =
   Sarek_ir_codegen.gen_variant_def
@@ -1201,6 +1166,18 @@ let generate_with_types ~(types : (string * (string * elttype) list) list)
   Buffer.add_string buf "}\n" ;
 
   Buffer.contents buf
+
+(** Generate complete OpenCL source for a kernel.
+
+    A special case of {!generate_with_types} with the kernel's OWN type
+    declarations, which is the only thing every production caller ever passed:
+    [~types] has exactly the type of the [kern_types] field
+    ([Sarek_ir_types.kernel]), so the parameter was redundant with the record it
+    travels in. This used to be a separate 30-80 line copy of the emit sequence
+    that silently omitted record typedefs, variant typedefs and
+    [current_variants] — source referencing an undeclared struct, with no error.
+    Delegating keeps one emit path per backend. *)
+let generate (k : kernel) : string = generate_with_types ~types:k.kern_types k
 
 (** Generate OpenCL source with double precision extension if needed *)
 let generate_with_fp64 (k : kernel) : string =

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -1457,40 +1457,6 @@ let reject_coopmat_kernel (k : kernel) : unit =
           matrices and their uint8 operand buffers are emitted only by the \
           Vulkan backend (backlog-62)")
 
-(** Generate complete WGSL source for a kernel. *)
-let generate ?block ?(log : string -> unit = fun _ -> ()) (k : kernel) : string
-    =
-  reject_float16_kernel k ;
-  reject_coopmat_kernel k ;
-  if params_have_float64 k.kern_params then
-    Codegen_error.raise_error
-      (Codegen_error.unsupported_construct
-         "f64 parameter"
-         "WGSL: f64 unsupported — WebGPU has no float64 type") ;
-  (* Inline vector-parameter helpers (buffers cannot be passed as WGSL function
-     arguments — see Sarek_ir_inline_vec). *)
-  let k = Sarek_ir_inline_vec.inline_vec_helpers ~backend:"WGSL" k in
-  scalar_param_names := [] ;
-  current_variants := k.kern_variants ;
-  let buf = Buffer.create 1024 in
-  let scalars = gen_bindings buf k.kern_params in
-  scalar_param_names := scalars ;
-  let wg_decls = collect_workgroup_decls k.kern_body in
-  gen_workgroup_module_decls buf wg_decls ;
-  gen_fmod_helper buf k ;
-  List.iter (gen_helper_func ~scalar_names:scalars buf) k.kern_funcs ;
-  Buffer.add_string buf (wgsl_header ~kernel_name:k.kern_name ?block ()) ;
-  (* Alpha-rename any body local that shadows a scalar param first (see
-     rename_scalar_shadowing_locals). *)
-  gen_stmt
-    buf
-    "  "
-    (rename_scalar_shadowing_locals ~scalar_names:scalars k.kern_body) ;
-  Buffer.add_string buf "}\n" ;
-  let shader = Buffer.contents buf in
-  log (Printf.sprintf "[WGSL] Generated shader:\n%s" shader) ;
-  shader
-
 (** Generate WGSL source with custom type definitions. *)
 let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
     ~(types : (string * (string * elttype) list) list) (k : kernel) : string =
@@ -1526,6 +1492,19 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   let shader = Buffer.contents buf in
   log (Printf.sprintf "[WGSL] Generated shader:\n%s" shader) ;
   shader
+
+(** Generate complete WGSL source for a kernel.
+
+    A special case of {!generate_with_types} with the kernel's OWN type
+    declarations, which is the only thing every production caller ever passed:
+    [~types] has exactly the type of the [kern_types] field
+    ([Sarek_ir_types.kernel]), so the parameter was redundant with the record it
+    travels in. This used to be a separate 30-80 line copy of the emit sequence
+    that silently omitted record typedefs, variant typedefs and
+    [current_variants] — source referencing an undeclared struct, with no error.
+    Delegating keeps one emit path per backend. *)
+let generate ?block ?log (k : kernel) : string =
+  generate_with_types ?block ?log ~types:k.kern_types k
 
 (** {1 ABI descriptor} *)
 

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -227,6 +227,16 @@
  (modules test_emitted_name_declared)
  (libraries sarek.codegen sarek_ir alcotest unix))
 
+; A backend's two entry points must agree (backlog-155). generate is defined as
+; generate_with_types ~types:k.kern_types, so their outputs must be byte-equal;
+; each used to be a separate copy of the emit sequence that dropped the
+; type-declaration step. Agreement, not correctness — the goldens own that.
+
+(test
+ (name test_entry_point_agreement)
+ (modules test_entry_point_agreement)
+ (libraries sarek.codegen sarek_ir alcotest))
+
 ; Intrinsic-surface reconciliation: derives its expectation from
 ; Sarek_registry's link-time record of every let%sarek_intrinsic, and checks it
 ; against Sarek_pure_registry (GPU codegen) and Sarek_cpu_runtime (native).

--- a/sarek/tests/unit/test_entry_point_agreement.ml
+++ b/sarek/tests/unit/test_entry_point_agreement.ml
@@ -1,0 +1,259 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * A backend's entry points must agree (backlog-155).
+ *
+ * WHAT THIS IS FOR
+ *
+ * Each of the five source-emitting backends exposes two entry points that
+ * SHOULD produce the same text for the same kernel:
+ *
+ *   generate k                             (* the plain one *)
+ *   generate_with_types ~types:k.kern_types k
+ *
+ * They should agree because [~types] has exactly the type of the [kern_types]
+ * FIELD of the kernel it travels with ([Sarek_ir_types.kernel]), and every
+ * production caller only ever passed that field. The parameter was redundant
+ * with the record.
+ *
+ * They did NOT agree. [generate] was a separate 34-84 line copy of the emit
+ * sequence in each backend, and each copy omitted the type-declaration step:
+ * no record typedefs, no variant typedefs, and (on four of the five) no
+ * [current_variants] assignment either. A kernel with a record type emitted
+ * through [generate] therefore produced source that USES the struct and never
+ * DECLARES it — the C-family backends emit `Point2 p = pts[idx];` against no
+ * `typedef struct ... Point2`. That is not a diagnostic; it is source the device
+ * compiler rejects, or worse on WGSL, where [generate] set [current_variants]
+ * (arming SMatch payload extraction) for types it then never declared.
+ *
+ * The public transpiler ([Sarek_transpile.emit_backend]) routes ALL FIVE
+ * backends through the plain [generate], so `sarek-transpile` on any kernel
+ * carrying a record or a variant emitted undeclared-type source — on every
+ * backend, for every user.
+ *
+ * HOW IT CHECKS, AND WHY THIS WAY
+ *
+ * Byte equality of the two outputs. Not a substring probe for `typedef`, not a
+ * singleton-identifier diff: one entry point is DEFINED as a special case of the
+ * other, so their outputs must be identical, and that is both the strongest
+ * available assertion and the cheapest. It needs no per-backend list of language
+ * builtins and no external validator, and it cannot be satisfied by a partial
+ * fix — emitting the record typedef but not the variant typedef still differs.
+ *
+ * The kernels below carry a record AND a variant, because the omission was
+ * per-step: a backend could restore one and not the other. The scalar kernel is
+ * the control — it carries neither, the two entry points agreed on it even
+ * before the fix, so a red there means this test broke rather than the backends.
+ *
+ * WHAT IT DOES NOT COVER
+ *
+ * Agreement, not correctness. If both entry points emit the same WRONG typedef,
+ * this is green — the golden suite and the device-compiler gates own that.
+ * PTX is absent: [Sarek_ir_ptx_kernel.generate_with_types] takes [~types:_] and
+ * ignores it (types reach it through [Sarek_ir_ptx_types] instead), so the two
+ * entry points are equal there by construction and the check would be vacuous.
+ * Stating that is the point: a green PTX row would have asserted nothing.
+ *
+ * Run with: dune exec sarek/tests/unit/test_entry_point_agreement.exe
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Wgsl = Sarek_codegen.Sarek_ir_wgsl
+module Metal = Sarek_codegen.Sarek_ir_metal
+module Cuda = Sarek_codegen.Sarek_ir_cuda
+module Opencl = Sarek_codegen.Sarek_ir_opencl
+module Glsl = Sarek_codegen.Sarek_ir_glsl
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let empty_kernel name params locals body =
+  {
+    kern_name = name;
+    kern_params = params;
+    kern_locals = locals;
+    kern_body = body;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(* ------------------------------------------------------------------------ *)
+(* Kernels                                                                   *)
+
+(** Carries a record type: reads a Point2, doubles both fields, writes it back.
+    [kern_types] is non-empty, which is the whole point — it is the input the
+    plain entry point used to drop. *)
+let record_kernel () =
+  let fields = [("x", TFloat32); ("y", TFloat32)] in
+  let point = TRecord ("Point2", fields) in
+  let pts = make_var "pts" (TVec point) in
+  let idx = make_var "idx" TInt32 in
+  let p = make_var "p" point in
+  let scaled f =
+    EBinop (Mul, ERecordField (EVar p, f), EConst (CFloat32 2.0))
+  in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SLet
+          ( p,
+            EArrayRead ("pts", EVar idx),
+            SAssign
+              ( LArrayElem ("pts", EVar idx),
+                ERecord ("Point2", [("x", scaled "x"); ("y", scaled "y")]) ) )
+      )
+  in
+  let k = empty_kernel "record_kernel" [DParam (pts, None)] [] body in
+  {k with kern_types = [("Point2", fields)]}
+
+(** Carries a variant type. Separate from the record kernel because the omission
+    was per-step: restoring record typedefs alone would leave this red. *)
+let variant_kernel () =
+  let constrs = [("OptNone", []); ("OptSome", [TFloat32])] in
+  let opt = TVariant ("Opt", constrs) in
+  let out = make_var "out" (TVec opt) in
+  let idx = make_var "idx" TInt32 in
+  let body =
+    SLet
+      ( idx,
+        EIntrinsic ([], "global_thread_id", []),
+        SAssign
+          ( LArrayElem ("out", EVar idx),
+            EVariant ("Opt", "OptSome", [EConst (CFloat32 1.0)]) ) )
+  in
+  let k = empty_kernel "variant_kernel" [DParam (out, None)] [] body in
+  {k with kern_variants = [("Opt", constrs)]}
+
+(** Control: neither a record nor a variant, so the two entry points agreed even
+    before the fix. A red here indicts the test, not the backends. *)
+let scalar_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let arr v =
+    DParam (v, Some {arr_elttype = TFloat32; arr_memspace = Global})
+  in
+  empty_kernel
+    "scalar_kernel"
+    [arr a; arr c]
+    []
+    (SAssign
+       ( LArrayElem ("c", EConst (CInt32 0l)),
+         EBinop
+           (Mul, EArrayRead ("a", EConst (CInt32 0l)), EConst (CFloat32 2.0)) ))
+
+(* ------------------------------------------------------------------------ *)
+(* The matrix                                                                *)
+
+type backend = {
+  label : string;
+  plain : kernel -> string;
+  with_types : kernel -> string;
+}
+
+let backends =
+  [
+    {
+      label = "CUDA";
+      plain = (fun k -> Cuda.generate k);
+      with_types = (fun k -> Cuda.generate_with_types ~types:k.kern_types k);
+    };
+    {
+      label = "OpenCL";
+      plain = (fun k -> Opencl.generate k);
+      with_types = (fun k -> Opencl.generate_with_types ~types:k.kern_types k);
+    };
+    {
+      label = "Metal";
+      plain = (fun k -> Metal.generate k);
+      with_types = (fun k -> Metal.generate_with_types ~types:k.kern_types k);
+    };
+    {
+      label = "WGSL";
+      plain = (fun k -> Wgsl.generate k);
+      with_types = (fun k -> Wgsl.generate_with_types ~types:k.kern_types k);
+    };
+    {
+      label = "GLSL";
+      plain = (fun k -> Glsl.generate k);
+      with_types = (fun k -> Glsl.generate_with_types ~types:k.kern_types k);
+    };
+  ]
+
+let kernels =
+  [
+    ("record", record_kernel);
+    ("variant", variant_kernel);
+    ("scalar (control)", scalar_kernel);
+  ]
+
+(* A backend may legitimately REFUSE a kernel (Metal has no f64, GLSL no f16).
+   A refusal is agreement as long as both entry points refuse identically, so
+   compare the outcome rather than only the success path — otherwise a backend
+   that raises on both sides would silently drop out of the matrix. *)
+let outcome f k = try Ok (f k) with e -> Error (Printexc.to_string e)
+
+let check b (kname, mk) () =
+  let k = mk () in
+  match (outcome b.plain k, outcome b.with_types k) with
+  | Ok plain, Ok with_types ->
+      if plain <> with_types then begin
+        (* Report the first differing line: the whole shader is unreadable in an
+           assertion message, and the interesting delta is a missing
+           declaration near the top. *)
+        let split s = String.split_on_char '\n' s in
+        let pl = split plain and wl = split with_types in
+        let rec first_diff i a b =
+          match (a, b) with
+          | x :: xs, y :: ys when x = y -> first_diff (i + 1) xs ys
+          | x :: _, y :: _ -> Printf.sprintf "line %d: %S vs %S" i x y
+          | [], y :: _ -> Printf.sprintf "line %d: <absent> vs %S" i y
+          | x :: _, [] -> Printf.sprintf "line %d: %S vs <absent>" i x
+          | [], [] -> "identical line-wise but not byte-wise"
+        in
+        Alcotest.failf
+          "%s/%s: generate and generate_with_types ~types:k.kern_types \
+           disagree (%d vs %d bytes) — %s"
+          b.label
+          kname
+          (String.length plain)
+          (String.length with_types)
+          (first_diff 1 pl wl)
+      end
+  | Error e1, Error e2 ->
+      (* Both refused: agreement, as long as it is the SAME refusal. *)
+      Alcotest.check Alcotest.string (b.label ^ "/" ^ kname ^ " refusal") e1 e2
+  | Ok _, Error e ->
+      Alcotest.failf
+        "%s/%s: generate succeeded but generate_with_types raised %s"
+        b.label
+        kname
+        e
+  | Error e, Ok _ ->
+      Alcotest.failf
+        "%s/%s: generate raised %s but generate_with_types succeeded"
+        b.label
+        kname
+        e
+
+let () =
+  Alcotest.run
+    "entry-point agreement"
+    [
+      ( "generate = generate_with_types ~types:k.kern_types",
+        List.concat_map
+          (fun b ->
+            List.map
+              (fun (kname, mk) ->
+                Alcotest.test_case
+                  (b.label ^ ": " ^ kname)
+                  `Quick
+                  (check b (kname, mk)))
+              kernels)
+          backends );
+    ]


### PR DESCRIPTION
Filed (backlog-155) as an OpenCL bug: `Opencl_plugin.generate_with_fp64` re-exports a
path that emits no record typedefs. It is the same defect in **all five**
source-emitting backends, and the plugin re-export is just where it was noticed.

## The defect

Each backend carried its own 34–84 line copy of the emit sequence under `generate`,
and every copy dropped the same step: no record typedefs, no variant typedefs, and
on four of the five no `current_variants` assignment either. A kernel with a record
emitted source that **uses** the struct and never **declares** it:

```c
__global__ void record_kernel(Point2* __restrict__ pts, int sarek_pts_length) {
```

against no `typedef struct { ... } Point2`. Not a diagnostic — source the device
compiler rejects. WGSL was worse: `generate` set `current_variants`, which arms
SMatch payload extraction, for types it then never declared.

## The fix

```ocaml
let generate k = generate_with_types ~types:k.kern_types k
```

Sound because `~types` has exactly the type of the `kern_types` **field** of the
kernel it travels with (`spoc/ir/Sarek_ir_types.ml:379`), and every production call
site already passed that field — the parameter was redundant with the record it
rides in. **Net −178 lines.**

Verified as a strict superset **before** relying on it: diffed each `generate`
against its `generate_with_types`, and the delta is only the three type-emitting
lines, on all five. So output is byte-identical for a kernel carrying neither a
record nor a variant — which the golden suite confirms, 74 goldens unchanged.

## Two things this repairs that the filed item did not mention

**`Sarek_transpile.emit_backend` routes all five backends through the plain
`generate`.** So `sarek-transpile` on any kernel carrying a record or a variant
emitted undeclared-type source, on every backend, for every user. Fixed by
inheritance; the transpiler is not touched.

**`generate_with_fp64` calls `generate`**, so the filed OpenCL symptom is fixed by
inheritance too.

Evidence the duplication had already bitten once: Metal's `generate_with_types`
carries a comment saying variant defs were *"previously omitted here, unlike the
CUDA/OpenCL backends"*. Someone found that divergence and repaired **one** of the
two copies. The second copy kept the bug for both of them.

## The test

15 cases — 5 backends × {record, variant, scalar control} — asserting **byte
equality** of the two entry points, rather than a substring probe for `typedef` or
a singleton-identifier diff. One entry point is *defined* as a special case of the
other, so identical output is both the strongest available assertion and the
cheapest: no per-backend builtin list, no external validator, and a partial fix
cannot satisfy it (emitting the record typedef but not the variant typedef still
differs).

Record and variant are separate kernels because the omission was per-step — a
backend could restore one and not the other.

**Prove-red split exactly as designed:** reverting `sarek/codegen/` to `origin/main`
turns the **10** record/variant cases red and leaves all **5** controls green. The
control is load-bearing: it carries neither type, both entry points agreed on it
even before the fix, so a red there would indict the test rather than the backends.
Measured from a checkpoint commit and restored **by sha** — on a branch with nothing
committed, `HEAD` is the base, so restoring from `HEAD` discards the work.

Refusals are compared, not skipped: a backend may legitimately reject a kernel
(Metal has no f64, GLSL no f16), and that is agreement only if both entry points
refuse with the same error. Treating a raise as "not applicable" would let a
backend drop out of the matrix silently.

## Scope and non-findings

- **Agreement, not correctness.** If both entry points emit the same wrong typedef,
  this is green; the goldens and the device-compiler gates own that.
- **PTX untouched**, and the test header says why: its `generate_with_types` takes
  `~types:_` and ignores it, so the two entry points are equal by construction and a
  green PTX row would assert nothing.
- `Sarek_ir_glsl.set_framework` looked like an adjacent omission — the transpiler
  sets `current_framework` on four modules and GLSL is not one of them. Checked
  before reporting it: **GLSL has no `current_framework` at all**, so the code is
  correct and there is nothing to fix.

## Verification

`dune build` clean, `dune test --force` 4885 lines / **0 `[FAIL]`** — up from
4864, the +15 cases being visible rather than asserted.

`@fmt` **failed in CI on the first push, and the earlier claim here that it was
clean was measured on the tree before the test file existed.** I promoted
formatting, then added `test_entry_point_agreement.ml`, and never re-ran the
gate — so the check was real but the state it certified was not the state that
shipped. Fixed by reformatting and force-pushing; `@fmt` now exits 0 on the
actual branch head. Worth stating rather than quietly amending: a verification
that runs before the last change is the same shape as the rest of this branch —
a check whose result is narrower than the claim made from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated CUDA, GLSL, Metal, OpenCL, and WGSL code to include required record and variant type definitions.
  * Improved handling of variant match payloads during shader and kernel generation.
  * Ensured generated output remains consistent across equivalent generation entry points.

* **Tests**
  * Added cross-backend tests covering record, variant, and scalar kernels to verify identical generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->