### PR TITLE
fix(review-gate): refuse a red_verified claim that carries no check

### DIFF
--- a/scripts/check-review-convergence-hardening.test.js
+++ b/scripts/check-review-convergence-hardening.test.js
@@ -669,6 +669,91 @@ check("#98 patch is DECLARED whenever it is applied", () => {
   }
 });
 
+// ── backlog-163: `red_verified` provenance ───────────────────────────────
+//
+// The filed defect ("the gate reads a missing review.json and passes, inert for
+// 4 rounds") DOES NOT EXIST — the gate fails closed on a missing file, verified
+// by running it. The real hole was next to it: `red_verified` is emitted by the
+// gate inside `checks[]` and merged back by roster-review, yet nothing in the
+// gate ever READ the field. It appeared in one comment. So a verdict could
+// assert `red_verified: true` on a finding with no `check` at all — a claim of
+// verification with nothing behind it — and the gate had no objection.
+//
+// This is not hypothetical: the only review verdict in the tree
+// (briefs/helper-scoping-review.json, status GO) carries exactly that on two of
+// its twelve findings. Written by hand, by me, during the session that produced
+// #354/#355.
+// Parameterised over every shape the implementation treats as absent. The
+// guard is `typeof check === "string" && check.trim() !== ""`, so it covers
+// three; asserting only `null` would let a regression that accepts `""` or
+// whitespace through — an assertion narrower than the code it guards.
+for (const [label, checkValue] of [
+  ["null", null],
+  ["absent", undefined],
+  ["empty string", ""],
+  ["whitespace only", "   "],
+]) {
+  check(`a finding claiming red_verified with check = ${label} is REFUSED`, () => {
+    const f = finding({ red_verified: true, check: checkValue });
+    if (checkValue === undefined) delete f.check;
+    const { status, report } = reports(base({ findings: [f] }));
+    assert.strictEqual(status, 1, "a forged verification claim must be a violation, not a pass");
+    const v = report.violations.filter((x) => x.type === "red-verified-without-check");
+    assert.strictEqual(v.length, 1, `expected exactly one provenance violation, got ${JSON.stringify(report.violations)}`);
+    assert.match(v[0].detail, /produced by the gate/, "the message must say WHY the combination is impossible");
+  });
+}
+
+// Scope, caught by review on #361. cross_runtime_findings are canonical
+// findings with GO authority and main() already runs the sibling structural
+// check over them; the provenance check first lived inside
+// runRedGreenVerification, which takes `findings` alone, so this array bypassed
+// it entirely. The in-source comment above that call had already named this
+// exact trap for three earlier checks.
+check("a CROSS-RUNTIME finding claiming red_verified without a check is REFUSED", () => {
+  const { status, report } = reports(
+    base({
+      findings: [],
+      cross_runtime_findings: [finding({ red_verified: true, check: null })],
+    })
+  );
+  assert.strictEqual(status, 1, "cross_runtime_findings must not be a bypass");
+  assert.strictEqual(
+    report.violations.filter((x) => x.type === "red-verified-without-check").length,
+    1,
+    `expected the cross-runtime finding to be flagged, got ${JSON.stringify(report.violations)}`
+  );
+});
+
+// Positive control. Without it, "refuses a forged claim" and "refuses every
+// finding" are the same observation — and the second would make the gate
+// useless rather than strict.
+check("a finding with red_verified AND a check is NOT refused", () => {
+  const { report } = reports(
+    base({
+      findings: [finding({ red_verified: true, check: "scripts/some-check.js" })],
+    })
+  );
+  assert.strictEqual(
+    report.violations.filter((x) => x.type === "red-verified-without-check").length,
+    0,
+    "a finding that carries the input the gate verifies must pass provenance"
+  );
+});
+
+// The check must survive --static, which is the mode the routing table calls on
+// every resume edge. Provenance is a structural property of the document, not a
+// verification, so the cheap mode has no reason to skip it — and skipping it
+// there would leave the hole open exactly where verdicts are re-read without
+// being re-run. runGate always passes --static, so the case above already
+// exercises this; asserted explicitly so a future "optimisation" that moves the
+// check behind the full-mode guard goes red here rather than silently.
+check("provenance is enforced in --static, not only in full mode", () => {
+  const { checkRedVerifiedProvenance } = require(GATE);
+  const staticViolations = checkRedVerifiedProvenance([{ red_verified: true, check: null, fingerprint: "f" }]);
+  assert.strictEqual(staticViolations.length, 1, "the pure function must flag it independently of mode");
+});
+
 check("local-patch markers are non-empty (an empty needle matches everything)", () => {
   const { markers } = markersUnderTest();
   assert.ok(markers.length > 0, "a reapply_on_upgrade patch with no markers cannot detect its own revert");

--- a/scripts/check-review-convergence-hardening.test.js
+++ b/scripts/check-review-convergence-hardening.test.js
@@ -614,11 +614,30 @@ function pristineUpstream(rel) {
   assert.strictEqual(log.status, 0, `cannot list the history of ${MANIFEST_PATH}: ${log.stderr.trim()}`);
   const commits = log.stdout.split("\n").filter(Boolean);
 
+  // PARSE the manifest at each commit; do not substring-search its bytes. The
+  // first version did `manifest.stdout.includes(PATCH_REF)`, and the manifest
+  // stores the ref with an ESCAPED em-dash ("#98 — convergence gate fails
+  // closed") while PATCH_REF here is a literal one. So the test was always
+  // false, every commit looked like it predated the declaration, and the anchor
+  // became the NEWEST manifest commit — putting this check back in exactly the
+  // HEAD-against-HEAD state the comment above says it was rewritten to escape.
+  // declaredPatch() compares `p.ref === PATCH_REF` against JSON.parse'd refs, so
+  // the two halves of one mechanism disagreed about encoding; both now decode.
   let anchor = null;
   for (const sha of commits) {
     const manifest = git("show", `${sha}:${MANIFEST_PATH}`);
     if (manifest.status !== 0) continue;
-    if (!manifest.stdout.includes(PATCH_REF)) {
+    let refs;
+    try {
+      const parsed = JSON.parse(manifest.stdout);
+      refs = (Array.isArray(parsed.local_patches) ? parsed.local_patches : []).map((p) => p && p.ref);
+    } catch {
+      // An unparseable manifest cannot answer "was the patch declared here?" —
+      // skip it rather than guessing, and let the `anchor` assertion below fire
+      // if no commit ever answers.
+      continue;
+    }
+    if (!refs.includes(PATCH_REF)) {
       anchor = sha;
       break;
     }
@@ -728,11 +747,20 @@ check("a CROSS-RUNTIME finding claiming red_verified without a check is REFUSED"
 // Positive control. Without it, "refuses a forged claim" and "refuses every
 // finding" are the same observation — and the second would make the gate
 // useless rather than strict.
+// Its own name claims acceptance, so it asserts the exit status too, caught by
+// review on #361: filtering for the absence of ONE violation type leaves the
+// case green when the gate exits 1 for any other reason, which is the same
+// "unusable gate" outcome the control exists to rule out.
 check("a finding with red_verified AND a check is NOT refused", () => {
-  const { report } = reports(
+  const { status, report } = reports(
     base({
       findings: [finding({ red_verified: true, check: "scripts/some-check.js" })],
     })
+  );
+  assert.strictEqual(
+    status,
+    0,
+    `valid provenance must be ACCEPTED, not merely un-flagged: ${JSON.stringify(report.violations)}`
   );
   assert.strictEqual(
     report.violations.filter((x) => x.type === "red-verified-without-check").length,
@@ -773,6 +801,25 @@ check("local-patch markers are PRESENT in every patched path", () => {
       assert.ok(body.includes(marker), `marker ${JSON.stringify(marker)} is absent from ${rel} — the guard would report a revert that did not happen`);
     }
   }
+});
+
+// The anchor resolution's own gate, caught on #361 by the escaped-em-dash bug
+// above. Asserting "the anchor's manifest lacks PATCH_REF" would be a tautology
+// — the loop selects on exactly that. So assert the CONTENT side instead: the
+// gate file at the anchor must not carry the applied patch's sentinel. That is
+// independent evidence, so ANY future way of resolving the anchor onto a patched
+// commit goes red here, naming the anchor, instead of surfacing as an
+// unsatisfiable marker assertion in the check below.
+check("the pristine-upstream anchor predates the patch it is the baseline for", () => {
+  const { anchor } = pristineUpstream(PATCH_PATH);
+  const blob = git("show", `${anchor}:${PATCH_PATH}`);
+  assert.strictEqual(blob.status, 0, `the anchor ${anchor.slice(0, 8)} has no ${PATCH_PATH} to compare against`);
+  assert.ok(
+    !blob.stdout.includes(APPLIED_SENTINEL),
+    `the resolved pristine-upstream anchor ${anchor.slice(0, 8)} ALREADY contains ${JSON.stringify(APPLIED_SENTINEL)}, ` +
+      "so it is not pre-patch content and every marker is present in it by construction — the anchor resolution is broken, " +
+      "not the markers"
+  );
 });
 
 check("local-patch markers are ABSENT from the pristine upstream file", () => {

--- a/scripts/check-review-convergence.js
+++ b/scripts/check-review-convergence.js
@@ -319,6 +319,49 @@ function computeFindingViolations(findings) {
   return violations;
 }
 
+// ── provenance of `red_verified` (BOTH modes) ───────────────────────────
+// backlog-163.
+//
+// `red_verified` is GATE-PRODUCED, never author-written: this script emits it
+// inside `checks[]` and roster-review merges that back into review.json (see
+// the comment above the report write). So a finding carrying
+// `red_verified: true` WITHOUT a `check` string cannot have come from here —
+// the verification loop below skips every finding whose `check` is not a
+// string, so it never looked at that finding at all. The value is either
+// hand-written or stale from an earlier verdict shape. Both are a claim of
+// verification with no mechanism behind it.
+//
+// This is not hypothetical. The only review verdict in this tree
+// (briefs/helper-scoping-review.json, status GO, round 1) has 12 findings, of
+// which TWO carry exactly that combination — written during the session that
+// produced PR #354/#355, by me, by hand. The gate could not have objected,
+// because until now nothing in this file READ the field; `red_verified`
+// appeared only in a comment.
+//
+// Runs in --static too, deliberately. Static mode skips VERIFICATION (it does
+// not execute checks), but this is not a verification — it is a structural
+// property of the input document, and static mode is the one the routing table
+// calls on every resume edge. A provenance check that the cheap mode skips
+// would be absent exactly where verdicts are re-read without re-running.
+function checkRedVerifiedProvenance(findings) {
+  const violations = [];
+  for (const f of findings) {
+    if (!f || typeof f !== "object") continue;
+    if (f.red_verified !== true) continue;
+    if (typeof f.check === "string" && f.check.trim() !== "") continue;
+    violations.push({
+      type: "red-verified-without-check",
+      cause: "review-integrity-failure",
+      fingerprint: f.fingerprint || f.id || f.title || "(unnamed finding)",
+      detail:
+        "finding claims red_verified: true but carries no `check` — this field " +
+        "is produced by the gate and merged back, so a value without the input " +
+        "that produces it was not verified by anything (backlog-163)",
+    });
+  }
+  return violations;
+}
+
 // ── red-before-green verification (full mode only) ──────────────────────
 // FR-035..FR-039. Returns { violations, checks, anyInconclusive }.
 function runRedGreenVerification(findings, args) {
@@ -433,7 +476,20 @@ function main() {
   // D1: cross_runtime_findings entries are canonical findings with GO
   // authority. They were exempt from the ratchet, the provenance check and the
   // unencodable-finding check purely because nothing ever opened the array.
-  violations.push(...computeFindingViolations(Array.isArray(review.cross_runtime_findings) ? review.cross_runtime_findings : []));
+  const crossRuntime = Array.isArray(review.cross_runtime_findings) ? review.cross_runtime_findings : [];
+  violations.push(...computeFindingViolations(crossRuntime));
+
+  // backlog-163, scope corrected by review on PR #361. The provenance check
+  // first lived inside runRedGreenVerification, which takes `findings` alone —
+  // so a cross-runtime finding could carry `red_verified: true` with no check
+  // and never be looked at. The comment directly above already named that trap
+  // ("exempt from ... the provenance check ... purely because nothing ever
+  // opened the array") for three earlier checks, and I walked into it anyway
+  // with a NEW one. It runs over both arrays here, beside its sibling, rather
+  // than inside a function whose name says verification: provenance is a
+  // property of the document, and burying it there is what scoped it wrongly.
+  violations.push(...checkRedVerifiedProvenance(findings));
+  violations.push(...checkRedVerifiedProvenance(crossRuntime));
 
   const strikeAudit = evaluateStrikesAndAudit(review, round, legacyRound, findings, args.strikes);
   violations.push(...strikeAudit.violations);
@@ -478,4 +534,11 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { parseArgs, isFullSha, evaluateStrikesAndAudit, buildReport, decideExit };
+module.exports = {
+  parseArgs,
+  isFullSha,
+  evaluateStrikesAndAudit,
+  buildReport,
+  decideExit,
+  checkRedVerifiedProvenance,
+};

--- a/scripts/review-bundle.manifest.json
+++ b/scripts/review-bundle.manifest.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "scripts/check-review-convergence.js",
-      "sha256": "3517b40534bf78d47df46c28a4a39c2a6ec52429640397b413a7460424389b69"
+      "sha256": "352d226650b96897f5910e6f45b15b9cd18a5b1a39e68848b919f6b83a644639"
     },
     {
       "path": "scripts/check-scope-diff.sh",
@@ -105,7 +105,7 @@
   ],
   "local_patches": [
     {
-      "ref": "#102 + F1 — cross-runtime fault attribution",
+      "ref": "#102 + F1 \u2014 cross-runtime fault attribution",
       "summary": "Outcomes carry fault: \"runtime\"|\"caller\"; only a runtime fault may arm the breaker. A nonzero exit is always a runtime fault (F1: a crashed runtime was being blamed on the caller). Adds --emit-contract and xruntime-contract.js.",
       "paths": [
         "scripts/lib/xruntime/xruntime-classify.js",
@@ -153,8 +153,8 @@
       "reapply_on_upgrade": true
     },
     {
-      "ref": "#98 — convergence gate fails closed",
-      "summary": "An under-populated verdict removed the gate’s ability to check anything and exited 0 with violations: [], byte-identical to a real pass. Wires the gate to scripts/lib/review-gate-hardening.js (repo-local, deliberately NOT bundle-owned so an upgrade cannot silently restore the holes), adds --allow-legacy as a RECORDED skip, and reads cross_runtime_findings. Closes D1-D11 plus G3/G5/G13/G14/G15.",
+      "ref": "#98 \u2014 convergence gate fails closed",
+      "summary": "An under-populated verdict removed the gate\u2019s ability to check anything and exited 0 with violations: [], byte-identical to a real pass. Wires the gate to scripts/lib/review-gate-hardening.js (repo-local, deliberately NOT bundle-owned so an upgrade cannot silently restore the holes), adds --allow-legacy as a RECORDED skip, and reads cross_runtime_findings. Closes D1-D11 plus G3/G5/G13/G14/G15.",
       "paths": [
         "scripts/check-review-convergence.js"
       ],
@@ -164,6 +164,21 @@
         "legacy_skip_authorized",
         "--allow-legacy"
       ],
+      "tests": "scripts/check-review-convergence-hardening.test.js",
+      "reapply_on_upgrade": true
+    },
+    {
+      "ref": "backlog-163 \u2014 red_verified provenance",
+      "summary": "checkRedVerifiedProvenance refuses a finding claiming red_verified: true with no `check`. That field is GATE-PRODUCED (emitted in checks[] and merged back by roster-review), so a value without the input that produces it was verified by nothing. Runs over BOTH findings and cross_runtime_findings, and in --static, which is the mode the routing table calls on every resume edge.",
+      "paths": [
+        "scripts/check-review-convergence.js"
+      ],
+      "markers": {
+        "scripts/check-review-convergence.js": [
+          "checkRedVerifiedProvenance",
+          "red-verified-without-check"
+        ]
+      },
       "tests": "scripts/check-review-convergence-hardening.test.js",
       "reapply_on_upgrade": true
     }


### PR DESCRIPTION
backlog-163 — **whose filed defect does not exist.**

Filed: *"check-review-convergence reads a missing review.json and passes; the gate
was inert for 4 rounds."* Verified by running it: the gate **fails closed, exit 2**,
on an absent file, and both callers block on exit 2. The filed remedy — *"write
review.json every round"* — would have changed nothing.

## The real hole was next to it

`red_verified` is **gate-produced**: this script emits it inside `checks[]` and
roster-review merges that back into `review.json` (the comment above the report write
says exactly that). But nothing in the gate ever **read** the field — before this
commit `red_verified` appeared in one place, a comment.

So a verdict could assert `red_verified: true` on a finding with **no `check` at
all**, and the gate had no objection: its verification loop skips every finding whose
`check` is not a string, so it never looked at that finding.

A claim of verification with no mechanism behind it — the class this repo keeps
closing, in the instrument that is supposed to close it.

## Not hypothetical

The only review verdict in the tree (`briefs/helper-scoping-review.json`, status GO,
round 1) has twelve findings and **two carry exactly that combination**. I wrote them
by hand during the session that produced #354/#355.

Against the fixed gate that verdict now exits 1 with two `red-verified-without-check`
violations plus the `go-with-design-violation` they imply — the correct verdict: those
two findings were never verified by anything. `briefs/` is gitignored, so the file
itself is not in this commit.

## `--static` too, deliberately

Static mode skips **verification** (it executes nothing), but provenance is a
structural property of the input document, and `--static` is the mode the routing
table calls on **every resume edge**. A provenance check the cheap mode skipped would
be absent exactly where verdicts are re-read without being re-run.

## Three cases, and the middle one is the point

```
a finding claiming red_verified without a check is REFUSED
a finding with red_verified AND a check is NOT refused      <- positive control
provenance is enforced in --static, not only in full mode
```

Without the control, *"refuses a forged claim"* and *"refuses every finding"* are the
same observation — and the second would make the gate useless rather than strict.

**Prove-red** from a checkpoint against `origin/main`: the first and third go red, the
control stays green. Self-test **53 passed / 0 failed** (was 50).

## Not fixed here, and it is the other half

Nothing **forces** the gate to be invoked. No `briefs/<task>-gate-report.json` exists
anywhere in the tree although roster-review requires one per round, and CI runs only
this file's self-test — never the gate itself on a real verdict. That is a harness
change in skill prose living outside this repository, and `briefs/` being gitignored
means no proof of invocation survives a session either. Filed, not silently absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review integrity validation to reject findings marked as verified when the associated check provenance is missing or empty.
  * The gate now emits a specific `red-verified-without-check` violation with clear details for the impossible verified-without-check scenario.
  * Applies the same validation to cross-runtime findings to prevent stale verified claims from being accepted.
* **Tests**
  * Added negative and positive test coverage for invalid vs. valid verified/check provenance, including static-mode enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->