### PR TITLE
feat(soa): carry an SoA binding on the vector, not a host_storage constructor

### DIFF
--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -65,8 +65,10 @@ existing enumeration — the STOP condition in the task did not fire).
   reference. **PASS** for `point3d` (3× f32) and `dpair` (2× f64) on RX 7900 XTX
   and CPU-as-CUDA under ZLUDA; `point3d`'s AoS leg also passes on
   OpenCL/Vulkan/Native/Interpreter. i32/i64 leaves are covered at the
-  PTX-instruction + ptxas-assembly level (device e2e for them is folded into
-  Tier 1c once the launch plumbing lands).
+  PTX-instruction + ptxas-assembly level AND on device — see the table below and
+  "Device e2e for the two integer combos: DONE" under it. The Tier 1c deferral
+  this bullet used to carry was discharged once ZLUDA supplied a CUDA/PTX
+  device.
 
 | Leaf type combo | PTX markers | ptxas | device e2e (ZLUDA) |
 |---|---|---|---|
@@ -198,7 +200,10 @@ codegen-level `~soa_params` knob:
 This is pure plumbing (no new coalescing) — the roadmap (§1.2c/e) rates it the
 bulk of the SoA cost; it was descoped here so the emitter could ship complete
 and proven. When it lands, extend `test_soa_emitter_equiv` to drive SoA through
-`Vector.create ~layout:SoA` + `run_vectors`, and add the i32/i64 device rows.
+the transparent constructor + `run_vectors`. The i32/i64 device rows this
+sentence used to also ask for are NOT outstanding: they landed with
+`check_mixed_widths` (see the table above), and leaving them listed here had a
+reader draw the opposite conclusion from the table.
 
 > **✅ CLOSED (2026-07-29) — was: PRECONDITION, generated param-name namespace.**
 > Option (a) shipped in `63ab6df1`: the emitter now mangles leaves as

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -72,13 +72,28 @@ existing enumeration — the STOP condition in the task did not fire).
 |---|---|---|---|
 | f32 × 3 (`point3d`) | ✓ | ✓ | ✓ |
 | f64 × 2 (`dpair`) | ✓ | ✓ | ✓ |
-| i32 + f64 (`{i;d}`) | ✓ | ✓ (`soa_mixed`) | (Tier 1c) |
-| i64 + i32 (`{p;q}`) | ✓ (`ld.global.s64`+`s32`) | ✓ (`soa_long`) | (Tier 1c) |
+| i32 + f64 (`{i;d}`) | ✓ | ✓ (`soa_mixed`) | ✓ (2026-07-30, ZLUDA) |
+| i64 + i32 (`{p;q}`) | ✓ (`ld.global.s64`+`s32`) | ✓ (`soa_long`) | ✓ (2026-07-30, ZLUDA) |
 
 All three SoA kernels (`soa_field_sum_f32`, `soa_mixed_i32_f64`,
 `soa_long_i64_i32`) go through `test_ptxas_assembles`; the i32+f64 and i64+i32
-combos additionally have dedicated marker tests. Device e2e for the two integer
-combos folds into Tier 1c with the launch plumbing.
+combos additionally have dedicated marker tests.
+
+**Device e2e for the two integer combos: DONE 2026-07-30.** They were open only
+for want of a CUDA/PTX device; ZLUDA on the RX 7900 XTX provides one.
+`check_mixed_widths` in `test_soa_emitter_equiv.ml` drives both through the
+TRANSPARENT path (`Soa_vector.create_transparent` + the generic
+`Execute.run_vectors`), so one case covers the mixed-width leaf addressing and
+the generic dispatch together. Each leaf is written to its own output array at
+its own width — deliberately no int<->float conversion, since a conversion folds
+both leaves into one number and a per-leaf stride error could then be masked by a
+compensating error in the other leaf.
+
+Observed: both rows OK on the N-leaf PTX ABI (2 ZLUDA devices) and OK on the AoS
+fallback (5 non-PTX devices); the i32+f64 row SKIPs on the 2 devices that report
+no fp64. The rows are gated on the DEVICE CAPABILITY (`Device.allows_fp64` /
+`allows_int64`) rather than on `framework = "CUDA/PTX"` the way the dpair row is,
+so they run wherever they can actually execute instead of only on PTX.
 
 ## Benchmark — the emitter's coalescing win (`benchmarks/bench_soa_emitter`)
 

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -89,9 +89,12 @@ its own width — deliberately no int<->float conversion, since a conversion fol
 both leaves into one number and a per-leaf stride error could then be masked by a
 compensating error in the other leaf.
 
-Observed: both rows OK on the N-leaf PTX ABI (2 ZLUDA devices) and OK on the AoS
-fallback (5 non-PTX devices); the i32+f64 row SKIPs on the 2 devices that report
-no fp64. The rows are gated on the DEVICE CAPABILITY (`Device.allows_fp64` /
+Observed: both rows OK on the N-leaf PTX ABI (2 ZLUDA devices). On the AoS
+fallback the two rows differ and are counted separately — the earlier single "5
+non-PTX devices" figure was the i32+f64 count applied to both: the **i64+i32** row
+is OK on **all 7** non-PTX devices, while the **i32+f64** row is OK on **5** and
+SKIPs on the 2 rusticl OpenCL devices that do not report fp64. The rows are gated
+on the DEVICE CAPABILITY (`Device.allows_fp64` /
 `allows_int64`) rather than on `framework = "CUDA/PTX"` the way the dpair row is,
 so they run wherever they can actually execute instead of only on PTX.
 

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -236,15 +236,31 @@ let create_transparent (custom : 'a Vector.custom_type) (length : int) :
                device the results were NOT on discarded them.
 
                One rule for both cases, so there is no [None] special case to
-               drift: after freeing, the leaves are authoritative iff some leaf
-               still has a device buffer somewhere. For [None] every leaf was
-               just released on every device, so this evaluates to [false] — and
-               it does so by observing the leaves rather than by asserting what
-               the loop above was supposed to have done. *)
+               drift: after freeing, the leaves are authoritative iff they
+               already WERE and some leaf still has a device buffer somewhere.
+               For [None] every leaf was just released on every device, so the
+               second conjunct is [false] — and it is so by observing the leaves
+               rather than by asserting what the loop above was supposed to have
+               done.
+
+               The first conjunct is not redundant, and leaving it out was a
+               resurrection bug: allocation is not authority. A packed launch
+               CLEARS this flag after gathering the leaves into host storage
+               (Execute.transfer_vectors_to_device), and the leaves it gathered
+               stay allocated on their device — so deriving from allocation alone
+               turned the flag back ON for leaves that now hold PRE-packed-launch
+               data. Measured (test_soa_cross_device_migration,
+               "a free does not resurrect stale leaf ownership"): SoA launch on
+               A, packed launch on B, [free_buffer sv B], packed launch again —
+               the last launch gathered A's stale leaves over the host copy of
+               B's result and ran on them. Narrowing only: this can clear the
+               flag, never set it. *)
             leaves_live :=
-              Array.exists
-                (fun (Leaf lv) -> Hashtbl.length lv.Vector.device_buffers > 0)
-                t.leaves);
+              !leaves_live
+              && Array.exists
+                   (fun (Leaf lv) ->
+                     Hashtbl.length lv.Vector.device_buffers > 0)
+                   t.leaves);
         soa_leaf_bufs =
           (fun dev -> Array.to_list (Array.map (leaf_buf dev) t.leaves));
       } ;

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -94,7 +94,31 @@ let scatter t =
     t.plan
     ~aos:(Vector.to_ctypes_ptr t.aos)
     ~length:t.length
-    ~leaves:(leaf_ptrs t)
+    ~leaves:(leaf_ptrs t) ;
+  (* The transpose above writes each leaf's HOST buffer through a raw ctypes
+     pointer, which performs no location bookkeeping. So without this a leaf
+     keeps whatever location it already had — and after a previous launch that
+     is [Both dev], on which [Transfer.to_device] logs "skip (Both)" and returns
+     without copying. A SECOND launch on the same vector then ran against the
+     FIRST launch's device data, silently, with no user workaround.
+
+     Marking [Stale_GPU dev] is the accurate statement and not a nudge: the host
+     copy is the one just written and the device copy is now out of date. It is
+     also the one location [to_device] does not short-circuit.
+
+     Only leaves that actually HAVE a buffer on a device are touched; a leaf
+     never transferred stays [CPU], which is already correct.
+
+     Done here rather than in the [soa_to_device] closure so the explicit
+     [Soa_launch.run_soa] path gets it too — both callers scatter through this
+     function, and this invariant must not have two answers. *)
+  Array.iter
+    (fun (Leaf lv) ->
+      match lv.Vector.location with
+      | Vector.Both d | Vector.GPU d | Vector.Stale_CPU d ->
+          lv.Vector.location <- Vector.Stale_GPU d
+      | Vector.CPU | Vector.Stale_GPU _ -> ())
+    t.leaves
 
 let gather t =
   Soa.gather

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -217,14 +217,34 @@ let create_transparent (custom : 'a Vector.custom_type) (length : int) :
                 Array.iter
                   (fun (Leaf lv) -> Transfer.free_all_buffers lv)
                   t.leaves) ;
-            (* The leaves now hold nothing a read-back could fetch, so the flag
+            (* The freed leaves hold nothing a read-back could fetch, so the flag
                that says "the leaves are authoritative" must stop saying it —
-               otherwise the next read-back follows freed buffers. Safe to clear
-               unconditionally even for the [Some d] case: this binding has one
-               flag for the whole vector, not one per device (see
-               [Transfer.has_device_data]), so there is no per-device answer to
-               preserve. *)
-            leaves_live := false);
+               otherwise the next read-back follows freed buffers.
+
+               DERIVED from what is still allocated, not assigned [false]. The
+               previous version cleared it unconditionally and justified that
+               with "this binding has one flag for the whole vector, so there is
+               no per-device answer to preserve". The premise is right and the
+               conclusion is backwards: precisely BECAUSE the flag covers the
+               whole vector, a per-device free ([Some d]) must not clear it while
+               leaves are still live on another device. Measured after a
+               migration — leaves on A, packed buffer on B — [free_buffer sv B]
+               released B's half and then reported the whole vector leaf-free
+               with A's leaves still allocated. [Transfer.has_device_data sv A]
+               then answered [false], so the drain-before-free in
+               [Transfer.free_buffer]/[free_all_buffers] skipped A: freeing a
+               device the results were NOT on discarded them.
+
+               One rule for both cases, so there is no [None] special case to
+               drift: after freeing, the leaves are authoritative iff some leaf
+               still has a device buffer somewhere. For [None] every leaf was
+               just released on every device, so this evaluates to [false] — and
+               it does so by observing the leaves rather than by asserting what
+               the loop above was supposed to have done. *)
+            leaves_live :=
+              Array.exists
+                (fun (Leaf lv) -> Hashtbl.length lv.Vector.device_buffers > 0)
+                t.leaves);
         soa_leaf_bufs =
           (fun dev -> Array.to_list (Array.map (leaf_buf dev) t.leaves));
       } ;

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -102,3 +102,52 @@ let gather t =
     ~leaves:(leaf_ptrs t)
     ~length:t.length
     ~aos:(Vector.to_ctypes_ptr t.aos)
