### PR TITLE
feat(soa): derive the SoA leaf layout instead of asking the caller for it

### DIFF
--- a/benchmarks/bench_soa_emitter.ml
+++ b/benchmarks/bench_soa_emitter.ml
@@ -71,19 +71,6 @@ let median arr =
   let n = Array.length a in
   if n = 0 then 0.0 else a.(n / 2)
 
-let fields =
-  Sarek_ir_types.
-    [
-      ("f0", TFloat32);
-      ("f1", TFloat32);
-      ("f2", TFloat32);
-      ("f3", TFloat32);
-      ("f4", TFloat32);
-      ("f5", TFloat32);
-      ("f6", TFloat32);
-      ("f7", TFloat32);
-    ]
-
 let is_ptx (dev : Device.t) = dev.Device.framework = "CUDA/PTX"
 
 (* Median wall time (ms) of [launch] over [iters], after [warmup] launches. *)
@@ -104,7 +91,7 @@ let run dev n =
   let ir = ir_of kernel in
   (* Storage via the real user-facing SoA API (Tier 1c). The SoA vector owns
      the AoS host buffer (used for the AoS leg) + the N per-leaf buffers. *)
-  let sv = Soa_vector.create wide_custom ~fields n in
+  let sv = Soa_vector.create wide_custom n in
   let pts = Soa_vector.aos_vector sv in
   for i = 0 to n - 1 do
     let v = float_of_int i in

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -128,10 +128,30 @@ codegen-level `~soa_params` knob:
 > for it, not work that is wholly outstanding. Read them as the plan for
 > transparency, not as a to-do list of missing plumbing.
 >
