### PR TITLE
fix(ptx): route the three unrouted Float64 conversions + drop machine names from sources

### DIFF
--- a/benchmarks/backend_metal.available.ml
+++ b/benchmarks/backend_metal.available.ml
@@ -1,6 +1,6 @@
 (******************************************************************************)
 (* SPDX-License-Identifier: CECILL-B                                          *)
-(* SPDX-FileCopyrightText: 2026 mathias <mathias@ladon.local> *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 
 (* Metal backend available - initialize unless disabled by env var *)

--- a/benchmarks/backend_metal.unavailable.ml
+++ b/benchmarks/backend_metal.unavailable.ml
@@ -1,6 +1,6 @@
 (******************************************************************************)
 (* SPDX-License-Identifier: CECILL-B                                          *)
-(* SPDX-FileCopyrightText: 2026 mathias <mathias@ladon.local> *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 
 (* Metal backend not available - no-op *)

--- a/docs/benchmarks/hip-vs-opencl-vulkan-2026-07-24.md
+++ b/docs/benchmarks/hip-vs-opencl-vulkan-2026-07-24.md
@@ -7,7 +7,7 @@
 
 | | |
 |---|---|
-| Host | tartarus (AMD Ryzen 9 7950X, 16-core) |
+| Host | AMD Ryzen 9 7950X, 16-core |
 | Discrete GPU (device under test) | AMD Radeon RX 7900 XTX — gfx1100 / Navi31 |
 | iGPU (present, **not** the comparison target) | Ryzen 9 7950X integrated (gfx1036 / Raphael) |
 | HIP backend | ROCm 7.2.4 (hipModuleLaunchKernel path) |

--- a/docs/design/f16-relaxed-accuracy.md
+++ b/docs/design/f16-relaxed-accuracy.md
@@ -879,8 +879,8 @@ refusal before slice 3.
 | **2** | `shaderFloat16` + driver-identity + capability plumbing | the gate can be keyed on a driver, not a device name | local, both devices | no | **DONE 2026-07-27** — plus the coopmat capability query and the fragment type of slice 4b |
 | **3** | GLSL scalar f16, allowlisted | Sarek-*generated* f16 shaders meet the contract | RX 7900 XTX (local) | **yes**, on an allowlist | open |
 | **4** | backlog-62 Vulkan coopmat, f16×f16→f32 | the tensor-core path, end to end | RX 7900 XTX (local) | yes (new capability) | **4a/4c DONE for the INTEGER configurations, 2026-07-27 — see below. The f16 half is untouched and 4a's numeric contract is still unmeasured.** |
-| **5** | backlog-63 Metal — **scalar f16 first** | the Metal row of §2 | ladon (M4) | no | **DONE 2026-07-27 — strict, 0/63488** |
-| **6** | backlog-63 Metal `simdgroup_matrix` | the Apple tensor-core path | ladon (M4) | yes | **DONE 2026-07-27 — availability + numerics; no integer path** |
+| **5** | backlog-63 Metal — **scalar f16 first** | the Metal row of §2 | Apple M4 | no | **DONE 2026-07-27 — strict, 0/63488** |
+| **6** | backlog-63 Metal `simdgroup_matrix` | the Apple tensor-core path | Apple M4 | yes | **DONE 2026-07-27 — availability + numerics; no integer path** |
 
 ### Slice 0 — make the contract fail-able (host-only, lands first)
 
@@ -1345,7 +1345,7 @@ and needs nothing from the DSL:
 ### Slices 5 and 6 — backlog-63, Metal — **DONE, 2026-07-27**
 
 Both were unschedulable pending access to an Apple GPU. Access was granted, the
-probes were run on ladon, and both slices are complete. Recorded in
+probes were run on an Apple M4, and both slices are complete. Recorded in
 `fp-contraction-policy.md` §10.14 and §10.15; the rows are in §2 above.
 
 - **Slice 5 — scalar f16 on Metal. Done: it does not fuse.** 0 / 63488 from
@@ -1400,7 +1400,7 @@ probes were run on ladon, and both slices are complete. Recorded in
 > swept — nothing is claimed about what it computes. It is the obvious cheap
 > extension of slice 6 and needs no new hardware access.
 
-**Ladon usage: requested, granted, used.** Two standalone probe binaries were
+**Apple M4 access: requested, granted, used.** Two standalone probe binaries were
 built and run in a scratch directory under `/tmp`; nothing installed, no settings
 changed, no working tree touched. The absence of Xcode (Command Line Tools only,
 so no offline `metal` compiler) turned out not to matter —
@@ -1417,7 +1417,7 @@ gate is a separate slice.
 
 ### Hardware this plan does not have
 
-- ~~**Apple GPU** — ladon, permission needed. Blocks slices 5–6 entirely.~~
+- ~~**Apple GPU** — an Apple M4 machine, permission needed. Blocks slices 5–6 entirely.~~
   **Resolved 2026-07-27**: access granted, slices 5 and 6 both executed on an
   Apple M4. What Metal still lacks is not hardware but coverage — the 20-shape
   catalogue, a `bfloat` sweep, and a codegen-side gate.

--- a/docs/design/width-addition-cost.md
+++ b/docs/design/width-addition-cost.md
@@ -200,7 +200,7 @@ The verification bar for a width on this project is bit-exact agreement between
 the interpreter and a real device. For bf16 on this host:
 
 - **CUDA** — `__nv_bfloat16` needs sm_80. There is no NVIDIA device on this box,
-  and echydna is sm_61. `nvrtc` would compile it host-side, but a compile is not
+  and the only NVIDIA GPU reachable from it is sm_61 (GTX 1070 Max-Q). `nvrtc` would compile it host-side, but a compile is not
   the agreement gate.
 - **HIP** — gfx1100 has bf16 in its ISA and `hiprtc` is available, so this is the
   one plausible backend. But CUDA and HIP **share `Sarek_ir_cuda.ml` verbatim**,

--- a/sarek-metal/Metal_api.ml
+++ b/sarek-metal/Metal_api.ml
@@ -1,6 +1,5 @@
 (******************************************************************************)
 (* SPDX-License-Identifier: CECILL-B                                          *)
-(* SPDX-FileCopyrightText: 2026 mathias <mathias@ladon.local> *)
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 

--- a/sarek-metal/Metal_types.ml
+++ b/sarek-metal/Metal_types.ml
@@ -1,6 +1,5 @@
 (******************************************************************************)
 (* SPDX-License-Identifier: CECILL-B                                          *)
-(* SPDX-FileCopyrightText: 2026 mathias <mathias@ladon.local> *)
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 

--- a/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
+++ b/sarek-vulkan/test/test_vulkan_coopmat_integer.ml
@@ -349,8 +349,8 @@ let test_negative_device_refuses () =
       (* But UNOBSERVABLE is not VIOLATED. On a host where no device advertises
          the extension at all, this control cannot be satisfied by any correct
          implementation, so asserting it reports a hardware inventory as a code
-         defect. Measured on echydna (GTX 1070 Max-Q + Intel UHD 630, neither of
-         which supports VK_KHR_cooperative_matrix): the two refusal arms passed
+         defect. Measured on a host whose only GPUs were a GTX 1070 Max-Q and an
+         Intel UHD 630, neither of which supports VK_KHR_cooperative_matrix: the two refusal arms passed
          and this line failed, taking `dune test` to exit 1. It is green on the
          dev box only because the RX 7900 XTX (RDNA3) does support it — so the
          suite's verdict was a property of the machine, not of the code.

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -2124,12 +2124,35 @@ and convert_intrinsic_handlers () : (string list * intrinsic_handler) list =
     ( ["int_of_float"; "int_of_float64"],
       fun buf alloc env _path name args ->
         Some (intr_unary_cast buf alloc env name TInt32 args) );
-    ( ["of_int"],
+    (* [of_int32] and [of_float32] widen to the module's own float width, so
+       they ride the same path-dependent arm as [of_int]. They were the actual
+       backlog-167 gap: unrouted here, [Float64.of_int32] died with "unsupported
+       construct: intrinsic: of_int32" on CUDA/PTX while passing on OpenCL,
+       Vulkan, Native and the Interpreter — CPU-passes/device-fails, invisible on
+       a host with no NVIDIA device because the PTX legs skip there.
+       test_f64_scalar_conversions and test_tailrec_vector_param both hit it.
+
+       No new emitter: [intr_unary_cast] already reaches [emit_cast], which emits
+       the right instructions ([cvt.rn.f64.s32] for the int widening, the exact
+       [cvt.f64.f32] with NO rounding modifier for f32->f64 — ptxas rejects
+       [cvt.rn.f64.f32] — and [cvt.rzi.s32.f64] for the truncation). Only the
+       NAMES were missing, which is why this is a dispatch entry, not codegen. *)
+    ( ["of_int"; "of_int32"; "of_float32"],
       fun buf alloc env path name args ->
         if List.exists (fun p -> p = "Float64") path then
           Some (intr_unary_cast buf alloc env name TFloat64 args)
         else Some (intr_unary_cast buf alloc env name TFloat32 args) );
-    ( ["to_int"],
+    (* [to_float32] is deliberately NOT here, and this is the one place PTX and
+       GLSL disagree: Sarek_ir_glsl's [glsl_conversions] omits BOTH [to_int] and
+       [to_float32] because their device templates round/truncate while the
+       [ocaml] field Native mirrors is [Stdlib.int_of_float] (63-bit) and the
+       IDENTITY respectively — three implementations already disagree. PTX has
+       accepted [to_int] since this table existed, so that half of the
+       disagreement is already reachable here; do not read the [to_int] arm as an
+       endorsement. Deciding the two semantics stays a separate item; this change
+       does not widen the set, because "while I am here" is how an unresolved
+       semantic acquires a third implementation. *)
+    ( ["to_int"; "to_int32"],
       fun buf alloc env _path name args ->
         Some (intr_unary_cast buf alloc env name TInt32 args) );
   ]

--- a/sarek/tests/e2e/backend_metal.available.ml
+++ b/sarek/tests/e2e/backend_metal.available.ml
@@ -1,6 +1,5 @@
 (******************************************************************************)
 (* SPDX-License-Identifier: CECILL-B                                          *)
-(* SPDX-FileCopyrightText: 2026 mathias <mathias@ladon.local> *)
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 

--- a/sarek/tests/e2e/backend_metal.unavailable.ml
+++ b/sarek/tests/e2e/backend_metal.unavailable.ml
@@ -1,6 +1,5 @@
 (******************************************************************************)
 (* SPDX-License-Identifier: CECILL-B                                          *)
-(* SPDX-FileCopyrightText: 2026 mathias <mathias@ladon.local> *)
 (* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
 (******************************************************************************)
 

--- a/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
+++ b/sarek/tests/unit/test_ptx_intrinsic_sweep.ml
@@ -179,6 +179,33 @@ let convert_recipes =
         ("to_int_f32", f32_path, "af32", "oi32");
         ("to_int_f64", f64_path, "af64", "oi32");
       ] );
+    (* backlog-167. These three joined the emitter's conversion table and this
+       gate caught their absence here by name, which is the whole point of it:
+       test_ptx_snapshot asserts the instruction TEXT (cvt.rn.f64.s32, the
+       modifier-free cvt.f64.f32, cvt.rzi.s32.f64), but only ptxas assembling a
+       real kernel proves those spellings are legal. Both module paths are
+       covered because the dispatch arm is path-dependent — it widens to f64
+       under Float64 and to f32 otherwise — so a single path would leave half the
+       arm unassembled. *)
+    ( "of_int32",
+      [
+        ("of_int32_f32", f32_path, "ai32", "of32");
+        ("of_int32_f64", f64_path, "ai32", "of64");
+      ] );
+    ( "of_float32",
+      [
+        (* Under Float64 this is the exact f32 -> f64 widening. Under Float32 it
+           is the identity, which emit_cast returns as the source register
+           unchanged — worth assembling anyway, since "emits nothing" is a claim
+           about the emitter that ptxas can check. *)
+        ("of_float32_f32", f32_path, "af32", "of32");
+        ("of_float32_f64", f64_path, "af32", "of64");
+      ] );
+    ( "to_int32",
+      [
+        ("to_int32_f32", f32_path, "af32", "oi32");
+        ("to_int32_f64", f64_path, "af64", "oi32");
+      ] );
   ]
 
 (* Atomics: (argument shape, element type). The array operand comes first, then

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -1136,6 +1136,92 @@ let assert_absent ptx marker ~why =
          why
          ptx)
 
+(** backlog-167: the Float64 scalar conversions must EMIT on PTX.
+
+    [Float64.of_int32] raised "unsupported construct: intrinsic: of_int32" on
+    CUDA/PTX while passing on OpenCL, Vulkan, Native and the Interpreter —
+    measured on a GTX 1070 Max-Q (sm_61, CUDA 12.9). The CPU-passes/device-fails
+    shape: the only coverage these intrinsics had was device-EXECUTION tests,
+    and those skip on a host with no CUDA device, so the suite was green here
+    and red on real hardware. test_f64_scalar_conversions and
+    test_tailrec_vector_param both hit it.
+
+    THIS IS THE TEST THAT WOULD HAVE CAUGHT IT WITHOUT NVIDIA HARDWARE, which is
+    the whole point of putting it here — PTX text generation needs no device.
+
+    Each conversion is asserted on its own emitted instruction, individually, so
+    dropping one name from the dispatch table fails on that name rather than
+    somewhere vague. [of_int] and [to_int] were already routed before
+    backlog-167 and are covered here too, so a regression in the shared arms is
+    caught. *)
+let test_f64_conversions_emit () =
+  let check_one name arg_ty out_elt want_instr =
+    let x = make_var "x" arg_ty in
+    let out = make_var "out" (TVec out_elt) in
+    let ptx =
+      base_kernel
+        ("f64_conv_" ^ name)
+        [
+          DParam (x, None);
+          DParam (out, Some {arr_elttype = out_elt; arr_memspace = Global});
+        ]
+        (SAssign
+           ( LArrayElem ("out", EConst (CInt32 0l)),
+             EIntrinsic (["Float64"], name, [EVar x]) ))
+        []
+      |> Sarek_ir_ptx.generate
+    in
+    assert_contains ptx want_instr ;
+    ptx
+  in
+  ignore (check_one "of_int32" TInt32 TFloat64 "cvt.rn.f64.s32") ;
+  ignore (check_one "of_int" TInt32 TFloat64 "cvt.rn.f64.s32") ;
+  ignore (check_one "to_int32" TFloat64 TInt32 "cvt.rzi.s32.f64") ;
+  (* Exact widening, so NO rounding modifier: ptxas rejects [cvt.rn.f64.f32]
+     outright ("Illegal modifier"). Assert both polarities on the same emitted
+     text — the instruction is present AND the illegal spelling is not — because
+     the presence check alone is satisfied by a string that CONTAINS it. *)
+  let widen = check_one "of_float32" TFloat32 TFloat64 "cvt.f64.f32" in
+  assert_absent
+    widen
+    "cvt.rn.f64.f32"
+    ~why:"f32 -> f64 is exact; ptxas rejects a rounding modifier on it"
+
+(** [to_float32] is the one conversion PTX still refuses, and this pins that the
+    backlog-167 fix did not quietly widen the set.
+
+    Sarek_ir_glsl's [glsl_conversions] omits BOTH [to_int] and [to_float32]
+    because their device templates round/truncate while the [ocaml] field Native
+    mirrors is [Stdlib.int_of_float] (63-bit) and the IDENTITY respectively —
+    three implementations already disagree. PTX is NOT symmetric with GLSL here:
+    it has accepted [to_int] since its conversion table existed (asserted
+    above), so that half of the disagreement is already reachable on this
+    backend. Only [to_float32] is genuinely unrouted, and it stays that way
+    until the semantics are settled rather than acquiring a third implementation
+    by accident. *)
+let test_f64_to_float32_still_refused () =
+  let x = make_var "x" TFloat64 in
+  let out = make_var "out" (TVec TFloat32) in
+  let k =
+    base_kernel
+      "f64_to_float32"
+      [
+        DParam (x, None);
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ]
+      (SAssign
+         ( LArrayElem ("out", EConst (CInt32 0l)),
+           EIntrinsic (["Float64"], "to_float32", [EVar x]) ))
+      []
+  in
+  match Sarek_ir_ptx.generate k with
+  | _ ->
+      Alcotest.fail
+        "Float64.to_float32 emitted PTX. Its semantics disagree across Native \
+         (identity), the device templates (narrowing) and GLSL (refused); it \
+         must stay refused until that is decided, not routed in passing."
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+
 let point_ty = TRecord ("point", [("x", TFloat32); ("y", TFloat32)])
 
 (** Local record construct + field reads live entirely in registers: the record
@@ -3158,5 +3244,14 @@ let () =
             "int32 index still generates (positive control)"
             `Quick
             test_int32_index_still_generates;
+          Alcotest.test_case
+            "Float64 scalar conversions EMIT on PTX (backlog-167)"
+            `Quick
+            test_f64_conversions_emit;
+          Alcotest.test_case
+            "Float64.to_float32 stays refused: semantics undecided \
+             (backlog-167)"
+            `Quick
+            test_f64_to_float32_still_refused;
         ] );
     ]


### PR DESCRIPTION
Two independent commits.

## 1. `fix(ptx)` — backlog-167

`Float64.of_int32` raised `unsupported construct: intrinsic: of_int32` on CUDA/PTX while passing on OpenCL, Vulkan, Native and the Interpreter. A **CPU-passes/device-fails** defect: the only coverage these intrinsics had was device-*execution* tests, which skip on a host with no CUDA device — so the suite read green on the dev box and red on real NVIDIA hardware (measured on a GTX 1070 Max-Q, sm_61, CUDA 12.9). `test_f64_scalar_conversions` and `test_tailrec_vector_param` both hit it.

**The gap was three names, not an emitter.** `of_int32`, `of_float32` and `to_int32` were absent from `convert_intrinsic_handlers`. `intr_unary_cast` already reaches `emit_cast`, which emits exactly the right instructions — `cvt.rn.f64.s32`, the exact `cvt.f64.f32` with *no* rounding modifier (ptxas rejects `cvt.rn.f64.f32`), and `cvt.rzi.s32.f64`. So the fix extends the two existing path-dependent arms instead of adding a parallel dispatch path.

**Scope is deliberately not symmetric with GLSL, and the comment now says so.** `Sarek_ir_glsl`'s `glsl_conversions` omits *both* `to_int` and `to_float32` because their semantics disagree three ways. PTX has accepted `to_int` since its conversion table existed, so only `to_float32` is genuinely unrouted; it stays that way until the semantics are decided rather than acquiring a third implementation in passing.

### Both polarities proven red
| Mutation | Expected | Observed |
|---|---|---|
| revert `Sarek_ir_ptx_expr.ml` to `origin/main` | EMIT case red, refusal case green | ✅ 1 failure, case 65 |
| add `to_float32` to the widening arm | refusal case red | ✅ 1 failure, case 66 |

66/66 in `test_ptx_snapshot`. **This is the test that catches it without NVIDIA hardware** — PTX text generation needs no device.

## 2. `chore` — machine names out of committed sources

Private host names had leaked into tracked files. A reader outside this setup cannot resolve them, and the machine name is never the load-bearing fact — the hardware is. Every site now names the GPU/CPU instead.

The six SPDX headers were a different shape than they looked: **four already carried the canonical contributor line** and had a machine-derived *second* line appended, so the fix there is a deletion. Only two had the machine-derived line alone; those are rewritten to the byte-exact canonical line used by the other 584 headers, preserving 80-column alignment. `scripts/add-license-headers.sh` is not the source — `get_primary_contributor` returns a hardcoded `MAINTAINER`.

**Not in scope, flagged:** `benchmarks/results/*.json` filenames and the `hostname` fields in `gh-pages/benchmarks/data/latest.json` still carry a machine name (~250 occurrences). Those are harness-emitted provenance data, published to the website — changing them means changing what the benchmark harness records, which is a decision, not a rename.

Build green, `@fmt` green, both licence gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)