### PR TITLE
refactor(ir): a base record so a new kernel field costs zero call sites

### DIFF
--- a/formal/codegen-ptx/PtxKernelSpec.ml
+++ b/formal/codegen-ptx/PtxKernelSpec.ml
@@ -98,6 +98,7 @@ let ex_st = {regs = ex_empty_regs; tc = ex_zero_tc; mem = ex_zero_mem}
 
 let ex_k_no_shared =
   {
+    default_kernel with
     kern_name =
       String
         ( Ascii (false, true, true, true, false, true, true, false),
@@ -151,7 +152,6 @@ let ex_k_no_shared =
                                               true,
                                               false ),
                                           EmptyString ) ) ) ) ) ) ) ) );
-    kern_params = [];
     kern_shared = [];
     kern_body = ISEmpty;
   }
@@ -1138,6 +1138,7 @@ let ex_shared_decl =
 
 let ex_k_with_shared =
   {
+    default_kernel with
     kern_name =
       String
         ( Ascii (true, true, true, false, true, true, true, false),
@@ -1212,7 +1213,6 @@ let ex_k_with_shared =
                                                       false ),
                                                   EmptyString ) ) ) ) ) ) ) ) )
             ) );
-    kern_params = [];
     kern_shared = ex_shared_decl :: [];
     kern_body = ISEmpty;
   }

--- a/formal/codegen-ptx/test/test_codegen_ptx_conformance.ml
+++ b/formal/codegen-ptx/test/test_codegen_ptx_conformance.ml
@@ -788,14 +788,11 @@ let make_var name ty =
 
 let make_kernel ?(params = []) ?(locals = []) ?(body = SEmpty) name =
   {
+    default_kernel with
     kern_name = name;
     kern_params = params;
     kern_locals = locals;
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* AC-1: DShared TFloat32 static → .shared .align 4 .b32 + st.shared.f32 *)

