### PR TITLE
fix(interp): an interpreter error must name what went wrong (+ delete the dead id allocator)

### DIFF
--- a/sarek/interp/Interp_error.ml
+++ b/sarek/interp/Interp_error.ml
@@ -57,3 +57,14 @@ let error_to_string = function
 
 (** Raise an interpreter error *)
 let raise_error err = raise (Interpreter_error err)
+
+(* Uncaught, [Interpreter_error] printed as an opaque constructor with none of
+   [error_to_string]'s detail, so every test that had to report one carried its
+   own `describe` wrapper — see the one in
+   sarek/tests/e2e/test_helper_scoping.ml, written for exactly this. The three
+   sibling error modules (Execute_error, Fusion_error, Kirc_error) all register a
+   printer; this one was the odd one out. *)
+let () =
+  Printexc.register_printer (function
+    | Interpreter_error err -> Some (error_to_string err)
+    | _ -> None)

--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -587,7 +587,23 @@ and assign_lvalue state env lv value =
   | LArrayElem (arr, idx_expr) ->
       let a = get_array env arr in
       let i = to_int (eval_expr state env idx_expr) in
-      a.(i) <- value
+      (* Same check as the LArrayElemExpr arm below, which had it while this one
+         did not — adjacent arms of one function disagreeing about whether an
+         out-of-range store is an interpreter error or an OCaml one.
+
+         NOT a memory-safety fix, and the backlog entry that claimed it was is
+         wrong: OCaml bounds-checks [a.(i) <- v] and raises
+         Invalid_argument "index out of bounds", so nothing was ever corrupted.
+         What was wrong is the DIAGNOSTIC. An interpreter that is the
+         cross-backend oracle should say which array, which index and what
+         length, the way error_to_string does — an opaque Invalid_argument names
+         none of the three, and on a GPU backend the same store is genuine
+         undefined behaviour, so this is the one place able to describe it. *)
+      if i < 0 || i >= Array.length a then
+        Interp_error.raise_error
+          (Array_bounds_error
+             {array_name = arr; index = i; length = Array.length a})
+      else a.(i) <- value
   | LArrayElemExpr (base_expr, idx_expr) ->
       let a =
         match eval_expr state env base_expr with

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -263,7 +263,6 @@ let ir_lower_stmt_count = ref 0
 
 (** Lowering state *)
 type state = {
-  mutable next_var_id : int;
   fun_map : (string, tparam list * texpr) Hashtbl.t;
   lowering_stack : (string, unit) Hashtbl.t;
   lowered_funs : (string, Ir.helper_func) Hashtbl.t;
@@ -280,7 +279,6 @@ type state = {
 
 let create_state fun_map =
   {
-    next_var_id = 0;
     fun_map;
     lowering_stack = Hashtbl.create 8;
     lowered_funs = Hashtbl.create 8;
@@ -289,17 +287,13 @@ let create_state fun_map =
     variants = Hashtbl.create 8;
   }
 
-(* DEAD as of this writing: [fresh_id] has no caller, and [next_var_id] is
-   touched only by it. Flagged rather than deleted (pre-existing dead code
-   outside this change's scope) but flagged deliberately, because a commit
-   message on this branch described it as one of three LIVE id allocators and
-   that was wrong — the live ones are the typer's [fresh_var_id] and, until it
-   was unified with it, the tail-recursion transform's. The only other live id
-   convention is the NEGATIVE range for tuple temporaries below. *)
-let fresh_id state =
-  let id = state.next_var_id in
-  state.next_var_id <- id + 1 ;
-  id
+(* There is ONE id allocator: the typer's [Sarek_typed_ast.fresh_var_id]. A
+   third one used to appear to live here ([fresh_id] over a [next_var_id] field)
+   and was deleted with its field — it had no caller, and a commit message that
+   called it live was wrong. The tail-recursion transform draws from the typer
+   directly, so a transform id cannot collide with a typer id by construction.
+   The only other id convention is the NEGATIVE range for tuple temporaries
+   below, disjoint from the typer's by sign. *)
 
 (** Register the synthesized [_tup_*] record for a primitive-component tuple in
     the codegen types table, so a kernel-local slot typed by that record (see

--- a/sarek/ppx/Sarek_tailrec_elim.ml
+++ b/sarek/ppx/Sarek_tailrec_elim.ml
@@ -392,6 +392,14 @@ let eliminate_tail_recursion (fname : string) (params : tparam list)
       | TReg Int64 -> {te = TEInt64 0L; ty = result_ty; te_loc = loc}
       | TReg Float32 -> {te = TEFloat 0.0; ty = result_ty; te_loc = loc}
       | TReg Float64 -> {te = TEDouble 0.0; ty = result_ty; te_loc = loc}
+      (* Float16 used to fall through to the [TEInt 0] wildcard below, giving a
+         tail-recursive f16 helper an INT-shaped initializer carrying an f16
+         type. Latent rather than observed — the value is overwritten before
+         use, which is why nothing caught it — but the wildcard's justification
+         ("it's just a placeholder") is exactly the silently-succeeding-wildcard
+         shape #94 exists to refuse, so the arm is spelled out. TEFloat, not
+         TEDouble: f16 narrows from binary32 on every backend that has it. *)
+      | TReg Float16 -> {te = TEFloat 0.0; ty = result_ty; te_loc = loc}
       | TReg Char -> {te = TEInt 0; ty = result_ty; te_loc = loc}
       | TReg (Custom _) -> {te = TEInt 0; ty = result_ty; te_loc = loc}
       | TPrim TBool -> {te = TEBool false; ty = result_ty; te_loc = loc}

--- a/sarek/tests/unit/test_ir_interp.ml
+++ b/sarek/tests/unit/test_ir_interp.ml
@@ -416,6 +416,60 @@ let test_stmt_assign () =
   | VInt32 n -> check int32 "assign" 99l n
   | _ -> fail "expected VInt32"
 
+(* An out-of-range store through LArrayElem must be the INTERPRETER's error, not
+   OCaml's. Both arms of assign_lvalue reject it — OCaml bounds-checks arrays, so
+   nothing was ever corrupted and the backlog entry claiming memory unsafety was
+   wrong — but LArrayElem raised a bare Invalid_argument naming neither the
+   array, the index nor the length, while the LArrayElemExpr arm beside it
+   raised Array_bounds_error naming all three. Matching the CONSTRUCTOR rather
+   than the rendered message: a reworded error_to_string must not silently
+   reclassify this. *)
+let test_stmt_assign_out_of_bounds () =
+  let env = make_env () in
+  let state = make_state () in
+  Hashtbl.add env.arrays "output" (Array.make 5 (VInt32 0l)) ;
+  let stmt =
+    SAssign (LArrayElem ("output", EConst (CInt32 7l)), EConst (CInt32 99l))
+  in
+  match exec_stmt state env stmt with
+  | () -> fail "expected an out-of-bounds store to raise"
+  | exception
+      Sarek.Interp_error.Interpreter_error
+        (Sarek.Interp_error.Array_bounds_error {array_name; index; length}) ->
+      check string "names the array" "output" array_name ;
+      check int "names the index" 7 index ;
+      check int "names the length" 5 length
+  | exception Invalid_argument _ ->
+      fail
+        "raised OCaml's Invalid_argument: the store is caught, but the \
+         diagnostic names neither array, index nor length"
+
+(* Uncaught, an interpreter error used to print as an opaque constructor with
+   none of error_to_string's detail, so every test reporting one carried its own
+   `describe` wrapper. The three sibling error modules register a printer; this
+   one did not. Asserts the printer is REACHED (the message is the detailed one)
+   rather than that some string is non-empty — Printexc always returns
+   something, so a length check would pass without the printer. *)
+let test_interp_error_has_printer () =
+  let e =
+    Sarek.Interp_error.Interpreter_error
+      (Sarek.Interp_error.Array_bounds_error
+         {array_name = "buf"; index = 9; length = 4})
+  in
+  let s = Printexc.to_string e in
+  let contains hay needle =
+    let nh = String.length hay and nn = String.length needle in
+    let rec go i =
+      i + nn <= nh && (String.sub hay i nn = needle || go (i + 1))
+    in
+    nn > 0 && go 0
+  in
+  check
+    bool
+    "printer reached (not the opaque constructor)"
+    true
+    (contains s "buf" && contains s "9" && contains s "4")
+
 let test_stmt_let () =
   let env = make_env () in
   let state = make_state () in
@@ -547,6 +601,8 @@ let () =
       ( "statements",
         [
           test_case "assign" `Quick test_stmt_assign;
+          test_case "assign_out_of_bounds" `Quick test_stmt_assign_out_of_bounds;
+          test_case "error_has_printer" `Quick test_interp_error_has_printer;
           test_case "let_binding" `Quick test_stmt_let;
           test_case "if_stmt" `Quick test_stmt_if;
           test_case "while_loop" `Quick test_stmt_while;


### PR DESCRIPTION
backlog-161 and backlog-162.

## backlog-161 as filed was three claims. One true, one inaccurate, one false.

I checked each before writing code, and all three verdicts are in the tree rather
than three fixes quietly shipped.

**TRUE — no `Printexc` printer.** Uncaught, an interpreter error printed as an opaque
constructor with none of `error_to_string`'s detail, so every test that had to report
one carried its own `describe` wrapper — there is one in `test_helper_scoping.ml`
written for exactly this. The three sibling error modules (`Execute_error`,
`Fusion_error`, `Kirc_error`) all register a printer; this was the odd one out.

**INACCURATE — "`LArrayElem` has no bounds check, so an out-of-range store is silent
memory corruption."** OCaml bounds-checks `a.(i) <- v`. The store raises
`Invalid_argument "index out of bounds"` and nothing was ever corrupted. The real
defect is smaller and still worth fixing: the arm raised a bare OCaml exception naming
neither array, index nor length, while the `LArrayElemExpr` arm **directly below it**
raised `Array_bounds_error` naming all three — two adjacent arms of one function
disagreeing about whose error this is. It matters because the interpreter is the
cross-backend oracle: the same store on a GPU backend is genuine undefined behaviour,
and this is the one side able to describe it.

**FALSE — "`default_for_type` is missing float arms."** `TReg Float32 -> TEFloat 0.0`
and `TReg Float64 -> TEDouble 0.0` are both there and always were. What *is* missing is
`Float16`, which fell through to the `TEInt 0` wildcard — an int-shaped initializer
carrying an f16 type. **Latent, not observed**: the value is overwritten before use,
which is why nothing caught it. Shipped anyway because "it's just a placeholder" is
exactly the silently-succeeding-wildcard justification #94 exists to refuse — and
claimed as latent, not as a repaired bug.

## backlog-162 — the dead allocator

`fresh_id` over a `next_var_id` field had **one** occurrence in the tree: its own
definition. Deleted with the field. The measurement is why it is deleted rather than
left: an earlier commit message of mine called it one of three *live* id allocators,
and that was false. After #355 there are two conventions, disjoint by construction —
the typer's monotone counter, and the negative range for tuple temporaries.

## Tests

Two new cases, both proven red from a checkpoint commit against `origin/main`:
`assign_out_of_bounds` fails with *"raised OCaml's Invalid_argument: the diagnostic
names neither array, index nor length"*, and `error_has_printer` fails outright.

The `Float16` arm has **no test**, because it has no observable effect. Saying so beats
inventing an assertion that would pass either way.

Both assertions are built to fail for the right reason: `assign_out_of_bounds` matches
the **constructor**, not the rendered string, so a reworded `error_to_string` cannot
silently reclassify it; `error_has_printer` requires the message to **contain the array
name, index and length** rather than be non-empty — `Printexc.to_string` always returns
something, so a length check would pass with no printer registered at all.

## Verification

`dune build` clean, `@fmt` clean (re-run **after** the last file was added — that
ordering is what broke #356's first push). Suite via `scripts/test-suite-counts.sh`:
**1712 cases across 118 suites, 0 FAIL**, 23 SKIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array bounds errors with clear details, including the array name, invalid index, and length.
  * Fixed initialization for tail-recursive `Float16` code paths.
  * Standardized interpreter error messages for clearer diagnostics.

* **Tests**
  * Added coverage for array bounds handling and readable interpreter error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->