### PR TITLE
fix(test): an unobservable separation control is a SKIP, not a failure

### DIFF
--- a/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
+++ b/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
@@ -346,6 +346,28 @@ let test_negative_device_refuses () =
          refuses, in the same run, under the same driver build. Without this the
          two arms above could both be vacuous. *)
       let permits = List.exists (fun d -> d.permits) devs in
+      (* But UNOBSERVABLE is not VIOLATED. On a host where no device advertises
+         the extension at all, this control cannot be satisfied by any correct
+         implementation, so asserting it reports a hardware inventory as a code
+         defect. Measured on echydna (GTX 1070 Max-Q + Intel UHD 630, neither of
+         which supports VK_KHR_cooperative_matrix): the two refusal arms passed
+         and this line failed, taking `dune test` to exit 1. It is green on the
+         dev box only because the RX 7900 XTX (RDNA3) does support it — so the
+         suite's verdict was a property of the machine, not of the code.
+         RECORDED rather than silently passed, per this repo's rule that a
+         skipped obligation must say so: what is unverified here is specifically
+         that the gate is not refusing vacuously. The refusal arms above already
+         ran, and would have failed had a no-extension device permitted. *)
+      if not permits then begin
+        Printf.printf
+          "  [SKIP] separation UNPROVEN on this host: no device advertises \
+           VK_KHR_cooperative_matrix (%s). The refusal arms DID run; what is \
+           unverified is that the gate separates rather than refusing \
+           everything. Re-run on a coopmat-capable device to close it.\n\
+           %!"
+          (String.concat ", " (List.map (fun d -> d.dev.Device.name) devs)) ;
+        Alcotest.skip ()
+      end ;
       Alcotest.(check bool)
         "some device permits, so the refusal above is a separation"
         true

--- a/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
+++ b/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
@@ -358,7 +358,23 @@ let test_negative_device_refuses () =
          skipped obligation must say so: what is unverified here is specifically
          that the gate is not refusing vacuously. The refusal arms above already
          ran, and would have failed had a no-extension device permitted. *)
-      if not permits then begin
+      (* The skip predicate is the EXTENSION BIT, not the verdict — caught by
+         review on #369, and it is the difference between a narrow escape and a
+         hole. `not permits` is true whenever nothing passes Sarek's full
+         configuration verdict, and that INCLUDES a device which advertises
+         VK_KHR_cooperative_matrix and is nonetheless refused because some other
+         required capability is missing. That case is a live gate/config
+         regression and must still FAIL; skipping it would hide precisely what
+         this control exists for, while the message claimed the extension was
+         absent. A predicate wider than its own diagnostic — the same defect
+         class this branch was opened to fix, one level up.
+         So: skip only when NO device advertises the extension, which is the
+         genuinely unobservable case. Advertised-but-refused still reaches the
+         assertion below. *)
+      let advertises =
+        List.exists (fun d -> d.dev.Device.coopmat_extension_advertised) devs
+      in
+      if not advertises then begin
         Printf.printf
           "  [SKIP] separation UNPROVEN on this host: no device advertises \
            VK_KHR_cooperative_matrix (%s). The refusal arms DID run; what is \


### PR DESCRIPTION
Found by running the full suite on **echydna** (GTX 1070 Max-Q + Intel UHD 630) — the first time this suite has executed on hardware where *no* device advertises `VK_KHR_cooperative_matrix`.

## The defect

The coopmat gate test asserts three things:

```
ASSERT Intel UHD 630: no VK_KHR_cooperative_matrix, so the verdict must refuse   ✓
ASSERT NVIDIA GTX 1070: no VK_KHR_cooperative_matrix, so the verdict must refuse ✓
ASSERT some device permits, so the refusal above is a separation              ✗ FAIL
```

The third is a positive control — proof the gate *separates* rather than refusing everything. It is a good control and its comment says exactly why it exists.

**But unobservable is not violated.** On a host where nothing supports the extension, no correct implementation can satisfy it, so asserting it reports a *hardware inventory* as a code defect. It is green on the dev box only because the RX 7900 XTX (RDNA3) supports coopmat — meaning **the suite's verdict was a property of the machine rather than of the code**, which is precisely what a test must not be. It took `dune test` to exit 1 on echydna.

## The fix, without weakening the control

- the two refusal arms **still execute** and still fail if a no-extension device permits — no protection surrendered;
- the separation claim is **dropped, not asserted true**: it prints which devices were inspected, states exactly what is left unverified (*that the gate separates rather than refusing everything*), and names the remedy (re-run on a coopmat-capable device);
- `printf` **and** `Alcotest.skip ()`, because backlog-113 recorded that a `printf` *alone* renders as green `[OK]` — Alcotest captures it, so the skip status has to be returned too. The four `ptx_*` probes already use this pattern.

## Verified on both sides

| host | before | after |
|---|---|---|
| echydna (no coopmat device) | `[FAIL] gate`, `dune test` exit 1 | `[SKIP] gate`, `test_rc=0` |
| dev box (7900 XTX permits) | `[OK] gate` | `[OK] gate`, 6 tests run — assertion still exercised |

The fix is inert where a device permits, which is the point. And on echydna `gate` now behaves like its neighbours in the same suite (`plumbing`, `numerics` were already skipping for the same reason) instead of being the odd one out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the cooperative matrix device validation test to skip gracefully when the required device capability is unavailable.
  * Preserved validation of device separation when compatible hardware is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->