### PR TITLE
fix(lower-ir): give a helper its own copy of the module constants it references

### DIFF
--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -747,6 +747,10 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                tuple-component error rather than miscompiling. *)
             register_tuple_type state ret_ty ;
             let name_of_helper = name in
+            (* Captured HERE, where [body] is still the helper's texpr: inside the
+               prefixing fold below, [body] is the accumulator statement and
+               shadows it. *)
+            let helper_loc = Sarek_ast.loc_to_ppxlib body.te_loc in
             Hashtbl.add state.lowering_stack name () ;
             let fun_body_ir = lower_stmt state body in
             Hashtbl.remove state.lowering_stack name ;
@@ -807,9 +811,19 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                                convergence, so this is refused rather than
                                silently changed. Names both the constant and the
                                intrinsic: "a barrier somewhere" is not actionable.
-                            *)
+
+                               LOCATED at the helper's body, not
+                               [Location.none]. The first version passed
+                               [Location.none] while the commit message and the
+                               PR body both claimed "a located error" — the claim
+                               was wider than the code, and a refusal the user
+                               cannot place in their source is barely better than
+                               a silent one. This file already threads real
+                               locations for comparable refusals (the [lsr] error
+                               and the shared-memory rejections), so there was no
+                               reason to drop it here. Caught by review on #362. *)
                             Ppxlib.Location.raise_errorf
-                              ~loc:Ppxlib.Location.none
+                              ~loc:helper_loc
                               "Module constant %S is referenced by helper %S \
                                and its initializer calls %S, a synchronising \
                                operation. Making it visible to the helper \

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -289,85 +289,129 @@ let ir_lower_stmt_count = ref 0
    initializer containing a BARRIER it would change convergence, so that case is
    refused rather than duplicated. *)
 
-(* Names referenced by an IR statement. Deliberately over-approximate: it
-   collects every [EVar]/[LVar] name, including ones bound locally inside the
-   body, so a local shadowing a module constant makes the constant look
-   referenced and gets its (unused, shadowed) [SLet] prefixed. Over-approximating
-   costs a dead declaration; under-approximating would emit an undeclared
-   identifier, which is the defect being fixed. *)
-let rec expr_names (e : Ir.expr) (acc : (string, unit) Hashtbl.t) : unit =
+(* FREE names of an IR statement: every [EVar]/[LVar] name that is not bound by
+   an enclosing binder. [bound] carries the binders in scope at each point.
+
+   The first version took no [bound] and collected every name, including
+   locally-bound ones, on the reasoning that over-approximating only costs a dead
+   declaration. It does not. The C-family backends emit [SLet] FLAT — [T name =
+   e;] followed by the body at the same indent, no braces — so a helper-local
+   [let c = ...] that merely SHARES a module constant's name made the constant
+   look referenced, got its [SLet] prefixed, and produced two [float c] in one
+   block: a redeclaration error on a helper that compiled fine before. Caught by
+   review on #362.
+
+   Binders covered: [SLet], [SLetMut], [SFor]. NOT match-pattern binders — those
+   stay uncovered, so a pattern-bound name still reads as free. That is the safe
+   direction (it can only over-approximate, never emit an undeclared identifier),
+   and it is why the fold below refuses a residual collision rather than assuming
+   this set is complete. *)
+let rec expr_names (e : Ir.expr) (bound : string list)
+    (acc : (string, unit) Hashtbl.t) : unit =
+  let add n = if not (List.mem n bound) then Hashtbl.replace acc n () in
+  let go a = expr_names a bound acc in
   match e with
-  | Ir.EVar v -> Hashtbl.replace acc v.Ir.var_name ()
+  | Ir.EVar v -> add v.Ir.var_name
   | Ir.EConst _ -> ()
   | Ir.EBinop (_, a, b) ->
-      expr_names a acc ;
-      expr_names b acc
-  | Ir.EUnop (_, a) -> expr_names a acc
+      go a ;
+      go b
+  | Ir.EUnop (_, a) -> go a
   | Ir.EArrayRead (n, i) ->
-      Hashtbl.replace acc n () ;
-      expr_names i acc
+      add n ;
+      go i
   | Ir.EArrayReadExpr (b, i) ->
-      expr_names b acc ;
-      expr_names i acc
-  | Ir.ERecordField (b, _) -> expr_names b acc
-  | Ir.EIntrinsic (_, _, args) -> List.iter (fun a -> expr_names a acc) args
-  | Ir.ECast (_, a) -> expr_names a acc
-  | Ir.ETuple es -> List.iter (fun a -> expr_names a acc) es
+      go b ;
+      go i
+  | Ir.ERecordField (b, _) -> go b
+  | Ir.EIntrinsic (_, _, args) -> List.iter go args
+  | Ir.ECast (_, a) -> go a
+  | Ir.ETuple es -> List.iter go es
   | Ir.EApp (f, args) ->
-      expr_names f acc ;
-      List.iter (fun a -> expr_names a acc) args
-  | Ir.ERecord (_, fs) -> List.iter (fun (_, a) -> expr_names a acc) fs
-  | Ir.EVariant (_, _, args) -> List.iter (fun a -> expr_names a acc) args
-  | Ir.EArrayLen n -> Hashtbl.replace acc n ()
-  | Ir.EArrayCreate (_, sz, _) -> expr_names sz acc
+      go f ;
+      List.iter go args
+  | Ir.ERecord (_, fs) -> List.iter (fun (_, a) -> go a) fs
+  | Ir.EVariant (_, _, args) -> List.iter go args
+  | Ir.EArrayLen n -> add n
+  | Ir.EArrayCreate (_, sz, _) -> go sz
   | Ir.EIf (c, t, e2) ->
-      expr_names c acc ;
-      expr_names t acc ;
-      expr_names e2 acc
+      go c ;
+      go t ;
+      go e2
   | Ir.EMatch (sc, cases) ->
-      expr_names sc acc ;
-      List.iter (fun (_, a) -> expr_names a acc) cases
+      go sc ;
+      List.iter (fun (_, a) -> go a) cases
 