+
+(* ── Transparent SoA: a plain Vector the generic launch path can dispatch on ──
+   backlog-54. Returns the AoS vector with its [soa] binding populated, so
+   [Execute.run] can bind the N-leaf ABI without ever naming this module.
+
+   Why that indirection exists: sarek/execute/jsoo/dune copies Execute.ml but
+   NOT Soa_launch.ml, so Execute.ml is compiled in a build where Soa_vector does
+   not exist. It therefore cannot call into here — the binding's closures are the
+   only channel, which is why they are closures and not a plan.
+
+   Why the constructor is HERE and not [Vector.create ~layout:SoA] as the Tier 1b
+   handoff proposed: Soa_vector depends on Vector, so putting it there would be a
+   layer inversion. The transparency that the item is actually about is at the
+   LAUNCH site — the user calls the generic Execute.run and the N-pointer ABI is
+   selected for them — and that is unaffected by which module names the
+   constructor. *)
+let create_transparent (custom : 'a Vector.custom_type) (length : int) :
+    ('a, unit) Vector.t =
+  let t = create custom length in
+  let leaf_buf (dev : Device.t) (Leaf lv) =
+    match Vector.get_buffer lv dev with
+    | Some b -> b
+    | None ->
+        (* Unreachable via the launch path: soa_to_device runs first and
+           allocates every leaf. Loud rather than silent, because a missing leaf
+           buffer would otherwise bind a short argument list to an N-pointer
+           signature — the kernel would then read whatever followed. *)
+        invalid_arg
+          (Printf.sprintf
+             "Soa_vector: leaf buffer not allocated on device %d; \
+              soa_to_device must run before soa_leaf_bufs"
+             dev.Device.id)
+  in
+  let v = t.aos in
+  v.Vector.soa <-
+    Some
+      {
+        Vector.soa_num_leaves = num_leaves t;
+        soa_aos_stride = t.plan.Soa.aos_stride;
+        soa_scatter = (fun () -> scatter t);
+        soa_gather = (fun () -> gather t);
+        soa_to_device =
+          (fun dev ->
+            scatter t ;
+            Array.iter (fun (Leaf lv) -> Transfer.to_device lv dev) t.leaves);
+        soa_leaf_bufs =
+          (fun dev -> Array.to_list (Array.map (leaf_buf dev) t.leaves));
+      } ;
+  v

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -160,11 +160,12 @@ let create_transparent (custom : 'a Vector.custom_type) (length : int) :
              dev.Device.id)
   in
   let v = t.aos in
-  (* SET only by [soa_to_device] below; cleared or narrowed by three other
-     writers outside this module (see [soa_leaves_live]'s doc in
-     Spoc_core_base.ml for the exhaustive list). No reader re-derives "SoA or
-     AoS?" from the vector's shape — that is the point of the flag, so that
-     read-back follows the launch's ABI decision. *)
+  (* SET only by [soa_to_device] below. Three other writers can clear or narrow
+     it: [soa_free_leaves], also in this record, narrows it; and
+     [Execute.transfer_vectors_to_device] and [Transfer.to_device] clear it. That
+     list is exhaustive — see [soa_leaves_live]'s doc in Spoc_core_base.ml. No
+     reader re-derives "SoA or AoS?" from the vector's shape; that is the point of
+     the flag, so that read-back follows the launch's ABI decision. *)
   let leaves_live = ref false in
   v.Vector.soa <-
     Some

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -197,6 +197,34 @@ let create_transparent (custom : 'a Vector.custom_type) (length : int) :
               (fun (Leaf lv) -> Transfer.to_cpu ~force:true lv)
               t.leaves ;
             gather t);
+        soa_free_leaves =
+          (fun dev ->
+            (* No read-back here. The CALLER (Transfer.free_buffer /
+               free_all_buffers) drains through [read_back_to_host] first, and
+               doing it again here would either be redundant or — once the flag
+               below is cleared — read the packed buffer instead. One drain, at
+               the site that owns the ordering.
+
+               [Transfer.free_buffer]/[free_all_buffers] on a LEAF, not
+               [B.free ()] directly: the leaves are ordinary scalar vectors, so
+               they get the location bookkeeping and the [Gpu_memory.track_free]
+               accounting for free, and a leaf whose buffer is already gone is a
+               no-op rather than a double free. *)
+            (match dev with
+            | Some d ->
+                Array.iter (fun (Leaf lv) -> Transfer.free_buffer lv d) t.leaves
+            | None ->
+                Array.iter
+                  (fun (Leaf lv) -> Transfer.free_all_buffers lv)
+                  t.leaves) ;
+            (* The leaves now hold nothing a read-back could fetch, so the flag
+               that says "the leaves are authoritative" must stop saying it —
+               otherwise the next read-back follows freed buffers. Safe to clear
+               unconditionally even for the [Some d] case: this binding has one
+               flag for the whole vector, not one per device (see
+               [Transfer.has_device_data]), so there is no per-device answer to
+               preserve. *)
+            leaves_live := false);
         soa_leaf_bufs =
           (fun dev -> Array.to_list (Array.map (leaf_buf dev) t.leaves));
       } ;

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -136,6 +136,9 @@ let create_transparent (custom : 'a Vector.custom_type) (length : int) :
              dev.Device.id)
   in
   let v = t.aos in
+  (* Set by [soa_to_device] below and only read by the read-back path, so that
+     read-back follows the launch's ABI decision rather than re-deriving it. *)
+  let leaves_live = ref false in
   v.Vector.soa <-
     Some
       {
@@ -143,10 +146,33 @@ let create_transparent (custom : 'a Vector.custom_type) (length : int) :
         soa_aos_stride = t.plan.Soa.aos_stride;
         soa_scatter = (fun () -> scatter t);
         soa_gather = (fun () -> gather t);
+        soa_leaves_live = leaves_live;
         soa_to_device =
           (fun dev ->
             scatter t ;
-            Array.iter (fun (Leaf lv) -> Transfer.to_device lv dev) t.leaves);
+            Array.iter (fun (Leaf lv) -> Transfer.to_device lv dev) t.leaves ;
+            leaves_live := true ;
+            (* The AoS vector itself gets no device buffer under this ABI — the
+               leaves hold the data — so without this its location stays [CPU]
+               and EVERY read-back path short-circuits: [Transfer.to_cpu],
+               [Transfer.sync] and the auto-sync callback all treat [CPU] as
+               "nothing on a device to fetch" and return before looking at the
+               SoA binding at all. Recording the device as authoritative and the
+               host copy as stale is not bookkeeping; it is what makes the
+               read-back reachable. *)
+            v.Vector.location <- Vector.Stale_CPU dev);
+        soa_from_device =
+          (fun _dev ->
+            (* [~force:true]: after a launch the leaves are [Vector.Both dev] —
+               the host copy is the pre-launch scatter, the device copy is the
+               result — and an unforced [to_cpu] treats [Both] as already in
+               sync and returns without reading anything back. That is exactly
+               the silent-stale-output failure this closure exists to prevent,
+               so the force is load-bearing and not defensive. *)
+            Array.iter
+              (fun (Leaf lv) -> Transfer.to_cpu ~force:true lv)
+              t.leaves ;
+            gather t);
         soa_leaf_bufs =
           (fun dev -> Array.to_list (Array.map (leaf_buf dev) t.leaves));
       } ;

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -160,8 +160,11 @@ let create_transparent (custom : 'a Vector.custom_type) (length : int) :
              dev.Device.id)
   in
   let v = t.aos in
-  (* Set by [soa_to_device] below and only read by the read-back path, so that
-     read-back follows the launch's ABI decision rather than re-deriving it. *)
+  (* SET only by [soa_to_device] below; cleared or narrowed by three other
+     writers outside this module (see [soa_leaves_live]'s doc in
+     Spoc_core_base.ml for the exhaustive list). No reader re-derives "SoA or
+     AoS?" from the vector's shape — that is the point of the flag, so that
+     read-back follows the launch's ABI decision. *)
   let leaves_live = ref false in
   v.Vector.soa <-
     Some

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -27,10 +27,17 @@
  * constructor on the core [host_storage] GADT. That much is unchanged; the
  * DEFERRAL this header used to describe is not.
  *
- * Generic [Execute.run] auto-dispatch is no longer deferred: {!create_transparent}
- * provides it, and a vector from it takes the N-leaf ABI through the ordinary
- * [Execute.run]/[run_vectors] with no SoA-specific entry point. Two earlier
- * halves are likewise closed — the leaf enumeration is derived from
+ * Auto-dispatch is no longer deferred: {!create_transparent} provides it, and a
+ * vector from it takes the N-leaf ABI through the ordinary
+ * {!Sarek.Execute.run_vectors} with no SoA-specific entry point. Named
+ * precisely, because bare [Execute.run] is NOT the same promise: [run_vectors]
+ * is what performs the leaf upload before dispatching. On CUDA/PTX — the only
+ * backend where the leaf ABI is selected at all — [run] called directly on a
+ * vector whose leaves were never transferred raises rather than launching, which
+ * is what [check_direct_run_refuses_untransferred] in test_soa_emitter_equiv.ml
+ * pins (and why that case carries the SoA-ABI blocker: on the CPU backends [run]
+ * executes against host vectors and there is no leaf upload to have skipped). Two earlier halves are likewise closed — the leaf
+ * enumeration is derived from
  * [custom_type.ir_fields] rather than supplied by the caller, and the launch
  * path threads the SoA param names itself.
  *

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -24,16 +24,24 @@
  * only. This module is pure host storage + transpose and is backend-agnostic.
  *
  * This is deliberately layered above {!Vector} + {!Soa} rather than being a new
- * constructor on the core [host_storage] GADT. A fully transparent
- * [Vector.create ~layout:SoA] + generic [Execute.run] auto-dispatch would
- * require threading SoA param names through every backend and generalising the
- * 1-buffer-per-device table — deferred (see
- * docs/optimization/tier1b-emitter-soa-handoff.md and the impl brief).
+ * constructor on the core [host_storage] GADT. That much is unchanged; the
+ * DEFERRAL this header used to describe is not.
  *
- * The layout half of that deferral is now closed: the leaf enumeration is
- * derived from [custom_type.ir_fields] rather than supplied by the caller, so
- * "the custom_type carries no record layout" is no longer a reason this cannot
- * be transparent. What remains is the backend threading and the buffer table.
+ * Generic [Execute.run] auto-dispatch is no longer deferred: {!create_transparent}
+ * provides it, and a vector from it takes the N-leaf ABI through the ordinary
+ * [Execute.run]/[run_vectors] with no SoA-specific entry point. Two earlier
+ * halves are likewise closed — the leaf enumeration is derived from
+ * [custom_type.ir_fields] rather than supplied by the caller, and the launch
+ * path threads the SoA param names itself.
+ *
+ * What is still deferred, and the only thing this header now claims: the
+ * dispatch is CUDA/PTX-only. No other backend's emitter lowers a record
+ * parameter to N base pointers, so everywhere else the same vector stays an
+ * ordinary packed AoS custom vector and takes the packed path — the documented
+ * "never wrong data" fallback, not a gap that produces different results. There
+ * is also still no [Vector.create ~layout:SoA]: the constructor lives here (see
+ * {!create_transparent} for why that is not the same question as transparency at
+ * the launch site).
  ******************************************************************************)
 
 (** A per-leaf host buffer, type-erased: a width-matched scalar vector used as a

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -93,3 +93,20 @@ val scatter : 'a t -> unit
 (** [gather t] transposes the N per-leaf host buffers back into the AoS host
     buffer (call after reading leaves back from a device that wrote them). *)
 val gather : 'a t -> unit
+
+(** [create_transparent custom length] is a SoA custom vector presented as an
+    ordinary {!Vector.t}: the generic {!Sarek.Execute.run_vectors} recognises it
+    and binds the N-leaf ABI on CUDA/PTX, falling back to the packed AoS path on
+    every other backend. Callers need no SoA-specific launch entry point
+    (backlog-54).
+
+    The returned vector IS the AoS source of truth — [Vector.get]/[set] and the
+    PPX accessors work on it exactly as on any custom vector, and the transpose
+    to and from the per-leaf buffers happens inside the launch.
+
+    Use this rather than {!create} + {!Sarek.Soa_launch.run_soa} unless you need
+    to drive the leaves yourself. {!create} remains the lower-level entry point.
+
+    Raises {!Soa.Unsupported} on an element type with no derivable flat-record
+    layout, exactly as {!create} does. *)
+val create_transparent : 'a Vector.custom_type -> int -> ('a, unit) Vector.t

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -307,9 +307,10 @@ end = struct
       not a cosmetic asymmetry: [soa_free_leaves] used to CLEAR the flag on a
       per-device free, which made this function answer [false] for a device
       whose leaves were still live, and the drain-before-free in
-      {!free_all_buffers} consults exactly this answer. It now re-derives the
-      flag from the leaves that survive, so a per-device release cannot disown
-      another device's. *)
+      {!free_all_buffers} consults exactly this answer. It now NARROWS the flag
+      — still set iff it already was and some leaf survives — so a per-device
+      release cannot disown another device's, and a release cannot resurrect
+      ownership a packed launch gave up either. *)
   let has_device_data (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : bool
       =
     Option.is_some (Vector.get_buffer vec dev)
@@ -430,10 +431,10 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
 
          Reaching here with the flag set means the host copy was authoritative or
          in sync first — that is what makes the upload above meaningful, and it is
-         what every path into this arm establishes: the migration arm three lines
-         up has just drained the other device through [read_back_to_host], and the
-         remaining locations ([CPU], [Both d], [Stale_GPU d]) each assert the host
-         copy is not behind. So this does not discard a pending leaf result; it
+         what every path into this arm establishes: the migration arm at the top of
+         this function has just drained the other device through
+         [read_back_to_host], and the remaining locations ([CPU], [Both d],
+         [Stale_GPU d]) each assert the host copy is not behind. So this does not discard a pending leaf result; it
          stops [read_back_to_host] from answering a question about [dev] by
          reading leaves on another device, which is the one thing the whole-vector
          flag cannot express (see {!Read_back.has_device_data}).

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -296,12 +296,28 @@ end = struct
 
       [dev] selects the packed buffer, and the SoA arm ignores it: the binding
       holds ONE [soa_leaves_live] flag for the whole vector, not one per device,
-      so it cannot answer "on [dev]" and does not pretend to. Unreachable as a
-      difference today — both callers pass the device the vector's own
-      [location] names, so the two questions coincide — and making the flag
-      per-device is the change that would let this arm honour [dev]. Until then
-      the honest reading of the result is "somewhere on a device", not "on
-      [dev]".
+      so it cannot answer "on [dev]" and does not pretend to. Every caller in
+      this module — all four listed on {!read_back_to_host} below — passes the
+      device the vector's own [location] names, so the two questions coincide
+      there; making the flag per-device is the change that would let this arm
+      honour [dev]. Until then the honest reading of the result is "somewhere on
+      a device", not "on [dev]".
+
+      That whole-vector scope is also a KNOWN EXPOSURE for a caller outside this
+      module, and one this branch does not close (there is no [Transfer.mli], so
+      {!read_back_to_host} is exported). Found by review of PR #375 round 5, and
+      pre-existing: two transparent launches, on A then B, leave leaf buffers on
+      both; [free_buffer sv B] drains B into host storage and releases B's
+      leaves, and the flag stays set because A's are still allocated —
+      correctly, since that is the rule which stops a per-device free from
+      disowning another device's live leaves. But A's leaves are now STALE (they
+      hold the first launch's data, the host holds the second's), and a direct
+      [read_back_to_host sv A] then takes the SoA arm and gathers them over the
+      host copy. No path inside this module reaches it: [to_cpu] returns before
+      the read-back on the [CPU] location a free leaves behind, and the free
+      paths guard on {!has_device_data} plus a device-naming location. Closing
+      it needs the flag to name a device, which is a change to the binding
+      contract and not to this function.
 
       That the flag is whole-vector while {!free_buffer} releases per-device is
       not a cosmetic asymmetry: [soa_free_leaves] used to CLEAR the flag on a

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -393,7 +393,7 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
   | Vector.Both d when d.id = dev.id -> Log.debug Log.Transfer "-> skip (Both)"
   | Vector.Stale_CPU d when d.id = dev.id ->
       Log.debug Log.Transfer "-> skip (Stale_CPU)"
-  | _ ->
+  | _ -> (
       (* Ensure buffer exists and transfer *)
       let buf = ensure_buffer vec dev in
       let (module B : Vector.DEVICE_BUFFER) = buf in
@@ -419,7 +419,32 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
       | Vector.Custom_storage {ptr; custom; length} ->
           B.host_ptr_to_device ptr ~byte_size:(length * custom.elem_size) ;
           ignore (Sys.opaque_identity ptr)) ;
-      vec.location <- Vector.Both dev
+      vec.location <- Vector.Both dev ;
+      (* The packed buffer on [dev] now holds host storage, so a read-back must
+         read IT and not the leaves — and only this arm may say so, because only
+         this arm uploaded anything. The two skip arms above upload nothing (a
+         [Stale_CPU dev] transparent vector is exactly the case where the leaves
+         ARE the device copy), so clearing there would disown live leaves.
+
+         Reaching here with the flag set means the host copy was authoritative or
+         in sync first — that is what makes the upload above meaningful, and it is
+         what every path into this arm establishes: the migration arm three lines
+         up has just drained the other device through [read_back_to_host], and the
+         remaining locations ([CPU], [Both d], [Stale_GPU d]) each assert the host
+         copy is not behind. So this does not discard a pending leaf result; it
+         stops [read_back_to_host] from answering a question about [dev] by
+         reading leaves on another device, which is the one thing the whole-vector
+         flag cannot express (see {!Read_back.has_device_data}).
+
+         [Execute.transfer_vectors_to_device] normalises the same flag on the
+         packed-launch path. That site is not this one: it runs before a LAUNCH
+         and gathers first, this one after an UPLOAD that has already made the
+         host copy authoritative. Both exist because the flag names the ABI of the
+         most recent operation that made a device copy authoritative, and an
+         upload is such an operation. *)
+      match vec.Vector.soa with
+      | Some b -> b.Vector.soa_leaves_live := false
+      | None -> ())
 
 (** Transfer vector data from device to CPU.
     @param force

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -316,6 +316,41 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
           ignore (Sys.opaque_identity ptr)) ;
       vec.location <- Vector.Both dev
 
+(** Is there device-resident data for [vec] on [dev] that a read-back could
+    actually fetch? Two disjoint sources, and under the SoA ABI it is the second
+    one: the packed buffer is not merely stale there, it was never allocated. *)
+let has_device_data (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : bool =
+  Option.is_some (Vector.get_buffer vec dev)
+  ||
+  match vec.Vector.soa with
+  | Some b -> !(b.Vector.soa_leaves_live)
+  | None -> false
+
+(** The ONE place that decides WHERE a read-back reads from, shared by every
+    path that pulls device data into host storage — [to_cpu] and both buffer
+    cleanup paths.
+
+    It exists as a function because the cleanup paths did not have this
+    decision: they called {!copy_device_to_host} directly, so after a
+    transparent SoA launch they downloaded a packed buffer the kernel never
+    wrote (silently discarding the output) or, with no packed buffer at all,
+    failed with "no device buffer to transfer from" from inside a free.
+
+    The condition reads the flag the UPLOAD set; it does not re-decide "SoA or
+    AoS?" from the device or the vector's shape. A second independent answer to
+    that question is how a round trip ends up uploading leaves and downloading a
+    packed buffer. *)
+let read_back_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit
+    =
+  match vec.Vector.soa with
+  | Some b when !(b.Vector.soa_leaves_live) ->
+      (* The launch took the SoA ABI, so the results are in the N leaf buffers
+         and the packed device buffer this function would otherwise download was
+         never written. Reading it back would hand the caller the pre-launch
+         host contents with no error anywhere. *)
+      b.Vector.soa_from_device dev
+  | Some _ | None -> copy_device_to_host vec dev
+
 (** Transfer vector data from device to CPU.
     @param force
       If true, always transfer even if location is Both (useful after kernel
@@ -350,25 +385,12 @@ let to_cpu ?(force = false) (type a b) (vec : (a, b) Vector.t) : unit =
       "to_cpu: transferring from dev=%d (force=%b)"
       dev.id
       force ;
-    match vec.Vector.soa with
-    | Some b when !(b.Vector.soa_leaves_live) ->
-        (* The launch took the SoA ABI, so the results are in the N leaf buffers
-           and the packed device buffer this function would otherwise download
-           was never written. Reading it back would hand the caller the
-           pre-launch host contents with no error anywhere.
-
-           The condition reads the flag the UPLOAD set; it does not re-decide
-           "SoA or AoS?" from the device or the vector's shape. A second
-           independent answer to that question is how a round trip ends up
-           uploading leaves and downloading a packed buffer. *)
-        b.Vector.soa_from_device dev ;
-        vec.location <- Vector.Both dev
-    | Some _ | None -> (
-        match Vector.get_buffer vec dev with
-        | None -> failwith "to_cpu: no device buffer to transfer from"
-        | Some _ ->
-            copy_device_to_host vec dev ;
-            vec.location <- Vector.Both dev)
+    (* [read_back_to_host] carries the SoA-vs-packed decision; the packed arm's
+       own "no device buffer to transfer from" failure comes from
+       [copy_device_to_host], so the precondition stays where the read happens
+       rather than being re-derived here. *)
+    read_back_to_host vec dev ;
+    vec.location <- Vector.Both dev
   end
   else
     Log.debugf
@@ -401,14 +423,21 @@ let sync (type a b) (vec : (a, b) Vector.t) : unit =
 
 (** Free device buffer for a vector *)
 let free_buffer (vec : (_, _) Vector.t) (dev : Device.t) : unit =
+  (* Read back BEFORE freeing, and through {!read_back_to_host}, which is why
+     this now sits OUTSIDE the [get_buffer] match: an SoA-dispatched vector has
+     no packed buffer of its own, so the old [None -> ()] early return threw the
+     output of a transparent launch away outright. [has_device_data] keeps the
+     no-op for the case that return was actually for — an AoS vector with
+     nothing on this device. *)
+  (match vec.location with
+  | (Vector.GPU d | Vector.Stale_CPU d)
+    when d.id = dev.id && has_device_data vec dev ->
+      read_back_to_host vec dev ;
+      vec.location <- Vector.Both dev
+  | _ -> ()) ;
   match Vector.get_buffer vec dev with
   | None -> ()
   | Some buf -> (
-      (match vec.location with
-      | (Vector.GPU d | Vector.Stale_CPU d) when d.id = dev.id ->
-          copy_device_to_host vec dev ;
-          vec.location <- Vector.Both dev
-      | _ -> ()) ;
       let (module B : Vector.DEVICE_BUFFER) = buf in
       B.free () ;
       Gpu_memory.track_free (B.size * B.elem_size) ;
@@ -423,9 +452,15 @@ let free_buffer (vec : (_, _) Vector.t) (dev : Device.t) : unit =
 
 (** Free all device buffers for a vector *)
 let free_all_buffers (vec : (_, _) Vector.t) : unit =
+  (* Same SoA-aware read-back as {!free_buffer}. Pre-fix this arm called
+     [copy_device_to_host] on a vector whose packed buffer does not exist after a
+     transparent launch, so freeing without an explicit [to_cpu] raised
+     "no device buffer to transfer from" from inside cleanup — and, when a packed
+     buffer DID exist from an earlier AoS launch, silently overwrote the host
+     storage with its pre-SoA-launch contents. *)
   (match vec.location with
-  | Vector.GPU d | Vector.Stale_CPU d ->
-      copy_device_to_host vec d ;
+  | (Vector.GPU d | Vector.Stale_CPU d) when has_device_data vec d ->
+      read_back_to_host vec d ;
       vec.location <- Vector.CPU
   | _ -> ()) ;
   Hashtbl.iter

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -266,6 +266,63 @@ let copy_device_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) :
           B.device_to_host_ptr ptr ~byte_size:(length * custom.elem_size) ;
           ignore (Sys.opaque_identity ptr))
 
+(** Is there device-resident data for [vec] that a read-back could actually
+    fetch? Two disjoint sources, and under the SoA ABI it is the second one: the
+    packed buffer is not merely stale there, it was never allocated.
+
+    [dev] selects the packed buffer, and the SoA arm ignores it: the binding
+    holds ONE [soa_leaves_live] flag for the whole vector, not one per device,
+    so it cannot answer "on [dev]" and does not pretend to. Unreachable as a
+    difference today — every caller passes the device the vector's own
+    [location] names, so the two questions coincide — and making the flag
+    per-device is the change that would let this arm honour [dev]. Until then
+    the honest reading of the result is "somewhere on a device", not "on [dev]".
+*)
+let has_device_data (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : bool =
+  Option.is_some (Vector.get_buffer vec dev)
+  ||
+  match vec.Vector.soa with
+  | Some b -> !(b.Vector.soa_leaves_live)
+  | None -> false
+
+(** The ONE place that decides WHERE a read-back reads from, shared by every
+    path in this module that pulls device data into host storage. As of
+    2026-07-30 that is four call sites, and the list is exhaustive by
+    construction — {!copy_device_to_host} is called directly nowhere else:
+
+    - {!to_cpu} (and {!sync} through it) — the explicit read-back;
+    - {!to_device}'s cross-device MIGRATION arm — a vector resident on one
+      device is drained to the host before being uploaded to another;
+    - {!free_buffer} and {!free_all_buffers} — drain before release.
+
+    It exists as a function because those paths did not have this decision: they
+    called {!copy_device_to_host} directly, so after a transparent SoA launch
+    they downloaded a packed buffer the kernel never wrote (silently discarding
+    the output) or, with no packed buffer at all, failed with "no device buffer
+    to transfer from" from inside a free or a migration.
+
+    An earlier version of this comment claimed the migration arm already shared
+    this decision. It did not — it still called {!copy_device_to_host} — and
+    both halves of the failure pair above were reachable through it (measured
+    2026-07-30 on two CUDA/PTX devices: the raise with no packed buffer, and
+    silent wrong data with one present). [check_cross_device_soa] in
+    [test_soa_emitter_equiv.ml] now pins both.
+
+    The condition reads the flag the UPLOAD set; it does not re-decide "SoA or
+    AoS?" from the device or the vector's shape. A second independent answer to
+    that question is how a round trip ends up uploading leaves and downloading a
+    packed buffer. *)
+let read_back_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit
+    =
+  match vec.Vector.soa with
+  | Some b when !(b.Vector.soa_leaves_live) ->
+      (* The launch took the SoA ABI, so the results are in the N leaf buffers
+         and the packed device buffer this function would otherwise download was
+         never written. Reading it back would hand the caller the pre-launch
+         host contents with no error anywhere. *)
+      b.Vector.soa_from_device dev
+  | Some _ | None -> copy_device_to_host vec dev
+
 (** Transfer vector data to a device *)
 let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
   let loc_str =
@@ -277,9 +334,18 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
     | Vector.Stale_GPU _ -> "Stale_GPU"
   in
   Log.debugf Log.Transfer "to_device: location=%s dev=%d" loc_str dev.id ;
+  (* MIGRATION: the vector is resident on another device, so drain it to the
+     host before uploading to [dev]. Through {!read_back_to_host}, not
+     {!copy_device_to_host} — this arm is one of the four paths that pull device
+     data into host storage, and it used to be the one that did NOT share the
+     decision. After a transparent SoA launch the results are in the leaves, so
+     the direct call either raised "no device buffer to transfer from" (no packed
+     buffer exists on that path) or, when an earlier packed upload had left one,
+     downloaded its pre-launch bytes over the host storage and discarded the
+     launch's output silently. *)
   (match vec.location with
   | (Vector.GPU d | Vector.Stale_CPU d) when d.id <> dev.id ->
-      copy_device_to_host vec d ;
+      read_back_to_host vec d ;
       vec.location <- Vector.Both d
   | _ -> ()) ;
   (* Check if already up-to-date on this device *)
@@ -315,41 +381,6 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
           B.host_ptr_to_device ptr ~byte_size:(length * custom.elem_size) ;
           ignore (Sys.opaque_identity ptr)) ;
       vec.location <- Vector.Both dev
-
-(** Is there device-resident data for [vec] on [dev] that a read-back could
-    actually fetch? Two disjoint sources, and under the SoA ABI it is the second
-    one: the packed buffer is not merely stale there, it was never allocated. *)
-let has_device_data (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : bool =
-  Option.is_some (Vector.get_buffer vec dev)
-  ||
-  match vec.Vector.soa with
-  | Some b -> !(b.Vector.soa_leaves_live)
-  | None -> false
-
-(** The ONE place that decides WHERE a read-back reads from, shared by every
-    path that pulls device data into host storage — [to_cpu] and both buffer
-    cleanup paths.
-
-    It exists as a function because the cleanup paths did not have this
-    decision: they called {!copy_device_to_host} directly, so after a
-    transparent SoA launch they downloaded a packed buffer the kernel never
-    wrote (silently discarding the output) or, with no packed buffer at all,
-    failed with "no device buffer to transfer from" from inside a free.
-
-    The condition reads the flag the UPLOAD set; it does not re-decide "SoA or
-    AoS?" from the device or the vector's shape. A second independent answer to
-    that question is how a round trip ends up uploading leaves and downloading a
-    packed buffer. *)
-let read_back_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit
-    =
-  match vec.Vector.soa with
-  | Some b when !(b.Vector.soa_leaves_live) ->
-      (* The launch took the SoA ABI, so the results are in the N leaf buffers
-         and the packed device buffer this function would otherwise download was
-         never written. Reading it back would hand the caller the pre-launch
-         host contents with no error anywhere. *)
-      b.Vector.soa_from_device dev
-  | Some _ | None -> copy_device_to_host vec dev
 
 (** Transfer vector data from device to CPU.
     @param force
@@ -435,6 +466,13 @@ let free_buffer (vec : (_, _) Vector.t) (dev : Device.t) : unit =
       read_back_to_host vec dev ;
       vec.location <- Vector.Both dev
   | _ -> ()) ;
+  (* Release the LEAVES too. Under the SoA ABI they are the only device memory
+     this vector has — the packed buffer below is never allocated — so without
+     this the call returned having freed nothing at all. Ordered after the
+     read-back above and before the flag it clears is needed again. *)
+  (match vec.Vector.soa with
+  | Some b -> b.Vector.soa_free_leaves (Some dev)
+  | None -> ()) ;
   match Vector.get_buffer vec dev with
   | None -> ()
   | Some buf -> (
@@ -463,6 +501,14 @@ let free_all_buffers (vec : (_, _) Vector.t) : unit =
       read_back_to_host vec d ;
       vec.location <- Vector.CPU
   | _ -> ()) ;
+  (* Same leaf release as {!free_buffer}, on every device. Pre-fix this function
+     was a no-op on a transparent SoA vector's memory: [device_buffers] is EMPTY
+     under that ABI, so the iteration below had nothing to free and the call
+     reported success having released zero bytes (measured with
+     [Gpu_memory.usage()]: 3840 B -> 4224 B across a launch + free). *)
+  (match vec.Vector.soa with
+  | Some b -> b.Vector.soa_free_leaves None
+  | None -> ()) ;
   Hashtbl.iter
     (fun _ buf ->
       let (module B : Vector.DEVICE_BUFFER) = buf in

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -350,11 +350,25 @@ let to_cpu ?(force = false) (type a b) (vec : (a, b) Vector.t) : unit =
       "to_cpu: transferring from dev=%d (force=%b)"
       dev.id
       force ;
-    match Vector.get_buffer vec dev with
-    | None -> failwith "to_cpu: no device buffer to transfer from"
-    | Some _ ->
-        copy_device_to_host vec dev ;
+    match vec.Vector.soa with
+    | Some b when !(b.Vector.soa_leaves_live) ->
+        (* The launch took the SoA ABI, so the results are in the N leaf buffers
+           and the packed device buffer this function would otherwise download
+           was never written. Reading it back would hand the caller the
+           pre-launch host contents with no error anywhere.
+
+           The condition reads the flag the UPLOAD set; it does not re-decide
+           "SoA or AoS?" from the device or the vector's shape. A second
+           independent answer to that question is how a round trip ends up
+           uploading leaves and downloading a packed buffer. *)
+        b.Vector.soa_from_device dev ;
         vec.location <- Vector.Both dev
+    | Some _ | None -> (
+        match Vector.get_buffer vec dev with
+        | None -> failwith "to_cpu: no device buffer to transfer from"
+        | Some _ ->
+            copy_device_to_host vec dev ;
+            vec.location <- Vector.Both dev)
   end
   else
     Log.debugf

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -422,9 +422,11 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
       vec.location <- Vector.Both dev ;
       (* The packed buffer on [dev] now holds host storage, so a read-back must
          read IT and not the leaves — and only this arm may say so, because only
-         this arm uploaded anything. The two skip arms above upload nothing (a
-         [Stale_CPU dev] transparent vector is exactly the case where the leaves
-         ARE the device copy), so clearing there would disown live leaves.
+         this arm uploaded anything. The three already-resident arms above
+         ([GPU], [Both], [Stale_CPU], each on [dev] itself) upload nothing — and
+         [Stale_CPU dev] on a transparent vector is exactly the case where the
+         leaves ARE the device copy — so clearing there would disown live
+         leaves.
 
          Reaching here with the flag set means the host copy was authoritative or
          in sync first — that is what makes the upload above meaningful, and it is

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -434,7 +434,8 @@ let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
          what every path into this arm establishes: the migration arm at the top of
          this function has just drained the other device through
          [read_back_to_host], and the remaining locations ([CPU], [Both d],
-         [Stale_GPU d]) each assert the host copy is not behind. So this does not discard a pending leaf result; it
+         [Stale_GPU d]) each assert the host copy is not behind. So this does not
+         discard a pending leaf result; it
          stops [read_back_to_host] from answering a question about [dev] by
          reading leaves on another device, which is the one thing the whole-vector
          flag cannot express (see {!Read_back.has_device_data}).

--- a/sarek/core/Transfer.ml
+++ b/sarek/core/Transfer.ml
@@ -239,89 +239,128 @@ let ensure_buffer (type a b) (vec : (a, b) Vector.t) (dev : Device.t) :
 
 (** {1 Transfer Operations} *)
 
-(** Copy vector data from a device buffer to CPU storage. *)
-let copy_device_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) :
-    unit =
-  match Vector.get_buffer vec dev with
-  | None -> failwith "to_cpu: no device buffer to transfer from"
-  | Some buf -> (
-      let (module B : Vector.DEVICE_BUFFER) = buf in
-      Log.debugf
-        Log.Transfer
-        "to_cpu: got buffer ptr=%Ld size=%d"
-        (Int64.of_nativeint B.device_ptr)
-        B.size ;
-      match vec.host with
-      | Vector.Bigarray_storage ba ->
-          let ptr, byte_size = Vector_transfer.bigarray_to_ptr ba B.elem_size in
-          B.device_to_host_ptr ptr ~byte_size ;
-          (* [device_to_host_ptr] takes a bare [nativeint] address (see
+(** Everything that reads device memory back into host storage, and NOTHING
+    else. The module exists for its signature: [copy_device_to_host] is defined
+    inside and deliberately absent from it, so the only code that can call the
+    packed-buffer read directly is {!Read_back.read_back_to_host} below.
+
+    That is the enforcement the previous version of this claim lacked. It said
+    the call sites were "exhaustive BY CONSTRUCTION" while nothing constructed
+    anything: there is no [Transfer.mli], so every top-level binding in this
+    file is exported and a fifth direct caller compiled fine. The claim happened
+    to be true when it was written — it was re-audited, and it held — but an
+    audited fact and an enforced one differ exactly where it matters, which is
+    the next person to add a read-back path. Three of the four existing call
+    sites were added or corrected in this branch precisely because they had
+    bypassed the decision, so "someone adds a fifth and bypasses it too" is the
+    observed failure mode, not a hypothetical one.
+
+    Now a bypass does not compile. *)
+module Read_back : sig
+  val has_device_data : ('a, 'b) Vector.t -> Device.t -> bool
+
+  val read_back_to_host : ('a, 'b) Vector.t -> Device.t -> unit
+end = struct
+  (** Copy vector data from a device buffer to CPU storage. *)
+  let copy_device_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) :
+      unit =
+    match Vector.get_buffer vec dev with
+    | None -> failwith "to_cpu: no device buffer to transfer from"
+    | Some buf -> (
+        let (module B : Vector.DEVICE_BUFFER) = buf in
+        Log.debugf
+          Log.Transfer
+          "to_cpu: got buffer ptr=%Ld size=%d"
+          (Int64.of_nativeint B.device_ptr)
+          B.size ;
+        match vec.host with
+        | Vector.Bigarray_storage ba ->
+            let ptr, byte_size =
+              Vector_transfer.bigarray_to_ptr ba B.elem_size
+            in
+            B.device_to_host_ptr ptr ~byte_size ;
+            (* [device_to_host_ptr] takes a bare [nativeint] address (see
              Framework_sig.ml:218-223), which is not a GC root, and this is a
              device->HOST WRITE: if [ba] were collected mid-transfer the backend
              would write into freed memory. Keep it reachable across the call —
              without this the transfer was the function's last expression and
              nothing rooted [ba]. *)
-          ignore (Sys.opaque_identity ba)
-      | Vector.Custom_storage {ptr; custom; length} ->
-          B.device_to_host_ptr ptr ~byte_size:(length * custom.elem_size) ;
-          ignore (Sys.opaque_identity ptr))
+            ignore (Sys.opaque_identity ba)
+        | Vector.Custom_storage {ptr; custom; length} ->
+            B.device_to_host_ptr ptr ~byte_size:(length * custom.elem_size) ;
+            ignore (Sys.opaque_identity ptr))
 
-(** Is there device-resident data for [vec] that a read-back could actually
-    fetch? Two disjoint sources, and under the SoA ABI it is the second one: the
-    packed buffer is not merely stale there, it was never allocated.
+  (** Is there device-resident data for [vec] that a read-back could actually
+      fetch? Two disjoint sources, and under the SoA ABI it is the second one:
+      the packed buffer is not merely stale there, it was never allocated.
 
-    [dev] selects the packed buffer, and the SoA arm ignores it: the binding
-    holds ONE [soa_leaves_live] flag for the whole vector, not one per device,
-    so it cannot answer "on [dev]" and does not pretend to. Unreachable as a
-    difference today — every caller passes the device the vector's own
-    [location] names, so the two questions coincide — and making the flag
-    per-device is the change that would let this arm honour [dev]. Until then
-    the honest reading of the result is "somewhere on a device", not "on [dev]".
-*)
-let has_device_data (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : bool =
-  Option.is_some (Vector.get_buffer vec dev)
-  ||
-  match vec.Vector.soa with
-  | Some b -> !(b.Vector.soa_leaves_live)
-  | None -> false
+      [dev] selects the packed buffer, and the SoA arm ignores it: the binding
+      holds ONE [soa_leaves_live] flag for the whole vector, not one per device,
+      so it cannot answer "on [dev]" and does not pretend to. Unreachable as a
+      difference today — both callers pass the device the vector's own
+      [location] names, so the two questions coincide — and making the flag
+      per-device is the change that would let this arm honour [dev]. Until then
+      the honest reading of the result is "somewhere on a device", not "on
+      [dev]".
 
-(** The ONE place that decides WHERE a read-back reads from, shared by every
-    path in this module that pulls device data into host storage. As of
-    2026-07-30 that is four call sites, and the list is exhaustive by
-    construction — {!copy_device_to_host} is called directly nowhere else:
+      That the flag is whole-vector while {!free_buffer} releases per-device is
+      not a cosmetic asymmetry: [soa_free_leaves] used to CLEAR the flag on a
+      per-device free, which made this function answer [false] for a device
+      whose leaves were still live, and the drain-before-free in
+      {!free_all_buffers} consults exactly this answer. It now re-derives the
+      flag from the leaves that survive, so a per-device release cannot disown
+      another device's. *)
+  let has_device_data (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : bool
+      =
+    Option.is_some (Vector.get_buffer vec dev)
+    ||
+    match vec.Vector.soa with
+    | Some b -> !(b.Vector.soa_leaves_live)
+    | None -> false
 
-    - {!to_cpu} (and {!sync} through it) — the explicit read-back;
-    - {!to_device}'s cross-device MIGRATION arm — a vector resident on one
-      device is drained to the host before being uploaded to another;
-    - {!free_buffer} and {!free_all_buffers} — drain before release.
+  (** The ONE place that decides WHERE a read-back reads from, shared by every
+      path in this module that pulls device data into host storage. As of
+      2026-07-30 that is four call sites, and the list is exhaustive because
+      [copy_device_to_host] is not in the enclosing module's signature — a fifth
+      direct caller does not compile:
 
-    It exists as a function because those paths did not have this decision: they
-    called {!copy_device_to_host} directly, so after a transparent SoA launch
-    they downloaded a packed buffer the kernel never wrote (silently discarding
-    the output) or, with no packed buffer at all, failed with "no device buffer
-    to transfer from" from inside a free or a migration.
+      - {!to_cpu} (and {!sync} through it) — the explicit read-back;
+      - {!to_device}'s cross-device MIGRATION arm — a vector resident on one
+        device is drained to the host before being uploaded to another;
+      - {!free_buffer} and {!free_all_buffers} — drain before release.
 
-    An earlier version of this comment claimed the migration arm already shared
-    this decision. It did not — it still called {!copy_device_to_host} — and
-    both halves of the failure pair above were reachable through it (measured
-    2026-07-30 on two CUDA/PTX devices: the raise with no packed buffer, and
-    silent wrong data with one present). [check_cross_device_soa] in
-    [test_soa_emitter_equiv.ml] now pins both.
+      It exists as a function because those paths did not have this decision:
+      they called {!copy_device_to_host} directly, so after a transparent SoA
+      launch they downloaded a packed buffer the kernel never wrote (silently
+      discarding the output) or, with no packed buffer at all, failed with "no
+      device buffer to transfer from" from inside a free or a migration.
 
-    The condition reads the flag the UPLOAD set; it does not re-decide "SoA or
-    AoS?" from the device or the vector's shape. A second independent answer to
-    that question is how a round trip ends up uploading leaves and downloading a
-    packed buffer. *)
-let read_back_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit
-    =
-  match vec.Vector.soa with
-  | Some b when !(b.Vector.soa_leaves_live) ->
-      (* The launch took the SoA ABI, so the results are in the N leaf buffers
-         and the packed device buffer this function would otherwise download was
-         never written. Reading it back would hand the caller the pre-launch
-         host contents with no error anywhere. *)
-      b.Vector.soa_from_device dev
-  | Some _ | None -> copy_device_to_host vec dev
+      An earlier version of this comment claimed the migration arm already
+      shared this decision. It did not — it still called {!copy_device_to_host}
+      — and both halves of the failure pair above were reachable through it
+      (measured 2026-07-30 on two CUDA/PTX devices: the raise with no packed
+      buffer, and silent wrong data with one present). [check_cross_device_soa]
+      in [test_soa_emitter_equiv.ml] now pins both.
+
+      The condition reads the flag the UPLOAD set; it does not re-decide "SoA or
+      AoS?" from the device or the vector's shape. A second independent answer
+      to that question is how a round trip ends up uploading leaves and
+      downloading a packed buffer. *)
+  let read_back_to_host (type a b) (vec : (a, b) Vector.t) (dev : Device.t) :
+      unit =
+    match vec.Vector.soa with
+    | Some b when !(b.Vector.soa_leaves_live) ->
+        (* The launch took the SoA ABI, so the results are in the N leaf buffers
+           and the packed device buffer this function would otherwise download
+           was never written. Reading it back would hand the caller the
+           pre-launch host contents with no error anywhere. *)
+        b.Vector.soa_from_device dev
+    | Some _ | None -> copy_device_to_host vec dev
+end
+
+let has_device_data = Read_back.has_device_data
+
+let read_back_to_host = Read_back.read_back_to_host
 
 (** Transfer vector data to a device *)
 let to_device (type a b) (vec : (a, b) Vector.t) (dev : Device.t) : unit =
@@ -452,41 +491,76 @@ let sync (type a b) (vec : (a, b) Vector.t) : unit =
 
 (** {1 Buffer Cleanup} *)
 
-(** Free device buffer for a vector *)
+(** Release the device memory [vec] holds on [dev], draining it to host storage
+    first.
+
+    FOUR steps, and not one of them may sit inside [get_buffer]'s [Some] arm.
+    Under the SoA ABI the leaves are the only device memory the vector has and
+    the packed buffer is never allocated, so on a transparent vector
+    [get_buffer] returns [None] ALWAYS — an early return there does not skip a
+    corner case, it skips the whole function.
+
+    The previous version of this comment already said "under the SoA ABI they
+    are the only device memory this vector has" while the bookkeeping below it
+    still lived in the [Some buf] arm and assumed a packed buffer existed. That
+    mismatch was the bug, not a wording slip: the location reset is the only
+    code here that assigns [CPU], so a transparent SoA vector came out of this
+    function with its leaves freed and [location] still naming [dev]. Two
+    measured consequences, both on a vector whose data was intact in host
+    storage:
+
+    - [to_cpu ~force:true] raised
+      [Failure "to_cpu: no device buffer to transfer from"] — [Both dev] plus
+      [force] means "read the device back", and there is nothing there to read;
+    - [to_device] on the same device took the "skip (Both)" short-circuit and
+      allocated nothing, reinstating the exact short-circuit the [Stale_CPU]
+      work earlier in this branch exists to eliminate.
+
+    {!free_all_buffers} was never exposed to this because it assigns [CPU]
+    unconditionally at the end. This function now does the same, scoped to
+    [dev]. *)
 let free_buffer (vec : (_, _) Vector.t) (dev : Device.t) : unit =
-  (* Read back BEFORE freeing, and through {!read_back_to_host}, which is why
-     this now sits OUTSIDE the [get_buffer] match: an SoA-dispatched vector has
-     no packed buffer of its own, so the old [None -> ()] early return threw the
-     output of a transparent launch away outright. [has_device_data] keeps the
-     no-op for the case that return was actually for — an AoS vector with
-     nothing on this device. *)
+  (* 1. Read back BEFORE freeing, and through {!read_back_to_host}: an
+     SoA-dispatched vector has no packed buffer of its own, so the old
+     [None -> ()] early return threw the output of a transparent launch away
+     outright. [has_device_data] keeps the no-op for the case that return was
+     actually for — an AoS vector with nothing on this device. *)
   (match vec.location with
   | (Vector.GPU d | Vector.Stale_CPU d)
     when d.id = dev.id && has_device_data vec dev ->
       read_back_to_host vec dev ;
       vec.location <- Vector.Both dev
   | _ -> ()) ;
-  (* Release the LEAVES too. Under the SoA ABI they are the only device memory
-     this vector has — the packed buffer below is never allocated — so without
-     this the call returned having freed nothing at all. Ordered after the
-     read-back above and before the flag it clears is needed again. *)
+  (* 2. Release the LEAVES. Under the SoA ABI they are the only device memory
+     this vector has, so without this the call returned having freed nothing at
+     all. Ordered after the read-back above and before the flag it updates is
+     needed again. *)
   (match vec.Vector.soa with
   | Some b -> b.Vector.soa_free_leaves (Some dev)
   | None -> ()) ;
-  match Vector.get_buffer vec dev with
+  (* 3. Release the packed buffer, if this vector ever had one on [dev]. *)
+  (match Vector.get_buffer vec dev with
   | None -> ()
-  | Some buf -> (
+  | Some buf ->
       let (module B : Vector.DEVICE_BUFFER) = buf in
       B.free () ;
       Gpu_memory.track_free (B.size * B.elem_size) ;
-      Hashtbl.remove vec.device_buffers dev.id ;
-      (* Update location *)
-      match vec.location with
-      | Vector.GPU d when d.id = dev.id -> vec.location <- Vector.CPU
-      | Vector.Both d when d.id = dev.id -> vec.location <- Vector.CPU
-      | Vector.Stale_CPU d when d.id = dev.id -> vec.location <- Vector.CPU
-      | Vector.Stale_GPU d when d.id = dev.id -> vec.location <- Vector.CPU
-      | _ -> ())
+      Hashtbl.remove vec.device_buffers dev.id) ;
+  (* 4. Location. Outside step 3's [Some] arm, which is the whole fix: steps 2
+     and 3 together released everything this vector held on [dev], whether that
+     was leaves, a packed buffer, or both, so the state that follows is the same
+     in all three cases and [CPU] is it.
+
+     Guarded on the device alone rather than per-constructor: every
+     device-naming constructor asserts something about [dev]'s contents, and
+     after steps 2-3 [dev] holds nothing, so all four collapse to the same
+     answer. A location naming a DIFFERENT device is untouched — that device's
+     memory was not freed. *)
+  match vec.location with
+  | (Vector.GPU d | Vector.Both d | Vector.Stale_CPU d | Vector.Stale_GPU d)
+    when d.id = dev.id ->
+      vec.location <- Vector.CPU
+  | _ -> ()
 
 (** Free all device buffers for a vector *)
 let free_all_buffers (vec : (_, _) Vector.t) : unit =

--- a/sarek/core/Vector.ml
+++ b/sarek/core/Vector.ml
@@ -111,10 +111,18 @@ let set : type a b. (a, b) t -> int -> a -> unit =
   (match vec.host with
   | Bigarray_storage ba -> Bigarray.Array1.set ba idx value
   | Custom_storage {ptr; custom; _} -> custom.set ptr idx value) ;
-  (* Mark GPU as stale if we had synced data. [Stale_CPU] is no longer reachable
-     here — [ensure_cpu_sync] above turns it into [Both] — so the remaining
-     no-op cases are the two with genuinely nothing to invalidate: [CPU] has no
-     device copy, and [Stale_GPU] is already marked. *)
+  (* Mark GPU as stale if we had synced data. [ensure_cpu_sync] above turns
+     [Stale_CPU] into [Both] on the DEFAULT path, so that arm is unreachable
+     there — but not unconditionally, which is what this comment used to claim:
+     [ensure_cpu_sync] returns immediately when [auto_sync] is cleared, and it
+     discards the callback's result, so a sync that did not happen or did not
+     succeed leaves [Stale_CPU] standing here.
+
+     The no-op is right in that case too, and for a reason worth stating: the
+     host buffer then holds one NEW element beside [length - 1] stale ones, so
+     the device copy is still the authoritative one and must not be marked
+     stale. The other two no-ops are the ones with nothing to invalidate:
+     [CPU] has no device copy and [Stale_GPU] is already marked. *)
   match vec.location with
   | Both d -> vec.location <- Stale_GPU d
   | GPU d -> vec.location <- Stale_GPU d
@@ -150,7 +158,9 @@ let unsafe_set : type a b. (a, b) t -> int -> a -> unit =
   (match vec.host with
   | Bigarray_storage ba -> Bigarray.Array1.unsafe_set ba idx value
   | Custom_storage {ptr; custom; _} -> custom.set ptr idx value) ;
-  (* [Stale_CPU] is unreachable after the sync above, exactly as in [set]. *)
+  (* Same three no-ops, and the same caveat as [set]: [Stale_CPU] is unreachable
+     here only on the default path — with [auto_sync] cleared it stands, and the
+     no-op remains correct because the device copy is still authoritative. *)
   match vec.location with
   | Both d -> vec.location <- Stale_GPU d
   | GPU d -> vec.location <- Stale_GPU d
@@ -176,6 +186,32 @@ let kernel_set : type a b. (a, b) t -> int -> a -> unit =
 
 (** {1 Auto-sync Control} *)
 
+(** Turn the implicit device->host read-back on [vec] on or off.
+
+    WHAT TURNING IT OFF MEANS, written here because this is where a caller
+    turning it off will look, and because until now it was written nowhere:
+    [Vector_transfer.ensure_cpu_sync] returns immediately when this is [false],
+    so every operation that relies on it stops pulling the device copy down. The
+    caller takes over that duty; the operations do not fail, they read whatever
+    host storage holds.
+
+    Three consequences that are not obvious from the flag's name:
+
+    - {!get} returns the HOST buffer on a [Stale_CPU] vector, i.e. the values
+      from before the launch, with no error;
+    - {!set}/{!unsafe_set} no longer read-modify-write against a current buffer,
+      so the element they write sits beside [length - 1] stale ones and the
+      location arm below correctly leaves the DEVICE copy authoritative;
+    - for a transparent SoA vector, [Soa_vector.scatter] transposes out of that
+      same host storage, so a launch result still sitting in the leaves is
+      overwritten by pre-launch bytes rather than gathered first. Raised in
+      review of PR #375; NOT changed there, because making the SoA path transfer
+      anyway would be this flag not meaning what it says. Drain explicitly
+      ([Transfer.to_cpu ~force:true]) before reusing such a vector.
+
+    [true] is the default and the state every test in this repository runs in
+    except where a case disables it deliberately to observe a specific transfer.
+*)
 let set_auto_sync (vec : ('a, 'b) t) (enabled : bool) : unit =
   vec.auto_sync <- enabled
 

--- a/sarek/core/Vector.ml
+++ b/sarek/core/Vector.ml
@@ -93,10 +93,28 @@ let set : type a b. (a, b) t -> int -> a -> unit =
          "Vector.set: index %d out of bounds [0, %d)"
          idx
          vec.length) ;
+  (* Same [ensure_cpu_sync] [get] does immediately above, and its absence here
+     was silent data loss on every vector, not just SoA ones (backlog-181).
+
+     A write is a READ-MODIFY-WRITE of the buffer: it replaces one element and
+     keeps the other [length - 1]. So on [Stale_CPU] — the state a vector is in
+     after a kernel wrote it and before anything read it back — the old code left
+     the host holding one NEW element beside [length - 1] STALE ones, and left
+     the location saying [Stale_CPU]. The next [get] (or the next
+     [Soa_vector.scatter], which calls [ensure_cpu_sync] for exactly this reason)
+     then pulled the whole buffer down from the device and overwrote the new
+     element along with everything else. The write vanished with no diagnostic.
+
+     Pulling first makes the rest of the buffer current, so the [Both] arm below
+     fires and correctly marks the device stale. *)
+  ensure_cpu_sync vec ;
   (match vec.host with
   | Bigarray_storage ba -> Bigarray.Array1.set ba idx value
   | Custom_storage {ptr; custom; _} -> custom.set ptr idx value) ;
-  (* Mark GPU as stale if we had synced data *)
+  (* Mark GPU as stale if we had synced data. [Stale_CPU] is no longer reachable
+     here — [ensure_cpu_sync] above turns it into [Both] — so the remaining
+     no-op cases are the two with genuinely nothing to invalidate: [CPU] has no
+     device copy, and [Stale_GPU] is already marked. *)
   match vec.location with
   | Both d -> vec.location <- Stale_GPU d
   | GPU d -> vec.location <- Stale_GPU d

--- a/sarek/core/Vector.ml
+++ b/sarek/core/Vector.ml
@@ -135,16 +135,36 @@ let unsafe_get : type a b. (a, b) t -> int -> a =
 
 let unsafe_set : type a b. (a, b) t -> int -> a -> unit =
  fun vec idx value ->
+  (* Same [ensure_cpu_sync] as [set] (backlog-190). This function is documented
+     as "no bounds check" and says NOTHING about staleness, so the only
+     difference a caller can reasonably expect from [set] is the bounds check.
+     Differing from it silently on a CORRECTNESS property is worse than either
+     alternative: it is a partial write into a host buffer that is stale relative
+     to the device, which the next read then discards wholesale.
+
+     The cost is a branch, not a copy: [ensure_cpu_sync] tests [auto_sync] and
+     the location and returns immediately unless the vector is actually
+     [Stale_CPU]. It allocates nothing, so the "unsafe" performance contract is
+     intact. *)
+  ensure_cpu_sync vec ;
   (match vec.host with
   | Bigarray_storage ba -> Bigarray.Array1.unsafe_set ba idx value
   | Custom_storage {ptr; custom; _} -> custom.set ptr idx value) ;
+  (* [Stale_CPU] is unreachable after the sync above, exactly as in [set]. *)
   match vec.location with
   | Both d -> vec.location <- Stale_GPU d
   | GPU d -> vec.location <- Stale_GPU d
   | CPU | Stale_CPU _ | Stale_GPU _ -> ()
 
-(** Kernel-safe set: no bounds check, no location update. Use this in parallel
-    kernel execution where:
+(** Kernel-safe set: no bounds check, no location update, AND no staleness sync.
+    After backlog-190 this is the only host writer exempt from the staleness
+    handling [set]/[unsafe_set]/[fill] all now perform, so the exemption is
+    stated rather than left as a difference a reader has to notice. It is
+    deliberate: a per-element location update would race across the threads this
+    function exists to serve, and the kernel already owns the buffer for the
+    duration of the launch.
+
+    Use this in parallel kernel execution where:
     - Bounds are guaranteed by kernel logic
     - Location tracking is not needed (data stays on same device)
     - Multiple threads may write to different indices concurrently *)
@@ -243,10 +263,25 @@ let fill : type a b. (a, b) t -> a -> unit =
       for i = 0 to length - 1 do
         custom.set ptr i value
       done) ;
+  (* NO [ensure_cpu_sync] here, and that is a decision rather than an omission
+     (backlog-190): [fill] overwrites EVERY element, so nothing of the old buffer
+     survives and pulling it down from the device first would be pure waste. What
+     [fill] does need — and previously lacked — is to mark the device stale from
+     [Stale_CPU] as well, because afterwards the host is wholly authoritative.
+
+     The arms are spelled out instead of the previous [| _ -> ()]. That catch-all
+     is how this class hid: it silently absorbed [Stale_CPU] alongside the two
+     cases that genuinely have nothing to invalidate, and a reader could not tell
+     which were deliberate. *)
   match vec.location with
   | Both d -> vec.location <- Stale_GPU d
   | GPU d -> vec.location <- Stale_GPU d
-  | _ -> ()
+  | Stale_CPU d ->
+      (* Was [| _ -> ()]. The host now holds all-new data, so the DEVICE copy is
+         the stale one — the opposite of what the location said. *)
+      vec.location <- Stale_GPU d
+  | CPU -> () (* no device copy to invalidate *)
+  | Stale_GPU _ -> () (* already marked *)
 
 (** Initialize with a function *)
 let init : type a b. (a, b) kind -> int -> (int -> a) -> (a, b) t =

--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -206,14 +206,17 @@ module Make (Ops : CUSTOM_OPS) = struct
             is what says the leaves are the ones holding the results. *)
     soa_free_leaves : Ops.device_t option -> unit;
         (** Release the leaf device buffers: [Some dev] frees them on that
-            device only, [None] on every device. Then RE-DERIVES
-            {!soa_leaves_live} from the leaves that are still allocated, rather
-            than clearing it: a freed leaf holds nothing a read-back could
-            fetch, but the flag covers the whole vector, so a [Some dev] free
-            must leave it set while leaves survive on another device. Clearing
-            it unconditionally made [free_buffer] on device B disown live leaves
-            on device A, and the drain-before-free then skipped A — freeing a
-            device the results were not on discarded them.
+            device only, [None] on every device. Then NARROWS {!soa_leaves_live}
+            — still set iff it already was and some leaf survives the free —
+            rather than clearing it: a freed leaf holds nothing a read-back
+            could fetch, but the flag covers the whole vector, so a [Some dev]
+            free must leave it set while leaves survive on another device.
+            Clearing it unconditionally made [free_buffer] on device B disown
+            live leaves on device A, and the drain-before-free then skipped A —
+            freeing a device the results were not on discarded them. Deriving it
+            from the surviving leaves alone is the mirror-image bug: it turned
+            the flag back ON for leaves a packed launch had already gathered and
+            given up.
 
             Its absence was a LEAK rather than a correctness bug, which is why
             it is easy to miss. Under this ABI the packed AoS buffer is never
@@ -238,19 +241,32 @@ module Make (Ops : CUSTOM_OPS) = struct
             [Execute.run_source], or any non-PTX backend) leaves it [false], and
             read-back then correctly downloads the packed buffer.
 
-            THREE writers, and the list is exhaustive — anything else that flips
-            this is a bug: {!soa_to_device} sets it; {!soa_free_leaves}
-            re-derives it from the leaves that survive the free; and
-            [Execute.transfer_vectors_to_device] clears it when a launch takes
-            the packed ABI. Between them it states the ABI of the MOST RECENT
-            operation, not of some operation — which is the property the
-            read-back paths rely on and the one that was missing when nothing
-            ever cleared it.
+            FOUR writers, and the list is exhaustive — anything else that flips
+            this is a bug. Exactly ONE of them can set it:
 
-            Note what "clears it" cost in {!soa_free_leaves}: this flag is
+            - {!soa_to_device} SETS it: the upload it performs is what makes the
+              leaves the device-side copy;
+            - [Execute.transfer_vectors_to_device] CLEARS it when a launch takes
+              the packed ABI, after gathering the leaves into host storage;
+            - [Transfer.to_device] CLEARS it after a packed host->device upload,
+              which makes the packed buffer on that device a faithful copy of
+              host storage;
+            - {!soa_free_leaves} NARROWS it: still set iff it already was AND
+              some leaf survives the free.
+
+            Between them it states the ABI of the MOST RECENT operation that
+            made a device copy authoritative, not of some operation — which is
+            the property the read-back paths rely on and the one that was
+            missing when nothing ever cleared it.
+
+            Note what {!soa_free_leaves} must and must not do. This flag is
             whole-vector while that free is per-device, so the two only agree
-            when the free covered every device. Deriving instead of assigning is
-            what keeps a single flag honest across a per-device release.
+            when the free covered every device: assigning [false] there disowned
+            leaves still live on another device. But deriving it from the
+            surviving leaves ALONE is the opposite error — allocation is not
+            authority, and a launch that gave up leaf ownership leaves those
+            buffers allocated — so it is a conjunction with the previous value:
+            that free can clear this flag, never set it.
 
             A [bool ref] rather than a mutable field so that the closure which
             performs the upload can set it itself. A mutable field would have to

--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -139,6 +139,44 @@ module Make (Ops : CUSTOM_OPS) = struct
       }
         -> ('a, unit) host_storage
 
+  (** Opt-in Structure-of-Arrays binding for a custom (flat-record) vector
+      (backlog-54). Present iff the vector was created with [~layout:SoA].
+
+      {b Why this is a field of closures and ints, and NOT a [host_storage]
+         constructor carrying a [Soa.plan].} The Tier 1b handoff doc proposed
+      the latter; it is not buildable. This library is deliberately FFI-free and
+      is compiled to [.bc.js] as well as [.bc] — its dune stanza must not list
+      [ctypes], and [sarek/core/ffi_free_gate] enforces that at build time.
+      [Soa]/[Soa_vector] live in [spoc_core] and use [Ctypes] directly to copy
+      raw words, and [Vector_types] is above this layer too, so naming any of
+      them here would either break that gate or force the plan representation to
+      be duplicated across the layer boundary — a drift hazard of exactly the
+      kind the [ir_fields] trust note warns about.
+
+      So the layer inversion is resolved with behaviour instead of types: the
+      producer ({!Vector.create} in [spoc_core], which may use ctypes freely)
+      supplies the transpose as closures plus the two plain numbers a launch
+      needs. Nothing ctypes-shaped crosses down, and this stays a value a jsoo
+      build can hold.
+
+      Choosing a record field over a GADT constructor is also what makes this
+      affordable: a new [host_storage] constructor forces all 51 match arms
+      across 5 files; a field forces only the 6 sites that build this record,
+      all of them in this file. It keeps the same property that made the GADT
+      attractive — the compiler finds every site — without the fan-out, and
+      without a hidden global side table keyed by vector id. *)
+  and soa_binding = {
+    soa_num_leaves : int;
+        (** Number of scalar leaves = number of base pointers a launch binds. *)
+    soa_aos_stride : int;  (** Packed AoS element size, in bytes. *)
+    soa_scatter : unit -> unit;
+        (** Transpose the AoS host buffer into the N per-leaf host buffers. Call
+            before transferring the leaves to a device. *)
+    soa_gather : unit -> unit;
+        (** Transpose the N per-leaf host buffers back into the AoS host buffer.
+            Call after reading leaves back from a device that wrote them. *)
+  }
+
   and ('a, 'b) t = {
     host : ('a, 'b) host_storage;
     device_buffers : (int, Ops.device_buf) Hashtbl.t;
@@ -147,6 +185,11 @@ module Make (Ops : CUSTOM_OPS) = struct
     mutable location : location;
     mutable auto_sync : bool;
     id : int;
+    mutable soa : soa_binding option;
+        (** [None] for every vector except one created with [~layout:SoA]. Read
+            by the launch path to decide whether to bind N leaf pointers instead
+            of one packed buffer; ignored by every host-side operation, which is
+            why [get]/[set] and the PPX accessors need no changes at all. *)
   }
 
   (** {2 Kind helpers — delegated to Spoc_core_base_scalar} *)
@@ -246,6 +289,7 @@ module Make (Ops : CUSTOM_OPS) = struct
         location = CPU;
         auto_sync = true;
         id = !next_id;
+        soa = None;
       }
     in
     (match dev with Some d -> vec.location <- Stale_GPU d | None -> ()) ;
@@ -267,6 +311,7 @@ module Make (Ops : CUSTOM_OPS) = struct
             location = CPU;
             auto_sync = true;
             id = !next_id;
+            soa = None;
           }
         in
         (match dev with Some d -> vec.location <- Stale_GPU d | None -> ()) ;
@@ -287,6 +332,7 @@ module Make (Ops : CUSTOM_OPS) = struct
       location = CPU;
       auto_sync = true;
       id = !next_id;
+      soa = None;
     }
 
   let of_raw_handle (c : 'a custom_type) (raw : nativeint) (length : int) :
@@ -301,6 +347,7 @@ module Make (Ops : CUSTOM_OPS) = struct
       location = CPU;
       auto_sync = true;
       id = !next_id;
+      soa = None;
     }
 
   (** {2 Accessors} *)
@@ -396,6 +443,7 @@ module Make (Ops : CUSTOM_OPS) = struct
       location = CPU;
       auto_sync = vec.auto_sync;
       id = !next_id;
+      soa = None;
     }
 
   let sub_vector_host (type a b) (vec : (a, b) t) ~(start : int) ~(len : int) :
@@ -425,6 +473,7 @@ module Make (Ops : CUSTOM_OPS) = struct
       location = CPU;
       auto_sync = vec.auto_sync;
       id = !next_id;
+      soa = None;
     }
 
   let sub_vector (type a b) (vec : (a, b) t) ~(start : int) ~(len : int)

--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -175,6 +175,17 @@ module Make (Ops : CUSTOM_OPS) = struct
     soa_gather : unit -> unit;
         (** Transpose the N per-leaf host buffers back into the AoS host buffer.
             Call after reading leaves back from a device that wrote them. *)
+    soa_to_device : Ops.device_t -> unit;
+        (** Scatter, then transfer every leaf to [device]. One closure rather
+            than "scatter" + "transfer" separately, so a caller cannot do the
+            first and forget the second. *)
+    soa_leaf_bufs : Ops.device_t -> Ops.device_buf list;
+        (** The N leaf device buffers in {!Soa.plan} leaf (record declaration)
+            order — exactly the order the emitted PTX param block expects. Typed
+            in [Ops] terms, which is what lets [Execute.ml] consume it: it is
+            compiled for the jsoo target too, where [Soa_vector] does not exist
+            (sarek/execute/jsoo/dune copies Execute.ml but not Soa_launch.ml),
+            so it can never name the SoA modules directly. *)
   }
 
   and ('a, 'b) t = {

--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -186,6 +186,33 @@ module Make (Ops : CUSTOM_OPS) = struct
             compiled for the jsoo target too, where [Soa_vector] does not exist
             (sarek/execute/jsoo/dune copies Execute.ml but not Soa_launch.ml),
             so it can never name the SoA modules directly. *)
+    soa_from_device : Ops.device_t -> unit;
+        (** The inverse of {!soa_to_device}: read every leaf back from [device],
+            then gather into the packed AoS host buffer.
+
+            Without this a kernel's OUTPUT is silently lost. A launch that took
+            the SoA ABI wrote into the N leaf buffers, and the packed device
+            buffer it did not touch is what an ordinary [Transfer.to_cpu]
+            downloads — so the host would see whatever the AoS buffer last held,
+            with no error anywhere. Paired with {!soa_leaves_live} below, which
+            is what says the leaves are the ones holding the results. *)
+    soa_leaves_live : bool ref;
+        (** Have the leaf buffers been written by an SoA-ABI launch?
+
+            The launch site and the read-back site must not answer "SoA or AoS?"
+            independently — that is the same divergence hazard the single
+            [soa_dispatch] predicate exists to prevent, one step later in the
+            round trip. So this is not a second predicate: {!soa_to_device} sets
+            it, and read-back only READS it. A launch that never took the SoA
+            ABI (an external source through [Execute.run_source], or any non-PTX
+            backend) leaves it [false], and read-back then correctly downloads
+            the packed buffer.
+
+            A [bool ref] rather than a mutable field so that the closure which
+            performs the upload can set it itself. A mutable field would have to
+            be set by the CALLER after invoking [soa_to_device] — exactly the
+            "do the first and forget the second" split that closure is shaped to
+            make impossible. *)
   }
 
   and ('a, 'b) t = {

--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -527,6 +527,16 @@ module Make (Ops : CUSTOM_OPS) = struct
       location = CPU;
       auto_sync = vec.auto_sync;
       id = !next_id;
+      (* The copy is AoS-only BY DESIGN, and this is the one [soa] decision in
+         this module that a reader could mistake for an omission. A binding's
+         closures capture the SOURCE vector's leaves — inheriting it would give
+         the copy a fast path that scatters from, and gathers into, memory the
+         copy does not own, so a launch on the copy would write the original's
+         leaves. Copying the leaves as well is a different feature, not a smaller
+         one: it needs a per-device duplicate of every leaf buffer. Dropping the
+         binding costs nothing but speed — the copy is still a complete packed AoS
+         vector, which is what every non-CUDA/PTX launch of the original uses
+         anyway. *)
       soa = None;
     }
 
@@ -557,6 +567,12 @@ module Make (Ops : CUSTOM_OPS) = struct
       location = CPU;
       auto_sync = vec.auto_sync;
       id = !next_id;
+      (* AoS-only for a stronger reason than {!copy_host_only} above: a
+         subvector's length is [len], while the parent binding's leaves are
+         [vec.length] long and its plan's scatter/gather run over that whole
+         length. There is no offset anywhere in the binding to narrow, so the
+         parent's binding does not describe this vector at all — it is not a
+         speed choice here but the only correct answer. *)
       soa = None;
     }
 

--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -206,8 +206,14 @@ module Make (Ops : CUSTOM_OPS) = struct
             is what says the leaves are the ones holding the results. *)
     soa_free_leaves : Ops.device_t option -> unit;
         (** Release the leaf device buffers: [Some dev] frees them on that
-            device only, [None] on every device. Clears {!soa_leaves_live},
-            because after this the leaves hold nothing a read-back could fetch.
+            device only, [None] on every device. Then RE-DERIVES
+            {!soa_leaves_live} from the leaves that are still allocated, rather
+            than clearing it: a freed leaf holds nothing a read-back could
+            fetch, but the flag covers the whole vector, so a [Some dev] free
+            must leave it set while leaves survive on another device. Clearing
+            it unconditionally made [free_buffer] on device B disown live leaves
+            on device A, and the drain-before-free then skipped A — freeing a
+            device the results were not on discarded them.
 
             Its absence was a LEAK rather than a correctness bug, which is why
             it is easy to miss. Under this ABI the packed AoS buffer is never
@@ -233,13 +239,18 @@ module Make (Ops : CUSTOM_OPS) = struct
             read-back then correctly downloads the packed buffer.
 
             THREE writers, and the list is exhaustive — anything else that flips
-            this is a bug: {!soa_to_device} sets it; {!soa_free_leaves} clears
-            it, because freed leaves hold nothing a read-back could fetch; and
+            this is a bug: {!soa_to_device} sets it; {!soa_free_leaves}
+            re-derives it from the leaves that survive the free; and
             [Execute.transfer_vectors_to_device] clears it when a launch takes
             the packed ABI. Between them it states the ABI of the MOST RECENT
             operation, not of some operation — which is the property the
             read-back paths rely on and the one that was missing when nothing
             ever cleared it.
+
+            Note what "clears it" cost in {!soa_free_leaves}: this flag is
+            whole-vector while that free is per-device, so the two only agree
+            when the free covered every device. Deriving instead of assigning is
+            what keeps a single flag honest across a per-device release.
 
             A [bool ref] rather than a mutable field so that the closure which
             performs the upload can set it itself. A mutable field would have to

--- a/sarek/core_base/Spoc_core_base.ml
+++ b/sarek/core_base/Spoc_core_base.ml
@@ -140,7 +140,15 @@ module Make (Ops : CUSTOM_OPS) = struct
         -> ('a, unit) host_storage
 
   (** Opt-in Structure-of-Arrays binding for a custom (flat-record) vector
-      (backlog-54). Present iff the vector was created with [~layout:SoA].
+      (backlog-54). Present iff the vector came from
+      [Soa_vector.create_transparent], which is the only producer of this
+      record.
+
+      There is no [Vector.create ~layout:SoA] and no [layout] parameter
+      anywhere; that shape was PROPOSED by the Tier 1b handoff and rejected —
+      see [Soa_vector.ml]'s [create_transparent] comment for why (it would
+      invert the [Vector] -> [Soa_vector] dependency, and the transparency the
+      item is about is at the LAUNCH site, not at the constructor).
 
       {b Why this is a field of closures and ints, and NOT a [host_storage]
          constructor carrying a [Soa.plan].} The Tier 1b handoff doc proposed
@@ -196,17 +204,42 @@ module Make (Ops : CUSTOM_OPS) = struct
             downloads — so the host would see whatever the AoS buffer last held,
             with no error anywhere. Paired with {!soa_leaves_live} below, which
             is what says the leaves are the ones holding the results. *)
+    soa_free_leaves : Ops.device_t option -> unit;
+        (** Release the leaf device buffers: [Some dev] frees them on that
+            device only, [None] on every device. Clears {!soa_leaves_live},
+            because after this the leaves hold nothing a read-back could fetch.
+
+            Its absence was a LEAK rather than a correctness bug, which is why
+            it is easy to miss. Under this ABI the packed AoS buffer is never
+            allocated, so [Transfer.free_all_buffers] iterated an EMPTY
+            [device_buffers] table and returned having released zero bytes —
+            measured 2026-07-30 with [Gpu_memory.usage()]: 3840 B before a
+            launch, 4224 B after the free (delta +384 = 32 elements x 3 leaves x
+            4 B, i.e. the leaves the call was asked to release). The data was
+            still correct afterwards, and the leaves were still reclaimed
+            EVENTUALLY — each carries a [Gpu_memory.register_finalizer] — so
+            nothing looked wrong. What the caller lost was the one thing an
+            explicit free is for: releasing the memory at a time it chooses,
+            while the structure is still reachable. *)
     soa_leaves_live : bool ref;
         (** Have the leaf buffers been written by an SoA-ABI launch?
 
             The launch site and the read-back site must not answer "SoA or AoS?"
             independently — that is the same divergence hazard the single
             [soa_dispatch] predicate exists to prevent, one step later in the
-            round trip. So this is not a second predicate: {!soa_to_device} sets
-            it, and read-back only READS it. A launch that never took the SoA
-            ABI (an external source through [Execute.run_source], or any non-PTX
-            backend) leaves it [false], and read-back then correctly downloads
-            the packed buffer.
+            round trip. So this is not a second predicate: read-back only READS
+            it. A launch that never took the SoA ABI (an external source through
+            [Execute.run_source], or any non-PTX backend) leaves it [false], and
+            read-back then correctly downloads the packed buffer.
+
+            THREE writers, and the list is exhaustive — anything else that flips
+            this is a bug: {!soa_to_device} sets it; {!soa_free_leaves} clears
+            it, because freed leaves hold nothing a read-back could fetch; and
+            [Execute.transfer_vectors_to_device] clears it when a launch takes
+            the packed ABI. Between them it states the ABI of the MOST RECENT
+            operation, not of some operation — which is the property the
+            read-back paths rely on and the one that was missing when nothing
+            ever cleared it.
 
             A [bool ref] rather than a mutable field so that the closure which
             performs the upload can set it itself. A mutable field would have to
@@ -224,10 +257,12 @@ module Make (Ops : CUSTOM_OPS) = struct
     mutable auto_sync : bool;
     id : int;
     mutable soa : soa_binding option;
-        (** [None] for every vector except one created with [~layout:SoA]. Read
-            by the launch path to decide whether to bind N leaf pointers instead
-            of one packed buffer; ignored by every host-side operation, which is
-            why [get]/[set] and the PPX accessors need no changes at all. *)
+        (** [None] for every vector except one from
+            [Soa_vector.create_transparent] (there is no [~layout] parameter —
+            see {!soa_binding}). Read by the launch path to decide whether to
+            bind N leaf pointers instead of one packed buffer; ignored by every
+            host-side operation, which is why [get]/[set] and the PPX accessors
+            need no changes at all. *)
   }
 
   (** {2 Kind helpers — delegated to Spoc_core_base_scalar} *)

--- a/sarek/core_base/Spoc_core_base.mli
+++ b/sarek/core_base/Spoc_core_base.mli
@@ -129,7 +129,10 @@ module Make (Ops : CUSTOM_OPS) : sig
         -> ('a, unit) host_storage
 
   (** Opt-in Structure-of-Arrays binding for a custom (flat-record) vector
-      (backlog-54); present iff the vector was created with [~layout:SoA].
+      (backlog-54); present iff the vector came from
+      [Soa_vector.create_transparent], its only producer. There is no
+      [Vector.create ~layout:SoA] and no [layout] parameter — the Tier 1b
+      handoff proposed one and it was rejected as a layer inversion.
 
       Deliberately closures and plain ints rather than a [Soa.plan]. This
       library is FFI-free and also builds as [.bc.js]
@@ -150,11 +153,25 @@ module Make (Ops : CUSTOM_OPS) : sig
             the packed AoS host buffer. Without it a kernel's output is silently
             lost — the packed device buffer an ordinary [Transfer.to_cpu] reads
             is the one the SoA launch did not write. *)
+    soa_free_leaves : Ops.device_t option -> unit;
+        (** Release the leaf device buffers — [Some dev] on that device, [None]
+            on every device — and clear [soa_leaves_live]. Without it
+            [Transfer.free_all_buffers] released ZERO bytes on a transparent SoA
+            vector (the packed buffer it iterates is never allocated under this
+            ABI): a leak, not wrong data, since each leaf also carries a
+            [Gpu_memory.register_finalizer]. *)
     soa_leaves_live : bool ref;
-        (** Set by [soa_to_device]; only READ elsewhere. It is what lets the
-            read-back path follow the launch's ABI decision instead of
-            re-deriving it. [false] whenever the launch used the packed AoS ABI
-            (an external source, or any non-CUDA/PTX backend). *)
+        (** Does the device hold results in the LEAVES rather than in the packed
+            AoS buffer? What lets the read-back path follow the launch's ABI
+            decision instead of re-deriving it.
+
+            Three writers, and only three — [soa_to_device] sets it,
+            [soa_free_leaves] clears it (the freed leaves hold nothing), and
+            [Execute.transfer_vectors_to_device] clears it when a launch takes
+            the packed ABI, so it states the ABI of the MOST RECENT operation
+            rather than of some operation. Every read-back path only READS it.
+            [false] whenever the launch used the packed AoS ABI — an external
+            source through [run_source], or any non-CUDA/PTX backend. *)
   }
 
   and ('a, 'b) t = {
@@ -166,9 +183,10 @@ module Make (Ops : CUSTOM_OPS) : sig
     mutable auto_sync : bool;
     id : int;
     mutable soa : soa_binding option;
-        (** [None] for every vector but one created with [~layout:SoA]. Read
-            only by the launch path; every host-side operation ignores it, which
-            is why [get]/[set] and the PPX accessors are unchanged. *)
+        (** [None] for every vector but one from [Soa_vector.create_transparent]
+            (no [~layout] parameter exists — see {!soa_binding}). Read only by
+            the launch path; every host-side operation ignores it, which is why
+            [get]/[set] and the PPX accessors are unchanged. *)
   }
 
   (** {2 Kind helpers — pure} *)

--- a/sarek/core_base/Spoc_core_base.mli
+++ b/sarek/core_base/Spoc_core_base.mli
@@ -145,6 +145,16 @@ module Make (Ops : CUSTOM_OPS) : sig
     soa_gather : unit -> unit;
     soa_to_device : Ops.device_t -> unit;
     soa_leaf_bufs : Ops.device_t -> Ops.device_buf list;
+    soa_from_device : Ops.device_t -> unit;
+        (** Inverse of [soa_to_device]: read every leaf back, then gather into
+            the packed AoS host buffer. Without it a kernel's output is silently
+            lost — the packed device buffer an ordinary [Transfer.to_cpu] reads
+            is the one the SoA launch did not write. *)
+    soa_leaves_live : bool ref;
+        (** Set by [soa_to_device]; only READ elsewhere. It is what lets the
+            read-back path follow the launch's ABI decision instead of
+            re-deriving it. [false] whenever the launch used the packed AoS ABI
+            (an external source, or any non-CUDA/PTX backend). *)
   }
 
   and ('a, 'b) t = {

--- a/sarek/core_base/Spoc_core_base.mli
+++ b/sarek/core_base/Spoc_core_base.mli
@@ -128,6 +128,23 @@ module Make (Ops : CUSTOM_OPS) : sig
       }
         -> ('a, unit) host_storage
 
+  (** Opt-in Structure-of-Arrays binding for a custom (flat-record) vector
+      (backlog-54); present iff the vector was created with [~layout:SoA].
+
+      Deliberately closures and plain ints rather than a [Soa.plan]. This
+      library is FFI-free and also builds as [.bc.js]
+      ([sarek/core/ffi_free_gate] enforces both), while [Soa]/[Soa_vector] use
+      [Ctypes] and live above it — so the transpose crosses down as behaviour,
+      not as types. See the implementation for the full rationale, including why
+      this is a record field instead of the [host_storage] constructor the Tier
+      1b handoff proposed. *)
+  and soa_binding = {
+    soa_num_leaves : int;
+    soa_aos_stride : int;
+    soa_scatter : unit -> unit;
+    soa_gather : unit -> unit;
+  }
+
   and ('a, 'b) t = {
     host : ('a, 'b) host_storage;
     device_buffers : (int, Ops.device_buf) Hashtbl.t;
@@ -136,6 +153,10 @@ module Make (Ops : CUSTOM_OPS) : sig
     mutable location : location;
     mutable auto_sync : bool;
     id : int;
+    mutable soa : soa_binding option;
+        (** [None] for every vector but one created with [~layout:SoA]. Read
+            only by the launch path; every host-side operation ignores it, which
+            is why [get]/[set] and the PPX accessors are unchanged. *)
   }
 
   (** {2 Kind helpers — pure} *)

--- a/sarek/core_base/Spoc_core_base.mli
+++ b/sarek/core_base/Spoc_core_base.mli
@@ -155,18 +155,22 @@ module Make (Ops : CUSTOM_OPS) : sig
             is the one the SoA launch did not write. *)
     soa_free_leaves : Ops.device_t option -> unit;
         (** Release the leaf device buffers — [Some dev] on that device, [None]
-            on every device — and clear [soa_leaves_live]. Without it
-            [Transfer.free_all_buffers] released ZERO bytes on a transparent SoA
-            vector (the packed buffer it iterates is never allocated under this
-            ABI): a leak, not wrong data, since each leaf also carries a
-            [Gpu_memory.register_finalizer]. *)
+            on every device — then RE-DERIVE [soa_leaves_live] from the leaves
+            still allocated. Without the release, [Transfer.free_all_buffers]
+            returned ZERO bytes on a transparent SoA vector (the packed buffer
+            it iterates is never allocated under this ABI): a leak, not wrong
+            data, since each leaf also carries a
+            [Gpu_memory.register_finalizer]. Without the re-derivation — it used
+            to assign [false] — a per-device free disowned live leaves on every
+            OTHER device, and that IS wrong data: the drain-before-free consults
+            this flag. *)
     soa_leaves_live : bool ref;
         (** Does the device hold results in the LEAVES rather than in the packed
             AoS buffer? What lets the read-back path follow the launch's ABI
             decision instead of re-deriving it.
 
             Three writers, and only three — [soa_to_device] sets it,
-            [soa_free_leaves] clears it (the freed leaves hold nothing), and
+            [soa_free_leaves] re-derives it from the surviving leaves, and
             [Execute.transfer_vectors_to_device] clears it when a launch takes
             the packed ABI, so it states the ABI of the MOST RECENT operation
             rather than of some operation. Every read-back path only READS it.

--- a/sarek/core_base/Spoc_core_base.mli
+++ b/sarek/core_base/Spoc_core_base.mli
@@ -143,6 +143,8 @@ module Make (Ops : CUSTOM_OPS) : sig
     soa_aos_stride : int;
     soa_scatter : unit -> unit;
     soa_gather : unit -> unit;
+    soa_to_device : Ops.device_t -> unit;
+    soa_leaf_bufs : Ops.device_t -> Ops.device_buf list;
   }
 
   and ('a, 'b) t = {

--- a/sarek/core_base/Spoc_core_base.mli
+++ b/sarek/core_base/Spoc_core_base.mli
@@ -155,27 +155,33 @@ module Make (Ops : CUSTOM_OPS) : sig
             is the one the SoA launch did not write. *)
     soa_free_leaves : Ops.device_t option -> unit;
         (** Release the leaf device buffers — [Some dev] on that device, [None]
-            on every device — then RE-DERIVE [soa_leaves_live] from the leaves
-            still allocated. Without the release, [Transfer.free_all_buffers]
-            returned ZERO bytes on a transparent SoA vector (the packed buffer
-            it iterates is never allocated under this ABI): a leak, not wrong
-            data, since each leaf also carries a
-            [Gpu_memory.register_finalizer]. Without the re-derivation — it used
-            to assign [false] — a per-device free disowned live leaves on every
-            OTHER device, and that IS wrong data: the drain-before-free consults
-            this flag. *)
+            on every device — then NARROW [soa_leaves_live]: still set iff it
+            already was and some leaf survives. Without the release,
+            [Transfer.free_all_buffers] returned ZERO bytes on a transparent SoA
+            vector (the packed buffer it iterates is never allocated under this
+            ABI): a leak, not wrong data, since each leaf also carries a
+            [Gpu_memory.register_finalizer]. Without consulting the surviving
+            leaves — it used to assign [false] — a per-device free disowned live
+            leaves on every OTHER device, and that IS wrong data: the
+            drain-before-free consults this flag. Without the conjunction with
+            the PREVIOUS value it was wrong in the mirror direction: a packed
+            launch clears the flag and leaves those buffers allocated, so
+            deriving from allocation alone resurrected ownership of leaves that
+            had already been gathered and given up. *)
     soa_leaves_live : bool ref;
         (** Does the device hold results in the LEAVES rather than in the packed
             AoS buffer? What lets the read-back path follow the launch's ABI
             decision instead of re-deriving it.
 
-            Three writers, and only three — [soa_to_device] sets it,
-            [soa_free_leaves] re-derives it from the surviving leaves, and
-            [Execute.transfer_vectors_to_device] clears it when a launch takes
-            the packed ABI, so it states the ABI of the MOST RECENT operation
-            rather than of some operation. Every read-back path only READS it.
-            [false] whenever the launch used the packed AoS ABI — an external
-            source through [run_source], or any non-CUDA/PTX backend. *)
+            Four writers, and only four, of which exactly one can SET it:
+            [soa_to_device] sets it; [Execute.transfer_vectors_to_device] clears
+            it when a launch takes the packed ABI; [Transfer.to_device] clears
+            it after a packed host->device upload; [soa_free_leaves] narrows it.
+            So it states the ABI of the most recent operation that made a device
+            copy authoritative, rather than of some operation. Every read-back
+            path only READS it. [false] whenever the launch used the packed AoS
+            ABI — an external source through [run_source], or any non-CUDA/PTX
+            backend. *)
   }
 
   and ('a, 'b) t = {

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -412,12 +412,18 @@ let expand_to_run_source_args ?(inject_lengths = true) ?(soa_abi = false)
     Framework_sig.run_source_arg list =
   List.concat_map
     (function
-      | Vec v when soa_dispatch ~soa_abi v dev <> None ->
+      | Vec v when Option.is_some (soa_dispatch ~soa_abi v dev) ->
           (* N leaf base pointers in leaf (record declaration) order, then ONE
              shared length — exactly the param block Sarek_ir_ptx.emit_params
              produces for a ~soa_params vector. The length is emitted even under
              ~inject_lengths:false: it is not an injected convenience here but a
              declared parameter of that ABI. *)
+          (* [Option.get] on a predicate the guard just evaluated: [soa_dispatch]
+             is pure (it reads [v.Vector.soa] and compares [dev]'s framework
+             string), so the second call cannot disagree with the first. Kept as
+             two calls rather than restructured into one [match] because the
+             packed arm below is shared with the non-dispatching [Vec] case and
+             merging them would duplicate it. *)
           let b = Option.get (soa_dispatch ~soa_abi v dev) in
           let len = Vector.length v in
           let bufs = b.Vector.soa_leaf_bufs dev in

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -332,29 +332,44 @@ let transfer_vectors_to_device ?(soa_abi = false) (args : vector_arg list)
                  buffer holding pre-SoA-launch bytes, or against no buffer at all
                  (the transparent path never allocates one, so the argument
                  expansion then raises [Transfer_failed]). *)
-              (* The gather runs UNCONDITIONALLY, through the binding's own
-                 [soa_from_device] rather than through [Transfer.to_cpu]. That is
-                 the only shape that is safe next to the line below it: clearing
-                 the flag is what makes the SoA arm of [Transfer.read_back_to_host]
-                 unreachable, and nothing ever sets the flag again, so a gather
-                 that can be SKIPPED means the launch's output can be stranded in
-                 the leaves with no path back to the host.
+              (* Gather where the LEAVES are the newer copy, skip where the HOST
+                 is, clear the flag either way. Two separate reasons, and the
+                 asymmetry between them is deliberate:
 
-                 [Transfer.to_cpu] can skip: it consults [v.location] and returns
-                 without reading anything on [Both]. Today every [Both] on a
-                 leaf-live vector is one where the host copy already IS the
-                 gathered result (only [to_cpu]/[sync]/[free_buffer] record it, each
-                 after a real read-back), so the previous unforced call did not
-                 produce wrong data. It made the correctness of THIS site depend on
-                 an invariant spanning four functions in another module; calling the
-                 gather directly is what makes that dependence go away.
+                 - the SKIP arms are a correctness requirement, and getting this
+                   wrong is how this round's first attempt lost data. [CPU] and
+                   [Stale_GPU] assert the host copy is the newer one, and on a
+                   leaf-live vector [Stale_GPU] is reachable through the public
+                   API: a transparent launch leaves [Stale_CPU dev], and a host
+                   [Vector.set]/[unsafe_set]/[fill] then gathers, writes the
+                   element and records [Stale_GPU dev] (Vector.ml). An
+                   unconditional gather replays the leaves OVER that write and it
+                   vanishes with no diagnostic — the backlog-181/190 class on the
+                   packed-after-SoA path. Pinned by
+                   [check_host_write_survives_packed].
+                 - deciding it HERE rather than delegating to [Transfer.to_cpu]'s
+                   [needs_transfer] is not a bug fix, and no test distinguishes the
+                   two. An unforced [to_cpu] also skips on [Both], and whether that
+                   is safe depends on the three functions that record [Both] doing
+                   so only after a real read-back — which they do, so the host
+                   there already holds the gathered result and the gather this arm
+                   performs is redundant today. The point is that clearing the flag
+                   on the next line makes the SoA arm of
+                   [Transfer.read_back_to_host] unreachable until the next
+                   transparent launch sets the flag again, so what may be skipped
+                   is a property this site must state rather than inherit from
+                   another module.
 
-                 [Transfer.to_cpu ~force:true] would also do it, but the jsoo build
-                 compiles this same file against [Transfer_jsx], whose [to_cpu]
-                 takes no [~force] — the binding closure is available in both. *)
+                 [Transfer.to_cpu ~force:true] is not the shape either way: it
+                 would gather on [Stale_GPU] (the data-loss arm above), and the
+                 jsoo build compiles this same file against [Transfer_jsx], whose
+                 [to_cpu] takes no [~force]. *)
               (match v.Vector.soa with
               | Some b when !(b.Vector.soa_leaves_live) ->
-                  b.Vector.soa_from_device dev ;
+                  (match v.Vector.location with
+                  | Vector.GPU _ | Vector.Stale_CPU _ | Vector.Both _ ->
+                      b.Vector.soa_from_device dev
+                  | Vector.CPU | Vector.Stale_GPU _ -> ()) ;
                   b.Vector.soa_leaves_live := false ;
                   v.Vector.location <- Vector.Stale_GPU dev
               | Some _ | None -> ()) ;

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -341,19 +341,35 @@ let transfer_vectors_to_device ?(soa_abi = false) (args : vector_arg list)
                    [Stale_GPU] assert the host copy is the newer one, and on a
                    leaf-live vector [Stale_GPU] is reachable through the public
                    API: a transparent launch leaves [Stale_CPU dev], and a host
-                   [Vector.set]/[unsafe_set]/[fill] then gathers, writes the
-                   element and records [Stale_GPU dev] (Vector.ml). An
+                   write then records [Stale_GPU dev] (Vector.ml) — [Vector.set]
+                   and [unsafe_set] gather the leaves first through
+                   [ensure_cpu_sync], while [Vector.fill] deliberately does not
+                   and moves [Stale_CPU dev] straight to [Stale_GPU dev]; the
+                   location this arm reads is the same either way. An
                    unconditional gather replays the leaves OVER that write and it
                    vanishes with no diagnostic — the backlog-181/190 class on the
                    packed-after-SoA path. Pinned by
                    [check_host_write_survives_packed].
+
+                   The case analysis is over LOCATIONS, so it inherits whatever
+                   the location bookkeeping is worth: with auto-sync disabled
+                   ([Vector.set_auto_sync] or [Transfer.disable_auto]) a host
+                   write after a transparent launch leaves the vector at
+                   [Stale_CPU dev] with the write pending, and the gather arm
+                   below then replays the leaves over it. That is the pre-existing
+                   auto-sync-off hazard [Vector.ml] documents, not something this
+                   condition can decide, and it is named here rather than left to
+                   be read as covered.
                  - deciding it HERE rather than delegating to [Transfer.to_cpu]'s
                    [needs_transfer] is not a bug fix, and no test distinguishes the
-                   two. An unforced [to_cpu] also skips on [Both], and whether that
-                   is safe depends on the three functions that record [Both] doing
-                   so only after a real read-back — which they do, so the host
-                   there already holds the gathered result and the gather this arm
-                   performs is redundant today. The point is that clearing the flag
+                   two. An unforced [to_cpu] also skips on [Both]. Whether that is
+                   safe depends on the sites that RECORD [Both] on a leaf-live
+                   vector — [to_cpu] and [sync] after a real read-back, and
+                   [free_buffer] after its drain — so the host copy there already
+                   holds the gathered result and the gather this arm performs is
+                   redundant today. ([Transfer.to_device] also records [Both], on
+                   an upload rather than a read-back, and that path clears this
+                   flag itself.) The point is that clearing the flag
                    on the next line makes the SoA arm of
                    [Transfer.read_back_to_host] unreachable until the next
                    transparent launch sets the flag again, so what may be skipped

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -259,18 +259,31 @@ let get_device_buffer (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
    The CUDA/PTX restriction is the documented "never wrong data" fallback: only
    that backend's emitter lowers a record param to N base pointers, so on every
    other backend the vector stays exactly what it also is — an ordinary packed
-   AoS custom vector — and takes the untouched path. *)
+   AoS custom vector — and takes the untouched path.
 
-(** Transfer all V2 Vector args to device *)
-let soa_dispatch (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
-    Vector.soa_binding option =
+   [soa_abi] is the caller's statement that the kernel about to run was emitted
+   by Sarek with [~soa_params] — i.e. that its signature really is N leaf
+   pointers plus one shared length. The two generated-JIT sites pass [true]
+   explicitly and everything else defaults to [false], because the dangerous
+   direction is an EXTERNAL kernel: [run_source] hands the backend a source
+   string Sarek did not emit, whose parameter block is the packed [(ptr, len)]
+   pair, and binding N leaf pointers to it is not a crash but silently wrong
+   data. A default of [true] would make that the behaviour any new caller
+   inherits by omission. *)
+let soa_dispatch (type a b) ~(soa_abi : bool) (v : (a, b) Vector.t)
+    (dev : Device.t) : Vector.soa_binding option =
   match v.Vector.soa with
-  | Some b when dev.Device.framework = "CUDA/PTX" -> Some b
+  | Some b when soa_abi && dev.Device.framework = "CUDA/PTX" -> Some b
   | Some _ | None -> None
 
 (* Kernel param names at the positions holding an SoA-dispatched vector.
    Positional, because that is the only correspondence there is: [vector_arg] is
-   existential, so nothing relates an argument to a parameter but its index. *)
+   existential, so nothing relates an argument to a parameter but its index.
+
+   [~soa_abi:true] is fixed here rather than a parameter: this function's whole
+   purpose is to compute the [~soa_params] argument to [generate_source], so it
+   is only ever reached on the generated-JIT path, and it is what MAKES that
+   kernel's signature the N-pointer one. *)
 let soa_param_names (ir : Sarek_ir_types.kernel) (args : vector_arg list)
     (dev : Device.t) : string list =
   let param_names =
@@ -283,16 +296,17 @@ let soa_param_names (ir : Sarek_ir_types.kernel) (args : vector_arg list)
   List.filteri
     (fun i _ ->
       match List.nth_opt args i with
-      | Some (Vec v) -> soa_dispatch v dev <> None
+      | Some (Vec v) -> soa_dispatch ~soa_abi:true v dev <> None
       | _ -> false)
     param_names
 
-let transfer_vectors_to_device (args : vector_arg list) (dev : Device.t) : unit
-    =
+(** Transfer all V2 Vector args to device *)
+let transfer_vectors_to_device ?(soa_abi = false) (args : vector_arg list)
+    (dev : Device.t) : unit =
   List.iter
     (function
       | Vec v -> (
-          match soa_dispatch v dev with
+          match soa_dispatch ~soa_abi v dev with
           | Some b -> b.Vector.soa_to_device dev
           | None -> Transfer.to_device v dev)
       | _ -> ())
@@ -309,17 +323,18 @@ let transfer_vectors_to_device (args : vector_arg list) (dev : Device.t) : unit
     happens to immediately follow a buffer (which is exactly what a
     [~inject_lengths:false] caller can pass) - see
     {!Framework_sig.run_source_arg}. *)
