### PR TITLE
fix(ci): the anti-vacuity gate covered one hardcoded path; widen it, with a declaration

### DIFF
--- a/sarek/core/ffi_free_gate/dune
+++ b/sarek/core/ffi_free_gate/dune
@@ -16,3 +16,11 @@
  (modules gate_numeric)
  (libraries spoc_core_base stub_ops)
  (preprocess no_preprocessing))
+
+; backlog-69: WIRED. A GATE that nothing invoked — the exact shape this repo
+; keeps closing. Passing when wired, verified before wiring.
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:gate_numeric.exe})))

--- a/sarek/tests/new_runtime/dune
+++ b/sarek/tests/new_runtime/dune
@@ -31,3 +31,20 @@
  ; broke `dune build` on machines with CUDA_PATH set but libnvrtc absent.
  (flags
   (:standard -w -33)))
+
+; backlog-69: WIRED. Both were declared as executables with no run rule, so
+; they built green and never executed. Both pass, verified before wiring.
+; test_runtime_comparison keeps its `enabled_if CUDA_PATH` guard, so dune skips
+; it entirely on a runner without CUDA rather than reporting a skip as a pass.
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_native_runtime.exe})))
+
+(rule
+ (alias runtest)
+ (enabled_if
+  (<> %{env:CUDA_PATH=} ""))
+ (action
+  (run %{dep:test_runtime_comparison.exe})))

--- a/sarek/transpile/test/dune
+++ b/sarek/transpile/test/dune
@@ -15,3 +15,14 @@
 ;  (modules test_transpile_proof)
 ;  (libraries sarek_transpile sarek_stdlib_meta)
 ;  (modes js))
+
+; backlog-69: WIRED. This is the only test of the transpiler, and it had never
+; run — no alias, no script, no CI step. That matters more than it sounds: the
+; transpiler routes all five backends through the plain `generate`, which #356
+; found to be a lossy copy dropping record and variant typedefs. Passing when
+; wired (verified before wiring, so this does not turn CI red).
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_transpile_proof.exe})))

--- a/scripts/check-dune-dir-visibility.sh
+++ b/scripts/check-dune-dir-visibility.sh
@@ -205,6 +205,19 @@ tracked = subprocess.run(
 ).stdout.decode().split("\0")
 dune_files = sorted({p for p in tracked if p == "dune" or p.endswith("/dune")})
 
+# Fixture dune files under scripts/prove-red-fixtures/ are INPUTS to another
+# gate's mutation tests, not build directories. They are invisible to dune, and
+# that is deliberate and permanent -- they exist to be parsed by
+# check-test-alias-coverage.sh, never built. Reporting them is true by the letter
+# of this check and meaningless in fact.
+#
+# Second gate to need this exclusion (the first was
+# check-test-alias-coverage.sh, which introduced the tree). If a THIRD
+# dune-walking gate appears, factor the rule out rather than adding a third copy
+# -- three hand-maintained copies of one convention is how the copies start
+# disagreeing.
+dune_files = [p for p in dune_files if not p.startswith("scripts/prove-red-fixtures/")]
+
 if not dune_files:
     print("ERROR: no tracked dune files found -- run from the repo root")
     sys.exit(2)

--- a/scripts/check-test-alias-coverage.sh
+++ b/scripts/check-test-alias-coverage.sh
@@ -3,24 +3,66 @@
 # SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com>
 # Guard against silently-unwired test executables (the "vacuous e2e" failure
 # mode fixed in 2026-07: an (executable) with no run rule builds green but