--- a/sarek-cuda/test/test_cuda_f16_nvrtc.ml
+++ b/sarek-cuda/test/test_cuda_f16_nvrtc.ml
@@ -27,16 +27,7 @@ let make_var name ty =
   {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
 
 let mk_kernel name params body =
-  {
-    kern_name = name;
-    kern_params = params;
-    kern_locals = [];
-    kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
-  }
+  {default_kernel with kern_name = name; kern_params = params; kern_body = body}
 
 (** The same "storage type, compute in f32" kernel the golden test asserts on:
     read an f16 element, widen to f32, double it, narrow back on store. *)

--- a/sarek-cuda/test/test_cuda_f16_sass.ml
+++ b/sarek-cuda/test/test_cuda_f16_sass.ml
@@ -46,16 +46,7 @@ let make_var name ty =
   {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
 
 let mk_kernel name params body =
-  {
-    kern_name = name;
-    kern_params = params;
-    kern_locals = [];
-    kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
-  }
+  {default_kernel with kern_name = name; kern_params = params; kern_body = body}
 
 (** The MIDROUND kernel — the exact shape that exposed the AMDGPU fusion:
 

--- a/sarek-cuda/test/test_cuda_fp_conformance.ml
+++ b/sarek-cuda/test/test_cuda_fp_conformance.ml
@@ -48,16 +48,7 @@ let make_var name ty =
   {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
 
 let mk_kernel name params body =
-  {
-    kern_name = name;
-    kern_params = params;
-    kern_locals = [];
-    kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
-  }
+  {default_kernel with kern_name = name; kern_params = params; kern_body = body}
 
 let f16_midround_kernel () =
   let out = make_var "out" (TVec TFloat16) in

--- a/sarek-cuda/test/test_cuda_nvrtc_gate.ml
+++ b/sarek-cuda/test/test_cuda_nvrtc_gate.ml
@@ -35,16 +35,7 @@ let make_var ?(mut = false) name ty =
   {var_name = name; var_id = 0; var_type = ty; var_mutable = mut}
 
 let base_kernel name params body =
-  {
-    kern_name = name;
-    kern_params = params;
-    kern_locals = [];
-    kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
-  }
+  {default_kernel with kern_name = name; kern_params = params; kern_body = body}
 
 let vec name ty = DParam (make_var name (TVec ty), None)
 

--- a/sarek-cuda/test/test_ptx_dynshared_probe.ml
+++ b/sarek-cuda/test/test_ptx_dynshared_probe.ml
@@ -56,15 +56,12 @@ let make_dynshared_kernel () : kernel =
           ] )
   in
   {
+    default_kernel with
     kern_name = "dynshared_probe";
     kern_params =
       [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})];
     kern_locals = [DShared ("dynbuf", TFloat32, None)];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let emitted_ptx () =

--- a/sarek-cuda/test/test_ptx_localarr_probe.ml
+++ b/sarek-cuda/test/test_ptx_localarr_probe.ml
@@ -82,15 +82,11 @@ let make_localarr_kernel () : kernel =
               ] ) )
   in
   {
+    default_kernel with
     kern_name = "localarr_probe";
     kern_params =
       [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let emitted_ptx () =

--- a/sarek-metal/test/test_sarek_ir_metal.ml
+++ b/sarek-metal/test/test_sarek_ir_metal.ml
@@ -283,14 +283,9 @@ let test_local_buffer_param_refused () =
 let mk_vec_kernel elt : kernel =
   let v = make_var "x" (TVec elt) in
   {
+    default_kernel with
     kern_name = "capgate";
     kern_params = [DParam (v, Some {arr_elttype = elt; arr_memspace = Global})];
-    kern_locals = [];
-    kern_body = SEmpty;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let substring_present haystack needle =
@@ -340,16 +335,12 @@ let test_float64_literal_gate () =
   let v = make_var "x" (TVec TFloat32) in
   let k : kernel =
     {
+      default_kernel with
       kern_name = "caplit";
       kern_params =
         [DParam (v, Some {arr_elttype = TFloat32; arr_memspace = Global})];
-      kern_locals = [];
       kern_body =
         SAssign (LArrayElem ("x", EConst (CInt32 0l)), EConst (CFloat64 3.14));
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   match

--- a/sarek-vulkan/test/test_vulkan_error_observability.ml
+++ b/sarek-vulkan/test/test_vulkan_error_observability.ml
@@ -40,19 +40,15 @@ let kernel_calling ~name ~arity =
   let arg = EArrayRead ("a", EConst (CInt32 0l)) in
   let args = List.init arity (fun _ -> arg) in
   {
+    default_kernel with
     kern_name = "observability_probe";
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body =
       SAssign (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic ([], name, args));
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* Dependency-light substring check (mirror of the codegen_golden helper). *)
@@ -125,21 +121,17 @@ let test_supported_kernel_ok () =
   let c = make_var "c" (TVec TFloat32) in
   let ir =
     {
+      default_kernel with
       kern_name = "identity_probe";
       kern_params =
         [
           DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
           DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
         ];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("c", EConst (CInt32 0l)),
             EArrayRead ("a", EConst (CInt32 0l)) );
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   match Backend.generate_source ir with

--- a/sarek/codegen/Sarek_ir_ptx.ml
+++ b/sarek/codegen/Sarek_ir_ptx.ml
@@ -59,6 +59,7 @@ let demo_vector_add_ptx () : string =
   in
   let k =
     {
+      default_kernel with
       kern_name = "vector_add";
       kern_params =
         [
@@ -67,12 +68,7 @@ let demo_vector_add_ptx () : string =
           DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
           DParam (n, None);
         ];
-      kern_locals = [];
       kern_body = body;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   generate k

--- a/sarek/ppx/Sarek_ir_ppx.ml
+++ b/sarek/ppx/Sarek_ir_ppx.ml
@@ -167,3 +167,23 @@ type kernel = {
       (** Placeholder for native function - actual function added during quoting
       *)
 }
+
+(** Base for a record update, mirroring {!Sarek_ir_types.default_kernel}.
+
+    This module's [kernel] and {!Sarek_ir_types.kernel} are two structurally
+    parallel records bridged by [Sarek_ir_conv.conv_kernel]: this one is what
+    lowering PRODUCES, the other is what the backends CONSUME. A field added to
+    one almost always has to be added to the other and threaded through the
+    converter, so both get the same escape hatch — otherwise migrating one type
+    and not the other just moves the problem. *)
+let default_kernel =
+  {
+    kern_name = "";
+    kern_params = [];
+    kern_locals = [];
+    kern_body = SEmpty;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }

--- a/sarek/sarek/Sarek_fusion.ml
+++ b/sarek/sarek/Sarek_fusion.ml
@@ -791,6 +791,7 @@ let fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
             ~fn:"fuse"
             ~intermediate
             {
+              default_kernel with
               kern_name = consumer.kern_name ^ "_fused";
               kern_params = fused_params @ new_params;
               kern_locals = consumer.kern_locals @ producer.kern_locals;
@@ -798,7 +799,6 @@ let fuse (producer : kernel) (consumer : kernel) (intermediate : string) :
               kern_types = consumer.kern_types @ producer.kern_types;
               kern_variants = consumer.kern_variants @ producer.kern_variants;
               kern_funcs = consumer.kern_funcs @ producer.kern_funcs;
-              kern_native_fn = None;
             })
 
 (** {1 High-level interface} *)
@@ -1042,6 +1042,7 @@ let fuse_reduction (map_kernel : kernel) (reduce_kernel : kernel)
             ~fn:"fuse_reduction"
             ~intermediate
             {
+              default_kernel with
               kern_name = reduce_kernel.kern_name ^ "_fused";
               kern_params = fused_params @ new_params;
               kern_locals = reduce_kernel.kern_locals @ map_kernel.kern_locals;
@@ -1050,7 +1051,6 @@ let fuse_reduction (map_kernel : kernel) (reduce_kernel : kernel)
               kern_variants =
                 reduce_kernel.kern_variants @ map_kernel.kern_variants;
               kern_funcs = reduce_kernel.kern_funcs @ map_kernel.kern_funcs;
-              kern_native_fn = None;
             })
 
 (** Try to fuse map+reduce, falling back to regular fusion if not applicable *)
@@ -1312,6 +1312,7 @@ let fuse_stencil (producer : kernel) (consumer : kernel) (intermediate : string)
             ~fn:"fuse_stencil"
             ~intermediate
             {
+              default_kernel with
               kern_name = consumer.kern_name ^ "_stencil_fused";
               kern_params = fused_params @ new_params;
               kern_locals = consumer.kern_locals @ producer.kern_locals;
@@ -1319,7 +1320,6 @@ let fuse_stencil (producer : kernel) (consumer : kernel) (intermediate : string)
               kern_types = consumer.kern_types @ producer.kern_types;
               kern_variants = consumer.kern_variants @ producer.kern_variants;
               kern_funcs = consumer.kern_funcs @ producer.kern_funcs;
-              kern_native_fn = None;
             })
 
 (** Enhanced try_fuse that includes stencil fusion *)

--- a/sarek/tests/codegen_golden/test_backend_type_width_totality.ml
+++ b/sarek/tests/codegen_golden/test_backend_type_width_totality.ml
@@ -464,13 +464,13 @@ let f64_scale_kernel () =
   let inp = make_var "inp" (TVec TFloat64) in
   let idx = make_var "idx" TInt32 in
   {
+    default_kernel with
     kern_name = "f64_scale";
     kern_params =
       [
         DParam (out, Some {arr_elttype = TFloat64; arr_memspace = Global});
         DParam (inp, Some {arr_elttype = TFloat64; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body =
       SLet
         ( idx,
@@ -479,10 +479,6 @@ let f64_scale_kernel () =
             ( LArrayElem ("out", EVar idx),
               EBinop (Mul, EArrayRead ("inp", EVar idx), EConst (CFloat64 2.0))
             ) );
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (** f64 reachable ONLY through a constant and an f64-typed local — the shape the
@@ -493,10 +489,10 @@ let f64_local_kernel () =
   let x = make_var "x" TFloat64 in
   let idx = make_var "idx" TInt32 in
   {
+    default_kernel with
     kern_name = "f64_local";
     kern_params =
       [DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global})];
-    kern_locals = [];
     kern_body =
       SLet
         ( idx,
@@ -506,10 +502,6 @@ let f64_local_kernel () =
               EConst (CFloat64 0.1),
               SAssign (LArrayElem ("out", EVar idx), ECast (TFloat32, EVar x))
             ) );
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let expect_metal_kernel_refused label gen =
@@ -543,13 +535,13 @@ let test_metal_still_accepts_f32 () =
   let idx = make_var "idx" TInt32 in
   let k =
     {
+      default_kernel with
       kern_name = "f32_scale";
       kern_params =
         [
           DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
           DParam (inp, Some {arr_elttype = TFloat32; arr_memspace = Global});
         ];
-      kern_locals = [];
       kern_body =
         SLet
           ( idx,
@@ -558,10 +550,6 @@ let test_metal_still_accepts_f32 () =
               ( LArrayElem ("out", EVar idx),
                 EBinop (Mul, EArrayRead ("inp", EVar idx), EConst (CFloat32 2.0))
               ) );
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   ignore (Sarek_ir_metal.generate k) ;

--- a/sarek/tests/codegen_golden/test_codegen_golden.ml
+++ b/sarek/tests/codegen_golden/test_codegen_golden.ml
@@ -29,14 +29,11 @@ let make_var name ty =
 
 let empty_kernel name params locals body =
   {
+    default_kernel with
     kern_name = name;
     kern_params = params;
     kern_locals = locals;
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (** Kernel 1: scalar vector-add. Equivalent to: fun (a : float32 vec) (b :

--- a/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
+++ b/sarek/tests/codegen_golden/test_cuda_f16_golden.ml
@@ -29,16 +29,7 @@ let make_var name ty =
   {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
 
 let mk_kernel name params body =
-  {
-    kern_name = name;
-    kern_params = params;
-    kern_locals = [];
-    kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
-  }
+  {default_kernel with kern_name = name; kern_params = params; kern_body = body}
 
 let reset () =
   Sarek_ir_cuda.current_framework := None ;

--- a/sarek/tests/codegen_golden/test_ematch_payload_binding.ml
+++ b/sarek/tests/codegen_golden/test_ematch_payload_binding.ml
@@ -101,18 +101,15 @@ let kernel_with ~vname ~constrs ~elt cases =
             EMatch (EArrayRead ("opt", EVar idx), cases) ) )
   in
   {
+    default_kernel with
     kern_name = "ematch_payload_probe";
     kern_params =
       [
         DParam (scrut, Some {arr_elttype = elt; arr_memspace = Global});
         DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
     kern_variants = [(vname, constrs)];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let v name = EVar (make_var name TFloat32)
@@ -203,18 +200,15 @@ let silent_wrong_kernel =
                     ] ) ) ) )
   in
   {
+    default_kernel with
     kern_name = "ematch_silent_wrong_probe";
     kern_params =
       [
         DParam (scrut, Some {arr_elttype = opt_type; arr_memspace = Global});
         DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
     kern_variants = [("Opt", opt_constrs)];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* CAPTURE. The outer arm's replacement term is built from the OUTER scrutinee
@@ -264,18 +258,15 @@ let capture_kernel =
                     ] ) ) ) )
   in
   {
+    default_kernel with
     kern_name = "ematch_capture_probe";
     kern_params =
       [
         DParam (shp, Some {arr_elttype = opt_type; arr_memspace = Global});
         DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
     kern_variants = [("Opt", opt_constrs); ("Choice", pick_constrs)];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* `match e with x -> ...`: the PPX lowers a plain variable pattern to
@@ -371,13 +362,13 @@ let atomic_scrutinee_kernel =
   let out = make_var "out" (TVec TFloat32) in
   let idx = make_var "idx" TInt32 in
   {
+    default_kernel with
     kern_name = "ematch_atomic_scrutinee";
     kern_params =
       [
         DParam (scrut, Some {arr_elttype = opt_type; arr_memspace = Global});
         DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body =
       SLet
         ( idx,
@@ -391,10 +382,7 @@ let atomic_scrutinee_kernel =
                       EBinop (Add, v "y", EConst (CFloat32 1.0)) );
                     (PConstr ("OptNone", []), EConst (CFloat32 0.0));
                   ] ) ) );
-    kern_types = [];
     kern_variants = [("Opt", opt_constrs)];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* The SAME multi-payload destructuring as a match STATEMENT. Both paths now
@@ -409,13 +397,13 @@ let smatch_multi_kernel =
   let out = make_var "out" (TVec TFloat32) in
   let idx = make_var "idx" TInt32 in
   {
+    default_kernel with
     kern_name = "smatch_multi_probe";
     kern_params =
       [
         DParam (scrut, Some {arr_elttype = pair_type; arr_memspace = Global});
         DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body =
       SLet
         ( idx,
@@ -430,10 +418,7 @@ let smatch_multi_kernel =
                 ( PConstr ("MkOne", ["c"]),
                   SAssign (LArrayElem ("out", EVar idx), v "c") );
               ] ) );
-    kern_types = [];
     kern_variants = [("Pair", pair_constrs)];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* --- backends ------------------------------------------------------------ *)

--- a/sarek/tests/codegen_golden/test_glsl_intrinsic_fallback.ml
+++ b/sarek/tests/codegen_golden/test_glsl_intrinsic_fallback.ml
@@ -40,20 +40,16 @@ let kernel_calling ~path ~name ~arity =
   let arg = EArrayRead ("a", EConst (CInt32 0l)) in
   let args = List.init arity (fun _ -> arg) in
   {
+    default_kernel with
     kern_name = "fallback_probe";
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body =
       SAssign
         (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic (path, name, args));
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let generate k = Glsl.generate_with_types ~types:[] k

--- a/sarek/tests/codegen_golden/test_glsl_name_collision.ml
+++ b/sarek/tests/codegen_golden/test_glsl_name_collision.ml
@@ -29,14 +29,10 @@ let make_var name ty =
 
 let kernel_with ~params ~funcs =
   {
+    default_kernel with
     kern_name = "collision_probe";
     kern_params = params;
-    kern_locals = [];
-    kern_body = SEmpty;
-    kern_types = [];
-    kern_variants = [];
     kern_funcs = funcs;
-    kern_native_fn = None;
   }
 
 (* No collision: the default base name is returned verbatim. *)

--- a/sarek/tests/codegen_golden/test_intrinsic_fallback_all.ml
+++ b/sarek/tests/codegen_golden/test_intrinsic_fallback_all.ml
@@ -37,20 +37,16 @@ let kernel_calling ~path ~name ~arity =
   let arg = EArrayRead ("a", EConst (CInt32 0l)) in
   let args = List.init arity (fun _ -> arg) in
   {
+    default_kernel with
     kern_name = "fallback_probe";
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body =
       SAssign
         (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic (path, name, args));
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* Each backend's IR-to-source entry point, uniformly [kernel -> string]. *)

--- a/sarek/tests/e2e/test_coopmat_integer_e2e.ml
+++ b/sarek/tests/e2e/test_coopmat_integer_e2e.ml
@@ -131,6 +131,7 @@ let make_ir ?(drop_c = false) ?(stride1_b = false) () : kernel =
       ]
   in
   {
+    default_kernel with
     kern_name = "coopmat_u8_s32";
     kern_params =
       [
@@ -139,12 +140,7 @@ let make_ir ?(drop_c = false) ?(stride1_b = false) () : kernel =
         DParam (c, Some {arr_elttype = TInt32; arr_memspace = Global});
         DParam (d, Some {arr_elttype = TInt32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = SSeq stmts;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* ------------------------------------------------------------------ *)

--- a/sarek/tests/e2e/test_domain_pool_stress.ml
+++ b/sarek/tests/e2e/test_domain_pool_stress.ml
@@ -55,15 +55,11 @@ let make_ir () : kernel =
             EBinop (Add, EVar idx, EConst (CInt32 1l)) ) )
   in
   {
+    default_kernel with
     kern_name = "domain_pool_stress";
     kern_params =
       [DParam (dst, Some {arr_elttype = TInt32; arr_memspace = Global})];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let block_size = 64

--- a/sarek/tests/e2e/test_float32_sin_pure.ml
+++ b/sarek/tests/e2e/test_float32_sin_pure.ml
@@ -49,18 +49,14 @@ let make_float32_sin_ir () : kernel =
             EIntrinsic (["Float32"], "sin", [EArrayRead ("a", EVar idx)]) ) )
   in
   {
+    default_kernel with
     kern_name = "float32_sin_pure";
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let n = 256

--- a/sarek/tests/e2e/test_float64_math_intrinsics.ml
+++ b/sarek/tests/e2e/test_float64_math_intrinsics.ml
@@ -60,18 +60,14 @@ let make_unary_ir name : kernel =
             EIntrinsic (["Float64"], name, [EArrayRead ("a", EVar idx)]) ) )
   in
   {
+    default_kernel with
     kern_name = "float64_" ^ name ^ "_unary";
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat64; arr_memspace = Global});
         DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let make_binary_ir name : kernel =