-let expand_to_run_source_args ?(inject_lengths = true) (args : vector_arg list)
-    (dev : Device.t) : Framework_sig.run_source_arg list =
+let expand_to_run_source_args ?(inject_lengths = true) ?(soa_abi = false)
+    (args : vector_arg list) (dev : Device.t) :
+    Framework_sig.run_source_arg list =
   List.concat_map
     (function
-      | Vec v when soa_dispatch v dev <> None ->
+      | Vec v when soa_dispatch ~soa_abi v dev <> None ->
           (* N leaf base pointers in leaf (record declaration) order, then ONE
              shared length — exactly the param block Sarek_ir_ptx.emit_params
              produces for a ~soa_params vector. The length is emitted even under
              ~inject_lengths:false: it is not an injected convenience here but a
              declared parameter of that ABI. *)
-          let b = Option.get (soa_dispatch v dev) in
+          let b = Option.get (soa_dispatch ~soa_abi v dev) in
           let len = Vector.length v in
           let leaf_args =
             List.map
@@ -793,7 +808,12 @@ let run ~(device : Device.t) ~(name : string)
                        })
               | Some source ->
                   (* Convert vector args to run_source_arg format (auto-injects lengths) *)
-                  let rs_args = expand_to_run_source_args args device in
+                  (* ~soa_abi:true: this is the generated-JIT path, and the
+                     source just produced above was emitted with the matching
+                     ~soa_params. *)
+                  let rs_args =
+                    expand_to_run_source_args ~soa_abi:true args device
+                  in
                   (* Set current device *)
                   let dev = B.Device.get device.backend_id in
                   B.Device.set_current dev ;
@@ -1094,8 +1114,10 @@ let run_vectors ~(device : Device.t) ~(ir : Sarek_ir_types.kernel)
      2. Pass vector_args to run (it expands for JIT, passes direct for Direct)
      3. Mark stale (CPU backends: no-op due to zero-copy) *)
 
-  (* 1. Transfer all vectors to device *)
-  transfer_vectors_to_device args device ;
+  (* 1. Transfer all vectors to device. ~soa_abi:true — this entry point runs a
+     Sarek-generated kernel, so an SoA-bound vector's leaves are what the launch
+     will read. [Execute.run_source] deliberately does NOT pass it. *)
+  transfer_vectors_to_device ~soa_abi:true args device ;
 
   (* 2. Dispatch via run - it handles expansion per backend *)
   run

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -353,13 +353,15 @@ let transfer_vectors_to_device ?(soa_abi = false) (args : vector_arg list)
 
                    The case analysis is over LOCATIONS, so it inherits whatever
                    the location bookkeeping is worth: with auto-sync disabled