-and lvalue_names (lv : Ir.lvalue) (acc : (string, unit) Hashtbl.t) : unit =
+and lvalue_names (lv : Ir.lvalue) (bound : string list)
+    (acc : (string, unit) Hashtbl.t) : unit =
+  let add n = if not (List.mem n bound) then Hashtbl.replace acc n () in
   match lv with
-  | Ir.LVar v -> Hashtbl.replace acc v.Ir.var_name ()
+  | Ir.LVar v -> add v.Ir.var_name
   | Ir.LArrayElem (n, i) ->
-      Hashtbl.replace acc n () ;
-      expr_names i acc
+      add n ;
+      expr_names i bound acc
   | Ir.LArrayElemExpr (b, i) ->
-      expr_names b acc ;
-      expr_names i acc
-  | Ir.LRecordField (b, _) -> lvalue_names b acc
+      expr_names b bound acc ;
+      expr_names i bound acc
+  | Ir.LRecordField (b, _) -> lvalue_names b bound acc
 
-and stmt_names (st : Ir.stmt) (acc : (string, unit) Hashtbl.t) : unit =
+and stmt_names (st : Ir.stmt) (bound : string list)
+    (acc : (string, unit) Hashtbl.t) : unit =
+  let goe e = expr_names e bound acc in
+  let gos s = stmt_names s bound acc in
   match st with
   | Ir.SAssign (lv, e) ->
-      lvalue_names lv acc ;
-      expr_names e acc
-  | Ir.SSeq sts -> List.iter (fun s -> stmt_names s acc) sts
+      lvalue_names lv bound acc ;
+      goe e
+  | Ir.SSeq sts -> List.iter gos sts
   | Ir.SIf (c, t, e) ->
-      expr_names c acc ;
-      stmt_names t acc ;
-      Option.iter (fun s -> stmt_names s acc) e
+      goe c ;
+      gos t ;
+      Option.iter gos e
   | Ir.SWhile (c, b) ->
-      expr_names c acc ;
-      stmt_names b acc
-  | Ir.SFor (_, lo, hi, _, b) ->
-      expr_names lo acc ;
-      expr_names hi acc ;
-      stmt_names b acc
+      goe c ;
+      gos b
+  | Ir.SFor (v, lo, hi, _, b) ->
+      (* The bounds are evaluated outside the binding, the body inside it. *)
+      goe lo ;
+      goe hi ;
+      stmt_names b (v.Ir.var_name :: bound) acc
   | Ir.SMatch (sc, cases) ->
-      expr_names sc acc ;
-      List.iter (fun (_, s) -> stmt_names s acc) cases
-  | Ir.SReturn e -> expr_names e acc
-  | Ir.SExpr e -> expr_names e acc
-  | Ir.SLet (_, e, b) | Ir.SLetMut (_, e, b) ->
-      expr_names e acc ;
-      stmt_names b acc
-  | Ir.SPragma (_, b) -> stmt_names b acc
-  | Ir.SBlock b -> stmt_names b acc
+      goe sc ;
+      List.iter (fun (_, s) -> gos s) cases
+  | Ir.SReturn e -> goe e
+  | Ir.SExpr e -> goe e
+  | Ir.SLet (v, e, b) | Ir.SLetMut (v, e, b) ->
+      (* Same asymmetry: [let c = c *. 2.] genuinely references the outer [c], so
+         the initializer is walked with the OLD scope. *)
+      goe e ;
+      stmt_names b (v.Ir.var_name :: bound) acc
+  | Ir.SPragma (_, b) -> gos b
+  | Ir.SBlock b -> gos b
   | Ir.SBarrier | Ir.SWarpBarrier | Ir.SMemFence | Ir.SEmpty -> ()
   | Ir.SNative _ -> ()
+
+(* Every name BOUND anywhere in a statement, at any depth. Used to detect the
+   residual case the free-name fix cannot make safe: a helper that both
+   references a module constant and rebinds that same name ([let c = c *. 2.]).
+   The reference is real, so the constant must be prefixed; the rebinding then
+   emits a second declaration of the same identifier in the same flat block.
+   There is no correct code to emit, so the fold refuses. *)
+let rec stmt_binders (st : Ir.stmt) (acc : (string, unit) Hashtbl.t) : unit =
+  match st with
+  | Ir.SLet (v, _, b) | Ir.SLetMut (v, _, b) | Ir.SFor (v, _, _, _, b) ->
+      Hashtbl.replace acc v.Ir.var_name () ;
+      stmt_binders b acc
+  | Ir.SSeq sts -> List.iter (fun s -> stmt_binders s acc) sts
+  | Ir.SIf (_, t, e) ->
+      stmt_binders t acc ;
+      Option.iter (fun s -> stmt_binders s acc) e
+  | Ir.SWhile (_, b) -> stmt_binders b acc
+  | Ir.SMatch (_, cases) -> List.iter (fun (_, s) -> stmt_binders s acc) cases
+  | Ir.SPragma (_, b) | Ir.SBlock b -> stmt_binders b acc
+  | Ir.SAssign _ | Ir.SReturn _ | Ir.SExpr _ | Ir.SBarrier | Ir.SWarpBarrier
+  | Ir.SMemFence | Ir.SEmpty | Ir.SNative _ ->
+      ()
 
 (* Does this initializer contain a synchronising operation? Prefixing would
    duplicate it per call site, which changes convergence, so that case is REFUSED
@@ -771,7 +815,7 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                drag an unreferenced barrier into the refusal path. *)
             let referenced =
               let acc = Hashtbl.create 8 in
-              stmt_names fun_body_ir acc ;
+              stmt_names fun_body_ir [] acc ;
               let rec close () =
                 let added = ref false in
                 Hashtbl.iter
@@ -780,7 +824,7 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                     | None -> ()
                     | Some (_, init) ->
                         let sub = Hashtbl.create 4 in
