### PR TITLE
test(audit): pin the three audit fixes that no test could fail on

### DIFF
--- a/sarek/framework/test/dune
+++ b/sarek/framework/test/dune
@@ -27,3 +27,18 @@
  (libraries spoc_framework_registry spoc_framework alcotest)
  (instrumentation
   (backend bisect_ppx)))
+
+; Probe-exception policy of the three availability accessors (available,
+; available_backends, best_backend). The registry used to swallow EVERY
+; exception from is_available, so a real Out_of_memory reached the user as
+; "no backends found"; 22745124 fixed one accessor and 339c8e2c the other two.
+; Own executable because the registry is process-global and this suite needs a
+; backend whose probe raises on demand, which must not leak into the other
+; suites' view of what is registered.
+
+(test
+ (name test_registry_probe_policy)
+ (modules test_registry_probe_policy probe_backend)
+ (libraries spoc_framework_registry spoc_framework alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek/framework/test/probe_backend.ml
+++ b/sarek/framework/test/probe_backend.ml
@@ -1,0 +1,185 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** A BACKEND whose [is_available] probe is programmable, for
+    test_registry_probe_policy.
+
+    Everything except [is_available] is the same inert stub as {!Dummy_backend}
+    \- the registry's probe policy is the only thing under test, so nothing else
+    here is ever called. It does NOT self-register: the test decides when the
+    backend enters the registry, because the registry is process-global and an
+    auto-registration would leak into the "no backends registered" baseline. *)
+
+open Spoc_framework.Framework_sig
+open Spoc_framework_registry
+
+(** What the next probe does. [Ordinary] stands for any run-of-the-mill probe
+    failure (a missing driver, a failed dlopen); [Fatal e] for the
+    asynchronous/fatal class the registry must not swallow. *)
+type mode = Ok | Unavailable | Ordinary | Fatal of exn
+
+let mode = ref Ok
+
+let probe_calls = ref 0
+
+let backend_name = "ProbeBackend"
+
+module Probe_backend : BACKEND = struct
+  let name = backend_name
+
+  let version = (1, 0, 0)
+
+  let is_available () =
+    incr probe_calls ;
+    match !mode with
+    | Ok -> true
+    | Unavailable -> false
+    | Ordinary -> raise Not_found
+    | Fatal e -> raise e
+
+  let execution_model = Custom
+
+  let supported_source_langs = []
+
+  let generate_source ?block:_ ?soa_params:_ _ir = None
+
+  let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args = ()
+
+  let wrap_kargs () = failwith "Probe backend: wrap_kargs not implemented"
+
+  let unwrap_kargs _ = None
+
+  let run_source ~source:_ ~lang:_ ~kernel_name:_ ~block:_ ~grid:_ ~shared_mem:_
+      _ =
+    ()
+
+  module Intrinsics = Intrinsic_registry.Make ()
+
+  module Device = struct
+    type t = unit
+
+    type id = int
+
+    let init () = ()
+
+    let count () = 0
+
+    let get _id = ()
+
+    let id () = 0
+
+    let set_current () = ()
+
+    let synchronize () = ()
+
+    let name () = "Probe Test Device"
+
+    let capabilities () =
+      {
+        max_threads_per_block = 1;
+        max_block_dims = (1, 1, 1);
+        max_grid_dims = (1, 1, 1);
+        shared_mem_per_block = 0;
+        total_global_mem = 0L;
+        compute_capability = (0, 0);
+        device_features = [];
+        coopmat = None;
+        supports_atomics = false;
+        warp_size = 1;
+        max_registers_per_block = 0;
+        clock_rate_khz = 0;
+        multiprocessor_count = 1;
+        is_cpu = true;
+      }
+  end
+
+  module Stream = struct
+    type t = unit
+
+    let create () = ()
+
+    let default () = ()
+
+    let synchronize () = ()
+
+    let destroy () = ()
+  end
+
+  module Memory = struct
+    type 'a buffer = unit
+
+    let alloc _dev _size _kind = ()
+
+    let alloc_custom _dev ~size:_ ~elem_size:_ = ()
+
+    let alloc_zero_copy _dev _ba _kind = None
+
+    let device_ptr _buf = Nativeint.zero
+
+    let is_zero_copy _buf = false
+
+    let host_to_device ~src:_ ~dst:_ = ()
+
+    let device_to_host ~src:_ ~dst:_ = ()
+
+    let device_to_device ~src:_ ~dst:_ = ()
+
+    let host_ptr_to_device ~src_ptr:_ ~byte_size:_ ~dst:_ = ()
+
+    let device_to_host_ptr ~src:_ ~dst_ptr:_ ~byte_size:_ = ()
+
+    let size _buf = 0
+
+    let free _buf = ()
+  end
+
+  module Kernel = struct
+    type t = unit
+
+    type args = unit
+
+    let compile _dev ~name:_ ~source:_ = ()
+
+    let compile_cached _dev ~name:_ ~source:_ = ()
+
+    let clear_cache () = ()
+
+    let load_from_ptx ~name:_ ~ptx:_ = ()
+
+    let create_args () = ()
+
+    let set_arg_buffer _args _idx _buf = ()
+
+    let set_arg_int32 _args _idx _v = ()
+
+    let set_arg_int64 _args _idx _v = ()
+
+    let set_arg_float32 _args _idx _v = ()
+
+    let set_arg_float64 _args _idx _v = ()
+
+    let set_arg_ptr _args _idx _ptr = ()
+
+    let launch _kernel ~args:_ ~grid:_ ~block:_ ~shared_mem:_ ~stream:_ = ()
+  end
+
+  module Event = struct
+    type t = unit
+
+    let create () = ()
+
+    let record _event _stream = ()
+
+    let synchronize _event = ()
+
+    let elapsed ~start:_ ~stop:_ = 0.0
+
+    let destroy _event = ()
+  end
+
+  let enable_profiling () = ()
+
+  let disable_profiling () = ()
+end

--- a/sarek/framework/test/test_registry_probe_policy.ml
+++ b/sarek/framework/test/test_registry_probe_policy.ml
@@ -1,0 +1,230 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression test for the Framework_registry error-swallowing fix.
+ *
+ * WHY THIS FILE EXISTS
+ *   `Framework_registry` used to filter its availability lists with
+ *   `try is_available () with _ -> false`, so an Out_of_memory or a
+ *   Stack_overflow raised inside a backend's probe was reported to the user as
+ *   "no backends found" — a real failure rendered as an empty result. Two
+ *   commits fixed it: 22745124 introduced the re-raise, but only in
+ *   `available`; 339c8e2c factored the policy into `probe_available` and
+ *   applied it to ALL THREE accessors (`available`, `available_backends`,
+ *   `best_backend`). The 2026-07-29 audit flagged the whole thing as untested,
+ *   and specifically noted that its own earlier patch had covered one accessor
+ *   of three.
+ *
+ *   So this file tests all three, symmetrically, rather than the one that
+ *   happened to be fixed first. Reverting `Framework_registry.ml` to 22745124
+ *   leaves `available` green and turns `available_backends` and `best_backend`
+ *   red, which is the distinction the audit is pointing at.
+ *
+ * BOTH POLARITIES
+ *   Good behaviour: an ORDINARY probe failure still counts as unavailable and
+ *   escapes as no exception at all. A "fix" that simply removed the handler
+ *   would satisfy the fatal cases and break these.
+ *   Bad behaviour absent: each of Out_of_memory, Stack_overflow and Sys.Break
+ *   must PROPAGATE out of each accessor rather than being turned into a silent
+ *   absence.
+ *
+ * NON-VACUITY
+ *   Every case asserts the probe was actually CALLED (`probe_calls`). Without
+ *   that, an accessor which never reached the probe — because the backend was
+ *   not registered, or because the table was empty — would satisfy "no
+ *   exception escaped" and "the list does not contain ProbeBackend" perfectly.
+ *   The `Ok` cases pin the other end: the backend IS found when its probe says
+ *   so, so "absent" is a decision and not a default.
+ ******************************************************************************)
+
+open Spoc_framework.Framework_sig
+open Spoc_framework_registry
+
+let () =
+  Framework_registry.register_backend
+    ~priority:42
+    (module Probe_backend.Probe_backend)
+
+let plugin_names l = List.map (fun (module P : S) -> P.name) l
+
+let backend_names l = List.map (fun (module B : BACKEND) -> B.name) l
+
+(** Run [f] with the probe in [mode], and report how many times the probe was
+    hit. *)
+let with_mode mode f =
+  Probe_backend.mode := mode ;
+  Probe_backend.probe_calls := 0 ;
+  let r = f () in
+  (r, !Probe_backend.probe_calls)
+
+let check_probed n =
+  Alcotest.(check bool)
+    "the probe was actually called (else this case is vacuous)"
+    true
+    (n > 0)
+
+(* ---------------------------------------------------------------- *)
+(* Non-vacuity controls: the probe decides, in both directions.      *)
+(* ---------------------------------------------------------------- *)
+
+let available_finds_the_backend () =
+  let names, n =
+    with_mode Probe_backend.Ok (fun () ->
+        plugin_names (Framework_registry.available ()))
+  in
+  check_probed n ;
+  Alcotest.(check bool)
+    "an available probe puts the backend in available ()"
+    true
+    (List.mem Probe_backend.backend_name names)
+
+let available_backends_finds_the_backend () =
+  let names, n =
+    with_mode Probe_backend.Ok (fun () ->
+        backend_names (Framework_registry.available_backends ()))
+  in
+  check_probed n ;
+  Alcotest.(check bool)
+    "an available probe puts the backend in available_backends ()"
+    true
+    (List.mem Probe_backend.backend_name names)
+
+let best_backend_finds_the_backend () =
+  let r, n =
+    with_mode Probe_backend.Ok (fun () -> Framework_registry.best_backend ())
+  in
+  check_probed n ;
+  Alcotest.(check bool)
+    "an available probe makes best_backend () return it"
+    true
+    (match r with
+    | Some (module B : BACKEND) -> B.name = Probe_backend.backend_name
+    | None -> false)
+
+let unavailable_is_excluded () =
+  let names, n =
+    with_mode Probe_backend.Unavailable (fun () ->
+        plugin_names (Framework_registry.available ()))
+  in
+  check_probed n ;
+  Alcotest.(check bool)
+    "a probe returning false excludes the backend"
+    false
+    (List.mem Probe_backend.backend_name names)
+
+(* ---------------------------------------------------------------- *)
+(* GOOD BEHAVIOUR: an ordinary probe failure = unavailable, no raise *)
+(* ---------------------------------------------------------------- *)
+
+let ordinary_failure_is_unavailable_in_available () =
+  let names, n =
+    with_mode Probe_backend.Ordinary (fun () ->
+        plugin_names (Framework_registry.available ()))
+  in
+  check_probed n ;
+  Alcotest.(check bool)
+    "available (): ordinary probe failure excludes, does not raise"
+    false
+    (List.mem Probe_backend.backend_name names)
+
+let ordinary_failure_is_unavailable_in_available_backends () =
+  let names, n =
+    with_mode Probe_backend.Ordinary (fun () ->
+        backend_names (Framework_registry.available_backends ()))
+  in
+  check_probed n ;
+  Alcotest.(check bool)
+    "available_backends (): ordinary probe failure excludes, does not raise"
+    false
+    (List.mem Probe_backend.backend_name names)
+
+let ordinary_failure_is_unavailable_in_best_backend () =
+  let r, n =
+    with_mode Probe_backend.Ordinary (fun () ->
+        Framework_registry.best_backend ())
+  in
+  check_probed n ;
+  Alcotest.(check bool)
+    "best_backend (): ordinary probe failure excludes, does not raise"
+    true
+    (r = None)
+
+(* ---------------------------------------------------------------- *)
+(* BAD BEHAVIOUR ABSENT: fatal exceptions propagate, all 3 accessors *)
+(* ---------------------------------------------------------------- *)
+
+let fatal_exceptions = [Out_of_memory; Stack_overflow; Sys.Break]
+
+let name_of_exn = Printexc.to_string
+
+(** [accessor] is forced to a value, so a lazy Seq.filter cannot postpone the
+    raise past the assertion. *)
+let fatal_propagates ~what accessor exn () =
+  Probe_backend.mode := Probe_backend.Fatal exn ;
+  Probe_backend.probe_calls := 0 ;
+  Alcotest.check_raises
+    (Printf.sprintf
+       "%s must propagate %s, not swallow it"
+       what
+       (name_of_exn exn))
+    exn
+    (fun () -> accessor ()) ;
+  check_probed !Probe_backend.probe_calls
+
+let fatal_cases what accessor =
+  List.map
+    (fun exn ->
+      Alcotest.test_case
+        (Printf.sprintf "%s propagates %s" what (name_of_exn exn))
+        `Quick
+        (fatal_propagates ~what accessor exn))
+    fatal_exceptions
+
+let () =
+  Alcotest.run
+    "Framework_registry probe policy"
+    [
+      ( "the probe decides (non-vacuity controls)",
+        [
+          Alcotest.test_case
+            "available finds it"
+            `Quick
+            available_finds_the_backend;
+          Alcotest.test_case
+            "available_backends finds it"
+            `Quick
+            available_backends_finds_the_backend;
+          Alcotest.test_case
+            "best_backend finds it"
+            `Quick
+            best_backend_finds_the_backend;
+          Alcotest.test_case "false excludes it" `Quick unavailable_is_excluded;
+        ] );
+      ( "ordinary probe failure counts as unavailable",
+        [
+          Alcotest.test_case
+            "available"
+            `Quick
+            ordinary_failure_is_unavailable_in_available;
+          Alcotest.test_case
+            "available_backends"
+            `Quick
+            ordinary_failure_is_unavailable_in_available_backends;
+          Alcotest.test_case
+            "best_backend"
+            `Quick
+            ordinary_failure_is_unavailable_in_best_backend;
+        ] );
+      ( "fatal probe failure propagates - available",
+        fatal_cases "available" (fun () ->
+            ignore (Framework_registry.available ())) );
+      ( "fatal probe failure propagates - available_backends",
+        fatal_cases "available_backends" (fun () ->
+            ignore (Framework_registry.available_backends ())) );
+      ( "fatal probe failure propagates - best_backend",
+        fatal_cases "best_backend" (fun () ->
+            ignore (Framework_registry.best_backend ())) );
+    ]

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -272,3 +272,23 @@
  (name test_lower_ir_refusal_triggers)
  (modules test_lower_ir_refusal_triggers)
  (libraries sarek_frontend))