-# never executes). Fails if any executable declared in sarek/tests/e2e/dune
-# is not referenced by at least one alias/rule in that file — i.e. every
-# test binary must be classified: runtest (executing or build-gated),
-# compile-only, e2e-gpu, or e2e-manual.
+# never executes). Every declared target must be classified: wired to an
+# alias/rule, or declared in scripts/unwired-targets.tsv with a reason.
+#
+# WIDENED TO THE WHOLE TREE (backlog-69). It used to read ONE hardcoded path,
+# sarek/tests/e2e/dune, so a gate against unwired tests was itself unwired
+# everywhere else. Measured on widening: 45 unwired out of 275 declared. Five of
+# them were real — test_transpile_proof (the only test of the transpiler, and the
+# transpiler is what #356 found routing five backends through a lossy emit path),
+# test_native_runtime, test_runtime_comparison, and gate_numeric + gate_framework,
+# which are GATES that nothing invoked. All five now wired; all five verified
+# passing BEFORE wiring, so this does not turn CI red.
+#
+# The other 40 are legitimately not runnable by `dune test` — GPU timing
+# benchmarks, js_of_ocaml browser targets, hardware probes, one operator tool —
+# and are declared in scripts/unwired-targets.tsv. A gate reporting 45 red on 39
+# non-problems gets switched off, which is why the widening ships with the
+# declaration rather than after it.
+#
+# BOTH DIRECTIONS ARE RED. Unwired with no declaration: red. A declaration for a
+# target that is now wired, or that no longer exists: also red — a stale
+# exemption silently keeps covering something already fixed or deleted, which is
+# the "declared but unverified" shape the declaration exists to close.
 set -euo pipefail
 
-DUNE_FILE="sarek/tests/e2e/dune"
-[ -f "$DUNE_FILE" ] || { echo "ERROR: $DUNE_FILE not found (run from repo root)"; exit 2; }
+# ROOT and DECL_FILE are arguments so prove-red can exercise this against a
+# small fixture tree instead of the repository. That is not a convenience: the
+# gate's input IS the whole tree, so prove-red's copy-a-few-files scratch world
+# would leave most dune files absent and every declaration for them would read
+# as STALE — a baseline that is red for a reason that has nothing to do with the
+# property. Defaults are the real tree, which is what CI runs.
+ROOT="${1:-.}"
+DECL_FILE="${2:-scripts/unwired-targets.tsv}"
+[ -d "$ROOT" ] || { echo "ERROR: root $ROOT not found"; exit 2; }
+[ -f "$DECL_FILE" ] || { echo "ERROR: $DECL_FILE not found (run from repo root)"; exit 2; }
 
-python3 - "$DUNE_FILE" <<'PYEOF'
-import re, sys
+python3 - "$DECL_FILE" "$ROOT" <<'PYEOF'
+import re, sys, pathlib
 
-path = sys.argv[1]
-src = open(path).read()
-# Strip line comments so names mentioned in prose don't count as wiring.
-src = re.sub(r";[^\n]*", "", src)
+decl_path = sys.argv[1]
+root = pathlib.Path(sys.argv[2])
+# Read the declaration: <dune file>::<target>\t<tag>\t<justification>.
+declared_exempt = {}
+for lineno, line in enumerate(open(decl_path), 1):
+    line = line.rstrip("\n")
+    if not line or line.startswith("#"):
+        continue
+    parts = line.split("\t")
+    if len(parts) < 3 or "::" not in parts[0] or not parts[1].strip() or not parts[2].strip():
+        print(f"ERROR: {decl_path}:{lineno}: expected '<dune>::<target>\\t<tag>\\t<why>', got: {line}")
+        sys.exit(2)
+    declared_exempt[parts[0]] = parts[1].strip()
 
-# Parse top-level s-expressions.
+VALID_TAGS = {"benchmark", "browser-target", "hardware-probe", "tool"}
+bad = {k: v for k, v in declared_exempt.items() if v not in VALID_TAGS}
+if bad:
+    for k, v in sorted(bad.items()):
+        print(f"ERROR: {k}: unknown reason tag {v!r} (expected one of {sorted(VALID_TAGS)})")
+    sys.exit(2)
+
+
 def toplevel_forms(s):
     forms, depth, start = [], 0, None
     for i, c in enumerate(s):
@@ -35,41 +77,80 @@ def toplevel_forms(s):
                 start = None
     return forms
 
-declared = set()
-for form in toplevel_forms(src):
-    head = form[1:].split(None, 1)[0] if form[1:].split(None, 1) else ""
-    if head == "executables":
-        m = re.search(r"\(names((?:[^()])*)\)", form)
-        if m:
-            declared.update(m.group(1).split())
-    elif head == "executable":
-        m = re.search(r"\(name\s+([A-Za-z0-9_]+)\s*\)", form)
-        if m:
-            declared.add(m.group(1))
 