-                        expr_names init sub ;
+                        expr_names init [] sub ;
                         Hashtbl.iter
                           (fun n () ->
                             if
@@ -797,10 +841,34 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
               close () ;
               acc
             in
+            (* Names the helper binds anywhere, at any depth. A constant that is
+               both referenced AND rebound cannot be prefixed: the backends emit
+               [SLet] flat, so the prefix and the rebinding are two declarations
+               of one identifier in one block. Refused below rather than emitted.
+               Caught by review on #362. *)
+            let helper_binders =
+              let acc = Hashtbl.create 8 in
+              stmt_binders fun_body_ir acc ;
+              acc
+            in
             let fun_body_ir =
               List.fold_left
                 (fun body name ->
                   if not (Hashtbl.mem referenced name) then body
+                  else if Hashtbl.mem helper_binders name then
+                    Ppxlib.Location.raise_errorf
+                      ~loc:helper_loc
+                      "Helper %S both references module constant %S and binds \
+                       a local of the same name. The constant has to be \
+                       declared inside the helper to be visible there, and the \
+                       generated device code declares locals in one flat \
+                       scope, so that would emit two declarations of %S in the \
+                       same block. Rename the local, or pass the constant in \
+                       as a parameter of %S."
+                      name_of_helper
+                      name
+                      name
+                      name_of_helper
                   else
                     match Hashtbl.find_opt state.mod_consts name with
                     | None -> body

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -261,6 +261,157 @@ let ir_lower_expr_count = ref 0
 
 let ir_lower_stmt_count = ref 0
 
+(* ── module constants referenced from a helper body (backlog-160) ─────────
+   A module constant is lexically visible inside a helper, but lowering puts it
+   in the KERNEL body while helpers are emitted out-of-line — so the helper names
+   an identifier its translation unit never declares. Emitted CUDA, verbatim:
+
+     __device__ float apply(float x) { return (x * scale); }
+     __global__ void k(...) { float scale = 2.0f; ... }
+
+   SEVEN paths break that way (CUDA-C, OpenCL, Metal, GLSL, WGSL, PTX and the
+   Interpreter); only Native works, because it emits an OCaml [let] the helper
+   closes over. A CPU-passes / device-fails divergence.
+
+   THE FIX IS TO PREFIX, NOT TO HOIST. Emitting the constants as top-level
+   [const] / [__constant] / [constant] / [__device__ const] declarations was the
+   first plan and it is unsound: a module-constant initializer is an arbitrary
+   kernel expression — the pipeline explicitly anticipates thread-dependent ones
+   (Sarek_convergence analyses thread/block and barrier usage) — and every one of
+   those storage classes requires a compile-time-constant initializer. Hoisting
+   [let (base : int32) = thread_idx_x] would break a kernel that compiles today.
+   Prefixing the [SLet] into the helper body handles both shapes, needs no IR
+   field and no backend change, and fixes all seven paths in one place.
+
+   ACCEPTED COST, stated because it is a real semantic change: the initializer is
+   evaluated once PER HELPER CALL instead of once per kernel. For a constant that
+   is what it says it is, that is redundant work and nothing else. For an
+   initializer containing a BARRIER it would change convergence, so that case is
+   refused rather than duplicated. *)
+
+(* Names referenced by an IR statement. Deliberately over-approximate: it
+   collects every [EVar]/[LVar] name, including ones bound locally inside the
+   body, so a local shadowing a module constant makes the constant look
+   referenced and gets its (unused, shadowed) [SLet] prefixed. Over-approximating
+   costs a dead declaration; under-approximating would emit an undeclared
+   identifier, which is the defect being fixed. *)
+let rec expr_names (e : Ir.expr) (acc : (string, unit) Hashtbl.t) : unit =
+  match e with
+  | Ir.EVar v -> Hashtbl.replace acc v.Ir.var_name ()
+  | Ir.EConst _ -> ()
+  | Ir.EBinop (_, a, b) ->
+      expr_names a acc ;
+      expr_names b acc
+  | Ir.EUnop (_, a) -> expr_names a acc
+  | Ir.EArrayRead (n, i) ->
+      Hashtbl.replace acc n () ;
+      expr_names i acc
+  | Ir.EArrayReadExpr (b, i) ->
+      expr_names b acc ;
+      expr_names i acc
+  | Ir.ERecordField (b, _) -> expr_names b acc
+  | Ir.EIntrinsic (_, _, args) -> List.iter (fun a -> expr_names a acc) args
+  | Ir.ECast (_, a) -> expr_names a acc
+  | Ir.ETuple es -> List.iter (fun a -> expr_names a acc) es
+  | Ir.EApp (f, args) ->
+      expr_names f acc ;
+      List.iter (fun a -> expr_names a acc) args
+  | Ir.ERecord (_, fs) -> List.iter (fun (_, a) -> expr_names a acc) fs
+  | Ir.EVariant (_, _, args) -> List.iter (fun a -> expr_names a acc) args
+  | Ir.EArrayLen n -> Hashtbl.replace acc n ()
+  | Ir.EArrayCreate (_, sz, _) -> expr_names sz acc
+  | Ir.EIf (c, t, e2) ->
+      expr_names c acc ;
+      expr_names t acc ;
+      expr_names e2 acc
+  | Ir.EMatch (sc, cases) ->
+      expr_names sc acc ;
+      List.iter (fun (_, a) -> expr_names a acc) cases
+
+and lvalue_names (lv : Ir.lvalue) (acc : (string, unit) Hashtbl.t) : unit =
+  match lv with
+  | Ir.LVar v -> Hashtbl.replace acc v.Ir.var_name ()
+  | Ir.LArrayElem (n, i) ->
+      Hashtbl.replace acc n () ;
+      expr_names i acc
+  | Ir.LArrayElemExpr (b, i) ->
+      expr_names b acc ;
+      expr_names i acc
+  | Ir.LRecordField (b, _) -> lvalue_names b acc
+
+and stmt_names (st : Ir.stmt) (acc : (string, unit) Hashtbl.t) : unit =
+  match st with
+  | Ir.SAssign (lv, e) ->
+      lvalue_names lv acc ;
+      expr_names e acc
+  | Ir.SSeq sts -> List.iter (fun s -> stmt_names s acc) sts
+  | Ir.SIf (c, t, e) ->
+      expr_names c acc ;
+      stmt_names t acc ;
+      Option.iter (fun s -> stmt_names s acc) e
+  | Ir.SWhile (c, b) ->
+      expr_names c acc ;
+      stmt_names b acc
+  | Ir.SFor (_, lo, hi, _, b) ->
+      expr_names lo acc ;
+      expr_names hi acc ;
+      stmt_names b acc
+  | Ir.SMatch (sc, cases) ->
+      expr_names sc acc ;
+      List.iter (fun (_, s) -> stmt_names s acc) cases
+  | Ir.SReturn e -> expr_names e acc
+  | Ir.SExpr e -> expr_names e acc
+  | Ir.SLet (_, e, b) | Ir.SLetMut (_, e, b) ->
+      expr_names e acc ;
+      stmt_names b acc
+  | Ir.SPragma (_, b) -> stmt_names b acc
+  | Ir.SBlock b -> stmt_names b acc
+  | Ir.SBarrier | Ir.SWarpBarrier | Ir.SMemFence | Ir.SEmpty -> ()
+  | Ir.SNative _ -> ()
+
+(* Does this initializer contain a synchronising operation? Prefixing would
+   duplicate it per call site, which changes convergence, so that case is REFUSED
+   rather than duplicated.
+
+   The first version of this function returned [false] unconditionally, reasoning
+   that only the statement forms carry a barrier and an [Ir.expr] cannot. The
+   first half is true — no [Ir.expr] constructor holds an [Ir.stmt] — and the
+   conclusion was still wrong: barriers reach the IR as INTRINSICS
+   (Sarek_core_primitives registers [block_barrier], [memory_fence_block],
+   [memory_fence_device]; [warp_barrier] joined them in backlog-70), and
+   [EIntrinsic] is an expression. A guard that cannot fire is the defect class
+   this repository keeps closing, so it is named here rather than quietly left.
+
+   Matched by NAME because that is what the IR carries at this point: lowering
+   does not turn these into [SBarrier], it leaves them as intrinsic calls (there
+   is no barrier-specific arm in this file). If a name is added to the primitive
+   table without being added here, this guard silently stops covering it — which
+   is why the list is stated in one place and the refusal message names the
+   intrinsic it found. *)
+let synchronising_intrinsics =
+  ["block_barrier"; "warp_barrier"; "memory_fence_block"; "memory_fence_device"]
+
+let rec expr_barrier (e : Ir.expr) : string option =
+  let first =
+    List.fold_left
+      (fun acc x -> match acc with Some _ -> acc | None -> expr_barrier x)
+      None
+  in
+  match e with
+  | Ir.EIntrinsic (_, name, args) ->
+      if List.mem name synchronising_intrinsics then Some name else first args
+  | Ir.EConst _ | Ir.EVar _ | Ir.EArrayLen _ -> None
+  | Ir.EBinop (_, a, b) | Ir.EArrayReadExpr (a, b) -> first [a; b]
+  | Ir.EUnop (_, a) | Ir.ECast (_, a) | Ir.ERecordField (a, _) -> expr_barrier a
+  | Ir.EArrayRead (_, i) -> expr_barrier i
+  | Ir.EArrayCreate (_, sz, _) -> expr_barrier sz
+  | Ir.ETuple es -> first es
+  | Ir.EApp (f, args) -> first (f :: args)
+  | Ir.ERecord (_, fs) -> first (List.map snd fs)
+  | Ir.EVariant (_, _, args) -> first args
+  | Ir.EIf (c, t, e2) -> first [c; t; e2]
+  | Ir.EMatch (sc, cases) -> first (sc :: List.map snd cases)
+
 (** Lowering state *)
 type state = {
   mutable next_var_id : int;
@@ -276,6 +427,16 @@ type state = {
   variants : (string, (string * Ir.elttype list) list) Hashtbl.t;
       (** Collected variant types: type_name ->
           [(constructor_name, payload_types); ...] *)
+  mod_consts : (string, Ir.var * Ir.expr) Hashtbl.t;
+      (** Module-level constants, by name, with their LOWERED initializer
+          (backlog-160). A helper body that names one must carry its own [SLet]:
+          the kernel-body copy is in a different scope, and helpers are emitted
+          out-of-line. See [prefix_referenced_consts]. *)
+  mutable mod_consts_order : string list;
+      (** Declaration order, reversed. Prefixing must be deterministic AND must
+          respect dependency order — a later constant may reference an earlier
+          one — so the prefix is emitted in declaration order, not hashtable
+          order. *)
 }
 
 let create_state fun_map =
@@ -287,6 +448,8 @@ let create_state fun_map =
     lowered_funs_order = [];
     types = Hashtbl.create 8;
     variants = Hashtbl.create 8;
+    mod_consts = Hashtbl.create 8;
+    mod_consts_order = [];
   }
 
 (* DEAD as of this writing: [fresh_id] has no caller, and [next_var_id] is
@@ -583,11 +746,87 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                no other site did. A non-primitive tuple return raises the located
                tuple-component error rather than miscompiling. *)
             register_tuple_type state ret_ty ;
+            let name_of_helper = name in
             Hashtbl.add state.lowering_stack name () ;
             let fun_body_ir = lower_stmt state body in
             Hashtbl.remove state.lowering_stack name ;
             (* Use make_returning to add return statements without re-traversing *)
             let fun_body_ir = make_returning fun_body_ir in
+            (* backlog-160: give the helper its own copy of every module constant
+               it references. Without this the emitted device function names an
+               identifier declared only in the kernel body — see the header above
+               [expr_names] for the emitted CUDA and for why hoisting to a
+               top-level [const] is unsound.
+
+               TRANSITIVE, and that is not decoration: a constant's initializer
+               may reference an earlier constant, so a fixpoint is taken over the
+               referenced set before prefixing. Prefixed in DECLARATION order, so
+               a dependency is declared before its user. Only the constants
+               actually referenced are prefixed — prefixing all of them would
+               evaluate initializers the helper does not need and, worse, would
+               drag an unreferenced barrier into the refusal path. *)
+            let referenced =
+              let acc = Hashtbl.create 8 in
+              stmt_names fun_body_ir acc ;
+              let rec close () =
+                let added = ref false in
+                Hashtbl.iter
+                  (fun name _ ->
+                    match Hashtbl.find_opt state.mod_consts name with
+                    | None -> ()
+                    | Some (_, init) ->
+                        let sub = Hashtbl.create 4 in
+                        expr_names init sub ;
+                        Hashtbl.iter
+                          (fun n () ->
+                            if
+                              Hashtbl.mem state.mod_consts n
+                              && not (Hashtbl.mem acc n)
+                            then begin
+                              Hashtbl.replace acc n () ;
+                              added := true
+                            end)
+                          sub)
+                  (Hashtbl.copy acc) ;
+                if !added then close ()
+              in
+              close () ;
+              acc
+            in
+            let fun_body_ir =
+              List.fold_left
+                (fun body name ->
+                  if not (Hashtbl.mem referenced name) then body
+                  else
+                    match Hashtbl.find_opt state.mod_consts name with
+                    | None -> body
+                    | Some (v, init) -> (
+                        match expr_barrier init with
+                        | Some intr ->
+                            (* Duplicating a barrier per call site changes
+                               convergence, so this is refused rather than
+                               silently changed. Names both the constant and the
+                               intrinsic: "a barrier somewhere" is not actionable.
+                            *)
+                            Ppxlib.Location.raise_errorf
+                              ~loc:Ppxlib.Location.none
+                              "Module constant %S is referenced by helper %S \
+                               and its initializer calls %S, a synchronising \
+                               operation. Making it visible to the helper \
+                               means evaluating the initializer once per call, \
+                               which would execute %S once per call site and \
+                               change convergence. Move the value into a \
+                               parameter of %S, or compute it in the kernel \
+                               body and pass it in."
+                              name
+                              name_of_helper
+                              intr
+                              intr
+                              name_of_helper
+                        | None -> Ir.SSeq [Ir.SLet (v, init, Ir.SEmpty); body]))
+                fun_body_ir
+                (List.rev state.mod_consts_order)
+            in
             (* Convert tparam list to var list *)
             let hf_params =
               List.mapi
@@ -1129,7 +1368,25 @@ let lower_kernel (kernel : tkernel) : Ir.kernel =
         match item with
         | TMConst (name, id, ty, expr) ->
             let v = make_var name id ty false in
-            Ir.SSeq [Ir.SLet (v, lower_expr state expr, Ir.SEmpty); acc]
+            let init = lower_expr state expr in
+            (* backlog-160: record it so a helper body that names this constant
+               can carry its own SLet. Populated HERE, while the kernel-body copy
+               is built, which is before the body is lowered — and helpers are
+               lowered lazily FROM the body, so by the time any helper needs a
+               constant, every constant is registered.
+
+               The residual ordering case, checked and stated rather than left
+               implicit: a helper can also be lowered while a CONSTANT's own
+               initializer is lowered (a constant may call a module function). At
+               that moment the constants declared after it are not yet in the
+               table, so such a helper gets only the earlier ones. That is the
+               correct scope — OCaml's own scoping gives the initializer access to
+               earlier bindings only — so the limitation matches the language
+               rather than being a gap. A helper referencing a LATER constant is
+               not expressible. *)
+            Hashtbl.replace state.mod_consts name (v, init) ;
+            state.mod_consts_order <- name :: state.mod_consts_order ;
+            Ir.SSeq [Ir.SLet (v, init, Ir.SEmpty); acc]
         | TMFun _ -> acc)
       all_mod_items
       Ir.SEmpty

--- a/sarek/tests/codegen_golden/dune
+++ b/sarek/tests/codegen_golden/dune
@@ -112,3 +112,30 @@
  (alias runtest)
  (action
   (run %{dep:test_helper_local_shadowing.exe})))
+
+; A module-level constant referenced from a HELPER body (backlog-160). The
+; frontend accepts it, but Sarek_lower_ir puts module constants in the KERNEL
+; body while helpers are emitted out-of-line — so the helper names an identifier
+; its translation unit never declares. Seven paths break; only Native works,
+; which makes it a CPU-passes / device-fails divergence.
+;
+; Asserts declaration-BEFORE-use ordering, not mere presence: a declaration
+; emitted after the helper is exactly as broken as none, and `contains "scale"`
+; would accept it. GLSL additionally goes through glslangValidator.
+;
+; The `dynamic` kernel is the DISCRIMINATOR, not extra coverage — it is what
+; distinguishes prefixing the SLet into the helper (works) from hoisting the
+; constant to a top-level `const` (illegal for a thread-dependent initializer).
+; Run with: dune exec sarek/tests/codegen_golden/test_module_const_in_helper.exe
+
+(executable
+ (name test_module_const_in_helper)
+ (modules test_module_const_in_helper)
+ (libraries sarek sarek.stdlib sarek_ir sarek_codegen spoc_core)
+ (preprocess
+  (pps sarek_ppx)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_module_const_in_helper.exe})))