+; Audit finding M8: Sarek_worklist.Host.drive must stop at the first OVERFLOW.
+; The e2e worklist test needs a device and never calls drive on an overflowing
+; queue, so the guard at Sarek_worklist.ml:208 was pinned by nothing. drive is
+; pure host logic, so this drives it against a simulated device - CPU-only.
+
+(test
+ (name test_worklist_drive)
+ (modules test_worklist_drive)
+ (libraries sarek.worklist spoc_core alcotest))
+
+; Audit finding L1: the tuple-shape registry's build-and-insert must be
+; single-winner, so concurrent first-time builders of one shape all observe the
+; SAME custom_type (hence the same Type_id the Native path resolves through
+; descriptor_by_name). Multi-domain; see the file header for what this test can
+; and cannot decide about the data-race half of the fix.
+
+(test
+ (name test_tuple_vec_registry)
+ (modules test_tuple_vec_registry)
+ (libraries sarek.tuple_vec spoc_core spoc.ir alcotest))

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -272,6 +272,7 @@
  (name test_lower_ir_refusal_triggers)
  (modules test_lower_ir_refusal_triggers)
  (libraries sarek_frontend))
+
 ; Audit finding M8: Sarek_worklist.Host.drive must stop at the first OVERFLOW.
 ; The e2e worklist test needs a device and never calls drive on an overflowing
 ; queue, so the guard at Sarek_worklist.ml:208 was pinned by nothing. drive is