-# Referenced names: every FOO.exe token (rule run actions use %{dep:FOO.exe},
-# alias deps list FOO.exe directly - both match).
-referenced = set(re.findall(r"([A-Za-z0-9_]+)\.exe", src))
+total_declared = 0
+unwired = []          # keys that are unwired in the tree
+for dune in sorted(root.rglob("dune")):
+    if "_build" in dune.parts:
+        continue
+    raw = dune.read_text()
+    # Strip line comments so names mentioned in prose do not count as wiring.
+    src = re.sub(r";[^\n]*", "", raw)
+    if src.count("(") != src.count(")"):
+        print(f"ERROR: unbalanced parentheses after comment-stripping in {dune} - parser assumptions violated")
+        sys.exit(2)
+    forms = toplevel_forms(src)
+    declared = set()
+    for form in forms:
+        head = form[1:].split(None, 1)[0] if form[1:].split(None, 1) else ""
+        if head in ("executables", "tests"):
+            m = re.search(r"\(names((?:[^()])*)\)", form)
+            if m:
+                declared.update(m.group(1).split())
+        elif head in ("executable", "test"):
+            m = re.search(r"\(name\s+([A-Za-z0-9_]+)\s*\)", form)
+            if m:
+                declared.add(m.group(1))
+    if not declared:
+        continue
+    total_declared += len(declared)
+    # A (test)/(tests) stanza is self-wiring: dune attaches it to runtest.
+    self_wired = set()
+    for form in forms:
+        head = form[1:].split(None, 1)[0] if form[1:].split(None, 1) else ""
+        if head == "test":
+            m = re.search(r"\(name\s+([A-Za-z0-9_]+)\s*\)", form)
+            if m:
+                self_wired.add(m.group(1))
+        elif head == "tests":
+            m = re.search(r"\(names((?:[^()])*)\)", form)
+            if m:
+                self_wired.update(m.group(1).split())
+    referenced = set(re.findall(r"([A-Za-z0-9_]+)\.exe", src)) | self_wired
+    for name in sorted(declared - referenced):
+        rel = dune.relative_to(root)
+        unwired.append(f"{rel}::{name}")
 
-if not declared:
-    print(f"ERROR: no executables parsed from {path} - parser broken or file restructured")
+if total_declared == 0:
+    print("ERROR: no executables or tests parsed from any dune file - parser broken or tree restructured")
     sys.exit(2)
-if src.count("(") != src.count(")"):
-    print(f"ERROR: unbalanced parentheses after comment-stripping in {path} - parser assumptions violated")
-    sys.exit(2)
 
-missing = sorted(declared - referenced)
-if missing:
-    for exe in missing:
-        print(f"UNWIRED: {exe} is declared in {path} but referenced by no alias or run rule")
+# DIRECTION 1 -- unwired with no declaration.
+undeclared = [k for k in unwired if k not in declared_exempt]
+# DIRECTION 2 -- a declaration that no longer describes anything unwired. This is
+# what stops the file rotting: a stale exemption would keep silently covering a
+# target that has since been wired or deleted.
+unwired_set = set(unwired)
+stale = [k for k in declared_exempt if k not in unwired_set]
+
+if undeclared or stale:
+    for k in sorted(undeclared):
+        print(f"UNWIRED: {k} is declared in a dune file, referenced by no alias or run rule,")
+        print(f"         and has no line in {decl_path}.")
+    for k in sorted(stale):
+        print(f"STALE:   {decl_path} exempts {k}, but it is not unwired (wired now, or gone).")
     print()
-    print("Every test executable must be attached to an alias: runtest (executing")
-    print("via (rule (alias runtest) (action (run ...))) or build-gated),")
-    print("compile-only, e2e-gpu, or e2e-manual. See the comment block in")
-    print(f"{path} and briefs/make-tests-actually-run-impl-notes.md.")
+    if undeclared:
+        print("If it is a TEST that can run, WIRE it:")
+        print("  (rule (alias runtest) (action (run %{dep:NAME.exe})))")
+        print(f"Only if it genuinely cannot run under `dune test`, add a line to {decl_path}")
+        print("with one of: benchmark | browser-target | hardware-probe | tool.")
+    if stale:
+        print(f"Remove the stale line(s) from {decl_path} - the exemption is no longer describing")
+        print("anything, and leaving it there means it silently covers whatever takes that name next.")
     sys.exit(1)
 
-print(f"OK: all {len(declared)} e2e test executables are wired to an alias")
+print(f"OK: {total_declared} target(s) across the tree; {len(unwired)} unwired, all declared with a reason")
 PYEOF
 
 # ---------------------------------------------------------------------------
