### PR TITLE
fix(lower-ir): seed constant-prefixing with helper PARAMETER names (H3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ test_negative:
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_char_vector.cma > "$$out" 2>&1; if grep -q "is not a supported Sarek element type" "$$out"; then echo "  PASS: char element type rejected"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "Testing polymorphic-helper instantiation diagnostic (names the callee)..."
 	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_poly_helper_f64.cma > "$$out" 2>&1; if grep -q "'norm' cannot be used at this call site" "$$out"; then echo "  PASS: polymorphic helper instantiation named the callee"; else cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
+	@echo "Testing helper-parameter / module-constant collision (backlog-180 H3)..."
+	@out=$$(mktemp); dune build --profile=negative sarek/tests/negative/neg_test_helper_param_shadows_const.cma > "$$out" 2>&1; if grep -q "has a parameter named" "$$out" && grep -q "is NOT a fix here" "$$out"; then echo "  PASS: helper-parameter/module-constant collision rejected, naming the parameter"; else echo "  FAIL: expected the parameter-collision wording (and its negated advice); got:"; cat "$$out"; rm -f "$$out"; exit 1; fi; rm -f "$$out"
 	@echo "All negative tests checked (see KNOWN-ISSUE line above for the one non-blocking gap, if any)"
 
 

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -882,18 +882,32 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                [SLet] flat, so the prefix and the rebinding are two declarations
                of one identifier in one block. Refused below rather than emitted.
                Caught by review on #362. *)
-            let helper_binders =
+            let body_binders =
               let acc = Hashtbl.create 8 in
               stmt_binders fun_body_ir acc ;
-              (* Parameters too, and this is not redundant with seeding
-                 [referenced] above. That seeding only covers a constant named
-                 DIRECTLY by the body. The transitive closure below also pulls in
-                 constants named by the INITIALIZER of a referenced constant, and
-                 those enter [referenced] regardless of what the parameters
-                 shadow — so a constant reachable only through another
-                 constant's initializer could still collide with a parameter.
-                 Present here, that case takes the refusal path instead of
-                 emitting the collision. *)
+              acc
+            in
+            (* Parameters too, and this is not redundant with seeding
+               [referenced] above. That seeding only covers a constant named
+               DIRECTLY by the body. The transitive closure below also pulls in
+               constants named by the INITIALIZER of a referenced constant, and
+               those enter [referenced] regardless of what the parameters
+               shadow — so a constant reachable only through another constant's
+               initializer could still collide with a parameter. Present here,
+               that case takes the refusal path instead of emitting the
+               collision.
+
+               Kept as a SEPARATE table from [body_binders] rather than merged
+               into one, because the refusal message has to say which kind of
+               binder collided and what to do about it, and those differ. For a
+               body-local the advice is "rename the local, or pass the constant
+               in as a parameter"; for a parameter that same advice is circular —
+               the parameter IS the thing it would tell you to add. An earlier
+               revision merged the two and emitted the body-local wording for
+               both, so the parameter case was told to fix the collision by
+               creating it. *)
+            let param_binders =
+              let acc = Hashtbl.create 8 in
               List.iter (fun n -> Hashtbl.replace acc n ()) param_names ;
               acc
             in
@@ -901,7 +915,34 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
               List.fold_left
                 (fun body name ->
                   if not (Hashtbl.mem referenced name) then body
-                  else if Hashtbl.mem helper_binders name then
+                  else if Hashtbl.mem param_binders name then
+                    (* The colliding binder is a PARAMETER. Note the helper does
+                       not necessarily name the constant itself: the seeding
+                       above removes a directly-named one from [referenced], so
+                       the way a parameter-named constant still gets here is
+                       through the initializer of some OTHER constant the helper
+                       does reference. Hence "directly or through" rather than a
+                       flat "references", which would be a claim wider than what
+                       was measured. *)
+                    Ppxlib.Location.raise_errorf
+                      ~loc:helper_loc
+                      "Helper %S has a parameter named %S, and module constant \
+                       %S is needed inside the helper (either named there \
+                       directly or reached through the initializer of another \
+                       constant the helper uses). To be visible, the constant \
+                       has to be declared inside the helper body, and the \
+                       generated device code declares locals in one flat scope \
+                       alongside the parameters — so that would put two \
+                       declarations of %S in the same block. Rename the \
+                       PARAMETER %S, or rename the module constant. Note that \
+                       passing the constant in as a parameter is NOT a fix \
+                       here: a parameter of that name is what collides."
+                      name_of_helper
+                      name
+                      name
+                      name
+                      name
+                  else if Hashtbl.mem body_binders name then
                     Ppxlib.Location.raise_errorf
                       ~loc:helper_loc
                       "Helper %S both references module constant %S and binds \

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -818,9 +818,32 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                actually referenced are prefixed — prefixing all of them would
                evaluate initializers the helper does not need and, worse, would
                drag an unreferenced barrier into the refusal path. *)
+            (* The helper's PARAMETER names. They are binders exactly as much as
+               [SLet]/[SLetMut]/[SFor] are, and the [expr_names] header above
+               documents the redeclaration bug for those — the fix landed for
+               locals (review on #362) and stopped one binder class short.
+
+               Read off [params] here rather than [hf_params], which is not built
+               until further down; both come from the same list, so there is no
+               second source of truth. *)
+            let param_names =
+              List.map (fun (p : tparam) -> p.tparam_name) params
+            in
             let referenced =
               let acc = Hashtbl.create 8 in
-              stmt_names fun_body_ir [] acc ;
+              (* Seeded with the parameter names, NOT [] — a parameter that
+                 merely shares a module constant's name made the constant look
+                 referenced, so its [SLet] got prefixed into a body that already
+                 binds that identifier as a parameter. Two declarations of one
+                 name in one flat scope: a hard compile error on all five device
+                 backends for a helper that compiled before, and on the
+                 interpreter the prefix overwrites the parameter, so the helper
+                 silently ignores its argument.
+
+                 The refusal message below advises "pass the constant in as a
+                 parameter", which was precisely the unchecked case — the
+                 guidance walked the user into the defect. *)
+              stmt_names fun_body_ir param_names acc ;
               let rec close () =
                 let added = ref false in
                 Hashtbl.iter
@@ -854,6 +877,16 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
             let helper_binders =
               let acc = Hashtbl.create 8 in
               stmt_binders fun_body_ir acc ;
+              (* Parameters too, and this is not redundant with seeding
+                 [referenced] above. That seeding only covers a constant named
+                 DIRECTLY by the body. The transitive closure below also pulls in
+                 constants named by the INITIALIZER of a referenced constant, and
+                 those enter [referenced] regardless of what the parameters
+                 shadow — so a constant reachable only through another
+                 constant's initializer could still collide with a parameter.
+                 Present here, that case takes the refusal path instead of
+                 emitting the collision. *)
+              List.iter (fun n -> Hashtbl.replace acc n ()) param_names ;
               acc
             in
             let fun_body_ir =

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -835,10 +835,18 @@ let rec lower_expr (state : state) (te : texpr) : Ir.expr =
                  merely shares a module constant's name made the constant look
                  referenced, so its [SLet] got prefixed into a body that already
                  binds that identifier as a parameter. Two declarations of one
-                 name in one flat scope: a hard compile error on all five device
-                 backends for a helper that compiled before, and on the
-                 interpreter the prefix overwrites the parameter, so the helper
-                 silently ignores its argument.
+                 name in one flat scope.
+
+                 MEASURED, per backend — this comment previously stated the
+                 opposite and was left uncorrected when the test header was
+                 fixed in 84fde09b: OpenCL and Vulkan give a LOUD compile error
+                 ("redefinition of 'scale'"), while the Interpreter and Native
+                 are CORRECT and do NOT silently ignore the argument. The silent
+                 case is PTX, which allocates registers rather than emitting a
+                 flat C scope of named locals, so the duplicate [SLet] never
+                 collides textually and simply overwrites the parameter's
+                 register. See the test header for the table and for how the
+                 CUDA/PTX row was obtained (through ZLUDA, not native NVIDIA).
 
                  The refusal message below advises "pass the constant in as a
                  parameter", which was precisely the unchecked case — the

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1542,3 +1542,41 @@
  (alias runtest)
  (action
   (run %{dep:test_hf_param_identity.exe})))
+
+; backlog-180 (H3): a helper PARAMETER whose name matches a module constant.
+; The backlog-160 constant-prefixing pass collected referenced names with an
+; empty bound list for parameters, so a parameter sharing a constant's name got
+; that constant's SLet prefixed into a body already binding the identifier —
+; hard compile error on the device backends, and on the interpreter the prefix
+; overwrote the parameter so the helper silently ignored its argument. Both a
+; collision case and a still-must-prefix case, so the fix cannot be "never
+; prefix".
+
+(executable
+ (name test_helper_param_const_collision)
+ (modules test_helper_param_const_collision)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  sarek.codegen
+  spoc_core
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ ; -26/-27 in addition to the usual set: the collision kernel's module constant
+ ; is deliberately shadowed by the helper parameter, so the generated native
+ ; OCaml never reads it. That unused binding is the shadowing WORKING, not a
+ ; defect in the test.
+ (flags
+  (:standard -w -26-27-32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_helper_param_const_collision.exe})))

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1546,11 +1546,19 @@
 ; backlog-180 (H3): a helper PARAMETER whose name matches a module constant.
 ; The backlog-160 constant-prefixing pass collected referenced names with an
 ; empty bound list for parameters, so a parameter sharing a constant's name got