--- a/sarek/tests/unit/test_tuple_vec_registry.ml
+++ b/sarek/tests/unit/test_tuple_vec_registry.ml
@@ -1,0 +1,257 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression test for audit finding L1 — the process-global tuple-shape
+ * registry in Sarek_tuple_vec must resolve a concurrent first-time build of one
+ * shape to a SINGLE winner.
+ *
+ * WHY THIS FILE EXISTS
+ *   The 2026-07-29 audit records L1 as "fixed more thoroughly than asked — no
+ *   test". Three commits are involved:
+ *     ac896b73  mutex around the build-and-insert in [memoize]
+ *     3aa4c1b9  drop the unlocked [find_opt] fast path in front of it
+ *     339c8e2c  take the same mutex for [lookup_shape] reads
+ *
+ * WHAT THIS TEST DECIDES, AND WHAT IT CANNOT
+ *   Only the FIRST of the three has an observable functional consequence, and
+ *   that is what is pinned here. [memoize] hands out a [custom_type] carrying a
+ *   freshly generated [Type_id]; the Native path later resolves the same shape
+ *   through [descriptor_by_name] and compares with [Type_id.equal]. With
+ *   build-and-insert unguarded, N domains racing on a shape that does not exist
+ *   yet each build their own descriptor and only one reaches the table, so
+ *   every other caller holds a descriptor that will fail that equality check —
+ *   an observable, assertable divergence, which is what [single_winner_*] below
+ *   asserts.
+ *
+ *   The other two are pure MEMORY-MODEL properties: an unlocked [Hashtbl]
+ *   read concurrent with a [replace] is a data race under OCaml 5 whether or
+ *   not it produces a wrong answer on any given run. There is no deterministic
+ *   OCaml-level assertion for "this access was correctly synchronised" — the
+ *   sound checker is a race detector (a TSan-instrumented runtime), which the
+ *   OCaml 5 toolchain does not ship. The stress loop below does hammer
+ *   [lookup_shape] from every domain while registrations are in flight, so a
+ *   corrupted table or a torn read shows up as a wrong value or an exception,
+ *   but that is a probabilistic bonus and NOT the gate: reverting 3aa4c1b9 or
+ *   the [lookup_shape] lock alone is expected to leave this test green, and
+ *   that limit is stated here rather than papered over.
+ *
+ * NON-VACUITY
+ *   The registry is process-global and each shape can only be raced ONCE per
+ *   executable (afterwards it is memoized and there is nothing left to race).
+ *   [fresh_before_the_race] therefore asserts, for every shape, that it was
+ *   genuinely unregistered before the domains started — without it this whole
+ *   file would degrade into a memoization test the moment a shape got built
+ *   during startup.
+ ******************************************************************************)
+
+module TV = Sarek_tuple_vec
+module Vector = Spoc_core.Vector
+module Type_id = Sarek_ir_types.Type_id
+
+let domains = max 4 (min 8 (Domain.recommended_domain_count ()))
+
+(** Run [f] on [domains] domains that all leave a spin barrier together, so the
+    first-time build really is concurrent rather than serialized by startup. *)
+let race (f : unit -> 'r) : 'r list =
+  let arrived = Atomic.make 0 in
+  let go = Atomic.make false in
+  let spawn () =
+    Domain.spawn (fun () ->
+        Atomic.incr arrived ;
+        while not (Atomic.get go) do
+          Domain.cpu_relax ()
+        done ;
+        f ())
+  in
+  let ds = List.init domains (fun _ -> spawn ()) in
+  while Atomic.get arrived < domains do
+    Domain.cpu_relax ()
+  done ;
+  Atomic.set go true ;
+  List.map Domain.join ds
+
+(** Every domain's descriptor must be the one canonical descriptor: same
+    [Type_id], same [vector_type_id], same identity as the one
+    [descriptor_by_name] resolves for generated Native code. *)
+let check_single_winner (type a) ~name (results : a Vector.custom_type list) =
+  let canonical = TV.descriptor_by_name name in
+  let same_type_id d =
+    match Type_id.equal d.Vector.type_id canonical.Vector.type_id with
+    | Some Type_id.Refl -> true
+    | None -> false
+  in
+  let same_vector_type_id d =
+    match
+      Type_id.equal d.Vector.vector_type_id canonical.Vector.vector_type_id
+    with
+    | Some Type_id.Refl -> true
+    | None -> false
+  in
+  Alcotest.(check int)
+    (name ^ ": every domain returned a descriptor")
+    domains
+    (List.length results) ;
+  Alcotest.(check int)
+    (name ^ ": no domain holds a descriptor with a divergent element Type_id")
+    0
+    (List.length (List.filter (fun d -> not (same_type_id d)) results)) ;
+  Alcotest.(check int)
+    (name ^ ": no domain holds a descriptor with a divergent vector Type_id")
+    0
+    (List.length (List.filter (fun d -> not (same_vector_type_id d)) results)) ;
+  (* Physical identity is the stronger statement and the one the memo table is
+     actually meant to provide. *)
+  Alcotest.(check int)
+    (name ^ ": every domain got the physically same descriptor")
+    0
+    (List.length (List.filter (fun d -> not (d == canonical)) results)) ;
+  (* The byte layout was registered once, not N times with divergent content. *)
+  match TV.lookup_shape name with
+  | None -> Alcotest.fail (name ^ ": shape layout was never registered")
+  | Some sh ->
+      Alcotest.(check string) (name ^ ": shape name") name sh.TV.sh_name ;
+      Alcotest.(check int)
+        (name ^ ": shape size agrees with the descriptor")
+        canonical.Vector.elem_size
+        sh.TV.sh_size
+
+(** Guards against the whole race being a no-op: the shape must not exist yet.
+*)
+let fresh_before_the_race name =
+  Alcotest.(check bool)
+    (name ^ ": unregistered before the race (else nothing is being raced)")
+    true
+    (TV.lookup_shape name = None)
+
+(* [lookup_shape] hammering, run inside every racing domain. Not a gate (see the
+   header) - it exists so that a table corrupted by an unsynchronised read has
+   somewhere to surface. *)
+let hammer_lookups name =
+  for _ = 1 to 200 do
+    match TV.lookup_shape name with
+    | None -> ()
+    | Some sh -> if sh.TV.sh_name <> name then failwith "torn shape read"
+  done
+
+let race_pair : type a b. string -> a TV.component -> b TV.component -> unit =
+ fun name ca cb ->
+  fresh_before_the_race name ;
+  let results =
+    race (fun () ->
+        let d = TV.pair ca cb in
+        hammer_lookups name ;
+        d)
+  in
+  check_single_winner ~name results
+
+let race_triple : type a b c.
+    string -> a TV.component -> b TV.component -> c TV.component -> unit =
+ fun name ca cb cc ->
+  fresh_before_the_race name ;
+  let results =
+    race (fun () ->
+        let d = TV.triple ca cb cc in
+        hammer_lookups name ;
+        d)
+  in
+  check_single_winner ~name results
+
+(* Sixteen pair shapes and four triple shapes. One shape can only be raced once
+   per process, so the count is the number of independent attempts this test
+   gets - a single attempt would make the outcome a coin flip. *)
+let single_winner_pairs () =
+  let comps =
+    [("float32", `F32); ("float64", `F64); ("int32", `I32); ("int64", `I64)]
+  in
+  List.iter
+    (fun (ta, ca) ->
+      List.iter
+        (fun (tb, cb) ->
+          let name = Printf.sprintf "_tup_%s_%s" ta tb in
+          match (ca, cb) with
+          | `F32, `F32 -> race_pair name TV.float32 TV.float32
+          | `F32, `F64 -> race_pair name TV.float32 TV.float64
+          | `F32, `I32 -> race_pair name TV.float32 TV.int32
+          | `F32, `I64 -> race_pair name TV.float32 TV.int64
+          | `F64, `F32 -> race_pair name TV.float64 TV.float32
+          | `F64, `F64 -> race_pair name TV.float64 TV.float64
+          | `F64, `I32 -> race_pair name TV.float64 TV.int32
+          | `F64, `I64 -> race_pair name TV.float64 TV.int64
+          | `I32, `F32 -> race_pair name TV.int32 TV.float32
+          | `I32, `F64 -> race_pair name TV.int32 TV.float64
+          | `I32, `I32 -> race_pair name TV.int32 TV.int32
+          | `I32, `I64 -> race_pair name TV.int32 TV.int64
+          | `I64, `F32 -> race_pair name TV.int64 TV.float32
+          | `I64, `F64 -> race_pair name TV.int64 TV.float64
+          | `I64, `I32 -> race_pair name TV.int64 TV.int32
+          | `I64, `I64 -> race_pair name TV.int64 TV.int64)
+        comps)
+    comps
+
+let single_winner_triples () =
+  race_triple "_tup_float32_int32_int64" TV.float32 TV.int32 TV.int64 ;
+  race_triple "_tup_float64_float32_int32" TV.float64 TV.float32 TV.int32 ;
+  race_triple "_tup_int32_int32_int32" TV.int32 TV.int32 TV.int32 ;
+  race_triple "_tup_int64_float64_float64" TV.int64 TV.float64 TV.float64
+
+(** Once the shape exists, every later caller keeps getting the same descriptor
+    - the memoization half of the contract, single-threaded and deterministic.
+*)
+let memoized_after_the_race () =
+  let name = "_tup_float32_int32" in
+  let d1 = TV.pair TV.float32 TV.int32 in
+  let d2 = TV.pair TV.float32 TV.int32 in
+  Alcotest.(check bool) "repeat build is the same descriptor" true (d1 == d2) ;
+  Alcotest.(check bool)
+    "descriptor_by_name agrees"
+    true
+    (d1 == TV.descriptor_by_name name)
+
+(** An unbuilt shape must fail loudly rather than hand back a wrong descriptor.
+*)
+let unbuilt_shape_refuses () =
+  Alcotest.(check bool)
+    "unbuilt shape has no layout"
+    true
+    (TV.lookup_shape "_tup_never_built" = None) ;
+  match TV.descriptor_by_name "_tup_never_built" with
+  | _ ->
+      Alcotest.fail
+        "descriptor_by_name returned a descriptor for an unbuilt shape"
+  | exception Failure msg ->
+      Alcotest.(check bool)
+        "the failure names the shape"
+        true
+        (String.length msg > 0
+        &&
+        let re = "_tup_never_built" in
+        let rec find i =
+          i + String.length re <= String.length msg
+          && (String.sub msg i (String.length re) = re || find (i + 1))
+        in
+        find 0)
+
+let () =
+  Alcotest.run
+    "Sarek_tuple_vec registry (audit L1)"
+    [
+      ( "single winner under concurrent first-time build",
+        [
+          Alcotest.test_case "16 pair shapes" `Quick single_winner_pairs;
+          Alcotest.test_case "4 triple shapes" `Quick single_winner_triples;
+        ] );
+      ( "deterministic registry contract",
+        [
+          Alcotest.test_case
+            "memoized after the race"
+            `Quick
+            memoized_after_the_race;
+          Alcotest.test_case
+            "unbuilt shape refuses"
+            `Quick
+            unbuilt_shape_refuses;
+        ] );
+    ]

--- a/sarek/tests/unit/test_tuple_vec_registry.ml
+++ b/sarek/tests/unit/test_tuple_vec_registry.ml
@@ -34,9 +34,17 @@
  *   OCaml 5 toolchain does not ship. The stress loop below does hammer
  *   [lookup_shape] from every domain while registrations are in flight, so a
  *   corrupted table or a torn read shows up as a wrong value or an exception,
- *   but that is a probabilistic bonus and NOT the gate: reverting 3aa4c1b9 or
- *   the [lookup_shape] lock alone is expected to leave this test green, and
- *   that limit is stated here rather than papered over.
+ *   but that is a probabilistic bonus and NOT the gate.
+ *
+ *   That limit is MEASURED, not assumed. Three variants of Sarek_tuple_vec.ml
+ *   were built and each run 20 times:
+ *     - build-and-insert unguarded (pre-ac896b73)  -> 20/20 RED
+ *     - unlocked fast path + locked double-check
+ *       (3aa4c1b9 reverted, still single-winner)   -> 20/20 GREEN
+ *     - [lookup_shape] read unlocked
+ *       (339c8e2c reverted)                        -> 20/20 GREEN
+ *   So this file pins ac896b73 and nothing more. Closing the remaining two
+ *   needs a race detector, which is a toolchain change, not a test.
  *
  * NON-VACUITY
  *   The registry is process-global and each shape can only be raced ONCE per

--- a/sarek/tests/unit/test_worklist_drive.ml
+++ b/sarek/tests/unit/test_worklist_drive.ml
@@ -1,0 +1,247 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Regression test for audit finding M8 — Sarek_worklist.Host.drive must stop
+ * at the first OVERFLOW (Sarek_worklist.ml:208, the `|| overflow t > 0`
+ * disjunct added by 473478c6).
+ *
+ * WHY THIS FILE EXISTS
+ *   The external audit of 2026-07-29 confirmed the M8 fix landed on main and
+ *   flagged it as pinned by nothing: reverting that line left the whole suite
+ *   green. The one existing worklist test (sarek/tests/e2e/test_worklist.ml)
+ *   does exercise the OVERFLOW flag, but only through the single-launch
+ *   `push_guarded` scenario — it never calls `drive` on an overflowing queue,
+ *   which is the only place the guard lives. It also needs a device, so it does
+ *   not run at all on a CPU-only machine.
+ *
+ * WHAT IS UNDER TEST, AND WHY NO DEVICE IS NEEDED
+ *   `drive` is pure host logic: it reads the device counters and calls a
+ *   caller-supplied [launch]. So the device is replaced here by an OCaml
+ *   function that reproduces exactly the counter arithmetic of the documented
+ *   level-synchronous frontier kernel (the one in the library's own header):
+ *
+ *     t = TAIL++ ; if t - HEAD >= cap then OVERFLOW++ else slots[t mod cap] <- child
+ *
+ *   HEAD is never advanced by the level-sync pattern, so a push overflows
+ *   exactly when its ticket reaches [cap].
+ *
+ * THE HARM BEING PINNED (both polarities)
+ *   Positive — the guard fires: once OVERFLOW is set, TAIL has counted tickets
+ *   whose ring slot was never written. The window [base, TAIL) handed to the
+ *   next level therefore contains ring positions holding something other than
+ *   the item that ticket logically stands for: with HEAD at 0 those positions
+ *   lap onto already-processed slots, so the next level re-processes items it
+ *   has already consumed (and TAIL keeps growing, so it does so for as many
+ *   levels as `max_levels` allows). `bad_tickets` and `visits` below assert
+ *   exactly that: no launch is ever handed an unwritten ticket, and no item is
+ *   processed twice.
+ *
+ *   (The fix's own comment says the poisoned positions still hold the -1 seed.
+ *   That is the shape for a caller whose kernel advances HEAD; in the pure
+ *   level-sync flow the guard is [t - 0 >= cap], so slots 0..cap-1 are all
+ *   written by the time OVERFLOW can be set and the garbage is a stale
+ *   duplicate rather than -1. The assertions here are written on "was this
+ *   ticket ever written", which covers both.)
+ *
+ *   Negative — the guard must not fire otherwise: `no_overflow_runs_to_fixpoint`
+ *   drives a queue that never overflows and pins the exact launch sequence and
+ *   full node coverage. A wrong-direction correction (`overflow t >= 0`, or
+ *   hoisting the check so it also cuts the first level) makes that case red.
+ *   `max_levels_still_respected` pins the pre-existing bound the new disjunct
+ *   sits next to.
+ ******************************************************************************)
+
+module WL = Sarek_worklist
+module Host = Sarek_worklist.Host
+module Ctrl = Sarek_worklist.Ctrl
+module Vector = Spoc_core.Vector
+
+(** A stand-in for the device: runs the documented level-synchronous frontier
+    push/pop arithmetic on the host, and records everything the assertions need.
+*)
+type sim = {
+  q : Host.t;
+  cap : int;
+  fanout : int -> int;
+  next_id : int ref;
+  written : (int, unit) Hashtbl.t;
+      (** tickets whose ring slot actually received a value *)
+  launches : (int * int) list ref;  (** windows handed to [launch], in order *)
+  bad_tickets : (int * int * int) list ref;
+      (** (base, snap, ticket) for every window entry that was never written *)
+  visits : int list ref;  (** items processed, in order *)
+}
+
+let make_sim ~cap ~fanout ~seed =
+  let q = Host.create ~capacity:cap in
+  Host.seed q (Array.map Int32.of_int seed) ;
+  let written = Hashtbl.create 64 in
+  (* Seeding writes the first |seed| ring slots, i.e. tickets 0..n-1. *)
+  Array.iteri (fun i _ -> Hashtbl.replace written i ()) seed ;
+  {
+    q;
+    cap;
+    fanout;
+    next_id = ref (Array.length seed);
+    written;
+    launches = ref [];
+    bad_tickets = ref [];
+    visits = ref [];
+  }
+
+(** One frontier "kernel launch" over the half-open window from [level_base] up
+    to [snapshot_tail]. *)
+let sim_launch s ~level_base ~snapshot_tail =
+  s.launches := !(s.launches) @ [(level_base, snapshot_tail)] ;
+  for i = level_base to snapshot_tail - 1 do
+    if not (Hashtbl.mem s.written i) then
+      s.bad_tickets := (level_base, snapshot_tail, i) :: !(s.bad_tickets)
+  done ;
+  for i = level_base to snapshot_tail - 1 do
+    let u = Int32.to_int (Vector.get s.q.Host.slots (i mod s.cap)) in
+    s.visits := !(s.visits) @ [u] ;
+    for _ = 1 to s.fanout u do
+      (* t = atomic_add(TAIL, 1); head = TAIL-unrelated read of HEAD *)
+      let t = Host.tail s.q in
+      Host.set_ctrl s.q Ctrl.tail (t + 1) ;
+      let head = Host.head s.q in
+      if t - head >= s.cap then
+        Host.set_ctrl s.q Ctrl.overflow (Host.overflow s.q + 1)
+      else begin
+        let child = !(s.next_id) in
+        incr s.next_id ;
+        Vector.set s.q.Host.slots (t mod s.cap) (Int32.of_int child) ;
+        Hashtbl.replace s.written t ()
+      end
+    done
+  done
+
+let drive_sim s ~max_levels =
+  Host.drive
+    s.q
+    ~launch:(fun ~level_base ~snapshot_tail ->
+      sim_launch s ~level_base ~snapshot_tail)
+    ~max_levels
+
+(* ------------------------------------------------------------------ *)
+
+let windows = Alcotest.(list (pair int int))
+
+let has_duplicate l =
+  let seen = Hashtbl.create 64 in
+  List.exists
+    (fun x ->
+      if Hashtbl.mem seen x then true
+      else (
+        Hashtbl.replace seen x () ;
+        false))
+    l
+
+(** POSITIVE POLARITY: a ring too small for the frontier. Level 1 overflows, so
+    level 2 must never be launched. *)
+let overflow_stops_the_driver () =
+  (* cap=8, fanout 3, seed {0}:
+     L0 window (0,1): 3 pushes, tickets 1..3   -> TAIL=4
+     L1 window (1,4): 9 pushes, tickets 4..12; 8..12 overflow -> TAIL=13
+     L2 would be window (4,13), whose tickets 8..12 were never written. *)
+  let s = make_sim ~cap:8 ~fanout:(fun _ -> 3) ~seed:[|0|] in
+  let levels = drive_sim s ~max_levels:20 in
+  Alcotest.(check int) "levels launched before the overflow" 2 levels ;
+  Alcotest.check
+    windows
+    "exactly the two pre-overflow windows"
+    [(0, 1); (1, 4)]
+    !(s.launches) ;
+  (* The overflow really happened - without this the case above could pass by
+     the frontier simply having drained. *)
+  Alcotest.(check bool)
+    "overflow flag is set for the caller to observe"
+    true
+    (Host.overflow s.q > 0) ;
+  (* BAD BEHAVIOUR ABSENT: no launch was handed a ring position that no push
+     ever wrote, and nothing was processed twice. *)
+  Alcotest.(check (list (triple int int int)))
+    "no launch window contains an unwritten ticket"
+    []
+    !(s.bad_tickets) ;
+  Alcotest.(check bool)
+    "no item processed twice"
+    false
+    (has_duplicate !(s.visits))
+
+(** POSITIVE POLARITY, minimal form: OVERFLOW already set on entry. Not one
+    launch may happen. *)
+let overflow_set_on_entry_launches_nothing () =
+  let s = make_sim ~cap:8 ~fanout:(fun _ -> 3) ~seed:[|0|] in
+  Host.set_ctrl s.q Ctrl.overflow 1 ;
+  let levels = drive_sim s ~max_levels:20 in
+  Alcotest.(check int) "no level launched" 0 levels ;
+  Alcotest.check windows "no window handed to launch" [] !(s.launches)
+
+(** NEGATIVE POLARITY: the guard must not cut a healthy run short. A 15-node
+    binary tree in a ring of 64 - no overflow is possible - must run to its
+    fixpoint and cover every node exactly once. *)
+let no_overflow_runs_to_fixpoint () =
+  let s =
+    make_sim ~cap:64 ~fanout:(fun u -> if u < 7 then 2 else 0) ~seed:[|0|]
+  in
+  let levels = drive_sim s ~max_levels:20 in
+  Alcotest.(check int) "all four levels launched" 4 levels ;
+  Alcotest.check
+    windows
+    "the full level-synchronous window sequence"
+    [(0, 1); (1, 3); (3, 7); (7, 15)]
+    !(s.launches) ;
+  Alcotest.(check int) "overflow never set" 0 (Host.overflow s.q) ;
+  Alcotest.(check (list int))
+    "every node visited exactly once, in BFS order"
+    (List.init 15 (fun i -> i))
+    !(s.visits) ;
+  Alcotest.(check (list (triple int int int)))
+    "no unwritten ticket"
+    []
+    !(s.bad_tickets)
+
+(** The pre-existing bound the overflow disjunct sits beside. *)
+let max_levels_still_respected () =
+  let s =
+    make_sim ~cap:64 ~fanout:(fun u -> if u < 7 then 2 else 0) ~seed:[|0|]
+  in
+  let levels = drive_sim s ~max_levels:2 in
+  Alcotest.(check int) "stopped at max_levels" 2 levels ;
+  Alcotest.check
+    windows
+    "only the first two windows"
+    [(0, 1); (1, 3)]
+    !(s.launches)
+
+let () =
+  Alcotest.run
+    "Sarek_worklist.Host.drive"
+    [
+      ( "M8 overflow guard",
+        [
+          Alcotest.test_case
+            "overflow stops the driver"
+            `Quick
+            overflow_stops_the_driver;
+          Alcotest.test_case
+            "overflow set on entry launches nothing"
+            `Quick
+            overflow_set_on_entry_launches_nothing;
+        ] );
+      ( "guard is not over-broad",
+        [
+          Alcotest.test_case
+            "no overflow runs to fixpoint"
+            `Quick
+            no_overflow_runs_to_fixpoint;
+          Alcotest.test_case
+            "max_levels still respected"
+            `Quick
+            max_levels_still_respected;
+        ] );
+    ]

--- a/sarek/tests/unit/test_worklist_drive.ml
+++ b/sarek/tests/unit/test_worklist_drive.ml
@@ -95,14 +95,14 @@ let make_sim ~cap ~fanout ~seed =
 (** One frontier "kernel launch" over the half-open window from [level_base] up
     to [snapshot_tail]. *)
 let sim_launch s ~level_base ~snapshot_tail =
-  s.launches := !(s.launches) @ [(level_base, snapshot_tail)] ;
+  s.launches := (level_base, snapshot_tail) :: !(s.launches) ;
   for i = level_base to snapshot_tail - 1 do
     if not (Hashtbl.mem s.written i) then
       s.bad_tickets := (level_base, snapshot_tail, i) :: !(s.bad_tickets)
   done ;
   for i = level_base to snapshot_tail - 1 do
     let u = Int32.to_int (Vector.get s.q.Host.slots (i mod s.cap)) in
-    s.visits := !(s.visits) @ [u] ;
+    s.visits := u :: !(s.visits) ;
     for _ = 1 to s.fanout u do
       (* t = atomic_add(TAIL, 1); head = TAIL-unrelated read of HEAD *)
       let t = Host.tail s.q in
@@ -126,6 +126,13 @@ let drive_sim s ~max_levels =
       sim_launch s ~level_base ~snapshot_tail)
     ~max_levels
 
+(* Both are accumulated head-first (appending with [@] is quadratic, and the
+   reverted-fix run below launches levels whose windows grow by a factor of the
+   fanout - it must fail on an assertion, not by taking forever). *)
+let launches s = List.rev !(s.launches)
+
+let visits s = List.rev !(s.visits)
+
 (* ------------------------------------------------------------------ *)
 
 let windows = Alcotest.(list (pair int int))
@@ -148,13 +155,15 @@ let overflow_stops_the_driver () =
      L1 window (1,4): 9 pushes, tickets 4..12; 8..12 overflow -> TAIL=13
      L2 would be window (4,13), whose tickets 8..12 were never written. *)
   let s = make_sim ~cap:8 ~fanout:(fun _ -> 3) ~seed:[|0|] in