@@ -99,6 +95,7 @@ let make_binary_ir name : kernel =
                 [EArrayRead ("a", EVar idx); EArrayRead ("b", EVar idx)] ) ) )
   in
   {
+    default_kernel with
     kern_name = "float64_" ^ name ^ "_binary";
     kern_params =
       [
@@ -106,12 +103,7 @@ let make_binary_ir name : kernel =
         DParam (b, Some {arr_elttype = TFloat64; arr_memspace = Global});
         DParam (c, Some {arr_elttype = TFloat64; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (** {1 Function specs}

--- a/sarek/tests/e2e/test_vulkan_float64.ml
+++ b/sarek/tests/e2e/test_vulkan_float64.ml
@@ -72,6 +72,7 @@ let make_fma_ir () : kernel =
                 EArrayRead ("c", EVar idx) ) ) )
   in
   {
+    default_kernel with
     kern_name = "float64_fma_vulkan";
     kern_params =
       [
@@ -80,12 +81,7 @@ let make_fma_ir () : kernel =
         DParam (c, Some {arr_elttype = TFloat64; arr_memspace = Global});
         DParam (dst, Some {arr_elttype = TFloat64; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let find_vulkan_device () =

--- a/sarek/tests/e2e/test_vulkan_int64.ml
+++ b/sarek/tests/e2e/test_vulkan_int64.ml
@@ -66,6 +66,7 @@ let make_add_ir () : kernel =
           ) )
   in
   {
+    default_kernel with
     kern_name = "int64_add_vulkan";
     kern_params =
       [
@@ -73,12 +74,7 @@ let make_add_ir () : kernel =
         DParam (b, Some {arr_elttype = TInt64; arr_memspace = Global});
         DParam (dst, Some {arr_elttype = TInt64; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* Select a Vulkan device that actually PROVIDES int64, not merely the first

--- a/sarek/tests/e2e/test_vulkan_recursion_vector.ml
+++ b/sarek/tests/e2e/test_vulkan_recursion_vector.ml
@@ -131,18 +131,15 @@ let make_ir () : kernel =
             None ) )
   in
   {
+    default_kernel with
     kern_name = "recursion_vector_vulkan";
     kern_params =
       [
         DParam (data, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
     kern_funcs = [sum_range_helper ()];
-    kern_native_fn = None;
   }
 
 let find_vulkan_device () =

--- a/sarek/tests/unit/test_backend_arm_parity.ml
+++ b/sarek/tests/unit/test_backend_arm_parity.ml
@@ -81,19 +81,15 @@ let kernel_calling ~name ~arity =
   let arg = EArrayRead ("a", EConst (CInt32 0l)) in
   let args = List.init arity (fun _ -> arg) in
   {
+    default_kernel with
     kern_name = "arm_parity_probe";
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body =
       SAssign (LArrayElem ("c", EConst (CInt32 0l)), EIntrinsic ([], name, args));
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let backends =

--- a/sarek/tests/unit/test_emitted_name_declared.ml
+++ b/sarek/tests/unit/test_emitted_name_declared.ml
@@ -116,18 +116,14 @@ let kernel_with rhs =
   let a = make_var "a" (TVec TFloat32) in
   let c = make_var "c" (TVec TFloat32) in
   {
+    default_kernel with
     kern_name = "emitted_name_probe";
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
     kern_body = SAssign (LArrayElem ("c", EConst (CInt32 0l)), rhs);
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* ------------------------------------------------------------------------ *)

--- a/sarek/tests/unit/test_entry_point_agreement.ml
+++ b/sarek/tests/unit/test_entry_point_agreement.ml
@@ -72,14 +72,11 @@ let make_var name ty =
 
 let empty_kernel name params locals body =
   {
+    default_kernel with
     kern_name = name;
     kern_params = params;
     kern_locals = locals;
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* ------------------------------------------------------------------------ *)

--- a/sarek/tests/unit/test_execute.ml
+++ b/sarek/tests/unit/test_execute.ml
@@ -214,15 +214,10 @@ let kernel_over elt : Sarek_ir_types.kernel =
     {var_name = "dst"; var_id = 0; var_type = TVec elt; var_mutable = false}
   in
   {
+    default_kernel with
     kern_name = "cap_probe";
     kern_params =
       [DParam (dst, Some {arr_elttype = elt; arr_memspace = Global})];
-    kern_locals = [];
-    kern_body = SEmpty;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let refusal_of ~device ir =
@@ -316,15 +311,10 @@ let coopmat_kernel (comp : Sarek_coopmat.component_type) : Sarek_ir_types.kernel
     }
   in
   {
+    default_kernel with
     kern_name = "interp_coopmat_probe";
-    kern_params = [];
-    kern_locals = [];
     kern_body =
       SCoopmat (CM_muladd {dst = "fd"; a = "fa"; b = "fb"; c = "fc"; cfg});
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (* THE POSITIVE CONTROL, and it is the load-bearing one. A gate observed only

--- a/sarek/tests/unit/test_fusion.ml
+++ b/sarek/tests/unit/test_fusion.ml
@@ -19,16 +19,7 @@ let thread_idx_x = EIntrinsic (["Gpu"], "thread_idx_x", [])
 
 (** Helper to create a minimal kernel record *)
 let mk_kernel name body =
-  {
-    kern_name = name;
-    kern_params = [];
-    kern_locals = [];
-    kern_body = body;
-    kern_types = [];
-    kern_funcs = [];
-    kern_native_fn = None;
-    kern_variants = [];
-  }
+  {default_kernel with kern_name = name; kern_body = body}
 
 let kernel_names kernels = List.map (fun k -> k.kern_name) kernels
 
@@ -40,18 +31,7 @@ let test_analyze_one_to_one () =
       ( LArrayElem ("output", thread_idx_x),
         EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l)) )
   in
-  let kernel =
-    {
-      kern_name = "scale";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = body;
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
-    }
-  in
+  let kernel = {default_kernel with kern_name = "scale"; kern_body = body} in
   let info = analyze kernel in
   assert (List.length info.reads = 1) ;
   assert (List.length info.writes = 1) ;
@@ -75,16 +55,7 @@ let test_analyze_with_barrier () =
       ]
   in
   let kernel =
-    {
-      kern_name = "with_barrier";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = body;
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
-    }
+    {default_kernel with kern_name = "with_barrier"; kern_body = body}
   in
   let info = analyze kernel in
   assert info.has_barriers ;
@@ -95,35 +66,25 @@ let test_can_fuse_compatible () =
   (* Producer: temp[i] = input[i] * 2 *)
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* Consumer: output[i] = temp[i] + 1 *)
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse producer consumer "temp" in
@@ -134,9 +95,8 @@ let test_can_fuse_compatible () =
 let test_can_fuse_with_barrier () =
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -145,25 +105,16 @@ let test_can_fuse_with_barrier () =
                 EArrayRead ("input", thread_idx_x) );
             SBarrier;
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EArrayRead ("temp", thread_idx_x) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse producer consumer "temp" in
@@ -176,9 +127,8 @@ let test_can_fuse_with_barrier () =
 let test_can_fuse_with_direct_atomic () =
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -189,25 +139,16 @@ let test_can_fuse_with_direct_atomic () =
               ( LArrayElem ("temp", thread_idx_x),
                 EArrayRead ("input", thread_idx_x) );
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EArrayRead ("temp", thread_idx_x) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse producer consumer "temp" in
@@ -235,31 +176,22 @@ let test_can_fuse_with_atomic_in_helper () =
   in
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           (LArrayElem ("temp", thread_idx_x), EArrayRead ("input", thread_idx_x));
-      kern_types = [];
       kern_funcs = [atomic_helper];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EArrayRead ("temp", thread_idx_x) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse producer consumer "temp" in
@@ -277,9 +209,8 @@ let test_can_fuse_with_atomic_in_assign_lvalue () =
   in
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -288,25 +219,16 @@ let test_can_fuse_with_atomic_in_assign_lvalue () =
               ( LArrayElem ("temp", thread_idx_x),
                 EArrayRead ("input", thread_idx_x) );
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EArrayRead ("temp", thread_idx_x) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse producer consumer "temp" in
@@ -317,34 +239,24 @@ let test_can_fuse_with_atomic_in_assign_lvalue () =
 let test_can_fuse_no_atomics_regression () =
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse producer consumer "temp" in
@@ -356,35 +268,25 @@ let test_fuse_simple () =
   (* Producer: temp[i] = input[i] * 2 *)
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* Consumer: output[i] = temp[i] + 1 *)
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let fused = fuse producer consumer "temp" in
@@ -402,50 +304,35 @@ let test_fuse_pipeline () =
   (* K1: a[i] = input[i] * 2 *)
   let k1 =
     {
+      default_kernel with
       kern_name = "k1";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("a", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* K2: b[i] = a[i] + 1 *)
   let k2 =
     {
+      default_kernel with
       kern_name = "k2";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("b", thread_idx_x),
             EBinop (Add, EArrayRead ("a", thread_idx_x), EConst (CInt32 1l)) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* K3: output[i] = b[i] * 3 *)
   let k3 =
     {
+      default_kernel with
       kern_name = "k3";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EBinop (Mul, EArrayRead ("b", thread_idx_x), EConst (CInt32 3l)) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let fused, eliminated = fuse_pipeline [k1; k2; k3] in
@@ -619,9 +506,8 @@ let test_is_reduction_kernel () =
   in
   let kernel =
     {
+      default_kernel with
       kern_name = "reduce_sum";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -636,10 +522,6 @@ let test_is_reduction_kernel () =
                     EBinop (Add, EVar acc, EArrayRead ("temp", EVar loop_var))
                   ) );
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = is_reduction_kernel kernel "temp" in
@@ -651,18 +533,13 @@ let test_can_fuse_reduction () =
   (* Map: temp[i] = input[i] * 2 *)
   let map_kernel =
     {
+      default_kernel with
       kern_name = "map";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* Reduce: sum = fold(+, temp) *)
@@ -674,9 +551,8 @@ let test_can_fuse_reduction () =
   in
   let reduce_kernel =
     {
+      default_kernel with
       kern_name = "reduce";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -691,10 +567,6 @@ let test_can_fuse_reduction () =
                     EBinop (Add, EVar acc, EArrayRead ("temp", EVar loop_var))
                   ) );
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse_reduction map_kernel reduce_kernel "temp" in
@@ -706,18 +578,13 @@ let test_fuse_reduction () =
   (* Map: temp[thread_idx_x] = input[thread_idx_x] * 2 *)
   let map_kernel =
     {
+      default_kernel with
       kern_name = "map";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* Reduce: sum = fold(+, temp) with loop var i *)
@@ -729,9 +596,8 @@ let test_fuse_reduction () =
   in
   let reduce_kernel =
     {
+      default_kernel with
       kern_name = "reduce";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -746,10 +612,6 @@ let test_fuse_reduction () =
                     EBinop (Add, EVar acc, EArrayRead ("temp", EVar loop_var))
                   ) );
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let fused = fuse_reduction map_kernel reduce_kernel "temp" in
@@ -764,18 +626,13 @@ let test_try_fuse_reduction () =
   (* Map: temp[i] = input[i] * 2 *)
   let map_kernel =
     {
+      default_kernel with
       kern_name = "map";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let loop_var =
@@ -786,9 +643,8 @@ let test_try_fuse_reduction () =
   in
   let reduce_kernel =
     {
+      default_kernel with
       kern_name = "reduce";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -803,10 +659,6 @@ let test_try_fuse_reduction () =
                     EBinop (Add, EVar acc, EArrayRead ("temp", EVar loop_var))
                   ) );
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = try_fuse map_kernel reduce_kernel "temp" in
@@ -818,9 +670,8 @@ let test_stencil_pattern () =
   (* Kernel: output[i] = (input[i-1] + input[i] + input[i+1]) / 3 *)
   let kernel =
     {
+      default_kernel with
       kern_name = "blur";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
@@ -838,10 +689,6 @@ let test_stencil_pattern () =
                       ("input", EBinop (Add, thread_idx_x, EConst (CInt32 1l)))
                   ),
                 EConst (CInt32 3l) ) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let info = analyze kernel in
@@ -868,9 +715,8 @@ let test_can_fuse_stencil () =
   (* Producer: temp[i] = input[i-1] + input[i+1] *)
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
@@ -880,18 +726,13 @@ let test_can_fuse_stencil () =
                   ("input", EBinop (Sub, thread_idx_x, EConst (CInt32 1l))),
                 EArrayRead
                   ("input", EBinop (Add, thread_idx_x, EConst (CInt32 1l))) ) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* Consumer: output[i] = temp[i-1] + temp[i] + temp[i+1] *)
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
@@ -904,10 +745,6 @@ let test_can_fuse_stencil () =
                     EArrayRead ("temp", thread_idx_x) ),
                 EArrayRead
                   ("temp", EBinop (Add, thread_idx_x, EConst (CInt32 1l))) ) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = can_fuse_stencil producer consumer "temp" in
