### PR TITLE
fix(registry): refuse a shading language instead of handing it CUDA spellings

### DIFF
--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -788,6 +788,15 @@ and glsl_backend =
           gen_glsl_conversion buf ~gen_expr name args ;
           true)
         else false);
+    (* INERT ON PURPOSE (backlog-159), not an unfinished symmetry. The three
+       C-family backends wire [Dispatch.emit_registry_template] here; doing the
+       same for GLSL would route intrinsics through
+       [Sarek_registry.cuda_or_opencl], a TWO-WAY C-family dispatch whose
+       wildcard is the CUDA branch — so all 133 stdlib intrinsics registered
+       through it would hand GLSL `sinf`/`fabsf`/`powf`, names no shader
+       compiler declares. Returning [false] means fall-through raises
+       [unknown_intrinsic] instead: loud, and correct. That registry now REFUSES
+       GLSL rather than guessing, so wiring this fails by name. *)
     post_hook = (fun _ _ _ _ -> false);
     invalid_arg_count = bad_arity;
     on_unknown =

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -716,6 +716,15 @@ and wgsl_backend =
               Codegen_error.raise_error
                 (Codegen_error.invalid_arg_count "fmod" 2 (List.length args))
         else false);
+    (* INERT ON PURPOSE (backlog-159), not an unfinished symmetry. The three
+       C-family backends wire [Dispatch.emit_registry_template] here; doing the
+       same for WGSL would route intrinsics through
+       [Sarek_registry.cuda_or_opencl], a TWO-WAY C-family dispatch whose
+       wildcard is the CUDA branch — so all 133 stdlib intrinsics registered
+       through it would hand WGSL `sinf`/`fabsf`/`powf`, names no shader
+       compiler declares. Returning [false] means fall-through raises
+       [unknown_intrinsic] instead: loud, and correct. That registry now REFUSES
+       WGSL rather than guessing, so wiring this fails by name. *)
     post_hook = (fun _ _ _ _ -> false);
     invalid_arg_count = bad_arity;
     on_unknown =

--- a/spoc/registry/Sarek_registry.ml
+++ b/spoc/registry/Sarek_registry.ml
@@ -233,6 +233,10 @@ let () =
  * Helper function for device-specific code
  ******************************************************************************)
 
+(** Raised when a shading-language framework asks this two-way dispatch for a
+    spelling it cannot supply. See {!cuda_or_opencl}. *)
+exception No_device_spelling of {framework : string; cuda : string}
+
 let cuda_or_opencl (framework : string) cuda_code opencl_code =
   match framework with
   (* Metal joins OpenCL, not CUDA: across the whole stdlib these two branches
@@ -241,8 +245,58 @@ let cuda_or_opencl (framework : string) cuda_code opencl_code =
      unsuffixed overloads and has no `fabsf`/`sinf`. This matches the spelling
      Sarek_pure_registry already emits for Metal via its `generic_name`. *)
   | "OpenCL" | "Metal" -> opencl_code
+  (* GLSL and WGSL get NEITHER branch. This dispatch has exactly two, and both
+     are C-family: the wildcard below sends anything unrecognised to CUDA, so a
+     shading language asking here would be handed `sinf`, `fabsf`, `powf` —
+     names no GLSL or WGSL compiler declares.
+
+     Today nothing reaches this arm: Sarek_ir_glsl and Sarek_ir_wgsl set
+     `post_hook = (fun _ _ _ _ -> false)`, so on fall-through they raise
+     `unknown_intrinsic` instead of consulting this registry. That inert
+     post_hook is the SAFE behaviour and must stay: the three C-family backends
+     wire `Dispatch.emit_registry_template` there, and doing the same for
+     GLSL/WGSL — which reads like an obvious symmetry, and which an earlier
+     backlog entry of mine explicitly recommended — would replace a loud refusal
+     with silently-invalid shader source, on all 133 stdlib intrinsics
+     registered through this helper (Float32 35, Float64 42, Gpu 21, Int32 16,
+     Int64 16, Math 3).
+
+     So this arm is a landmine guard, not a live path: it makes that mistake
+     fail immediately and by name rather than emit C into a shader. It raises
+     rather than returning a value because there is no correct value to return —
+     a spelling for these frameworks has to be REGISTERED, not derived. The
+     model to copy is Sarek_pure_registry, which dispatches on framework and
+     carries the GLSL exceptions explicitly (`glsl_override_name`: fabs→abs,
+     rsqrt→inversesqrt, atan2→atan); the un-suffixed OpenCL branch happens to be
+     right for most GLSL builtins, which is exactly why guessing here is
+     dangerous — it would be right often enough to look correct.
+
+     This is an OCaml exception rather than a located Codegen_error because this
+     module sits below codegen and must not depend on it. Reaching it is a
+     programming error in the dispatcher wiring, not a user error in a kernel. *)
+  | ("GLSL" | "WGSL") as fw ->
+      raise (No_device_spelling {framework = fw; cuda = cuda_code})
   | "CUDA" | "Native" | "Interpreter" | _ -> cuda_code