-                   ([Vector.set_auto_sync] or [Transfer.disable_auto]) a host
-                   write after a transparent launch leaves the vector at
-                   [Stale_CPU dev] with the write pending, and the gather arm
-                   below then replays the leaves over it. That is the pre-existing
-                   auto-sync-off hazard [Vector.ml] documents, not something this
-                   condition can decide, and it is named here rather than left to
-                   be read as covered.
+                   ([Vector.set_auto_sync] or [Transfer.disable_auto]) a
+                   [Vector.set]/[unsafe_set] after a transparent launch leaves the
+                   vector at [Stale_CPU dev] with the write pending, and the
+                   gather arm below then replays the leaves over it. ([Vector.fill]
+                   is unaffected: it never gathers and records [Stale_GPU dev]
+                   either way, which this arm skips.) Stated here rather than
+                   cited: no doc comment in [Vector.ml] describes that
+                   consequence of disabling auto-sync, so there is nothing to
+                   point at, and it is not something this condition can decide.
                  - deciding it HERE rather than delegating to [Transfer.to_cpu]'s
                    [needs_transfer] is not a bug fix, and no test distinguishes the
                    two. An unforced [to_cpu] also skips on [Both]. Whether that is
@@ -367,9 +369,10 @@ let transfer_vectors_to_device ?(soa_abi = false) (args : vector_arg list)
                    vector — [to_cpu] and [sync] after a real read-back, and
                    [free_buffer] after its drain — so the host copy there already
                    holds the gathered result and the gather this arm performs is
-                   redundant today. ([Transfer.to_device] also records [Both], on
-                   an upload rather than a read-back, and that path clears this
-                   flag itself.) The point is that clearing the flag
+                   redundant today. ([Transfer.to_device] also records [Both] —
+                   twice: after its migration read-back and again after the
+                   upload — and that path clears this flag itself before it
+                   returns.) The point is that clearing the flag
                    on the next line makes the SoA arm of
                    [Transfer.read_back_to_host] unreachable until the next
                    transparent launch sets the flag again, so what may be skipped

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -387,20 +387,16 @@ let expand_to_run_source_args ?(inject_lengths = true) ?(soa_abi = false)
           let b = Option.get (soa_dispatch ~soa_abi v dev) in
           let len = Vector.length v in
           let bufs = b.Vector.soa_leaf_bufs dev in
-          (* The binding declares its leaf count ([soa_num_leaves]) and separately
-             produces the buffers, and it is the DECLARED count that reached the
-             emitter: [soa_param_names] marks this parameter as SoA and
-             [Sarek_ir_ptx.emit_params] then expands it from the record's
-             registered layout. Two derivations of one number, and this is the one
-             place they meet, so it is the only place that can compare them.
-
-             Checked rather than assumed because the consequence of a short list
-             is not a wrong result but a driver over-read: [Cuda_api.Kernel.launch]
-             sizes the argument array with [List.length args] and passes
+          (* The binding declares a leaf count ([soa_num_leaves]) and separately
+             produces the buffers; this is the only place those two meet, so it is
+             the only place that can compare them. A disagreement is not a wrong
+             result but a malformed kernel-argument array:
+             [Cuda_api.Kernel.launch] sizes it with [List.length args] and passes
              [cuLaunchKernel] a bare pointer with no count (the same mechanism
-             [check_launch_args] documents at the ARITY level below), so the driver
-             reads past the end and dereferences whatever follows as a leaf
-             pointer.
+             [check_launch_args] documents at the ARITY level below), so a SHORT
+             list makes the driver read past the end and dereference whatever
+             follows as a leaf pointer, and a LONG one shifts every parameter
+             after this vector.
 
              Not reachable through [Soa_vector.create_transparent] today: its
              [soa_leaf_bufs] maps over the leaf array, so it returns exactly
@@ -408,7 +404,22 @@ let expand_to_run_source_args ?(inject_lengths = true) ?(soa_abi = false)
              buffer on [dev] (Soa_vector.ml:148-160). The binding is a record of
              closures crossing a module boundary that exists precisely so
              [Execute] cannot see [Soa_vector] — the count agreement is therefore
-             a cross-module convention, and this makes it a checked one. *)
+             a cross-module convention, and this makes it a checked one.
+
+             WHAT IT DOES NOT CHECK, because both sides of the comparison come
+             from the VECTOR: that the vector's leaf count is the one the KERNEL
+             declares. The emitter derives the parameter block from the [TRecord]
+             on the kernel's own [DParam], so a transparent vector bound to a
+             parameter of a DIFFERENT record type disagrees with the generated
+             signature while satisfying this check. [Soa_launch.run_soa] has that
+             comparison ([check_soa_layout], on the whole plan rather than the
+             count); the generic transparent path does not, and did not before
+             this check either — [check_launch_args] skips the element comparison
+             for [Custom] elements on the grounds that both sides derive from one
+             registered layout, which is the assumption the SoA ABI makes
+             load-bearing. Not closed here: [Execute] cannot call [Soa_launch]
+             (the dependency runs the other way) and this function does not have
+             the IR. *)
           let got = List.length bufs in
           if got <> b.Vector.soa_num_leaves then
             Execute_error.raise_error
@@ -418,10 +429,9 @@ let expand_to_run_source_args ?(inject_lengths = true) ?(soa_abi = false)
                    reason =
                      Printf.sprintf
                        "the SoA binding produced %d leaf buffer(s) on device \
-                        %d but declares %d leaves, which is the count the \
-                        kernel's parameter block was generated from; binding \
-                        this list would hand the driver a short \
-                        kernel-argument array"
+                        %d but declares %d leaves; binding a list of the wrong \
+                        length to the generated N-pointer parameter block \
+                        hands the driver a malformed kernel-argument array"
                        got
                        dev.Device.id
                        b.Vector.soa_num_leaves;

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -246,10 +246,57 @@ let get_device_buffer (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
         (Transfer_failed
            {vector = "unknown"; reason = "Vector has no device buffer"})
 
+(* An SoA-bound vector transfers its N LEAVES, not its packed AoS buffer
+   (backlog-54). soa_to_device scatters first, so a host [set] made before the
+   launch is always reflected on the device — the same coherence contract
+   Soa_launch documents.
+
+   [soa_dispatch] is the ONE predicate that decides SoA vs AoS, so the transfer
+   and the argument expansion below cannot disagree about which ABI a launch
+   uses. Two sites answering that question separately is how you get N leaf
+   buffers transferred and a single packed pointer bound, or the reverse.
+
+   The CUDA/PTX restriction is the documented "never wrong data" fallback: only
+   that backend's emitter lowers a record param to N base pointers, so on every
+   other backend the vector stays exactly what it also is — an ordinary packed
+   AoS custom vector — and takes the untouched path. *)
+
 (** Transfer all V2 Vector args to device *)
+let soa_dispatch (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
+    Vector.soa_binding option =
+  match v.Vector.soa with
+  | Some b when dev.Device.framework = "CUDA/PTX" -> Some b
+  | Some _ | None -> None
+
+(* Kernel param names at the positions holding an SoA-dispatched vector.
+   Positional, because that is the only correspondence there is: [vector_arg] is
+   existential, so nothing relates an argument to a parameter but its index. *)
+let soa_param_names (ir : Sarek_ir_types.kernel) (args : vector_arg list)
+    (dev : Device.t) : string list =
+  let param_names =
+    List.filter_map
+      (function
+        | Sarek_ir_types.DParam (v, _) -> Some v.Sarek_ir_types.var_name
+        | _ -> None)
+      ir.Sarek_ir_types.kern_params
+  in
+  List.filteri
+    (fun i _ ->
+      match List.nth_opt args i with
+      | Some (Vec v) -> soa_dispatch v dev <> None
+      | _ -> false)
+    param_names
+
 let transfer_vectors_to_device (args : vector_arg list) (dev : Device.t) : unit
     =
-  List.iter (function Vec v -> Transfer.to_device v dev | _ -> ()) args
+  List.iter
+    (function
+      | Vec v -> (
+          match soa_dispatch v dev with
+          | Some b -> b.Vector.soa_to_device dev
+          | None -> Transfer.to_device v dev)
+      | _ -> ())
+    args
 
 (** Expand vector args to run_source_arg format.
     @param inject_lengths
@@ -266,6 +313,23 @@ let expand_to_run_source_args ?(inject_lengths = true) (args : vector_arg list)
     (dev : Device.t) : Framework_sig.run_source_arg list =
   List.concat_map
     (function
+      | Vec v when soa_dispatch v dev <> None ->
+          (* N leaf base pointers in leaf (record declaration) order, then ONE
+             shared length — exactly the param block Sarek_ir_ptx.emit_params
+             produces for a ~soa_params vector. The length is emitted even under
+             ~inject_lengths:false: it is not an injected convenience here but a
+             declared parameter of that ABI. *)
+          let b = Option.get (soa_dispatch v dev) in
+          let len = Vector.length v in
+          let leaf_args =
+            List.map
+              (fun buf ->
+                let (module B : Vector.DEVICE_BUFFER) = buf in
+                Framework_sig.RSA_Buffer
+                  {binder = B.bind_to_kargs; length = len})
+              (b.Vector.soa_leaf_bufs dev)
+          in
+          leaf_args @ [Framework_sig.RSA_Vector_Length (Int32.of_int len)]
       | Vec v ->
           let buf = get_device_buffer v dev in
           let (module B : Vector.DEVICE_BUFFER) = buf in
@@ -707,7 +771,16 @@ let run ~(device : Device.t) ~(name : string)
                  device capability rather than letting the backend emit a
                  shader the device cannot legally load. *)
               check_device_capabilities ~device ir ;
-              match B.generate_source ~block ir with
+              (* SoA param names, derived from the ARGUMENTS by the same
+                 predicate the transfer and expansion use (backlog-54). The
+                 emitted signature and the bound argument list are then two
+                 consequences of one decision rather than two decisions that
+                 could disagree — a disagreement here is not a crash but N
+                 pointers bound to a packed-AoS param block, i.e. silently wrong
+                 data. Empty list on every non-CUDA/PTX backend, where
+                 generate_source ignores it anyway. *)
+              let soa_params = soa_param_names ir args device in
+              match B.generate_source ~block ~soa_params ir with
               | None ->
                   Execute_error.raise_error
                     (Compilation_failed

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -308,7 +308,37 @@ let transfer_vectors_to_device ?(soa_abi = false) (args : vector_arg list)
       | Vec v -> (
           match soa_dispatch ~soa_abi v dev with
           | Some b -> b.Vector.soa_to_device dev
-          | None -> Transfer.to_device v dev)
+          | None ->
+              (* This launch takes the PACKED AoS ABI. If an EARLIER launch on
+                 this vector took the SoA one, its results are still sitting in
+                 the leaves and [soa_leaves_live] still says so — and nothing
+                 else ever clears it, so read-back would keep following leaves
+                 for the rest of the vector's life and silently discard whatever
+                 the packed kernel writes. The reachable sequence is a
+                 transparent CUDA/PTX launch followed by [run_source] on the same
+                 vector.
+
+                 The flag is therefore normalised on BOTH outcomes of the one
+                 [soa_dispatch] predicate, so it states the ABI of the MOST
+                 RECENT launch rather than of some launch.
+
+                 Clearing it is not enough on its own, and the two extra lines
+                 are not bookkeeping: after an SoA launch the AUTHORITATIVE copy
+                 is the leaves, so the gather has to happen before this launch
+                 can upload anything meaningful, and the location then has to be
+                 one [to_device] does not short-circuit. It records [Stale_CPU d]
+                 on this very device, which [to_device] skips ("skip
+                 (Stale_CPU)") — leaving the packed launch to run against a
+                 buffer holding pre-SoA-launch bytes, or against no buffer at all
+                 (the transparent path never allocates one, so the argument
+                 expansion then raises [Transfer_failed]). *)
+              (match v.Vector.soa with
+              | Some b when !(b.Vector.soa_leaves_live) ->
+                  Transfer.to_cpu v ;
+                  b.Vector.soa_leaves_live := false ;
+                  v.Vector.location <- Vector.Stale_GPU dev
+              | Some _ | None -> ()) ;
+              Transfer.to_device v dev)
       | _ -> ())
     args
 

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -332,9 +332,29 @@ let transfer_vectors_to_device ?(soa_abi = false) (args : vector_arg list)
                  buffer holding pre-SoA-launch bytes, or against no buffer at all
                  (the transparent path never allocates one, so the argument
                  expansion then raises [Transfer_failed]). *)
+              (* The gather runs UNCONDITIONALLY, through the binding's own
+                 [soa_from_device] rather than through [Transfer.to_cpu]. That is
+                 the only shape that is safe next to the line below it: clearing
+                 the flag is what makes the SoA arm of [Transfer.read_back_to_host]
+                 unreachable, and nothing ever sets the flag again, so a gather
+                 that can be SKIPPED means the launch's output can be stranded in
+                 the leaves with no path back to the host.
+
+                 [Transfer.to_cpu] can skip: it consults [v.location] and returns
+                 without reading anything on [Both]. Today every [Both] on a
+                 leaf-live vector is one where the host copy already IS the
+                 gathered result (only [to_cpu]/[sync]/[free_buffer] record it, each
+                 after a real read-back), so the previous unforced call did not
+                 produce wrong data. It made the correctness of THIS site depend on
+                 an invariant spanning four functions in another module; calling the
+                 gather directly is what makes that dependence go away.
+
+                 [Transfer.to_cpu ~force:true] would also do it, but the jsoo build
+                 compiles this same file against [Transfer_jsx], whose [to_cpu]
+                 takes no [~force] — the binding closure is available in both. *)
               (match v.Vector.soa with
               | Some b when !(b.Vector.soa_leaves_live) ->
-                  Transfer.to_cpu v ;
+                  b.Vector.soa_from_device dev ;
                   b.Vector.soa_leaves_live := false ;
                   v.Vector.location <- Vector.Stale_GPU dev
               | Some _ | None -> ()) ;
@@ -366,13 +386,53 @@ let expand_to_run_source_args ?(inject_lengths = true) ?(soa_abi = false)
              declared parameter of that ABI. *)
           let b = Option.get (soa_dispatch ~soa_abi v dev) in
           let len = Vector.length v in
+          let bufs = b.Vector.soa_leaf_bufs dev in
+          (* The binding declares its leaf count ([soa_num_leaves]) and separately
+             produces the buffers, and it is the DECLARED count that reached the
+             emitter: [soa_param_names] marks this parameter as SoA and
+             [Sarek_ir_ptx.emit_params] then expands it from the record's
+             registered layout. Two derivations of one number, and this is the one
+             place they meet, so it is the only place that can compare them.
+
+             Checked rather than assumed because the consequence of a short list
+             is not a wrong result but a driver over-read: [Cuda_api.Kernel.launch]
+             sizes the argument array with [List.length args] and passes
+             [cuLaunchKernel] a bare pointer with no count (the same mechanism
+             [check_launch_args] documents at the ARITY level below), so the driver
+             reads past the end and dereferences whatever follows as a leaf
+             pointer.
+
+             Not reachable through [Soa_vector.create_transparent] today: its
+             [soa_leaf_bufs] maps over the leaf array, so it returns exactly
+             [soa_num_leaves] buffers or raises [invalid_arg] for a leaf with no
+             buffer on [dev] (Soa_vector.ml:148-160). The binding is a record of
+             closures crossing a module boundary that exists precisely so
+             [Execute] cannot see [Soa_vector] — the count agreement is therefore
+             a cross-module convention, and this makes it a checked one. *)
+          let got = List.length bufs in
+          if got <> b.Vector.soa_num_leaves then
+            Execute_error.raise_error
+              (Transfer_failed
+                 {
+                   vector = "SoA-dispatched vector";
+                   reason =
+                     Printf.sprintf
+                       "the SoA binding produced %d leaf buffer(s) on device \
+                        %d but declares %d leaves, which is the count the \
+                        kernel's parameter block was generated from; binding \
+                        this list would hand the driver a short \
+                        kernel-argument array"
+                       got
+                       dev.Device.id
+                       b.Vector.soa_num_leaves;
+                 }) ;
           let leaf_args =
             List.map
               (fun buf ->
                 let (module B : Vector.DEVICE_BUFFER) = buf in
                 Framework_sig.RSA_Buffer
                   {binder = B.bind_to_kargs; length = len})
-              (b.Vector.soa_leaf_bufs dev)
+              bufs
           in
           leaf_args @ [Framework_sig.RSA_Vector_Length (Int32.of_int len)]
       | Vec v ->

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -978,9 +978,15 @@
 ; the host enumerates, so a host that reaches its OpenCL ICD, Vulkan loader or
 ; Mesa drivers through an inherited LD_LIBRARY_PATH lost THOSE devices too — they
 ; simply stop enumerating, which costs real rows and fails nothing.
-; %{env:LD_LIBRARY_PATH=} expands to the empty string when the variable is unset,
-; leaving a trailing colon; the loader reads an empty entry as the current
-; directory, which under dune is the sandboxed build directory.
+; BOTH %{env:...} defaults are non-empty, and that is a loader-safety requirement
+; rather than tidiness. With an empty default for LD_LIBRARY_PATH the value ends
+; in a colon, and the dynamic loader reads a trailing empty entry as the CURRENT
+; DIRECTORY -- under dune the sandboxed build directory, so any stray .so written
+; there would be a candidate for loading ahead of the system copy. /usr/lib is the
+; harmless stand-in: it is already on the default search path, so naming it adds
+; no directory that was not being searched. With an empty default for HOME the
+; first entry becomes the absolute /opt/zluda, a path outside this checkout that
+; nothing here owns; /nonexistent keeps the entry inert instead.
 ; Same precedent as the RUSTICL_FEATURES=fp64 rule further down: set the variable
 ; that makes a leg actually exercised, rather than documenting it in a comment and
 ; letting the leg quietly not run.
@@ -990,7 +996,7 @@
  (action
   (setenv
    LD_LIBRARY_PATH
-   %{env:HOME=}/opt/zluda:%{env:LD_LIBRARY_PATH=}
+   %{env:HOME=/nonexistent}/opt/zluda:%{env:LD_LIBRARY_PATH=/usr/lib}
    (run %{dep:test_soa_emitter_equiv.exe}))))
 
 ; Cross-device migration of a transparent SoA vector: Transfer.to_device to a
@@ -1026,7 +1032,7 @@
  (action
   (setenv
    LD_LIBRARY_PATH
-   %{env:HOME=}/opt/zluda:%{env:LD_LIBRARY_PATH=}
+   %{env:HOME=/nonexistent}/opt/zluda:%{env:LD_LIBRARY_PATH=/usr/lib}
    (run %{dep:test_soa_cross_device_migration.exe}))))
 
 ; L17b polymorphic bare float literals: bare (unsuffixed) literals inferred as

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1005,6 +1005,7 @@
  (libraries
   sarek
   sarek.stdlib
+  sarek.codegen
   sarek_ir
   spoc_core
   test_helpers

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -953,10 +953,74 @@
  (flags
   (:standard -w -32-33-34-69)))
 
+; LD_LIBRARY_PATH is set so the ZLUDA CUDA/PTX driver is actually reachable and
+; the PTX-gated cases in this test RUN in the default gate.
+;
+; They did not. Every one of them is behind [if is_ptx dev], nothing in this file
+; put ZLUDA on the loader path (it appeared only in COMMENTS, on the two rules
+; below), and so a plain `dune runtest` enumerated no CUDA/PTX device and four
+; cases — the three [check_relaunch] writers, [check_soa_then_packed] and
+; [check_free_preserves_soa] — printed ZERO lines and asserted nothing while the
+; alias read green. That is the skip-as-pass shape. Two changes close it: the test
+; now prints a named skip line for every guarded case (so a silent no-op is
+; impossible even where this rule finds nothing), and this rule makes the device
+; present where it exists.
+;
+; $HOME/opt/zluda is the location the neighbouring rules already document as this
+; project's ZLUDA checkout. The trade-offs of setting it here, stated rather than
+; assumed:
+;   - a machine WITHOUT ZLUDA: the loader ignores a nonexistent directory, so the
+;     rule is a no-op and the cases print their skip lines. No new failure.
+;   - a machine with a NATIVE CUDA driver: libcuda.so.1 lives on the default
+;     loader path, so replacing LD_LIBRARY_PATH does not hide it. A host that
+;     reaches its CUDA driver ONLY through an inherited LD_LIBRARY_PATH loses the
+;     PTX leg here — and gets the loud skip, not a false green.
+; Same precedent as the RUSTICL_FEATURES=fp64 rule further down: set the variable
+; that makes a leg actually exercised, rather than documenting it in a comment and
+; letting the leg quietly not run.
+
 (rule
  (alias runtest)
  (action
-  (run %{dep:test_soa_emitter_equiv.exe})))
+  (setenv
+   LD_LIBRARY_PATH
+   %{env:HOME=}/opt/zluda
+   (run %{dep:test_soa_emitter_equiv.exe}))))
+
+; Cross-device migration of a transparent SoA vector: Transfer.to_device to a
+; device the vector is NOT resident on drains the source device first, and that
+; drain bypassed the SoA-aware read-back. Needs two devices, one CUDA/PTX; skips
+; loudly (exit 0) otherwise. Same ZLUDA path as the rule above, for the same
+; reason.
+
+(executable
+ (name test_soa_cross_device_migration)
+ (modules test_soa_cross_device_migration)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  test_helpers
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (setenv
+   LD_LIBRARY_PATH
+   %{env:HOME=}/opt/zluda
+   (run %{dep:test_soa_cross_device_migration.exe}))))
 
 ; L17b polymorphic bare float literals: bare (unsuffixed) literals inferred as
 ; float64 from an f64 context, executed on all devices vs an OCaml f64 reference.

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -995,8 +995,8 @@
 
 ; Cross-device migration of a transparent SoA vector: Transfer.to_device to a
 ; device the vector is NOT resident on drains the source device first, and that
-; drain bypassed the SoA-aware read-back. Needs two devices, one CUDA/PTX; skips
-; loudly (exit 0) otherwise. Same ZLUDA path as the rule above, prepended for the
+; drain bypassed the SoA-aware read-back. Needs two devices, at least one
+; CUDA/PTX (its leaf-ownership case needs both); skips loudly (exit 0) otherwise. Same ZLUDA path as the rule above, prepended for the
 ; same reason.
 
 (executable

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -978,15 +978,35 @@
 ; the host enumerates, so a host that reaches its OpenCL ICD, Vulkan loader or
 ; Mesa drivers through an inherited LD_LIBRARY_PATH lost THOSE devices too — they
 ; simply stop enumerating, which costs real rows and fails nothing.
-; BOTH %{env:...} defaults are non-empty, and that is a loader-safety requirement
-; rather than tidiness. With an empty default for LD_LIBRARY_PATH the value ends
-; in a colon, and the dynamic loader reads a trailing empty entry as the CURRENT
-; DIRECTORY -- under dune the sandboxed build directory, so any stray .so written
-; there would be a candidate for loading ahead of the system copy. /usr/lib is the
-; harmless stand-in: it is already on the default search path, so naming it adds
-; no directory that was not being searched. With an empty default for HOME the
-; first entry becomes the absolute /opt/zluda, a path outside this checkout that
-; nothing here owns; /nonexistent keeps the entry inert instead.
+; Composed by `sh`, not by (setenv) + %{env:...}, and that is a loader-safety
+; requirement rather than a style choice. An empty entry in LD_LIBRARY_PATH -- a
+; leading, trailing or doubled colon -- is read by the dynamic loader as the
+; CURRENT DIRECTORY, which under dune is the sandboxed build directory, so a
+; stray .so written there would be a candidate ahead of the system copy.
+; %{env:LD_LIBRARY_PATH=default} cannot prevent that: dune substitutes the
+; default only when the variable is UNSET, so a variable that is defined and
+; EMPTY still yields a trailing colon. ${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} is
+; the shell form that distinguishes the two -- the colon and the value appear
+; together or not at all.
+; Scope of that, stated because the obvious reading is wider than the code: this
+; stops the rule from ADDING an empty entry (unset and defined-empty both yield
+; just the ZLUDA directory). It does not sanitize empty components already inside
+; an inherited NON-empty value -- LD_LIBRARY_PATH=":" gives "...zluda::" and
+; "/opt/x:" keeps its trailing colon -- and it cannot, because such a value is
+; already in effect for the loader that starts `sh` itself, before any expression
+; here runs. Sanitising an inherited path is a different job than not corrupting
+; it, and only the second is claimed.
+; ${HOME:?} makes an unset or empty HOME a loud failure of this rule rather than
+; an absolute /opt/zluda, a path outside this checkout that nothing here owns.
+; The case statement is not defensive either: %{dep:...} expands to a path
+; RELATIVE to the action's directory, and `exec` on a bare relative word searches
+; PATH and does not find it -- caught by `dune runtest --force`, which reported
+; "exec: test_soa_emitter_equiv.exe: not found" for both rules. The absolute arm
+; is there so the rule does not depend on that expansion staying relative.
+; Note what this rule does NOT claim: prepending the ZLUDA directory does change
+; loader PRECEDENCE for every name it contains. That is the point of the rule --
+; it is how libcuda.so.1 resolves to ZLUDA -- and it is scoped to these two test
+; executables.
 ; Same precedent as the RUSTICL_FEATURES=fp64 rule further down: set the variable
 ; that makes a leg actually exercised, rather than documenting it in a comment and
 ; letting the leg quietly not run.
@@ -994,10 +1014,11 @@
 (rule
  (alias runtest)
  (action
-  (setenv
-   LD_LIBRARY_PATH
-   %{env:HOME=/nonexistent}/opt/zluda:%{env:LD_LIBRARY_PATH=/usr/lib}
-   (run %{dep:test_soa_emitter_equiv.exe}))))
+  (run
+   sh
+   -c
+   "LD_LIBRARY_PATH=\"${HOME:?}/opt/zluda${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"; export LD_LIBRARY_PATH; case \"$0\" in /*) exec \"$0\";; *) exec \"./$0\";; esac"
+   %{dep:test_soa_emitter_equiv.exe})))
 
 ; Cross-device migration of a transparent SoA vector: Transfer.to_device to a
 ; device the vector is NOT resident on drains the source device first, and that
@@ -1030,10 +1051,11 @@
 (rule
  (alias runtest)
  (action
-  (setenv
-   LD_LIBRARY_PATH
-   %{env:HOME=/nonexistent}/opt/zluda:%{env:LD_LIBRARY_PATH=/usr/lib}
-   (run %{dep:test_soa_cross_device_migration.exe}))))
+  (run
+   sh
+   -c
+   "LD_LIBRARY_PATH=\"${HOME:?}/opt/zluda${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"; export LD_LIBRARY_PATH; case \"$0\" in /*) exec \"$0\";; *) exec \"./$0\";; esac"
+   %{dep:test_soa_cross_device_migration.exe})))
 
 ; L17b polymorphic bare float literals: bare (unsuffixed) literals inferred as
 ; float64 from an f64 context, executed on all devices vs an OCaml f64 reference.

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -996,8 +996,8 @@
 ; Cross-device migration of a transparent SoA vector: Transfer.to_device to a
 ; device the vector is NOT resident on drains the source device first, and that
 ; drain bypassed the SoA-aware read-back. Needs two devices, at least one
-; CUDA/PTX (its leaf-ownership case needs both); skips loudly (exit 0) otherwise. Same ZLUDA path as the rule above, prepended for the
-; same reason.
+; CUDA/PTX (its leaf-ownership case needs both); skips loudly (exit 0)
+; otherwise. Same ZLUDA path as the rule above, prepended for the same reason.
 
 (executable
  (name test_soa_cross_device_migration)

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -972,9 +972,15 @@
 ;   - a machine WITHOUT ZLUDA: the loader ignores a nonexistent directory, so the
 ;     rule is a no-op and the cases print their skip lines. No new failure.
 ;   - a machine with a NATIVE CUDA driver: libcuda.so.1 lives on the default
-;     loader path, so replacing LD_LIBRARY_PATH does not hide it. A host that
-;     reaches its CUDA driver ONLY through an inherited LD_LIBRARY_PATH loses the
-;     PTX leg here — and gets the loud skip, not a false green.
+;     loader path, so this rule does not hide it.
+; PREPENDED, not assigned. The first version assigned, and the loss was not
+; limited to the CUDA driver this rule is about: this test asserts on every device
+; the host enumerates, so a host that reaches its OpenCL ICD, Vulkan loader or
+; Mesa drivers through an inherited LD_LIBRARY_PATH lost THOSE devices too — they
+; simply stop enumerating, which costs real rows and fails nothing.
+; %{env:LD_LIBRARY_PATH=} expands to the empty string when the variable is unset,
+; leaving a trailing colon; the loader reads an empty entry as the current
+; directory, which under dune is the sandboxed build directory.
 ; Same precedent as the RUSTICL_FEATURES=fp64 rule further down: set the variable
 ; that makes a leg actually exercised, rather than documenting it in a comment and
 ; letting the leg quietly not run.
@@ -984,14 +990,14 @@
  (action
   (setenv
    LD_LIBRARY_PATH
-   %{env:HOME=}/opt/zluda
+   %{env:HOME=}/opt/zluda:%{env:LD_LIBRARY_PATH=}
    (run %{dep:test_soa_emitter_equiv.exe}))))
 
 ; Cross-device migration of a transparent SoA vector: Transfer.to_device to a
 ; device the vector is NOT resident on drains the source device first, and that
 ; drain bypassed the SoA-aware read-back. Needs two devices, one CUDA/PTX; skips
-; loudly (exit 0) otherwise. Same ZLUDA path as the rule above, for the same
-; reason.
+; loudly (exit 0) otherwise. Same ZLUDA path as the rule above, prepended for the
+; same reason.
 
 (executable
  (name test_soa_cross_device_migration)
@@ -1019,7 +1025,7 @@
  (action
   (setenv
    LD_LIBRARY_PATH
-   %{env:HOME=}/opt/zluda
+   %{env:HOME=}/opt/zluda:%{env:LD_LIBRARY_PATH=}
    (run %{dep:test_soa_cross_device_migration.exe}))))
 
 ; L17b polymorphic bare float literals: bare (unsuffixed) literals inferred as

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -153,6 +153,83 @@ let check ~label ~(packed_first : bool) (src : Device.t) (dst : Device.t) =
   Printf.printf "  %-58s %s\n%!" label (if !ok then "OK" else "FAILED") ;
   !ok
 
+(* SoA -> SoA on a DIFFERENT device, with no host read-back in between.
+
+   Raised in review of round 5: [soa_to_device] always [scatter]s the AoS host
+   buffer before uploading leaves, and [Execute.transfer_vectors_to_device] calls
+   that closure directly rather than going through [Transfer.to_device]. So if
+   nothing drains device A first, the second launch would scatter PRE-A host bytes
+   into B's leaves and B would run on them, losing A's output — and every case
+   above covers SoA -> PACKED, where [Transfer.to_device]'s migration arm is what
+   does the drain. The sequence really was uncovered.
+
+   It does not lose the output, and the drain is inside [scatter]:
+   [Soa_vector.scatter] opens with [Vector.ensure_cpu_sync t.aos], which on the
+   [Stale_CPU A] a transparent launch leaves fires the sync callback, and that
+   reaches [Transfer.to_cpu] -> [read_back_to_host] -> the SoA arm -> A's leaves.
+   Asserted rather than argued, because that chain is four indirections long and
+   two of them are function pointers.
+
+   The precondition is auto-sync, exactly as in
+   [check_host_write_survives_packed]: [ensure_cpu_sync] is a no-op when
+   [auto_sync] is false on the vector or auto mode is off globally
+   (Vector_transfer.ml), and this case does not disable either.
+
+   y0 = i+1; each launch doubles y, so two launches give 4*y0 and a second launch
+   fed pre-A host bytes gives 2*y0 — never equal for y0 > 0. *)
+let check_soa_then_soa_other_device (src : Device.t) (dst : Device.t) =
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  let ok = ref true in
+  let launch dev =
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of scale_y_kernel)
+      ~args:[Vec sv; Int n]
+      ~block:(Sarek.Execute.dims1d threads)
+      ~grid:(Sarek.Execute.dims1d ((n + threads - 1) / threads))
+      () ;
+    Transfer.flush dev
+  in
+  (match
+     launch src ;
+     (* No read-back here, deliberately: inserting one would drain A by another
+        route and the case would pass without the drain inside [scatter]. *)
+     launch dst
+   with
+  | exception e ->
+      Printf.printf
+        "  the SoA -> SoA relaunch on another device raised: %s\n%!"
+        (Printexc.to_string e) ;
+      ok := false
+  | () ->
+      let first = ref true in
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y and want = y0 i *. 4.0 in
+        if Float.abs (got -. want) > 1e-3 && !first then begin
+          first := false ;
+          Printf.printf
+            "  second SoA launch ran on pre-first-launch host bytes @%d: \
+             got=%g want=%g (scattering the un-drained host copy gives %g)\n\
+             %!"
+            i
+            got
+            want
+            (y0 i *. 2.0) ;
+          ok := false
+        end
+      done) ;
+  Transfer.free_all_buffers sv ;
+  ignore (Sys.opaque_identity sv) ;
+  Printf.printf
+    "  %-58s %s\n%!"
+    "a second SoA launch on another device sees the first"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
 (* A free must not RESURRECT leaf ownership the previous launch gave up.
    Found by a cross-runtime review of the round-5 fix that made the packed
    launch's gather unconditional, and it is a defect of the two together:
@@ -542,6 +619,22 @@ let () =
              backend but Cuda_ptx_plugin. A heterogeneous pair would make this
              file exit 1 on an environment shortfall rather than on an assertion,
              so it is a NAMED skip instead. *)
+          (* Both of the last two need a CUDA/PTX [dst]: this one because the SoA
+             ABI dispatches on no other backend, so a non-PTX [dst] would take
+             the packed path and the case would be a duplicate of [a] and [b]. *)
+          let e =
+            if is_ptx dst then check_soa_then_soa_other_device src dst
+            else begin
+              Printf.printf
+                "  %-58s SKIP (needs a SECOND CUDA/PTX device; %s is %s, where \
+                 the SoA ABI does not dispatch)\n\
+                 %!"
+                "a second SoA launch on another device sees the first"
+                dst.Device.name
+                dst.Device.framework ;
+              true
+            end
+          in
           let d =
             if is_ptx dst then check_free_does_not_resurrect_leaves src dst
             else begin
@@ -555,4 +648,4 @@ let () =
               true
             end
           in
-          if not (a && b && c && d) then exit 1)
+          if not (a && b && c && d && e) then exit 1)

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -55,6 +55,11 @@ module Soa_vector = Spoc_core.Soa_vector
 module Gpu_memory = Spoc_core.Gpu_memory
 module Benchmarks = Test_helpers.Benchmarks
 
+(* [Sarek_ir_ptx.generate], for the PACKED run_source launch in
+   {!check_free_does_not_resurrect_leaves}: run_vectors would take the SoA ABI on
+   a CUDA/PTX device, and that case needs the packed one on such a device. *)
+open Sarek_codegen
+
 type ('a, 'b) vector = ('a, 'b) Vector.t
 
 type float32 = float
@@ -145,6 +150,136 @@ let check ~label ~(packed_first : bool) (src : Device.t) (dst : Device.t) =
       done) ;
   Printf.printf "  %-58s %s\n%!" label (if !ok then "OK" else "FAILED") ;
   !ok
+
+(* A free must not RESURRECT leaf ownership the previous launch gave up.
+   Found by a cross-runtime review of the round-5 fix that made the packed
+   launch's gather unconditional, and it is a defect of the two together:
+
+   - [Execute.transfer_vectors_to_device], on a launch that takes the PACKED ABI,
+     gathers the leaves into host storage and then CLEARS [soa_leaves_live]. The
+     leaves it gathered are not freed — they stay allocated on their device,
+     holding what is now the previous generation of the data.
+   - [Soa_vector]'s [soa_free_leaves] then re-derived that flag from the leaves
+     that are still ALLOCATED. Allocation is not authority: a free on a device the
+     leaves are not on turned the flag back ON.
+
+   With the gather gated on [location] (an unforced [to_cpu]) the resurrected flag
+   was harmless — the location said CPU and the gather was skipped anyway. Made
+   unconditional, it becomes data loss: the next packed launch gathers the stale
+   leaves OVER the host copy of the newer packed result and runs on them.
+
+   Needs two devices, which is why it lives in this file: the free has to happen
+   on a device the leaves are NOT on, or the leaves are freed and the flag would
+   go false either way. Single-device suites cannot construct it.
+
+   [Vector.get] is deliberately called before the LAST launch as well as after:
+   without pinning the host copy at that point, "the final value is wrong" could
+   also be read as the packed launch having produced it, and the point is that the
+   input it consumed was replaced behind it. *)
+let check_free_does_not_resurrect_leaves (src : Device.t) (dst : Device.t) =
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  let ok = ref true in
+  let fail fmt =
+    Printf.ksprintf
+      (fun s ->
+        Printf.printf "  %s\n%!" s ;
+        ok := false)
+      fmt
+  in
+  let ir = ir_of scale_y_kernel in
+  let block = Sarek.Execute.dims1d threads in
+  let grid = Sarek.Execute.dims1d ((n + threads - 1) / threads) in
+  let packed_launch dev =
+    (* run_source defaults to ~soa_abi:false, so this is the PACKED ABI even on a
+       CUDA/PTX device — the sequence needs a packed launch on a device where the
+       SoA one would otherwise be selected. *)
+    Sarek.Execute.run_source
+      ~device:dev
+      ~source:(Sarek_ir_ptx.generate ir)
+      ~lang:Sarek.Execute.PTX
+      ~kernel_name:ir.Sarek_ir_types.kern_name
+      ~block
+      ~grid
+      [Sarek.Execute.Vec sv; Sarek.Execute.Int n] ;
+    Transfer.flush dev
+  in
+  match
+    (* 1. TRANSPARENT launch on src: y := 2*y0 in the leaves, which src owns. *)
+    Sarek.Execute.run_vectors
+      ~device:src
+      ~ir
+      ~args:[Vec sv; Int n]
+      ~block
+      ~grid
+      () ;
+    Transfer.flush src ;
+    (* 2. PACKED launch on dst: gathers (host := 2*y0), clears the ownership
+       flag, uploads, doubles again on the device. src's leaves still hold
+       2*y0. *)
+    packed_launch dst ;
+    (* 3. Per-device free on dst. Drains dst into host storage (4*y0) and
+       releases dst's packed buffer; src's leaves are correctly left alone. This
+       is where the flag used to come back to life. *)
+    Transfer.free_buffer sv dst
+  with
+  | exception e ->
+      fail
+        "the SoA -> packed -> free sequence raised: %s"
+        (Printexc.to_string e) ;
+      Printf.printf
+        "  %-58s %s\n%!"
+        "a free does not resurrect stale leaf ownership"
+        "FAILED" ;
+      false
+  | () ->
+      let host_after_free = Array.init n (fun i -> (Vector.get sv i).y) in
+      let mismatched = ref 0 in
+      for i = 0 to n - 1 do
+        if Float.abs (host_after_free.(i) -. (y0 i *. 4.0)) > 1e-3 then
+          incr mismatched
+      done ;
+      if !mismatched > 0 then
+        fail
+          "the drain in free_buffer did not bring back dst's result: %d of %d \
+           indices differ (@0 got=%g want=%g); the claim below would then be \
+           about the wrong starting value"
+          !mismatched
+          n
+          host_after_free.(0)
+          (y0 0 *. 4.0) ;
+      (* 4. Another PACKED launch. Its input must be the host copy asserted just
+         above, not src's leaves. *)
+      (match packed_launch src with
+      | () ->
+          let first = ref true in
+          for i = 0 to n - 1 do
+            let got = (Vector.get sv i).y and want = y0 i *. 8.0 in
+            if Float.abs (got -. want) > 1e-3 && !first then begin
+              first := false ;
+              fail
+                "packed relaunch after the free ran on stale leaves @%d: \
+                 got=%g want=%g (src's leaves from step 1 would give %g)"
+                i
+                got
+                want
+                (y0 i *. 4.0)
+            end
+          done
+      | exception e ->
+          fail
+            "the packed relaunch after the free raised: %s"
+            (Printexc.to_string e)) ;
+      Transfer.free_all_buffers sv ;
+      ignore (Sys.opaque_identity sv) ;
+      Printf.printf
+        "  %-58s %s\n%!"
+        "a free does not resurrect stale leaf ownership"
+        (if !ok then "OK" else "FAILED") ;
+      !ok
 
 (* [free_buffer] is PER-DEVICE; [soa_leaves_live] is WHOLE-VECTOR. Those two
    scopes only agree when the free covered every device, and [soa_free_leaves]
@@ -368,4 +503,7 @@ let () =
              device boundary". It lives here because this is the only test with
              two devices in hand. *)
           let c = check_per_device_leaf_free src dst in
-          if not (a && b && c) then exit 1)
+          (* Also two-device-only: the free has to land on a device the leaves are
+             not on for the ownership flag to be resurrectable at all. *)
+          let d = check_free_does_not_resurrect_leaves src dst in
+          if not (a && b && c && d) then exit 1)

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -34,8 +34,12 @@
  * pipeline requires to be self-contained; and half A's pre-fix red state is a
  * RAISE, so a shared binary would abort before the other half reported.
  *