-; that constant's SLet prefixed into a body already binding the identifier —
-; hard compile error on the device backends, and on the interpreter the prefix
-; overwrote the parameter so the helper silently ignored its argument. Both a
-; collision case and a still-must-prefix case, so the fix cannot be "never
-; prefix".
+; that constant's SLet prefixed into a body already binding the identifier.
+;
+; The measured pre-fix split, which is NOT "device backends hard-error,
+; interpreter silently overwrites" — that was the reported split and the two
+; halves are swapped:
+;   Interpreter, Native  correct
+;   CUDA/PTX             silently wrong data (200 for want 2); measured through
+;                        ZLUDA on an AMD RX 7900 XTX, there being no NVIDIA
+;                        device on this host
+;   OpenCL, Vulkan       compile failure, "redefinition of 'scale'"
+; Both a collision case and a still-must-prefix case, so the fix cannot be
+; "never prefix". See the test header for the full table and the mutations that
+; make each case red.
 
 (executable
  (name test_helper_param_const_collision)

--- a/sarek/tests/e2e/test_helper_param_const_collision.ml
+++ b/sarek/tests/e2e/test_helper_param_const_collision.ml
@@ -13,7 +13,7 @@
  * free — and its declaration got prefixed into a body that already binds that
  * identifier as a parameter.
  *
- * MEASURED pre-fix behaviour, per backend, on this host. It does NOT match the
+ * MEASURED pre-fix behaviour, per backend. It does NOT match the
  * "device backends hard-error, interpreter silently overwrites" split the
  * finding was reported with — the two halves are swapped, and the real one is
  * worse:
@@ -21,7 +21,9 @@
  *   Interpreter x2  OK        — correct. It does NOT silently ignore the
  *                               argument, contrary to the report.
  *   Native          OK        — correct.
- *   CUDA/PTX x2     got 200, want 2   <- SILENTLY WRONG DATA
+ *   CUDA/PTX        got 200, want 2   <- SILENTLY WRONG DATA
+ *                               (measured THROUGH ZLUDA on an AMD RX 7900 XTX,
+ *                               not on native NVIDIA — see the note below)
  *   OpenCL x2       compile failure (loud)
  *   Vulkan x2       compile failure (loud)
  *
@@ -38,6 +40,18 @@
  * this shape existed.
  *
  * Metal and HIP are unmeasured (no such device on this host).
+ *
+ * HOW THE CUDA/PTX ROW WAS OBTAINED, because "on this host" was doing too much
+ * work here. A bare run of this test enumerates four frameworks — Interpreter,
+ * Native, OpenCL, Vulkan — and NO CUDA device; there is no NVIDIA hardware and
+ * no nvidia-smi. The CUDA/PTX row exists only with
+ * LD_LIBRARY_PATH=$HOME/opt/zluda, which puts ZLUDA's CUDA implementation on an
+ * AMD GPU. So the row is a real execution of the real PTX the emitter produced,
+ * but through a reimplementation of the CUDA driver, not through NVIDIA's.
+ * Treat it as strong evidence about the EMITTED PTX and weaker evidence about
+ * what an NVIDIA driver does with it. Verified: without ZLUDA the device list
+ * is [Interpreter, Native, OpenCL, Vulkan]; with it, [CUDA/PTX, Interpreter,
+ * Native, OpenCL, Vulkan].
  *
  * The [expr_names] header documents this exact redeclaration bug for LOCAL
  * binders ([SLet]/[SLetMut]/[SFor], "caught by review on #362"); the fix landed

--- a/sarek/tests/e2e/test_helper_param_const_collision.ml
+++ b/sarek/tests/e2e/test_helper_param_const_collision.ml
@@ -70,6 +70,40 @@
  *     shadow must still get its copy. Without this case the fix could be
  *     "never prefix anything", which also makes the first case pass while
  *     breaking backlog-160 outright.
+ *
+ * WHICH MUTATION MAKES EACH CASE RED, and whether it reaches EXECUTION. The
+ * table above records a pre-fix state that this test does not re-derive on each
+ * run, so it is evidence only to the extent the mutations below were actually
+ * observed. All three were run on 2026-07-30 with LD_LIBRARY_PATH pointed at
+ * ZLUDA, so all 9 devices were live:
+ *
+ *   Revert BOTH halves of the fix in Sarek_lower_ir.ml (i.e. the file as it is
+ *   on main). Builds cleanly, and the run REACHES EXECUTION and exits 1:
+ *   CUDA/PTX x2 report "got 200 want 2", OpenCL x2 fail with "redefinition of
+ *   'scale'", Vulkan x2 fail to compile, Interpreter x2 and Native pass. This
+ *   is the mutation that reproduces the header table, and it is why the table
+ *   is not merely asserted.
+ *
+ *   Revert ONLY the [referenced] seeding, keeping the parameter names in the
+ *   binder table. This does NOT reach execution: it stops at a BUILD error, the
+ *   refusal guard firing on the collision. Worth stating explicitly, because
+ *   the seeding and the guard shipped in one commit, and the seeding alone is
+ *   therefore not observable through this test — the guard masks it.
+ *
+ *   Replace the seeding call with [ignore] so nothing is ever considered
+ *   referenced (the degenerate "never prefix anything" fix). Builds cleanly and
+ *   REACHES EXECUTION, exit 1, on the prefixing-still-works case: "Unbound
+ *   variable 'offset'" on the Interpreter, "PTX codegen: unbound variable:
+ *   offset" on CUDA/PTX, a compile failure on OpenCL and Vulkan. NOTE that
+ *   Native passes this mutation — it resolves [offset] from the enclosing OCaml
+ *   scope — so Native alone is blind to a missing prefix, and case 2's value
+ *   comes from the other backends.
+ *
+ * The refusal guard's own behaviour is NOT covered here, because it fires
+ * during lowering and so is unobservable from a running test. It is pinned as a
+ * negative-compile case instead:
+ * sarek/tests/negative/test_helper_param_shadows_const.ml, asserted by
+ * `make test_negative`.
  ******************************************************************************)
 
 module Device = Spoc_core.Device