@@ -919,26 +756,20 @@ let test_fuse_stencil () =
   (* Producer: temp[i] = input[i] * 2 (simple case) *)
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* Consumer: output[i] = temp[i-1] + temp[i+1] *)
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
@@ -948,10 +779,6 @@ let test_fuse_stencil () =
                   ("temp", EBinop (Sub, thread_idx_x, EConst (CInt32 1l))),
                 EArrayRead
                   ("temp", EBinop (Add, thread_idx_x, EConst (CInt32 1l))) ) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let fused = fuse_stencil producer consumer "temp" in
@@ -966,34 +793,24 @@ let test_try_fuse_all () =
   (* Simple OneToOne case should use vertical fusion *)
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let result = try_fuse_all producer consumer "temp" in
@@ -1004,34 +821,24 @@ let test_try_fuse_all () =
 let test_should_fuse_one_to_one () =
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EBinop (Add, EArrayRead ("temp", thread_idx_x), EConst (CInt32 1l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let hint = should_fuse producer consumer "temp" in
@@ -1042,9 +849,8 @@ let test_should_fuse_one_to_one () =
 let test_should_fuse_barrier () =
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SSeq
           [
@@ -1053,25 +859,16 @@ let test_should_fuse_barrier () =
                 EArrayRead ("input", thread_idx_x) );
             SBarrier;
           ];
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EArrayRead ("temp", thread_idx_x) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let hint = should_fuse producer consumer "temp" in
@@ -1082,26 +879,20 @@ let test_should_fuse_barrier () =
 let test_should_fuse_small_stencil () =
   let producer =
     {
+      default_kernel with
       kern_name = "producer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* Consumer reads temp[i-1], temp[i], temp[i+1] *)
   let consumer =
     {
+      default_kernel with
       kern_name = "consumer";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
@@ -1114,10 +905,6 @@ let test_should_fuse_small_stencil () =
                     EArrayRead ("temp", thread_idx_x) ),
                 EArrayRead
                   ("temp", EBinop (Add, thread_idx_x, EConst (CInt32 1l))) ) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let hint = should_fuse producer consumer "temp" in
@@ -1129,50 +916,35 @@ let test_auto_fuse_pipeline () =
   (* K1: a[i] = input[i] * 2 *)
   let k1 =
     {
+      default_kernel with
       kern_name = "k1";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("a", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* K2: b[i] = a[i] + 1 *)
   let k2 =
     {
+      default_kernel with
       kern_name = "k2";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("b", thread_idx_x),
             EBinop (Add, EArrayRead ("a", thread_idx_x), EConst (CInt32 1l)) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* K3: output[i] = b[i] * 3 *)
   let k3 =
     {
+      default_kernel with
       kern_name = "k3";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
             EBinop (Mul, EArrayRead ("b", thread_idx_x), EConst (CInt32 3l)) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let fused, eliminated, skipped = auto_fuse_pipeline [k1; k2; k3] in
@@ -1191,26 +963,20 @@ let test_auto_fuse_pipeline_skip_stencil () =
   (* K1: temp[i] = input[i] * 2 *)
   let k1 =
     {
+      default_kernel with
       kern_name = "k1";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("temp", thread_idx_x),
             EBinop (Mul, EArrayRead ("input", thread_idx_x), EConst (CInt32 2l))
           );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   (* K2: output[i] = temp[i-1] + temp[i+1] (stencil) *)
   let k2 =
     {
+      default_kernel with
       kern_name = "k2";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LArrayElem ("output", thread_idx_x),
@@ -1220,10 +986,6 @@ let test_auto_fuse_pipeline_skip_stencil () =
                   ("temp", EBinop (Sub, thread_idx_x, EConst (CInt32 1l))),
                 EArrayRead
                   ("temp", EBinop (Add, thread_idx_x, EConst (CInt32 1l))) ) );
-      kern_types = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-      kern_variants = [];
     }
   in
   let fused, eliminated, skipped = auto_fuse_pipeline_list [k1; k2] in

--- a/sarek/tests/unit/test_intrinsic_surface.ml
+++ b/sarek/tests/unit/test_intrinsic_surface.ml
@@ -329,17 +329,13 @@ let f32_call_kernel name arity : Sarek_ir_types.kernel =
   in
   let arg = EArrayRead ("a", EVar idx) in
   {
+    default_kernel with
     kern_name = "ffi_fallback_" ^ name;
     kern_params =
       [
         DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (b, Some {arr_elttype = TFloat32; arr_memspace = Global});
       ];
-    kern_locals = [];
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
     kern_body =
       SLet
         ( idx,

--- a/sarek/tests/unit/test_opencl_gate.ml
+++ b/sarek/tests/unit/test_opencl_gate.ml
@@ -25,14 +25,11 @@ let make_var name ty =
 
 let empty_kernel name params locals body =
   {
+    default_kernel with
     kern_name = name;
     kern_params = params;
     kern_locals = locals;
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (** A kernel calling helper [pow2], whose body is [hf_body]. *)

--- a/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
+++ b/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
@@ -101,18 +101,14 @@ let arr a ty = EVar (mk a (TVec ty))
 
 let kernel label out e =
   {
+    default_kernel with
     kern_name = "k_" ^ label;
     kern_params = params;
-    kern_locals = [];
     kern_body =
       SLet
         ( tid,
           EIntrinsic ([], "global_thread_id", []),
           SAssign (LArrayElem (out, EVar tid), e) );
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let f32_path = ["Sarek_stdlib"; "Float32"]

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -38,6 +38,7 @@ let make_vector_add_kernel () : kernel =
             None ) )
   in
   {
+    default_kernel with
     kern_name = "vector_add";
     kern_params =
       [
@@ -46,12 +47,7 @@ let make_vector_add_kernel () : kernel =
         DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
         DParam (n, None);
       ];
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 (** Check that [ptx] contains [marker]; fail with a readable message if not. *)
@@ -127,14 +123,11 @@ let make_var name ty =
 
 let base_kernel name params body funcs =
   {
+    default_kernel with
     kern_name = name;
     kern_params = params;
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
     kern_funcs = funcs;
-    kern_native_fn = None;
   }
 
 (** Shared-array reduction shape: let%shared sdata = 256 lowers to SLet (sdata,

--- a/sarek/tests/unit/test_quote_ir.ml
+++ b/sarek/tests/unit/test_quote_ir.ml
@@ -592,17 +592,7 @@ let test_quote_decl_shared () =
 
 let test_quote_kernel_simple () =
   let kern =
-    Ir.
-      {
-        kern_name = "test_kernel";
-        kern_params = [];
-        kern_locals = [];
-        kern_body = Ir.SEmpty;
-        kern_types = [];
-        kern_variants = [];
-        kern_funcs = [];
-        kern_native_fn = None;
-      }
+    Ir.{default_kernel with kern_name = "test_kernel"; kern_body = Ir.SEmpty}
   in
   let e = Sarek_quote_ir.quote_kernel ~loc:dummy_loc kern in
   (* Just check it produces an expression *)
@@ -618,14 +608,10 @@ let test_quote_kernel_with_params () =
   let kern =
     Ir.
       {
+        default_kernel with
         kern_name = "kernel_with_params";
         kern_params = [Ir.DParam (v, None)];
-        kern_locals = [];
         kern_body = Ir.SEmpty;
-        kern_types = [];
-        kern_variants = [];
-        kern_funcs = [];
-        kern_native_fn = None;
       }
   in
   let e = Sarek_quote_ir.quote_kernel ~loc:dummy_loc kern in
@@ -638,14 +624,10 @@ let test_quote_kernel_with_types () =
   let kern =
     Ir.
       {
+        default_kernel with
         kern_name = "kernel_with_types";
-        kern_params = [];
-        kern_locals = [];
         kern_body = Ir.SEmpty;
         kern_types = [("Point", [("x", Ir.TInt32); ("y", Ir.TInt32)])];
-        kern_variants = [];
-        kern_funcs = [];
-        kern_native_fn = None;
       }
   in
   let e = Sarek_quote_ir.quote_kernel ~loc:dummy_loc kern in
@@ -658,14 +640,10 @@ let test_quote_kernel_with_variants () =
   let kern =
     Ir.
       {
+        default_kernel with
         kern_name = "kernel_with_variants";
-        kern_params = [];
-        kern_locals = [];
         kern_body = Ir.SEmpty;
-        kern_types = [];
         kern_variants = [("Option", [("Some", [Ir.TInt32]); ("None", [])])];
-        kern_funcs = [];
-        kern_native_fn = None;
       }
   in
   let e = Sarek_quote_ir.quote_kernel ~loc:dummy_loc kern in
@@ -690,14 +668,10 @@ let test_quote_kernel_with_helper_funcs () =
   let kern =
     Ir.
       {
+        default_kernel with
         kern_name = "kernel_with_helpers";
-        kern_params = [];
-        kern_locals = [];
         kern_body = Ir.SEmpty;
-        kern_types = [];
-        kern_variants = [];
         kern_funcs = [hf];
-        kern_native_fn = None;
       }
   in
   let e = Sarek_quote_ir.quote_kernel ~loc:dummy_loc kern in

--- a/sarek/tests/unit/test_shader_recursion_vector.ml
+++ b/sarek/tests/unit/test_shader_recursion_vector.ml
@@ -35,14 +35,11 @@ let make_var name ty =
 
 let base_kernel name params body funcs =
   {
+    default_kernel with
     kern_name = name;
     kern_params = params;
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
     kern_funcs = funcs;
-    kern_native_fn = None;
   }
 
 (** A vector-reduction helper in the exact shape the tail-recursion elimination

--- a/sarek/tests/unit/test_sync_stmt_emission.ml
+++ b/sarek/tests/unit/test_sync_stmt_emission.ml
@@ -37,14 +37,10 @@ let sync_kernel stmt : kernel =
     {var_name = "tid"; var_id = 1; var_type = TInt32; var_mutable = false}
   in
   {
+    default_kernel with
     kern_name = "sync_probe";
     kern_params =
       [DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global})];
-    kern_locals = [];
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
     kern_body =
       SLet
         ( tid,

--- a/spoc/ir/Sarek_ir_types.ml
+++ b/spoc/ir/Sarek_ir_types.ml
@@ -387,3 +387,41 @@ type kernel = {
   kern_native_fn : native_fn_t option;
       (** Optional pre-compiled native function for CPU execution *)
 }
+
+(** A kernel with every field at its empty value, for use as the base of a
+    record update: [{default_kernel with kern_name = "k"; kern_body = b}].
+
+    WHY THIS EXISTS. OCaml requires every field at every record literal, so
+    adding one field to {!kernel} used to mean editing all 119 construction
+    sites in the tree — which is why the type has been avoided rather than
+    extended. A record UPDATE names only the fields it sets, so once a site is
+    written this way a new field costs it nothing.
+
+    Prefer this over spelling out the empty fields. {!make_kernel} is the same
+    thing with labels, for new code that would otherwise set most fields. *)
+let default_kernel =
+  {
+    kern_name = "";
+    kern_params = [];
+    kern_locals = [];
+    kern_body = SEmpty;
+    kern_types = [];
+    kern_variants = [];
+    kern_funcs = [];
+    kern_native_fn = None;
+  }
+
+(** {!default_kernel} with labels. [~name] and [~body] are required because a
+    kernel with neither is not a kernel; everything else defaults to empty. *)
+let make_kernel ?(params = []) ?(locals = []) ?(types = []) ?(variants = [])
+    ?(funcs = []) ?native_fn ~name ~body () =
+  {
+    kern_name = name;
+    kern_params = params;
+    kern_locals = locals;
+    kern_body = body;
+    kern_types = types;
+    kern_variants = variants;
+    kern_funcs = funcs;
+    kern_native_fn = native_fn;
+  }

--- a/spoc/ir/test/test_sarek_capability.ml
+++ b/spoc/ir/test/test_sarek_capability.ml
@@ -152,14 +152,9 @@ let mk_kernel elt : kernel =
     {var_name = "x"; var_id = 0; var_type = TVec elt; var_mutable = false}
   in
   {
+    default_kernel with
     kern_name = "test";
     kern_params = [DParam (v, Some {arr_elttype = elt; arr_memspace = Global})];
-    kern_locals = [];
-    kern_body = SEmpty;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 exception Refused of string

--- a/spoc/ir/test/test_sarek_ir_analysis.ml
+++ b/spoc/ir/test/test_sarek_ir_analysis.ml
@@ -299,30 +299,20 @@ let test_kernel_uses_float64_params () =
 
   let k_f64 : kernel =
     {
+      default_kernel with
       kern_name = "test";
       kern_params =
         [DParam (v_f64, Some {arr_elttype = TFloat64; arr_memspace = Global})];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_float64 k_f64 = true) ;
 
   let k_f32 : kernel =
     {
+      default_kernel with
       kern_name = "test";
       kern_params =
         [DParam (v_f32, Some {arr_elttype = TFloat32; arr_memspace = Global})];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_float64 k_f32 = false) ;
@@ -332,28 +322,18 @@ let test_kernel_uses_float64_params () =
 let test_kernel_uses_float64_types () =
   let k_with_f64_type : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
       kern_types = [("point", [("x", TFloat64); ("y", TFloat64)])];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_float64 k_with_f64_type = true) ;
 
   let k_with_f32_type : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
       kern_types = [("point", [("x", TFloat32); ("y", TFloat32)])];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_float64 k_with_f32_type = false) ;
@@ -363,14 +343,9 @@ let test_kernel_uses_float64_types () =
 let test_kernel_uses_float64_variants () =
   let k_with_f64_variant : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
       kern_variants = [("number", [("Float", [TFloat64])])];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_float64 k_with_f64_variant = true) ;
@@ -445,33 +420,17 @@ let test_helper_uses_atomics () =
 let test_kernel_uses_atomics_direct () =
   let k_direct : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SExpr
           (EIntrinsic
              ([], "atomic_add_int32", [EConst (CInt32 0l); EConst (CInt32 1l)]));
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_atomics k_direct = true) ;
 
-  let k_none : kernel =
-    {
-      kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-    }
-  in
+  let k_none : kernel = {default_kernel with kern_name = "test"} in
   assert (kernel_uses_atomics k_none = false) ;
   print_endline "  kernel_uses_atomics direct: OK"
 
@@ -492,16 +451,7 @@ let test_kernel_uses_atomics_in_helper () =
     }
   in
   let k_helper_atomic : kernel =
-    {
-      kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [hf_atomic];
-      kern_native_fn = None;
-    }
+    {default_kernel with kern_name = "test"; kern_funcs = [hf_atomic]}
   in
   assert (kernel_uses_atomics k_helper_atomic = true) ;
   print_endline "  kernel_uses_atomics via helper: OK"
@@ -537,14 +487,9 @@ let test_kernel_uses_atomics_in_assign_lvalue () =
   in
   let k_lvalue_atomic : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
       kern_body = SAssign (LArrayElem ("arr", atomic_idx), EConst (CInt32 5l));
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_atomics k_lvalue_atomic = true) ;
@@ -563,14 +508,9 @@ let test_kernel_uses_atomics_snative () =
      here". Pre-fix this returned false unconditionally. *)
   let k_native : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
       kern_body = SNative {gpu = dummy_native_gpu; ocaml = dummy_native_ocaml};
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_atomics k_native = true) ;
@@ -617,32 +557,16 @@ let test_kernel_uses_int_mod_in_record_field_lvalue () =
   let mod_idx = EBinop (Mod, EConst (CInt32 7l), EConst (CInt32 2l)) in
   let k_lvalue_mod : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LRecordField (LArrayElem ("arr", mod_idx), "field"),
             EConst (CInt32 5l) );
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_int_mod k_lvalue_mod = true) ;
-  let k_none : kernel =
-    {
-      kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-    }
-  in
+  let k_none : kernel = {default_kernel with kern_name = "test"} in
   assert (kernel_uses_int_mod k_none = false) ;
   print_endline "  kernel_uses_int_mod via record-field lvalue: OK"
 