- * Exit codes: 0 = pass (including an honest skip), 1 = an assertion fired,
- * 2 = setup could not produce the device pair this needs.
+ * Exit codes: 0 = pass, INCLUDING both honest skips (no CUDA/PTX device, or only
+ * one device to migrate between) — an absent device is not a regression, and
+ * every skip prints a line naming the class it needed; 1 = an assertion fired.
+ * There is no third code: a previous version of this header documented
+ * "2 = setup could not produce the device pair this needs" while both skip paths
+ * exit 0, so the row described a state this file cannot reach.
  *
  * Needs TWO devices, at least one of them CUDA/PTX (the SoA ABI dispatches
  * nowhere else). Locally that is ZLUDA on an AMD RX 7900 XTX — a CUDA/PTX
@@ -309,7 +313,19 @@ let () =
   | src :: _ -> (
       (* [dst] only has to be a DIFFERENT device — it receives an ordinary packed
          upload, so any framework will do. Another CUDA/PTX device is preferred
-         so the pair is homogeneous. *)
+         so the pair is homogeneous.
+
+         "Any framework" includes the CPU backends, and that holds for the BYTE
+         assertions in [check_per_device_leaf_free] too, which is the half that
+         could plausibly depend on it: the accounting is not the backend's.
+         [Transfer.ensure_buffer] calls [Gpu_memory.track_alloc (size *
+         elem_size)] for every framework (Transfer.ml:232) on a wrapper whose
+         [size]/[elem_size] come from the requested length and element size
+         (Transfer.ml:150-152), and [free_buffer] tracks the same product back. So
+         a Native or Interpreter [dst] still yields a non-zero packed-byte delta
+         and the split is still measurable — no GPU-only restriction on [dst] is
+         needed, and adding one would drop the heterogeneous pair, which is the
+         more interesting migration. *)
       let others =
         Array.to_list devs
         |> List.filter (fun (d : Device.t) -> d.Device.id <> src.Device.id)

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -1,0 +1,209 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Cross-device MIGRATION of a transparent SoA vector (backlog-54).
+ *
+ * [Transfer.to_device vec dev] has an arm nothing else has: when [vec] is
+ * resident on a DIFFERENT device it first drains that device into host storage,
+ * then uploads the host copy to [dev]. That drain is a read-back, and it called
+ * [copy_device_to_host] DIRECTLY — it did not go through
+ * [Transfer.read_back_to_host], the function whose whole purpose is to decide
+ * whether a read-back reads the packed AoS buffer or the N SoA leaves.
+ *
+ * So after a transparent SoA launch this arm reproduced BOTH halves of the
+ * failure pair the SoA read-back work claims to have eliminated:
+ *
+ *   - with no packed buffer (the transparent path never allocates one), it
+ *     raised [Failure "to_cpu: no device buffer to transfer from"] from inside
+ *     what the caller asked to be a transfer;
+ *   - with a packed buffer present from an earlier upload, it downloaded that
+ *     buffer's PRE-LAUNCH bytes over the host storage and discarded the
+ *     launch's output silently — no exception, no warning, wrong data.
+ *
+ * This was filed against PR #375 round 2 and REFUTED as already fixed. The
+ * refutation was wrong: the fix covered [to_cpu] and the two cleanup paths, and
+ * the migration arm was a fourth caller that the comment on
+ * [read_back_to_host] even claimed to include. Round 3 routes it and this file
+ * is the check that keeps it routed.
+ *
+ * A SEPARATE FILE, not a case in test_soa_emitter_equiv.ml, for two reasons:
+ * it is the ratchet check for a finding that survived a review round, which the
+ * pipeline requires to be self-contained; and half A's pre-fix red state is a
+ * RAISE, so a shared binary would abort before the other half reported.
+ *
+ * Exit codes: 0 = pass (including an honest skip), 1 = an assertion fired,
+ * 2 = setup could not produce the device pair this needs.
+ *
+ * Needs TWO devices, at least one of them CUDA/PTX (the SoA ABI dispatches
+ * nowhere else). Locally that is ZLUDA on an AMD RX 7900 XTX — a CUDA/PTX
+ * device, NOT NVIDIA hardware:
+ *   LD_LIBRARY_PATH=$HOME/opt/zluda \
+ *     dune exec sarek/tests/e2e/test_soa_cross_device_migration.exe
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+module Soa_vector = Spoc_core.Soa_vector
+module Benchmarks = Test_helpers.Benchmarks
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+type float32 = float
+
+(* Mutable so the kernel can write the y leaf in place. *)
+type point3d = {mutable x : float32; mutable y : float32; mutable z : float32}
+[@@sarek.type]
+
+let scale_y_kernel =
+  snd
+    [%kernel
+      fun (pts : point3d vector) (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then pts.(tid).y <- pts.(tid).y *. 2.0]
+
+let ir_of kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let is_ptx (dev : Device.t) = dev.Device.framework = "CUDA/PTX"
+
+let n = 256
+
+let threads = 128
+
+(* One round of the sequence, parameterised on the ONE thing that distinguishes
+   the two halves: whether a packed AoS buffer already exists on the source
+   device when the transparent launch runs. That is what selects which pre-fix
+   failure you get, and both must be pinned — a fix that only stopped the raise
+   would leave the silent-wrong-data half live, and it is the worse of the two.
+
+   No explicit [to_cpu] before the migration, deliberately: inserting one would
+   drain the leaves by another route and the case would pass unfixed. *)
+let check ~label ~(packed_first : bool) (src : Device.t) (dst : Device.t) =
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  let outcome =
+    match
+      (* Give the vector a PACKED buffer on [src] first, in the [packed_first]
+         half. This is what makes the buggy read-back SUCCEED instead of
+         raising, which is what makes it silent. *)
+      if packed_first then Transfer.to_device sv src ;
+      (* Transparent SoA launch: run_vectors passes ~soa_abi:true, so on a
+         CUDA/PTX device this binds the N-leaf ABI, doubles the y LEAF, and
+         leaves the vector SoA-owned (location Stale_CPU src). *)
+      Sarek.Execute.run_vectors
+        ~device:src
+        ~ir:(ir_of scale_y_kernel)
+        ~args:[Vec sv; Int n]
+        ~block:(Sarek.Execute.dims1d threads)
+        ~grid:(Sarek.Execute.dims1d ((n + threads - 1) / threads))
+        () ;
+      Transfer.flush src ;
+      (* THE CALL UNDER TEST. Resident on [src], asked for [dst] -> the
+         migration arm drains [src] into host storage. *)
+      Transfer.to_device sv dst
+    with
+    | () -> None
+    | exception e -> Some (Printexc.to_string e)
+  in
+  let ok = ref true in
+  (match outcome with
+  | Some msg ->
+      (* Reported rather than left to abort: a red state that is a crash is not
+         an observation, and this half's pre-fix red IS a raise. *)
+      Printf.printf "  migration raised: %s\n%!" msg ;
+      ok := false
+  | None ->
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y in
+        let want = y0 i *. 2.0 in
+        if Float.abs (got -. want) > 1e-3 then begin
+          if !ok then
+            Printf.printf
+              "  migration data wrong @%d: got=%g want=%g (the stale packed \
+               buffer holds %g)\n\
+               %!"
+              i
+              got
+              want
+              (y0 i) ;
+          ok := false
+        end
+      done) ;
+  Printf.printf "  %-58s %s\n%!" label (if !ok then "OK" else "FAILED") ;
+  !ok
+
+let () =
+  (* REGISTER the backends before asking for devices. [Device.init] only
+     enumerates frameworks that have registered themselves, and registration is a
+     link-time side effect that [Benchmarks.init] (Backend_loader) forces —
+     without it [Device.all ()] came back EMPTY on a host with nine devices and
+     this file reported "0 device(s) enumerated, none CUDA/PTX", a skip that was
+     loud and wrong at the same time. Measured while writing this test. *)
+  Benchmarks.init () ;
+  ignore (Device.init ()) ;
+  let devs = Device.all () in
+  let ptx = Array.to_list devs |> List.filter is_ptx in
+  match ptx with
+  | [] ->
+      (* A skip that names the device class it needs and why it was absent. Exit
+         0: an absent device is not a regression. But it must never be
+         SILENT — that shape is how four cases in test_soa_emitter_equiv.ml sat
+         unexercised while runtest read green. *)
+      Printf.printf
+        "test_soa_cross_device_migration: SKIP - needs a CUDA/PTX device (the \
+         SoA ABI dispatches on no other backend); %d device(s) enumerated, \
+         none CUDA/PTX. Locally: LD_LIBRARY_PATH=$HOME/opt/zluda\n\
+         %!"
+        (Array.length devs) ;
+      exit 0
+  | src :: _ -> (
+      (* [dst] only has to be a DIFFERENT device — it receives an ordinary packed
+         upload, so any framework will do. Another CUDA/PTX device is preferred
+         so the pair is homogeneous. *)
+      let others =
+        Array.to_list devs
+        |> List.filter (fun (d : Device.t) -> d.Device.id <> src.Device.id)
+      in
+      let dst =
+        match List.filter is_ptx others with
+        | d :: _ -> Some d
+        | [] -> ( match others with d :: _ -> Some d | [] -> None)
+      in
+      match dst with
+      | None ->
+          Printf.printf
+            "test_soa_cross_device_migration: SKIP - needs TWO devices to \
+             migrate BETWEEN; only 1 enumerated (%s). The migration arm is \
+             unreachable with a single device.\n\
+             %!"
+            src.Device.name ;
+          exit 0
+      | Some dst ->
+          Printf.printf
+            "test_soa_cross_device_migration: %s -> %s\n%!"
+            src.Device.name
+            dst.Device.name ;
+          let a =
+            check
+              ~label:"migration after a transparent SoA launch (no packed buf)"
+              ~packed_first:false
+              src
+              dst
+          in
+          let b =
+            check
+              ~label:"migration after a transparent SoA launch (packed present)"
+              ~packed_first:true
+              src
+              dst
+          in
+          if not (a && b) then exit 1)

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -48,6 +48,7 @@ module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 module Transfer = Spoc_core.Transfer
 module Soa_vector = Spoc_core.Soa_vector
+module Gpu_memory = Spoc_core.Gpu_memory
 module Benchmarks = Test_helpers.Benchmarks
 
 type ('a, 'b) vector = ('a, 'b) Vector.t
@@ -141,6 +142,146 @@ let check ~label ~(packed_first : bool) (src : Device.t) (dst : Device.t) =
   Printf.printf "  %-58s %s\n%!" label (if !ok then "OK" else "FAILED") ;
   !ok
 
+(* [free_buffer] is PER-DEVICE; [soa_leaves_live] is WHOLE-VECTOR. Those two
+   scopes only agree when the free covered every device, and [soa_free_leaves]
+   used to assign [false] regardless — so releasing one device disowned the
+   leaves still live on every other one.
+
+   The consequence is data loss, not a leak, and this case is built to show that
+   rather than to count bytes. [free_buffer sv other] is called on a device this
+   vector has NOTHING on: no packed buffer, no leaves, and [other] is not what
+   [location] names, so every arm of the function correctly declines to touch
+   anything. It is as close to a no-op as the API offers. Pre-fix it still
+   cleared the flag, and the very next read-back — of results sitting untouched
+   in [src]'s leaves — followed the packed buffer instead. On this path there is
+   no packed buffer, so it raises; give the vector one first and it returns
+   pre-launch bytes silently, which is the same pair of failures the migration
+   arm had.
+
+   Deliberately NO [to_cpu] before the free: draining first would move the
+   results to host storage by another route and the case would pass unfixed.
+
+   The byte split the reviewer measured is asserted too, as a second and weaker
+   observation: [free_buffer sv dst] after a migration must release [dst]'s
+   packed buffer and leave [src]'s leaves alone — a per-device free that freed
+   both would be a different bug in the opposite direction. *)
+let check_per_device_leaf_free (src : Device.t) (other : Device.t) =
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  Gc.full_major () ;
+  let ok = ref true in
+  let fail fmt =
+    Printf.ksprintf
+      (fun s ->
+        Printf.printf "  %s\n%!" s ;
+        ok := false)
+      fmt
+  in
+  let base = Gpu_memory.usage () in
+  Sarek.Execute.run_vectors
+    ~device:src
+    ~ir:(ir_of scale_y_kernel)
+    ~args:[Vec sv; Int n]
+    ~block:(Sarek.Execute.dims1d threads)
+    ~grid:(Sarek.Execute.dims1d ((n + threads - 1) / threads))
+    () ;
+  Transfer.flush src ;
+  let leaves_bytes = Gpu_memory.usage () - base in
+  if leaves_bytes <= 0 then
+    fail
+      "the launch allocated %d bytes on %s, so the release assertions below \
+       would be vacuous"
+      leaves_bytes
+      src.Device.name ;
+  (* Half 1: freeing a device the vector holds nothing on must not disown the
+     device it does. *)
+  Transfer.free_buffer sv other ;
+  if not (Transfer.has_device_data sv src) then
+    fail
+      "after free_buffer on %s (which holds nothing), has_device_data says %s \
+       holds nothing either — the whole-vector leaf flag was cleared by a \
+       per-device free"
+      other.Device.name
+      src.Device.name ;
+  if Gpu_memory.usage () - base <> leaves_bytes then
+    fail
+      "free_buffer on %s released %d bytes; it holds none of this vector's \
+       memory and must release nothing"
+      other.Device.name
+      (leaves_bytes - (Gpu_memory.usage () - base)) ;
+  (match Transfer.to_cpu ~force:true sv with
+  | () ->
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y and want = y0 i *. 2.0 in
+        if Float.abs (got -. want) > 1e-3 && !ok then
+          fail
+            "read-back after free_buffer on an unrelated device is wrong @%d: \
+             got=%g want=%g (the pre-launch host value is %g)"
+            i
+            got
+            want
+            (y0 i)
+      done
+  | exception e ->
+      fail
+        "to_cpu after free_buffer on an unrelated device raised: %s"
+        (Printexc.to_string e)) ;
+  Transfer.free_all_buffers sv ;
+  ignore (Sys.opaque_identity sv) ;
+  (* Half 2: the byte split of a per-device free after a real migration. *)
+  let sv2 = Soa_vector.create_transparent point3d_custom n in
+  for i = 0 to n - 1 do
+    Vector.set sv2 i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  Gc.full_major () ;
+  let base2 = Gpu_memory.usage () in
+  Sarek.Execute.run_vectors
+    ~device:src
+    ~ir:(ir_of scale_y_kernel)
+    ~args:[Vec sv2; Int n]
+    ~block:(Sarek.Execute.dims1d threads)
+    ~grid:(Sarek.Execute.dims1d ((n + threads - 1) / threads))
+    () ;
+  Transfer.flush src ;
+  let after_launch2 = Gpu_memory.usage () in
+  Transfer.to_device sv2 other ;
+  let after_migration = Gpu_memory.usage () in
+  let packed_bytes = after_migration - after_launch2 in
+  if packed_bytes <= 0 then
+    fail
+      "the migration to %s allocated %d bytes, so the split below is not \
+       measurable"
+      other.Device.name
+      packed_bytes ;
+  Transfer.free_buffer sv2 other ;
+  let released = after_migration - Gpu_memory.usage () in
+  if released <> packed_bytes then
+    fail
+      "free_buffer on %s released %d bytes, want exactly its own %d (%s's \
+       leaves hold the other %d and are not this call's to free)"
+      other.Device.name
+      released
+      packed_bytes
+      src.Device.name
+      (after_launch2 - base2) ;
+  Transfer.free_all_buffers sv2 ;
+  if Gpu_memory.usage () > base2 then
+    fail
+      "after free_buffer on %s and free_all_buffers, %d bytes are still held — \
+       the per-device free orphaned %s's leaves"
+      other.Device.name
+      (Gpu_memory.usage () - base2)
+      src.Device.name ;
+  ignore (Sys.opaque_identity sv2) ;
+  Printf.printf
+    "  %-58s %s\n%!"
+    "a per-device free keeps another device's leaves"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
 let () =
   (* REGISTER the backends before asking for devices. [Device.init] only
      enumerates frameworks that have registered themselves, and registration is a
@@ -206,4 +347,9 @@ let () =
               src
               dst
           in
-          if not (a && b) then exit 1)
+          (* Same two-device fixture, a different question: not "does the
+             migration drain correctly" but "does a PER-DEVICE free respect the
+             device boundary". It lives here because this is the only test with
+             two devices in hand. *)
+          let c = check_per_device_leaf_free src dst in
+          if not (a && b && c) then exit 1)

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -458,9 +458,19 @@ let check_per_device_leaf_free (src : Device.t) (other : Device.t) =
       (leaves_bytes - (Gpu_memory.usage () - base)) ;
   (match Transfer.to_cpu ~force:true sv with
   | () ->
+      (* Per-LOOP first-mismatch flag, not the function-wide [ok]. The two byte
+         assertions above can already have cleared [ok], and gating the print on
+         it then reports FAILED for this case while printing no index evidence for
+         the data claim — the defect the sibling file
+         ([test_soa_emitter_equiv.ml], claim 2 of [check_free_buffer_coherent])
+         documents and fixes the same way. It was fixed there this round and not
+         carried across to here, which is the shape of a fix that stops at the
+         file it was reported in. *)
+      let first_mismatch = ref true in
       for i = 0 to n - 1 do
         let got = (Vector.get sv i).y and want = y0 i *. 2.0 in
-        if Float.abs (got -. want) > 1e-3 && !ok then
+        if Float.abs (got -. want) > 1e-3 && !first_mismatch then begin
+          first_mismatch := false ;
           fail
             "read-back after free_buffer on an unrelated device is wrong @%d: \
              got=%g want=%g (the pre-launch host value is %g)"
@@ -468,6 +478,7 @@ let check_per_device_leaf_free (src : Device.t) (other : Device.t) =
             got
             want
             (y0 i)
+        end
       done
   | exception e ->
       fail
@@ -610,18 +621,9 @@ let () =
              device boundary". It lives here because this is the only test with
              two devices in hand. *)
           let c = check_per_device_leaf_free src dst in
-          (* Also two-device-only: the free has to land on a device the leaves
-             are not on for the ownership flag to be resurrectable at all. But
-             unlike the three above it needs BOTH devices to be CUDA/PTX, because
-             its step 2 is a PACKED launch on [dst] through [run_source ~lang:PTX]
-             and [Execute.run_source] raises [Unsupported_argument] on a backend
-             whose [supported_source_langs] does not list PTX — which is every
-             backend but Cuda_ptx_plugin. A heterogeneous pair would make this
-             file exit 1 on an environment shortfall rather than on an assertion,
-             so it is a NAMED skip instead. *)
-          (* Both of the last two need a CUDA/PTX [dst]: this one because the SoA
-             ABI dispatches on no other backend, so a non-PTX [dst] would take
-             the packed path and the case would be a duplicate of [a] and [b]. *)
+          (* [e] needs a CUDA/PTX [dst] because the SoA ABI dispatches on no
+             other backend: a non-PTX [dst] would take the packed path and the
+             case would be a duplicate of [a] and [b]. *)
           let e =
             if is_ptx dst then check_soa_then_soa_other_device src dst
             else begin
@@ -635,6 +637,15 @@ let () =
               true
             end
           in
+          (* Also two-device-only: the free has to land on a device the leaves
+             are not on for the ownership flag to be resurrectable at all. And
+             [d] needs a CUDA/PTX [dst] for its own reason, not [e]'s — its step 2
+             is a PACKED launch on [dst] through [run_source ~lang:PTX], and
+             [Execute.run_source] raises [Unsupported_argument] on a backend whose
+             [supported_source_langs] does not list PTX, which is every backend
+             but Cuda_ptx_plugin. A heterogeneous pair would make this file exit 1
+             on an environment shortfall rather than on an assertion, so it is a
+             NAMED skip instead. *)
           let d =
             if is_ptx dst then check_free_does_not_resurrect_leaves src dst
             else begin

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -34,16 +34,18 @@
  * pipeline requires to be self-contained; and half A's pre-fix red state is a
  * RAISE, so a shared binary would abort before the other half reported.
  *
- * Exit codes: 0 = pass, INCLUDING both honest skips (no CUDA/PTX device, or only
- * one device to migrate between) — an absent device is not a regression, and
- * every skip prints a line naming the class it needed; 1 = an assertion fired.
- * There is no third code: a previous version of this header documented
- * "2 = setup could not produce the device pair this needs" while both skip paths
- * exit 0, so the row described a state this file cannot reach.
+ * Exit codes: 0 = pass, INCLUDING every honest skip (no CUDA/PTX device, only
+ * one device to migrate between, or a second device that is not CUDA/PTX for the
+ * one case that needs that) — an absent device is not a regression, and every
+ * skip prints a line naming the class it needed; 1 = an assertion fired. There is
+ * no third code: a previous version of this header documented "2 = setup could
+ * not produce the device pair this needs" while every skip path exits 0, so the
+ * row described a state this file cannot reach.
  *
  * Needs TWO devices, at least one of them CUDA/PTX (the SoA ABI dispatches
- * nowhere else). Locally that is ZLUDA on an AMD RX 7900 XTX — a CUDA/PTX
- * device, NOT NVIDIA hardware:
+ * nowhere else); the leaf-ownership case additionally needs the SECOND one to be
+ * CUDA/PTX and skips by name without it. Locally both are ZLUDA on AMD hardware
+ * — CUDA/PTX devices, NOT NVIDIA:
  *   LD_LIBRARY_PATH=$HOME/opt/zluda \
  *     dune exec sarek/tests/e2e/test_soa_cross_device_migration.exe
  ******************************************************************************)
@@ -446,9 +448,11 @@ let () =
         (Array.length devs) ;
       exit 0
   | src :: _ -> (
-      (* [dst] only has to be a DIFFERENT device — it receives an ordinary packed
-         upload, so any framework will do. Another CUDA/PTX device is preferred
-         so the pair is homogeneous.
+      (* For the three MIGRATION cases [dst] only has to be a DIFFERENT device —
+         each receives an ordinary packed upload, so any framework will do.
+         Another CUDA/PTX device is preferred so the pair is homogeneous, and the
+         fourth case below REQUIRES that (it launches PTX on [dst]) and skips by
+         name otherwise.
 
          "Any framework" includes the CPU backends, and that holds for the BYTE
          assertions in [check_per_device_leaf_free] too, which is the half that
@@ -458,9 +462,9 @@ let () =
          [size]/[elem_size] come from the requested length and element size
          (Transfer.ml:150-152), and [free_buffer] tracks the same product back. So
          a Native or Interpreter [dst] still yields a non-zero packed-byte delta
-         and the split is still measurable — no GPU-only restriction on [dst] is
-         needed, and adding one would drop the heterogeneous pair, which is the
-         more interesting migration. *)
+         and the split is still measurable — those three cases need no GPU-only
+         restriction on [dst], and imposing one would drop the heterogeneous
+         pair, which is the more interesting migration. *)
       let others =
         Array.to_list devs
         |> List.filter (fun (d : Device.t) -> d.Device.id <> src.Device.id)
@@ -503,7 +507,26 @@ let () =
              device boundary". It lives here because this is the only test with
              two devices in hand. *)
           let c = check_per_device_leaf_free src dst in
-          (* Also two-device-only: the free has to land on a device the leaves are
-             not on for the ownership flag to be resurrectable at all. *)
-          let d = check_free_does_not_resurrect_leaves src dst in
+          (* Also two-device-only: the free has to land on a device the leaves
+             are not on for the ownership flag to be resurrectable at all. But
+             unlike the three above it needs BOTH devices to be CUDA/PTX, because
+             its step 2 is a PACKED launch on [dst] through [run_source ~lang:PTX]
+             and [Execute.run_source] raises [Unsupported_argument] on a backend
+             whose [supported_source_langs] does not list PTX — which is every
+             backend but Cuda_ptx_plugin. A heterogeneous pair would make this
+             file exit 1 on an environment shortfall rather than on an assertion,
+             so it is a NAMED skip instead. *)
+          let d =
+            if is_ptx dst then check_free_does_not_resurrect_leaves src dst
+            else begin
+              Printf.printf
+                "  %-58s SKIP (needs a SECOND CUDA/PTX device; %s is %s, and \
+                 this case launches PTX on it)\n\
+                 %!"
+                "a free does not resurrect stale leaf ownership"
+                dst.Device.name
+                dst.Device.framework ;
+              true
+            end
+          in
           if not (a && b && c && d) then exit 1)

--- a/sarek/tests/e2e/test_soa_cross_device_migration.ml
+++ b/sarek/tests/e2e/test_soa_cross_device_migration.ml
@@ -165,10 +165,20 @@ let check ~label ~(packed_first : bool) (src : Device.t) (dst : Device.t) =
      that are still ALLOCATED. Allocation is not authority: a free on a device the
      leaves are not on turned the flag back ON.
 
-   With the gather gated on [location] (an unforced [to_cpu]) the resurrected flag
-   was harmless — the location said CPU and the gather was skipped anyway. Made
-   unconditional, it becomes data loss: the next packed launch gathers the stale
-   leaves OVER the host copy of the newer packed result and runs on them.
+   WHAT IS ASSERTED, and why it is the FLAG and not only the data. The flag is
+   the property: after a packed launch has taken ownership away from the leaves, no
+   free may hand it back. The data consequence depends on a second thing — which
+   locations the packed launch's gather runs on — and that is now gated on
+   [location] (Execute.transfer_vectors_to_device), which after [free_buffer]
+   reports [CPU] and skips. So with the data check ALONE this case reads green with
+   the fix removed: measured, it printed OK against a [soa_free_leaves] whose
+   derivation had the previous value dropped. It was a gate that could not fail for
+   one commit, which is exactly why the invariant is read directly here.
+
+   The data check stays as a second, weaker observation: it is what the resurrected
+   flag DID cost when the gather was unconditional (the next packed launch gathered
+   the stale leaves over the host copy of the newer result and ran on them), and it
+   is the shape the failure takes again if the gather condition is ever widened.
 
    Needs two devices, which is why it lives in this file: the free has to happen
    on a device the leaves are NOT on, or the leaves are freed and the flag would
@@ -238,6 +248,22 @@ let check_free_does_not_resurrect_leaves (src : Device.t) (dst : Device.t) =
         "FAILED" ;
       false
   | () ->
+      (* THE INVARIANT, read directly. [soa_leaves_live] is reachable from the
+         test because the binding is a public field of [Vector.t]; a vector with no
+         binding at all would be a different bug and is reported as one rather
+         than passing by default. *)
+      (match sv.Vector.soa with
+      | Some b when !(b.Vector.soa_leaves_live) ->
+          fail
+            "free_buffer on %s resurrected leaf ownership: soa_leaves_live is \
+             true again, and the leaves it points at hold the \
+             pre-packed-launch data"
+            dst.Device.name
+      | Some _ -> ()
+      | None ->
+          fail
+            "the vector lost its SoA binding, so this case asserted nothing \
+             about leaf ownership") ;
       let host_after_free = Array.init n (fun i -> (Vector.get sv i).y) in
       let mismatched = ref 0 in
       for i = 0 to n - 1 do

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -1336,6 +1336,96 @@ let check_transparent_roundtrip dev n =
    launch has no buffer to bind, because the transparent path never allocates
    one), which is why the exception is caught and reported rather than left to
    abort the binary: a red state that is a crash is not an observation. *)
+(* A HOST WRITE between a transparent launch and a packed one must survive.
+
+   Same two launches as {!check_soa_then_packed}, with one statement added
+   between them, and that statement is the whole case: after the transparent
+   launch the vector is [Stale_CPU dev] with the leaves authoritative, and
+   [Vector.set] gathers them, writes the element, and records [Stale_GPU dev] —
+   the host copy is now the NEWER one while [soa_leaves_live] still says
+   "leaves".
+
+   The packed launch must then normalise that flag WITHOUT re-gathering. A gather
+   there replays the leaves over the host write and the write vanishes with no
+   diagnostic. Found by review of this round's first attempt, which made the
+   gather unconditional for the opposite failure (a gather skipped on a
+   device-authoritative location strands the launch output in the leaves) — the
+   two are one condition, on which copy is authoritative, and the case exists
+   because pinning only one of them is what let the other in.
+
+   Distinguishable in both directions. y0 = i+1; the transparent launch doubles y
+   to 2*y0; the host write sets y := 100+i, which is neither a multiple nor a
+   scalar function of y0; the packed launch doubles that to 2*(100+i). Discarding
+   the host write gives 4*y0 = 4*(i+1) instead, and 2*(100+i) = 4*(i+1) has no
+   integer solution for i >= 0. *)
+let check_host_write_survives_packed dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  let ir = ir_of p3_scale_y_kernel in
+  let written i = float_of_int (100 + i) in
+  let ok = ref true in
+  (match
+     Sarek.Execute.run_vectors
+       ~device:dev
+       ~ir
+       ~args:[Vec sv; Int n]
+       ~block
+       ~grid
+       () ;
+     Transfer.flush dev ;
+     (* The host write. Gathers the leaves first (auto-sync), so what it lands on
+        top of is the transparent launch's result, and leaves the vector
+        [Stale_GPU dev]. *)
+     for i = 0 to n - 1 do
+       Vector.set
+         sv
+         i
+         {x = float_of_int i; y = written i; z = float_of_int (n - i)}
+     done ;
+     (* PACKED launch: run_source defaults to ~soa_abi:false. *)
+     Sarek.Execute.run_source
+       ~device:dev
+       ~source:(Sarek_ir_ptx.generate ir)
+       ~lang:Sarek.Execute.PTX
+       ~kernel_name:ir.Sarek_ir_types.kern_name
+       ~block
+       ~grid
+       [Sarek.Execute.Vec sv; Sarek.Execute.Int n] ;
+     Transfer.flush dev
+   with
+  | exception e ->
+      Printf.printf
+        "  host write then packed launch raised: %s\n%!"
+        (Printexc.to_string e) ;
+      ok := false
+  | () ->
+      let first = ref true in
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y and want = written i *. 2.0 in
+        if Float.abs (got -. want) > 1e-3 && !first then begin
+          first := false ;
+          Printf.printf
+            "  host write lost @%d: got=%g want=%g (re-gathered leaves would \
+             give %g)\n\
+             %!"
+            i
+            got
+            want
+            (y0 i *. 4.0) ;
+          ok := false
+        end
+      done) ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "a host write between an SoA and a packed launch survives"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
 let check_soa_then_packed dev n =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -1894,9 +1984,11 @@ let () =
       (* The skip is NAMED. Gating the call on [dev_can_f64] alone printed
          nothing at all on a device without fp64, and a row that prints nothing is
          indistinguishable from one that passed — the exact skip-as-pass shape the
-         guarded cases below were restructured to make unrepresentable, and this
-         is the last plain capability gate in the driver loop. Same wording as the
-         two arms of [check_mixed_widths], which report the same capability. *)
+         guarded cases below were restructured to make unrepresentable. Same
+         wording as the fp64 arm of [check_mixed_widths] (its other arm reports
+         int64, a different capability). Not the last bare gate in this loop:
+         [check_roundtrip] at the end is still [if is_ptx dev && …] and prints
+         nothing on a non-PTX device. *)
       if not dev_can_f64 then
         Printf.printf
           "SoA-emitter dpair(f64) [%s] %s: SKIP (device reports no fp64)\n%!"