--- a/sarek/tests/codegen_golden/test_module_const_in_helper.ml
+++ b/sarek/tests/codegen_golden/test_module_const_in_helper.ml
@@ -1,0 +1,242 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * A module-level constant referenced from a HELPER body (backlog-160).
+ *
+ * THE DEFECT. A module constant is lexically visible inside a helper — the
+ * frontend accepts it — but `Sarek_lower_ir` lowers `TMConst` to an `SLet`
+ * prepended to the KERNEL body, while helpers are emitted as out-of-line device
+ * functions. So the helper's emitted body names an identifier that its
+ * translation unit never declares.
+ *
+ * SEVEN paths break, not one. The item was filed as a "Vulkan/GLSL" defect;
+ * CUDA-C, OpenCL, Metal, GLSL, WGSL, PTX and the Interpreter all break, and only
+ * Native works — because `Sarek_native_gen` emits the constant as an OCaml `let`
+ * in a scope the helper closes over. That asymmetry is the interesting part: it
+ * is a CPU-passes / device-fails divergence, the shape that gets a kernel
+ * shipped.
+ *
+ * WHY THIS TEST EXISTS BEFORE THE FIX. Of the 129 files in this tree containing
+ * `[%kernel]`, exactly ONE declares a module constant (test_module_const.ml) and
+ * it has no helper. The broken combination is covered nowhere, which is why the
+ * defect is reachable from the surface language and still invisible.
+ *
+ * WHAT IT ASSERTS, AND WHY NOT A DEVICE RESULT. The emitted source, not a
+ * computed value: the failure is a translation-unit-scope error, so on the
+ * backends with a compiler available it is "undeclared identifier" rather than a
+ * wrong number, and on the others there is no device in this suite to run. For
+ * GLSL the real compiler is the oracle (glslangValidator); for the C-family and
+ * WGSL the assertion is declaration-BEFORE-use ordering, because a declaration
+ * emitted after the helper is exactly as broken as one not emitted at all and a
+ * mere `contains "scale"` would accept it.
+ *
+ * THE SECOND KERNEL IS THE DISCRIMINATOR, not extra coverage. `dynamic` binds
+ * its constant to `thread_idx_x`. The remedy originally approved for this item —
+ * hoist module constants to TOP-LEVEL `const`/`__constant`/`constant`
+ * declarations — cannot express that: every one of those storage classes
+ * requires a compile-time-constant initializer, so hoisting would turn a kernel
+ * that works today into one that does not compile. The remedy actually taken
+ * (prefix the referenced constants' `SLet`s into the helper body) handles both,
+ * at the cost of evaluating the initializer once per helper call. A test that
+ * only covered the static case would have passed under either, and would have
+ * let the wrong one ship.
+ *
+ * Run with: dune exec sarek/tests/codegen_golden/test_module_const_in_helper.exe
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+
+(* `scale` is a module constant with a CONSTANT initializer, referenced from the
+   body of `apply` — a helper, hence out-of-line. The kernel body itself never
+   names `scale`, deliberately: if it did, the kernel-body `SLet` would make the
+   name appear in the output and a naive "is it declared" check would pass while
+   the helper stayed broken. *)
+let static_const_kernel =
+  [%kernel
+    let open Std in
+    let (scale : float32) = 2.0 in
+    let apply (x : float32) : float32 = x *. scale in
+    fun (out : float32 vector) (src : float32 vector) ->
+      let t = global_thread_id in
+      if t < 1l then out.(0l) <- apply src.(0l)]
+
+(* Same shape, but the initializer is THREAD-DEPENDENT. This is what a
+   top-level-constant remedy cannot express. *)
+let dynamic_const_kernel =
+  [%kernel
+    let open Std in
+    let (base : int32) = thread_idx_x in
+    let bump (x : int32) : int32 = x + base in
+    fun (out : int32 vector) ->
+      let t = global_thread_id in
+      if t < 1l then out.(0l) <- bump 10l]
+
+(* Index of the first occurrence, or -1. Ordering is the property: a declaration
+   emitted AFTER the helper that uses it is exactly as broken as none. *)
+let index_of hay needle =
+  let nh = String.length hay and nn = String.length needle in
+  let rec go i =
+    if i + nn > nh then -1
+    else if String.sub hay i nn = needle then i
+    else go (i + 1)
+  in
+  if nn = 0 then -1 else go 0
+
+let ir_of k =
+  let _, kirc = k in
+  match kirc.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let failures = ref 0
+
+let expect label cond =
+  Printf.printf "  %-62s %s\n%!" label (if cond then "OK" else "FAIL") ;
+  if not cond then incr failures
+
+let glslang_available =
+  Sys.command "command -v glslangValidator > /dev/null 2>&1" = 0
+
+let glslang_ok src =
+  let f = Filename.temp_file "sarek_modconst" ".comp" in
+  let oc = open_out f in
+  output_string oc src ;
+  close_out oc ;
+  let rc =
+    Sys.command
+      (Printf.sprintf
+         "glslangValidator -V -S comp -o /dev/null %s > /dev/null 2>&1"
+         (Filename.quote f))
+  in
+  Sys.remove f ;
+  rc = 0
+
+(* THE PROPERTY, and my first version of it was wrong — recorded because the
+   mistake is the interesting part.
+
+   I first asserted that the constant is declared BEFORE the helper's signature,
+   on the assumption that visibility means file-scope-before-use. glslangValidator
+   then accepted a shader this predicate called broken: the shipped fix declares
+   the constant INSIDE the helper body, which is textually after the signature and
+   perfectly visible. The assertion encoded ONE valid shape and the correct fix
+   uses another — an assertion narrower than the property, in a test written to
+   catch exactly that class.
+
+   The property actually is: within the helper's own body, the first mention of
+   the constant is its DECLARATION, not a bare use. That covers the shipped shape
+   (a prefixed `SLet`) and still fails the defect (a bare use with the only
+   declaration in the kernel body, elsewhere in the file).
+
+   The helper body is taken from its signature to the end of the source rather
+   than to a matched brace: WGSL, GLSL and the C family close differently, and the
+   first-mention test does not need the exact end — anything after the helper can
+   only add later mentions, which cannot make a bare first use look like a
+   declaration. *)
+let declares_before_use ~src ~const_name ~helper_name =
+  let sig_at = index_of src (helper_name ^ "(") in
+  if sig_at < 0 then false
+  else
+    let body = String.sub src sig_at (String.length src - sig_at) in
+    let first = index_of body const_name in
+    if first < 0 then false
+    else
+      (* A declaration binds; a bare use does not. TWO spellings, because the
+         emitted languages differ and asserting only one made this fail on WGSL
+         while glslangValidator was already accepting the equivalent GLSL:
+
+           C family / GLSL   `float scale = 2.0f;`     -> name then " = "
+           WGSL              `let scale : f32 = 2.0f;` -> name then " : "
+
+         A bare use is followed by an operator or a delimiter (`)`, `*`, `;`,
+         `,`), never by either of these, so the predicate still fails the defect
+         it was written for. Enumerated rather than reduced to "contains an =",
+         which `(x * scale)` inside `return (x * scale) = ...` could not produce
+         but a looser predicate would eventually accept. *)
+      let after = first + String.length const_name in
+      let starts_with tok =
+        let n = String.length tok in
+        after + n <= String.length body && String.sub body after n = tok
+      in
+      starts_with " = " || starts_with " : "
+
+let check_backend name gen ~const_name ~helper_name kernel_label ir =
+  match gen ir with
+  | src ->
+      expect
+        (Printf.sprintf
+           "%s/%s: %s is visible to %s"
+           name
+           kernel_label
+           const_name
+           helper_name)
+        (declares_before_use ~src ~const_name ~helper_name) ;
+      if name = "GLSL" && glslang_available then
+        expect
+          (Printf.sprintf
+             "%s/%s: glslangValidator accepts the shader"
+             name
+             kernel_label)
+          (glslang_ok src)
+  | exception e ->
+      (* A REFUSAL is an acceptable outcome and must be distinguished from a
+         silent miscompile: a backend that cannot express the construct should
+         say so. It is recorded, not counted as a failure, so that adding an
+         explicit refusal to a backend does not turn this test red. *)
+      Printf.printf
+        "  %-62s REFUSED (%s)\n%!"
+        (Printf.sprintf "%s/%s" name kernel_label)
+        ( Printexc.to_string e |> fun s ->
+          String.sub s 0 (min 60 (String.length s)) )
+
+let backends =
+  [
+    ("CUDA", fun ir -> Sarek_codegen.Sarek_ir_cuda.generate ir);
+    ("OpenCL", fun ir -> Sarek_codegen.Sarek_ir_opencl.generate ir);
+    ("Metal", fun ir -> Sarek_codegen.Sarek_ir_metal.generate ir);
+    ("GLSL", fun ir -> Sarek_codegen.Sarek_ir_glsl.generate ir);
+    ("WGSL", fun ir -> Sarek_codegen.Sarek_ir_wgsl.generate ir);
+  ]
+
+let () =
+  print_endline "=== a module constant referenced from a helper body ===" ;
+  if not glslang_available then
+    print_endline
+      "  glslangValidator absent — the GLSL compile gate is SKIPPED (not a \
+       pass)" ;
+  List.iter
+    (fun (name, gen) ->
+      check_backend
+        name
+        gen
+        ~const_name:"scale"
+        ~helper_name:"apply"
+        "static"
+        (ir_of static_const_kernel))
+    backends ;
+  print_endline "" ;
+  print_endline "  --- dynamic initializer: the discriminator ---" ;
+  List.iter
+    (fun (name, gen) ->
+      check_backend
+        name
+        gen
+        ~const_name:"base"
+        ~helper_name:"bump"
+        "dynamic"
+        (ir_of dynamic_const_kernel))
+    backends ;
+  if Sys.getenv_opt "DUMP" <> None then
+    List.iter
+      (fun (name, gen) ->
+        Printf.printf
+          "--- %s (static) ---\n%s\n"
+          name
+          (try gen (ir_of static_const_kernel) with e -> Printexc.to_string e))
+      backends ;
+  if !failures > 0 then exit 1

--- a/sarek/tests/codegen_golden/test_module_const_in_helper.ml
+++ b/sarek/tests/codegen_golden/test_module_const_in_helper.ml
@@ -77,6 +77,28 @@ let dynamic_const_kernel =
       let t = global_thread_id in
       if t < 1l then out.(0l) <- bump 10l]
 
