### PR TITLE
fix(soa-launch): route run_soa through check_launch_args (H4)

### DIFF
--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -215,6 +215,43 @@ let run_soa ~(device : Device.t) ~(ir : Sarek_ir_types.kernel)
              message = "Backend not found in registry";
            })
   | Some (module B : Framework_sig.BACKEND) ->
+      (* Arity and per-position types, through the SAME check every other
+         launch path uses (backlog-182, H4). This path called B.run_source
+         directly and never reached it.
+
+         It is memory safety, not tidiness, and check_launch_args' own message
+         states why: the launch builds its device argument array from the
+         SUPPLIED count (Cuda_api.launch: CArray.make (ptr void) (List.length
+         args); Hip_api.launch likewise) while the driver reads the COMPILED
+         parameter count. So a SHORT list leaves the driver reading slots past
+         the end of that array and dereferencing whatever it finds as a device
+         address. Note the array is correctly sized FOR THE LIST and wrong FOR
+         THE KERNEL — which is why no amount of care inside [launch] can fix it:
+         [launch] does not know the kernel's arity. Only a check holding the IR
+         can, and this is it.
+
+         The positional loop below did have an arity guard, but only "at most":
+         [List.nth_opt params_info i] returning [None] catches too MANY
+         arguments at an SA_Soa position and says nothing about too FEW. That is
+         also the mechanism behind the accepted-mismatch case — omit an early
+         scalar and every later SA_Soa is compared against the WRONG parameter,
+         because index i no longer means what it did. check_launch_args does
+         arity FIRST and unconditionally, so both are closed before any
+         positional comparison is trusted.
+
+         Mapping each soa_arg to the vector_arg it stands for: an SA_Soa is its
+         AoS vector, which carries the record element type the check needs; an
+         SA_Reg is already one. The arities correspond 1:1 because the kernel IR
+         still declares ONE parameter per record vector — the expansion into N
+         leaf pointers happens in the emitter, under ~soa_params, not here. *)
+      Execute.check_launch_args
+        ~kernel:ir.Sarek_ir_types.kern_name
+        ir
+        (List.map
+           (function
+             | SA_Soa sv -> Execute.Vec (Soa_vector.aos_vector sv)
+             | SA_Reg a -> a)
+           args) ;
       (* SoA parameter names = kernel param name at each SA_Soa position. *)
       let params_info = kernel_params_info ir in
       let param_names = List.map fst params_info in

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -643,6 +643,64 @@ let check_layout_validation () =
    a [dpair] vector (2 x f64, stride 16) binds to a [point3d] parameter (3 x f32,
    stride 12) without complaint. Both the leaf list and the stride disagree, so
    the launch check is what stands between that and a kernel reading garbage. *)
+(* A SHORT argument list must be refused ON ARITY (backlog-182, H4).
+
+   run_soa called B.run_source directly and never reached
+   Execute.check_launch_args. That check's own message says why it matters: the
+   launch sizes its device argument array from the SUPPLIED count (Cuda_api.launch:
+   CArray.make (ptr void) (List.length args); Hip_api.launch likewise) while the
+   driver reads the COMPILED parameter count. A short list therefore leaves the
+   driver reading slots past the end of that array and dereferencing whatever it
+   finds as a device address. The array is correctly sized FOR THE LIST and wrong
+   FOR THE KERNEL.
+
+   The positional loop already refused too MANY arguments at an SA_Soa position
+   (List.nth_opt returning None); it said nothing about too FEW.
+
+   ASSERTS THE MESSAGE, not merely that something was raised, and that is what
+   makes this case able to fail. Pre-fix, a short list is still refused on a
+   non-PTX device -- but by the CUDA/PTX gate, for an unrelated reason. Only the
+   arity wording separates "refused because the call is wrong" from "refused
+   because the device is wrong".
+
+   Deliberately NOT asserted by observing a crash: an out-of-bounds read is not a
+   reliable observation, and a test whose red state is a segfault is not
+   evidence. *)
+let check_short_arg_list dev =
+  Printf.printf "SoA-arity  [%s] %s: %!" dev.Device.framework dev.Device.name ;
+  let sv = Soa_vector.create point3d_custom 16 in
+  let ir = ir_of p3_kernel in
+  let contains hay needle =
+    let n = String.length needle and m = String.length hay in
+    let rec go i = i + n <= m && (String.sub hay i n = needle || go (i + 1)) in
+    go 0
+  in
+  (* p3_kernel takes (pts, out, n) -- three parameters. Supply two. *)
+  match
+    Soa_launch.run_soa
+      ~device:dev
+      ~ir
+      ~args:[Soa_launch.SA_Soa sv; Soa_launch.SA_Reg (Sarek.Execute.Int 16)]
+      ~block:(dims 16)
+      ~grid:(dims 1)
+      ()
+  with
+  | () ->
+      Printf.printf "FAILED (a 2-arg call to a 3-param kernel was accepted)\n%!" ;
+      false
+  | exception Sarek.Execute_error.Execution_error err ->
+      let msg = Sarek.Execute_error.error_to_string err in
+      (* Matching the count language rather than an exact string, so a reworded
+         diagnostic still passes while a refusal for a DIFFERENT reason fails. *)
+      if contains msg "argument" && contains msg "3" then begin
+        Printf.printf "refused on arity OK\n%!" ;
+        true
+      end
+      else begin
+        Printf.printf "FAILED (refused, but not on arity: %s)\n%!" msg ;
+        false
+      end
+
 let check_layout_wired dev =
   let ir = ir_of p3_kernel in
   let sv = Soa_vector.create dpair_custom 8 in