@@ -88,8 +122,15 @@ type float32 = float
 type ('a, 'b) vector = ('a, 'b) Vector.t
 
 (* The helper parameter [scale] shadows the module constant [scale]. Correct
-   behaviour: [boost x] is [x *. 2.0]. Pre-fix, the prefixed constant makes it
-   [100.0 *. 2.0] on the interpreter and a redeclaration error on the rest. *)
+   behaviour: [boost x] is [x *. 2.0].
+
+   Pre-fix, per the measured table in the header — NOT "interpreter silently
+   wrong, everything else a compile error", which is what this comment used to
+   say and which is the reported split rather than the observed one. Observed:
+   the Interpreter and Native are CORRECT; CUDA/PTX silently computes
+   [100.0 *. 2.0] because it allocates registers instead of a flat C scope, so
+   the duplicated declaration overwrites the parameter rather than colliding;
+   OpenCL and Vulkan fail to compile ("redefinition of 'scale'"). *)
 let collision_kernel =
   snd
     [%kernel
@@ -178,10 +219,13 @@ let () =
   let any_failure = ref false in
   Array.iter
     (fun dev ->
-      (* param shadows the constant -> the ARGUMENT must win (x *. 2.0).
-         Pre-fix interpreter answer would be 100.0 *. 2.0 = 200.0 for every
-         element, which this expectation separates by two orders of
-         magnitude. *)
+      (* param shadows the constant -> the ARGUMENT must win (x *. 2.0). The
+         wrong answer is 100.0 *. 2.0 = 200.0 for every element, two orders of
+         magnitude away from the right one, which is what makes the SILENT
+         backend's failure visible at all. Pre-fix that 200.0 was produced by
+         CUDA/PTX (measured through ZLUDA on an AMD RX 7900 XTX); the
+         Interpreter was correct here, so the expectation is not separating an
+         interpreter answer. *)
       if
         not
           (run_case

--- a/sarek/tests/e2e/test_helper_param_const_collision.ml
+++ b/sarek/tests/e2e/test_helper_param_const_collision.ml
@@ -1,0 +1,171 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * A helper PARAMETER whose name matches a module constant (backlog-180, H3).
+ *
+ * backlog-160 gives a helper its own copy of every module constant it
+ * references, by prefixing that constant's [SLet] into the helper body. The set
+ * of "referenced" names was collected with an EMPTY bound list for parameters,
+ * so a parameter that merely shares a constant's name made the constant look
+ * free — and its declaration got prefixed into a body that already binds that
+ * identifier as a parameter. Two declarations of one name in one flat scope:
+ *
+ *   device backends: hard compile error, on a helper that compiled before.
+ *   interpreter:     the prefix OVERWRITES the parameter, so the helper
+ *                    silently ignores its argument and computes from the
+ *                    constant instead. Wrong data, no diagnostic.
+ *
+ * The [expr_names] header documents this exact redeclaration bug for LOCAL
+ * binders ([SLet]/[SLetMut]/[SFor], "caught by review on #362"); the fix landed
+ * for locals and stopped one binder class short of parameters. The refusal
+ * message on that path even advises "pass the constant in as a parameter",
+ * which was precisely the unchecked case.
+ *
+ * TWO CASES, both required:
+ *
+ *   collision — the helper's parameter is named [scale] and a module constant
+ *     [scale] exists. The values are deliberately far apart (argument-derived
+ *     result 2.0, constant-derived result 200.0) so the SILENT symptom is
+ *     visible: a test whose two answers coincide cannot see it.
+ *
+ *   prefixing-still-works — a helper that references a constant it does NOT
+ *     shadow must still get its copy. Without this case the fix could be
+ *     "never prefix anything", which also makes the first case pass while
+ *     breaking backlog-160 outright.
+ ******************************************************************************)
+
+module Device = Spoc_core.Device
+module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
+
+let () =
+  Sarek_native.Native_plugin.init () ;
+  Sarek_interpreter.Interpreter_plugin.init () ;
+  Sarek_cuda.Cuda_plugin.init () ;
+  Sarek_opencl.Opencl_plugin.init () ;
+  Sarek_vulkan.Vulkan_plugin.init ()
+
+type float32 = float
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+(* The helper parameter [scale] shadows the module constant [scale]. Correct
+   behaviour: [boost x] is [x *. 2.0]. Pre-fix, the prefixed constant makes it
+   [100.0 *. 2.0] on the interpreter and a redeclaration error on the rest. *)
+let collision_kernel =
+  snd
+    [%kernel
+      let open Std in
+      let (scale : float32) = 100.0 in
+      let boost (scale : float32) : float32 = scale *. 2.0 in
+      fun (out : float32 vector) (src : float32 vector) (n : int32) ->
+        let t = thread_idx_x + (block_idx_x * block_dim_x) in
+        if t < n then out.(t) <- boost src.(t)]
+
+(* No shadowing: the helper names a constant it does not bind, so the constant
+   MUST still be prefixed into it. This is the backlog-160 feature the fix must
+   not regress. *)
+let prefixing_kernel =
+  snd
+    [%kernel
+      let open Std in
+      let (offset : float32) = 7.0 in
+      let shifted (x : float32) : float32 = x +. offset in
+      fun (out : float32 vector) (src : float32 vector) (n : int32) ->
+        let t = thread_idx_x + (block_idx_x * block_dim_x) in
+        if t < n then out.(t) <- shifted src.(t)]
+
+let ir_of kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+let n = 32
+
+let run_case (dev : Device.t) ~label ~kernel ~expected : bool =
+  Printf.printf
+    "helper-const %-22s [%s] %s: %!"
+    label
+    dev.Device.framework
+    dev.Device.name ;
+  let src = Vector.create Vector.float32 n in
+  let out = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set src i (float_of_int (i + 1)) ;
+    Vector.set out i 0.0
+  done ;
+  match
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of kernel)
+      ~args:[Vec out; Vec src; Int n]
+      ~block:(Sarek.Execute.dims1d n)
+      ~grid:(Sarek.Execute.dims1d 1)
+      ()
+  with
+  | exception e ->
+      (* Not a skip. Both kernels are ordinary DSL and every backend listed
+         executes ordinary scalar kernels; a refusal here IS the defect. *)
+      Printf.printf "FAILED (raised: %s)\n%!" (Printexc.to_string e) ;
+      false
+  | () ->
+      Transfer.flush dev ;
+      let ok = ref true in
+      let reported = ref 0 in
+      for i = 0 to n - 1 do
+        let want = expected (float_of_int (i + 1)) in
+        let got = Vector.get out i in
+        if Float.abs (got -. want) > 1e-4 then begin
+          ok := false ;
+          if !reported < 3 then begin
+            incr reported ;
+            Printf.printf "\n  @%d got %g want %g" i got want
+          end
+        end
+      done ;
+      if !ok then Printf.printf "OK\n%!" else Printf.printf "\n  FAILED\n%!" ;
+      !ok
+
+let () =
+  let devs =
+    Device.init
+      ~frameworks:
+        ["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"; "Metal"; "HIP"]
+      ()
+  in
+  if Array.length devs = 0 then begin
+    print_endline "No devices found — nothing asserted, and that is a gap" ;
+    exit 1
+  end ;
+  let any_failure = ref false in
+  Array.iter
+    (fun dev ->
+      (* param shadows the constant -> the ARGUMENT must win (x *. 2.0).
+         Pre-fix interpreter answer would be 100.0 *. 2.0 = 200.0 for every
+         element, which this expectation separates by two orders of
+         magnitude. *)
+      if
+        not
+          (run_case
+             dev
+             ~label:"param shadows const"
+             ~kernel:collision_kernel
+             ~expected:(fun x -> x *. 2.0))
+      then any_failure := true ;
+      (* no shadowing -> the constant must still reach the helper (x +. 7.0).
+         If this regresses, the emitted device code names an identifier it never
+         declared, which is a compile error rather than wrong data. *)
+      if
+        not
+          (run_case
+             dev
+             ~label:"const still prefixed"
+             ~kernel:prefixing_kernel
+             ~expected:(fun x -> x +. 7.0))
+      then any_failure := true)
+    devs ;
+  Printf.printf "%d device(s) exercised\n%!" (Array.length devs) ;
+  if !any_failure then exit 1

--- a/sarek/tests/e2e/test_helper_param_const_collision.ml
+++ b/sarek/tests/e2e/test_helper_param_const_collision.ml
@@ -11,12 +11,33 @@
  * of "referenced" names was collected with an EMPTY bound list for parameters,
  * so a parameter that merely shares a constant's name made the constant look
  * free — and its declaration got prefixed into a body that already binds that
- * identifier as a parameter. Two declarations of one name in one flat scope:
+ * identifier as a parameter.
  *
- *   device backends: hard compile error, on a helper that compiled before.
- *   interpreter:     the prefix OVERWRITES the parameter, so the helper
- *                    silently ignores its argument and computes from the
- *                    constant instead. Wrong data, no diagnostic.
+ * MEASURED pre-fix behaviour, per backend, on this host. It does NOT match the
+ * "device backends hard-error, interpreter silently overwrites" split the
+ * finding was reported with — the two halves are swapped, and the real one is
+ * worse:
+ *
+ *   Interpreter x2  OK        — correct. It does NOT silently ignore the
+ *                               argument, contrary to the report.
+ *   Native          OK        — correct.
+ *   CUDA/PTX x2     got 200, want 2   <- SILENTLY WRONG DATA
+ *   OpenCL x2       compile failure (loud)
+ *   Vulkan x2       compile failure (loud)
+ *
+ * PTX is the silent one because it does not emit a flat C scope of named
+ * locals: it allocates registers, so a duplicated [SLet] never collides
+ * textually. The prefixed constant simply overwrote the parameter's register
+ * and the helper computed 100.0 *. 2.0 for every element.
+ *
+ * That inversion matters for how much this is worth. A silent bug on the
+ * INTERPRETER would be caught by any cross-backend differential test, because
+ * the interpreter is the oracle and it would disagree with the GPUs. Here the
+ * oracle is RIGHT and only a real GPU backend is wrong, so agreement-with-
+ * interpreter is exactly the check that would have caught it — and no test of
+ * this shape existed.
+ *
+ * Metal and HIP are unmeasured (no such device on this host).
  *
  * The [expr_names] header documents this exact redeclaration bug for LOCAL
  * binders ([SLet]/[SLetMut]/[SFor], "caught by review on #362"); the fix landed

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -382,7 +382,10 @@
 (library
  (name neg_test_helper_param_shadows_const)
  (modules test_helper_param_shadows_const)
- (libraries sarek sarek.stdlib sarek.ppx.lib)
+ ; spoc_core is listed because this case actually USES it (the vector type), so
+ ; that a guard that stops firing yields a clean compile rather than an unbound
+ ; module from a sibling's copied preamble.
+ (libraries sarek sarek.stdlib sarek.ppx.lib spoc_core)
  (preprocess
   (pps sarek_ppx))
  (flags

--- a/sarek/tests/negative/dune
+++ b/sarek/tests/negative/dune
@@ -373,3 +373,19 @@
   (:standard -w -33))
  (enabled_if
   (= %{profile} "negative")))
+
+; backlog-180 (H3): a helper PARAMETER colliding with a module constant the
+; helper needs transitively (through another constant's initializer). This is the
+; one shape the H3 fix turned into a hard rejection rather than a correction, so
+; it is the half of that fix no running test can observe.
+
+(library
+ (name neg_test_helper_param_shadows_const)
+ (modules test_helper_param_shadows_const)
+ (libraries sarek sarek.stdlib sarek.ppx.lib)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -33))
+ (enabled_if
+  (= %{profile} "negative")))