-(* Use CUDA syntax for CUDA, interpreter, and native *)
+(* Use CUDA syntax for CUDA, interpreter, and native. The wildcard also covers
+   the "generic" default of [fun_device_template] and is deliberately NOT a
+   refusal: "generic" is a live value with C-family semantics. Only the two
+   shading languages above are refused, because only they are MEASURED to be
+   mis-served by both branches. *)
+
+let () =
+  Printexc.register_printer (function
+    | No_device_spelling {framework; cuda} ->
+        Some
+          (Printf.sprintf
+             "Sarek_registry.cuda_or_opencl: no %s spelling for an intrinsic \
+              registered with only CUDA/OpenCL templates (CUDA form: %S). This \
+              two-way dispatch cannot serve a shading language — register a %s \
+              template instead of routing %s through the FFI registry."
+             framework
+             cuda
+             framework
+             framework)
+    | _ -> None)
 
 (* Note: All intrinsics (Float32, Float64, Int32, Int64, GPU) are defined in
    Sarek_stdlib modules and auto-register via %sarek_intrinsic when that

--- a/spoc/registry/test/test_sarek_registry.ml
+++ b/spoc/registry/test/test_sarek_registry.ml
@@ -236,6 +236,70 @@ let test_cuda_or_opencl () =
   assert (cuda_or_opencl "Native" "cuda_code" "opencl_code" = "cuda_code") ;
   print_endline "  cuda_or_opencl: OK"
 
+(* backlog-159. A shading language must NOT be served by this two-way dispatch:
+   both branches are C-family, and the wildcard sends anything unrecognised to
+   CUDA, so GLSL/WGSL used to be handed `sinf`/`fabsf` — names no shader compiler
+   declares. It was never reached (the GLSL/WGSL post_hooks are inert), which is
+   why nothing caught it; the refusal is what keeps it unreachable BY DESIGN
+   rather than by accident, so wiring those post_hooks fails by name instead of
+   emitting C into a shader. *)
+let test_shading_languages_are_refused () =
+  List.iter
+    (fun fw ->
+      match cuda_or_opencl fw "sinf" "sin" with
+      | s ->
+          failwith
+            (Printf.sprintf
+               "cuda_or_opencl %S returned %S instead of refusing: a shading \
+                language must not be given a C-family spelling"
+               fw
+               s)
+      | exception Sarek_registry.No_device_spelling {framework; cuda} ->
+          assert (framework = fw) ;
+          assert (cuda = "sinf"))
+    ["GLSL"; "WGSL"] ;
+  (* The five frameworks this dispatch DOES serve must be unaffected. Listed
+     explicitly rather than sampled: the point of the change is that it narrows
+     the wildcard, so the cases still falling through are the assertion. *)
+  List.iter
+    (fun (fw, expected) ->
+      let got = cuda_or_opencl fw "cuda_code" "opencl_code" in
+      if got <> expected then
+        failwith
+          (Printf.sprintf
+             "cuda_or_opencl %S: expected %S, got %S"
+             fw
+             expected
+             got))
+    [
+      ("CUDA", "cuda_code");
+      ("OpenCL", "opencl_code");
+      ("Metal", "opencl_code");
+      ("Native", "cuda_code");
+      ("Interpreter", "cuda_code");
+      (* "generic" is the live default of fun_device_template and keeps C-family
+         semantics — refusing it would break that entry point. *)
+      ("generic", "cuda_code");
+    ] ;
+  (* The printer must be registered, or the guard reports as an opaque
+     constructor naming neither the framework nor the spelling it refused. *)
+  let msg =
+    match cuda_or_opencl "GLSL" "fabsf" "fabs" with
+    | _ -> assert false
+    | exception e -> Printexc.to_string e
+  in
+  let contains hay needle =
+    let nh = String.length hay and nn = String.length needle in
+    let rec go i =
+      i + nn <= nh && (String.sub hay i nn = needle || go (i + 1))
+    in
+    nn > 0 && go 0
+  in
+  assert (contains msg "GLSL") ;
+  assert (contains msg "fabsf") ;
+  print_endline
+    "  shading languages refused (GLSL/WGSL), 6 C-family unchanged: OK"
+
 (** {1 Main} *)
 
 let () =
@@ -257,4 +321,5 @@ let () =
   test_fun_device_code () ;
   test_fun_device_template () ;
   test_cuda_or_opencl () ;
+  test_shading_languages_are_refused () ;
   print_endline "All Sarek_registry tests passed!"


### PR DESCRIPTION
backlog-159, **filed with the wrong remedy — by me.**

The entry said: *"GLSL and WGSL have no registry-template fallback — wire
`Dispatch.emit_registry_template` into their `post_hook` like the other three
backends."* The hook exists, both are literally `(fun _ _ _ _ -> false)`, and the
symmetry is obvious. Implementing it would have been a regression.

## Why

`Sarek_registry.cuda_or_opencl` is a **two-way** dispatch and both branches are
C-family:

```ocaml
| "OpenCL" | "Metal" -> opencl_code
| "CUDA" | "Native" | "Interpreter" | _ -> cuda_code
```

GLSL and WGSL hit the wildcard, so the registry would hand them `sinf`, `fabsf`,
`powf` — names no shader compiler declares. **133 stdlib intrinsics** go through
this helper (Float32 35, Float64 42, Gpu 21, Int32 16, Int64 16, Math 3).

Today those backends raise `unknown_intrinsic` on fall-through, which is **loud**.
Wiring the hook would have replaced a loud refusal with silently-invalid shader
source — the exact class this repo keeps closing, introduced while believing I was
closing it.

## What changed — surgical

The inert `post_hook` is the correct behaviour. This makes it correct **by design**
rather than by accident:

- `cuda_or_opencl` now **refuses** `"GLSL"`/`"WGSL"` (`No_device_spelling`, with a
  registered printer) instead of falling through to CUDA. There is no right value to
  return: a spelling for these frameworks must be **registered**, not derived —
  which is what `Sarek_pure_registry` already does, dispatching on framework and
  carrying the GLSL exceptions explicitly (`fabs`→`abs`, `rsqrt`→`inversesqrt`,
  `atan2`→`atan`).
- both `post_hook`s now say **why** they are inert, so the next reader does not redo
  the mistake my own backlog entry recommended.

**Deliberately not a blanket refusal.** `"generic"` is the live default of
`fun_device_template` (`test_sarek_registry` calls it with no `~framework`) and has
C-family semantics; `Native` and `Interpreter` are intentional CUDA-branch users.
Only the two frameworks *measured* to be mis-served by both branches are refused.

## Verification

**Nothing reaches the new arm today, and that is measured rather than assumed:**
full suite green with **zero** `No_device_spelling` occurrences — positive evidence
that no live path passes GLSL/WGSL here. The arm is a landmine guard, not a live path.

**Prove-red is behavioural, not a compile error.** Reverting the whole file only
gives `Unbound constructor`, which proves the test needs the new type and nothing
about behaviour. The honest mutation keeps the exception defined and makes the arm
return `cuda_code` — the old behaviour — and the test then fails with
`cuda_or_opencl "GLSL" returned "sinf" instead of refusing`.

The test pins the **six** frameworks that must be unaffected (CUDA, OpenCL, Metal,
Native, Interpreter, generic), listed explicitly rather than sampled: this change
*narrows a wildcard*, so what still falls through it is the property. It also asserts
the printer is **reached** — the message must contain the framework and the refused
spelling — because `Printexc.to_string` always returns something, so a non-empty
check would pass with no printer registered at all.

Suite via `scripts/test-suite-counts.sh`: **1725 cases across 119 suites, 0 FAIL**,
23 SKIP. `dune build` and `@fmt` clean, the latter re-run after the last edit.

## What this does NOT do

It does not give GLSL/WGSL a registry fallback. That needs the registration surface
to become framework-complete — a spelling per shading language, or an explicit
refusal, at each of the 133 sites — which is a design change, not a bug fix. This PR
makes the absence safe and self-documenting; it does not pretend to fill it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported GLSL and WGSL intrinsic names.
  * Prevented shading-language code from incorrectly using CUDA/OpenCL spellings.
  * Added clearer error messages when an appropriate device-specific spelling is unavailable.

* **Tests**
  * Added coverage confirming GLSL and WGSL requests fail clearly while existing C-family behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->