@@ -713,6 +771,10 @@ let () =
       (* Wiring + ordering: a mismatched must surface the LAYOUT error,
          not the device gate, on this very non-PTX device. *)
       if not (check_layout_wired dev) then ok := false ;
+      (* H4: a short arg list must be refused on ARITY, on every device — the
+         check is device-independent, which is what makes it testable without a
+         CUDA host. *)
+      if not (check_short_arg_list dev) then ok := false ;
       (* Leaf-write round-trip (D2H + gather) on CUDA/PTX. *)
       if is_ptx dev && not (check_roundtrip dev n) then ok := false)
     devs ;


### PR DESCRIPTION
backlog-182, review finding **H4**. Both claims verified at the lines before changing anything.

`Soa_launch.ml` called `B.run_source` directly and never reached `Execute.check_launch_args` (called at `Execute.ml:705/753/762` and nowhere else). The arg array really is sized from the supplied list — `Cuda_api.launch:671` and `Hip_api.launch:486` both do `CArray.make (ptr void) (List.length args)`.

## The mechanism, stated precisely — the filing was slightly off on the locus

Our code does **not** overrun the array; `List.iteri` fills exactly the slots it allocated. **The driver does.** `cuLaunchKernel` reads as many parameter slots as the *compiled* kernel declares, so a short list leaves it reading past the end of an OCaml-allocated ctypes array and dereferencing whatever it finds as a device address. The array is correctly sized **for the list** and wrong **for the kernel**.

That distinction decides where the fix belongs: nothing inside `launch` can close it, because `launch` doesn't know the kernel's arity. Only a check holding the IR can — and `check_launch_args`' own error message already says exactly this:

> *"the launch builds its device argument array from the SUPPLIED count while the driver reads the COMPILED parameter count, so a mismatch is unsafe, not merely wrong"*

The right check existed. This path skipped it.

## What the existing guard did and didn't cover

The positional layout loop has `List.nth_opt params_info i` with a `None` branch, so too **many** arguments at an `SA_Soa` position were already refused. Too **few** were not — `nth_opt` returns `Some` for every position of a short list.

That same indexing is the mechanism behind the accepted-mismatch case the review named: omit an early scalar and every later `SA_Soa` is compared against the **wrong** parameter, because index `i` no longer means what it did. `check_launch_args` does arity **first and unconditionally**, so both are closed before any positional comparison is trusted.

Mapping `soa_arg` → `vector_arg`: an `SA_Soa` is its AoS vector, which carries the record element type the check needs; an `SA_Reg` already is one. Arities correspond 1:1 because the kernel IR still declares **one** parameter per record vector — expansion into N leaf pointers happens in the emitter under `~soa_params`, not here.

## Evidence

`check_short_arg_list` — **9/9 devices** "refused on arity OK". The 36 existing SoA assertions are unchanged, so a correct call is unaffected.

**Prove-red gave two different reds, and the split is the interesting part:**

| Devices | Result with the check removed |
|---|---|
| CUDA/PTX (ZLUDA ×2) | **rc=139 SIGSEGV** — the out-of-bounds read, demonstrated live |
| 7 non-PTX | rc=1, *"refused, but not on arity: … SoA lowering requires a CUDA/PTX device"* |

The segfault is empirical confirmation that this is genuine memory-unsafety rather than a bad diagnostic. But it is **not** what the test relies on: a crash kills the process so nothing after it runs, and it needs a PTX device CI doesn't have. The test asserts the **message**, which is why it produces a clean red on the 7 non-PTX devices — i.e. it will actually work as a regression gate in CI. Only the arity wording separates *"the call is wrong"* from *"the device is wrong"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