-> Separately shipped on the launch path: the `~fields` precondition is now
-> ENFORCED there (PR #366) rather than documented — `run_soa` compares the
-> declared plan against the kernel's authoritative `TRecord` and refuses a
-> mismatch instead of transposing silently-corrupt data.
+> Separately shipped on the launch path: the layout is CHECKED there (PR #366)
+> rather than documented — `run_soa` compares the vector's plan against the
+> kernel's authoritative `TRecord` and refuses a mismatch instead of transposing
+> silently-corrupt data.
+>
+> **UPDATE — the `~fields` argument is gone (slice 1 of this item).**
+> `Soa_vector.create` no longer takes the field layout; it DERIVES it from
+> `custom_type.ir_fields`, which the PPX populates for every `[@@sarek.type]`
+> record from the same `aligned_record_offsets` call that produces
+> `elem_size`/`get`/`set`. The premise both this doc and the code stated — "the
+> PPX `custom_type` carries no record layout" — was stale. That closes the
+> hazard at the source instead of intercepting it: there is no longer a second
+> description of the layout available to disagree with the first, so a
+> caller-supplied wrong list is not expressible.
+>
+> The PR #366 launch check STAYS, on a different axis. `create` sees only the
+> vector's element type; the launch also holds the kernel's `DParam`. `SA_Soa` is
+> existential, so binding a vector of one record type to a parameter of another
+> still typechecks — and that is what the check now refuses. The wiring test was
+> re-expressed accordingly (a `dpair` vector bound to a `point3d` parameter),
+> because its old mechanism, passing a permuted `~fields`, became impossible.
+>
+> So of the transparency bullets below, the LAYOUT blocker is closed. What
+> remains is the backend threading and the 1-buffer-per-device table.
 
 - **Host storage variant** (`Spoc_core_base.host_storage`, GADT at
   `sarek/core_base/Spoc_core_base.ml:111-120`): add `Custom_storage_soa` holding

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -28,8 +28,39 @@ let leaf_vector_of_size length size : packed_leaf =
            "Soa_vector: unsupported leaf byte size %d (expected 4 or 8)"
            size)
 
-let create (custom : 'a Vector.custom_type)
-    ~(fields : (string * Sarek_ir_types.elttype) list) (length : int) : 'a t =
+(* The leaf layout is DERIVED from the element type, never supplied. [create]
+   used to take a [~fields] list, on the stated premise that "the PPX
+   [custom_type] carries no layout" — which stopped being true once
+   [custom_type.ir_fields] landed. The PPX populates it for every
+   [[@@sarek.type]] record (Sarek_ppx.ml), from the same
+   [aligned_record_offsets] call that produces [elem_size]/[get]/[set], and
+   [test_ir_fields.ml] pins that agreement against the bytes [set] actually
+   writes.
+
+   Deriving it removes a hazard rather than documenting one: a caller-supplied
+   list that disagreed with the real record (wrong order, wrong widths,
+   missing/extra field) made scatter/gather transpose against the wrong byte
+   offsets, which is silently corrupted data and not an error. That failure mode
+   is now unreachable — there is no longer a second description of the layout to
+   disagree with the first.
+
+   [ir_fields = None] means "no derivable flat-scalar layout", which the
+   [custom_type] doc requires consumers to read as "no SoA". The only producer
+   that sets it is the variant deriver, and [Soa.plan] rejects a non-flat-record
+   anyway, so this refuses exactly the element types SoA could never represent. *)
+let create (custom : 'a Vector.custom_type) (length : int) : 'a t =
+  let fields =
+    match custom.Vector.ir_fields with
+    | Some fields -> fields
+    | None ->
+        raise
+          (Soa.Unsupported
+             (Printf.sprintf
+                "element type %S has no derivable flat-record layout \
+                 (custom_type.ir_fields is None), so it cannot be stored as \
+                 Structure-of-Arrays"
+                custom.Vector.name))
+  in
   let plan = Soa.plan ~name:custom.Vector.name fields in
   let aos = Vector.create_custom custom length in
   let leaves =

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -24,12 +24,16 @@
  * only. This module is pure host storage + transpose and is backend-agnostic.
  *
  * This is deliberately layered above {!Vector} + {!Soa} rather than being a new
- * constructor on the core [host_storage] GADT: the PPX [custom_type] carries no
- * record layout (so the field list must be supplied here), and a fully
- * transparent [Vector.create ~layout:SoA] + generic [Execute.run] auto-dispatch
- * would additionally require threading SoA param names through every backend and
- * generalising the 1-buffer-per-device table — deferred (see
+ * constructor on the core [host_storage] GADT. A fully transparent
+ * [Vector.create ~layout:SoA] + generic [Execute.run] auto-dispatch would
+ * require threading SoA param names through every backend and generalising the
+ * 1-buffer-per-device table — deferred (see
  * docs/optimization/tier1b-emitter-soa-handoff.md and the impl brief).
+ *
+ * The layout half of that deferral is now closed: the leaf enumeration is
+ * derived from [custom_type.ir_fields] rather than supplied by the caller, so
+ * "the custom_type carries no record layout" is no longer a reason this cannot
+ * be transparent. What remains is the backend threading and the buffer table.
  ******************************************************************************)
 
 (** A per-leaf host buffer, type-erased: a width-matched scalar vector used as a
@@ -39,26 +43,23 @@ type packed_leaf = Leaf : ('e, 'f) Vector.t -> packed_leaf
 (** A SoA custom vector of element type ['a]. *)
 type 'a t
 
-(** [create custom ~fields length] builds a SoA custom vector of [length]
-    elements. [custom] is the PPX-generated custom type (the AoS source of
-    truth); [fields] is the record's field layout [(name, scalar type)].
+(** [create custom length] builds a SoA custom vector of [length] elements.
+    [custom] is the PPX-generated custom type (the AoS source of truth), and the
+    leaf layout is {b derived} from it via [custom.ir_fields].
 
-    {b Precondition — [fields] MUST match the record's declaration order and
-       types exactly.} The [custom_type] carries no layout, so this cannot be
-    checked: [fields] is the sole description of how the packed AoS element is
-    split into leaves. If it disagrees with the actual record layout (wrong
-    order, wrong widths, missing/extra field), {!scatter}/{!gather} transpose
-    against the wrong byte offsets and the vector carries
-    {e silently transposed / corrupted} data with no error. Pass exactly the
-    fields the [[@@sarek.type]] record declares, in order — the same list the
-    kernel IR's [TRecord] uses.
+    There is deliberately no [~fields] parameter. There used to be one, on the
+    premise that the [custom_type] carried no layout; [ir_fields] now does, and
+    the PPX fills it for every [[@@sarek.type]] record from the same source as
+    [elem_size]/[get]/[set]. A caller-supplied list was the only way for the
+    described layout to disagree with the real one — and that disagreement was
+    not an error but {e silently transposed data}, since {!scatter}/{!gather}
+    would index at the wrong byte offsets. Deriving makes that unreachable
+    instead of checking for it.
 
-    Raises {!Soa.Unsupported} if [fields] is not a flat record. *)
-val create :
-  'a Vector.custom_type ->
-  fields:(string * Sarek_ir_types.elttype) list ->
-  int ->
-  'a t
+    Raises {!Soa.Unsupported} if the element type has no derivable flat-record
+    layout ([ir_fields = None], i.e. a variant) or is otherwise not
+    SoA-representable. *)
+val create : 'a Vector.custom_type -> int -> 'a t
 
 (** The AoS host vector (source of truth). Use it for the non-PTX host fallback
     (drive it through the ordinary {!Sarek.Execute.run_vectors} AoS path). *)

--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -65,23 +65,25 @@ let describe_leaf (l : Soa.leaf) : string =
 let describe_leaves (leaves : Soa.leaf list) : string =
   String.concat ", " (List.map describe_leaf leaves)
 
-(* The [~fields] precondition, ENFORCED rather than documented.
-   [Soa_vector.create] takes the record's field layout as an argument because the
-   PPX [custom_type] carries no layout, and its .mli states that a wrong list
-   (wrong order, wrong widths, missing/extra field) makes scatter/gather
-   transpose against the wrong byte offsets and yields "silently transposed /
-   corrupted data with no error" — adding that it "cannot be checked".
-   That is true where it is written, at [create], which never sees a kernel. It
-   is NOT true HERE: [run_soa] receives the kernel IR, whose [DParam] carries the
-   authoritative [TRecord] for that very parameter. So the launch can derive the
-   real plan and compare it against the one the vector will actually transpose
-   with, turning silent corruption into a refusal at the last moment before any
-   data moves.
+(* The vector's layout vs the KERNEL's — two independent declarations.
+   This used to guard a caller-supplied [~fields] list: [Soa_vector.create] took
+   the record's field layout as an argument, and a wrong one transposed against
+   the wrong byte offsets, which was silent corruption rather than an error.
+   [create] now DERIVES the layout from [custom_type.ir_fields], so that
+   particular hazard is closed at the source and this is no longer the only thing
+   standing between a wrong list and bad data.
+   It still guards a real and DIFFERENT axis, which is why it stays. [create]
+   sees only the vector's element type; [run_soa] additionally holds the kernel
+   IR, whose [DParam] carries the authoritative [TRecord] for that very
+   parameter. Nothing relates the two — [SA_Soa] is existential — so binding a
+   vector of one record type to a parameter of another is expressible and would
+   have the kernel read N leaf pointers under the wrong layout. Deriving inside
+   [create] cannot detect that; only the launch can.
    Compared: the LEAF LIST and the AoS stride — the two things scatter/gather
-   index with. Deliberately NOT the plan's [name]: the declared and authoritative
-   plans get their names from different places (the caller's [~fields] label vs
-   the record's own type name), so comparing it would reject correct programs.
-   An assertion wider than the property is its own defect. *)
+   index with. Deliberately NOT the plan's [name]: the two plans get their names
+   from different places (the vector's own type name vs the kernel record's), so
+   comparing it would reject correct programs. An assertion wider than the
+   property is its own defect. *)
 let check_soa_layout ~(param : string)
     ~(kernel_ty : Sarek_ir_types.elttype option) ~(declared : Soa.plan) : unit =
   match kernel_ty with
@@ -127,15 +129,15 @@ let check_soa_layout ~(param : string)
                        authoritative.Soa.aos_stride;
                    actual =
                      Printf.sprintf
-                       "leaves [%s] stride %d (from the ~fields given to \
-                        Soa_vector.create)"
+                       "leaves [%s] stride %d (from the SoA vector's own \
+                        element type)"
                        (describe_leaves declared.Soa.leaves)
                        declared.Soa.aos_stride;
                    context =
                      Printf.sprintf
-                       "SoA layout for kernel parameter %S. The ~fields list \
-                        must match the record's declaration order and types \
-                        exactly; it does not, so scatter/gather would \
+                       "SoA layout for kernel parameter %S. The SoA vector's \
+                        element type must match the record this parameter \
+                        declares; it does not, so scatter/gather would \
                         transpose against the wrong byte offsets and the \
                         kernel would read silently corrupted data. Refused \
                         before any transfer"
@@ -216,11 +218,11 @@ let run_soa ~(device : Device.t) ~(ir : Sarek_ir_types.kernel)
       (* SoA parameter names = kernel param name at each SA_Soa position. *)
       let params_info = kernel_params_info ir in
       let param_names = List.map fst params_info in
-      (* Enforce the ~fields precondition BEFORE anything is scattered or
-         transferred: a mismatch is refused at zero cost, and no device buffer is
-         left holding half-transposed data.
-         ORDERED BEFORE the PTX gate, deliberately. A wrong ~fields list is an
-         error in the CALL — true whatever device it is dispatched to — so
+      (* Check the layout BEFORE anything is scattered or transferred: a
+         mismatch is refused at zero cost, and no device buffer is left holding
+         half-transposed data.
+         ORDERED BEFORE the PTX gate, deliberately. A vector bound to a
+         parameter of a different record type is an error in the CALL — true whatever device it is dispatched to — so
          reporting it first is more useful than telling the caller to switch
          devices and only then, on a CUDA host, discovering their layout was
          wrong all along. It also makes this check reachable on a machine with no

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -195,13 +195,7 @@ let run_p3 dev n =
   let out_api =
     if not (is_ptx dev) then None
     else begin
-      let sv =
-        Soa_vector.create
-          point3d_custom
-          ~fields:
-            Sarek_ir_types.[("x", TFloat32); ("y", TFloat32); ("z", TFloat32)]
-          n
-      in
+      let sv = Soa_vector.create point3d_custom n in
       for i = 0 to n - 1 do
         Soa_vector.set
           sv
@@ -266,12 +260,7 @@ let run_dpair dev n =
   let out_api =
     if not (is_ptx dev) then None
     else begin
-      let sv =
-        Soa_vector.create
-          dpair_custom
-          ~fields:Sarek_ir_types.[("u", TFloat64); ("v", TFloat64)]
-          n
-      in
+      let sv = Soa_vector.create dpair_custom n in
       for i = 0 to n - 1 do
         Soa_vector.set
           sv
@@ -351,13 +340,7 @@ let check_gate dev =
   else begin
     Printf.printf "SoA-gate [%s] %s: %!" dev.Device.framework dev.Device.name ;
     let ir = ir_of p3_kernel in
-    let sv =
-      Soa_vector.create
-        point3d_custom
-        ~fields:
-          Sarek_ir_types.[("x", TFloat32); ("y", TFloat32); ("z", TFloat32)]
-        16
-    in
+    let sv = Soa_vector.create point3d_custom 16 in
     let out = Vector.create Vector.float32 16 in
     match
       run_soa_via_api dev ir ~sv ~out ~n:16 ~block:(dims 16) ~grid:(dims 1)
@@ -384,13 +367,7 @@ let check_roundtrip dev n =
     try
       let threads = min 128 n in
       let block = dims threads and grid = dims ((n + threads - 1) / threads) in
-      let sv =
-        Soa_vector.create
-          point3d_custom
-          ~fields:
-            Sarek_ir_types.[("x", TFloat32); ("y", TFloat32); ("z", TFloat32)]
-          n
-      in
+      let sv = Soa_vector.create point3d_custom n in
       let orig i =
         {
           x = float_of_int i;
@@ -451,13 +428,23 @@ let check_roundtrip dev n =
       false
   end
 
-(* ── the ~fields precondition is ENFORCED, not just documented ──────────────
-   Soa_vector.create takes the record's field layout as an argument, and its .mli
-   warns that a wrong list transposes against the wrong byte offsets and yields
-   "silently transposed / corrupted data with no error" — adding that it "cannot
-   be checked". True at [create], which has no kernel. False at the LAUNCH, which
-   holds the kernel IR and therefore the authoritative TRecord. These cases pin
-   that the launch compares the two and refuses.
+(* ── the launch still checks the layout, on a DIFFERENT axis than create ─────
+   History, because it changes what these cases are for. [Soa_vector.create] used
+   to take the field layout as a [~fields] argument, and a wrong list transposed
+   against the wrong byte offsets — silently corrupted data, not an error. The
+   launch check below existed to catch that at the last moment before any data
+   moved. [create] now DERIVES the layout from [custom_type.ir_fields], so a
+   caller can no longer describe it wrongly and that particular hazard is gone at
+   the source rather than intercepted here.
+
+   These cases are still real, and still guard something [create] cannot see:
+   [create] knows only the VECTOR's element type, while the launch also holds the
+   KERNEL's [DParam] [TRecord]. Those are two independent declarations, and
+   binding a vector of one record type to a kernel parameter of another is still
+   expressible — a mismatch that no amount of deriving inside [create] can
+   detect. That is the axis these cases pin, which is why they build their
+   declared plans by hand instead of going through [create]: the point is
+   precisely to present the check with a plan that disagrees with the kernel.
 
    Device-independent by construction: the check is a pure function of (param
    name, kernel element type, declared plan), so it runs on this machine with no
@@ -505,10 +492,67 @@ let refuses ~label ~param ~kernel_ty ~declared ~expect_substr =
           msg ;
         false)
 
+(* The DERIVATION, which replaced the [~fields] argument (backlog-54 slice 1).
+   [Soa_vector.create] now builds its plan from [custom_type.ir_fields], so this
+   asserts the derived plan is the RIGHT one — the leaf list and stride these
+   records used to be given by hand. Without it, deriving from a wrong source
+   (say a reversed or truncated [ir_fields]) would still typecheck, still refuse
+   nothing, and silently transpose at the wrong offsets: exactly the failure the
+   argument's removal was meant to make unreachable.
+
+   Device-independent — [create] allocates host buffers and touches no device, so
+   this runs on a machine with no GPU at all. Stride is asserted alongside the
+   leaves because the two are what scatter/gather index with, and a plan can have
+   correct leaves with a wrong stride (padding), which would corrupt every
+   element after the first. *)
+let check_field_derivation () =
+  let ok = ref true in
+  let check_plan label (plan : Soa.plan) ~expect_leaves ~expect_stride =
+    let got =
+      List.map
+        (fun (l : Soa.leaf) -> (l.Soa.path, l.Soa.aos_offset, l.Soa.size))
+        plan.Soa.leaves
+    in
+    if got <> expect_leaves then (
+      let show l =
+        String.concat
+          ", "
+          (List.map (fun (p, o, s) -> Printf.sprintf "%s@%d:%d" p o s) l)
+      in
+      Printf.printf
+        "  %-56s FAIL (leaves [%s], expected [%s])\n%!"
+        label
+        (show got)
+        (show expect_leaves) ;
+      ok := false)
+    else if plan.Soa.aos_stride <> expect_stride then (
+      Printf.printf
+        "  %-56s FAIL (stride %d, expected %d)\n%!"
+        label
+        plan.Soa.aos_stride
+        expect_stride ;
+      ok := false)
+    else Printf.printf "  %-56s OK\n%!" label
+  in
+  (* point3d: three 4-byte f32 leaves, packed, stride 12. *)
+  check_plan
+    "derived plan for point3d (3 x f32)"
+    (Soa_vector.plan (Soa_vector.create point3d_custom 4))
+    ~expect_leaves:[("x", 0, 4); ("y", 4, 4); ("z", 8, 4)]
+    ~expect_stride:12 ;
+  (* dpair: two 8-byte f64 leaves, stride 16. A different width AND a different
+     leaf count, so a derivation hard-wired to point3d cannot pass both. *)
+  check_plan
+    "derived plan for dpair (2 x f64)"
+    (Soa_vector.plan (Soa_vector.create dpair_custom 4))
+    ~expect_leaves:[("u", 0, 8); ("v", 8, 8)]
+    ~expect_stride:16 ;
+  !ok
+
 let check_layout_validation () =
   let authoritative = Soa.plan_of_elttype xyz_ty in
   let ok = ref true in
-  print_endline "  --- ~fields precondition enforced at launch ---" ;
+  print_endline "  --- precondition enforced at launch ---" ;
   (* POSITIVE CONTROL first. Without it, "refuses a wrong list" and "refuses
      every list" are the same observation, and the second would make SoA
      unusable rather than safe. *)
@@ -523,17 +567,17 @@ let check_layout_validation () =
     | exception e ->
         Printf.printf
           "  %-56s FAIL (rejected the CORRECT layout: %s)\n%!"
-          "matching ~fields is accepted"
+          "matching is accepted"
           (Printexc.to_string e) ;
         false
-  then Printf.printf "  %-56s OK\n%!" "matching ~fields is accepted"
+  then Printf.printf "  %-56s OK\n%!" "matching is accepted"
   else ok := false ;
   (* Wrong ORDER: same fields, same widths, permuted. The offsets move, so the
      transpose would read every field from the wrong column. *)
   if
     not
       (refuses
-         ~label:"permuted ~fields is refused"
+         ~label:"permuted is refused"
          ~param:"pts"
          ~kernel_ty:(Some xyz_ty)
          ~declared:
@@ -584,20 +628,24 @@ let check_layout_validation () =
 
 (* The WIRING, which the direct calls above cannot establish: run_soa must
    actually consult the check. Driven on ANY device, including non-PTX, and that
-   is the point — a mismatched ~fields list must surface the LAYOUT error rather
-   than the CUDA/PTX device gate. If the check sat behind the gate (where it
-   originally was) this case would report the gate message instead, so it pins
-   the ordering as well as the call. *)
+   is the point — the mismatch must surface the LAYOUT error rather than the
+   CUDA/PTX device gate. If the check sat behind the gate (where it originally
+   was) this case would report the gate message instead, so it pins the ordering
+   as well as the call.
+
+   The mismatch is now built by binding a SoA vector of the WRONG RECORD TYPE to
+   the parameter, not by handing [create] a wrong field list. That is a
+   deliberate change of mechanism, forced by [create] deriving its layout from
+   [ir_fields]: a permuted list is no longer expressible, so the case that used
+   one could no longer fail for its stated reason. What IS still expressible is
+   this: [SA_Soa] is existential ([SA_Soa : 'a Soa_vector.t -> soa_arg]), so the
+   type system does not relate the vector's element type to the parameter's, and
+   a [dpair] vector (2 x f64, stride 16) binds to a [point3d] parameter (3 x f32,
+   stride 12) without complaint. Both the leaf list and the stride disagree, so
+   the launch check is what stands between that and a kernel reading garbage. *)
 let check_layout_wired dev =
   let ir = ir_of p3_kernel in
-  let sv =
-    (* Permuted vs point3d's declaration order (x, y, z). Same widths, so only
-       the offsets/paths disagree — the subtle end of the mismatch space. *)
-    Soa_vector.create
-      point3d_custom
-      ~fields:Sarek_ir_types.[("y", TFloat32); ("x", TFloat32); ("z", TFloat32)]
-      8
-  in
+  let sv = Soa_vector.create dpair_custom 8 in
   let out = Vector.create Vector.float32 8 in
   match
     Soa_launch.run_soa
@@ -615,7 +663,7 @@ let check_layout_wired dev =
   with
   | () ->
       Printf.printf
-        "  %-56s FAIL (ran with a mismatched ~fields)\n%!"
+        "  %-56s FAIL (ran with a mismatched record type)\n%!"
         "run_soa consults the layout check"
       |> fun () -> false
   | exception Sarek.Execute_error.Execution_error e ->
@@ -636,7 +684,8 @@ let () =
   (* Device-independent, so it runs BEFORE the no-device early exit — otherwise
      a machine with no device would report SKIPPED while silently not checking a
      property that needs no device at all. *)
-  let layout_ok = check_layout_validation () in
+  let derive_ok = check_field_derivation () in
+  let layout_ok = check_layout_validation () && derive_ok in
   let devs = Device.all () in
   if Array.length devs = 0 then (
     print_endline
@@ -661,7 +710,7 @@ let () =
       if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;
-      (* Wiring + ordering: a mismatched ~fields must surface the LAYOUT error,
+      (* Wiring + ordering: a mismatched must surface the LAYOUT error,
          not the device gate, on this very non-PTX device. *)
       if not (check_layout_wired dev) then ok := false ;
       (* Leaf-write round-trip (D2H + gather) on CUDA/PTX. *)


### PR DESCRIPTION
**backlog-54 slice 1.** Closes the layout half of the Tier 1c transparency deferral.

## The stale premise

`Soa_vector.create` took a `~fields` list describing the record's layout. Three places justified it identically — the `.mli`, `Soa_launch.ml`, and the Tier 1b handoff doc — with:

> the PPX `custom_type` carries no record layout

That is no longer true. `custom_type.ir_fields` exists, and the PPX populates it for every `[@@sarek.type]` record (`Sarek_ppx.ml:1009`) from the same `aligned_record_offsets` call that produces `elem_size`/`get`/`set`; `test_ir_fields.ml` pins that agreement against the bytes `set` actually writes.

## Deleting the hazard instead of checking it

`create` now derives the plan and `~fields` is gone. The documented failure mode of a wrong list was *silently corrupted data, not an error* — scatter/gather indexing at the wrong byte offsets. Deriving makes that **unreachable**: there is no longer a second description of the layout available to disagree with the first.

`ir_fields = None` raises `Soa.Unsupported`. That is only the variant deriver, and `Soa.plan` rejected non-flat-records anyway, so this refuses exactly the element types SoA could never represent.

## The launch check stays, and its message was wrong

PR #366's `check_soa_layout` guards a **different axis**, and both its comment and its user-facing error text described a `~fields` argument that no longer exists. `create` sees only the vector's element type; `run_soa` also holds the kernel's `DParam` `TRecord`. `SA_Soa` is existential (`SA_Soa : 'a Soa_vector.t -> soa_arg`), so binding a vector of one record type to a parameter of another still typechecks — and no amount of deriving inside `create` can see that.

**That forced a change of mechanism.** `check_layout_wired` built its mismatch *by passing a permuted `~fields`*, which is now inexpressible, so it could no longer fail for its stated reason. I watched it fail first — on all six devices, reporting the PTX gate instead of the layout error — then re-expressed it as a `dpair` vector (2×f64, stride 16) bound to the `point3d` parameter (3×f32, stride 12).

## New coverage, proven red

`check_field_derivation` (device-independent — `create` touches no device) asserts the *derived* plan is the right one: leaf paths, offsets, sizes, **and** the AoS stride, for both records. Two shapes with different widths and different leaf counts, so a derivation hard-wired to either cannot pass both. Stride is asserted alongside the leaves because a plan can have correct leaves with a wrong stride, which corrupts every element after the first.

Prove-red — `create` deriving from `List.rev ir_fields`:
```
derived plan for point3d (3 x f32)   FAIL (leaves [z@0:4, y@4:4, x@8:4], expected [x@0:4, y@4:4, z@8:4])
derived plan for dpair (2 x f64)     FAIL (leaves [v@0:8, u@8:8], expected [u@0:8, v@8:8])
```

## What remains of Tier 1c

The handoff doc is updated to say so: the **layout** blocker is closed, so "the custom_type carries no record layout" is no longer a reason transparency is impossible. Still outstanding for `Vector.create ~layout:SoA` + generic `Execute.run` auto-dispatch: threading SoA param names through the backends, and generalising the 1-buffer-per-device table.

Full suite: **1727 cases across 119 suites, 0 failures**, `dune test` rc=0. Build, `@fmt`, and both licence gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SoA vector layouts are now derived automatically from the element type, eliminating the need to provide field lists manually.
  * Added validation to reject incompatible kernel and vector layouts before launch.

* **Bug Fixes**
  * Prevented potential data corruption caused by mismatched manually specified field layouts.

* **Documentation**
  * Updated SoA usage and launch behavior documentation to reflect automatic layout derivation and mismatch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->