### PR TITLE
test(metal): a skip must say why — and this one read backwards on a Mac (#179 refuted as filed)

### DIFF
--- a/sarek-metal/test/test_metal_compile_options.ml
+++ b/sarek-metal/test/test_metal_compile_options.ml
@@ -34,14 +34,26 @@ open Sarek_metal
    which machine can answer the question. *)
 let objc_runtime_absent () = not (Metal_bindings.is_available ())
 
+(* One shared skip, so no case can skip SILENTLY. [test_is_repeatable] used to
+   call [Alcotest.skip ()] bare, which on a Mac printed nothing at all: the
+   reader saw a [SKIP] under a group named "fail-soft without an Objective-C
+   runtime" and had no way to tell that the runtime being PRESENT is the reason.
+   A skip that does not say why is indistinguishable from a skip for the wrong
+   reason — the family of defect this repo keeps finding. *)
+let skip_because_runtime_present name =
+  Printf.printf
+    "[SKIP] %s: Metal IS available on this host, so the fail-soft path (which \
+     requires the Objective-C runtime to be ABSENT) cannot be reached here. \
+     Linux and CI answer this question; the Metal FP behaviour itself is \
+     measured separately by tools/probes/metal_math_mode_probe.m and \
+     metal_contraction_barrier_probe.m — see docs/fp-contraction-policy.md.\n\
+     %!"
+    name ;
+  Alcotest.skip ()
+
 let test_returns_none_without_objc () =
-  if not (objc_runtime_absent ()) then begin
-    Printf.printf
-      "[SKIP] Metal is available on this host, so the no-Objective-C fail-soft \
-       path cannot be reached here\n\
-       %!" ;
-    Alcotest.skip ()
-  end
+  if not (objc_runtime_absent ()) then
+    skip_because_runtime_present "returns None rather than raising"
   else
     match Metal_bindings.mtl_compile_options_conformant () with
     | None -> ()
@@ -63,7 +75,8 @@ let test_returns_none_without_objc () =
 (* Called twice: a first call that succeeded in caching something bad, or a
    lazy that raised once and is now poisoned, must not change the answer. *)
 let test_is_repeatable () =
-  if not (objc_runtime_absent ()) then Alcotest.skip ()
+  if not (objc_runtime_absent ()) then
+    skip_because_runtime_present "is repeatable"
   else
     let attempt n =
       match Metal_bindings.mtl_compile_options_conformant () with
@@ -80,7 +93,12 @@ let () =
   Alcotest.run
     "Metal_compile_options"
     [
-      ( "fail-soft without an Objective-C runtime",
+      (* Named for the PROPERTY, not for the host condition. The old name,
+         "fail-soft without an Objective-C runtime", read backwards wherever it
+         mattered most: on a Mac the cases SKIP precisely because the runtime is
+         PRESENT, so a reader saw [SKIP] under a heading naming its absence and
+         reasonably concluded the Mac lacked libobjc. *)
+      ( "mtl_compile_options_conformant fails soft (runtime-absent hosts only)",
         [
           Alcotest.test_case
             "returns None rather than raising"


### PR DESCRIPTION
backlog-179, **refuted as filed**. I filed this as a skip-as-pass hiding a HIGH. Both halves were wrong, and reading the test says so plainly.

## What I got wrong

The subject is the **fail-soft** path: `mtl_compile_options_conformant` must return `None` rather than raise on a host where the Objective-C runtime is **absent**. That path is unreachable on a Mac *by construction*, so skipping there is correct — and the file's own header already said so: *"On a Mac this test cannot reach that path and skips, rather than passing while checking nothing."*

Verified on Linux: the suite **runs**, 2 tests, both OK.

And **backlog-125 is not ungated.** It's measured on the M4 by `tools/probes/metal_math_mode_probe.m` and `metal_contraction_barrier_probe.m`, written up in `docs/fp-contraction-policy.md`:

> `a*b+c` contracted **8773/8773** under every compile-option setting *including* `mathMode=Safe`, **0/8773** with the pragma; options honoured on **16017** and **22135** of 65536 math-function results.

Far stronger evidence than this file could give. My inference — that a wrong predicate would leave 125 ungated anywhere — was false in both directions.

## What was real, and it's small

**The second case skipped silently.** `test_is_repeatable` called `Alcotest.skip ()` bare, so on a Mac it printed nothing. A reader saw `[SKIP]` with no way to learn the reason — and a skip that doesn't say why is indistinguishable from a skip for the *wrong* reason, which is the family this repo keeps finding (#113, #131, #140).

**The group name read backwards exactly where it mattered.** The old name stated the property, but on a Mac the cases skip *because the runtime is **present***. So the reader saw a skip under a heading naming its **absence** and reasonably concluded the Mac lacked libobjc. That is precisely what I concluded when I filed this — the label produced the false report.

## The fix

Both cases route through one `skip_because_runtime_present` helper stating the condition, naming which hosts *do* answer the question, and pointing at the probes that measure the FP behaviour. The group is named for the property with the host condition attached.

**Measured on both instruments:**

| host | result |
|---|---|
| Linux (libobjc absent) | 2 tests **run**, both OK |
| ladon, Apple M4 | both `[SKIP]` under `mtl_compile_options_conformant fails soft (runtime-absent hosts only)` |

And the reason is reachable rather than swallowed — verified in the captured per-case output on ladon, for **both** cases (the second previously had none):

```
[SKIP] returns None rather than raising: Metal IS available on this host, so the
fail-soft path (which requires the Objective-C runtime to be ABSENT) cannot be
reached here. Linux and CI answer this question; the Metal FP behaviour itself is
measured separately by tools/probes/metal_math_mode_probe.m and
metal_contraction_barrier_probe.m — see docs/fp-contraction-policy.md.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test output by displaying clear reasons when host-specific tests are skipped.
  * Standardized skip behavior across runtime-dependent test cases.
  * Updated test and suite names to more clearly describe the conditions being validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->