--- a/sarek/tests/negative/test_helper_param_shadows_const.ml
+++ b/sarek/tests/negative/test_helper_param_shadows_const.ml
@@ -1,0 +1,48 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(* Test kernel that should FAIL to compile (backlog-180, H3).
+
+   A helper PARAMETER named [scale] collides with a module constant [scale] that
+   the helper genuinely needs. The collision is deliberately NOT a direct
+   reference: [scale] is named by the INITIALIZER of [base], and [base] is what
+   the helper body references. That routing matters, because the fix for H3 seeds
+   the referenced-name scan with the parameter names, which removes a DIRECTLY
+   named constant from the set — so a direct collision compiles cleanly and is
+   covered by the e2e test instead. The transitive closure runs with an empty
+   bound list, so a constant reached through another constant's initializer still
+   enters the set, and this is the shape that reaches the refusal.
+
+   Why a negative-compile case rather than an e2e assertion: the outcome is a
+   [Location.raise_errorf] during lowering, so the kernel never reaches a device
+   and nothing about it is observable from a running test. It is also the ONLY
+   user-visible behaviour the H3 fix added — the seeding half makes previously
+   miscompiled kernels correct, but pairing it with the parameter names in the
+   binder table makes this shape a hard REJECTION of source that used to build.
+   A rejection nothing asserts is a rejection that can silently widen.
+
+   What is pinned is the message, not just the failure. Before this case existed
+   the guard emitted the body-local wording for a parameter collision, which was
+   false twice over: it called the parameter "a local", and it advised "pass the
+   constant in as a parameter", which is precisely what collides. Asserting only
+   "some error" would have kept both. *)
+
+open Spoc
+open Sarek
+
+let () =
+  let bad_kernel =
+    [%kernel
+      let open Std in
+      let (scale : float32) = 100.0 in
+      let (base : float32) = scale +. 1.0 in
+      let shifted (scale : float32) : float32 = base +. scale in
+      fun (out : float32 vector) (src : float32 vector) (n : int32) ->
+        let t = thread_idx_x + (block_idx_x * block_dim_x) in
+        if t < n then out.(t) <- shifted src.(t)]
+  in
+  let _, kirc = bad_kernel in
+  Kirc.print_ast kirc.Kirc.body ;
+  print_endline "This should not print - test should have failed to compile"

