### PR TITLE
fix(ptx): float <> must emit unordered setp.neu, not ordered setp.ne

### DIFF
--- a/docs/formal/rocq-value-ledger.md
+++ b/docs/formal/rocq-value-ledger.md
@@ -323,6 +323,55 @@ least-checked link was inside the verification apparatus rather than in the code
 it verified. Worth remembering when reading any of the catches above: they are
 claims about a chain that had an unchecked link in it until 2026-07-27.
 
+### M-04 — the model had the right answer and could not be asked the question
+
+| | |
+|---|---|
+| Date | 2026-07-30 |
+| Instances | 1 (`Ne` on float operands in the PTX emitter) |
+| Where | `sarek/codegen/Sarek_ir_ptx_expr.ml`, comparison-family arm |
+| Fixed in | `fix/ptx-float-ne-nan` |
+
+Float `<>` lowered to `setp.ne.f32`/`setp.ne.f64`. Those are PTX's **ordered**
+not-equal, false as soon as an operand is NaN, while every other backend emits
+C's `!=` or uses OCaml's structural `<>`, both true. `nan <> x` returned 0 on
+PTX and 1 everywhere else.
+
+**The model does not have this wrong.** `formal/codegen-ptx` models `float` as
+Rocq's primitive IEEE-754 float (`Stdlib.Floats`), so `PNe` on `F32`/`F64` is
+`negb (eqb a b)` with `PrimFloat.eqb` — IEEE `==`, false for NaN — which makes
+the specified `Ne` the **unordered** one, exactly what the fix emits. The
+hand-written OCaml mirror in `formal/codegen-ptx/test/test_codegen_ptx_conformance.ml`
+agrees (`nat_cmp (a <> b)` on OCaml floats). Both halves of the apparatus
+specified the correct semantics and the implementation shipped the other one.
+
+**Why it was missed, specifically.** The model stops one layer above the
+defect. `ptx_cmp_tag` is an abstract tag — `PEq | PNe | PLt | PLe | PGt | PGe` —
+and nothing in `formal/` maps a tag to a **setp mnemonic**: the string `setp`
+appears in those theories only in comments. `ptx_cmp_agrees` (`PtxExprSpec.v`)
+proves that IR-level and PTX-level *evaluation* agree, but both sides are the
+same abstract semantics, so the theorem is a tag-mapping identity. The choice
+between `ne` and `neu` is instruction selection, which is unmodelled, and the
+tag `PNe` is a single name covering two different PTX instructions with
+different NaN behaviour.
+
+**Counterfactual — review would have found this, and did.** No proof failed and
+no conformance run produced a counterexample; the divergence was found by
+reading the opcode table next to the `ECast`-to-bool path 160 lines below, which
+already used `setp.neu` with a comment explaining why. Recorded as a miss rather
+than a catch on those grounds.
+
+**Same shape as M-01 above, and the same lesson.** The interesting model
+abstracted away the boring mapping, and the defect was in the boring mapping.
+What would have caught it is not a deeper semantics but a total function from
+`ptx_cmp_tag` × operand class to a mnemonic string, exhaustively tabulated —
+which is what the added marker assertions in `test_ptx_snapshot.ml`
+(`test_float_ne_unordered_markers`) now do for this one row, in the cheap
+executable form M-01 argued for. It is not yet a table over the whole family;
+that remains open, and `Lt/Le/Gt/Ge` on floats are ordered on both sides
+(`PrimFloat.ltb`/`leb` are false on NaN, matching `setp.lt`/`setp.le`), so the
+family's remaining exposure is `Eq` only, and `Eq` is correct.
+
 ## Null results
 
 <a id="n-01"></a>

--- a/sarek/codegen/Sarek_ir_ptx_expr.ml
+++ b/sarek/codegen/Sarek_ir_ptx_expr.ml
@@ -1147,10 +1147,28 @@ and emit_binop buf alloc env op e1 e2 : string =
          which is invalid PTX and fails at module load. Sarek ints are
          signed, so the integer forms are s32/s64 (sign matters for
          Lt/Le/Gt/Ge; for Eq/Ne it is irrelevant but harmless). *)