@@ -80,29 +161,64 @@ PYEOF
 # that matters: this gate's whole job is to notice unwired executables, and a
 # parse that finds zero of them would otherwise report "OK: all 0 ... wired".
 #
+# The subject runs against a FIXTURE tree, not the repository. That is forced,
+# not preferred: this gate's input is the whole tree, so a scratch world holding
+# only a few copied dune files would leave most of them absent and every
+# declaration for them would read STALE — a baseline red for a reason unrelated
+# to the property being proven. The fixture carries a wired target AND a
+# legitimately-unwired declared one, so "refuses an undeclared target" and
+# "refuses every unwired target" cannot be confused.
+#
 # BEGIN prove-red-spec
 # copy: scripts/check-test-alias-coverage.sh
-# copy: sarek/tests/e2e/dune
+# copy: scripts/prove-red-fixtures/alias-coverage/decl.tsv
+# copy: scripts/prove-red-fixtures/alias-coverage/wired/dune
+# copy: scripts/prove-red-fixtures/alias-coverage/exempt/dune
 # invoke: scripts/check-test-alias-coverage.sh
+# baseline-argv: scripts/prove-red-fixtures/alias-coverage scripts/prove-red-fixtures/alias-coverage/decl.tsv
 # baseline-exit: 0
-# baseline-message: e2e test executables are wired to an alias
+# baseline-message: 1 unwired, all declared with a reason
 #
-# mutation: unwired-executable
-#   desc: an executable is declared and attached to no alias or run rule -- the "builds green, never executes" shape the gate exists for.
-#   apply: printf '\n(executable (name zz_prove_red_probe))\n' >> sarek/tests/e2e/dune
+# mutation: unwired-undeclared
+#   desc: a target declared with no alias, no run rule and no line in the declaration — the "builds green, never executes" shape this gate exists for.
+#   apply: printf '\n(executable (name zz_probe))\n' >> scripts/prove-red-fixtures/alias-coverage/wired/dune
+#   argv: scripts/prove-red-fixtures/alias-coverage scripts/prove-red-fixtures/alias-coverage/decl.tsv
 #   expect-exit: 1
-#   expect-message: UNWIRED: zz_prove_red_probe
+#   expect-message: UNWIRED: wired/dune::zz_probe
 #
-# mutation: missing-input
-#   desc: the dune file the gate reads is gone. An environment mutation: the gate must refuse rather than pass having read nothing.
-#   apply: rm -f sarek/tests/e2e/dune
+# mutation: stale-declaration
+#   desc: the OTHER direction, and the one that stops the declaration rotting. A line exempting a target that is NOT unwired (wired since, or renamed) must be red — otherwise the exemption silently keeps covering whatever takes that name next.
+#   apply: printf 'wired/dune::fixture_wired\tbenchmark\tnot actually unwired\n' >> scripts/prove-red-fixtures/alias-coverage/decl.tsv
+#   argv: scripts/prove-red-fixtures/alias-coverage scripts/prove-red-fixtures/alias-coverage/decl.tsv
+#   expect-exit: 1
+#   expect-message: STALE
+#
+# mutation: bad-reason-tag
+#   desc: a tag outside the closed set. Free-text reasons would let "TODO" or "flaky" become exemptions, so the vocabulary is fixed and an unknown tag is a usage error, not a silent pass.
+#   apply: printf 'exempt/dune::zz_tag\twhatever\tunknown tag\n' >> scripts/prove-red-fixtures/alias-coverage/decl.tsv
+#   argv: scripts/prove-red-fixtures/alias-coverage scripts/prove-red-fixtures/alias-coverage/decl.tsv
+#   expect-exit: 2
+#   expect-message: unknown reason tag
+#
+# mutation: malformed-declaration-line
+#   desc: a line missing its justification column. A declaration whose reason is empty is an exemption with no stated cause, which is the thing this file exists to prevent.
+#   apply: printf 'exempt/dune::zz_bad\tbenchmark\n' >> scripts/prove-red-fixtures/alias-coverage/decl.tsv
+#   argv: scripts/prove-red-fixtures/alias-coverage scripts/prove-red-fixtures/alias-coverage/decl.tsv
+#   expect-exit: 2
+#   expect-message: expected
+#
+# mutation: missing-declaration-file
+#   desc: the declaration is gone. An environment mutation: with no exemptions the gate must refuse rather than proceed, because "no exemptions read" and "nothing needs exempting" are not the same statement.
+#   apply: rm -f scripts/prove-red-fixtures/alias-coverage/decl.tsv
+#   argv: scripts/prove-red-fixtures/alias-coverage scripts/prove-red-fixtures/alias-coverage/decl.tsv
 #   expect-exit: 2
 #   expect-message: not found
 #
 # mutation: empty-declared-set