@@ -1999,6 +2091,11 @@ let () =
         [
           ( "packed AoS launch after a transparent SoA one",
             fun () -> check_soa_then_packed dev n );
+          (* Same pair of launches with a HOST WRITE in between: the flag must be
+             normalised without the gather replaying the leaves over it. The two
+             cases pin the two directions of one condition. *)
+          ( "a host write between an SoA and a packed launch survives",
+            fun () -> check_host_write_survives_packed dev n );
           ( "free_all_buffers preserves a transparent SoA result",
             fun () -> check_free_preserves_soa dev n );
           (* And the free must RELEASE, not merely preserve — a separate claim

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -138,6 +138,140 @@ let is_ptx (dev : Device.t) = dev.Device.framework = "CUDA/PTX"
 
 let dims threads = Sarek.Execute.dims1d threads
 
+(* ── Guarded cases: the reason a case is skipped, and the devices it is true of ──
+
+   A skip line is a CLAIM about a class of devices, and this file has now got
+   that claim wrong twice in a row, each time while fixing the previous attempt:
+
+     round 2: the guarded cases printed NOTHING on a non-PTX device. Silent
+              no-op and pass are the same observation — skip-as-pass.
+     round 3: every guarded case got a NAMED skip line. But the name was wired to
+              the guard [is_ptx], and one of the two reasons — backlog-172 — is
+              true only of the two CPU backends. So four cases printed
+              "blocked on backlog-172" on OpenCL x2 and Vulkan x2, four devices
+              where the construct works fine. 16 real assertions withheld under a
+              false reason, among them the ONLY non-PTX coverage of the
+              Vector.unsafe_set / Vector.fill Stale_CPU write-loss fix, which is
+              host-side and not PTX-specific at all.
+
+   The shape of both failures is the same: the guard and the reason were two
+   independent statements, and nothing checked that they agreed. So a reason is
+   no longer a string handed to an else-branch. It is a record that carries its
+   own predicate, and the predicate is what SELECTS it — a case is skipped
+   because some blocker applies, and the line printed is that blocker's. A reason
+   printed on a device its predicate does not describe is now unrepresentable.
+
+   [applies] takes the framework NAME rather than a [Device.t] so that
+   {!check_skip_reason_scope} can evaluate it over every framework Sarek can
+   enumerate, not merely the ones plugged into the host running the suite. Both
+   real blockers are framework-level facts, so nothing is lost. *)
+type blocker = {
+  reason : string;
+      (** Printed verbatim as the skip line. Must be true of every framework in
+          [describes] and of no other. *)
+  applies : string -> bool;
+      (** [applies framework]: is a case carrying this blocker unrunnable there?
+      *)
+  describes : string list;
+      (** The frameworks [reason] claims to be about. Compared against [applies]
+          over the whole framework universe by {!check_skip_reason_scope} — this
+          is the second, independent statement, deliberately written out rather
+          than derived, because a check that derives its expectation from the
+          thing it checks cannot fail. *)
+}
+
+(* Every framework Sarek can enumerate. The universe {!check_skip_reason_scope}
+   quantifies over; a blocker predicate that fires outside its [describes] on ANY
+   of these is a false claim waiting for that device to appear, whether or not
+   this host has one. *)
+let all_frameworks =
+  ["CUDA/PTX"; "OpenCL"; "Vulkan"; "Metal"; "Native"; "Interpreter"]
+
+(* `v.(i).f <- e` from inside a kernel — a record-field store — is unsupported on
+   the two CPU backends and ONLY those two: the Interpreter raises
+   [Unsupported_operation "record field assignment"]
+   (Sarek_ir_interp_eval.assign_lvalue, [LRecordField] arm), and Native accepts
+   it and silently drops the store (measured: y unchanged at 1 where 2 was
+   expected). Tracked as backlog-172; when it lands, this blocker is deleted and
+   the cases it guards need no other change.
+
+   It has nothing to do with CUDA/PTX. Measured 2026-07-30 on this host: all four
+   cases carrying this blocker PASS on OpenCL x2 (radeonsi: RX 7900 XTX +
+   7950X iGPU) and Vulkan x2 (RADV: same two), through the packed AoS fallback —
+   which is the stronger assertion anyway, since the same [Vector.get] must
+   return the same answer under either ABI. *)
+let blocker_cpu_field_store =
+  {
+    reason = "SKIP (v.(i).f <- unsupported on this CPU backend: backlog-172)";
+    applies = (fun fw -> fw = "Native" || fw = "Interpreter");
+    describes = ["Native"; "Interpreter"];
+  }
+
+(* The SoA ABI is selected on CUDA/PTX and nowhere else. Unlike the blocker
+   above this is by design and permanent, not a defect that will lift — which is
+   why the two are separate records rather than one merged "not supported here". *)
+let blocker_needs_soa_abi =
+  {
+    reason = "SKIP (needs CUDA/PTX: the SoA ABI dispatches nowhere else)";
+    applies = (fun fw -> fw <> "CUDA/PTX");
+    describes = ["OpenCL"; "Vulkan"; "Metal"; "Native"; "Interpreter"];
+  }
+
+let all_blockers = [blocker_cpu_field_store; blocker_needs_soa_abi]
+
+(* THE check that would have caught round 3, and it needs no device at all — so
+   it runs on a CUDA-less host, and before the no-device early exit.
+
+   For each blocker, evaluate [applies] over {!all_frameworks} and compare the
+   set that fires with the set the reason claims to describe. With round 3's
+   wiring the backlog-172 reason fired on OpenCL, Vulkan and Metal, none of which
+   it describes, and this would have printed all three and failed.
+
+   [describes] is also required to be a subset of the universe, so a typo
+   ("Cuda/PTX") shows up as a named failure instead of quietly shrinking the
+   expected set to nothing. *)
+let check_skip_reason_scope () =
+  let ok = ref true in
+  List.iter
+    (fun b ->
+      let unknown =
+        List.filter (fun fw -> not (List.mem fw all_frameworks)) b.describes
+      in
+      if unknown <> [] then begin
+        Printf.printf
+          "  skip reason %S names framework(s) Sarek cannot enumerate: [%s]\n%!"
+          b.reason
+          (String.concat "; " unknown) ;
+        ok := false
+      end ;
+      let fires = List.filter b.applies all_frameworks in
+      let sorted = List.sort_uniq compare in
+      if sorted fires <> sorted b.describes then begin
+        Printf.printf
+          "  skip reason %S fires on [%s] but describes [%s]\n%!"
+          b.reason
+          (String.concat "; " fires)
+          (String.concat "; " b.describes) ;
+        ok := false
+      end)
+    all_blockers ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "each skip reason is true of exactly the devices it prints on"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
+(* Run [body], or print the reason of the FIRST blocker that applies to this
+   device. The printed reason is selected by the predicate, which is what keeps
+   it honest — there is no else-branch holding a second opinion. *)
+let guarded (dev : Device.t) ~(blockers : blocker list) ~(label : string)
+    (body : unit -> bool) =
+  match List.find_opt (fun b -> b.applies dev.Device.framework) blockers with
+  | Some b ->
+      Printf.printf "  %-56s %s\n%!" label b.reason ;
+      true
+  | None -> body ()
+
 (* Launch the SoA compilation of [ir] whose first param (a flat 2/3-field record
    vector) is lowered SoA. [leaves] are the per-leaf scalar vectors (declaration
    order); [out] the scalar output. Arg order mirrors the emitted param block:
@@ -836,16 +970,21 @@ let check_transparent dev n =
    an ordinary [Transfer.to_cpu] downloads. Every assertion above would still
    have passed while a kernel's output was silently discarded.
 
-   CUDA/PTX only, and the reason is a defect elsewhere rather than a property of
-   this path. Extending it to every device would be the stronger test — the same
-   [Vector.get] should return the same answer through the packed AoS fallback —
-   but [pts.(tid).y <- …] does not work on the two CPU backends: the Interpreter
-   REFUSES it (Sarek_ir_interp_eval.assign_lvalue's [LRecordField] arm raises
-   [Unsupported_operation "record field assignment"]), and Native accepts it and
-   silently drops the store (measured: y unchanged at 1 where 2 was expected).
-   That is tracked as backlog-172 and is not this case's subject; asserting the
-   non-PTX arm here would pin a red on an unrelated gap. When 172 lands, drop the
-   [is_ptx] guard — the assertion below needs no other change. *)
+   Runs on every device EXCEPT the two CPU backends — see
+   {!blocker_cpu_field_store}. The stronger test was always the wider one: the
+   same [Vector.get] should return the same answer through the packed AoS
+   fallback, and as of 2026-07-30 it is asserted there, on OpenCL x2 and Vulkan
+   x2 as well as on CUDA/PTX.
+
+   Until round 4 this was gated on [is_ptx], with the CPU-backend defect
+   (backlog-172) given as the reason. The defect is real — the Interpreter
+   REFUSES [pts.(tid).y <- …] (Sarek_ir_interp_eval.assign_lvalue's
+   [LRecordField] arm raises [Unsupported_operation "record field assignment"])
+   and Native accepts it and silently drops the store (measured: y unchanged at 1
+   where 2 was expected) — but it is a defect of those two backends only, and
+   using it to withhold the case from OpenCL and Vulkan withheld four real
+   assertions under a reason false of all four devices. When 172 lands, delete
+   the blocker; the assertion below needs no other change. *)
 (* TWO launches on ONE vector, with different host data in between (H5,
    backlog-181). This is the case no existing test constructs — every other one
    allocates a fresh vector — and that is exactly why the defect was invisible to
@@ -964,7 +1103,15 @@ let check_transparent_roundtrip dev n =
   done ;
   Printf.printf
     "  %-56s %s\n%!"
-    "transparent SoA output read back (PTX: leaf D2H + gather)"
+    (Printf.sprintf
+       "transparent SoA output read back (%s)"
+       (* The label named the PTX mechanism unconditionally while the case now
+          runs on OpenCL and Vulkan too, where the round trip goes through the
+          packed AoS buffer. Same claim, two mechanisms — and naming the wrong
+          one is the same species of false line as a skip reason that does not
+          describe its device. *)
+       (if is_ptx dev then "PTX: leaf D2H + gather"
+        else "non-PTX: packed AoS fallback"))
     (if !ok then "OK" else "FAILED") ;
   !ok
 
@@ -1189,6 +1336,170 @@ let check_free_releases_leaves dev n =
     (if ok then "OK" else "FAILED") ;
   ok
 
+(* [free_buffer] — the SINGLE-device free — must leave the vector in a coherent
+   state, and nothing covered it: every case above frees through
+   [free_all_buffers]. That gap is why the incoherence shipped, so this case
+   exists as much for the coverage as for the assertion.
+
+   [free_all_buffers] escapes the bug by assigning [CPU] unconditionally at the
+   end. [free_buffer] kept its location reset INSIDE the [get_buffer] [Some buf]
+   arm, and under this ABI there is never a packed buffer — so the [None -> ()]
+   arm was taken ALWAYS, after the leaves had already been released. The vector
+   came back with its device memory gone and [location] still [Both dev].
+
+   Three assertions, because "coherent" is three separate observable claims and
+   the location value itself is the least of them:
+
+   1. [location = CPU]. The direct statement. Checked first so a failure names
+      the cause rather than a downstream symptom.
+   2. [to_cpu ~force:true] must not raise. [Both dev] + [force] means "read the
+      device back"; with the leaves gone there is nothing to read and
+      [copy_device_to_host] raises [Failure "to_cpu: no device buffer to transfer
+      from"] — on a vector whose data is intact in host storage. The data is
+      re-checked after the call, so a [to_cpu] that returns quietly having
+      overwritten the host copy is not mistaken for a pass.
+   3. [to_device] on the same device must ALLOCATE. This is the one that matters
+      most: with [location] left at [Both dev], [to_device] logs "skip (Both)"
+      and returns having allocated nothing — reinstating the very [skip (Both)]
+      short-circuit the [Stale_CPU]/scatter work earlier in this branch was
+      written to eliminate. Asserted in BYTES via [Gpu_memory.usage()], because
+      "did not raise" is exactly what the broken version also does.
+
+   [allocated_before_free > 0] is asserted too: without it a launch that
+   allocated nothing would make claim 3 vacuous. *)
+let check_free_buffer_coherent dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  Gc.full_major () ;
+  let before = Gpu_memory.usage () in
+  Sarek.Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of p3_scale_y_kernel)
+    ~args:[Vec sv; Int n]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let after_launch = Gpu_memory.usage () in
+  Transfer.free_buffer sv dev ;
+  let ok = ref true in
+  let fail fmt =
+    Printf.ksprintf
+      (fun s ->
+        Printf.printf "  %s\n%!" s ;
+        ok := false)
+      fmt
+  in
+  if after_launch - before <= 0 then
+    fail
+      "the launch allocated %d bytes, so the re-upload claim below would be \
+       vacuous"
+      (after_launch - before) ;
+  (* Claim 1. *)
+  (match sv.Vector.location with
+  | Vector.CPU -> ()
+  | Vector.GPU d ->
+      fail "location after free_buffer: GPU %d, want CPU" d.Device.id
+  | Vector.Both d ->
+      fail
+        "location after free_buffer: Both %d, want CPU — the leaves were freed \
+         and the location still names the device"
+        d.Device.id
+  | Vector.Stale_CPU d ->
+      fail "location after free_buffer: Stale_CPU %d, want CPU" d.Device.id
+  | Vector.Stale_GPU d ->
+      fail "location after free_buffer: Stale_GPU %d, want CPU" d.Device.id) ;
+  (* Claim 2. *)
+  (match Transfer.to_cpu ~force:true sv with
+  | () ->
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y and want = y0 i *. 2.0 in
+        if Float.abs (got -. want) > 1e-3 && !ok then
+          fail
+            "to_cpu after free_buffer corrupted @%d: got=%g want=%g \
+             (pre-launch host value is %g)"
+            i
+            got
+            want
+            (y0 i)
+      done
+  | exception e ->
+      fail
+        "to_cpu ~force:true after free_buffer raised: %s"
+        (Printexc.to_string e)) ;
+  (* Claim 3. *)
+  let before_reupload = Gpu_memory.usage () in
+  (match Transfer.to_device sv dev with
+  | () ->
+      let reallocated = Gpu_memory.usage () - before_reupload in
+      if reallocated <= 0 then
+        fail
+          "to_device after free_buffer allocated %d bytes — it took the \
+           skip-when-already-resident short-circuit on a vector with no device \
+           memory left"
+          reallocated
+  | exception e ->
+      fail "to_device after free_buffer raised: %s" (Printexc.to_string e)) ;
+  (* Claims 4 and 5. Round 3 verified both BY HAND against its own version of
+     [free_buffer]; this round restructured that function's control flow — all
+     four steps moved out of the [get_buffer] [Some] arm — so a hand check of the
+     old shape says nothing about the new one. Asserted here instead.
+
+     4. Double free. The second call must be a no-op, not a double release: the
+        leaves are gone, the packed buffer is gone, and [location] is already
+        [CPU], so every step must decline. Step 4 in particular must not fire on
+        a [CPU] location.
+     5. Free, then relaunch. [location = CPU] is what makes this reachable at
+        all — the scatter + upload has to run again from host storage — and the
+        result must be the SECOND launch's, not the first's. y is doubled twice
+        from the same host values, so a relaunch that reused stale device data
+        would give 2*y0 where 4*y0 is expected. *)
+  (match Transfer.free_buffer sv dev with
+  | () -> ()
+  | exception e -> fail "second free_buffer raised: %s" (Printexc.to_string e)) ;
+  (match
+     Sarek.Execute.run_vectors
+       ~device:dev
+       ~ir:(ir_of p3_scale_y_kernel)
+       ~args:[Vec sv; Int n]
+       ~block
+       ~grid
+       () ;
+     Transfer.flush dev
+   with
+  | () ->
+      for i = 0 to n - 1 do
+        (* Round 1 doubled y0 to 2*y0 and [to_cpu] above gathered it into host
+           storage, so this second launch doubles that to 4*y0. Stale device data
+           would leave 2*y0 — never equal for y0 > 0. *)
+        let got = (Vector.get sv i).y and want = y0 i *. 4.0 in
+        if Float.abs (got -. want) > 1e-3 && !ok then
+          fail
+            "relaunch after free_buffer is wrong @%d: got=%g want=%g (the \
+             first launch's result is %g)"
+            i
+            got
+            want
+            (y0 i *. 2.0)
+      done
+  | exception e ->
+      fail "relaunch after free_buffer raised: %s" (Printexc.to_string e)) ;
+  Transfer.free_all_buffers sv ;
+  (* Load-bearing, as in {!check_free_releases_leaves}: a collected [sv] frees
+     its own leaves through the finalizer and the byte deltas above stop meaning
+     what they say. *)
+  ignore (Sys.opaque_identity sv) ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "free_buffer leaves the vector coherent (location/re-read/re-upload)"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
 (* The two integer-leaf device rows the handoff left open. Driven through the
    TRANSPARENT path, so one case covers both the mixed-width leaf addressing and
    the generic dispatch. Each leaf is compared to the reference independently. *)
@@ -1325,7 +1636,13 @@ let () =
      a machine with no device would report SKIPPED while silently not checking a
      property that needs no device at all. *)
   let derive_ok = check_field_derivation () in
-  let layout_ok = check_layout_validation () && derive_ok in
+  (* Also device-independent, and deliberately so — it quantifies over every
+     framework Sarek can enumerate rather than over the ones present here, so a
+     skip reason that is false of a device class stays caught on a host that has
+     no such device. Before the no-device exit for the same reason as the two
+     above. *)
+  let scope_ok = check_skip_reason_scope () in
+  let layout_ok = check_layout_validation () && derive_ok && scope_ok in
   let devs = Device.all () in
   if Array.length devs = 0 then (
     print_endline
@@ -1368,113 +1685,116 @@ let () =
       if dev_can_f64 && not (check "dpair(f64)" dev n run_dpair) then
         ok := false ;
       if not (check_transparent dev n) then ok := false ;
-      (* Transparent OUTPUT read-back. PTX-gated — see the case's header for why
-         the non-PTX arm is blocked on backlog-172 rather than omitted. *)
-      if is_ptx dev then begin
-        if not (check_transparent_roundtrip dev n) then ok := false ;
-        (* H5 (backlog-181): relaunch on the SAME vector. PTX-gated for the same
-           reason as the case above — `v.(i).f <- e` is blocked on the two CPU
-           backends until backlog-172 lands. *)
-        (* One case per host writer (backlog-190). Vector.set was fixed with H5;
-           unsafe_set carried the identical Stale_CPU arm and fill's was a wider
-           catch-all. Separate cases so a fix to one cannot make the others read
-           as covered. kernel_set is deliberately absent: it is documented to skip
-           location handling entirely, because a per-element update would race
-           across the threads it exists to serve. *)
-        List.iter
-          (fun (writer_name, write, y_expected, stale_note) ->
-            if
-              not
-                (check_relaunch
-                   dev
-                   n
-                   ~writer_name
-                   ~write
-                   ~y_expected
-                   ~stale_note)
-            then ok := false)
-          [
-            ( "Vector.set",
-              (fun sv n y_of ->
-                for i = 0 to n - 1 do
-                  Vector.set
-                    sv
-                    i
-                    {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
-                done),
-              (fun i -> float_of_int (1000 - i) *. 2.0),
-              fun i -> float_of_int (i + 1) *. 4.0 );
-            ( "Vector.unsafe_set",
-              (fun sv n y_of ->
-                for i = 0 to n - 1 do
-                  Vector.unsafe_set
-                    sv
-                    i
-                    {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
-                done),
-              (fun i -> float_of_int (1000 - i) *. 2.0),
-              fun i -> float_of_int (i + 1) *. 4.0 );
-            (* fill writes ONE value to every element, so both the expectation
+      (* Transparent OUTPUT read-back. Its only blocker is the CPU field-store
+         gap, NOT the SoA ABI: on OpenCL/Vulkan the launch takes the packed AoS
+         fallback and the same [Vector.get] must return the same answer, which is
+         the stronger claim. Round 3 gated this on [is_ptx] and printed the
+         backlog-172 reason on four devices that reason is false of. *)
+      if
+        not
+          (guarded
+             dev
+             ~blockers:[blocker_cpu_field_store]
+             ~label:"transparent SoA output read back"
+             (fun () -> check_transparent_roundtrip dev n))
+      then ok := false ;
+      (* H5 (backlog-181): relaunch on the SAME vector. Same single blocker —
+         `v.(i).f <- e` is what the kernel does, so the two CPU backends cannot
+         run it, and every other backend can.
+
+         One case per host writer (backlog-190). Vector.set was fixed with H5;
+         unsafe_set carried the identical Stale_CPU arm and fill's was a wider
+         catch-all. Separate cases so a fix to one cannot make the others read as
+         covered. That write-loss is HOST-side and not PTX-specific, so running
+         these three on OpenCL and Vulkan is not padding: before round 4 the fix
+         had no non-PTX coverage anywhere in the suite. kernel_set is deliberately
+         absent: it is documented to skip location handling entirely, because a
+         per-element update would race across the threads it exists to serve. *)
+      List.iter
+        (fun (writer_name, write, y_expected, stale_note) ->
+          if
+            not
+              (guarded
+                 dev
+                 ~blockers:[blocker_cpu_field_store]
+                 ~label:
+                   (Printf.sprintf
+                      "second launch sees the second host write (%s)"
+                      writer_name)
+                 (fun () ->
+                   check_relaunch
+                     dev
+                     n
+                     ~writer_name
+                     ~write
+                     ~y_expected
+                     ~stale_note))
+          then ok := false)
+        [
+          ( "Vector.set",
+            (fun sv n y_of ->
+              for i = 0 to n - 1 do
+                Vector.set
+                  sv
+                  i
+                  {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
+              done),
+            (fun i -> float_of_int (1000 - i) *. 2.0),
+            fun i -> float_of_int (i + 1) *. 4.0 );
+          ( "Vector.unsafe_set",
+            (fun sv n y_of ->
+              for i = 0 to n - 1 do
+                Vector.unsafe_set
+                  sv
+                  i
+                  {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
+              done),
+            (fun i -> float_of_int (1000 - i) *. 2.0),
+            fun i -> float_of_int (i + 1) *. 4.0 );
+          (* fill writes ONE value to every element, so both the expectation
                and the stale value are uniform. It takes y_of 0: round 1 fills
                y=1 which the kernel doubles to 2; round 2 fills y=1000, doubled
                to 2000. A stale round 2 would re-double round 1's result to 4 --
                far from 2000, so the two cannot be confused. *)
-            ( "Vector.fill",
-              (fun sv n y_of ->
-                Vector.fill sv {x = 0.0; y = y_of 0; z = float_of_int n}),
-              (fun _ -> 2000.0),
-              fun _ -> 4.0 );
-          ] ;
-        (* Whose ABI does read-back follow? The two cases below are the two ways
-           that question got a stale answer, and they are separate cases because
-           the two paths that asked it are separate: the LAUNCH path
-           (Execute.transfer_vectors_to_device, which never cleared the flag) and
-           the CLEANUP path (Transfer.free_*, which had no SoA arm at all). *)
-        if not (check_soa_then_packed dev n) then ok := false ;
-        if not (check_free_preserves_soa dev n) then ok := false ;
-        (* And the free must RELEASE, not merely preserve — a separate claim from
-           the case above, which passed while zero bytes came back. *)
-        if not (check_free_releases_leaves dev n) then ok := false
-      end
-      else begin
-        (* ONE skip line PER GUARDED CASE, each naming the device class it needs
-           and why it was absent.
+          ( "Vector.fill",
+            (fun sv n y_of ->
+              Vector.fill sv {x = 0.0; y = y_of 0; z = float_of_int n}),
+            (fun _ -> 2000.0),
+            fun _ -> 4.0 );
+        ] ;
+      (* The cases below genuinely need the SoA ABI itself — they are about which
+         ABI a read-back or a free follows, so a device that never selects the
+         SoA ABI has no such question to get wrong. That reason is by design and
+         permanent, which is why it is a different blocker from the one above and
+         is not collapsed into a single "not supported here".
 
-           Before 2026-07-30 this else-branch printed a single line, for
-           [check_transparent_roundtrip] only. The three [check_relaunch]
-           writers, [check_soa_then_packed] and [check_free_preserves_soa]
-           printed NOTHING — so on a host where no CUDA/PTX device enumerates
-           (which, with no LD_LIBRARY_PATH for ZLUDA, was every default `dune
-           runtest`) five assertions were absent from the output and from the
-           verdict, and the alias still exited 0. A silent no-op and a pass are
-           the same observation, which is the whole failure.
-
-           The two reasons are genuinely different and are not collapsed:
-           backlog-172 is a defect that will LIFT the guard on the first four
-           cases when it lands; the SoA ABI dispatching only on CUDA/PTX is by
-           design and permanent for the last three. *)
-        let skip_172 label =
-          Printf.printf
-            "  %-56s %s\n%!"
-            label
-            "SKIP (non-PTX: v.(i).f <- blocked on backlog-172)"
-        in
-        let skip_ptx label =
-          Printf.printf
-            "  %-56s %s\n%!"
-            label
-            "SKIP (needs CUDA/PTX: the SoA ABI dispatches nowhere else)"
-        in
-        skip_172 "transparent SoA output read back" ;
-        List.iter
-          (fun w ->
-            skip_172
-              (Printf.sprintf "second launch sees the second host write (%s)" w))
-          ["Vector.set"; "Vector.unsafe_set"; "Vector.fill"] ;
-        skip_ptx "packed AoS launch after a transparent SoA one" ;
-        skip_ptx "free_all_buffers preserves a transparent SoA result" ;
-        skip_ptx "free_all_buffers RELEASES a transparent SoA vector's leaves"
-      end ;
+         Whose ABI does read-back follow? The first two are the two ways that
+         question got a stale answer, and they are separate cases because the two
+         paths that asked it are separate: the LAUNCH path
+         (Execute.transfer_vectors_to_device, which never cleared the flag) and
+         the CLEANUP path (Transfer.free_*, which had no SoA arm at all). *)
+      List.iter
+        (fun (label, body) ->
+          if
+            not
+              (guarded dev ~blockers:[blocker_needs_soa_abi] ~label (fun () ->
+                   body ()))
+          then ok := false)
+        [
+          ( "packed AoS launch after a transparent SoA one",
+            fun () -> check_soa_then_packed dev n );
+          ( "free_all_buffers preserves a transparent SoA result",
+            fun () -> check_free_preserves_soa dev n );
+          (* And the free must RELEASE, not merely preserve — a separate claim
+             from the case above, which passed while zero bytes came back. *)
+          ( "free_all_buffers RELEASES a transparent SoA vector's leaves",
+            fun () -> check_free_releases_leaves dev n );
+          (* free_buffer, the SINGLE-device free, was covered by nothing at all —
+             every case above frees through free_all_buffers, which is why its
+             incoherent location bookkeeping shipped. *)
+          ( "free_buffer leaves the vector coherent (location/re-read/re-upload)",
+            fun () -> check_free_buffer_coherent dev n );
+        ] ;
       if not (check_mixed_widths dev n) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -1389,9 +1389,10 @@ let check_host_write_survives_packed dev n =
         of is the transparent launch's result, and it leaves the vector
         [Stale_GPU dev]. That precondition is named because it is load-bearing:
         with auto-sync OFF the gather does not happen and the vector stays
-        [Stale_CPU dev] with a pending host write, which is the pre-existing
-        auto-sync-off hazard [Vector.ml] documents and NOT what this case
-        covers. *)
+        [Stale_CPU dev] with a pending host write, which the packed launch then
+        replays the leaves over. That is a pre-existing consequence of disabling
+        auto-sync — undocumented in [Vector.ml], so stated here rather than cited
+        — and NOT what this case covers. *)
      for i = 0 to n - 1 do
        Vector.set
          sv

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -828,13 +828,18 @@ let check_mixed_widths dev n =
     if not good then ok := false
   in
   (* i32 + f64. Gated on the DEVICE's fp64 capability rather than on
-     "CUDA/PTX only" the way the dpair row is: the f64 leaf makes this an fp64
-     kernel, and the launch gate refuses it on a device that does not report
-     double precision (radeonsi/OpenCL here). Keying on the capability rather
-     than the framework runs the row on every device that can actually execute
-     it — and keeps this test measuring SoA leaf addressing rather than
-     re-discovering the fp64 gate. A CPU backend evaluates in OCaml doubles, so
-     it is always able. *)
+     "CUDA/PTX only": the f64 leaf makes this an fp64 kernel, and the launch
+     gate refuses it wherever the driver does not ADVERTISE double precision.
+
+     Note what the skip does and does not mean. On this host the two OpenCL
+     devices are rusticl, which does not expose cl_khr_fp64 unless
+     RUSTICL_FEATURES=fp64 is set — measured both ways with clinfo and with this
+     test, which goes from 5 OK + 2 SKIP to 7 OK with the variable. The RX 7900
+     XTX has fp64 in hardware. So a skip here reports a DRIVER CONFIGURATION,
+     never a hardware limitation, and the gate is still correct: emitting an fp64
+     kernel against a driver that has not enabled the extension is exactly what
+     it must refuse. A CPU backend evaluates in OCaml doubles and is always
+     able. *)
   let f = dev.Device.framework in
   let can_f64 = f = "Native" || f = "Interpreter" || Device.allows_fp64 dev in
   if not can_f64 then
@@ -959,11 +964,30 @@ let () =
       (* point3d (f32) runs everywhere: cross-backend AoS + reference, plus the
          PTX SoA leg. *)
       if not (check "point3d(f32)" dev n run_p3) then ok := false ;
-      (* dpair (f64) exists to prove the f64 SoA leaf on PTX; run it on CUDA/PTX
-         only. (Some non-PTX backends — e.g. OpenCL/radeonsi — have an unrelated
-         f64 custom-vector gap that is out of scope for this emitter test and is
-         exercised elsewhere.) *)
-      if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false ;
+      (* dpair (f64) proves the 8-byte SoA leaf. Gated on the DEVICE's fp64
+         capability, not on CUDA/PTX.
+
+         CORRECTED 2026-07-30 — the previous restriction to PTX was justified as
+         "some non-PTX backends, e.g. OpenCL/radeonsi, have an unrelated f64
+         custom-vector gap". That attribution is wrong. Measured: with
+         RUSTICL_FEATURES=fp64 set, this row PASSES on OpenCL/radeonsi (both
+         devices), Vulkan, Native and the Interpreter. There is no f64
+         custom-vector gap; rusticl simply does not advertise cl_khr_fp64 unless
+         that variable is set, and Sarek's fp64 launch gate then correctly
+         refuses. clinfo agrees: "Double-precision Floating-point support (n/a)"
+         becomes "(cl_khr_fp64)" with the variable set. The RX 7900 XTX has fp64
+         in hardware, so nothing about the DEVICE was ever the reason.
+
+         Keying on the capability therefore turns a 1-device row into a 7-device
+         one (or 5 + 2 honest skips without the variable), and stops the test
+         asserting a device limitation that does not exist. *)
+      let dev_can_f64 =
+        dev.Device.framework = "Native"
+        || dev.Device.framework = "Interpreter"
+        || Device.allows_fp64 dev
+      in
+      if dev_can_f64 && not (check "dpair(f64)" dev n run_dpair) then
+        ok := false ;
       if not (check_transparent dev n) then ok := false ;
       if not (check_mixed_widths dev n) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -810,6 +810,83 @@ let check_transparent dev n =
     (if !ok then "OK" else "FAILED") ;
   !ok
 
+(* Transparent OUTPUT round-trip: a kernel writes the y leaf and the host reads
+   the result back with a plain [Vector.get] — no leaf iteration, no explicit
+   gather. That is the whole claim of the transparent path, and it is a different
+   claim from {!check_roundtrip}, which does the D2H and the gather BY HAND
+   because [Soa_launch.run_soa] documents that as the caller's job.
+
+   Nothing covered it before, and the gap was not cosmetic: [check_transparent]
+   above writes its results into a separate plain [out] vector, so it holds the
+   SoA vector INPUT-only. With the SoA ABI selected, a launch writes the N leaf
+   buffers and leaves the packed AoS buffer untouched — which is precisely what
+   an ordinary [Transfer.to_cpu] downloads. Every assertion above would still
+   have passed while a kernel's output was silently discarded.
+
+   CUDA/PTX only, and the reason is a defect elsewhere rather than a property of
+   this path. Extending it to every device would be the stronger test — the same
+   [Vector.get] should return the same answer through the packed AoS fallback —
+   but [pts.(tid).y <- …] does not work on the two CPU backends: the Interpreter
+   REFUSES it (Sarek_ir_interp_eval.assign_lvalue's [LRecordField] arm raises
+   [Unsupported_operation "record field assignment"]), and Native accepts it and
+   silently drops the store (measured: y unchanged at 1 where 2 was expected).
+   That is tracked as backlog-172 and is not this case's subject; asserting the
+   non-PTX arm here would pin a red on an unrelated gap. When 172 lands, drop the
+   [is_ptx] guard — the assertion below needs no other change. *)
+let check_transparent_roundtrip dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let orig i =
+    {
+      x = float_of_int i;
+      y = (float_of_int i *. 0.5) +. 1.0;
+      z = float_of_int (n - i);
+    }
+  in
+  for i = 0 to n - 1 do
+    Vector.set sv i (orig i)
+  done ;
+  let ir = ir_of p3_scale_y_kernel in
+  Sarek.Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Vec sv; Int n]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    (* Plain host read. No Soa_vector.leaves, no Soa_vector.gather. *)
+    let got = Vector.get sv i in
+    let o = orig i in
+    if
+      Float.abs (got.y -. (o.y *. 2.0)) > 1e-3
+      || Float.abs (got.x -. o.x) > 1e-3
+      || Float.abs (got.z -. o.z) > 1e-3
+    then begin
+      if !ok then
+        Printf.printf
+          "  transparent round-trip mismatch @%d: got {x=%g;y=%g;z=%g} want \
+           {x=%g;y=%g;z=%g}\n\
+           %!"
+          i
+          got.x
+          got.y
+          got.z
+          o.x
+          (o.y *. 2.0)
+          o.z ;
+      ok := false
+    end
+  done ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "transparent SoA output read back (PTX: leaf D2H + gather)"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
 (* The two integer-leaf device rows the handoff left open. Driven through the
    TRANSPARENT path, so one case covers both the mixed-width leaf addressing and
    the generic dispatch. Each leaf is compared to the reference independently. *)
@@ -989,6 +1066,16 @@ let () =
       if dev_can_f64 && not (check "dpair(f64)" dev n run_dpair) then
         ok := false ;
       if not (check_transparent dev n) then ok := false ;
+      (* Transparent OUTPUT read-back. PTX-gated — see the case's header for why
+         the non-PTX arm is blocked on backlog-172 rather than omitted. *)
+      if is_ptx dev then begin
+        if not (check_transparent_roundtrip dev n) then ok := false
+      end
+      else
+        Printf.printf
+          "  %-56s %s\n%!"
+          "transparent SoA output read back"
+          "SKIP (non-PTX: v.(i).f <- blocked on backlog-172)" ;
       if not (check_mixed_widths dev n) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -849,7 +849,7 @@ let check_transparent dev n =
    or a stale-input result could coincide with a correct one. Round 1 doubles
    y = i+1; round 2 starts from y = 1000-i, so a stale second round yields
    4*(i+1) and a correct one 2*(1000-i) — never equal for i in range. *)
-let check_relaunch dev n =
+let check_relaunch dev n ~writer_name ~write ~y_expected ~stale_note =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
   let sv = Soa_vector.create_transparent point3d_custom n in
@@ -864,11 +864,13 @@ let check_relaunch dev n =
       () ;
     Transfer.flush dev
   in
-  let fill y_of =
-    for i = 0 to n - 1 do
-      Vector.set sv i {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
-    done
-  in
+  (* The WRITER is a parameter, because the Stale_CPU write-loss is a property of
+     each host writer separately and not of the SoA path (backlog-190). Vector.set
+     was fixed first; unsafe_set carried the identical arm and fill's was a `| _
+     -> ()` catch-all, wider still. One case per writer, so a fix to one cannot
+     make the others look covered -- which is exactly how the class survived the
+     first fix. *)
+  let fill y_of = write sv n y_of in
   (* Round 1 — passes with or without the fix; it is here to establish the
      post-launch leaf state that the bug depends on. *)
   fill (fun i -> float_of_int (i + 1)) ;
@@ -880,7 +882,7 @@ let check_relaunch dev n =
   launch () ;
   let ok = ref true in
   for i = 0 to n - 1 do
-    let want = float_of_int (1000 - i) *. 2.0 in
+    let want = y_expected i in
     let got = (Vector.get sv i).y in
     if Float.abs (got -. want) > 1e-3 then begin
       if !ok then
@@ -889,13 +891,13 @@ let check_relaunch dev n =
           i
           got
           want
-          (float_of_int (i + 1) *. 4.0) ;
+          (stale_note i) ;
       ok := false
     end
   done ;
   Printf.printf
     "  %-56s %s\n%!"
-    "second launch sees the second host write"
+    (Printf.sprintf "second launch sees the second host write (%s)" writer_name)
     (if !ok then "OK" else "FAILED") ;
   !ok
 
@@ -1139,7 +1141,56 @@ let () =
         (* H5 (backlog-181): relaunch on the SAME vector. PTX-gated for the same
            reason as the case above — `v.(i).f <- e` is blocked on the two CPU
            backends until backlog-172 lands. *)
-        if not (check_relaunch dev n) then ok := false
+        (* One case per host writer (backlog-190). Vector.set was fixed with H5;
+           unsafe_set carried the identical Stale_CPU arm and fill's was a wider
+           catch-all. Separate cases so a fix to one cannot make the others read
+           as covered. kernel_set is deliberately absent: it is documented to skip
+           location handling entirely, because a per-element update would race
+           across the threads it exists to serve. *)
+        List.iter
+          (fun (writer_name, write, y_expected, stale_note) ->
+            if
+              not
+                (check_relaunch
+                   dev
+                   n
+                   ~writer_name
+                   ~write
+                   ~y_expected
+                   ~stale_note)
+            then ok := false)
+          [
+            ( "Vector.set",
+              (fun sv n y_of ->
+                for i = 0 to n - 1 do
+                  Vector.set
+                    sv
+                    i
+                    {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
+                done),
+              (fun i -> float_of_int (1000 - i) *. 2.0),
+              fun i -> float_of_int (i + 1) *. 4.0 );
+            ( "Vector.unsafe_set",
+              (fun sv n y_of ->
+                for i = 0 to n - 1 do
+                  Vector.unsafe_set
+                    sv
+                    i
+                    {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
+                done),
+              (fun i -> float_of_int (1000 - i) *. 2.0),
+              fun i -> float_of_int (i + 1) *. 4.0 );
+            (* fill writes ONE value to every element, so both the expectation
+               and the stale value are uniform. It takes y_of 0: round 1 fills
+               y=1 which the kernel doubles to 2; round 2 fills y=1000, doubled
+               to 2000. A stale round 2 would re-double round 1's result to 4 --
+               far from 2000, so the two cannot be confused. *)
+            ( "Vector.fill",
+              (fun sv n y_of ->
+                Vector.fill sv {x = 0.0; y = y_of 0; z = float_of_int n}),
+              (fun _ -> 2000.0),
+              fun _ -> 4.0 );
+          ]
       end
       else
         Printf.printf

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -700,6 +700,71 @@ let check_short_arg_list dev =
         Printf.printf "FAILED (refused, but not on arity: %s)\n%!" msg ;
         false
       end
+(* The TRANSPARENT path (backlog-54): Soa_vector.create_transparent + the
+   GENERIC Execute.run_vectors, with no SoA-specific launch entry point. This is
+   what the item is actually about — the caller opts a vector into SoA storage
+   and then launches normally.
+
+   Two properties, and they need different devices to be interesting:
+
+   - on CUDA/PTX the result must equal the AoS result (same kernel, same IR,
+     N-leaf ABI instead of one packed pointer);
+   - on every OTHER backend it must ALSO equal the AoS result, by silently taking
+     the packed path — that is the documented "never wrong data" fallback, and
+     asserting it here is the only thing that distinguishes "the fallback works"
+     from "the fallback was never exercised". This machine has no NVIDIA device,
+     so locally it is the fallback half that runs, and it would catch a
+     soa_dispatch predicate that fired on the wrong backend.
+
+   Correctness is checked against the pure-OCaml reference rather than against a
+   second GPU run, so a bug common to both device paths cannot hide. *)
+let check_transparent dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  for i = 0 to n - 1 do
+    Vector.set
+      sv
+      i
+      {
+        x = float_of_int i;
+        y = (float_of_int i *. 0.5) +. 1.0;
+        z = float_of_int (n - i);
+      }
+  done ;
+  let out = Vector.create Vector.float32 n in
+  let ir = ir_of p3_kernel in
+  Sarek.Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:[Vec sv; Vec out; Int n]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    let want =
+      float_of_int i +. ((float_of_int i *. 0.5) +. 1.0) +. float_of_int (n - i)
+    in
+    let got = Vector.get out i in
+    if Float.abs (got -. want) > 1e-3 then begin
+      if !ok then
+        Printf.printf
+          "  transparent SoA mismatch @%d: got=%g want=%g\n%!"
+          i
+          got
+          want ;
+      ok := false
+    end
+  done ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    (Printf.sprintf
+       "transparent SoA == reference (%s)"
+       (if is_ptx dev then "PTX: N-leaf ABI" else "non-PTX: AoS fallback"))
+    (if !ok then "OK" else "FAILED") ;
+  !ok
 
 let check_layout_wired dev =
   let ir = ir_of p3_kernel in
@@ -766,6 +831,7 @@ let () =
          f64 custom-vector gap that is out of scope for this emitter test and is
          exercised elsewhere.) *)
       if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false ;
+      if not (check_transparent dev n) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;
       (* Wiring + ordering: a mismatched must surface the LAYOUT error,

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -1438,6 +1438,142 @@ let check_host_write_survives_packed dev n =
     (if !ok then "OK" else "FAILED") ;
   !ok
 
+(* [Execute.sync_vectors_to_cpu] must bring a TRANSPARENT launch's output back.
+
+   Raised in review: that function is one line — [List.iter (function Vec v ->
+   Transfer.to_cpu v | _ -> ())] — with no [soa_from_device] anywhere in it, so it
+   "downloads the packed AoS buffer the SoA kernel never wrote". The premise about
+   the line is right and the conclusion does not follow: [Transfer.to_cpu] is not
+   the packed read. It is the dispatcher — it calls [Transfer.read_back_to_host]
+   (Transfer.ml:507), whose SoA arm calls [soa_from_device] when
+   [soa_leaves_live]. Selecting the arm at THIS call site instead would be a
+   second site answering "SoA or AoS?", which is the divergence the single
+   decision point exists to prevent.
+
+   Asserted rather than argued, and with auto-sync DISABLED on the vector, which
+   is what makes the observation about [sync_vectors_to_cpu] rather than about
+   [Vector.get]: with auto-sync on, [get] would gather through [ensure_cpu_sync]
+   and the row would pass whatever this function did. Off, the only thing between
+   the launch and the assertion is the call under test.
+
+   This is also the function's only coverage anywhere in the tree: nothing else in
+   the repository calls it (it is public API reached only from user code), which
+   is how a claim about it could stand unchecked for a whole review round. *)
+let check_sync_vectors_to_cpu_gathers dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  (* AFTER the host writes, so the scatter inside the launch still sees them. *)
+  Vector.set_auto_sync sv false ;
+  let ok = ref true in
+  (match
+     Sarek.Execute.run_vectors
+       ~device:dev
+       ~ir:(ir_of p3_scale_y_kernel)
+       ~args:[Vec sv; Int n]
+       ~block
+       ~grid
+       () ;
+     Transfer.flush dev ;
+     (* THE CALL UNDER TEST, and the only read-back in this case. *)
+     Sarek.Execute.sync_vectors_to_cpu [Vec sv; Int n]
+   with
+  | exception e ->
+      Printf.printf
+        "  sync_vectors_to_cpu after a transparent launch raised: %s\n%!"
+        (Printexc.to_string e) ;
+      ok := false
+  | () ->
+      let first = ref true in
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y and want = y0 i *. 2.0 in
+        if Float.abs (got -. want) > 1e-3 && !first then begin
+          first := false ;
+          Printf.printf
+            "  sync_vectors_to_cpu did not gather @%d: got=%g want=%g (the \
+             un-gathered host value is %g)\n\
+             %!"
+            i
+            got
+            want
+            (y0 i) ;
+          ok := false
+        end
+      done) ;
+  Vector.set_auto_sync sv true ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "sync_vectors_to_cpu gathers a transparent launch's output"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
+(* A direct [Execute.run] — not [run_vectors] — on a transparent vector whose
+   leaves were never uploaded must REFUSE, not bind a short argument list.
+
+   Raised in review: [run] can be called directly, in which case
+   [transfer_vectors_to_device] never ran and [soa_leaf_bufs dev] "may return
+   fewer buffers than the leaf count baked into the source", giving the driver a
+   short kernel-argument array — the over-read [check_launch_args] documents, on
+   the expansion side.
+
+   Two answers, and this case executes the first. [soa_leaf_bufs] does not return
+   a short list: [Soa_vector]'s [leaf_buf] raises [invalid_arg] for a leaf with no
+   buffer on [dev] (Soa_vector.ml:148-160), which is exactly the never-transferred
+   case. And the leaf-count guard added this round is INSIDE
+   [expand_to_run_source_args] (Execute.ml, the [Vec] arm), which [run] itself
+   calls on the generated-JIT path — so it is on a direct [run]'s path, not only
+   [run_vectors]'.
+
+   Either refusal is accepted, but a LAUNCH is not: what must never happen is the
+   call returning normally, because that is the short-argument-array case. The
+   message is checked for the leaf-buffer wording so an unrelated failure cannot
+   satisfy it. *)
+let check_direct_run_refuses_untransferred dev n =
+  let threads = min 32 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = float_of_int i; z = 0.0}
+  done ;
+  let ir = ir_of p3_scale_y_kernel in
+  let label = "direct run without a transfer is refused, not launched" in
+  match
+    (* No transfer_vectors_to_device, deliberately: that is the whole case. *)
+    Sarek.Execute.run
+      ~device:dev
+      ~name:ir.Sarek_ir_types.kern_name
+      ~ir:(Some (lazy ir))
+      ~native_fn:None
+      ~block
+      ~grid
+      [Vec sv; Int n]
+  with
+  | () ->
+      Printf.printf
+        "  %-56s FAILED (it launched with no leaf buffers uploaded)\n%!"
+        label ;
+      false
+  | exception e ->
+      let msg = Printexc.to_string e in
+      let named =
+        contains msg "leaf buffer not allocated"
+        || contains msg "soa_to_device must run"
+        || contains msg "leaf buffer(s) on device"
+      in
+      if named then (
+        Printf.printf "  %-56s OK (refused)\n%!" label ;
+        true)
+      else (
+        Printf.printf
+          "  %-56s FAILED (raised, but not about the leaves: %s)\n%!"
+          label
+          msg ;
+        false)
+
 let check_soa_then_packed dev n =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -2108,6 +2244,15 @@ let () =
              cases pin the two directions of one condition. *)
           ( "a host write between an SoA and a packed launch survives",
             fun () -> check_host_write_survives_packed dev n );
+          (* The two cases the round-5 review asked for by name: whether
+             [Execute.sync_vectors_to_cpu] reaches the leaves, and whether a
+             direct [Execute.run] can bind a short leaf-pointer list. Both are
+             about the SoA ABI itself, so they carry the same blocker as the rest
+             of this group. *)
+          ( "sync_vectors_to_cpu gathers a transparent launch's output",
+            fun () -> check_sync_vectors_to_cpu_gathers dev n );
+          ( "direct run without a transfer is refused, not launched",
+            fun () -> check_direct_run_refuses_untransferred dev n );
           ( "free_all_buffers preserves a transparent SoA result",
             fun () -> check_free_preserves_soa dev n );
           (* And the free must RELEASE, not merely preserve — a separate claim

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -696,9 +696,12 @@ let check_gate dev =
    leaf back (D2H) and gather into the AoS vector, and check the AoS y values.
    Exercises the leaf-writeback + Soa_vector.gather path (no other shipped test
    writes an SoA leaf). CUDA/PTX only. *)
+(* No [is_ptx] early return: the caller routes this through [guarded], which
+   prints the named skip. Returning [true] silently here as well would be the
+   skip-as-pass shape twice over, and the guard would then be the only thing
+   keeping the row visible. *)
 let check_roundtrip dev n =
-  if not (is_ptx dev) then true
-  else begin
+  begin
     Printf.printf
       "SoA-roundtrip [%s] %s: %!"
       dev.Device.framework
@@ -1086,7 +1089,7 @@ let check_short_arg_list dev =
      from "the fallback was never exercised". It would catch a soa_dispatch
      predicate that fired on the wrong backend.
 
-     CORRECTED 2026-07-30 — this comment used to add "this machine has no NVIDIA
+     CORRECTED — this comment used to add "this machine has no NVIDIA
      device, so locally it is the fallback half that runs", which contradicted the
      header of the integer-combo cases in this same file ("it needs a CUDA/PTX
      device. ZLUDA provides one") and pointed a reader away from the arm that
@@ -1147,34 +1150,6 @@ let check_transparent dev n =
     (if !ok then "OK" else "FAILED") ;
   !ok
 
-(* Transparent OUTPUT round-trip: a kernel writes the y leaf and the host reads
-   the result back with a plain [Vector.get] — no leaf iteration, no explicit
-   gather. That is the whole claim of the transparent path, and it is a different
-   claim from {!check_roundtrip}, which does the D2H and the gather BY HAND
-   because [Soa_launch.run_soa] documents that as the caller's job.
-
-   Nothing covered it before, and the gap was not cosmetic: [check_transparent]
-   above writes its results into a separate plain [out] vector, so it holds the
-   SoA vector INPUT-only. With the SoA ABI selected, a launch writes the N leaf
-   buffers and leaves the packed AoS buffer untouched — which is precisely what
-   an ordinary [Transfer.to_cpu] downloads. Every assertion above would still
-   have passed while a kernel's output was silently discarded.
-
-   Runs on every device EXCEPT the two CPU backends — see
-   {!blocker_cpu_field_store}. The stronger test was always the wider one: the
-   same [Vector.get] should return the same answer through the packed AoS
-   fallback, and as of 2026-07-30 it is asserted there, on OpenCL x2 and Vulkan
-   x2 as well as on CUDA/PTX.
-
-   Until round 4 this was gated on [is_ptx], with the CPU-backend defect
-   (backlog-172) given as the reason. The defect is real — the Interpreter
-   REFUSES [pts.(tid).y <- …] (Sarek_ir_interp_eval.assign_lvalue's
-   [LRecordField] arm raises [Unsupported_operation "record field assignment"])
-   and Native accepts it and silently drops the store (measured: y unchanged at 1
-   where 2 was expected) — but it is a defect of those two backends only, and
-   using it to withhold the case from OpenCL and Vulkan withheld four real
-   assertions under a reason false of all four devices. When 172 lands, delete
-   the blocker; the assertion below needs no other change. *)
 (* TWO launches on ONE vector, with different host data in between (H5,
    backlog-181). This is the case no existing test constructs — every other one
    allocates a fresh vector — and that is exactly why the defect was invisible to
@@ -1251,6 +1226,34 @@ let check_relaunch dev n ~writer_name ~write ~y_expected ~stale_note =
     (if !ok then "OK" else "FAILED") ;
   !ok
 
+(* Transparent OUTPUT round-trip: a kernel writes the y leaf and the host reads
+   the result back with a plain [Vector.get] — no leaf iteration, no explicit
+   gather. That is the whole claim of the transparent path, and it is a different
+   claim from {!check_roundtrip}, which does the D2H and the gather BY HAND
+   because [Soa_launch.run_soa] documents that as the caller's job.
+
+   Nothing covered it before, and the gap was not cosmetic: [check_transparent]
+   above writes its results into a separate plain [out] vector, so it holds the
+   SoA vector INPUT-only. With the SoA ABI selected, a launch writes the N leaf
+   buffers and leaves the packed AoS buffer untouched — which is precisely what
+   an ordinary [Transfer.to_cpu] downloads. Every assertion above would still
+   have passed while a kernel's output was silently discarded.
+
+   Runs on every device EXCEPT the two CPU backends — see
+   {!blocker_cpu_field_store}. The stronger test was always the wider one: the
+   same [Vector.get] should return the same answer through the packed AoS
+   fallback, and as of 2026-07-30 it is asserted there, on OpenCL x2 and Vulkan
+   x2 as well as on CUDA/PTX.
+
+   Until round 4 this was gated on [is_ptx], with the CPU-backend defect
+   (backlog-172) given as the reason. The defect is real — the Interpreter
+   REFUSES [pts.(tid).y <- …] (Sarek_ir_interp_eval.assign_lvalue's
+   [LRecordField] arm raises [Unsupported_operation "record field assignment"])
+   and Native accepts it and silently drops the store (measured: y unchanged at 1
+   where 2 was expected) — but it is a defect of those two backends only, and
+   using it to withhold the case from OpenCL and Vulkan withheld four real
+   assertions under a reason false of all four devices. When 172 lands, delete
+   the blocker; the assertion below needs no other change. *)
 let check_transparent_roundtrip dev n =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -1313,29 +1316,6 @@ let check_transparent_roundtrip dev n =
     (if !ok then "OK" else "FAILED") ;
   !ok
 
-(* SoA ABI, then PACKED AoS ABI, on ONE vector, with NO host read-back in
-   between.
-
-   [soa_leaves_live] was only ever set — nothing cleared it. So once a transparent
-   CUDA/PTX launch had run, EVERY later read-back on that vector followed the
-   leaves for the rest of its life, no matter which ABI the most recent launch
-   actually used. [Execute.run_source] deliberately keeps the packed ABI (it hands
-   the backend a source string Sarek did not emit), which makes this sequence
-   reachable through the public API with no unusual step.
-
-   The second launch is the assertion; the first would pass either way. And the
-   missing read-back in between is the whole point — inserting one would clear the
-   staleness by accident and the case would pass unfixed.
-
-   The packed source is the SAME IR compiled WITHOUT ~soa_params rather than
-   hand-written PTX, so this case cannot pass or fail for a PTX-authoring reason.
-
-   Both expectations are distinguishable: y0 = i+1, each launch doubles y, so the
-   correct answer is 4*(i+1) and following the stale leaves gives 2*(i+1) —
-   never equal. Pre-fix the failure is in fact LOUDER than that (the packed
-   launch has no buffer to bind, because the transparent path never allocates
-   one), which is why the exception is caught and reported rather than left to
-   abort the binary: a red state that is a crash is not an observation. *)
 (* A HOST WRITE between a transparent launch and a packed one must survive.
 
    Same two launches as {!check_soa_then_packed}, with one statement added
@@ -1459,6 +1439,66 @@ let check_host_write_survives_packed dev n =
    This is also the function's only coverage anywhere in the tree: nothing else in
    the repository calls it (it is public API reached only from user code), which
    is how a claim about it could stand unchecked for a whole review round. *)
+(* Does [Gpu_memory] track allocations on a NON-GPU device?
+
+   The migration suite's byte-split arm accepts any framework for its destination,
+   and review asked twice whether that holds — whether [Device.all ()] hands back
+   Native/Interpreter devices and whether their allocations are counted, because
+   if they are not, the byte delta there is 0 and the arm fails instead of
+   measuring anything. I refuted it by citation
+   ([Transfer.ensure_buffer] calls [Gpu_memory.track_alloc (B.size * B.elem_size)]
+   at Transfer.ml:232, on a wrapper whose [size]/[elem_size] come from the request
+   at Transfer.ml:150-152, with nothing backend-conditional between them).
+
+   A citation is not a measurement, and the measurement is cheap, so it is here
+   instead. Asserted for EVERY enumerated device rather than only the CPU
+   backends: "the accounting is framework-agnostic" is the claim, and checking it
+   only where it is doubted would leave the general form unchecked.
+
+   Exactly [length * elem_size], not merely "> 0": a tracker that counted
+   allocations rather than bytes would satisfy the weaker form, and the migration
+   arm compares deltas against each other, so the number has to be the right
+   one. *)
+let check_alloc_tracking_is_framework_agnostic dev =
+  let n = 64 in
+  let v = Vector.create_custom point3d_custom n in
+  let expect = n * point3d_custom.Vector.elem_size in
+  Gc.full_major () ;
+  let before = Gpu_memory.usage () in
+  let ok =
+    match Transfer.to_device v dev with
+    | () ->
+        let got = Gpu_memory.usage () - before in
+        if got = expect then true
+        else begin
+          Printf.printf
+            "  alloc tracking on [%s] %s: %d bytes tracked, want %d (%d elems \
+             x %d B)\n\
+             %!"
+            dev.Device.framework
+            dev.Device.name
+            got
+            expect
+            n
+            point3d_custom.Vector.elem_size ;
+          false
+        end
+    | exception e ->
+        Printf.printf
+          "  alloc tracking on [%s] %s: to_device raised: %s\n%!"
+          dev.Device.framework
+          dev.Device.name
+          (Printexc.to_string e) ;
+        false
+  in
+  Transfer.free_all_buffers v ;
+  ignore (Sys.opaque_identity v) ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "Gpu_memory tracks this device's bytes (any framework)"
+    (if ok then "OK" else "FAILED") ;
+  ok
+
 let check_sync_vectors_to_cpu_gathers dev n =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -1531,7 +1571,19 @@ let check_sync_vectors_to_cpu_gathers dev n =
    Either refusal is accepted, but a LAUNCH is not: what must never happen is the
    call returning normally, because that is the short-argument-array case. The
    message is checked for the leaf-buffer wording so an unrelated failure cannot
-   satisfy it. *)
+   satisfy it.
+
+   WHAT THIS ROW CAN AND CANNOT REPORT. Its red state is a process CRASH, not a
+   FAILED line, and that is the finding rather than a shortcoming: with the guard
+   disabled AND [soa_leaf_bufs] changed to drop leaves that have no buffer instead
+   of raising, this call SIGSEGVs — measured, exit 139, immediately after the row
+   above it prints. So the mutation kills the binary before this row can print
+   anything, which is exactly the driver over-read the guard exists to prevent,
+   observed. The positive control for this case is therefore the exit code of the
+   whole run, and what the row itself asserts is the narrower thing: that on the
+   current code the call is REFUSED, by name, rather than reaching a launch. A
+   FAILED line here would mean [run] returned normally — the third outcome, and
+   the only one nothing else would catch. *)
 let check_direct_run_refuses_untransferred dev n =
   let threads = min 32 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -1574,6 +1626,29 @@ let check_direct_run_refuses_untransferred dev n =
           msg ;
         false)
 
+(* SoA ABI, then PACKED AoS ABI, on ONE vector, with NO host read-back in
+   between.
+
+   [soa_leaves_live] was only ever set — nothing cleared it. So once a transparent
+   CUDA/PTX launch had run, EVERY later read-back on that vector followed the
+   leaves for the rest of its life, no matter which ABI the most recent launch
+   actually used. [Execute.run_source] deliberately keeps the packed ABI (it hands
+   the backend a source string Sarek did not emit), which makes this sequence
+   reachable through the public API with no unusual step.
+
+   The second launch is the assertion; the first would pass either way. And the
+   missing read-back in between is the whole point — inserting one would clear the
+   staleness by accident and the case would pass unfixed.
+
+   The packed source is the SAME IR compiled WITHOUT ~soa_params rather than
+   hand-written PTX, so this case cannot pass or fail for a PTX-authoring reason.
+
+   Both expectations are distinguishable: y0 = i+1, each launch doubles y, so the
+   correct answer is 4*(i+1) and following the stale leaves gives 2*(i+1) —
+   never equal. Pre-fix the failure is in fact LOUDER than that (the packed
+   launch has no buffer to bind, because the transparent path never allocates
+   one), which is why the exception is caught and reported rather than left to
+   abort the binary: a red state that is a crash is not an observation. *)
 let check_soa_then_packed dev n =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -2110,7 +2185,7 @@ let () =
       (* dpair (f64) proves the 8-byte SoA leaf. Gated on the DEVICE's fp64
          capability, not on CUDA/PTX.
 
-         CORRECTED 2026-07-30 — the previous restriction to PTX was justified as
+         CORRECTED — the previous restriction to PTX was justified as
          "some non-PTX backends, e.g. OpenCL/radeonsi, have an unrelated f64
          custom-vector gap". That attribution is wrong. Measured: with
          RUSTICL_FEATURES=fp64 set, this row PASSES on OpenCL/radeonsi (both
@@ -2265,6 +2340,10 @@ let () =
           ( "free_buffer leaves the vector coherent (location/re-read/re-upload)",
             fun () -> check_free_buffer_coherent dev n );
         ] ;
+      (* Device-independent in the sense that matters: it asserts the SAME
+         property on every framework, which is what the migration suite's
+         any-framework destination rests on. *)
+      if not (check_alloc_tracking_is_framework_agnostic dev) then ok := false ;
       if not (check_mixed_widths dev n) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;
@@ -2276,6 +2355,18 @@ let () =
          CUDA host. *)
       if not (check_short_arg_list dev) then ok := false ;
       (* Leaf-write round-trip (D2H + gather) on CUDA/PTX. *)
-      if is_ptx dev && not (check_roundtrip dev n) then ok := false)
+      (* Through [guarded] like the group above it, not a bare [if is_ptx]:
+         that conjunct printed nothing at all on a non-PTX device, which is the
+         last skip-as-pass row in this loop. The blocker is the SoA-ABI one — the
+         hand-written D2H + gather this case performs is only meaningful where
+         the leaf ABI was selected. *)
+      if
+        not
+          (guarded
+             dev
+             ~blockers:[blocker_needs_soa_abi]
+             ~label:"SoA leaf-write round trip"
+             (fun () -> check_roundtrip dev n))
+      then ok := false)
     devs ;
   if not (!ok && layout_ok) then exit 1

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -190,17 +190,37 @@ type blocker = {
    asserting it was "every framework Sarek can enumerate". It was not, and the
    comment is what made that unfalsifiable. Three names were missing:
 
-     - "CUDA/C"  — sarek-cuda/Cuda_c_plugin.ml, [let name = "CUDA/C"], entered
-                   into the table by [Framework_registry.register_backend].
-                   [Device.ml:32] documents "<family>/<variant>" names as first
-                   class, so "CUDA/PTX" and "CUDA/C" are two frameworks, not two
-                   spellings of one.
-     - "WebGPU"  — sarek/plugins/webgpu/Webgpu_plugin.ml, likewise a
-                   [register_backend] backend that produces devices whose
-                   [framework] field carries that name.
-     - "HIP"     — requested by [Device.init]'s default framework list
-                   ([Device.ml:42-43]) and special-cased by [Device.is_gpu]
-                   ([:203]), with no registering backend today.
+     - "CUDA/C"  — sarek-cuda/Cuda_c_plugin.ml, [let name = "CUDA/C"] ([:26]),
+                   entered into the table by
+                   [Framework_registry.register_backend] ([:89]).
+                   [Device.ml:30-34] documents "<family>/<variant>" names as
+                   first class, so "CUDA/PTX" and "CUDA/C" are two frameworks,
+                   not two spellings of one.
+     - "WebGPU"  — sarek/plugins/webgpu/Webgpu_plugin.ml, [let name = "WebGPU"]
+                   ([:43]), likewise a [register_backend] backend ([:191]) that
+                   produces devices whose [framework] field carries that name.
+     - "HIP"     — sarek-hip/Hip_plugin.ml, likewise a [register_backend]
+                   backend ([:86]) under [let name = "HIP"]
+                   ([Hip_plugin_base.ml:17]), forced at module init on [:93]. It
+                   is additionally requested by [Device.init]'s default framework
+                   list ([Device.ml:41-43]) and special-cased by [Device.is_gpu]
+                   ([:203]). Round 5 of this comment (and its commit message,
+                   which cannot be rewritten) said HIP had "no registering
+                   backend today"; that was false, and this bullet supersedes it.
+
+   All three sit in one category, and it is the category the union below exists
+   for: a [register_backend] backend whose name is absent from THIS host's table
+   only because nothing forced its registration or [is_available ()] returned
+   false. None of them is a name Sarek cannot produce a [Device.t] for.
+
+   One name in [Device.init]'s default list is deliberately NOT in the floor: the
+   bare family name "CUDA" ([Device.ml:43]), which [Device.is_cuda_framework]
+   ([:140]) also recognises. No backend registers under it — [resolve_framework]
+   ([:35-38]) expands a family name to the registered variants, so no [Device.t]
+   ever carries "CUDA" in its [framework] field, and the floor is a set of names
+   a device can actually have (which is what [applies] and [describes] are
+   quantified over). If a backend ever did register under the bare name, the
+   staleness check below would name it rather than let it pass.
 
    Adding them makes round 4's own wiring FAIL: [blocker_needs_soa_abi] fired on
    all three while describing none of them, so the guarantee two comments above —
@@ -218,15 +238,20 @@ type blocker = {
 
    Why the registry is not the sole source either, though that would be
    drift-proof by construction: a backend enters that table only when something
-   forces its registration AND its [is_available ()] returns true on this host —
-   [Cuda_ptx_plugin.ml:80-95] and [Cuda_c_plugin.ml:80-99] are both [lazy] behind
-   an explicit [register ()]. The table is a snapshot of what this host can run,
-   not of what Sarek can name. Two consequences, both fatal to deriving from it:
-   in THIS executable [Backend_loader.init] forces only [Cuda_plugin.init], which
-   forces only the PTX plugin ([Cuda_plugin.ml:11]), so "CUDA/C" never appears in
-   the table however complete the tree is; and on a CUDA-less host "CUDA/PTX"
-   would drop out of the universe, leaving [describes] naming a framework the
-   universe no longer contains. Deriving from the registry would shrink the
+   forces its registration AND its [is_available ()] returns true on this host.
+   Every plugin's [registered_backend] is [lazy], and the forcing comes in two
+   shapes: at module init unless the backend is env-disabled
+   ([Cuda_ptx_plugin.ml:99], [Hip_plugin.ml:93], [Webgpu_plugin.ml:195]), or only
+   from an explicit [register ()] call ([Cuda_c_plugin.ml:98-99]). The table is a
+   snapshot of what this host can run, not of what Sarek can name. Three
+   consequences, all fatal to deriving from it: in THIS executable
+   [Backend_loader.init] forces only [Cuda_plugin.init], which forces only the
+   PTX plugin ([Cuda_plugin.ml:11]), so "CUDA/C" never appears in the table
+   however complete the tree is; "HIP" and "WebGPU" cannot appear either, because
+   module-init forcing needs the module to be LINKED and neither sarek-hip nor
+   the webgpu plugin is in this executable's [libraries]; and on a CUDA-less host
+   "CUDA/PTX" would drop out of the universe, leaving [describes] naming a
+   framework the universe no longer contains. Deriving from the registry would shrink the
    universe to the local hardware — precisely what taking a framework NAME rather
    than a [Device.t] exists to avoid.
 

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -78,6 +78,50 @@ let p3_scale_y_kernel =
         let tid = thread_idx_x + (block_idx_x * block_dim_x) in
         if tid < n then pts.(tid).y <- pts.(tid).y *. 2.0]
 
+(* INTEGER leaf combos, executed on device. The Tier 1b handoff shipped these two
+   at the PTX-instruction and ptxas-assembly level only and marked device
+   execution "(Tier 1c)" — the row it could not fill, because it needs a CUDA/PTX
+   device. ZLUDA provides one.
+
+   Not redundant with point3d/dpair: those are uniform-width (3 x 4B, 2 x 8B),
+   while these MIX widths, which is what makes the per-leaf stride and the AoS
+   padding distinguishable. [mixed] is 4B then 8B (pad after the i32),
+   [longpair] is 8B then 4B (trailing pad) — the two orders put the padding in
+   different places. *)
+type mixed = {i : int32; d : float64} [@@sarek.type]
+
+type longpair = {p : int64; q : int32} [@@sarek.type]
+
+(* Each leaf goes to its OWN output array, at its own width. Deliberately no
+   int<->float conversion: a conversion folds both leaves into one number, and a
+   per-leaf stride error could then be masked by a compensating error in the
+   other leaf. Separate outputs make each leaf independently falsifiable. *)
+let mixed_kernel =
+  snd
+    [%kernel
+      fun (mv : mixed vector)
+          (oi : int32 vector)
+          (od : float64 vector)
+          (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then begin
+          oi.(tid) <- mv.(tid).i ;
+          od.(tid) <- mv.(tid).d
+        end]
+
+let longpair_kernel =
+  snd
+    [%kernel
+      fun (lv : longpair vector)
+          (op : int64 vector)
+          (oq : int32 vector)
+          (n : int32) ->
+        let tid = thread_idx_x + (block_idx_x * block_dim_x) in
+        if tid < n then begin
+          op.(tid) <- lv.(tid).p ;
+          oq.(tid) <- lv.(tid).q
+        end]
+
 let ir_of kirc =
   match kirc.Sarek.Kirc_types.body_ir with
   | Some ir -> ir
@@ -766,6 +810,95 @@ let check_transparent dev n =
     (if !ok then "OK" else "FAILED") ;
   !ok
 
+(* The two integer-leaf device rows the handoff left open. Driven through the
+   TRANSPARENT path, so one case covers both the mixed-width leaf addressing and
+   the generic dispatch. Each leaf is compared to the reference independently. *)
+let check_mixed_widths dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let ok = ref true in
+  let report label good =
+    Printf.printf
+      "  %-56s %s\n%!"
+      (Printf.sprintf
+         "%s (%s)"
+         label
+         (if is_ptx dev then "PTX: N-leaf ABI" else "non-PTX: AoS fallback"))
+      (if good then "OK" else "FAILED") ;
+    if not good then ok := false
+  in
+  (* i32 + f64. Gated on the DEVICE's fp64 capability rather than on
+     "CUDA/PTX only" the way the dpair row is: the f64 leaf makes this an fp64
+     kernel, and the launch gate refuses it on a device that does not report
+     double precision (radeonsi/OpenCL here). Keying on the capability rather
+     than the framework runs the row on every device that can actually execute
+     it — and keeps this test measuring SoA leaf addressing rather than
+     re-discovering the fp64 gate. A CPU backend evaluates in OCaml doubles, so
+     it is always able. *)
+  let f = dev.Device.framework in
+  let can_f64 = f = "Native" || f = "Interpreter" || Device.allows_fp64 dev in
+  if not can_f64 then
+    Printf.printf
+      "  %-56s SKIP (device reports no fp64)\n%!"
+      "SoA i32+f64 leaves == reference"
+  else begin
+    let mv = Soa_vector.create_transparent mixed_custom n in
+    for k = 0 to n - 1 do
+      Vector.set mv k {i = Int32.of_int (k * 3); d = float_of_int k *. 0.25}
+    done ;
+    let oi = Vector.create Vector.int32 n in
+    let od = Vector.create Vector.float64 n in
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of mixed_kernel)
+      ~args:[Vec mv; Vec oi; Vec od; Int n]
+      ~block
+      ~grid
+      () ;
+    Transfer.flush dev ;
+    let good = ref true in
+    for k = 0 to n - 1 do
+      if Int32.to_int (Vector.get oi k) <> k * 3 then good := false ;
+      if Float.abs (Vector.get od k -. (float_of_int k *. 0.25)) > 1e-12 then
+        good := false
+    done ;
+    report "SoA i32+f64 leaves == reference" !good
+  end ;
+  (* i64 + i32. No f64 leaf, but a 64-bit INTEGER one, which is its own
+     device-optional capability (shaderInt64 on Vulkan) — same reasoning, same
+     shape of gate. *)
+  let can_i64 = f = "Native" || f = "Interpreter" || Device.allows_int64 dev in
+  if not can_i64 then
+    Printf.printf
+      "  %-56s SKIP (device reports no int64)\n%!"
+      "SoA i64+i32 leaves == reference"
+  else begin
+    let lv = Soa_vector.create_transparent longpair_custom n in
+    for k = 0 to n - 1 do
+      Vector.set
+        lv
+        k
+        {p = Int64.of_int ((k * 1000003) + 7); q = Int32.of_int (k - 5)}
+    done ;
+    let op = Vector.create Vector.int64 n in
+    let oq = Vector.create Vector.int32 n in
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of longpair_kernel)
+      ~args:[Vec lv; Vec op; Vec oq; Int n]
+      ~block
+      ~grid
+      () ;
+    Transfer.flush dev ;
+    let good = ref true in
+    for k = 0 to n - 1 do
+      if Int64.to_int (Vector.get op k) <> (k * 1000003) + 7 then good := false ;
+      if Int32.to_int (Vector.get oq k) <> k - 5 then good := false
+    done ;
+    report "SoA i64+i32 leaves == reference" !good
+  end ;
+  !ok
+
 let check_layout_wired dev =
   let ir = ir_of p3_kernel in
   let sv = Soa_vector.create dpair_custom 8 in
@@ -832,6 +965,7 @@ let () =
          exercised elsewhere.) *)
       if is_ptx dev && not (check "dpair(f64)" dev n run_dpair) then ok := false ;
       if not (check_transparent dev n) then ok := false ;
+      if not (check_mixed_widths dev n) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;
       (* Wiring + ordering: a mismatched must surface the LAYOUT error,

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -162,9 +162,11 @@ let dims threads = Sarek.Execute.dims1d threads
    printed on a device its predicate does not describe is now unrepresentable.
 
    [applies] takes the framework NAME rather than a [Device.t] so that
-   {!check_skip_reason_scope} can evaluate it over every framework Sarek can
-   enumerate, not merely the ones plugged into the host running the suite. Both
-   real blockers are framework-level facts, so nothing is lost. *)
+   {!check_skip_reason_scope} can evaluate it over a declared, host-independent
+   set of framework names (see {!declared_frameworks} for what that set is and,
+   as importantly, what it does not claim to be) rather than merely the backends
+   plugged into the host running the suite. Both real blockers are
+   framework-level facts, so nothing is lost. *)
 type blocker = {
   reason : string;
       (** Printed verbatim as the skip line. Must be true of every framework in
@@ -180,12 +182,76 @@ type blocker = {
           thing it checks cannot fail. *)
 }
 
-(* Every framework Sarek can enumerate. The universe {!check_skip_reason_scope}
-   quantifies over; a blocker predicate that fires outside its [describes] on ANY
-   of these is a false claim waiting for that device to appear, whether or not
-   this host has one. *)
-let all_frameworks =
-  ["CUDA/PTX"; "OpenCL"; "Vulkan"; "Metal"; "Native"; "Interpreter"]
+(* The universe {!check_skip_reason_scope} quantifies over: a blocker predicate
+   that fires outside its [describes] on ANY member is a false claim waiting for
+   that device to appear, whether or not this host has one.
+
+   Round 4 wrote this as a hand-maintained list of six names under a comment
+   asserting it was "every framework Sarek can enumerate". It was not, and the
+   comment is what made that unfalsifiable. Three names were missing:
+
+     - "CUDA/C"  — sarek-cuda/Cuda_c_plugin.ml, [let name = "CUDA/C"], entered
+                   into the table by [Framework_registry.register_backend].
+                   [Device.ml:32] documents "<family>/<variant>" names as first
+                   class, so "CUDA/PTX" and "CUDA/C" are two frameworks, not two
+                   spellings of one.
+     - "WebGPU"  — sarek/plugins/webgpu/Webgpu_plugin.ml, likewise a
+                   [register_backend] backend that produces devices whose
+                   [framework] field carries that name.
+     - "HIP"     — requested by [Device.init]'s default framework list
+                   ([Device.ml:42-43]) and special-cased by [Device.is_gpu]
+                   ([:203]), with no registering backend today.
+
+   Adding them makes round 4's own wiring FAIL: [blocker_needs_soa_abi] fired on
+   all three while describing none of them, so the guarantee two comments above —
+   "a reason printed on a device its predicate does not describe is now
+   unrepresentable" — was false of exactly the frameworks the list had dropped.
+
+   The omissions are the symptom. The defect is a hand-maintained list that only
+   a reader's diligence keeps in step with the plugin tree, so the list stops
+   being the sole source: the universe is the declared floor below UNION every
+   name in [Framework_registry.all_backend_names ()] at check time, and
+   {!check_skip_reason_scope} additionally fails if the registry holds a name the
+   floor does not declare. A backend added later joins the universe on its own,
+   and is reported as a staleness failure here rather than silently widening a
+   blocker's claim.
+
+   Why the registry is not the sole source either, though that would be
+   drift-proof by construction: a backend enters that table only when something
+   forces its registration AND its [is_available ()] returns true on this host —
+   [Cuda_ptx_plugin.ml:80-95] and [Cuda_c_plugin.ml:80-99] are both [lazy] behind
+   an explicit [register ()]. The table is a snapshot of what this host can run,
+   not of what Sarek can name. Two consequences, both fatal to deriving from it:
+   in THIS executable [Backend_loader.init] forces only [Cuda_plugin.init], which
+   forces only the PTX plugin ([Cuda_plugin.ml:11]), so "CUDA/C" never appears in
+   the table however complete the tree is; and on a CUDA-less host "CUDA/PTX"
+   would drop out of the universe, leaving [describes] naming a framework the
+   universe no longer contains. Deriving from the registry would shrink the
+   universe to the local hardware — precisely what taking a framework NAME rather
+   than a [Device.t] exists to avoid.
+
+   So: the floor buys host-independence, the union buys anti-drift, and the
+   staleness check makes a stale floor a named failure instead of a quiet gap.
+   The check prints both halves, so a run shows which source contributed what
+   rather than leaving the union's second half to be assumed. *)
+let declared_frameworks =
+  [
+    "CUDA/PTX";
+    "CUDA/C";
+    "HIP";
+    "OpenCL";
+    "Vulkan";
+    "Metal";
+    "WebGPU";
+    "Native";
+    "Interpreter";
+  ]
+
+let registered_frameworks () =
+  Spoc_framework_registry.Framework_registry.all_backend_names ()
+
+let all_frameworks () =
+  List.sort_uniq compare (declared_frameworks @ registered_frameworks ())
 
 (* `v.(i).f <- e` from inside a kernel — a record-field store — is unsupported on
    the two CPU backends and ONLY those two: the Interpreter raises
@@ -199,7 +265,14 @@ let all_frameworks =
    cases carrying this blocker PASS on OpenCL x2 (radeonsi: RX 7900 XTX +
    7950X iGPU) and Vulkan x2 (RADV: same two), through the packed AoS fallback —
    which is the stronger assertion anyway, since the same [Vector.get] must
-   return the same answer under either ABI. *)
+   return the same answer under either ABI.
+
+   On the three frameworks in {!declared_frameworks} that no device here provides
+   — CUDA/C, WebGPU, HIP — this blocker not applying is a claim about the SCOPE OF
+   BACKLOG-172, which is a defect of the two CPU backends' lvalue handling, and
+   not a measured pass. Those cases are skipped there by
+   {!blocker_needs_soa_abi} in any case, so the distinction costs no coverage
+   today; it is stated so the [describes] set is not read as evidence it is not. *)
 let blocker_cpu_field_store =
   {
     reason = "SKIP (v.(i).f <- unsupported on this CPU backend: backlog-172)";
@@ -209,12 +282,35 @@ let blocker_cpu_field_store =
 
 (* The SoA ABI is selected on CUDA/PTX and nowhere else. Unlike the blocker
    above this is by design and permanent, not a defect that will lift — which is
-   why the two are separate records rather than one merged "not supported here". *)
+   why the two are separate records rather than one merged "not supported here".
+
+   [Execute.ml:276] gates the SoA path on [framework = "CUDA/PTX"], a string
+   equality against that one name, so the skip is semantically right on the three
+   frameworks round 4's universe had omitted: CUDA/C is a DIFFERENT registered
+   backend name and does not satisfy that equality, and neither do WebGPU or HIP.
+   [describes] therefore widens to every declared framework except "CUDA/PTX" —
+   the reason was already true of them, only unstated. It is written out in full
+   rather than as [List.filter (( <> ) "CUDA/PTX") declared_frameworks] on
+   purpose: derived from the universe it would agree with [applies] by
+   construction and the comparison could never fail, which is the property the
+   [describes] field exists to have. The cost is that a backend registered later
+   fails this check until someone restates the claim; that is the alarm, not a
+   defect. *)
 let blocker_needs_soa_abi =
   {
     reason = "SKIP (needs CUDA/PTX: the SoA ABI dispatches nowhere else)";
     applies = (fun fw -> fw <> "CUDA/PTX");
-    describes = ["OpenCL"; "Vulkan"; "Metal"; "Native"; "Interpreter"];
+    describes =
+      [
+        "CUDA/C";
+        "HIP";
+        "OpenCL";
+        "Vulkan";
+        "Metal";
+        "WebGPU";
+        "Native";
+        "Interpreter";
+      ];
   }
 
 let all_blockers = [blocker_cpu_field_store; blocker_needs_soa_abi]
@@ -229,9 +325,48 @@ let all_blockers = [blocker_cpu_field_store; blocker_needs_soa_abi]
 
    [describes] is also required to be a subset of the universe, so a typo
    ("Cuda/PTX") shows up as a named failure instead of quietly shrinking the
-   expected set to nothing. *)
+   expected set to nothing.
+
+   Three things are printed before the verdict, because a universe that shrank —
+   to the empty list, to the floor alone, or to a floor that no longer covers the
+   plugin tree — would otherwise satisfy every comparison below vacuously: the
+   registry names actually found at this point, the universe the comparisons run
+   over, and a named failure for any registered name the floor does not declare.
+   [Benchmarks.init] (the first statement of [main]) runs [Backend_loader.init],
+   so the registry is populated by the time this runs; the printed list is the
+   evidence, not the assumption. *)
 let check_skip_reason_scope () =
   let ok = ref true in
+  let registered = registered_frameworks () in
+  let all_frameworks = all_frameworks () in
+  Printf.printf
+    "  skip-reason universe: %d declared, registry contributed [%s], \
+     quantifying over [%s]\n\
+     %!"
+    (List.length declared_frameworks)
+    (String.concat "; " (List.sort compare registered))
+    (String.concat "; " all_frameworks) ;
+  (* A registered backend the floor does not declare means the floor is stale:
+     the union above already put it in the universe, so the blocker comparisons
+     did cover it, but a name nobody wrote down is a name nobody checked the
+     claims against. Fail here so it is restated deliberately. *)
+  let undeclared =
+    List.filter (fun fw -> not (List.mem fw declared_frameworks)) registered
+  in
+  if undeclared <> [] then begin
+    Printf.printf
+      "  registered backend(s) missing from the declared framework floor: [%s]\n\
+       %!"
+      (String.concat "; " (List.sort compare undeclared)) ;
+    ok := false
+  end ;
+  if registered = [] then begin
+    Printf.printf
+      "  the backend registry is empty here — the union half of the universe \
+       contributed nothing, so this check ran against the declared floor alone\n\
+       %!" ;
+    ok := false
+  end ;
   List.iter
     (fun b ->
       let unknown =
@@ -1636,11 +1771,12 @@ let () =
      a machine with no device would report SKIPPED while silently not checking a
      property that needs no device at all. *)
   let derive_ok = check_field_derivation () in
-  (* Also device-independent, and deliberately so — it quantifies over every
-     framework Sarek can enumerate rather than over the ones present here, so a
-     skip reason that is false of a device class stays caught on a host that has
-     no such device. Before the no-device exit for the same reason as the two
-     above. *)
+  (* Also device-independent, and deliberately so — it quantifies over the
+     declared framework floor unioned with the registered backends rather than
+     over the devices present here, so a skip reason that is false of a device
+     class stays caught on a host that has no such device. Before the no-device
+     exit for the same reason as the two above. It must stay AFTER
+     [Benchmarks.init] above, which is what populates the registry half. *)
   let scope_ok = check_skip_reason_scope () in
   let layout_ok = check_layout_validation () && derive_ok && scope_ok in
   let devs = Device.all () in

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -32,6 +32,7 @@
 module Device = Spoc_core.Device
 module Vector = Spoc_core.Vector
 module Transfer = Spoc_core.Transfer
+module Gpu_memory = Spoc_core.Gpu_memory
 module Soa = Spoc_core.Soa
 module Soa_vector = Spoc_core.Soa_vector
 module Soa_launch = Sarek.Soa_launch
@@ -491,10 +492,11 @@ let check_roundtrip dev n =
    precisely to present the check with a plan that disagrees with the kernel.
 
    Device-independent by construction: the check is a pure function of (param
-   name, kernel element type, declared plan), so it runs on this machine with no
-   NVIDIA device. It is also ordered BEFORE run_soa's PTX gate precisely so the
-   refusal is reachable off a CUDA host — behind the gate it could only ever fire
-   where the gate passes, which is what would have made it untestable here. *)
+   name, kernel element type, declared plan), so it runs on every device this
+   host enumerates, CUDA/PTX or not. It is also ordered BEFORE run_soa's PTX gate
+   precisely so the refusal is reachable on a NON-PTX device — behind the gate it
+   could only ever fire where the gate passes, and it would then be asserting
+   nothing on the 7 non-PTX devices here. *)
 
 let xyz_ty =
   Sarek_ir_types.TRecord
@@ -757,9 +759,19 @@ let check_short_arg_list dev =
    - on every OTHER backend it must ALSO equal the AoS result, by silently taking
      the packed path — that is the documented "never wrong data" fallback, and
      asserting it here is the only thing that distinguishes "the fallback works"
-     from "the fallback was never exercised". This machine has no NVIDIA device,
-     so locally it is the fallback half that runs, and it would catch a
-     soa_dispatch predicate that fired on the wrong backend.
+     from "the fallback was never exercised". It would catch a soa_dispatch
+     predicate that fired on the wrong backend.
+
+     CORRECTED 2026-07-30 — this comment used to add "this machine has no NVIDIA
+     device, so locally it is the fallback half that runs", which contradicted the
+     header of the integer-combo cases in this same file ("it needs a CUDA/PTX
+     device. ZLUDA provides one") and pointed a reader away from the arm that
+     carries every fix in this file. Measured: 9 devices enumerate here and TWO of
+     them are CUDA/PTX — ZLUDA on an AMD RX 7900 XTX, reached with
+     LD_LIBRARY_PATH=$HOME/opt/zluda. There is no NVIDIA hardware in this host,
+     which is the grain of truth the wrong half grew from, but "no NVIDIA device"
+     and "no CUDA/PTX device" are not the same statement and only the second one
+     is what [is_ptx] tests. BOTH halves run locally.
 
    Correctness is checked against the pure-OCaml reference rather than against a
    second GPU run, so a bug common to both device paths cannot hide. *)
@@ -1108,6 +1120,75 @@ let check_free_preserves_soa dev n =
     (if !ok then "OK" else "FAILED") ;
   !ok
 
+(* Freeing must also RELEASE something. Correctness and reclamation are two
+   different claims, and {!check_free_preserves_soa} above only makes the first:
+   it proves the data survives the free. It passed while the free released ZERO
+   bytes.
+
+   Under this ABI the AoS vector never gets a packed buffer, so
+   [Transfer.free_all_buffers] iterated an EMPTY [device_buffers] table and
+   returned successfully having freed nothing. Measured with
+   [Gpu_memory.usage()] at n=32: 3840 B before the launch, 4224 B after the
+   free — a delta of +384 = 32 x 3 leaves x 4 B, i.e. exactly the memory the call
+   was asked to release still held.
+
+   Not a correctness bug, which is why nothing caught it: every leaf carries a
+   [Gpu_memory.register_finalizer], so the bytes come back once the structure
+   becomes unreachable. What the caller lost is the only thing an explicit free
+   offers over the GC — releasing at a moment it chooses, while the vector is
+   still live. So this case keeps [sv] reachable across the measurement
+   ([Sys.opaque_identity] below): let it be collected and the finalizer frees the
+   leaves for us and the assertion passes on the unfixed code.
+
+   [allocated > 0] is asserted, not assumed. Without it a launch that allocated
+   nothing would give released = allocated = 0 and the case would pass while
+   checking nothing at all. *)
+let check_free_releases_leaves dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  for i = 0 to n - 1 do
+    Vector.set
+      sv
+      i
+      {x = float_of_int i; y = float_of_int (i + 1); z = float_of_int (n - i)}
+  done ;
+  (* Flush finalizers pending from earlier cases BEFORE the baseline, so their
+     bytes are not counted against this one. *)
+  Gc.full_major () ;
+  let before = Gpu_memory.usage () in
+  Sarek.Execute.run_vectors
+    ~device:dev
+    ~ir:(ir_of p3_scale_y_kernel)
+    ~args:[Vec sv; Int n]
+    ~block
+    ~grid
+    () ;
+  Transfer.flush dev ;
+  let after_launch = Gpu_memory.usage () in
+  Transfer.free_all_buffers sv ;
+  let after_free = Gpu_memory.usage () in
+  (* Load-bearing: see the header. A collected [sv] frees its own leaves. *)
+  ignore (Sys.opaque_identity sv) ;
+  let allocated = after_launch - before in
+  let released = after_launch - after_free in
+  let ok = allocated > 0 && released >= allocated in
+  if not ok then
+    Printf.printf
+      "  free_all_buffers released %d of the %d bytes the launch allocated \
+       (usage: %d before -> %d after launch -> %d after free)\n\
+       %!"
+      released
+      allocated
+      before
+      after_launch
+      after_free ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "free_all_buffers RELEASES a transparent SoA vector's leaves"
+    (if ok then "OK" else "FAILED") ;
+  ok
+
 (* The two integer-leaf device rows the handoff left open. Driven through the
    TRANSPARENT path, so one case covers both the mixed-width leaf addressing and
    the generic dispatch. Each leaf is compared to the reference independently. *)
@@ -1350,13 +1431,50 @@ let () =
            (Execute.transfer_vectors_to_device, which never cleared the flag) and
            the CLEANUP path (Transfer.free_*, which had no SoA arm at all). *)
         if not (check_soa_then_packed dev n) then ok := false ;
-        if not (check_free_preserves_soa dev n) then ok := false
+        if not (check_free_preserves_soa dev n) then ok := false ;
+        (* And the free must RELEASE, not merely preserve — a separate claim from
+           the case above, which passed while zero bytes came back. *)
+        if not (check_free_releases_leaves dev n) then ok := false
       end
-      else
-        Printf.printf
-          "  %-56s %s\n%!"
-          "transparent SoA output read back"
-          "SKIP (non-PTX: v.(i).f <- blocked on backlog-172)" ;
+      else begin
+        (* ONE skip line PER GUARDED CASE, each naming the device class it needs
+           and why it was absent.
+
+           Before 2026-07-30 this else-branch printed a single line, for
+           [check_transparent_roundtrip] only. The three [check_relaunch]
+           writers, [check_soa_then_packed] and [check_free_preserves_soa]
+           printed NOTHING — so on a host where no CUDA/PTX device enumerates
+           (which, with no LD_LIBRARY_PATH for ZLUDA, was every default `dune
+           runtest`) five assertions were absent from the output and from the
+           verdict, and the alias still exited 0. A silent no-op and a pass are
+           the same observation, which is the whole failure.
+
+           The two reasons are genuinely different and are not collapsed:
+           backlog-172 is a defect that will LIFT the guard on the first four
+           cases when it lands; the SoA ABI dispatching only on CUDA/PTX is by
+           design and permanent for the last three. *)
+        let skip_172 label =
+          Printf.printf
+            "  %-56s %s\n%!"
+            label
+            "SKIP (non-PTX: v.(i).f <- blocked on backlog-172)"
+        in
+        let skip_ptx label =
+          Printf.printf
+            "  %-56s %s\n%!"
+            label
+            "SKIP (needs CUDA/PTX: the SoA ABI dispatches nowhere else)"
+        in
+        skip_172 "transparent SoA output read back" ;
+        List.iter
+          (fun w ->
+            skip_172
+              (Printf.sprintf "second launch sees the second host write (%s)" w))
+          ["Vector.set"; "Vector.unsafe_set"; "Vector.fill"] ;
+        skip_ptx "packed AoS launch after a transparent SoA one" ;
+        skip_ptx "free_all_buffers preserves a transparent SoA result" ;
+        skip_ptx "free_all_buffers RELEASES a transparent SoA vector's leaves"
+      end ;
       if not (check_mixed_widths dev n) then ok := false ;
       (* Item 3: SoA launch must be rejected (never wrong data) on non-PTX. *)
       if not (check_gate dev) then ok := false ;

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -1353,11 +1353,17 @@ let check_transparent_roundtrip dev n =
    two are one condition, on which copy is authoritative, and the case exists
    because pinning only one of them is what let the other in.
 
-   Distinguishable in both directions. y0 = i+1; the transparent launch doubles y
-   to 2*y0; the host write sets y := 100+i, which is neither a multiple nor a
-   scalar function of y0; the packed launch doubles that to 2*(100+i). Discarding
-   the host write gives 4*y0 = 4*(i+1) instead, and 2*(100+i) = 4*(i+1) has no
-   integer solution for i >= 0. *)
+   Distinguishable at EVERY index, which took a second attempt. y0 = i+1; the
+   transparent launch doubles y to 2*y0; the host write sets y := i + 0.5; the
+   packed launch doubles that to 2i+1. Discarding the host write gives 4*y0 =
+   4i+4 instead. 2i+1 = 4i+4 has the single solution i = -1.5, so the two never
+   coincide on an index — whereas the first version of this case wrote y := 100+i
+   and 2*(100+i) = 4*(i+1) holds at i = 98, inside the n = 1024 range. It would
+   still have failed (at i = 0, and the loop checks every index), but one row of
+   the check was asserting nothing.
+
+   The half-integer is also what makes the write independent of the leaf value in
+   the ONE way that matters here: 2i+1 is odd and 4i+4 is a multiple of 4. *)
 let check_host_write_survives_packed dev n =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -1367,7 +1373,7 @@ let check_host_write_survives_packed dev n =
     Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
   done ;
   let ir = ir_of p3_scale_y_kernel in
-  let written i = float_of_int (100 + i) in
+  let written i = float_of_int i +. 0.5 in
   let ok = ref true in
   (match
      Sarek.Execute.run_vectors
@@ -1378,9 +1384,14 @@ let check_host_write_survives_packed dev n =
        ~grid
        () ;
      Transfer.flush dev ;
-     (* The host write. Gathers the leaves first (auto-sync), so what it lands on
-        top of is the transparent launch's result, and leaves the vector
-        [Stale_GPU dev]. *)
+     (* The host write. With auto-sync on (the default, and this suite does not
+        disable it) [Vector.set] gathers the leaves first, so what it lands on top
+        of is the transparent launch's result, and it leaves the vector
+        [Stale_GPU dev]. That precondition is named because it is load-bearing:
+        with auto-sync OFF the gather does not happen and the vector stays
+        [Stale_CPU dev] with a pending host write, which is the pre-existing
+        auto-sync-off hazard [Vector.ml] documents and NOT what this case
+        covers. *)
      for i = 0 to n - 1 do
        Vector.set
          sv

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -796,7 +796,15 @@ let xyz_ty =
   Sarek_ir_types.TRecord
     ("point3d", [("x", TFloat32); ("y", TFloat32); ("z", TFloat32)])
 
-let mixed_ty = Sarek_ir_types.TRecord ("mixed", [("a", TInt32); ("b", TFloat64)])
+(* A hand-built record type that exists ONLY as a layout-mismatch fixture. Named
+   [mismatch_ty] over the record "ab_pair", deliberately not "mixed": the real
+   [mixed] record declared above this file's kernels is [{i : int32; d : float64}]
+   and a fixture sharing its name reads as a description of it. Nothing compares
+   the NAME — [Soa_launch.check_soa_layout] compares leaves and stride only
+   (Soa_launch.ml:117-121) — so the rename cannot change what these cases
+   assert. *)
+let mismatch_ty =
+  Sarek_ir_types.TRecord ("ab_pair", [("a", TInt32); ("b", TFloat64)])
 
 (* [check_soa_layout] raises via Execute_error.raise_error; a refusal is any
    Execution_error whose rendering mentions the parameter. Asserting on the
@@ -887,6 +895,28 @@ let check_field_derivation () =
     (Soa_vector.plan (Soa_vector.create dpair_custom 4))
     ~expect_leaves:[("u", 0, 8); ("v", 8, 8)]
     ~expect_stride:16 ;
+  (* The two MIXED-width records, which point3d and dpair cannot cover: both are
+     uniform-width, so neither can distinguish a correct offset from one that
+     ignores alignment padding. These two put the padding in different places —
+     [mixed] is 4B then 8B, so the f64 leaf is at 8 and not at 4; [longpair] is 8B
+     then 4B, so the stride is 16 and not 12 (trailing pad).
+
+     Here rather than only in [check_mixed_widths] because that case needs a
+     device — a CUDA/PTX one for the SoA leg, and fp64/int64 capability for the
+     leaves — while an offset or stride regression is a property of the derived
+     plan alone. On a host with no GPU, and in this repository's CI, the device
+     case cannot run at all, so without these two rows the padding-sensitive
+     layouts have no check that executes there. *)
+  check_plan
+    "derived plan for mixed (i32 then f64: pad after the i32)"
+    (Soa_vector.plan (Soa_vector.create mixed_custom 4))
+    ~expect_leaves:[("i", 0, 4); ("d", 8, 8)]
+    ~expect_stride:16 ;
+  check_plan
+    "derived plan for longpair (i64 then i32: trailing pad)"
+    (Soa_vector.plan (Soa_vector.create longpair_custom 4))
+    ~expect_leaves:[("p", 0, 8); ("q", 8, 4)]
+    ~expect_stride:16 ;
   !ok
 
 let check_layout_validation () =
@@ -933,10 +963,10 @@ let check_layout_validation () =
       (refuses
          ~label:"wrong leaf WIDTH is refused"
          ~param:"m"
-         ~kernel_ty:(Some mixed_ty)
+         ~kernel_ty:(Some mismatch_ty)
          ~declared:
            (Soa.plan
-              ~name:"mixed"
+              ~name:"ab_pair"
               [("a", Sarek_ir_types.TInt32); ("b", TFloat32)])
          ~expect_substr:"wrong byte offsets")
   then ok := false ;
@@ -1161,6 +1191,14 @@ let check_transparent dev n =
    or a stale-input result could coincide with a correct one. Round 1 doubles
    y = i+1; round 2 starts from y = 1000-i, so a stale second round yields
    4*(i+1) and a correct one 2*(1000-i) — never equal for i in range. *)
+(* ONE definition of this case's label, because it is printed from two places
+   that must not drift: the pass/FAILED line at the end of [check_relaunch] and
+   the [guarded] SKIP line at the call site, which is printed INSTEAD of running
+   the function. Two [Printf.sprintf]s meant a reword in one desynchronised the
+   skip row from the pass row for the same case. *)
+let relaunch_label writer_name =
+  Printf.sprintf "second launch sees the second host write (%s)" writer_name
+
 let check_relaunch dev n ~writer_name ~write ~y_expected ~stale_note =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -1209,7 +1247,7 @@ let check_relaunch dev n ~writer_name ~write ~y_expected ~stale_note =
   done ;
   Printf.printf
     "  %-56s %s\n%!"
-    (Printf.sprintf "second launch sees the second host write (%s)" writer_name)
+    (relaunch_label writer_name)
     (if !ok then "OK" else "FAILED") ;
   !ok
 
@@ -1574,19 +1612,26 @@ let check_free_buffer_coherent dev n =
       fail "location after free_buffer: Stale_CPU %d, want CPU" d.Device.id
   | Vector.Stale_GPU d ->
       fail "location after free_buffer: Stale_GPU %d, want CPU" d.Device.id) ;
-  (* Claim 2. *)
+  (* Claim 2. [first_mismatch] is per-CLAIM, not the function-wide [ok]: gating
+     the print on [!ok] made claim 1 (or claim 3) failing suppress every index
+     line here and in claim 5, so the case reported FAILED naming a claim while
+     printing no evidence for the claim that actually broke. One ref per loop
+     keeps "print only the first index" without letting one claim silence
+     another. *)
+  let first_mismatch = ref true in
   (match Transfer.to_cpu ~force:true sv with
   | () ->
       for i = 0 to n - 1 do
         let got = (Vector.get sv i).y and want = y0 i *. 2.0 in
-        if Float.abs (got -. want) > 1e-3 && !ok then
+        if Float.abs (got -. want) > 1e-3 && !first_mismatch then (
+          first_mismatch := false ;
           fail
             "to_cpu after free_buffer corrupted @%d: got=%g want=%g \
              (pre-launch host value is %g)"
             i
             got
             want
-            (y0 i)
+            (y0 i))
       done
   | exception e ->
       fail
@@ -1633,19 +1678,22 @@ let check_free_buffer_coherent dev n =
      Transfer.flush dev
    with
   | () ->
+      (* Claim 5's own first-mismatch ref, for the reason given at claim 2. *)
+      let first_mismatch = ref true in
       for i = 0 to n - 1 do
         (* Round 1 doubled y0 to 2*y0 and [to_cpu] above gathered it into host
            storage, so this second launch doubles that to 4*y0. Stale device data
            would leave 2*y0 — never equal for y0 > 0. *)
         let got = (Vector.get sv i).y and want = y0 i *. 4.0 in
-        if Float.abs (got -. want) > 1e-3 && !ok then
+        if Float.abs (got -. want) > 1e-3 && !first_mismatch then (
+          first_mismatch := false ;
           fail
             "relaunch after free_buffer is wrong @%d: got=%g want=%g (the \
              first launch's result is %g)"
             i
             got
             want
-            (y0 i *. 2.0)
+            (y0 i *. 2.0))
       done
   | exception e ->
       fail "relaunch after free_buffer raised: %s" (Printexc.to_string e)) ;
@@ -1843,8 +1891,18 @@ let () =
         || dev.Device.framework = "Interpreter"
         || Device.allows_fp64 dev
       in
-      if dev_can_f64 && not (check "dpair(f64)" dev n run_dpair) then
-        ok := false ;
+      (* The skip is NAMED. Gating the call on [dev_can_f64] alone printed
+         nothing at all on a device without fp64, and a row that prints nothing is
+         indistinguishable from one that passed — the exact skip-as-pass shape the
+         guarded cases below were restructured to make unrepresentable, and this
+         is the last plain capability gate in the driver loop. Same wording as the
+         two arms of [check_mixed_widths], which report the same capability. *)
+      if not dev_can_f64 then
+        Printf.printf
+          "SoA-emitter dpair(f64) [%s] %s: SKIP (device reports no fp64)\n%!"
+          dev.Device.framework
+          dev.Device.name
+      else if not (check "dpair(f64)" dev n run_dpair) then ok := false ;
       if not (check_transparent dev n) then ok := false ;
       (* Transparent OUTPUT read-back. Its only blocker is the CPU field-store
          gap, NOT the SoA ABI: on OpenCL/Vulkan the launch takes the packed AoS
@@ -1878,10 +1936,7 @@ let () =
               (guarded
                  dev
                  ~blockers:[blocker_cpu_field_store]
-                 ~label:
-                   (Printf.sprintf
-                      "second launch sees the second host write (%s)"
-                      writer_name)
+                 ~label:(relaunch_label writer_name)
                  (fun () ->
                    check_relaunch
                      dev

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -744,6 +744,7 @@ let check_short_arg_list dev =
         Printf.printf "FAILED (refused, but not on arity: %s)\n%!" msg ;
         false
       end
+
 (* The TRANSPARENT path (backlog-54): Soa_vector.create_transparent + the
    GENERIC Execute.run_vectors, with no SoA-specific launch entry point. This is
    what the item is actually about — the caller opts a vector into SoA storage
@@ -952,6 +953,158 @@ let check_transparent_roundtrip dev n =
   Printf.printf
     "  %-56s %s\n%!"
     "transparent SoA output read back (PTX: leaf D2H + gather)"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
+(* SoA ABI, then PACKED AoS ABI, on ONE vector, with NO host read-back in
+   between.
+
+   [soa_leaves_live] was only ever set — nothing cleared it. So once a transparent
+   CUDA/PTX launch had run, EVERY later read-back on that vector followed the
+   leaves for the rest of its life, no matter which ABI the most recent launch
+   actually used. [Execute.run_source] deliberately keeps the packed ABI (it hands
+   the backend a source string Sarek did not emit), which makes this sequence
+   reachable through the public API with no unusual step.
+
+   The second launch is the assertion; the first would pass either way. And the
+   missing read-back in between is the whole point — inserting one would clear the
+   staleness by accident and the case would pass unfixed.
+
+   The packed source is the SAME IR compiled WITHOUT ~soa_params rather than
+   hand-written PTX, so this case cannot pass or fail for a PTX-authoring reason.
+
+   Both expectations are distinguishable: y0 = i+1, each launch doubles y, so the
+   correct answer is 4*(i+1) and following the stale leaves gives 2*(i+1) —
+   never equal. Pre-fix the failure is in fact LOUDER than that (the packed
+   launch has no buffer to bind, because the transparent path never allocates
+   one), which is why the exception is caught and reported rather than left to
+   abort the binary: a red state that is a crash is not an observation. *)
+let check_soa_then_packed dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  let ir = ir_of p3_scale_y_kernel in
+  let outcome =
+    match
+      (* Launch 1 — TRANSPARENT. run_vectors passes ~soa_abi:true, so on CUDA/PTX
+         this binds the N-leaf ABI, writes the y LEAF, and leaves the vector
+         SoA-owned. *)
+      Sarek.Execute.run_vectors
+        ~device:dev
+        ~ir
+        ~args:[Vec sv; Int n]
+        ~block
+        ~grid
+        () ;
+      Transfer.flush dev ;
+      (* Launch 2 — PACKED. run_source defaults to ~soa_abi:false. *)
+      Sarek.Execute.run_source
+        ~device:dev
+        ~source:(Sarek_ir_ptx.generate ir)
+        ~lang:Sarek.Execute.PTX
+        ~kernel_name:ir.Sarek_ir_types.kern_name
+        ~block
+        ~grid
+        [Sarek.Execute.Vec sv; Sarek.Execute.Int n] ;
+      Transfer.flush dev
+    with
+    | () -> None
+    | exception e -> Some (Printexc.to_string e)
+  in
+  let ok = ref true in
+  (match outcome with
+  | Some msg ->
+      Printf.printf "  packed launch after a transparent one raised: %s\n%!" msg ;
+      ok := false
+  | None ->
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y in
+        let want = y0 i *. 4.0 in
+        if Float.abs (got -. want) > 1e-3 then begin
+          if !ok then
+            Printf.printf
+              "  SoA->packed mismatch @%d: got=%g want=%g (stale leaves would \
+               be %g)\n\
+               %!"
+              i
+              got
+              want
+              (y0 i *. 2.0) ;
+          ok := false
+        end
+      done) ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "packed AoS launch after a transparent SoA one"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
+(* Freeing the device buffers must not throw the results away.
+
+   [Transfer.free_buffer] and [free_all_buffers] read a vector back before
+   releasing its memory — but they called [copy_device_to_host] DIRECTLY, so
+   they had no SoA arm. After a transparent launch there is no packed buffer at
+   all, so [free_all_buffers] raised "no device buffer to transfer from" from
+   inside cleanup, and [free_buffer]'s [get_buffer = None -> ()] early return
+   discarded the output silently.
+
+   No explicit [to_cpu] before the free, deliberately: that is the sequence with
+   the defect, and adding one would make this case pass unfixed. Both a raised
+   exception and wrong data are reported the same way, so either red state is an
+   observation rather than an abort. *)
+let check_free_preserves_soa dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let y0 i = float_of_int (i + 1) in
+  for i = 0 to n - 1 do
+    Vector.set sv i {x = float_of_int i; y = y0 i; z = float_of_int (n - i)}
+  done ;
+  let ir = ir_of p3_scale_y_kernel in
+  let outcome =
+    match
+      Sarek.Execute.run_vectors
+        ~device:dev
+        ~ir
+        ~args:[Vec sv; Int n]
+        ~block
+        ~grid
+        () ;
+      Transfer.flush dev ;
+      Transfer.free_all_buffers sv
+    with
+    | () -> None
+    | exception e -> Some (Printexc.to_string e)
+  in
+  let ok = ref true in
+  (match outcome with
+  | Some msg ->
+      Printf.printf "  free_all_buffers raised: %s\n%!" msg ;
+      ok := false
+  | None ->
+      for i = 0 to n - 1 do
+        let got = (Vector.get sv i).y in
+        let want = y0 i *. 2.0 in
+        if Float.abs (got -. want) > 1e-3 then begin
+          if !ok then
+            Printf.printf
+              "  free-then-read mismatch @%d: got=%g want=%g (pre-launch host \
+               value is %g)\n\
+               %!"
+              i
+              got
+              want
+              (y0 i) ;
+          ok := false
+        end
+      done) ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "free_all_buffers preserves a transparent SoA result"
     (if !ok then "OK" else "FAILED") ;
   !ok
 
@@ -1190,7 +1343,14 @@ let () =
                 Vector.fill sv {x = 0.0; y = y_of 0; z = float_of_int n}),
               (fun _ -> 2000.0),
               fun _ -> 4.0 );
-          ]
+          ] ;
+        (* Whose ABI does read-back follow? The two cases below are the two ways
+           that question got a stale answer, and they are separate cases because
+           the two paths that asked it are separate: the LAUNCH path
+           (Execute.transfer_vectors_to_device, which never cleared the flag) and
+           the CLEANUP path (Transfer.free_*, which had no SoA arm at all). *)
+        if not (check_soa_then_packed dev n) then ok := false ;
+        if not (check_free_preserves_soa dev n) then ok := false
       end
       else
         Printf.printf

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -833,6 +833,72 @@ let check_transparent dev n =
    That is tracked as backlog-172 and is not this case's subject; asserting the
    non-PTX arm here would pin a red on an unrelated gap. When 172 lands, drop the
    [is_ptx] guard — the assertion below needs no other change. *)
+(* TWO launches on ONE vector, with different host data in between (H5,
+   backlog-181). This is the case no existing test constructs — every other one
+   allocates a fresh vector — and that is exactly why the defect was invisible to
+   a green suite rather than merely untested.
+
+   [Soa_vector.scatter] writes each leaf's host buffer through a raw ctypes
+   pointer, which does no location bookkeeping. After the first launch a leaf
+   sits at [Both dev], and [Transfer.to_device] short-circuits that state
+   ("skip (Both)") — so the second launch ran against the FIRST launch's device
+   data. Silent, and with no user workaround.
+
+   The assertion that matters is the SECOND launch's: the first would pass either
+   way. And the two rounds' inputs must not be scalar multiples of each other,
+   or a stale-input result could coincide with a correct one. Round 1 doubles
+   y = i+1; round 2 starts from y = 1000-i, so a stale second round yields
+   4*(i+1) and a correct one 2*(1000-i) — never equal for i in range. *)
+let check_relaunch dev n =
+  let threads = min 128 n in
+  let block = dims threads and grid = dims ((n + threads - 1) / threads) in
+  let sv = Soa_vector.create_transparent point3d_custom n in
+  let ir = ir_of p3_scale_y_kernel in
+  let launch () =
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir
+      ~args:[Vec sv; Int n]
+      ~block
+      ~grid
+      () ;
+    Transfer.flush dev
+  in
+  let fill y_of =
+    for i = 0 to n - 1 do
+      Vector.set sv i {x = float_of_int i; y = y_of i; z = float_of_int (n - i)}
+    done
+  in
+  (* Round 1 — passes with or without the fix; it is here to establish the
+     post-launch leaf state that the bug depends on. *)
+  fill (fun i -> float_of_int (i + 1)) ;
+  launch () ;
+  (* Round 2 — the real assertion. [Vector.set] below reads the results back
+     first (auto-sync -> leaf D2H -> gather), so this also exercises the write
+     path landing on top of a device-authoritative vector. *)
+  fill (fun i -> float_of_int (1000 - i)) ;
+  launch () ;
+  let ok = ref true in
+  for i = 0 to n - 1 do
+    let want = float_of_int (1000 - i) *. 2.0 in
+    let got = (Vector.get sv i).y in
+    if Float.abs (got -. want) > 1e-3 then begin
+      if !ok then
+        Printf.printf
+          "  relaunch mismatch @%d: got=%g want=%g (stale would be %g)\n%!"
+          i
+          got
+          want
+          (float_of_int (i + 1) *. 4.0) ;
+      ok := false
+    end
+  done ;
+  Printf.printf
+    "  %-56s %s\n%!"
+    "second launch sees the second host write"
+    (if !ok then "OK" else "FAILED") ;
+  !ok
+
 let check_transparent_roundtrip dev n =
   let threads = min 128 n in
   let block = dims threads and grid = dims ((n + threads - 1) / threads) in
@@ -1069,7 +1135,11 @@ let () =
       (* Transparent OUTPUT read-back. PTX-gated — see the case's header for why
          the non-PTX arm is blocked on backlog-172 rather than omitted. *)
       if is_ptx dev then begin
-        if not (check_transparent_roundtrip dev n) then ok := false
+        if not (check_transparent_roundtrip dev n) then ok := false ;
+        (* H5 (backlog-181): relaunch on the SAME vector. PTX-gated for the same
+           reason as the case above — `v.(i).f <- e` is blocked on the two CPU
+           backends until backlog-172 lands. *)
+        if not (check_relaunch dev n) then ok := false
       end
       else
         Printf.printf


### PR DESCRIPTION
**backlog-54, first slice of the transparency work — and it corrects the persisted plan, which is not buildable as written.**

## The plan's design violates a gated invariant

The Tier 1b handoff's §1 says to add a `Custom_storage_soa` constructor to the `host_storage` GADT in `spoc_core_base`, holding the plan and N leaf sub-buffers. Two facts the doc doesn't record:

- **`spoc_core_base` is deliberately FFI-free** — its dune stanza must not list `ctypes`/`unix`/`spoc_framework` — and it is *additionally* compiled to `.bc.js`. `sarek/core/ffi_free_gate` enforces **both** at build time (`(modes byte js)`).
- **`Soa` uses `Ctypes` directly** to copy raw words, and both it and `Vector_types` live in `spoc_core`, *above* that layer.

So naming `Soa.plan` down there either breaks that gate or forces the plan representation to be duplicated across a layer boundary — the drift hazard the `ir_fields` trust note warns about, and probably the real reason the earlier work chose the layered `Soa_vector` in the first place.

## Resolved with behaviour instead of types

`soa_binding` carries the transpose as two closures plus the only two numbers a launch needs (leaf count, AoS stride). Nothing ctypes-shaped crosses down, and the value is one a jsoo build can hold. The producer is `Vector.create` in `spoc_core`, which may use ctypes freely.

## A record field, not a GADT constructor — measured, not guessed

| Approach | Forced edits |
|---|---|
| new `host_storage` constructor | **51 match arms across 5 files** (`Spoc_core_base` 16, `Vector` 14, `Interpreter_plugin_base` 8, `Native_plugin_base` 7, `Vector_jsx` 6) |
| record field | **6 sites**, all in `Spoc_core_base.ml` |

The field keeps the property that made the GADT attractive — the compiler finds every site — without the fan-out, and without a hidden global side table keyed by vector id. The doc's "~25 forced match sites" estimate was low by 2×.

`soa = None` on the copy/sub-vector paths is not a placeholder: the handoff keeps `of_ctypes_ptr` and `sub_vector` AoS-only, so `None` is the correct value there.

## Scope of this PR

**No behaviour change — nothing reads the field yet.** Host access is untouched *by construction*, which is why `get`/`set` and the PPX accessors needed no edits at all. This is the foundation plus the corrected design record.

Still to come on this branch: `Vector.create ~layout:SoA` populating the binding; the two device-facing closures the launch needs (`Ops.device_t -> Ops.device_buf list` — expressible because `core_base` already parameterises over `Ops`); `Execute.run` auto-dispatch on CUDA/PTX with the AoS fallback elsewhere; then extending `test_soa_emitter_equiv` through the transparent path.

Build green, `@fmt` green, **`ffi_free_gate` builds both `byte` and `js`** (the invariant this design exists to preserve), **1729 cases across 119 suites, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transparent SoA vectors that work with standard execution flows.
  * Added support for SoA data across device transfers and migrations.
* **Bug Fixes**
  * Improved device-to-host read-back and stale-data handling.
  * Fixed cleanup, freeing, and cross-device behavior to prevent incorrect data reuse.
* **Tests**
  * Expanded coverage for mixed-width records, relaunches, round trips, and cross-device migration.
* **Documentation**
  * Updated correctness evidence with completed mixed-width SoA device results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->