### PR TITLE
feat(soa): enforce the `~fields` precondition at launch instead of documenting it

### DIFF
--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -172,27 +172,31 @@ and proven. When it lands, extend `test_soa_emitter_equiv` to drive SoA through
 > returns 64/64. The collision is one-directional and fully closed, because a user
 > param cannot itself be `sarek_`-prefixed (#258 reserves it).
 >
-> Do NOT redo this as part of Tier 1c. The original text is kept below because it
-> records why the hazard was real and why (a) was chosen over (b).
+> Do NOT redo this as part of Tier 1c.
 >
-> **PRECONDITION — generated param-name namespace (latent today, MUST fix in
-> Tier 1c).** The emitter mangles each SoA leaf param as
-> `param_<vec>_soa_<field>` (`Sarek_ir_ptx_kernel.emit_params`). This can
-> **collide** with a distinct user vector/scalar parameter whose own generated
-> name is `param_<vec>_soa_<field>` — e.g. a user param literally named
-> `x_soa_y` alongside a SoA vector `x` with field `y`. The reserved `sarek_`
-> prefix does **not** cover this infix mangle. It is unreachable today because
-> `~soa_params` is only ever passed by the emitter's own tests (never from user
-> code), but the moment Tier 1c lets a user opt a vector into SoA it becomes a
-> real (silently-wrong-PTX) hazard. Tier 1c **MUST** close it, by either:
-> (a) `sarek_`-prefixing the generated SoA params
-> (`param_sarek_soa_<vec>_<field>`) so they live in the already-reserved
-> namespace and cannot alias a user name; or (b) validating the kernel's param
-> names against the generated SoA pattern and rejecting a collision with a
-> precise error. Option (a) is preferred (no user-facing rejection, consistent
-> with the existing `sarek_<vec>_length` convention). Add a regression test that
-> a kernel mixing a SoA vector `x` (field `y`) with a scalar param `x_soa_y`
-> compiles to distinct PTX operands.
+> #### Historical record — why the hazard was real, and why (a) beat (b)
+>
+> Rewritten into the past tense after review on PR #366: the paragraph below used
+> to be a live "MUST fix in Tier 1c" instruction, and leaving it in the
+> imperative next to a CLOSED banner is exactly how completed work gets reopened
+> by a reader who skims. Kept for the rationale, not as a task.
+>
+> The emitter **used to** mangle each SoA leaf param as `param_<vec>_soa_<field>`
+> (`Sarek_ir_ptx_kernel.emit_params`). That **could** collide with a distinct user
+> vector/scalar parameter whose own generated name was `param_<vec>_soa_<field>` —
+> e.g. a user param literally named `x_soa_y` alongside a SoA vector `x` with
+> field `y`. The reserved `sarek_` prefix did **not** cover that infix mangle. It
+> was unreachable at the time because `~soa_params` was only ever passed by the
+> emitter's own tests, never from user code — but it would have become a real
+> silently-wrong-PTX hazard the moment Tier 1c let a user opt a vector into SoA.
+>
+> Two closures were considered: (a) `sarek_`-prefixing the generated SoA params so
+> they live in the already-reserved namespace and cannot alias a user name; or
+> (b) validating the kernel's param names against the generated SoA pattern and
+> rejecting a collision with a precise error. **(a) was chosen** — no user-facing
+> rejection, and consistent with the existing `sarek_<vec>_length` convention.
+> (b) would have made a legal program fail for a reason the user could not act on
+> without renaming their own parameter.
 
 ### 2. `ld.global.nc` for read-only params (opt-ptx-passes.md pass 3 — High, cost S)
 

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -115,6 +115,24 @@ a single custom-vector argument.)
 The emitter is ready; what remains is making SoA reachable without the
 codegen-level `~soa_params` knob:
 