+(* THE NEGATIVE CASE, from review on #362. `gain` is a module constant AND the
+   name of a local inside `twice`, which does not reference the constant at all.
+
+   The first version of the fix collected every `EVar` name in the helper body,
+   locally-bound ones included, on the reasoning that over-approximating only
+   costs a dead declaration. It does not: the backends emit `SLet` FLAT, so the
+   prefixed constant and the local became two declarations of `gain` in one
+   block — a redeclaration error on a helper that compiled before the fix. The
+   kernel body references `gain` too, so the constant is still live and still
+   declared there; only the helper must not get a copy. *)
+let shadow_const_kernel =
+  [%kernel
+    let open Std in
+    let (gain : float32) = 3.0 in
+    let twice (x : float32) : float32 =
+      let gain = 2.0 in
+      x *. gain
+    in
+    fun (out : float32 vector) (src : float32 vector) ->
+      let t = global_thread_id in
+      if t < 1l then out.(0l) <- twice src.(0l) +. gain]
+
 (* Index of the first occurrence, or -1. Ordering is the property: a declaration
    emitted AFTER the helper that uses it is exactly as broken as none. *)
 let index_of hay needle =
@@ -165,6 +187,91 @@ let declares_before_use ~src ~const_name ~helper_name =
       in
       starts_with " = " || starts_with " : "
 