--- a/sarek/tests/negative/test_helper_param_shadows_const.ml
+++ b/sarek/tests/negative/test_helper_param_shadows_const.ml
@@ -27,13 +27,24 @@
    the guard emitted the body-local wording for a parameter collision, which was
    false twice over: it called the parameter "a local", and it advised "pass the
    constant in as a parameter", which is precisely what collides. Asserting only
-   "some error" would have kept both. *)
+   "some error" would have kept both.
 
-open Spoc
-open Sarek
+   DELIBERATELY SELF-CONTAINED. The sibling negative tests here open [Spoc] and
+   reach for [Kirc], neither of which is in their library dependencies — they
+   only get away with it because the refusal fires before those names are
+   resolved. That makes the guard-stopped-firing case report "Unbound module
+   Spoc" instead of the kernel having compiled, which is a real error in place of
+   the informative one. Measured while proving this case red: with the guard
+   reverted, that is exactly what the first draft of this file printed. So this
+   file depends only on what it uses, and if the refusal ever stops firing it
+   compiles and reaches the [print_endline] below. *)
+
+type float32 = float
+
+type ('a, 'b) vector = ('a, 'b) Spoc_core.Vector.t
 
 let () =
-  let bad_kernel =
+  let _bad_kernel =
     [%kernel
       let open Std in
       let (scale : float32) = 100.0 in
@@ -43,6 +54,4 @@ let () =
         let t = thread_idx_x + (block_idx_x * block_dim_x) in
         if t < n then out.(t) <- shifted src.(t)]
   in