-#   desc: the file parses cleanly but declares no executables. An empty declared set turns this strict check into a permissive one, so it must be exit 2 and not "OK: all 0".
-#   apply: printf '(rule (alias runtest))\n' > sarek/tests/e2e/dune
+#   desc: the tree parses cleanly but declares no targets. An empty declared set turns this strict check into a permissive one, so it must be exit 2 rather than "OK: 0 target(s)".
+#   apply: printf '(rule (alias runtest))\n' > scripts/prove-red-fixtures/alias-coverage/wired/dune && printf '(rule (alias runtest))\n' > scripts/prove-red-fixtures/alias-coverage/exempt/dune
+#   argv: scripts/prove-red-fixtures/alias-coverage scripts/prove-red-fixtures/alias-coverage/decl.tsv
 #   expect-exit: 2
-#   expect-message: no executables parsed
+#   expect-message: no executables or tests parsed
 # END prove-red-spec
 # ---------------------------------------------------------------------------

--- a/scripts/check-test-alias-coverage.sh
+++ b/scripts/check-test-alias-coverage.sh
@@ -80,8 +80,24 @@ def toplevel_forms(s):
 
 total_declared = 0
 unwired = []          # keys that are unwired in the tree
+
+# This gate's OWN prove-red fixtures are dune files describing deliberately
+# unwired targets. Once the walk went whole-tree they were scanned as if they
+# were real, and CI reported `alias-coverage/exempt/dune::fixture_exempt` as an
+# undeclared unwired target — correct by the letter, meaningless in fact. Never
+# seen locally because every local run passed the fixture dir as the root.
+#
+# The exclusion is conditional on the root, and that is the load-bearing part:
+# when prove-red invokes this WITH the fixture dir as root, the fixtures are the
+# subject and must still be scanned. A blanket skip would make those mutations
+# find nothing, which is why the `unwired-executable` mutation is what catches a
+# regression here — it asserts UNWIRED is still detected inside that tree.
+root_in_fixtures = "prove-red-fixtures" in root.resolve().parts
+
 for dune in sorted(root.rglob("dune")):
     if "_build" in dune.parts:
+        continue
+    if not root_in_fixtures and "prove-red-fixtures" in dune.parts:
         continue
     raw = dune.read_text()
     # Strip line comments so names mentioned in prose do not count as wiring.

--- a/scripts/prove-red-fixtures/alias-coverage/decl.tsv
+++ b/scripts/prove-red-fixtures/alias-coverage/decl.tsv
@@ -1,0 +1,2 @@
+# Fixture declaration for the alias-coverage prove-red spec.
+exempt/dune::fixture_exempt	benchmark	unwired on purpose; the positive control

--- a/scripts/prove-red-fixtures/alias-coverage/exempt/dune
+++ b/scripts/prove-red-fixtures/alias-coverage/exempt/dune
@@ -1,0 +1,6 @@
+; Fixture: one target that is unwired ON PURPOSE and declared in the fixture's
+; own declaration file. It is the positive control — the gate must stay green on
+; a legitimately-unwired, declared target, otherwise "refuses an undeclared one"
+; and "refuses every unwired one" are the same observation.
+(executable
+ (name fixture_exempt))

--- a/scripts/prove-red-fixtures/alias-coverage/wired/dune
+++ b/scripts/prove-red-fixtures/alias-coverage/wired/dune
@@ -1,0 +1,9 @@
+; Fixture for scripts/check-test-alias-coverage.sh's prove-red spec: one target
+; wired to runtest, which must NOT be reported.
+(executable
+ (name fixture_wired))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:fixture_wired.exe})))

