### PR TITLE
fix(counter): warning-as-error is a build failure, and `^Error:` never matched it

### DIFF
--- a/scripts/prove-red-fixtures/dune-test-warning-as-error-log.txt
+++ b/scripts/prove-red-fixtures/dune-test-warning-as-error-log.txt
@@ -1,0 +1,271 @@
+Sarek_ir_types tests:
+  memspace: OK
+  elttype primitives: OK
+  elttype record: OK
+  elttype variant: OK
+  elttype array: OK
+  elttype vec: OK
+  var: OK
+  var mutable: OK
+  const int32: OK
+  const int64: OK
+  const float32: OK
+  const float64: OK
+  const bool: OK
+  const unit: OK
+  binop: OK
+  unop: OK
+  expr const: OK
+  expr var: OK
+  expr binop: OK
+  expr intrinsic: OK
+  expr record: OK
+  expr if: OK
+  lvalue var: OK
+  lvalue array: OK
+  stmt assign: OK
+  stmt seq: OK
+  stmt if: OK
+  stmt for: OK
+  stmt barrier: OK
+  stmt let: OK
+  stmt pragma: OK
+  decl param: OK
+  decl local: OK
+  decl shared: OK
+  kernel: OK
+  helper_func: OK
+  native_arg: OK
+  vec_length: OK
+  pattern: OK
+All Sarek_ir_types tests passed!
+Sarek_ir_pp tests:
+  string_of_elttype primitives: OK
+  string_of_elttype record: OK
+  string_of_elttype variant: OK
+  string_of_elttype array: OK
+  string_of_elttype vec: OK
+  string_of_memspace: OK
+  string_of_binop: OK
+  string_of_unop: OK
+  pp_expr const: OK
+  pp_expr var: OK
+  pp_expr binop: OK
+  pp_expr unop: OK
+  pp_expr array_read: OK
+  pp_expr intrinsic: OK
+  pp_expr record: OK
+  pp_expr if: OK
+  pp_stmt assign: OK
+  pp_stmt barrier: OK
+  pp_stmt warp_barrier: OK
+  pp_stmt mem_fence: OK
+  pp_stmt return: OK
+  pp_stmt empty: OK
+  pp_decl param: OK
+  pp_decl param array: OK
+  pp_decl local: OK
+  pp_decl shared: OK
+  pp_kernel: OK
+  pp_pattern: OK
+All Sarek_ir_pp tests passed!
+Sarek_ir_analysis tests:
+  elttype_uses_float64 primitives: OK
+  elttype_uses_float64 record: OK
+  elttype_uses_float64 variant: OK
+  elttype_uses_float64 array: OK
+  elttype_uses_float64 vec: OK
+  const_uses_float64: OK
+  expr_uses_float64 const: OK
+  expr_uses_float64 var: OK
+  expr_uses_float64 binop: OK
+  expr_uses_float64 cast: OK
+  expr_uses_float64 intrinsic: OK
+  expr_uses_float64 if: OK
+  stmt_uses_float64 assign: OK
+  stmt_uses_float64 seq: OK
+  stmt_uses_float64 if: OK
+  stmt_uses_float64 for: OK
+  stmt_uses_float64 let: OK
+  stmt_uses_float64 barrier/empty: OK
+  decl_uses_float64 param: OK
+  decl_uses_float64 local: OK
+  decl_uses_float64 shared: OK
+  helper_uses_float64: OK
+  kernel_uses_float64 params: OK
+  kernel_uses_float64 types: OK
+  kernel_uses_float64 variants: OK
+  elttype_uses_float16 primitives: OK
+  elttype_uses_float16 nested: OK
+  expr_uses_float16: OK
+  stmt/decl_uses_float16: OK
+  kernel_uses_float16: OK
+  feature API agrees with the per-width aliases: OK
+  const_uses is width-specific: OK
+  kernel_requirements: OK
+  is_atomic_intrinsic_name: OK
+  expr_uses_atomics: OK
+  helper_uses_atomics: OK
+  kernel_uses_atomics direct: OK
+  kernel_uses_atomics via helper: OK
+  lvalue_uses_atomics: OK
+  kernel_uses_atomics via assign lvalue: OK
+  kernel_uses_atomics via SNative (conservative): OK
+  expr_uses_int_mod: OK
+  lvalue_uses_int_mod: OK
+  kernel_uses_int_mod via record-field lvalue: OK
+  is_copysign_intrinsic_name: OK
+  expr_uses_copysign: OK
+  lvalue_uses_copysign: OK
+  kernel_uses_copysign via record-field lvalue: OK
+  kernel_uses_copysign via helper: OK
+  kernel_uses_nonfinite_float64: OK
+  kernel_uses_intrinsic: OK
+  kernel_float64_intrinsics: OK
+  coopmat detection: OK
+  coopmat configs: OK
+All Sarek_ir_analysis tests passed!
+Testing Sarek_capability (#64 slice 1)...
+  device_verdict: Unknown refuses, widths independent: OK
+  permits: Unknown does not permit: OK
+  first_refusal: OK
+  kind_needs_device: OK
+  kind_name: OK
+  evidence: OK
+  explain: OK
+  refuse_if_used: fires on f64, silent on f32: OK
+All Sarek_capability tests passed!
+Testing `Sarek_coopmat'.
+This run has ID `QN2LBYVT'.
+
+  [OK]          local hardware record          0   NAVI31: 14 configurations,...
+  [OK]          accuracy regime                0   integer accumulate is exac...
+  [OK]          accuracy regime                1   component classification.
+  [OK]          device verdict                 0   unprobed device is refused.
+  [OK]          device verdict                 1   capable device permits (po...
+  [OK]          device verdict                 2   probed device with no supp...
+  [OK]          device verdict                 3   unadvertised configuration...
+  [OK]          device verdict                 4   find_config.
+  [OK]          fragment type                  0   dimensions are derived fro...
+  [OK]          fragment type                  1   integer component types ar...
+  [OK]          fragment type                  2   Metal's 8x8 is expressible.
+  [OK]          subgroup ABI                   0   components per invocation.
+  [OK]          subgroup ABI                   1   config fits subgroup.
+
+Full test results in `/workspace/sarek/_build/default/spoc/ir/test/_build/_tests/Sarek_coopmat'.
+Test Successful in 0.001s. 13 tests run.
+  float32 paths expose exactly the 33-entry set: OK
+  Float64 paths expose exactly the 33-entry set: OK
+  Math.Float64 paths expose exactly the 16-entry set: OK
+  Math.Float64 paths still omit the 11 unsupported intrinsics: OK
+  Float64.rsqrt and Sarek_stdlib_meta.Float64.rsqrt agree on GLSL name (inversesqrt): OK
+  Float64.abs_float emits fabs (abs on GLSL), never abs_float: OK
+All Sarek_pure_registry tests passed!
+File "spoc/registry/test/test_sarek_registry.ml", line 262, characters 4-27:
+262 | let unused_backlog157_probe x = x + 1
+          ^^^^^^^^^^^^^^^^^^^^^^^
+Error (warning 32 [unused-value-declaration]): unused value unused_backlog157_probe.
+Framework_sig tests:
+  dims_1d: OK
+  dims_2d: OK
+  dims_3d: OK
+  dims record: OK
+  capabilities: OK
+  device: OK
+  execution_model: OK
+  source_lang: OK
+  convergence: OK
+  exec_arg basic: OK
+  run_source_arg: OK
+All Framework_sig tests passed!
+Typed_value tests:
+  PInt32: OK
+  PInt64: OK
+  PFloat: OK
+  PBool: OK
+  PBytes: OK
+  Int32_type: OK
+  Int64_type: OK
+  Float32_type: OK
+  Float64_type: OK
+  Bool_type: OK
+  Registry.find_scalar: OK
+  Registry.list_scalars: OK
+  Registry.register_scalar (custom): OK
+  scalar_value: OK
+  typed_value (scalar): OK
+  exec_arg_of_typed_value: OK
+  typed_value_of_exec_arg (Int32): OK
+  typed_value_of_exec_arg (Float64): OK
+  type_name_of_exec_arg: OK
+  field_desc: OK
+All Typed_value tests passed!
+Device_type tests:
+  Device_type.t = Framework_sig.device: OK
+  Device_type fields: OK
+  Device_type CPU device: OK
+  Cross-module compatibility: OK
+All Device_type tests passed!
+Testing `Backend_error'.
+This run has ID `388EUDXT'.
+
+  [OK]          codegen             0   codegen errors.
+  [OK]          runtime             0   runtime errors.
+  [OK]          plugin              0   plugin errors.
+  [OK]          backends            0   multiple backends.
+  [OK]          exceptions          0   exception handling.
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Backend_error'.
+Test Successful in 0.000s. 5 tests run.
+Testing `Kernel_args'.
+This run has ID `TD61S3U6'.
+
+  [OK]          ordering               0   out of order set.
+  [OK]          ordering               1   to_sorted_list.
+  [OK]          ordering               2   count.
+  [OK]          last-set-wins          0   duplicate idx last wins.
+  [OK]          validation             0   gap detection.
+  [OK]          validation             1   count mismatch extra.
+  [OK]          validation             2   unexpected index beyond range.
+  [OK]          validation             3   negative expected_count.
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Kernel_args'.
+Test Successful in 0.000s. 8 tests run.
+Testing `Compile_cache'.
+This run has ID `0GE9XOVU'.
+
+  [OK]          key_identity          0   same inputs same key.
+  [OK]          key_identity          1   same source, different kernel name ...
+  [OK]          key_identity          2   different device -> different key.
+  [OK]          key_identity          3   different source -> different key.
+  [OK]          options               0   option order canonicalized.
+  [OK]          options               1   different option values -> differen...
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Compile_cache'.
+Test Successful in 0.000s. 6 tests run.
+Testing `Guarded_cache'.
+This run has ID `S7BRJ15Q'.
+
+  [OK]          concurrency          0   stress: shared + distinct keys, N do...
+  [OK]          concurrency          1   concurrent clear vs find_or_build.
+  [OK]          concurrency          2   concurrent evict_device.
+  [OK]          concurrency          3   evict_device during an in-flight bui...
+  [OK]          concurrency          4   clear during an in-flight build is r...
+  [OK]          concurrency          5   clear during an in-flight build stil...
+  [OK]          concurrency          6   a raising destroy does not strand th...
+  [OK]          concurrency          7   a raising destroy on a lost race sti...
+  [OK]          concurrency          8   red demo (unguarded, opt-in).
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Guarded_cache'.
+Test Successful in 0.062s. 9 tests run.
+Testing `Cache_hooks'.
+This run has ID `MURWW51U'.
+
+  [OK]          around_clear                            0   notifies on both ...
+  [OK]          around_clear                            1   nested scopes not...
+  [OK]          notification                            0   device destroy ca...
+  [OK]          notification                            1   a failing listene...
+  [OK]          around_clear failure isolation          0   a failing listene...
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Cache_hooks'.
+Test Successful in 0.000s. 5 tests run.

--- a/scripts/test-suite-counts.sh
+++ b/scripts/test-suite-counts.sh
@@ -121,6 +121,22 @@
 # preamble, so a tree that merely warns read as a failed run. This file's own
 # trunc-early fixture caught it.
 #
+# Then it was `^Error:` alone, and THAT was too narrow — the correction
+# overshot. A warning promoted to an error (this repo builds with warnings as
+# errors) is printed by the compiler as
+#
+#     Error (warning 32 [unused-value-declaration]): unused value foo.
+#
+# which has no colon after `Error`, so `^Error:` never matched it. Measured on a
+# real captured log of exactly that failure: exit 0 and a clean
+# "46 cases across 6 suites" for a run whose build never completed — the precise
+# false green this gate exists to prevent, reintroduced by its own fix.
+#
+# The pattern therefore accepts `Error:` and `Error (<...>):`, and NOT a bare
+# `^Error ` — a test that prints "Error handling works" starts a line with
+# `Error ` and must not be read as a broken build. Requiring the closing `):`
+# keeps the parenthesised form tight.
+#
 # Usage:
 #   scripts/test-suite-counts.sh [--min-suites N] [--dune-exit N] <logfile>
 #   dune test --force 2>&1 | scripts/test-suite-counts.sh [--min-suites N]
@@ -282,15 +298,20 @@ text = sys.stdin.read() if src == "-" else open(src, errors="replace").read()
 # cases, so this separates "the build died" from "a test failed" — which is why
 # they get different exit codes rather than one catch-all.
 #
-# `^Error:` ONLY, deliberately. The first version also matched `^File "`, on the
-# reasoning that dune prints `File "x.ml", line 1:` above the error. It does —
-# but it prints the same line above a WARNING, and above a truncated preamble.
-# This file's own trunc-early fixture opens with `File "sarek/tests/unit/dune",
-# line 1, characters 0-0:` and started reporting exit 5 for a log whose build
-# never failed. A tree that merely warns would have been called a failed run.
-# The error line is the one that means an error; the File line means dune has
-# something to say about a file.
-build_errors = re.findall(r"(?m)^Error:", text)
+# An `Error` LABEL at column 0, deliberately not `^File "`. The first version
+# also matched `^File "`, on the reasoning that dune prints `File "x.ml", line 1:`
+# above the error. It does — but it prints the same line above a WARNING, and
+# above a truncated preamble. This file's own trunc-early fixture opens with
+# `File "sarek/tests/unit/dune", line 1, characters 0-0:` and started reporting
+# exit 5 for a log whose build never failed. A tree that merely warns would have
+# been called a failed run. The error line is the one that means an error; the
+# File line means dune has something to say about a file.
+#
+# Both spellings of the label, because narrowing to `^Error:` alone missed
+# warning-as-error ("Error (warning 32 [...]): ...") and reintroduced a false
+# green — see the header. A bare `^Error ` is NOT accepted: a test printing
+# "Error handling works" would match it.
+build_errors = re.findall(r"(?m)^Error(?::| \([^)\n]*\):)", text)
 
 # Alcotest: "Test Successful in 0.004s. 61 tests run." and the SINGULAR
 # "1 test run." / "0 test run.". Matching `tests?` is the whole point.
@@ -486,5 +507,19 @@ python3 -c "$PYPROG" "$SRC" "$MIN_SUITES" "$DUNE_EXIT"
 #   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
 #   expect-exit: 4
 #   expect-message: failing case
+#
+# mutation: warning-as-error
+#   desc: the same shape as build-failed but with the spelling the compiler actually uses when a warning is promoted -- `Error (warning 32 [...]):`, no colon after Error. The `^Error:` pattern missed it entirely and reported a clean total for a run whose build never completed. Kept as its own mutation because build-failed passes on a pattern that has this hole.
+#   apply: printf 'File "sarek/ppx/Sarek_lower_ir.ml", line 850, characters 16-30:\nError (warning 26 [unused-var]): unused variable helper_binders.\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
+#   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
+#   expect-exit: 5
+#   expect-message: dune/compiler error marker
 # END prove-red-spec
+#
+# The other polarity -- a test that PRINTS "Error handling works" must NOT read
+# as a broken build -- is deliberately NOT a mutation above. A prove-red mutation
+# asserts the subject CATCHES a defect; a case whose correct answer is the
+# baseline verdict asserts the opposite, and prove-red.sh's immune-checker
+# rejects it by design ("asserts the subject did not notice"). That control lives
+# in scripts/test-suite-counts.test.sh, which is where a negative case belongs.
 # ---------------------------------------------------------------------------

--- a/scripts/test-suite-counts.sh
+++ b/scripts/test-suite-counts.sh
@@ -107,8 +107,9 @@
 # reported is exit 5, not 4. That is deliberate. Its FAIL tally is taken over a
 # partial run, so 4 ("complete, N failures") would understate it.
 #
-# The build-failure check is a LOG HEURISTIC (`^Error:` at column 0, which is
-# dune's own formatting), and heuristics in a gate are what this file
+# The build-failure check is a LOG HEURISTIC (an `Error:` or `Error (<...>):`
+# label at column 0, which is dune's own formatting; the two spellings are
+# argued below), and heuristics in a gate are what this file
 # spends 60 lines arguing against. So it is the fallback, not the mechanism:
 # --dune-exit lets the caller pass the one authoritative fact the script cannot
 # derive from a log. Measured before choosing the pattern: 0 matches in a green
@@ -292,8 +293,9 @@ min_suites = int(sys.argv[2])
 dune_exit = sys.argv[3] if len(sys.argv) > 3 else ""
 text = sys.stdin.read() if src == "-" else open(src, errors="replace").read()
 
-# Dune reports a compile error as `Error: ...` at column 0, while alcotest
-# indents everything it prints. Measured before the pattern was chosen: 0
+# Dune reports a compile error with an `Error` label at column 0 -- `Error: ...`
+# or `Error (warning N [...]): ...` -- while alcotest indents everything it
+# prints. Measured before the pattern was chosen: 0
 # matches in a green 4885-line log AND 0 in a log of genuinely FAILING alcotest
 # cases, so this separates "the build died" from "a test failed" — which is why
 # they get different exit codes rather than one catch-all.

--- a/scripts/test-suite-counts.test.sh
+++ b/scripts/test-suite-counts.test.sh
@@ -11,6 +11,15 @@ set -uo pipefail
 CNT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-suite-counts.sh"
 [ -x "$CNT" ] || { echo "FAIL: $CNT not found or not executable"; exit 2; }
 
+# Real captured dune logs, used where the exact spelling the compiler emits is
+# the subject. Asserted present rather than left to fail as a mystery exit code:
+# a missing fixture makes `cat` produce nothing, which the counter reports as
+# "no output recognised" (2) — a number that looks like an unrelated bug.
+FIXTURES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/prove-red-fixtures"
+for f in dune-test-sample-log.txt dune-test-warning-as-error-log.txt; do
+  [ -f "$FIXTURES/$f" ] || { echo "FAIL: fixture $FIXTURES/$f is missing"; exit 2; }
+done
+
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/suite-counts-test.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -303,6 +312,40 @@ Error: Syntax error
 LOG
 "$CNT" --min-suites 0 "$TMP/both.log" >/dev/null 2>&1
 check "a died run outranks its failing cases (5, not 4)" "$?" "5"
+
+# WARNING-AS-ERROR. This repo builds with warnings as errors, and the compiler
+# prints that failure as `Error (warning 32 [...]): ...` — no colon after
+# `Error`, so the `^Error:` pattern this file's own gate narrowed to never
+# matched it. Measured on the real captured log below: exit 0 and a clean
+# "46 cases across 6 suites" for a run whose build never completed.
+#
+# The fixture is a REAL 271-line dune log rather than a two-line heredoc,
+# because the whole defect is in the exact spelling the compiler emits — a
+# hand-written approximation is where a wrong guess about that spelling hides.
+"$CNT" --min-suites 0 "$FIXTURES/dune-test-warning-as-error-log.txt" >/dev/null 2>&1
+check "a warning-as-error build failure exits 5, not 0" "$?" "5"
+
+# The composite is the dangerous shape, and the one the plausibility floor does
+# NOT save: enough suites completed to clear the floor, then the build died. The
+# single-fixture case above is only 6 suites, so on its own it would also have
+# been caught by the floor for an unrelated reason.
+{ cat "$FIXTURES/dune-test-sample-log.txt" "$FIXTURES/dune-test-sample-log.txt" \
+       "$FIXTURES/dune-test-sample-log.txt" "$FIXTURES/dune-test-sample-log.txt" \
+       "$FIXTURES/dune-test-sample-log.txt"
+  printf 'File "sarek/ppx/Sarek_lower_ir.ml", line 850, characters 16-30:\n'
+  printf 'Error (warning 26 [unused-var]): unused variable helper_binders.\n'
+} > "$TMP/warn-after-suites.log"
+"$CNT" "$TMP/warn-after-suites.log" >/dev/null 2>&1
+check "warning-as-error AFTER enough suites to clear the floor is 5, not 0" "$?" "5"
+
+# The control that keeps the widened pattern from becoming the `^File "` mistake
+# in the other direction. A bare `^Error ` is NOT an error label: a test that
+# prints a line starting with "Error handling..." must still read as a clean run.
+{ cat "$FIXTURES/dune-test-sample-log.txt"
+  printf 'Error handling works as expected\n'
+} > "$TMP/prints-error-word.log"
+"$CNT" --min-suites 0 "$TMP/prints-error-word.log" >/dev/null 2>&1
+check "  (control) a test PRINTING \"Error handling...\" is still 0" "$?" "0"
 
 # Argument handling: a malformed invocation is an error, not a default.
 "$CNT" --min-suites nope "$TMP/plausible.log" >/dev/null 2>&1


### PR DESCRIPTION
A false green in merged `main`, in the gate whose whole purpose is refusing a count for a run that did not complete — introduced by the fix that closed that class.

## What happened

#357 narrowed the build-error heuristic from `^Error:|^File "` to `^Error:`, because `^File "` also matches the line dune prints above a *warning* (and above a truncated preamble). That correction was right, and it overshot. This repo builds with warnings as errors, and the compiler spells that failure:

```
Error (warning 32 [unused-value-declaration]): unused value foo.
```

No colon after `Error`. `^Error:` never matched it.

## Measured

On a real captured log of that failure:

| input | before | after |
|---|---|---|
| warning-as-error log (6 suites) | **exit 0**, "46 cases across 6 suites" | exit 5 |
| enough suites to clear the floor, then warning-as-error | **exit 0**, "120 cases across 20 suites" | exit 5 |
| plain `Error:` | exit 5 | exit 5 |
| green log | exit 0 | exit 0 |
| a test *printing* "Error handling works" | exit 0 | exit 0 |

The second row is the dangerous one. The small case was only caught by the plausibility floor, for an unrelated reason; once enough suites finish, nothing catches it.

## The fix

The pattern accepts `Error:` and `Error (<...>):`, and **not** a bare `^Error ` — a test printing `Error handling works` starts a line that way. Requiring the closing `):` keeps the parenthesised form tight.

Pinned from both sides, which is the point of the two new cases plus a control:

- revert to `^Error:` → the two new failure cases go red
- widen to bare `^Error` → the new control goes red

45 passed / 0 failed (was 42). prove-red: 4 subjects, 17 mutations, all declared-red.

## Provenance

The fixture is a real 271-line dune log, not a heredoc, because the entire defect is in the exact spelling the compiler emits — a hand-written approximation is precisely where a wrong guess about that spelling hides. It is salvaged from the abandoned PR #351, whose `warning-as-error` case **would have caught this**. That PR carries four such captured logs; this takes the one with a live defect behind it.

## Notes

The opposite-polarity control is deliberately *not* a prove-red mutation. `prove-red.sh`'s immune-checker rejects a mutation whose expectation equals the baseline, correctly — that asserts the subject did not notice. It rejected my first attempt to put it there, so the control lives in the test suite where a negative case belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of compiler errors and warnings treated as errors in test output.
  - Prevented ordinary messages beginning with “Error handling...” from being incorrectly classified as build failures.

- **Tests**
  - Added coverage for warning-as-error scenarios, including failures appearing after extensive test output.
  - Added captured test output to validate detection against real compiler logs.
  - Added checks ensuring required test fixtures are available before validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->