+      let is_float = is_f64 r1 || is_f32 r1 in
       let cmp =
         match op with
         | Eq -> "eq"
-        | Ne -> "ne"
+        (* Float [<>] must use the UNORDERED not-equal (setp.neu), not
+           setp.ne: setp.ne.f32/f64 is ORDERED, so it is false when either
+           operand is NaN, while C's [!=] - what every C-family backend emits -
+           and the interpreter's structural [<>] are both true. Left as
+           setp.ne, [nan <> x] silently returned 0 on PTX and 1 everywhere
+           else. Same reasoning as the ECast-to-bool path below, which already
+           uses setp.neu.f32/f64 so that (bool)NaN = 1.
+           Do NOT "fix" Eq to match - the asymmetry is deliberate. C's [==] is
+           also false for NaN, so the ordered setp.eq.f32/f64 is already
+           correct there; the unordered setp.equ would wrongly make
+           [nan = nan] true.
+           Integers have no NaN, so they keep the ordered [ne].
+           Formal spec note: formal/codegen-ptx models [PNe] on F32/F64 as
+           [negb (PrimFloat.eqb a b)] over Rocq's IEEE-754 float, i.e. the
+           unordered form - the model already specified this and cannot see the
+           defect, because nothing in formal/ maps a [ptx_cmp_tag] to a setp
+           mnemonic. See docs/formal/rocq-value-ledger.md, M-04. *)
+        | Ne -> if is_float then "neu" else "ne"
         | Lt -> "lt"
         | Le -> "le"
         | Gt -> "gt"

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1074,6 +1074,35 @@
  (action
   (run %{dep:test_ptx_signed_arith.exe})))
 