--- a/scripts/unwired-targets.tsv
+++ b/scripts/unwired-targets.tsv
@@ -1,0 +1,67 @@
+# Executables and tests that are DECLARED in a dune file but wired to no alias
+# or rule — with the reason, one per line (backlog-69).
+#
+# WHY THIS FILE EXISTS. scripts/check-test-alias-coverage.sh guards against the
+# "vacuous test" shape: an (executable) with no run rule builds green and never
+# executes. It only looked at sarek/tests/e2e/dune, one hardcoded path. Widened
+# to the whole tree it finds 45 unwired targets out of 275 — and 40 of those are
+# legitimately not runnable by `dune test`. A gate that reports 45 red on 39
+# non-problems gets switched off, so the widening is only shippable together
+# with a declaration: each unwired target states WHY, and anything unwired
+# without a declaration is red.
+#
+# THE CHECK RUNS IN BOTH DIRECTIONS, and the second is what stops this file
+# rotting. An unwired target with no line here is red. A line here for a target
+# that is now WIRED, or that no longer exists, is ALSO red — otherwise a stale
+# exemption would silently keep covering something that had been fixed or
+# deleted, which is the same "declared but unverified" shape the declaration is
+# supposed to close.
+#
+# Format:  <dune file>::<target>\t<reason-tag>\t<justification>
+# Tags:    benchmark | browser-target | hardware-probe | tool
+#
+# ADDING A LINE IS A DECISION, not a way to silence the gate. If the target is a
+# TEST that could run, wire it instead — that is what happened to the five this
+# widening surfaced (test_transpile_proof, gate_numeric, gate_framework,
+# test_native_runtime, test_runtime_comparison), two of which were GATES that
+# nothing invoked.
+benchmarks/dune::aggregate	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_bitonic_sort	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_conv2d	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_dot_product	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_gather_scatter	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_histogram	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_mandelbrot	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_matrix_mul	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_matrix_mul_tiled	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_nbody	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_pinned_transfer	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_radix_sort	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_reduction	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_reduction_max	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_scan	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_soa_aos	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_soa_emitter	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_stencil_2d	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_stream_triad	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_transpose	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_transpose_tiled	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_vector_add	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::bench_vector_copy	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::deduplicate_results	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::generate_backend_code	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::to_csv	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+benchmarks/dune::to_web	benchmark	GPU timing loop, run by benchmarks/run_all_benchmarks.sh. Wiring it to runtest would put device-dependent timing on CPU-only CI.
+sarek/core_js/test/dune::smoke	browser-target	js_of_ocaml target; the artifact is JavaScript for a browser or worker, not a runnable native test.
+sarek/core_js/webgpu/lessons/dune::compose_driver	browser-target	js_of_ocaml target; the artifact is JavaScript for a browser or worker, not a runnable native test.
+sarek/core_js/webgpu/spike-worker/dune::worker_spike	browser-target	js_of_ocaml target; the artifact is JavaScript for a browser or worker, not a runnable native test.
+sarek/core_js/webgpu/test/dune::runtime_driver	browser-target	js_of_ocaml target; the artifact is JavaScript for a browser or worker, not a runnable native test.
+sarek/execute/jsoo/dune::smoke	browser-target	js_of_ocaml smoke target; the artifact is JavaScript, not a native executable.
+sarek/plugins/webgpu/spike/numeric_core/dune::test_numeric_spike	browser-target	WebGPU spike; needs a browser with a GPU adapter, which no CI runner here provides.
+sarek/plugins/webgpu/spike/webgpu_binding/dune::webgpu_jsoo_spike	browser-target	WebGPU spike; needs a browser with a GPU adapter, which no CI runner here provides.
+sarek/transpile/web/dune::transpile_js	browser-target	js_of_ocaml transpiler bundle; built by the docs job, not executed.
+sarek-opencl/probe/dune::probe_opencl_f16_model_agreement	hardware-probe	Hardware capability probe: it reports what a specific device advertises. There is no device on a CPU-only runner, so a wired run would be a skip reported as a pass.
+sarek-vulkan/probe/dune::probe_vulkan_coopmat_configs	hardware-probe	Hardware capability probe: it reports what a specific device advertises. There is no device on a CPU-only runner, so a wired run would be a skip reported as a pass.
+sarek-vulkan/probe/dune::probe_vulkan_f16_model_agreement	hardware-probe	Hardware capability probe: it reports what a specific device advertises. There is no device on a CPU-only runner, so a wired run would be a skip reported as a pass.
+tools/dune::device_info	tool	Operator tool, not a test: it prints the local device inventory.
+tools/f16_shape_catalogue/probe/dune::probe_f16_shape_separation	hardware-probe	Hardware capability probe: it reports what a specific device advertises. There is no device on a CPU-only runner, so a wired run would be a skip reported as a pass.