@@ -726,32 +650,16 @@ let test_kernel_uses_copysign_in_record_field_lvalue () =
   in
   let k_lvalue_cs : kernel =
     {
+      default_kernel with
       kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
       kern_body =
         SAssign
           ( LRecordField (LArrayElem ("arr", cs_idx), "field"),
             EConst (CInt32 5l) );
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (kernel_uses_copysign k_lvalue_cs = true) ;
-  let k_none : kernel =
-    {
-      kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
-    }
-  in
+  let k_none : kernel = {default_kernel with kern_name = "test"} in
   assert (kernel_uses_copysign k_none = false) ;
   print_endline "  kernel_uses_copysign via record-field lvalue: OK"
 
@@ -773,16 +681,7 @@ let test_kernel_uses_copysign_in_helper () =
     }
   in
   let k : kernel =
-    {
-      kern_name = "test";
-      kern_params = [];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [hf_cs];
-      kern_native_fn = None;
-    }
+    {default_kernel with kern_name = "test"; kern_funcs = [hf_cs]}
   in
   assert (kernel_uses_copysign k = true) ;
   print_endline "  kernel_uses_copysign via helper: OK"
@@ -795,16 +694,7 @@ let test_kernel_uses_copysign_in_helper () =
     non-finite-free (native code carries its own literals). *)
 
 let empty_kernel body : kernel =