+> **STATUS (2026-07-29) — partly superseded.** The host and launch halves were
+> since built, but NOT by the design sketched below. `Spoc_core.Soa_vector` layers
+> SoA storage *above* `Vector` + `Soa` (an AoS vector as source of truth + N
+> width-matched scalar leaf vectors) instead of adding a `host_storage` GADT
+> constructor, and `Sarek.Soa_launch.run_soa` is a separate CUDA/PTX-only entry
+> point instead of generalising `Execute.run`. That deliberately avoided the ~25
+> forced GADT match sites and the 1-buffer-per-device table, at the cost of not
+> being *transparent*. So what actually remains of this item is the transparency
+> itself — `Vector.create ~layout:SoA` and auto-dispatch from the generic
+> `Execute.run` — and the bullets below describe the design that would be needed
+> for it, not work that is wholly outstanding. Read them as the plan for
+> transparency, not as a to-do list of missing plumbing.
+>
+> Separately shipped on the launch path: the `~fields` precondition is now
+> ENFORCED there (PR #366) rather than documented — `run_soa` compares the
+> declared plan against the kernel's authoritative `TRecord` and refuses a
+> mismatch instead of transposing silently-corrupt data.
+
 - **Host storage variant** (`Spoc_core_base.host_storage`, GADT at
   `sarek/core_base/Spoc_core_base.ml:111-120`): add `Custom_storage_soa` holding
   the AoS host buffer (keep host `get`/`set` and the PPX accessors **unchanged**
@@ -144,6 +162,19 @@ bulk of the SoA cost; it was descoped here so the emitter could ship complete
 and proven. When it lands, extend `test_soa_emitter_equiv` to drive SoA through
 `Vector.create ~layout:SoA` + `run_vectors`, and add the i32/i64 device rows.
 
+> **✅ CLOSED (2026-07-29) — was: PRECONDITION, generated param-name namespace.**
+> Option (a) shipped in `63ab6df1`: the emitter now mangles leaves as
+> `param_sarek_soa_<vec>_<field>`, inside the already-reserved `sarek_`
+> namespace, so it cannot alias a user name. The requested regression test exists
+> — `test_soa_param_name_collision_safe` in `sarek/tests/unit/test_ptx_snapshot.ml`
+> — and was re-verified as a real gate rather than a passing formality: reverting
+> the mangle to the old infix form turns that case red (5 failures), restoring it
+> returns 64/64. The collision is one-directional and fully closed, because a user
+> param cannot itself be `sarek_`-prefixed (#258 reserves it).
+>
+> Do NOT redo this as part of Tier 1c. The original text is kept below because it
+> records why the hazard was real and why (a) was chosen over (b).
+>
 > **PRECONDITION — generated param-name namespace (latent today, MUST fix in
 > Tier 1c).** The emitter mangles each SoA leaf param as
 > `param_<vec>_soa_<field>` (`Sarek_ir_ptx_kernel.emit_params`). This can

--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -35,13 +35,112 @@ type soa_arg =
   | SA_Soa : 'a Soa_vector.t -> soa_arg
   | SA_Reg of Execute.vector_arg
 
-(** Names of the kernel's [DParam]s, in declaration order. *)
-let kernel_param_names (ir : Sarek_ir_types.kernel) : string list =
+(** The kernel's [DParam]s as [(name, array element type)], in declaration
+    order. ONE source of positional truth: [run_soa] aligns [args] with this
+    list by index, both to name the SoA params and to validate their layout, so
+    the two must not be derived by separate traversals that could disagree. *)
+let kernel_params_info (ir : Sarek_ir_types.kernel) :
+    (string * Sarek_ir_types.elttype option) list =
   List.filter_map
     (function
-      | Sarek_ir_types.DParam (v, _) -> Some v.Sarek_ir_types.var_name
+      | Sarek_ir_types.DParam (v, arr) ->
+          Some
+            ( v.Sarek_ir_types.var_name,
+              Option.map (fun a -> a.Sarek_ir_types.arr_elttype) arr )
       | _ -> None)
     ir.Sarek_ir_types.kern_params
+
+(** Names of the kernel's [DParam]s, in declaration order. *)
+let kernel_param_names (ir : Sarek_ir_types.kernel) : string list =
+  List.map fst (kernel_params_info ir)
+
+let describe_leaf (l : Soa.leaf) : string =
+  Printf.sprintf
+    "%s:%s@%d+%d"
+    l.Soa.path
+    (Sarek_ir_pp.string_of_elttype l.Soa.ty)
+    l.Soa.aos_offset
+    l.Soa.size
+
+let describe_leaves (leaves : Soa.leaf list) : string =
+  String.concat ", " (List.map describe_leaf leaves)
+
+(* The [~fields] precondition, ENFORCED rather than documented.
+   [Soa_vector.create] takes the record's field layout as an argument because the
+   PPX [custom_type] carries no layout, and its .mli states that a wrong list
+   (wrong order, wrong widths, missing/extra field) makes scatter/gather
+   transpose against the wrong byte offsets and yields "silently transposed /
+   corrupted data with no error" — adding that it "cannot be checked".
+   That is true where it is written, at [create], which never sees a kernel. It
+   is NOT true HERE: [run_soa] receives the kernel IR, whose [DParam] carries the
+   authoritative [TRecord] for that very parameter. So the launch can derive the
+   real plan and compare it against the one the vector will actually transpose
+   with, turning silent corruption into a refusal at the last moment before any
+   data moves.
+   Compared: the LEAF LIST and the AoS stride — the two things scatter/gather
+   index with. Deliberately NOT the plan's [name]: the declared and authoritative
+   plans get their names from different places (the caller's [~fields] label vs
+   the record's own type name), so comparing it would reject correct programs.
+   An assertion wider than the property is its own defect. *)
+let check_soa_layout ~(param : string)
+    ~(kernel_ty : Sarek_ir_types.elttype option) ~(declared : Soa.plan) : unit =
+  match kernel_ty with
+  | None ->
+      raise_error
+        (Type_mismatch
+           {
+             expected = "an array parameter of flat-record element type";
+             actual = "a non-array (scalar) parameter";
+             context =
+               Printf.sprintf
+                 "SoA argument bound to kernel parameter %S: a SoA vector \
+                  supplies N leaf base pointers, which only an array parameter \
+                  can receive"
+                 param;
+           })
+  | Some ty -> (
+      match Soa.plan_of_elttype ty with
+      | exception Soa.Unsupported msg ->
+          raise_error
+            (Type_mismatch
+               {
+                 expected = "a flat-record element type (SoA-representable)";
+                 actual = Sarek_ir_pp.string_of_elttype ty;
+                 context =
+                   Printf.sprintf
+                     "SoA argument bound to kernel parameter %S: %s"
+                     param
+                     msg;
+               })
+      | authoritative ->
+          if
+            authoritative.Soa.leaves <> declared.Soa.leaves
+            || authoritative.Soa.aos_stride <> declared.Soa.aos_stride
+          then
+            raise_error
+              (Type_mismatch
+                 {
+                   expected =
+                     Printf.sprintf
+                       "leaves [%s] stride %d (from the kernel's record type)"
+                       (describe_leaves authoritative.Soa.leaves)
+                       authoritative.Soa.aos_stride;
+                   actual =
+                     Printf.sprintf
+                       "leaves [%s] stride %d (from the ~fields given to \
+                        Soa_vector.create)"
+                       (describe_leaves declared.Soa.leaves)
+                       declared.Soa.aos_stride;
+                   context =
+                     Printf.sprintf
+                       "SoA layout for kernel parameter %S. The ~fields list \
+                        must match the record's declaration order and types \
+                        exactly; it does not, so scatter/gather would \
+                        transpose against the wrong byte offsets and the \
+                        kernel would read silently corrupted data. Refused \
+                        before any transfer"
+                       param;
+                 }))
 
 (** [run_source_arg]s for one regular vector: (buffer, length). *)
 let rs_args_of_reg_vector (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
@@ -114,6 +213,50 @@ let run_soa ~(device : Device.t) ~(ir : Sarek_ir_types.kernel)
              message = "Backend not found in registry";
            })
   | Some (module B : Framework_sig.BACKEND) ->
+      (* SoA parameter names = kernel param name at each SA_Soa position. *)
+      let params_info = kernel_params_info ir in
+      let param_names = List.map fst params_info in
+      (* Enforce the ~fields precondition BEFORE anything is scattered or
+         transferred: a mismatch is refused at zero cost, and no device buffer is
+         left holding half-transposed data.
+         ORDERED BEFORE the PTX gate, deliberately. A wrong ~fields list is an
+         error in the CALL — true whatever device it is dispatched to — so
+         reporting it first is more useful than telling the caller to switch
+         devices and only then, on a CUDA host, discovering their layout was
+         wrong all along. It also makes this check reachable on a machine with no
+         NVIDIA device, which is what lets it be tested at all; behind the gate
+         it could only ever run where the gate passes. A CORRECT call is
+         unaffected: the layout check passes and the gate then fires exactly as
+         before. *)
+      List.iteri
+        (fun i arg ->
+          match arg with
+          | SA_Soa sv -> (
+              match List.nth_opt params_info i with
+              | Some (name, kernel_ty) ->
+                  check_soa_layout
+                    ~param:name
+                    ~kernel_ty
+                    ~declared:(Soa_vector.plan sv)
+              | None ->
+                  raise_error
+                    (Type_mismatch
+                       {
+                         expected =
+                           Printf.sprintf
+                             "at most %d arguments (the kernel's parameter \
+                              count)"
+                             (List.length params_info);
+                         actual =
+                           Printf.sprintf "%d arguments" (List.length args);
+                         context =
+                           Printf.sprintf
+                             "SoA argument at position %d has no corresponding \
+                              kernel parameter"
+                             i;
+                       }))
+          | SA_Reg _ -> ())
+        args ;
       (* Gate: SoA lowering is PTX-only. Never emit the SoA N-pointer ABI for a
          backend that generates AoS code. *)
       if not (List.mem Framework_sig.PTX B.supported_source_langs) then
@@ -127,8 +270,6 @@ let run_soa ~(device : Device.t) ~(ir : Sarek_ir_types.kernel)
                     the AoS host vector through run_vectors for other \
                     backends)";
              }) ;
-      (* SoA parameter names = kernel param name at each SA_Soa position. *)
-      let param_names = kernel_param_names ir in
       let soa_params =
         List.filteri
           (fun i _ ->

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -451,13 +451,198 @@ let check_roundtrip dev n =
       false
   end
 
+(* ── the ~fields precondition is ENFORCED, not just documented ──────────────
+   Soa_vector.create takes the record's field layout as an argument, and its .mli
+   warns that a wrong list transposes against the wrong byte offsets and yields
+   "silently transposed / corrupted data with no error" — adding that it "cannot
+   be checked". True at [create], which has no kernel. False at the LAUNCH, which
+   holds the kernel IR and therefore the authoritative TRecord. These cases pin
+   that the launch compares the two and refuses.
+
+   Device-independent by construction: the check is a pure function of (param
+   name, kernel element type, declared plan), so it runs on this machine with no
+   NVIDIA device. It is also ordered BEFORE run_soa's PTX gate precisely so the
+   refusal is reachable off a CUDA host — behind the gate it could only ever fire
+   where the gate passes, which is what would have made it untestable here. *)
+
+let xyz_ty =
+  Sarek_ir_types.TRecord
+    ("point3d", [("x", TFloat32); ("y", TFloat32); ("z", TFloat32)])
+
+let mixed_ty = Sarek_ir_types.TRecord ("mixed", [("a", TInt32); ("b", TFloat64)])
+
+(* [check_soa_layout] raises via Execute_error.raise_error; a refusal is any
+   Execution_error whose rendering mentions the parameter. Asserting on the
+   MESSAGE as well as the exception, because "raised something" would also be
+   satisfied by an unrelated failure inside the plan builders. *)
+let contains hay needle =
+  let nh = String.length hay and nn = String.length needle in
+  let rec go i =
+    if i + nn > nh then false
+    else if String.sub hay i nn = needle then true
+    else go (i + 1)
+  in
+  nn = 0 || go 0
+
+let refuses ~label ~param ~kernel_ty ~declared ~expect_substr =
+  match Sarek.Soa_launch.check_soa_layout ~param ~kernel_ty ~declared with
+  | () ->
+      Printf.printf "  %-56s FAIL (accepted a mismatch)\n%!" label ;
+      false
+  | exception Sarek.Execute_error.Execution_error e ->
+      let msg = Sarek.Execute_error.error_to_string e in
+      let has_param = contains msg param in
+      let has_expect = contains msg expect_substr in
+      if has_param && has_expect then (
+        Printf.printf "  %-56s OK (refused)\n%!" label ;
+        true)
+      else (
+        Printf.printf
+          "  %-56s FAIL (refused, but message names neither %S nor %S: %s)\n%!"
+          label
+          param
+          expect_substr
+          msg ;
+        false)
+
+let check_layout_validation () =
+  let authoritative = Soa.plan_of_elttype xyz_ty in
+  let ok = ref true in
+  print_endline "  --- ~fields precondition enforced at launch ---" ;
+  (* POSITIVE CONTROL first. Without it, "refuses a wrong list" and "refuses
+     every list" are the same observation, and the second would make SoA
+     unusable rather than safe. *)
+  if
+    match
+      Sarek.Soa_launch.check_soa_layout
+        ~param:"pts"
+        ~kernel_ty:(Some xyz_ty)
+        ~declared:authoritative
+    with
+    | () -> true
+    | exception e ->
+        Printf.printf
+          "  %-56s FAIL (rejected the CORRECT layout: %s)\n%!"
+          "matching ~fields is accepted"
+          (Printexc.to_string e) ;
+        false
+  then Printf.printf "  %-56s OK\n%!" "matching ~fields is accepted"
+  else ok := false ;
+  (* Wrong ORDER: same fields, same widths, permuted. The offsets move, so the
+     transpose would read every field from the wrong column. *)
+  if
+    not
+      (refuses
+         ~label:"permuted ~fields is refused"
+         ~param:"pts"
+         ~kernel_ty:(Some xyz_ty)
+         ~declared:
+           (Soa.plan
+              ~name:"point3d"
+              [("y", Sarek_ir_types.TFloat32); ("x", TFloat32); ("z", TFloat32)])
+         ~expect_substr:"wrong byte offsets")
+  then ok := false ;
+  (* Wrong WIDTH at the same position: f32 declared where the record has f64.
+     This is the case a name-and-order-only comparison would accept. *)
+  if
+    not
+      (refuses
+         ~label:"wrong leaf WIDTH is refused"
+         ~param:"m"
+         ~kernel_ty:(Some mixed_ty)
+         ~declared:
+           (Soa.plan
+              ~name:"mixed"
+              [("a", Sarek_ir_types.TInt32); ("b", TFloat32)])
+         ~expect_substr:"wrong byte offsets")
+  then ok := false ;
+  (* MISSING field: fewer leaves than the record has. *)
+  if
+    not
+      (refuses
+         ~label:"missing field is refused"
+         ~param:"pts"
+         ~kernel_ty:(Some xyz_ty)
+         ~declared:
+           (Soa.plan
+              ~name:"point3d"
+              [("x", Sarek_ir_types.TFloat32); ("y", TFloat32)])
+         ~expect_substr:"wrong byte offsets")
+  then ok := false ;
+  (* A SoA argument bound to a SCALAR parameter: there is no record to compare
+     against, and N leaf pointers cannot bind to it. *)
+  if
+    not
+      (refuses
+         ~label:"SoA bound to a non-array param is refused"
+         ~param:"scalar"
+         ~kernel_ty:None
+         ~declared:authoritative
+         ~expect_substr:"non-array")
+  then ok := false ;
+  !ok
+
+(* The WIRING, which the direct calls above cannot establish: run_soa must
+   actually consult the check. Driven on ANY device, including non-PTX, and that
+   is the point — a mismatched ~fields list must surface the LAYOUT error rather
+   than the CUDA/PTX device gate. If the check sat behind the gate (where it
+   originally was) this case would report the gate message instead, so it pins
+   the ordering as well as the call. *)
+let check_layout_wired dev =
+  let ir = ir_of p3_kernel in
+  let sv =
+    (* Permuted vs point3d's declaration order (x, y, z). Same widths, so only
+       the offsets/paths disagree — the subtle end of the mismatch space. *)
+    Soa_vector.create
+      point3d_custom
+      ~fields:Sarek_ir_types.[("y", TFloat32); ("x", TFloat32); ("z", TFloat32)]
+      8
+  in
+  let out = Vector.create Vector.float32 8 in
+  match
+    Soa_launch.run_soa
+      ~device:dev
+      ~ir
+      ~args:
+        [
+          Soa_launch.SA_Soa sv;
+          Soa_launch.SA_Reg (Sarek.Execute.Vec out);
+          Soa_launch.SA_Reg (Sarek.Execute.Int 8);
+        ]
+      ~block:(dims 8)
+      ~grid:(dims 1)
+      ()
+  with
+  | () ->
+      Printf.printf
+        "  %-56s FAIL (ran with a mismatched ~fields)\n%!"
+        "run_soa consults the layout check"
+      |> fun () -> false
+  | exception Sarek.Execute_error.Execution_error e ->
+      let msg = Sarek.Execute_error.error_to_string e in
+      if contains msg "wrong byte offsets" then (
+        Printf.printf "  %-56s OK\n%!" "run_soa consults the layout check" ;
+        true)
+      else (
+        Printf.printf
+          "  %-56s FAIL (raised, but not the layout error: %s)\n%!"
+          "run_soa consults the layout check"
+          msg ;
+        false)
+
 let () =
   Benchmarks.init () ;
   let n = 1024 in
+  (* Device-independent, so it runs BEFORE the no-device early exit — otherwise
+     a machine with no device would report SKIPPED while silently not checking a
+     property that needs no device at all. *)
+  let layout_ok = check_layout_validation () in
   let devs = Device.all () in
   if Array.length devs = 0 then (
-    print_endline "test_soa_emitter_equiv: no device - SKIPPED" ;
-    exit 0) ;
+    print_endline
+      "test_soa_emitter_equiv: no device - SKIPPED (layout validation still \
+       checked above)" ;
+    exit (if layout_ok then 0 else 1)) ;
   let any_ptx = Array.exists is_ptx devs in
   if not any_ptx then
     print_endline
@@ -476,7 +661,10 @@ let () =
       if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;
+      (* Wiring + ordering: a mismatched ~fields must surface the LAYOUT error,
+         not the device gate, on this very non-PTX device. *)
+      if not (check_layout_wired dev) then ok := false ;
       (* Leaf-write round-trip (D2H + gather) on CUDA/PTX. *)
       if is_ptx dev && not (check_roundtrip dev n) then ok := false)
     devs ;
-  if not !ok then exit 1
+  if not (!ok && layout_ok) then exit 1


### PR DESCRIPTION
Tier 1c (backlog-54), first shipped slice — turning a documented silent-corruption footgun into a refusal.

## The defect

`Soa_vector.create` takes the record's field layout as an argument, because the PPX `custom_type` carries no layout. Its own `.mli` says what happens when that list is wrong:

> If it disagrees with the actual record layout (wrong order, wrong widths, missing/extra field), scatter/gather transpose against the wrong byte offsets and the vector carries **silently transposed / corrupted data with no error**.

…and adds that it **"cannot be checked"**.

That is true where it is written. `create` never sees a kernel. It is **not** true at the launch: `run_soa` already receives the kernel IR, whose `DParam` carries the authoritative `TRecord` for that very parameter. So the launch can derive the real plan with `Soa.plan_of_elttype` and compare it against the plan the vector will actually transpose with — before a single byte moves.

## What is compared, and what deliberately is not

The **leaf list** and the **AoS stride**: the two things `scatter`/`gather` index with.

Not the plan's `name`. The declared and authoritative plans take their names from different places (the caller's `~fields` label vs the record's own type name), so comparing it would reject correct programs. An assertion wider than the property is its own defect.

## Ordering is a decision, not an accident

The check runs **before** the CUDA/PTX gate:

- A wrong `~fields` list is an error in the *call*, true whatever device it is dispatched to. Reporting it first beats telling the caller to switch devices and only then, on a CUDA host, discovering the layout was wrong all along.
- It makes the check reachable **without an NVIDIA device**. Behind the gate it could only ever run where the gate passes — which would have left it untestable on this machine.
- A correct call is unaffected: the layout check passes and the gate fires exactly as before.

## Coverage

Six cases. Positive control **first**, so "refuses a wrong list" can never be confused with "refuses everything" (which would make SoA unusable rather than safe):

| case | asserts |
|---|---|
| matching `~fields` | ACCEPTED |
| permuted order | refused |
| wrong leaf width at the same offset | refused — the case a name-and-order-only compare would accept |
| missing field | refused |
| SoA bound to a scalar param | refused |
| `run_soa` consults the check | wiring **and** ordering, on every device present |

## Proven red, twice

- **No-op the check** → 11 failures, including the wiring case.
- **Move the check back behind the PTX gate** → the wiring case fails naming the *device-gate* message instead of the layout error. That is what pins the ordering rather than merely asserting it.

## Two stale premises found while starting this item

Both already done; the handoff doc is out of date on them:

- The `tier1b` handoff's **"MUST fix in Tier 1c"** SoA param-name collision (`param_<vec>_soa_<field>` aliasing a user param named `x_soa_y`) landed in `63ab6df1` as `param_sarek_soa_*`. Its regression test exists **and** I confirmed it goes red when the prefix is removed — so it is a real gate, not theatre.
- `Soa_vector` and `Soa_launch` already exist as the host and launch halves.

What genuinely remains for *transparent* dispatch is `Vector.create ~layout:SoA` and generic `Execute.run` auto-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added fast validation of custom SoA `~fields` against the kernel’s expected record layout.
  * Now rejects mismatches (field order/widths, missing fields, incorrect leaf list + AoS stride, and binding SoA to non-array/scalar parameters) with immediate `Type_mismatch`/layout-related errors.
  * Improves error clarity by ensuring messages reference the parameter and expected offset details.

* **Tests**
  * Expanded end-to-end SoA emitter equivalence coverage, including detailed failure cases and error-message verification.
  * Confirms the validation is enforced in the real execution path across devices.

* **Documentation**
  * Updated Tier 1c handoff notes to reflect the current SoA transparency and `~fields` enforcement status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->