### PR TITLE
fix(license): name the file on a duplicate copyright line instead of dying in sed

### DIFF
--- a/scripts/add-license-headers.sh
+++ b/scripts/add-license-headers.sh
@@ -35,6 +35,7 @@ MAINTAINER="Mathias Bourgoin <mathias.bourgoin@gmail.com>"
 
 # Colors
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
@@ -42,6 +43,10 @@ NC='\033[0m'
 # Counters
 UPDATED_COUNT=0
 SKIPPED_COUNT=0
+# Files carrying two copyright lines for the same contributor. Not fixable
+# here (this script cannot choose which to keep), so it reports and exits
+# non-zero rather than feeding a multi-line value to sed and dying namelessly.
+DUPLICATE_COUNT=0
 
 # Get copyright info from git
 get_copyright_years() {
@@ -135,9 +140,27 @@ add_ocaml_header() {
         # person (root cause of the sarek/codegen/Sarek_ir_ptx_stmt.mli
         # header mangling).
         if head -"$header_end_line" "$file" 2>/dev/null | grep "SPDX-FileCopyrightText:" | grep -qi "$contributor_email"; then
-            # Contributor exists - check if year needs updating
+            # Contributor exists - check if year needs updating.
+            #
+            # This grep can match MORE THAN ONE line: a header carrying two
+            # copyright lines for the same email is exactly what the duplicate
+            # bug above produces. A multi-line value then reached the `sed -i
+            # "s/$existing_years..."` below, which is not a well-formed s
+            # command -- sed died with "unterminated `s' command", the fixer
+            # exited 1 mid-walk having silently skipped every remaining file,
+            # and it never said WHICH file. Refuse explicitly and name it,
+            # because a duplicate line is itself the defect to fix (four files
+            # in this repo had one), not a state to paper over by taking the
+            # first match.
+            local matches
+            matches=$(head -"$header_end_line" "$file" | grep "SPDX-FileCopyrightText:" | grep -ci "$contributor_email")
+            if [ "$matches" -gt 1 ]; then
+                echo -e "${RED}DUPLICATE${NC}: $file has $matches SPDX-FileCopyrightText lines for <$contributor_email>; remove the extra one (this script cannot choose between them)" >&2
+                DUPLICATE_COUNT=$((DUPLICATE_COUNT + 1))
+                return
+            fi
             local contributor_line=$(head -"$header_end_line" "$file" | grep "SPDX-FileCopyrightText:" | grep -i "$contributor_email")
-            local existing_years=$(echo "$contributor_line" | grep -oP '\d{4}(-\d{4})?')
+            local existing_years=$(echo "$contributor_line" | grep -oP '\d{4}(-\d{4})?' | head -1)
             local first_year=$(echo "$existing_years" | cut -d- -f1)
 
             if [[ "$existing_years" =~ - ]]; then
@@ -424,7 +447,15 @@ else
     echo "Files updated: $UPDATED_COUNT"
 fi
 echo "Files skipped: $SKIPPED_COUNT"
+if [ $DUPLICATE_COUNT -gt 0 ]; then
+    echo -e "${RED}Files with duplicate copyright lines: $DUPLICATE_COUNT${NC} (listed above; fix by hand)"
+fi
 echo ""
+
+# A duplicate is a real defect and must not read as success in either mode.
+if [ $DUPLICATE_COUNT -gt 0 ]; then
+    exit 2
+fi
 
 if $DRY_RUN; then
     if [ $UPDATED_COUNT -gt 0 ]; then

--- a/scripts/add-license-headers.sh
+++ b/scripts/add-license-headers.sh
@@ -139,52 +139,70 @@ add_ocaml_header() {
         # kept appending a duplicate SPDX-FileCopyrightText line for the same
         # person (root cause of the sarek/codegen/Sarek_ir_ptx_stmt.mli
         # header mangling).
-        if head -"$header_end_line" "$file" 2>/dev/null | grep "SPDX-FileCopyrightText:" | grep -qi "$contributor_email"; then
-            # Contributor exists - check if year needs updating.
+        # -F, and matched on the BRACKETED address. Without -F the email is a
+        # REGEX, so every "." matches any character: two distinct contributors
+        # whose addresses differ only where a dot sits would match each other,
+        # which now means a false DUPLICATE below and a spurious exit 2 on a
+        # correct header. Any of [ ] * ^ $ \ in an address would be worse than
+        # loose -- it would be a grep error. Bracketing pins the match to a whole
+        # address rather than a substring of a longer one. -i stays: providers
+        # are case-insensitive by spec (see the note below).
+        local email_pat="<$contributor_email>"
+        if head -"$header_end_line" "$file" 2>/dev/null | grep "SPDX-FileCopyrightText:" | grep -qiF "$email_pat"; then
+            # Contributor exists - check if the year needs updating.
             #
             # This grep can match MORE THAN ONE line: a header carrying two
             # copyright lines for the same email is exactly what the duplicate
-            # bug above produces. A multi-line value then reached the `sed -i
-            # "s/$existing_years..."` below, which is not a well-formed s
-            # command -- sed died with "unterminated `s' command", the fixer
-            # exited 1 mid-walk having silently skipped every remaining file,
-            # and it never said WHICH file. Refuse explicitly and name it,
-            # because a duplicate line is itself the defect to fix (four files
-            # in this repo had one), not a state to paper over by taking the
-            # first match.
+            # bug noted above produces. A multi-line value then reached a
+            # `sed "s/$existing_years..."`, which is not a well-formed s command
+            # -- sed died with "unterminated `s' command", the fixer exited 1
+            # mid-walk having silently skipped every remaining file, and it never
+            # said WHICH file. Refuse explicitly and name it, because a duplicate
+            # line is itself the defect to fix (four files in this repo had one),
+            # not a state to paper over by taking the first match.
             local matches
-            matches=$(head -"$header_end_line" "$file" | grep "SPDX-FileCopyrightText:" | grep -ci "$contributor_email")
+            matches=$(head -"$header_end_line" "$file" | grep "SPDX-FileCopyrightText:" | grep -ciF "$email_pat")
             if [ "$matches" -gt 1 ]; then
-                echo -e "${RED}DUPLICATE${NC}: $file has $matches SPDX-FileCopyrightText lines for <$contributor_email>; remove the extra one (this script cannot choose between them)" >&2
+                echo -e "${RED}DUPLICATE${NC}: $file has $matches SPDX-FileCopyrightText lines for $email_pat; remove the extra one (this script cannot choose between them)" >&2
                 DUPLICATE_COUNT=$((DUPLICATE_COUNT + 1))
                 return
             fi
-            local contributor_line=$(head -"$header_end_line" "$file" | grep "SPDX-FileCopyrightText:" | grep -i "$contributor_email")
+            local contributor_line lineno
+            contributor_line=$(head -"$header_end_line" "$file" | grep "SPDX-FileCopyrightText:" | grep -iF "$email_pat")
+            lineno=$(head -"$header_end_line" "$file" | grep -n "SPDX-FileCopyrightText:" | grep -iF "$email_pat" | cut -d: -f1)
             local existing_years=$(echo "$contributor_line" | grep -oP '\d{4}(-\d{4})?' | head -1)
             local first_year=$(echo "$existing_years" | cut -d- -f1)
 
+            # Decide the new year span first, then rewrite the line by NUMBER.
+            #
+            # The year is substituted with bash ${var/pat/repl}, which is glob and
+            # not regex, and the year is digits plus a dash -- no metacharacters.
+            # The old code interpolated the email into a sed PATTERN, which had
+            # the same regex defect as the greps above; targeting the line we
+            # already located removes regex from this path entirely. Carrying the
+            # rest of the line verbatim also preserves the address's existing
+            # casing, which the old code needed a \1 backreference to do.
+            local new_years="" label=""
             if [[ "$existing_years" =~ - ]]; then
-                # Has year range - check if last year matches
                 local end_year=$(echo "$existing_years" | cut -d- -f2)
                 if [ "$last_commit_year" != "$end_year" ]; then
-                    # Update year range (operate on a copy so --check never
-                    # touches the real file; \1 preserves the email's
-                    # existing casing, the match itself is case-insensitive).
-                    local tmpfile=$(mktemp)
-                    cp "$file" "$tmpfile"
-                    sed -i "s/$existing_years\(.*$contributor_email\)/$first_year-$last_commit_year\1/I" "$tmpfile"
-                    apply_change "$file" "$tmpfile" "UPDATED YEAR ($first_year-$end_year -> $first_year-$last_commit_year)"
-                    return
+                    new_years="$first_year-$last_commit_year"
+                    label="UPDATED YEAR ($first_year-$end_year -> $new_years)"
                 fi
             else
-                # Single year - check if we need range
                 if [ "$last_commit_year" != "$first_year" ]; then
-                    local tmpfile=$(mktemp)
-                    cp "$file" "$tmpfile"
-                    sed -i "s/$first_year\(.*$contributor_email\)/$first_year-$last_commit_year\1/I" "$tmpfile"
-                    apply_change "$file" "$tmpfile" "UPDATED YEAR ($first_year -> $first_year-$last_commit_year)"
-                    return
+                    new_years="$first_year-$last_commit_year"
+                    label="UPDATED YEAR ($first_year -> $new_years)"
                 fi
+            fi
+
+            if [ -n "$new_years" ]; then
+                local new_line="${contributor_line/$existing_years/$new_years}"
+                local tmpfile=$(mktemp)
+                awk -v ln="$lineno" -v repl="$new_line" \
+                    'NR==ln {print repl; next} {print}' "$file" > "$tmpfile"
+                apply_change "$file" "$tmpfile" "$label"
+                return
             fi
 
             echo -e "${YELLOW}SKIP${NC}: $file (already up-to-date)"

--- a/scripts/check-license-headers.test.sh
+++ b/scripts/check-license-headers.test.sh
@@ -244,6 +244,85 @@ else
   pass=$((pass + 1))
 fi
 
+# --- Case 11: the year-update path actually updates the year -----------------
+# This path had NO case before, which is how it could be rewritten (from a
+# `sed` interpolating the email into a regex, to an awk rewrite of the located
+# line) with the suite still reading 12/12 green. A refactor of an uncovered
+# path is indistinguishable from a break of it.
+d="$(make_project case11)"
+sed -i 's/2026 Mathias/2019 Mathias/' "$d/sarek/covered.ml"
+out="$(cd "$d" && ./scripts/add-license-headers.sh 2>&1)"
+line="$(grep 'SPDX-FileCopyrightText' "$d/sarek/covered.ml")"
+this_year="$(date +%Y)"
+if ! printf '%s' "$out" | grep -qF "UPDATED YEAR"; then
+  echo "  FAIL: case11: a stale year was not reported as UPDATED YEAR"
+  echo "$out" | sed 's/^/        /'
+  fail=$((fail + 1))
+elif ! printf '%s' "$line" | grep -qF "2019-$this_year"; then
+  echo "  FAIL: case11: expected the span 2019-$this_year, got: $line"
+  fail=$((fail + 1))
+elif ! printf '%s' "$line" | grep -qF "<mathias.bourgoin@gmail.com>"; then
+  echo "  FAIL: case11: the rewrite lost or mangled the address: $line"
+  fail=$((fail + 1))
+else
+  echo "  PASS: case11: stale single year becomes a span, address intact"
+  pass=$((pass + 1))
+fi
+
+# --- Case 12: the address is matched LITERALLY, not as a regex ---------------
+# The email went into `grep -i` unquoted-as-regex, so every "." matched any
+# character. A DIFFERENT contributor whose address differs only where the dots
+# sit ("mathiasXbourgoin@gmailXcom" vs "mathias.bourgoin@gmail.com" — the same
+# string with only the dots replaced) satisfied that grep. The fixer then believed the
+# maintainer already had a line, took the year-update branch, and never added
+# the maintainer's own copyright — a missing attribution, silently.
+#
+# Asserted on the OUTCOME (the maintainer's exact address must end up in the
+# file) rather than on a message, so it holds however the branch is worded.
+d="$(make_project case12)"
+# NB the @ is kept. It is LITERAL in the regex, so an address that also
+# replaces it (mathiasXbourgoinXgmail.com) does not match the buggy pattern
+# either, and the case would pass against the defect it claims to catch — the
+# first cut of this case did exactly that. Only the DOTS may differ.
+foreign='(* SPDX-FileCopyrightText: 2020 Someone Else <mathiasXbourgoin@gmailXcom> *)'
+awk -v line="$foreign" '
+  /SPDX-License-Identifier/ { print; print line; next }
+  !/SPDX-FileCopyrightText/ { print }
+' "$d/sarek/covered.ml" > "$d/sarek/covered.ml.tmp" && mv "$d/sarek/covered.ml.tmp" "$d/sarek/covered.ml"
+out="$(cd "$d" && ./scripts/add-license-headers.sh 2>&1)"
+if printf '%s' "$out" | grep -qF "DUPLICATE"; then
+  echo "  FAIL: case12: a foreign address was mistaken for this contributor (DUPLICATE)"
+  echo "$out" | sed 's/^/        /'
+  fail=$((fail + 1))
+elif ! grep -qF '<mathias.bourgoin@gmail.com>' "$d/sarek/covered.ml"; then
+  echo "  FAIL: case12: the maintainer's own copyright line was never added"
+  grep 'SPDX-' "$d/sarek/covered.ml" | sed 's/^/        /'
+  fail=$((fail + 1))
+else
+  echo "  PASS: case12: a regex-matching but different address is not this contributor"
+  pass=$((pass + 1))
+fi
+
+# --- Case 13: case-insensitive matching SURVIVED the switch to -F ------------
+# -i is load-bearing and documented in the fixer: providers are case-insensitive
+# by spec, and a case-sensitive match previously made a differently-cased
+# address look like a new contributor on every run, appending a duplicate line
+# each time. Adding -F must not have dropped that, so this pins the opposite
+# polarity of case12: same address, different casing, must be the SAME person —
+# no second line appended.
+d="$(make_project case13)"
+sed -i 's/<mathias\.bourgoin@gmail\.com>/<Mathias.Bourgoin@Gmail.Com>/' "$d/sarek/covered.ml"
+out="$(cd "$d" && ./scripts/add-license-headers.sh 2>&1)"
+n="$(grep -c 'SPDX-FileCopyrightText' "$d/sarek/covered.ml")"
+if [ "$n" != 1 ]; then
+  echo "  FAIL: case13: differently-cased address produced $n copyright lines, expected 1"
+  grep 'SPDX-' "$d/sarek/covered.ml" | sed 's/^/        /'
+  fail=$((fail + 1))
+else
+  echo "  PASS: case13: differently-cased address is still the same contributor"
+  pass=$((pass + 1))
+fi
+
 echo ""
 echo "  $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/check-license-headers.test.sh
+++ b/scripts/check-license-headers.test.sh
@@ -202,6 +202,48 @@ else
   fail=$((fail + 1))
 fi
 
+# --- Case 10: a duplicate copyright line is named, not a nameless sed crash ---
+# Two SPDX-FileCopyrightText lines for the SAME email made the year-update grep
+# return two lines, which went into `sed -i "s/$existing_years..."` as a
+# multi-line value. sed died with "unterminated `s' command", the fixer exited 1
+# partway through its walk having silently skipped every remaining file, and it
+# never printed the offending path -- so the operator saw a red run with no
+# location. Four files in this repo were in exactly that state.
+#
+# Both halves are asserted, because the exit status alone is satisfied by the
+# old crash too: it must exit 2 (not 1, which is "files need updating") AND name
+# the file AND say what is wrong with it.
+d="$(make_project case10)"
+dup_line='(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)'
+# Insert a second, identical copyright line inside the header block.
+awk -v line="$dup_line" '
+  /SPDX-FileCopyrightText:/ && !done { print; print line; done=1; next }
+  { print }
+' "$d/sarek/covered.ml" > "$d/sarek/covered.ml.tmp" && mv "$d/sarek/covered.ml.tmp" "$d/sarek/covered.ml"
+
+out="$(cd "$d" && ./scripts/add-license-headers.sh --check 2>&1)"
+got=$?
+if [ "$got" != 2 ]; then
+  echo "  FAIL: case10: duplicate copyright line -- expected exit 2, got $got"
+  echo "$out" | sed 's/^/        /'
+  fail=$((fail + 1))
+elif ! printf '%s' "$out" | grep -qF -- "sarek/covered.ml"; then
+  echo "  FAIL: case10: exit 2 as expected, but the output never named sarek/covered.ml"
+  echo "$out" | sed 's/^/        /'
+  fail=$((fail + 1))
+elif ! printf '%s' "$out" | grep -qF -- "DUPLICATE"; then
+  echo "  FAIL: case10: exit 2 and named the file, but never said what was wrong"
+  echo "$out" | sed 's/^/        /'
+  fail=$((fail + 1))
+elif printf '%s' "$out" | grep -qF -- "unterminated"; then
+  echo "  FAIL: case10: sed still crashed rather than the duplicate being refused"
+  echo "$out" | sed 's/^/        /'
+  fail=$((fail + 1))
+else
+  echo "  PASS: case10: duplicate copyright line is refused by path (exit 2)"
+  pass=$((pass + 1))
+fi
+
 echo ""
 echo "  $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Found while fixing the SPDX headers in #371, and it cost me real time there.

## The defect

The year-update path in `scripts/add-license-headers.sh` extracts the contributor's copyright line with a grep that **can match more than one line**. A header carrying two `SPDX-FileCopyrightText` lines for the same email — the exact state the case-insensitivity bug documented just above it used to produce, and which **four files in this repo were in** — makes that a multi-line value, which then reaches:

```sh
sed -i "s/$existing_years\(.*$contributor_email\)/.../I"
```

as the pattern. That is not a well-formed `s` command:

```
sed: -e expression n°1, caractère 6 : commande « s » inachevée
```

The fixer stopped mid-walk having silently skipped every remaining file, exited 1, and **never printed the offending path**. A red run with no location.

## The fix

A duplicate line is itself the defect to fix, so this refuses it by path rather than papering over it by taking the first match:

- `DUPLICATE` names the file *and* the email, on stderr
- `DUPLICATE_COUNT` is surfaced in the summary
- exit code **2**, distinct from 1 which already means "files need updating"
- the years extraction also takes `head -1`, so a second 4-digit match on a single line cannot reintroduce the same shape

## Scope, honestly

This is the **operator-facing fixer, not the CI gate**. `ci.yml:84` runs `check-license-headers.sh`, which was green throughout — the blast radius was developer time, not a broken build.

## Coverage

Case 10 in `scripts/check-license-headers.test.sh`, which CI *does* run (`ci.yml:168`). It asserts four things, because **the exit status alone was satisfied by the old crash too**: exit 2, the output names the file, it says `DUPLICATE`, and `unterminated` is absent.

Prove-red — removing the guard and restoring the un-`head`ed extraction:
```
FAIL: case10: duplicate copyright line -- expected exit 2, got 1
11 passed, 1 failed
```
With the fix: **12 passed, 0 failed**, and the CI gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license header validation to detect duplicate copyright lines reliably.
  * Reports the affected file and duplicate count without triggering misleading errors.
  * License checks now fail consistently when duplicate entries are found, including check-only runs.

* **Tests**
  * Added coverage for duplicate OCaml copyright headers, including expected error codes and diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->