+(* The helper's own body, brace-matched. The first-mention predicate above
+   deliberately runs to end-of-source because a later mention cannot make a bare
+   first use look like a declaration. COUNTING is the opposite: the kernel body
+   declares the constant too, so an unbounded region would always read 2 and the
+   check would be red on the fix and on the defect alike. All five emitted
+   languages brace their function bodies, so matching is enough. *)
+let helper_body ~src ~helper_name =
+  let sig_at = index_of src (helper_name ^ "(") in
+  if sig_at < 0 then None
+  else
+    let n = String.length src in
+    let rec find_open i =
+      if i >= n then None
+      else if src.[i] = '{' then Some i
+      else find_open (i + 1)
+    in
+    match find_open sig_at with
+    | None -> None
+    | Some o ->
+        let rec close i depth =
+          if i >= n then None
+          else
+            match src.[i] with
+            | '{' -> close (i + 1) (depth + 1)
+            | '}' -> if depth = 1 then Some i else close (i + 1) (depth - 1)
+            | _ -> close (i + 1) depth
+        in
+        Option.map (fun c -> String.sub src o (c - o + 1)) (close o 0)
+
+(* Occurrences of [name] in declaration position — the same two spellings
+   [declares_before_use] enumerates, for the same reason. *)
+let declaration_count body name =
+  let nb = String.length body and nn = String.length name in
+  let starts_at i tok =
+    let nt = String.length tok in
+    i + nt <= nb && String.sub body i nt = tok
+  in
+  let rec go i acc =
+    if i + nn > nb then acc
+    else if
+      String.sub body i nn = name
+      && (starts_at (i + nn) " = " || starts_at (i + nn) " : ")
+    then go (i + nn) (acc + 1)
+    else go (i + 1) acc
+  in
+  go 0 0
+
+(* The negative case, from review on #362: a helper whose local merely SHARES a
+   module constant's name must get exactly ONE declaration of it — its own. Two
+   is the redeclaration the over-approximating collector produced; zero would
+   mean the local itself went missing. *)
+let check_shadow name gen ~const_name ~helper_name ir =
+  match gen ir with
+  | src -> (
+      match helper_body ~src ~helper_name with
+      | None ->
+          expect
+            (Printf.sprintf
+               "%s/shadow: helper %s found in output"
+               name
+               helper_name)
+            false
+      | Some body ->
+          let c = declaration_count body const_name in
+          expect
+            (Printf.sprintf
+               "%s/shadow: %s declared exactly once in %s (got %d)"
+               name
+               const_name
+               helper_name
+               c)
+            (c = 1) ;
+          if name = "GLSL" && glslang_available then
+            expect
+              (Printf.sprintf
+                 "%s/shadow: glslangValidator accepts the shader"
+                 name)
+              (glslang_ok src))
+  | exception e ->
+      Printf.printf
+        "  %-62s REFUSED (%s)\n%!"
+        (Printf.sprintf "%s/shadow" name)
+        ( Printexc.to_string e |> fun s ->
+          String.sub s 0 (min 60 (String.length s)) )
+
 let check_backend name gen ~const_name ~helper_name kernel_label ir =
   match gen ir with
   | src ->