-  let _, kirc = bad_kernel in
-  Kirc.print_ast kirc.Kirc.body ;
   print_endline "This should not print - test should have failed to compile"


### PR DESCRIPTION
backlog-180 (review finding H3). Verified at the lines before changing anything.

`Sarek_lower_ir.ml` collected the helper's referenced-constant set with `stmt_names fun_body_ir [] acc` — an **empty** bound list. So a helper parameter that merely shares a module constant's name made that constant look free, and backlog-160's prefixing pass inserted its `SLet` into a body that already binds the identifier as a parameter.

The `expr_names` header documents this exact redeclaration bug for **local** binders (`SLet`/`SLetMut`/`SFor`, "caught by review on #362"). That fix landed for locals and stopped one binder class short. And the refusal message on the same path advises *"pass the constant in as a parameter"* — precisely the unchecked case, so the guidance walked the user into the defect.

## The reported backend split was inverted, and the truth is worse

Measured on the pre-fix code:

| Backend | Pre-fix |
|---|---|
| Interpreter ×2 | **OK** — correct; does *not* ignore its argument |
| Native | **OK** |
| CUDA/PTX ×2 | **`got 200 want 2` — silently wrong data** |
| OpenCL ×2 | compile failure (loud) |
| Vulkan ×2 | compile failure (loud) |