-  let levels = drive_sim s ~max_levels:20 in
+  let levels = drive_sim s ~max_levels:4 in
+  (* max_levels is 4, deliberately above the expected 2: the OVERFLOW guard has
+     to be what stops the driver, not the bound. *)
   Alcotest.(check int) "levels launched before the overflow" 2 levels ;
   Alcotest.check
     windows
     "exactly the two pre-overflow windows"
     [(0, 1); (1, 4)]
-    !(s.launches) ;
+    (launches s) ;
   (* The overflow really happened - without this the case above could pass by
      the frontier simply having drained. *)
   Alcotest.(check bool)
@@ -170,16 +179,16 @@ let overflow_stops_the_driver () =
   Alcotest.(check bool)
     "no item processed twice"
     false
-    (has_duplicate !(s.visits))
+    (has_duplicate (visits s))
 
 (** POSITIVE POLARITY, minimal form: OVERFLOW already set on entry. Not one
     launch may happen. *)
 let overflow_set_on_entry_launches_nothing () =
   let s = make_sim ~cap:8 ~fanout:(fun _ -> 3) ~seed:[|0|] in
   Host.set_ctrl s.q Ctrl.overflow 1 ;
-  let levels = drive_sim s ~max_levels:20 in
+  let levels = drive_sim s ~max_levels:4 in
   Alcotest.(check int) "no level launched" 0 levels ;