@@ -230,6 +337,17 @@ let () =
         ~helper_name:"bump"
         "dynamic"
         (ir_of dynamic_const_kernel))
+    backends ;
+  print_endline "" ;
+  print_endline "  --- a helper-local that only SHARES the constant's name ---" ;
+  List.iter
+    (fun (name, gen) ->
+      check_shadow
+        name
+        gen
+        ~const_name:"gain"
+        ~helper_name:"twice"
+        (ir_of shadow_const_kernel))
     backends ;
   if Sys.getenv_opt "DUMP" <> None then
     List.iter


### PR DESCRIPTION
backlog-160. Filed as a Vulkan/GLSL defect with a remedy that would have made things worse; the
audit corrected both, and this ships the corrected one.

## The defect, verbatim from the repro

A module constant is lexically visible inside a helper — the frontend accepts it — but lowering put
it in the **kernel** body while helpers are emitted out-of-line:

```c
__device__ float apply(float x) { return (x * scale); }
__global__ void k(...) { float scale = 2.0f; ... }
```

**Seven paths** broke that way (CUDA-C, OpenCL, Metal, GLSL, WGSL, PTX, Interpreter). Only Native
worked, because it emits an OCaml `let` the helper closes over — so this was a **CPU-passes /
device-fails divergence**, not the one-backend defect it was filed as.