PTX is the silent one because it doesn't emit a flat C scope of named locals — it allocates registers, so a duplicated `SLet` never collides textually. The prefixed constant overwrote the parameter's register and the helper computed `100.0 *. 2.0` for every element.

This changes the value of the fix. A silent bug on the *interpreter* would be caught by any cross-backend differential test, since the interpreter is the oracle and would disagree with the GPUs. Here the oracle is **right** and only a real GPU backend is wrong — so agreement-with-interpreter is exactly the check that catches it, and no test of this shape existed.

Metal and HIP unmeasured (no such device on this host).

## Two changes, and the second is not redundant

- `referenced` — seeded with `param_names`, so a shadowed constant is never counted as referenced.
- `helper_binders` — `param_names` added too. The transitive closure also pulls in constants named by a referenced constant's **initializer**, and those enter the set regardless of what the parameters shadow. Present here, that residual case takes the existing refusal path instead of emitting the collision.

`param_names` is read off `params` (in scope since line 770) rather than `hf_params` (not built until ~929); both derive from the same list, so no second source of truth.

**A property worth stating:** reverting *only* the seeding leaves `helper_binders` as a backstop, and the collision surfaces as the existing located refusal rather than wrong data. Reproducing the original symptoms needed both halves reverted. So if a future binder class is missed again, the failure mode is a refusal, not a silent miscompile.

## Evidence

`test_helper_param_const_collision` — **18 cases green** (9 devices × 2 kernels).

Two kernels, both required. The collision case's values are deliberately two orders of magnitude apart (argument-derived 2.0 vs constant-derived 200.0) so the silent symptom is visible at all. The second kernel references a constant it does *not* shadow and must still receive its copy — without it, "never prefix anything" would also pass the first case while breaking backlog-160 outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed helper code generation when a helper parameter shares a name with a module constant.
  * Ensured parameter values take precedence while referenced constants remain correctly qualified.

* **Tests**
  * Added end-to-end coverage for name-collision scenarios across supported execution backends.
  * Added validation for both shadowed parameters and correctly referenced module constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->