--- a/spoc/framework/ffi_free_gate/dune
+++ b/spoc/framework/ffi_free_gate/dune
@@ -10,3 +10,10 @@
  (modules gate_framework)
  (libraries spoc_framework)
  (preprocess no_preprocessing))
+
+; backlog-69: WIRED. Same as sarek/core/ffi_free_gate: a gate nobody called.
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:gate_framework.exe})))


### PR DESCRIPTION
`scripts/check-test-alias-coverage.sh` guards against the *vacuous test* shape — an
`(executable)` with no run rule builds green and never executes. It read **one hardcoded
path**, `sarek/tests/e2e/dune`. So a gate against unwired tests was itself unwired
everywhere else in the tree.

## Measured on widening — and the composition is the result, not the count

**45 unwired out of 275 declared.** The backlog item said 30; that was wrong, and the
breakdown matters more than either number:

| | | |
|---|---|---|
| 27 | benchmarks | GPU timing loops, run by `run_all_benchmarks.sh` |
| 8 | browser targets | js_of_ocaml / WebGPU spikes, not native executables |
| 4 | hardware probes | report what a device advertises; no device in CI |
| 1 | tool | `device_info`, an operator tool, not a test |
| **5** | **real** | the ones that mattered |

The five: `test_transpile_proof`, `test_native_runtime`, `test_runtime_comparison`,
`gate_numeric`, `gate_framework`. **All wired now**, and all five verified passing
**before** wiring so this does not turn CI red.

**Two of them are gates that nothing invoked** — the exact shape this repo keeps
closing, found by widening a gate against exactly that. And `test_transpile_proof` is
the **only test of the transpiler** — the component #356 found routing all five
backends through a lossy emit path that dropped record and variant typedefs. It had
never run.

## Why the declaration ships in the same commit

A gate reporting 45 red on 39 non-problems gets switched off. So the widening comes
with `scripts/unwired-targets.tsv`: each legitimately-unwired target states *why*, with
a tag from a **closed set** (`benchmark | browser-target | hardware-probe | tool`) so
"TODO" or "flaky" cannot become an exemption.

**Both directions are red**, and the second is what stops the file rotting:

```
unwired with no declaration            -> UNWIRED
a declaration for something now wired  -> STALE
```

A stale exemption silently keeps covering whatever takes that name next — the same
declared-but-unverified shape the declaration exists to close.

## Root and declaration are arguments, and that is forced

This gate's input is the *whole tree*, so prove-red's copy-a-few-files scratch world
left most dune files absent and **every declaration for them read STALE** — a baseline
red for a reason unrelated to the property. It now runs against a fixture carrying a
wired target **and** a legitimately-unwired declared one, so *"refuses an undeclared
target"* and *"refuses every unwired target"* cannot be confused. Defaults are the real
tree, which is what CI runs.

## Verification

- **Six prove-red mutations**, one per refusal and one per direction:
  `unwired-undeclared`, `stale-declaration`, `bad-reason-tag`,
  `malformed-declaration-line`, `missing-declaration-file`, `empty-declared-set`.
  prove-red now **4 subjects / 19 mutations**, every one red as declared.
- prove-red also caught that `scripts/unwired-targets.tsv` was **untracked** — absent on
  a fresh clone, so the gate would pass here and exit 2 in CI.
- `dune test --force` **1725 cases / 119 suites / 0 FAIL**, and the five newly wired
  targets verified to have **run** by finding their own output in the suite log rather
  than assuming the rules fired.

## Scope

This is #69's hygiene half (A/B), which the audit recommended doing now. It does **not**
certify feature coverage — #69's actual subject — and it deliberately does not wire the
22 benchmarks to `runtest`: that would put device-dependent timing loops on a CPU-only
runner, which the audit flagged as the plausible-but-wrong version of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added runtime test execution for native and CUDA comparison tests when CUDA is available.
  * Added test-run coverage for FFI-free gate checks and transpiler proof validation.
  * Expanded automated checks to detect unwired, stale, or invalid test-alias declarations.
  * Added fixtures covering wired and intentionally exempt test targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->