## Prefix, not hoist

Emitting the constants as top-level `const` / `__constant` / `constant` / `__device__ const` was the
first plan and it is **unsound**: a module-constant initializer is an arbitrary kernel expression —
the pipeline explicitly anticipates thread-dependent ones — and every one of those storage classes
requires a compile-time-constant initializer. Hoisting `let (base : int32) = thread_idx_x` breaks a
kernel that compiles today.

Prefixing the `SLet` into the helper body handles both shapes, needs **no IR field and no backend
change**, and fixes all seven paths in one place.

**Transitive**, not decoration: a constant's initializer may reference an earlier constant, so a
fixpoint runs over the referenced set and the prefix is emitted in declaration order. Only
referenced constants are prefixed.

**Accepted cost, stated in-source:** the initializer is evaluated once per helper *call* rather than
once per kernel. For a barrier-bearing initializer that would change convergence, so that case is
**refused** with a located error naming both the constant and the intrinsic.

## Three things I got wrong first, all caught by a real compiler or the type system

**The barrier guard could not fire.** I wrote `expr_has_barrier` returning `false` unconditionally,
reasoning that only statement forms carry a barrier and no `Ir.expr` constructor holds an `Ir.stmt`.
The premise is true and the conclusion was wrong: barriers reach the IR as **intrinsics**
(`block_barrier`, `warp_barrier`, `memory_fence_block`, `memory_fence_device`), and `EIntrinsic` is
an expression. A guard that cannot fire is the class this repo keeps closing.

**Test predicate v1:** "the constant is declared before the helper's signature". `glslangValidator`
then **accepted** a shader this predicate called broken — the fix declares it *inside* the helper
body, textually after the signature and perfectly visible. The assertion encoded one valid shape
while the fix used another.

**Test predicate v2:** first mention inside the body must be followed by `" = "`. That is C-family
syntax; WGSL emits `let scale : f32 = 2.0f;`, so the case failed on WGSL while glslang was already
accepting the equivalent GLSL. Both spellings are now enumerated — enumerated rather than loosened
to "contains an `=`", which would eventually accept a bare use.

Twice the real compiler disagreed with my textual proxy and the compiler was right. That is the
argument for keeping the glslang gate in the same file as the textual checks.

## Verification

- **12 cases**: 5 backends × {static, dynamic}. **12 red before, 12 green after**, prove-red run
  from a checkpoint commit that *contains* the work — restoring from a pre-change checkpoint
  destroys it, which happened twice earlier today.
- The **dynamic** kernel is the discriminator, not extra coverage: it is what the refuted remedy
  cannot express, and a static-only test would have passed under both and let the wrong one ship.
- `dune build` clean; `@fmt` clean and re-run **after** the last file was added (that ordering broke
  #356's first push); `dune test --force` **1725 cases across 119 suites, 0 FAIL** — count unchanged
  because this is a plain executable, not an alcotest suite, and I verified it **ran** by finding
  its header in the suite log rather than assuming the `runtest` rule fired.
- Coverage context: of the 129 files containing `[%kernel]`, exactly **one** declares a module
  constant and it has no helper. That is why a defect reachable from the surface language on seven
  of eight paths was invisible.

## Not in scope

**backlog-158** (`hf_params` positional ids) sits in the same function and is deliberately untouched
— separate one-line fix, separate PR, and its own probe is currently broken. PTX and the Interpreter
are fixed by inheritance (both read `hf_body`) but get no test here: no PTX device in this suite, and
the Interpreter needs an e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation to ensure module-level constants referenced inside helper bodies are declared before first use.
  * Prevented incorrect duplication by detecting synchronization-related intrinsics in constant initializers and failing safely.
* **Tests**
  * Added a new cross-backend golden regression test covering static vs thread-dependent constant initializers referenced from helpers.
  * Optionally validates GLSL shader compilation when the validator is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->