-  {
-    kern_name = "test";
-    kern_params = [];
-    kern_locals = [];
-    kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
-  }
+  {default_kernel with kern_name = "test"; kern_body = body}
 
 (** {1 Float16 detection Tests}
 
@@ -929,14 +819,10 @@ let test_kernel_uses_float16 () =
   in
   let kern_with params body : kernel =
     {
+      default_kernel with
       kern_name = "test";
       kern_params = params;
-      kern_locals = [];
       kern_body = body;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   (* Positive: an f16 vector parameter. This is the case that must switch the
@@ -995,14 +881,10 @@ let test_kernel_uses_float16 () =
 
 let feature_kern params body : kernel =
   {
+    default_kernel with
     kern_name = "test";
     kern_params = params;
-    kern_locals = [];
     kern_body = body;
-    kern_types = [];
-    kern_variants = [];
-    kern_funcs = [];
-    kern_native_fn = None;
   }
 
 let test_feature_api_agrees_with_aliases () =

--- a/spoc/ir/test/test_sarek_ir_pp.ml
+++ b/spoc/ir/test/test_sarek_ir_pp.ml
@@ -259,6 +259,7 @@ let test_pp_kernel () =
   in
   let k : kernel =
     {
+      default_kernel with
       kern_name = "simple_kernel";
       kern_params =
         [
@@ -266,12 +267,7 @@ let test_pp_kernel () =
             (input_var, Some {arr_elttype = TFloat32; arr_memspace = Global});
           DParam (n_var, None);
         ];
-      kern_locals = [];
       kern_body = SReturn (EConst CUnit);
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   let s = pp_to_string pp_kernel k in

--- a/spoc/ir/test/test_sarek_ir_types.ml
+++ b/spoc/ir/test/test_sarek_ir_types.ml
@@ -360,6 +360,7 @@ let test_kernel () =
   in
   let k : kernel =
     {
+      default_kernel with
       kern_name = "vector_add";
       kern_params =
         [
@@ -368,12 +369,6 @@ let test_kernel () =
           DParam
             (output_var, Some {arr_elttype = TFloat32; arr_memspace = Global});
         ];
-      kern_locals = [];
-      kern_body = SEmpty;
-      kern_types = [];
-      kern_variants = [];
-      kern_funcs = [];
-      kern_native_fn = None;
     }
   in
   assert (k.kern_name = "vector_add") ;


### PR DESCRIPTION
**Pure refactor**, PR A of the backlog-160 split you approved. No behaviour change, no
golden artifact touched, suite identical. The field and the top-level emission come in
PR B.

## Why

OCaml requires every field at every record literal, so adding one field to the kernel
record meant editing every construction site — which is why the type has been worked
*around* rather than extended. A record **update** names only the fields it sets, so
once a site is written that way the next field costs it nothing.

`default_kernel` is added to **both** kernel types, because there are two:
`Sarek_ir_types.kernel` (consumed by the five backends) and `Sarek_ir_ppx.kernel`
(produced by lowering), bridged by `Sarek_ir_conv.conv_kernel`. A field added to one
almost always has to be added to the other and threaded through the converter;
migrating one and not the other would just move the problem. `make_kernel` is provided
alongside, with labels, for new code.

## Form

`{default_kernel with ...}` rather than restructuring every site into
`make_kernel ~name ~body ()`. Same property, but an update is an insertion plus the
deletion of the fields already at their default, whereas the labelled form rewrites
each multi-line nested literal whole.

**44 files, +179 −712, net −533 lines.**

Dropping the default-valued fields is *not* cosmetic: warning 23
(`useless-record-with`) is an error in this tree and fires whenever a `with` lists
every field — which most of these sites did. Removing them is what makes the update an
update.

## The count was wrong twice, and both corrections are in the commit

| stage | figure | why it was wrong |
| --- | --- | --- |
| first report | 149 literals, one type | didn't know `Sarek_ir_ppx.kernel` existed |
| second | 150 sites | `grep kern_name =` counts field READS and other records |
| **measured** | **119 literals**, two IR types | see below |

`PtxKernelSpec.ml` reads `k.kern_name` into a `ptx_kern_name`. `Sarek_typed_ast`'s
kernel has `kern_name : string option` next to `kern_module_items`/`kern_loc` — a
**third** record sharing the field name. `test_typer.ml` was converted by the script
and reverted whole once the compiler named it.

## Verification

The claim is *"nothing changes"*, so the evidence has to be that nothing changed:

- `dune build` clean, `@fmt` clean
- `dune test --force`: **1725 cases across 119 suites, 0 FAIL** — the same numbers as
  before the change
- **zero non-`.ml` files modified**, i.e. no generated golden artifact moved

The codegen goldens are the real oracle here: they are byte-compared, so a literal that
lost a field it needed would surface there rather than in a pass/fail count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)