-  Alcotest.check windows "no window handed to launch" [] !(s.launches)
+  Alcotest.check windows "no window handed to launch" [] (launches s)
 
 (** NEGATIVE POLARITY: the guard must not cut a healthy run short. A 15-node
     binary tree in a ring of 64 - no overflow is possible - must run to its
@@ -194,12 +203,12 @@ let no_overflow_runs_to_fixpoint () =
     windows
     "the full level-synchronous window sequence"
     [(0, 1); (1, 3); (3, 7); (7, 15)]
-    !(s.launches) ;
+    (launches s) ;
   Alcotest.(check int) "overflow never set" 0 (Host.overflow s.q) ;
   Alcotest.(check (list int))
     "every node visited exactly once, in BFS order"
     (List.init 15 (fun i -> i))
-    !(s.visits) ;
+    (visits s) ;
   Alcotest.(check (list (triple int int int)))
     "no unwritten ticket"
     []
@@ -216,7 +225,7 @@ let max_levels_still_respected () =
     windows
     "only the first two windows"
     [(0, 1); (1, 3)]
-    !(s.launches)
+    (launches s)
 
 let () =
   Alcotest.run


### PR DESCRIPTION
The 2026-07-29 audit confirmed 20 prior fixes landed on main and flagged three
as pinned by nothing. It verified one concretely: reverting
`Sarek_worklist.ml:208` left the whole suite green. This adds a regression test
for each, and every one has been observed failing with that one fix reverted and
passing with it restored.

## M8 — `Host.drive` must stop at the first OVERFLOW

`sarek/tests/unit/test_worklist_drive.ml` (4 cases, in `runtest`)

`drive` is pure host logic, so the device is a host function reproducing the
counter arithmetic of the documented level-synchronous frontier kernel. The one
existing worklist test does exercise OVERFLOW, but only via the single-launch
`push_guarded` scenario — it never calls `drive` on an overflowing queue, and it
needs a device, so on a CPU-only machine it does not run at all.

Both polarities:

* guard fires — exact launch count and window sequence; **no launch is handed a
  ring position no push ever wrote**; no item processed twice; OVERFLOW
  observable to the caller afterwards. Plus the minimal form: OVERFLOW already
  set on entry means not one launch.
* guard is not over-broad — a queue that cannot overflow still runs to its
  fixpoint over all 15 nodes in BFS order, and `max_levels` is unchanged. A
  wrong-direction correction (`overflow t >= 0`, or hoisting the check) is red
  here.

Prove-red — `git checkout 473478c6^ -- sarek/Sarek_worklist/Sarek_worklist.ml`
(a clean one-line revert; nothing else has touched that file):

```
> [FAIL]        M8 overflow guard                0   overflow stops the driver.
  [FAIL]        M8 overflow guard                1   overflow set on entry la...
  [OK]          guard is not over-broad          0   no overflow runs to fixp...
  [OK]          guard is not over-broad          1   max_levels still respected.

ASSERT levels launched before the overflow
FAIL levels launched before the overflow
   Expected: `2'
   Received: `4'
```

The first attempt at this red path came back as a **hang**, not a failure:
`max_levels` was 20 and the reverted driver keeps launching levels whose windows
grow by the fanout, so it never reached an assertion. A test whose red path is a
timeout is not evidence. Bounded to 4 (still above the expected 2, so the guard
and not the bound is what stops it) and the recording lists accumulate head-first
instead of with a quadratic append; it now fails in 0.000s.

## Framework_registry probe policy — all three accessors

`sarek/framework/test/test_registry_probe_policy.ml` (16 cases, in `runtest`),
with `probe_backend.ml`, a BACKEND whose `is_available` raises on demand.

`available`, `available_backends` and `best_backend` are tested symmetrically
rather than just the one that was fixed first. Both polarities on each: an
ordinary probe failure still counts as unavailable and raises nothing;
`Out_of_memory` / `Stack_overflow` / `Sys.Break` propagate instead of becoming a
silent "no backends found". Every case asserts the probe was actually called, so
none of them can pass vacuously, and four control cases pin the other end (an
available probe *is* found).

Prove-red, full revert
(`git checkout 22745124^ -- sarek/framework/Framework_registry.ml`) — 9 of 16
red, all nine fatal cases, the seven others still green:

```
FAIL available must propagate Out of memory, not swallow it:
     expecting Out of memory, got nothing.
...
9 failures! in 0.001s. 16 tests run.
```

Prove-red, **partial** revert to `22745124` — the state the audit is pointing at,
where only one accessor of three had been fixed:

```
  [OK]          fatal probe failure propagates - available            0   ...Out of memory....
  [OK]          fatal probe failure propagates - available            1   ...Stack overflow....
> [FAIL]        fatal probe failure propagates - available            2   ...Sys.Break....
  [FAIL]        fatal probe failure propagates - available_backends   0   ...Out of memory....
  [FAIL]        fatal probe failure propagates - available_backends   1   ...Stack overflow....
  [FAIL]        fatal probe failure propagates - available_backends   2   ...Sys.Break....
  [FAIL]        fatal probe failure propagates - best_backend         0   ...Out of memory....
  [FAIL]        fatal probe failure propagates - best_backend         1   ...Stack overflow....
  [FAIL]        fatal probe failure propagates - best_backend         2   ...Sys.Break....
7 failures! in 0.001s. 16 tests run.
```

Seven, not six: `22745124` also did not yet cover `Sys.Break` in `available`.

## L1 — tuple-vec registry, and what it cannot decide

`sarek/tests/unit/test_tuple_vec_registry.ml` (4 cases, in `runtest`)

Three commits are involved and **only one of them has an observable functional
consequence**. That one is pinned: N domains released from a single barrier onto
a shape that does not exist yet must all end up with the same descriptor and the
same `Type_id` — the identity generated Native code later resolves through
`descriptor_by_name` and compares with `Type_id.equal`. 16 pair shapes and 4
triple shapes, because a shape can only be raced once per process and one
attempt would be a coin flip. Every shape asserts it was unregistered before the
race, so the file cannot silently degrade into a memoization test.

Prove-red — build-and-insert unguarded (pre-`ac896b73`), 7 of 8 domains diverged
on the very first shape:

```
FAIL _tup_float32_float32: no domain holds a descriptor with a divergent element Type_id
   Expected: `0'
   Received: `7'
```

**The other two thirds of that fix are not encodable, and this is measured
rather than assumed.** Dropping the unlocked `find_opt` fast path (`3aa4c1b9`)
and locking `lookup_shape` (`339c8e2c`) are pure memory-model properties: an
unlocked `Hashtbl` read racing a `replace` is a data race whether or not it
produces a wrong answer on any run, and there is no OCaml-level assertion for
"this access was correctly synchronised". Three variants were built and each run
20 times:

| variant | result |
|---|---|
| build-and-insert unguarded (pre-`ac896b73`) | **20/20 red** |
| unlocked fast path + locked double-check (`3aa4c1b9` reverted) | 20/20 green |
| `lookup_shape` read unlocked (`339c8e2c` reverted) | 20/20 green |

With the fix in place: 20/20 green. Closing the remaining two needs a race
detector (a TSan-instrumented runtime), which is a toolchain change, not a test.
That is stated in the file header rather than left for a reader to discover.

## Registration and verification

* `check-test-alias-coverage.sh`: 280 targets, up from 277 — all three new ones
  are `(test)` stanzas, so dune self-wires them to `runtest`; confirmed running
  under `dune build @…/runtest --force`.
* `dune build`, `dune build @fmt`, `dune test --force` clean; log non-empty.
* `check-alcotest-registration.js`, `check-license-headers.sh`,
  `check-kb-properties.sh`, `check-negative-case-coverage.sh`,
  `check-dune-dir-visibility.sh`, `prove-red.sh` all pass.
* No `*.opam` changes committed.

Reverts were done with `git checkout <ref> -- <path>` throughout — no `git
stash`. Where a clean historical ref did not exist (the tuple-vec file has four
later commits on top), the pre-fix shape was reapplied by hand and restored with
`git checkout HEAD -- <path>`; the tree was verified free of scratch markers
before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for framework registry probe handling across available, unavailable, ordinary failure, and fatal exception propagation scenarios (including isolation of probe-raising behavior).
  * Added concurrency regression tests for tuple-shape registry consistency and deterministic reuse under simultaneous first-time builds.
  * Added worklist drive regression tests ensuring safe stopping at overflow and correct behavior across overflow/no-overflow and max-level limits.
  * Added additional Alcotest unit executables, including coverage for `Sarek_lower_ir` ppx-time refusal triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->