+; H2 comparison-family probe: float [<>] against NaN. PTX used to emit the
+; ORDERED setp.ne.f32/f64, which is false when an operand is NaN, while the
+; C-family backends' [!=], the native path and the interpreter all say true.
+; Runs on every available device against a pure-OCaml reference; a wrong
+; result from Native/Interpreter/CUDA-PTX is a hard failure. This is the
+; executed proof of the setp.neu retarget the snapshot only asserts.
+; Run with:
+;   LD_LIBRARY_PATH=$HOME/opt/zluda \
+;     dune exec sarek/tests/e2e/test_ptx_float_ne_nan.exe
+
+(executable
+ (name test_ptx_float_ne_nan)
+ (modules test_ptx_float_ne_nan)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  test_helpers
+  unix
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_ptx_float_ne_nan.exe})))
+
 (executable
  (name test_glsl_mod_single_eval)
  (modules test_glsl_mod_single_eval)

--- a/sarek/tests/e2e/test_ptx_float_ne_nan.ml
+++ b/sarek/tests/e2e/test_ptx_float_ne_nan.ml
@@ -1,0 +1,262 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E hardware probe for float [<>] against NaN (H2 comparison family).
+ *
+ * The PTX emitter used to lower a float [<>] to [setp.ne.f32]/[setp.ne.f64].
+ * Those are PTX's ORDERED not-equal, i.e. false as soon as either operand is
+ * NaN. Every other backend disagrees: the C-family emitters (CUDA, OpenCL,
+ * Metal, GLSL, WGSL) emit [!=], which is true for NaN, and both the native
+ * path and the interpreter use OCaml's structural [<>], also true. So
+ * [nan <> x] returned 0 on PTX and 1 everywhere else - a silent wrong answer,
+ * not a crash, on one backend only. The fix emits the UNORDERED [setp.neu].
+ *
+ * test_ptx_snapshot.ml asserts the emitted instruction (both polarities:
+ * [setp.neu.*] present AND [setp.ne.f32]/[setp.ne.f64] absent). This test
+ * proves the RESULT on real hardware, running the kernel on every available
+ * device against a pure-OCaml reference.
+ *
+ * NaN reaches the kernel through the input VECTOR, written host-side - the DSL
+ * needs no NaN literal for this path.
+ *
+ * The reference is OCaml's [<>] on the same float pair, which is the semantics
+ * every non-PTX backend already implements. Note the deliberate asymmetry that
+ * is also pinned here: [=] on NaN is FALSE in OCaml, in C and in ordered PTX
+ * [setp.eq], so the eq column must stay 0 for every NaN row. A backend that
+ * "fixed" Eq to the unordered [setp.equ] would fail this test.
+ *
+ * Run with (surfaces the CUDA/PTX device):
+ *   LD_LIBRARY_PATH=$HOME/opt/zluda \
+ *     dune exec sarek/tests/e2e/test_ptx_float_ne_nan.exe
+ ******************************************************************************)
+
+[@@@warning "-33"]
+
+open Sarek
+module Std = Sarek_stdlib.Std
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () = Test_helpers.Benchmarks.init_backends ()
+
+(* ne.(tid) = (a.(tid) <> b.(tid)), eq.(tid) = (a.(tid) = b.(tid)), as 0/1.
+   Plain DSL [<>] and [=] on float32 -> Ir.Ne / Ir.Eq, the operators the
+   comparison-family lowering retargets. *)
+let float_ne_kernel_f32 =
+  [%kernel
+    fun (a : float32 vector)
+        (b : float32 vector)
+        (ne : int32 vector)
+        (eq : int32 vector)
+        (n : int32) ->
+      let open Std in
+      let tid = global_thread_id in
+      if tid < n then begin
+        if a.(tid) <> b.(tid) then ne.(tid) <- 1l else ne.(tid) <- 0l ;
+        if a.(tid) = b.(tid) then eq.(tid) <- 1l else eq.(tid) <- 0l
+      end]
+
+let float_ne_kernel_f64 =
+  [%kernel
+    fun (a : float64 vector)
+        (b : float64 vector)
+        (ne : int32 vector)
+        (eq : int32 vector)
+        (n : int32) ->
+      let open Std in
+      let tid = global_thread_id in
+      if tid < n then begin
+        if a.(tid) <> b.(tid) then ne.(tid) <- 1l else ne.(tid) <- 0l ;
+        if a.(tid) = b.(tid) then eq.(tid) <- 1l else eq.(tid) <- 0l
+      end]
+
+let nan = Float.nan
+
+(* Rows 0-4 carry a NaN and are the ones the ordered/unordered distinction
+   decides; rows 5-8 are NaN-free controls so a backend that returned a
+   constant could not pass. *)
+let cases =
+  [|
+    (nan, 1.0);
+    (1.0, nan);
+    (nan, nan);
+    (nan, 0.0);
+    (nan, Float.infinity);
+    (1.0, 1.0);
+    (1.0, 2.0);
+    (0.0, 0.0);
+    (Float.infinity, Float.infinity);
+  |]
+
+let n = Array.length cases
+
+let run_f32 (dev : Device.t) ir =
+  let a = Vector.create Vector.float32 n in
+  let b = Vector.create Vector.float32 n in
+  let ne = Vector.create Vector.int32 n in
+  let eq = Vector.create Vector.int32 n in
+  for i = 0 to n - 1 do
+    let av, bv = cases.(i) in
+    Vector.set a i av ;
+    Vector.set b i bv ;
+    (* Seed the outputs with the WRONG answer for the NaN rows, so a kernel
+       that never wrote them cannot read as a pass. *)
+    Vector.set ne i 7l ;
+    Vector.set eq i 7l
+  done ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:
+      [
+        Execute.Vec a;
+        Execute.Vec b;
+        Execute.Vec ne;
+        Execute.Vec eq;
+        Execute.Int n;
+      ]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  (Vector.to_array ne, Vector.to_array eq)
+
+let run_f64 (dev : Device.t) ir =
+  let a = Vector.create Vector.float64 n in
+  let b = Vector.create Vector.float64 n in
+  let ne = Vector.create Vector.int32 n in
+  let eq = Vector.create Vector.int32 n in
+  for i = 0 to n - 1 do
+    let av, bv = cases.(i) in
+    Vector.set a i av ;
+    Vector.set b i bv ;
+    Vector.set ne i 7l ;
+    Vector.set eq i 7l
+  done ;
+  Execute.run_vectors
+    ~device:dev
+    ~ir
+    ~args:
+      [
+        Execute.Vec a;
+        Execute.Vec b;
+        Execute.Vec ne;
+        Execute.Vec eq;
+        Execute.Int n;
+      ]
+    ~block:(Execute.dims1d n)
+    ~grid:(Execute.dims1d 1)
+    () ;
+  Transfer.flush dev ;
+  (Vector.to_array ne, Vector.to_array eq)
+
+(* Pure-OCaml reference: [<>] / [=] on the same pair. This is the semantics
+   the C-family backends, the native path and the interpreter all share. *)
+let expected_ne i =
+  let av, bv = cases.(i) in
+  if av <> bv then 1l else 0l
+
+let expected_eq i =
+  let av, bv = cases.(i) in
+  if av = bv then 1l else 0l
+
+let verify label got_ne got_eq =
+  let bad = ref 0 in
+  for i = 0 to n - 1 do
+    let av, bv = cases.(i) in
+    let ene = expected_ne i and eeq = expected_eq i in
+    if got_ne.(i) <> ene || got_eq.(i) <> eeq then begin
+      if !bad < 6 then
+        Printf.printf
+          "    %s mismatch @%d: (%h <> %h) got ne=%ld eq=%ld exp ne=%ld eq=%ld\n\
+           %!"
+          label
+          i
+          av
+          bv
+          got_ne.(i)
+          got_eq.(i)
+          ene
+          eeq ;
+      incr bad
+    end
+  done ;
+  !bad
+
+let is_native (dev : Device.t) =
+  dev.Device.framework = "Native" || dev.Device.framework = "Interpreter"
+
+(* Backends whose float [<>] is claimed to be C's [!=]: the PTX emitter (the
+   fix under test), the interpreter and the native oracle. A wrong result from
+   any of these is a hard failure. Other GPU backends emit [!=] in source
+   form, but the driver/compiler is free to apply fast-math style NaN
+   assumptions we do not control here, so they are reported, not gated. *)
+let is_gated (dev : Device.t) =
+  is_native dev || dev.Device.framework = "CUDA/PTX"
+
+let ir_of kern name =
+  let _, kirc = kern in
+  match kirc.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith (name ^ " kernel has no IR")
+
+let () =
+  let ir32 = ir_of float_ne_kernel_f32 "float32 <>" in
+  let ir64 = ir_of float_ne_kernel_f64 "float64 <>" in
+  let devs = Device.init () in
+  print_endline "=== float <> against NaN, E2E (H2 comparison family) ===" ;
+  if Array.length devs = 0 then begin
+    print_endline "test_ptx_float_ne_nan: FAILED - no devices found" ;
+    exit 1
+  end ;
+  let native_ran = ref false in
+  let failed = ref false in
+  Array.iter
+    (fun (dev : Device.t) ->
+      let native = is_native dev in
+      let gated = is_gated dev in
+      List.iter
+        (fun (label, runner, ir) ->
+          try
+            let got_ne, got_eq = runner dev ir in
+            let bad = verify label got_ne got_eq in
+            Printf.printf
+              "  %-11s %-34s %-4s %s (%d/%d ok)%s\n%!"
+              dev.Device.framework
+              dev.Device.name
+              label
+              (if bad = 0 then "PASS" else if gated then "FAIL" else "DIVERGES")
+              (n - bad)
+              n
+              (if bad <> 0 && not gated then " [ungated backend, reported only]"
+               else "") ;
+            if bad <> 0 && gated then failed := true ;
+            if native then native_ran := true
+          with e ->
+            Printf.printf
+              "  %-11s %-34s %-4s %s (%s)\n%!"
+              dev.Device.framework
+              dev.Device.name
+              label
+              (if native then "ERROR" else "SKIP (backend could not launch)")
+              (Printexc.to_string e) ;
+            (* Native/Interpreter must always run. A GPU backend that cannot
+               even launch is only reported; a wrong RESULT from a gated
+               backend that DID run is always a hard failure. *)
+            if native then failed := true)
+        [("f32", run_f32, ir32); ("f64", run_f64, ir64)])
+    devs ;
+  if not !native_ran then begin
+    print_endline
+      "test_ptx_float_ne_nan: FAILED - no native/interpreter device ran" ;
+    exit 1
+  end ;
+  if !failed then begin
+    print_endline "test_ptx_float_ne_nan: FAILED" ;
+    exit 1
+  end ;
+  print_endline "test_ptx_float_ne_nan: PASSED"

