### PR TITLE
fix(counter): a `dune --verbose` command failure is a failed run too

### DIFF
--- a/scripts/prove-red-fixtures/dune-verbose-command-exit-log.txt
+++ b/scripts/prove-red-fixtures/dune-verbose-command-exit-log.txt
@@ -1,0 +1,333 @@
+Shared cache enabled cache_enabled: Disabed
+Shared cache location root_dir: "/home/user/.cache/dune/db"
+Workspace root root: "/workspace/sarek"
+Dune context context: { name = "default"
+; kind = "default"
+; profile = Dev
+; merlin = true
+; fdo_target_exe = None
+; build_dir = In_build_dir "default"
+; instrument_with = []
+}
+Running[1]: (cd _build/default && /workspace/sarek/_opam/bin/ocamlopt.opt -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -I spoc/registry/test/.test_sarek_registry.eobjs/byte -I spoc/registry/test/.test_sarek_registry.eobjs/native -I spoc/registry/.sarek_registry.objs/byte -I spoc/registry/.sarek_registry.objs/native -cmi-file spoc/registry/test/.test_sarek_registry.eobjs/byte/dune__exe__Test_sarek_registry.cmi -no-alias-deps -opaque -o spoc/registry/test/.test_sarek_registry.eobjs/native/dune__exe__Test_sarek_registry.cmx -c -impl spoc/registry/test/test_sarek_registry.ml)
+Running[2]: (cd _build/default/spoc/ir/test && ./test_sarek_ir_types.exe)
+Output[2]:
+Sarek_ir_types tests:
+  memspace: OK
+  elttype primitives: OK
+  elttype record: OK
+  elttype variant: OK
+  elttype array: OK
+  elttype vec: OK
+  var: OK
+  var mutable: OK
+  const int32: OK
+  const int64: OK
+  const float32: OK
+  const float64: OK
+  const bool: OK
+  const unit: OK
+  binop: OK
+  unop: OK
+  expr const: OK
+  expr var: OK
+  expr binop: OK
+  expr intrinsic: OK
+  expr record: OK
+  expr if: OK
+  lvalue var: OK
+  lvalue array: OK
+  stmt assign: OK
+  stmt seq: OK
+  stmt if: OK
+  stmt for: OK
+  stmt barrier: OK
+  stmt let: OK
+  stmt pragma: OK
+  decl param: OK
+  decl local: OK
+  decl shared: OK
+  kernel: OK
+  helper_func: OK
+  native_arg: OK
+  vec_length: OK
+  pattern: OK
+All Sarek_ir_types tests passed!
+Running[3]: (cd _build/default/spoc/ir/test && ./test_sarek_ir_pp.exe)
+Output[3]:
+Sarek_ir_pp tests:
+  string_of_elttype primitives: OK
+  string_of_elttype record: OK
+  string_of_elttype variant: OK
+  string_of_elttype array: OK
+  string_of_elttype vec: OK
+  string_of_memspace: OK
+  string_of_binop: OK
+  string_of_unop: OK
+  pp_expr const: OK
+  pp_expr var: OK
+  pp_expr binop: OK
+  pp_expr unop: OK
+  pp_expr array_read: OK
+  pp_expr intrinsic: OK
+  pp_expr record: OK
+  pp_expr if: OK
+  pp_stmt assign: OK
+  pp_stmt barrier: OK
+  pp_stmt warp_barrier: OK
+  pp_stmt mem_fence: OK
+  pp_stmt return: OK
+  pp_stmt empty: OK
+  pp_decl param: OK
+  pp_decl param array: OK
+  pp_decl local: OK
+  pp_decl shared: OK
+  pp_kernel: OK
+  pp_pattern: OK
+All Sarek_ir_pp tests passed!
+Running[4]: (cd _build/default/spoc/ir/test && ./test_sarek_ir_analysis.exe)
+Output[4]:
+Sarek_ir_analysis tests:
+  elttype_uses_float64 primitives: OK
+  elttype_uses_float64 record: OK
+  elttype_uses_float64 variant: OK
+  elttype_uses_float64 array: OK
+  elttype_uses_float64 vec: OK
+  const_uses_float64: OK
+  expr_uses_float64 const: OK
+  expr_uses_float64 var: OK
+  expr_uses_float64 binop: OK
+  expr_uses_float64 cast: OK
+  expr_uses_float64 intrinsic: OK
+  expr_uses_float64 if: OK
+  stmt_uses_float64 assign: OK
+  stmt_uses_float64 seq: OK
+  stmt_uses_float64 if: OK
+  stmt_uses_float64 for: OK
+  stmt_uses_float64 let: OK
+  stmt_uses_float64 barrier/empty: OK
+  decl_uses_float64 param: OK
+  decl_uses_float64 local: OK
+  decl_uses_float64 shared: OK
+  helper_uses_float64: OK
+  kernel_uses_float64 params: OK
+  kernel_uses_float64 types: OK
+  kernel_uses_float64 variants: OK
+  elttype_uses_float16 primitives: OK
+  elttype_uses_float16 nested: OK
+  expr_uses_float16: OK
+  stmt/decl_uses_float16: OK
+  kernel_uses_float16: OK
+  feature API agrees with the per-width aliases: OK
+  const_uses is width-specific: OK
+  kernel_requirements: OK
+  is_atomic_intrinsic_name: OK
+  expr_uses_atomics: OK
+  helper_uses_atomics: OK
+  kernel_uses_atomics direct: OK
+  kernel_uses_atomics via helper: OK
+  lvalue_uses_atomics: OK
+  kernel_uses_atomics via assign lvalue: OK
+  kernel_uses_atomics via SNative (conservative): OK
+  expr_uses_int_mod: OK
+  lvalue_uses_int_mod: OK
+  kernel_uses_int_mod via record-field lvalue: OK
+  is_copysign_intrinsic_name: OK
+  expr_uses_copysign: OK
+  lvalue_uses_copysign: OK
+  kernel_uses_copysign via record-field lvalue: OK
+  kernel_uses_copysign via helper: OK
+  kernel_uses_nonfinite_float64: OK
+  kernel_uses_intrinsic: OK
+  kernel_float64_intrinsics: OK
+  coopmat detection: OK
+  coopmat configs: OK
+All Sarek_ir_analysis tests passed!
+Running[5]: (cd _build/default/spoc/ir/test && ./test_sarek_capability.exe)
+Output[5]:
+Testing Sarek_capability (#64 slice 1)...
+  device_verdict: Unknown refuses, widths independent: OK
+  permits: Unknown does not permit: OK
+  first_refusal: OK
+  kind_needs_device: OK
+  kind_name: OK
+  evidence: OK
+  explain: OK
+  refuse_if_used: fires on f64, silent on f32: OK
+All Sarek_capability tests passed!
+Running[6]: (cd _build/default/spoc/ir/test && ./test_sarek_coopmat.exe)
+Output[6]:
+Testing `Sarek_coopmat'.
+This run has ID `IQC5I5IJ'.
+
+  [OK]          local hardware record          0   NAVI31: 14 configurations,...
+  [OK]          accuracy regime                0   integer accumulate is exac...
+  [OK]          accuracy regime                1   component classification.
+  [OK]          device verdict                 0   unprobed device is refused.
+  [OK]          device verdict                 1   capable device permits (po...
+  [OK]          device verdict                 2   probed device with no supp...
+  [OK]          device verdict                 3   unadvertised configuration...
+  [OK]          device verdict                 4   find_config.
+  [OK]          fragment type                  0   dimensions are derived fro...
+  [OK]          fragment type                  1   integer component types ar...
+  [OK]          fragment type                  2   Metal's 8x8 is expressible.
+  [OK]          subgroup ABI                   0   components per invocation.
+  [OK]          subgroup ABI                   1   config fits subgroup.
+
+Full test results in `/workspace/sarek/_build/default/spoc/ir/test/_build/_tests/Sarek_coopmat'.
+Test Successful in 0.001s. 13 tests run.
+Running[7]: (cd _build/default/spoc/ir/test && ./test_sarek_pure_registry.exe)
+Output[7]:
+  float32 paths expose exactly the 33-entry set: OK
+  Float64 paths expose exactly the 33-entry set: OK
+  Math.Float64 paths expose exactly the 16-entry set: OK
+  Math.Float64 paths still omit the 11 unsupported intrinsics: OK
+  Float64.rsqrt and Sarek_stdlib_meta.Float64.rsqrt agree on GLSL name (inversesqrt): OK
+  Float64.abs_float emits fabs (abs on GLSL), never abs_float: OK
+All Sarek_pure_registry tests passed!
+Running[8]: (cd _build/default/spoc/framework/test && ./test_framework_sig.exe)
+Output[8]:
+Framework_sig tests:
+  dims_1d: OK
+  dims_2d: OK
+  dims_3d: OK
+  dims record: OK
+  capabilities: OK
+  device: OK
+  execution_model: OK
+  source_lang: OK
+  convergence: OK
+  exec_arg basic: OK
+  run_source_arg: OK
+All Framework_sig tests passed!
+Running[9]: (cd _build/default/spoc/framework/test && ./test_typed_value.exe)
+Output[9]:
+Typed_value tests:
+  PInt32: OK
+  PInt64: OK
+  PFloat: OK
+  PBool: OK
+  PBytes: OK
+  Int32_type: OK
+  Int64_type: OK
+  Float32_type: OK
+  Float64_type: OK
+  Bool_type: OK
+  Registry.find_scalar: OK
+  Registry.list_scalars: OK
+  Registry.register_scalar (custom): OK
+  scalar_value: OK
+  typed_value (scalar): OK
+  exec_arg_of_typed_value: OK
+  typed_value_of_exec_arg (Int32): OK
+  typed_value_of_exec_arg (Float64): OK
+  type_name_of_exec_arg: OK
+  field_desc: OK
+All Typed_value tests passed!
+Running[10]: (cd _build/default/spoc/framework/test && ./test_device_type.exe)
+Output[10]:
+Device_type tests:
+  Device_type.t = Framework_sig.device: OK
+  Device_type fields: OK
+  Device_type CPU device: OK
+  Cross-module compatibility: OK
+All Device_type tests passed!
+Running[11]: (cd _build/default/spoc/framework/test && ./test_backend_error.exe)
+Output[11]:
+Testing `Backend_error'.
+This run has ID `1PM574SK'.
+
+  [OK]          codegen             0   codegen errors.
+  [OK]          runtime             0   runtime errors.
+  [OK]          plugin              0   plugin errors.
+  [OK]          backends            0   multiple backends.
+  [OK]          exceptions          0   exception handling.
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Backend_error'.
+Test Successful in 0.000s. 5 tests run.
+Running[12]: (cd _build/default/spoc/framework/test && ./test_kernel_args.exe)
+Output[12]:
+Testing `Kernel_args'.
+This run has ID `OH35QFZZ'.
+
+  [OK]          ordering               0   out of order set.
+  [OK]          ordering               1   to_sorted_list.
+  [OK]          ordering               2   count.
+  [OK]          last-set-wins          0   duplicate idx last wins.
+  [OK]          validation             0   gap detection.
+  [OK]          validation             1   count mismatch extra.
+  [OK]          validation             2   unexpected index beyond range.
+  [OK]          validation             3   negative expected_count.
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Kernel_args'.
+Test Successful in 0.000s. 8 tests run.
+Running[13]: (cd _build/default/spoc/framework/test && ./test_compile_cache.exe)
+Output[13]:
+Testing `Compile_cache'.
+This run has ID `B58DVBWW'.
+
+  [OK]          key_identity          0   same inputs same key.
+  [OK]          key_identity          1   same source, different kernel name ...
+  [OK]          key_identity          2   different device -> different key.
+  [OK]          key_identity          3   different source -> different key.
+  [OK]          options               0   option order canonicalized.
+  [OK]          options               1   different option values -> differen...
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Compile_cache'.
+Test Successful in 0.000s. 6 tests run.
+Running[14]: (cd _build/default/spoc/framework/test && ./test_guarded_cache.exe)
+Output[14]:
+Testing `Guarded_cache'.
+This run has ID `92GUW5NW'.
+
+  [OK]          concurrency          0   stress: shared + distinct keys, N do...
+  [OK]          concurrency          1   concurrent clear vs find_or_build.
+  [OK]          concurrency          2   concurrent evict_device.
+  [OK]          concurrency          3   evict_device during an in-flight bui...
+  [OK]          concurrency          4   clear during an in-flight build is r...
+  [OK]          concurrency          5   clear during an in-flight build stil...
+  [OK]          concurrency          6   a raising destroy does not strand th...
+  [OK]          concurrency          7   a raising destroy on a lost race sti...
+  [OK]          concurrency          8   red demo (unguarded, opt-in).
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Guarded_cache'.
+Test Successful in 0.061s. 9 tests run.
+Running[15]: (cd _build/default/spoc/framework/test && ./test_cache_hooks.exe)
+Output[15]:
+Testing `Cache_hooks'.
+This run has ID `4234W6WQ'.
+
+  [OK]          around_clear                            0   notifies on both ...
+  [OK]          around_clear                            1   nested scopes not...
+  [OK]          notification                            0   device destroy ca...
+  [OK]          notification                            1   a failing listene...
+  [OK]          around_clear failure isolation          0   a failing listene...
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Cache_hooks'.
+Test Successful in 0.000s. 5 tests run.
+Running[16]: (cd _build/default && /workspace/sarek/_opam/bin/ocamlopt.opt -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o spoc/registry/test/test_sarek_registry.exe spoc/registry/sarek_registry.cmxa spoc/registry/test/.test_sarek_registry.eobjs/native/dune__exe__Test_sarek_registry.cmx)
+Running[17]: (cd _build/default/spoc/registry/test && ./test_sarek_registry.exe)
+File "spoc/registry/test/dune", line 2, characters 8-27:
+2 |  (names test_sarek_registry)
+            ^^^^^^^^^^^^^^^^^^^
+Command [17] exited with code 3:
+$ (cd _build/default/spoc/registry/test && ./test_sarek_registry.exe)
+Sarek_registry tests:
+  builtin types: OK
+  register_type: OK
+  find_type: OK
+  type_device_code: OK
+  register_record: OK
+  find_record: OK
+  record_fields: OK
+  find_record_by_short_name: OK
+  register_variant: OK
+  find_variant: OK
+  variant_constructors: OK
+  register_fun: OK
+  register_fun with module: OK
+  find_fun: OK
+  fun_device_code: OK
+  fun_device_template: OK
+  cuda_or_opencl: OK
+All Sarek_registry tests passed!

--- a/scripts/prove-red-fixtures/dune-verbose-signal-log.txt
+++ b/scripts/prove-red-fixtures/dune-verbose-signal-log.txt
@@ -1,0 +1,333 @@
+Shared cache enabled cache_enabled: Disabed
+Shared cache location root_dir: "/home/user/.cache/dune/db"
+Workspace root root: "/workspace/sarek"
+Dune context context: { name = "default"
+; kind = "default"
+; profile = Dev
+; merlin = true
+; fdo_target_exe = None
+; build_dir = In_build_dir "default"
+; instrument_with = []
+}
+Running[1]: (cd _build/default && /workspace/sarek/_opam/bin/ocamlopt.opt -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -I spoc/registry/test/.test_sarek_registry.eobjs/byte -I spoc/registry/test/.test_sarek_registry.eobjs/native -I spoc/registry/.sarek_registry.objs/byte -I spoc/registry/.sarek_registry.objs/native -cmi-file spoc/registry/test/.test_sarek_registry.eobjs/byte/dune__exe__Test_sarek_registry.cmi -no-alias-deps -opaque -o spoc/registry/test/.test_sarek_registry.eobjs/native/dune__exe__Test_sarek_registry.cmx -c -impl spoc/registry/test/test_sarek_registry.ml)
+Running[2]: (cd _build/default/spoc/ir/test && ./test_sarek_ir_types.exe)
+Output[2]:
+Sarek_ir_types tests:
+  memspace: OK
+  elttype primitives: OK
+  elttype record: OK
+  elttype variant: OK
+  elttype array: OK
+  elttype vec: OK
+  var: OK
+  var mutable: OK
+  const int32: OK
+  const int64: OK
+  const float32: OK
+  const float64: OK
+  const bool: OK
+  const unit: OK
+  binop: OK
+  unop: OK
+  expr const: OK
+  expr var: OK
+  expr binop: OK
+  expr intrinsic: OK
+  expr record: OK
+  expr if: OK
+  lvalue var: OK
+  lvalue array: OK
+  stmt assign: OK
+  stmt seq: OK
+  stmt if: OK
+  stmt for: OK
+  stmt barrier: OK
+  stmt let: OK
+  stmt pragma: OK
+  decl param: OK
+  decl local: OK
+  decl shared: OK
+  kernel: OK
+  helper_func: OK
+  native_arg: OK
+  vec_length: OK
+  pattern: OK
+All Sarek_ir_types tests passed!
+Running[3]: (cd _build/default/spoc/ir/test && ./test_sarek_ir_pp.exe)
+Output[3]:
+Sarek_ir_pp tests:
+  string_of_elttype primitives: OK
+  string_of_elttype record: OK
+  string_of_elttype variant: OK
+  string_of_elttype array: OK
+  string_of_elttype vec: OK
+  string_of_memspace: OK
+  string_of_binop: OK
+  string_of_unop: OK
+  pp_expr const: OK
+  pp_expr var: OK
+  pp_expr binop: OK
+  pp_expr unop: OK
+  pp_expr array_read: OK
+  pp_expr intrinsic: OK
+  pp_expr record: OK
+  pp_expr if: OK
+  pp_stmt assign: OK
+  pp_stmt barrier: OK
+  pp_stmt warp_barrier: OK
+  pp_stmt mem_fence: OK
+  pp_stmt return: OK
+  pp_stmt empty: OK
+  pp_decl param: OK
+  pp_decl param array: OK
+  pp_decl local: OK
+  pp_decl shared: OK
+  pp_kernel: OK
+  pp_pattern: OK
+All Sarek_ir_pp tests passed!
+Running[4]: (cd _build/default/spoc/ir/test && ./test_sarek_ir_analysis.exe)
+Output[4]:
+Sarek_ir_analysis tests:
+  elttype_uses_float64 primitives: OK
+  elttype_uses_float64 record: OK
+  elttype_uses_float64 variant: OK
+  elttype_uses_float64 array: OK
+  elttype_uses_float64 vec: OK
+  const_uses_float64: OK
+  expr_uses_float64 const: OK
+  expr_uses_float64 var: OK
+  expr_uses_float64 binop: OK
+  expr_uses_float64 cast: OK
+  expr_uses_float64 intrinsic: OK
+  expr_uses_float64 if: OK
+  stmt_uses_float64 assign: OK
+  stmt_uses_float64 seq: OK
+  stmt_uses_float64 if: OK
+  stmt_uses_float64 for: OK
+  stmt_uses_float64 let: OK
+  stmt_uses_float64 barrier/empty: OK
+  decl_uses_float64 param: OK
+  decl_uses_float64 local: OK
+  decl_uses_float64 shared: OK
+  helper_uses_float64: OK
+  kernel_uses_float64 params: OK
+  kernel_uses_float64 types: OK
+  kernel_uses_float64 variants: OK
+  elttype_uses_float16 primitives: OK
+  elttype_uses_float16 nested: OK
+  expr_uses_float16: OK
+  stmt/decl_uses_float16: OK
+  kernel_uses_float16: OK
+  feature API agrees with the per-width aliases: OK
+  const_uses is width-specific: OK
+  kernel_requirements: OK
+  is_atomic_intrinsic_name: OK
+  expr_uses_atomics: OK
+  helper_uses_atomics: OK
+  kernel_uses_atomics direct: OK
+  kernel_uses_atomics via helper: OK
+  lvalue_uses_atomics: OK
+  kernel_uses_atomics via assign lvalue: OK
+  kernel_uses_atomics via SNative (conservative): OK
+  expr_uses_int_mod: OK
+  lvalue_uses_int_mod: OK
+  kernel_uses_int_mod via record-field lvalue: OK
+  is_copysign_intrinsic_name: OK
+  expr_uses_copysign: OK
+  lvalue_uses_copysign: OK
+  kernel_uses_copysign via record-field lvalue: OK
+  kernel_uses_copysign via helper: OK
+  kernel_uses_nonfinite_float64: OK
+  kernel_uses_intrinsic: OK
+  kernel_float64_intrinsics: OK
+  coopmat detection: OK
+  coopmat configs: OK
+All Sarek_ir_analysis tests passed!
+Running[5]: (cd _build/default/spoc/ir/test && ./test_sarek_capability.exe)
+Output[5]:
+Testing Sarek_capability (#64 slice 1)...
+  device_verdict: Unknown refuses, widths independent: OK
+  permits: Unknown does not permit: OK
+  first_refusal: OK
+  kind_needs_device: OK
+  kind_name: OK
+  evidence: OK
+  explain: OK
+  refuse_if_used: fires on f64, silent on f32: OK
+All Sarek_capability tests passed!
+Running[6]: (cd _build/default/spoc/ir/test && ./test_sarek_coopmat.exe)
+Output[6]:
+Testing `Sarek_coopmat'.
+This run has ID `K2VS1UF2'.
+
+  [OK]          local hardware record          0   NAVI31: 14 configurations,...
+  [OK]          accuracy regime                0   integer accumulate is exac...
+  [OK]          accuracy regime                1   component classification.
+  [OK]          device verdict                 0   unprobed device is refused.
+  [OK]          device verdict                 1   capable device permits (po...
+  [OK]          device verdict                 2   probed device with no supp...
+  [OK]          device verdict                 3   unadvertised configuration...
+  [OK]          device verdict                 4   find_config.
+  [OK]          fragment type                  0   dimensions are derived fro...
+  [OK]          fragment type                  1   integer component types ar...
+  [OK]          fragment type                  2   Metal's 8x8 is expressible.
+  [OK]          subgroup ABI                   0   components per invocation.
+  [OK]          subgroup ABI                   1   config fits subgroup.
+
+Full test results in `/workspace/sarek/_build/default/spoc/ir/test/_build/_tests/Sarek_coopmat'.
+Test Successful in 0.001s. 13 tests run.
+Running[7]: (cd _build/default/spoc/ir/test && ./test_sarek_pure_registry.exe)
+Output[7]:
+  float32 paths expose exactly the 33-entry set: OK
+  Float64 paths expose exactly the 33-entry set: OK
+  Math.Float64 paths expose exactly the 16-entry set: OK
+  Math.Float64 paths still omit the 11 unsupported intrinsics: OK
+  Float64.rsqrt and Sarek_stdlib_meta.Float64.rsqrt agree on GLSL name (inversesqrt): OK
+  Float64.abs_float emits fabs (abs on GLSL), never abs_float: OK
+All Sarek_pure_registry tests passed!
+Running[8]: (cd _build/default/spoc/framework/test && ./test_framework_sig.exe)
+Output[8]:
+Framework_sig tests:
+  dims_1d: OK
+  dims_2d: OK
+  dims_3d: OK
+  dims record: OK
+  capabilities: OK
+  device: OK
+  execution_model: OK
+  source_lang: OK
+  convergence: OK
+  exec_arg basic: OK
+  run_source_arg: OK
+All Framework_sig tests passed!
+Running[9]: (cd _build/default/spoc/framework/test && ./test_typed_value.exe)
+Output[9]:
+Typed_value tests:
+  PInt32: OK
+  PInt64: OK
+  PFloat: OK
+  PBool: OK
+  PBytes: OK
+  Int32_type: OK
+  Int64_type: OK
+  Float32_type: OK
+  Float64_type: OK
+  Bool_type: OK
+  Registry.find_scalar: OK
+  Registry.list_scalars: OK
+  Registry.register_scalar (custom): OK
+  scalar_value: OK
+  typed_value (scalar): OK
+  exec_arg_of_typed_value: OK
+  typed_value_of_exec_arg (Int32): OK
+  typed_value_of_exec_arg (Float64): OK
+  type_name_of_exec_arg: OK
+  field_desc: OK
+All Typed_value tests passed!
+Running[10]: (cd _build/default/spoc/framework/test && ./test_device_type.exe)
+Output[10]:
+Device_type tests:
+  Device_type.t = Framework_sig.device: OK
+  Device_type fields: OK
+  Device_type CPU device: OK
+  Cross-module compatibility: OK
+All Device_type tests passed!
+Running[11]: (cd _build/default/spoc/framework/test && ./test_backend_error.exe)
+Output[11]:
+Testing `Backend_error'.
+This run has ID `EP7RMAPU'.
+
+  [OK]          codegen             0   codegen errors.
+  [OK]          runtime             0   runtime errors.
+  [OK]          plugin              0   plugin errors.
+  [OK]          backends            0   multiple backends.
+  [OK]          exceptions          0   exception handling.
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Backend_error'.
+Test Successful in 0.000s. 5 tests run.
+Running[12]: (cd _build/default/spoc/framework/test && ./test_kernel_args.exe)
+Output[12]:
+Testing `Kernel_args'.
+This run has ID `6SU1XTLX'.
+
+  [OK]          ordering               0   out of order set.
+  [OK]          ordering               1   to_sorted_list.
+  [OK]          ordering               2   count.
+  [OK]          last-set-wins          0   duplicate idx last wins.
+  [OK]          validation             0   gap detection.
+  [OK]          validation             1   count mismatch extra.
+  [OK]          validation             2   unexpected index beyond range.
+  [OK]          validation             3   negative expected_count.
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Kernel_args'.
+Test Successful in 0.000s. 8 tests run.
+Running[13]: (cd _build/default/spoc/framework/test && ./test_compile_cache.exe)
+Output[13]:
+Testing `Compile_cache'.
+This run has ID `EKJAFE6C'.
+
+  [OK]          key_identity          0   same inputs same key.
+  [OK]          key_identity          1   same source, different kernel name ...
+  [OK]          key_identity          2   different device -> different key.
+  [OK]          key_identity          3   different source -> different key.
+  [OK]          options               0   option order canonicalized.
+  [OK]          options               1   different option values -> differen...
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Compile_cache'.
+Test Successful in 0.000s. 6 tests run.
+Running[14]: (cd _build/default/spoc/framework/test && ./test_guarded_cache.exe)
+Output[14]:
+Testing `Guarded_cache'.
+This run has ID `7L6XJ82J'.
+
+  [OK]          concurrency          0   stress: shared + distinct keys, N do...
+  [OK]          concurrency          1   concurrent clear vs find_or_build.
+  [OK]          concurrency          2   concurrent evict_device.
+  [OK]          concurrency          3   evict_device during an in-flight bui...
+  [OK]          concurrency          4   clear during an in-flight build is r...
+  [OK]          concurrency          5   clear during an in-flight build stil...
+  [OK]          concurrency          6   a raising destroy does not strand th...
+  [OK]          concurrency          7   a raising destroy on a lost race sti...
+  [OK]          concurrency          8   red demo (unguarded, opt-in).
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Guarded_cache'.
+Test Successful in 0.060s. 9 tests run.
+Running[15]: (cd _build/default/spoc/framework/test && ./test_cache_hooks.exe)
+Output[15]:
+Testing `Cache_hooks'.
+This run has ID `G3NDABSA'.
+
+  [OK]          around_clear                            0   notifies on both ...
+  [OK]          around_clear                            1   nested scopes not...
+  [OK]          notification                            0   device destroy ca...
+  [OK]          notification                            1   a failing listene...
+  [OK]          around_clear failure isolation          0   a failing listene...
+
+Full test results in `/workspace/sarek/_build/default/spoc/framework/test/_build/_tests/Cache_hooks'.
+Test Successful in 0.000s. 5 tests run.
+Running[16]: (cd _build/default && /workspace/sarek/_opam/bin/ocamlopt.opt -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o spoc/registry/test/test_sarek_registry.exe spoc/registry/sarek_registry.cmxa spoc/registry/test/.test_sarek_registry.eobjs/native/dune__exe__Test_sarek_registry.cmx)
+Running[17]: (cd _build/default/spoc/registry/test && ./test_sarek_registry.exe)
+File "spoc/registry/test/dune", line 2, characters 8-27:
+2 |  (names test_sarek_registry)
+            ^^^^^^^^^^^^^^^^^^^
+Command [17] got signal SEGV:
+$ (cd _build/default/spoc/registry/test && ./test_sarek_registry.exe)
+Sarek_registry tests:
+  builtin types: OK
+  register_type: OK
+  find_type: OK
+  type_device_code: OK
+  register_record: OK
+  find_record: OK
+  record_fields: OK
+  find_record_by_short_name: OK
+  register_variant: OK
+  find_variant: OK
+  variant_constructors: OK
+  register_fun: OK
+  register_fun with module: OK
+  find_fun: OK
+  fun_device_code: OK
+  fun_device_template: OK
+  cuda_or_opencl: OK
+All Sarek_registry tests passed!

--- a/scripts/test-suite-counts.sh
+++ b/scripts/test-suite-counts.sh
@@ -313,12 +313,18 @@ text = sys.stdin.read() if src == "-" else open(src, errors="replace").read()
 # warning-as-error ("Error (warning 32 [...]): ...") and reintroduced a false
 # green — see the header. A bare `^Error ` is NOT accepted: a test printing
 # "Error handling works" would match it.
-build_errors = re.findall(
-    r"(?m)^(?:Error(?::| \([^)\n]*\):)"
-    r"|Command \[\d+\] got signal \w+"
-    r"|Command \[\d+\] exited with code (?!0\b)\d+)",
+# TWO categories, kept apart on purpose. Both mean "the run did not complete",
+# so both are exit 5 — but they call for DIFFERENT actions, and a diagnostic that
+# says "Fix the build" to someone whose build succeeded and whose test segfaulted
+# has sent them to the wrong place. Caught by review on #367: the collection was
+# named build_errors and every match was reported as a "dune/compiler error",
+# which became false the moment runtime command failures joined it.
+compile_errors = re.findall(r"(?m)^Error(?::| \([^)\n]*\):)", text)
+command_failures = re.findall(
+    r"(?m)^Command \[\d+\] (?:got signal \w+|exited with code (?!0\b)\d+)",
     text,
 )
+run_failed_markers = len(compile_errors) + len(command_failures)
 
 # Alcotest: "Test Successful in 0.004s. 61 tests run." and the SINGULAR
 # "1 test run." / "0 test run.". Matching `tests?` is the whole point.
@@ -357,7 +363,7 @@ suites = len(alco) + len(qcheck)
 #
 # Exit 5 therefore OUTRANKS 2, 3 and 4: a run that did not complete is not
 # described by any of them, whatever its log happens to parse to.
-if dune_exit not in ("", "0") or build_errors:
+if dune_exit not in ("", "0") or run_failed_markers:
     if suites:
         print(f"partial: {sum(alco) + sum(qcheck)} case(s) across {suites} suite(s) "
               "ran before the failure")
@@ -370,11 +376,19 @@ if dune_exit not in ("", "0") or build_errors:
               "ran before it stopped. Not a result.")
     else:
         print()
-        print(f"ERROR: this log contains {len(build_errors)} dune/compiler error "
-              "marker(s) at column 0, so the run did not complete and any count "
-              "above is only the suites built before the failure. Fix the build and "
-              "re-run; pass --dune-exit to make this authoritative rather than "
-              "inferred.")
+        what = []
+        if compile_errors:
+            what.append(f"{len(compile_errors)} compiler error marker(s) "
+                        "(the build failed -- fix the build)")
+        if command_failures:
+            what.append(f"{len(command_failures)} failed-command marker(s) "
+                        f"[{'; '.join(command_failures)}] (the build succeeded and a "
+                        "test command exited non-zero or died on a signal -- fix the "
+                        "test, not the build)")
+        print(f"ERROR: this log contains {' and '.join(what)} at column 0, so the "
+              "run did not complete and any count above is only the suites that ran "
+              "before the failure. Pass --dune-exit to make this authoritative "
+              "rather than inferred.")
     sys.exit(5)
 
 # GATE 1 -- did we read a test log at all? (backlog-150)
@@ -500,7 +514,7 @@ python3 -c "$PYPROG" "$SRC" "$MIN_SUITES" "$DUNE_EXIT"
 #   apply: printf 'File "sarek/tests/unit/test_thing.ml", line 12, characters 0-1:\nError: Syntax error\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
 #   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
 #   expect-exit: 5
-#   expect-message: dune/compiler error marker
+#   expect-message: compiler error marker
 #
 # mutation: dune-exit-nonzero
 #   desc: the log parses clean and dune says the run failed. An ENVIRONMENT mutation, like empty-stdin: no file changes, and the authoritative fact is one a log cannot carry.
@@ -520,21 +534,21 @@ python3 -c "$PYPROG" "$SRC" "$MIN_SUITES" "$DUNE_EXIT"
 #   apply: printf 'File "sarek/ppx/Sarek_lower_ir.ml", line 850, characters 16-30:\nError (warning 26 [unused-var]): unused variable helper_binders.\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
 #   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
 #   expect-exit: 5
-#   expect-message: dune/compiler error marker
+#   expect-message: compiler error marker
 #
 # mutation: verbose-command-exit
 #   desc: under `dune test --verbose` a test binary that exits non-zero is reported as "Command [N] exited with code M:" -- no Error label at all, so the Error-only pattern read the whole run as clean. Distinct from build-failed because nothing failed to BUILD; a compiled test ran and returned failure.
 #   apply: printf 'Command [17] exited with code 3:\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
 #   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
 #   expect-exit: 5
-#   expect-message: dune/compiler error marker
+#   expect-message: failed-command marker
 #
 # mutation: verbose-command-signal
 #   desc: the same shape for a test killed by a signal -- "Command [N] got signal SEGV:". Its own mutation because a segfaulting test is the case this repo has actually hit (backlog-53/80, RADV driver segfaults) and it must not be reported as a clean count.
 #   apply: printf 'Command [17] got signal SEGV:\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
 #   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
 #   expect-exit: 5
-#   expect-message: dune/compiler error marker
+#   expect-message: failed-command marker
 # END prove-red-spec
 #
 # The other polarity -- a test that PRINTS "Error handling works" must NOT read

--- a/scripts/test-suite-counts.sh
+++ b/scripts/test-suite-counts.sh
@@ -313,7 +313,12 @@ text = sys.stdin.read() if src == "-" else open(src, errors="replace").read()
 # warning-as-error ("Error (warning 32 [...]): ...") and reintroduced a false
 # green — see the header. A bare `^Error ` is NOT accepted: a test printing
 # "Error handling works" would match it.
-build_errors = re.findall(r"(?m)^Error(?::| \([^)\n]*\):)", text)
+build_errors = re.findall(
+    r"(?m)^(?:Error(?::| \([^)\n]*\):)"
+    r"|Command \[\d+\] got signal \w+"
+    r"|Command \[\d+\] exited with code (?!0\b)\d+)",
+    text,
+)
 
 # Alcotest: "Test Successful in 0.004s. 61 tests run." and the SINGULAR
 # "1 test run." / "0 test run.". Matching `tests?` is the whole point.
@@ -513,6 +518,20 @@ python3 -c "$PYPROG" "$SRC" "$MIN_SUITES" "$DUNE_EXIT"
 # mutation: warning-as-error
 #   desc: the same shape as build-failed but with the spelling the compiler actually uses when a warning is promoted -- `Error (warning 32 [...]):`, no colon after Error. The `^Error:` pattern missed it entirely and reported a clean total for a run whose build never completed. Kept as its own mutation because build-failed passes on a pattern that has this hole.
 #   apply: printf 'File "sarek/ppx/Sarek_lower_ir.ml", line 850, characters 16-30:\nError (warning 26 [unused-var]): unused variable helper_binders.\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
+#   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
+#   expect-exit: 5
+#   expect-message: dune/compiler error marker
+#
+# mutation: verbose-command-exit
+#   desc: under `dune test --verbose` a test binary that exits non-zero is reported as "Command [N] exited with code M:" -- no Error label at all, so the Error-only pattern read the whole run as clean. Distinct from build-failed because nothing failed to BUILD; a compiled test ran and returned failure.
+#   apply: printf 'Command [17] exited with code 3:\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
+#   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
+#   expect-exit: 5
+#   expect-message: dune/compiler error marker
+#
+# mutation: verbose-command-signal
+#   desc: the same shape for a test killed by a signal -- "Command [N] got signal SEGV:". Its own mutation because a segfaulting test is the case this repo has actually hit (backlog-53/80, RADV driver segfaults) and it must not be reported as a clean count.
+#   apply: printf 'Command [17] got signal SEGV:\n' >> scripts/prove-red-fixtures/dune-test-sample-log.txt
 #   argv: scripts/prove-red-fixtures/dune-test-sample-log.txt --min-suites 0
 #   expect-exit: 5
 #   expect-message: dune/compiler error marker

--- a/scripts/test-suite-counts.test.sh
+++ b/scripts/test-suite-counts.test.sh
@@ -245,8 +245,14 @@ check "a build failure in the log exits 5" "$?" "5"
 # runs before the count block) is what changed the wording, and "partial" is the
 # more honest framing for a total taken over a run that died.
 bf_out="$("$CNT" --min-suites 0 "$TMP/build-failed.log" 2>&1 || true)"
+# Anchored on the `partial:` LINE, not on a bare substring. It used to grep for
+# "ran before the failure" anywhere in the output, which silently also matched
+# the ERROR paragraph once #367 reworded it from "suites built before" to "suites
+# that ran before" — count 1 became 2 and the case failed for a reason that had
+# nothing to do with the partial count. The assertion was looser than its own
+# name ("shows the partial count"), so it was coupled to prose it does not own.
 check "build failure still shows the partial count" \
-  "$(echo "$bf_out" | /usr/bin/grep -c 'ran before the failure')" "1"
+  "$(echo "$bf_out" | /usr/bin/grep -cE '^partial: .* ran before the failure')" "1"
 
 # --dune-exit is authoritative: the log parses clean, dune says otherwise.
 "$CNT" --min-suites 0 --dune-exit 1 "$TMP/mixed.log" >/dev/null 2>&1

--- a/scripts/test-suite-counts.test.sh
+++ b/scripts/test-suite-counts.test.sh
@@ -16,7 +16,8 @@ CNT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-suite-counts.sh"
 # a missing fixture makes `cat` produce nothing, which the counter reports as
 # "no output recognised" (2) — a number that looks like an unrelated bug.
 FIXTURES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/prove-red-fixtures"
-for f in dune-test-sample-log.txt dune-test-warning-as-error-log.txt; do
+for f in dune-test-sample-log.txt dune-test-warning-as-error-log.txt \
+         dune-verbose-command-exit-log.txt dune-verbose-signal-log.txt; do
   [ -f "$FIXTURES/$f" ] || { echo "FAIL: fixture $FIXTURES/$f is missing"; exit 2; }
 done
 
@@ -346,6 +347,32 @@ check "warning-as-error AFTER enough suites to clear the floor is 5, not 0" "$?"
 } > "$TMP/prints-error-word.log"
 "$CNT" --min-suites 0 "$TMP/prints-error-word.log" >/dev/null 2>&1
 check "  (control) a test PRINTING \"Error handling...\" is still 0" "$?" "0"
+
+# DUNE --verbose COMMAND FAILURES. Under `dune test --verbose` a test binary that
+# exits non-zero or dies on a signal is reported not as `Error:` but as
+#     Command [17] exited with code 3:
+#     Command [17] got signal SEGV:
+# so the `Error`-label pattern never matched either. Measured on two real captured
+# logs: exit 0 and a clean "46 cases across 6 suites" for runs that FAILED.
+# Third instance of this class after `^File "` (too broad) and `^Error:` (too
+# narrow) — the heuristic has now been wrong in both directions and in a third
+# spelling, which is the argument for --dune-exit being the authority and this
+# being only the fallback.
+"$CNT" --min-suites 0 "$FIXTURES/dune-verbose-command-exit-log.txt" >/dev/null 2>&1
+check "a --verbose command exiting non-zero is 5, not 0" "$?" "5"
+
+"$CNT" --min-suites 0 "$FIXTURES/dune-verbose-signal-log.txt" >/dev/null 2>&1
+check "a --verbose command killed by a signal is 5, not 0" "$?" "5"
+
+# Both controls that keep this widening from becoming the `^File "` mistake again.
+# `exited with code 0` is dune reporting SUCCESS and must not read as a failure;
+# an INDENTED mention is test output, not dune's own report.
+{ cat "$FIXTURES/dune-test-sample-log.txt"
+  printf 'Command [17] exited with code 0:\n'
+  printf '  a test printed: Command [3] got signal handling right\n'
+} > "$TMP/verbose-benign.log"
+"$CNT" --min-suites 0 "$TMP/verbose-benign.log" >/dev/null 2>&1
+check "  (control) 'exited with code 0' + an indented mention stay 0" "$?" "0"
 
 # Argument handling: a malformed invocation is an error, not a default.
 "$CNT" --min-suites nope "$TMP/plausible.log" >/dev/null 2>&1


### PR DESCRIPTION
Two more false greens in merged `main` — same class as #365, found by **finishing** the #351 triage instead of closing it as a duplicate.

## The defect

Under `dune test --verbose`, a test binary that exits non-zero or dies on a signal carries no `Error` label at all:

```
Command [17] exited with code 3:
Command [17] got signal SEGV:
```

So the pattern never matched either. Measured on two real captured logs:

| input | before | after |
|---|---|---|
| `--verbose` command exited 3 | **exit 0**, "46 cases across 6 suites" | 5 |
| `--verbose` command got SIGSEGV | **exit 0**, "46 cases across 6 suites" | 5 |
| warning-as-error (#365) | 5 | 5 |
| clean log | 0 | 0 |
| a log *printing* those words | 0 | 0 |

The signal case is not hypothetical in this repo — backlog-53 and backlog-80 are segfaulting tests on RADV. A clean count reported off a segfaulting run is precisely what this gate exists to prevent.

## Not over-broadened

`exited with code 0` is **excluded**: that spelling is dune reporting *success*, and matching it would flag every verbose log as failed — the `^File "` over-broadening mistake in a new costume. An indented mention (test output rather than dune's own report) is likewise ignored.

Both polarities pinned:
- revert to the `Error`-label-only pattern → the two new cases go red
- drop the `code 0` exclusion → the control goes red

48 passed / 0 failed (was 45). prove-red: 4 subjects, 22 mutations.

## Third time for this heuristic

Too broad with `^File "`, too narrow with `^Error:`, and blind to a third spelling entirely. That track record is the argument for `--dune-exit` being the authority and the log scan staying strictly the fallback — now stated in the header rather than left as a pattern for someone to rediscover.

## One process note

My first version put `(?m)` inside the alternation, which Python 3.11+ rejects (*"global flags not at the start"*). Every case then returned 1 from the crash — and what caught it was the **clean-log control returning a wrong code**, not the new failure cases. A suite of only-negative cases would have gone all-red and looked like a working gate.

## #351

Fixtures salvaged from that abandoned PR, whose verbose logs are what exposed this. Its remaining unique content is now empty, so it can be closed — which is the outcome I would have reached prematurely, and wrongly, two turns earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Dune test failures reported through non-zero exit codes or signals.
  * Prevented successful commands reporting exit code 0 from being misclassified as failures.

* **Tests**
  * Added regression coverage and representative verbose Dune logs for command-exit and signal-failure scenarios.
  * Confirmed failure cases return the expected error status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->