--- a/sarek/tests/unit/test_ptx_snapshot.ml
+++ b/sarek/tests/unit/test_ptx_snapshot.ml
@@ -876,6 +876,69 @@ let test_int64_compare_minmax_markers () =
   if contains ptx "setp.lt.s32" || contains ptx "not.b32" then
     Alcotest.fail "32-bit instruction emitted for 64-bit operand"
 
+(** The [Ne] member of that same comparison family, which the H2 test above left
+    uncovered on float operands. Float [<>] must lower to the UNORDERED
+    not-equal (setp.neu.f32/f64). The ordered setp.ne.f32/f64 is false when
+    either operand is NaN, contradicting C's [!=] (every C-family backend), the
+    native path's OCaml [<>] and the interpreter's structural [<>] - a silent
+    wrong answer on PTX only. Integer [<>] keeps the ordered [ne] (no NaN), and
+    float [=] keeps the ordered setp.eq.f32/f64 on purpose: C's [==] is false
+    for NaN too, so the Eq/Ne asymmetry is correct and must not be "fixed". *)
+let test_float_ne_unordered_markers () =
+  let fa = make_var "fa" (TVec TFloat32) in
+  let da = make_var "da" (TVec TFloat64) in
+  let out = make_var "out" (TVec TInt32) in
+  let tid = make_var "tid" TInt32 in
+  let store e = SAssign (LArrayElem ("out", EVar tid), e) in
+  let body =
+    SLet
+      ( tid,
+        EIntrinsic ([], "global_thread_id", []),
+        SSeq
+          [
+            store
+              (EBinop (Ne, EArrayRead ("fa", EVar tid), EConst (CFloat32 1.0)));
+            store
+              (EBinop (Ne, EArrayRead ("da", EVar tid), EConst (CFloat64 1.0)));
+            (* Eq must stay ordered, and integer Ne must stay ordered. *)
+            store
+              (EBinop (Eq, EArrayRead ("fa", EVar tid), EConst (CFloat32 1.0)));
+            store (EBinop (Ne, EVar tid, EConst (CInt32 3l)));
+          ] )
+  in
+  let k =
+    base_kernel
+      "float_ne"
+      [
+        DParam (fa, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (da, Some {arr_elttype = TFloat64; arr_memspace = Global});
+        DParam (out, Some {arr_elttype = TInt32; arr_memspace = Global});
+      ]
+      body
+      []
+  in
+  let ptx = Sarek_ir_ptx.generate k in
+  (* Positive polarity: the unordered form is what float [<>] emits. *)
+  assert_contains ptx "setp.neu.f32" ;
+  assert_contains ptx "setp.neu.f64" ;
+  (* Negative polarity: the ordered float form must be absent. Both halves are
+     needed - "setp.neu.f32" contains neither "setp.ne.f32" nor
+     "setp.ne.f64" as a substring, so a lone positive assertion above would
+     still pass against an emitter that emits BOTH forms, and a lone negative
+     assertion would pass against an emitter that emits neither. A one-sided
+     marker assertion on this file has misfired before. *)
+  if contains ptx "setp.ne.f32" then
+    Alcotest.fail "float <> emitted ordered setp.ne.f32: NaN <> x would be 0" ;
+  if contains ptx "setp.ne.f64" then
+    Alcotest.fail "float <> emitted ordered setp.ne.f64: NaN <> x would be 0" ;
+  (* Scope guard: the fix is Ne-on-float only. *)
+  assert_contains ptx "setp.eq.f32" ;
+  assert_contains ptx "setp.ne.u32" ;
+  if contains ptx "setp.equ.f32" then
+    Alcotest.fail "float = must stay ordered setp.eq.f32 (NaN = NaN is false)" ;
+  if contains ptx "setp.neu.u32" then
+    Alcotest.fail "integer <> must stay setp.ne.u32 (no unordered int form)"
+
 (** ECast scalar-matrix coverage: bool casts normalize to a u32 0/1 via
     setp+selp (float sources use unordered neu so NaN -> 1, matching C); i32 ->
     i64 sign-extends (cvt.s64.s32); i64 -> i32 truncates (cvt.u32.u64). *)
@@ -3051,6 +3114,10 @@ let () =
             "int64 compare/not/min emit 64-bit forms"
             `Quick
             test_int64_compare_minmax_markers;
+          Alcotest.test_case
+            "float <> emits unordered setp.neu, not ordered setp.ne"
+            `Quick
+            test_float_ne_unordered_markers;
           Alcotest.test_case
             "plain f32 division emits div.rn.f32"
             `Quick


### PR DESCRIPTION
## The bug

`sarek/codegen/Sarek_ir_ptx_expr.ml`, comparison-family arm: the opcode table mapped `Ne -> "ne"` and the type suffix became `f32`/`f64` for float operands, so a float `<>` emitted **`setp.ne.f32` / `setp.ne.f64`** — PTX's *ordered* not-equal, which is false as soon as either operand is NaN.

Every other backend disagrees:

| backend | float `<>` | NaN result |
|---|---|---|
| PTX (before) | `setp.ne.f32` (ordered) | **0** |
| CUDA / OpenCL / Metal / GLSL / WGSL | `!=` | 1 |
| native (`Sarek_native_gen.ml:214`) | OCaml `<>` | 1 |
| interpreter (`Sarek_ir_interp_value.ml:223`) | structural `<>` | 1 |

So `nan <> x` returned 0 on PTX and 1 everywhere else — a silent wrong answer on one backend, not a crash.

## The fix

Float `Ne` now emits the **unordered** `setp.neu`, the same instruction the `ECast`-to-bool path 160 lines below already used for the same reason (its comment: *"UNordered ne (setp.neu): NaN != 0.0 is true in C"*).

Emitted instruction, `float32 vector` element vs `1.0`:

```
before:   setp.ne.f32  %p0, %f0, %f1;
after:    setp.neu.f32 %p0, %f0, %f1;
```

Scope is `Ne`-on-float only, and the comment at the site says so explicitly so a future reader does not "fix" the asymmetry:

- **`Eq` is untouched and correct.** C's `==` is also false for NaN, so ordered `setp.eq.f32/f64` already matches; the unordered `setp.equ` would wrongly make `nan = nan` true.
- **Integer `Ne` is untouched** — `setp.ne.u32` / `setp.ne.s64`. Integers have no NaN and PTX has no unordered integer form.
- `Lt/Le/Gt/Ge` unchanged; ordered on both sides already.

## Tests

**`test_ptx_snapshot.ml` → `test_float_ne_unordered_markers`**, adjacent to the H2 comparison-family test that left `Ne` uncovered on float operands. It asserts **both polarities** — `setp.neu.f32/f64` present *and* `setp.ne.f32` / `setp.ne.f64` absent — because either half alone passes against a broken emitter: `"setp.neu.f32"` contains neither ordered marker as a substring, so the positive half cannot see an emitter that emits both forms, and the negative half cannot see one that emits neither. It also pins the `Eq` and integer-`Ne` scope.

**`test_ptx_float_ne_nan.ml`** is the executed proof, modelled on the H1 sibling `test_ptx_signed_arith.ml`. NaN enters through the input **vector**, written host-side, so the DSL needs no NaN literal on this path. The kernel writes `a <> b` and `a = b` as 0/1 and every available device is compared against OCaml's `<>`/`=` on the same pair. Anti-vacuity: outputs are seeded with a wrong value (`7l`) so an unwritten buffer cannot read as a pass, and the five NaN rows are joined by four NaN-free control rows so a constant-returning backend cannot pass either. Native / Interpreter / CUDA-PTX are hard-gated; the run exits non-zero if no device was found or if no native/interpreter device ran.

## Prove-red

The emitter was committed first, then reverted, and both new assertions were confirmed to fail.

Snapshot test, positive half:

```
ASSERT Expected PTX to contain "setp.neu.f32" but it did not.
FAIL   Expected PTX to contain "setp.neu.f32" but it did not.
1 failure! in 0.010s. 67 tests run.
```

Snapshot test, negative half — proven independently, by disabling the two positive assertions while the emitter was still reverted, so the negative half is demonstrably not vacuous:

```
ASSERT float <> emitted ordered setp.ne.f32: NaN <> x would be 0
FAIL   float <> emitted ordered setp.ne.f32: NaN <> x would be 0
1 failure! in 0.011s. 67 tests run.
```

E2E probe on the reverted emitter — this is the divergence itself, on one build, at one moment:

```
    f32 mismatch @0: (nan <> 0x1p+0) got ne=0 eq=0 exp ne=1 eq=0
    f32 mismatch @2: (nan <> nan)    got ne=0 eq=0 exp ne=1 eq=0
  CUDA/PTX    AMD Radeon RX 7900 XTX [ZLUDA]     f32  FAIL (4/9 ok)
  CUDA/PTX    AMD Radeon RX 7900 XTX [ZLUDA]     f64  FAIL (4/9 ok)
  OpenCL      AMD Radeon RX 7900 XTX ...         f32  PASS (9/9 ok)
  Vulkan      AMD Radeon RX 7900 XTX (RADV NAVI31) f32  PASS (9/9 ok)
  Vulkan      AMD Radeon RX 7900 XTX (RADV NAVI31) f64  PASS (9/9 ok)
  Native      CPU Native (Parallel, 32 cores)    f32  PASS (9/9 ok)
  Interpreter CPU Interpreter (Sequential)       f32  PASS (9/9 ok)
test_ptx_float_ne_nan: FAILED
```

Only the five NaN rows fail, and only on PTX. Restored, everything is green.

## Devices actually run

`LD_LIBRARY_PATH=$HOME/opt/zluda`, RX 7900 XTX host:

- **CUDA/PTX under ZLUDA** — RX 7900 XTX and the Ryzen 9 7950X ZLUDA device, f32 + f64, PASS 9/9
- **Vulkan RADV** — NAVI31 and RAPHAEL_MENDOCINO, f32 + f64, PASS 9/9
- **OpenCL** — both devices f32 PASS 9/9; f64 skipped, neither device reports `cl_khr_fp64`
- **Native** (32-core parallel) and **Interpreter** (sequential + parallel), f32 + f64, PASS 9/9

## Also: `docs/formal/rocq-value-ledger.md` M-04

`formal/codegen-ptx` **already specified the correct semantics**: `float` there is Rocq's primitive IEEE-754 float, so `PNe` on `F32`/`F64` is `negb (PrimFloat.eqb a b)` — false for NaN under `eqb`, hence *true* for `nan <> x`, i.e. the unordered form. The hand-written OCaml mirror in `test_codegen_ptx_conformance.ml` agrees. Both halves of the apparatus said the right thing and the implementation shipped the other one.

It could not catch this, and the reason is specific: nothing in `formal/` maps a `ptx_cmp_tag` to a **setp mnemonic** — the string `setp` appears in those theories only in comments. `ptx_cmp_agrees` proves IR-level and PTX-level *evaluation* agree, but both sides are the same abstract semantics, so it is a tag-mapping identity. `PNe` is one tag covering two PTX instructions with different NaN behaviour, and instruction selection is unmodelled. Same shape as M-01: the interesting model abstracted away the boring mapping, and the defect was in the boring mapping. Logged as a miss, not a catch — no proof failed; this was found by reading the opcode table next to the `ECast` path below it.

## Checks

- `dune build` clean
- `dune build @fmt` clean (only pre-existing odoc markup warnings elsewhere in the two touched files)
- `dune test sarek/tests/unit sarek/tests/codegen_golden formal --force` — exit 0, 2073-line non-empty log, every suite `Test Successful`, including `ptx_snapshot` at 67 tests
- no `*.opam` churn; nothing generated committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
