### PR TITLE
fix(codegen): a nested record's struct was declared after the struct using it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,12 +104,19 @@
   failed the same way. `Sarek_ir_codegen.sort_record_types_by_dependency` now
   orders the declarations, stably — ties break on the incoming list position,
   so an already-correct order is returned unchanged and no committed golden
-  moved. A record cycle raises `Record_type_cycle` instead of being emitted in
-  some wrong order; that path is unreachable through the PPX, which refuses a
-  self- or mutually-referencing record field while resolving its alignment
-  (measured: both spellings stop at *unknown alignment for field type*), and is
-  kept for hand-built IR. Interpreter and Native were never affected — they
-  carry values, not struct declarations.
+  moved. A cycle between distinct record declarations raises `Record_type_cycle`
+  instead of being emitted in some wrong order (a self-referencing field is
+  dropped, not reported); that path is unreachable through the PPX, which
+  refuses a self- or mutually-referencing record field while resolving its
+  alignment (measured: both spellings stop at *unknown alignment for field
+  type*), and is kept as a backstop for hand-built IR. Interpreter and Native
+  were never affected — they carry values, not struct declarations. This orders
+  records against records only. Records are NOT ordered against variants, and
+  both directions of that gap are still live: on the C family, which emits
+  variants first, a variant with a record payload names a struct declared later
+  (measured on OpenCL, `error: unknown type name 'Probe_pt'`); on GLSL/WGSL,
+  which emit records first, the mirror case is a record with a variant-typed
+  field.
 - `Sarek_df64` silently ran at plain float32 precision on real NVIDIA
   hardware (CUDA/PTX and NVIDIA OpenCL): `ptxas` contracted the multiply in
   `two_prod` into the `add`/`sub` of the `quick_two_sum` closing `df64_mul`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,24 @@
 
 ### Fixed
 
+- A `[@@sarek.type]` record with a record-typed field had its inner struct
+  emitted AFTER the struct that referenced it, so no kernel touching a nested
+  record compiled on any shader backend. Both declaration-emission loops walked
+  `kern_types` in list order, and that is not a dependency order: the PPX
+  prepends the types reachable through the registry to the ones the kernel
+  payload declares. Measured on an RX 7900 XTX host, a read-only nested access
+  (`dst.(tid) <- src.(tid).mid.b`) failed on OpenCL ×2 with
+  `unknown type name 'Test_..._triple'` and on Vulkan ×2 with a glslang parse
+  error at the field line; a three-level chain and two independent nested types
+  failed the same way. `Sarek_ir_codegen.sort_record_types_by_dependency` now
+  orders the declarations, stably — ties break on the incoming list position,
+  so an already-correct order is returned unchanged and no committed golden
+  moved. A record cycle raises `Record_type_cycle` instead of being emitted in
+  some wrong order; that path is unreachable through the PPX, which refuses a
+  self- or mutually-referencing record field while resolving its alignment
+  (measured: both spellings stop at *unknown alignment for field type*), and is
+  kept for hand-built IR. Interpreter and Native were never affected — they
+  carry values, not struct declarations.
 - `Sarek_df64` silently ran at plain float32 precision on real NVIDIA
   hardware (CUDA/PTX and NVIDIA OpenCL): `ptxas` contracted the multiply in
   `two_prod` into the `add`/`sub` of the `quick_two_sum` closing `df64_mul`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,7 +116,9 @@
   variants first, a variant with a record payload names a struct declared later
   (measured on OpenCL, `error: unknown type name 'Probe_pt'`); on GLSL/WGSL,
   which emit records first, the mirror case is a record with a variant-typed
-  field.
+  field (measured on Vulkan/RADV, `syntax error, unexpected IDENTIFIER`). Each
+  half is reachable from ordinary `[@@sarek.type]` source and each passes on the
+  family the other fails on.
 - `Sarek_df64` silently ran at plain float32 precision on real NVIDIA
   hardware (CUDA/PTX and NVIDIA OpenCL): `ptxas` contracted the multiply in
   `two_prod` into the `add`/`sub` of the `quick_two_sum` closing `df64_mul`,

--- a/sarek/codegen/Sarek_ir_glsl.ml
+++ b/sarek/codegen/Sarek_ir_glsl.ml
@@ -2030,8 +2030,12 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
        ~uses_uint8:(Sarek_ir_analysis.kernel_uses Sarek_ir_analysis.Coopmat k)
        ()) ;
 
-  (* Generate record type definitions (simple structs without tag) *)
-  List.iter (gen_record_def buf) types ;
+  (* Generate record type definitions (simple structs without tag), inner
+     structs first — GLSL requires a struct type to be declared before the
+     field that names it (backlog-203). *)
+  List.iter
+    (gen_record_def buf)
+    (Sarek_ir_codegen.sort_record_types_by_dependency types) ;
 
   (* Generate variant type definitions (structs with tag) *)
   List.iter (gen_variant_def buf) k.kern_variants ;

--- a/sarek/codegen/Sarek_ir_wgsl.ml
+++ b/sarek/codegen/Sarek_ir_wgsl.ml
@@ -1482,7 +1482,11 @@ let generate_with_types ?block ?(log : string -> unit = fun _ -> ())
   scalar_param_names := [] ;
   current_variants := k.kern_variants ;
   let buf = Buffer.create 1024 in
-  List.iter (gen_record_def buf) types ;
+  (* Inner structs first: WGSL, like GLSL, requires a struct type to be
+     declared before the field that names it (backlog-203). *)
+  List.iter
+    (gen_record_def buf)
+    (Sarek_ir_codegen.sort_record_types_by_dependency types) ;
   List.iter (gen_variant_def buf) k.kern_variants ;
   let scalars = gen_bindings buf k.kern_params in
   scalar_param_names := scalars ;

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1588,3 +1588,34 @@
  (alias runtest)
  (action
   (run %{dep:test_helper_param_const_collision.exe})))
+
+; record-nested-struct-order (backlog-203): a [@@sarek.type] record with a
+; record-typed field must have the inner struct emitted BEFORE the struct that
+; references it. Covers one-level nesting, a three-level chain, and two
+; independent nested types in one record. Runs on every available device with
+; no per-backend tolerance — the C-family "unknown type name" and the
+; GLSL/WGSL parse error at the field line are exactly what it detects.
+
+(executable
+ (name test_record_nested_struct_order)
+ (modules test_record_nested_struct_order)
+ (libraries
+  sarek
+  sarek.stdlib
+  sarek_ir
+  spoc_core
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_record_nested_struct_order.exe})))

--- a/sarek/tests/e2e/test_record_nested_struct_order.ml
+++ b/sarek/tests/e2e/test_record_nested_struct_order.ml
@@ -1,0 +1,206 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test: a [@@sarek.type] record with a RECORD-TYPED field must have its
+ * inner struct declared BEFORE the struct that uses it (backlog-203).
+ *
+ * The declaration-emission loops walked [kern_types] in list order, which is
+ * not a dependency order: the PPX merges registered types ahead of the
+ * payload's own, so a record whose field type is another record could be
+ * emitted first and reference an as-yet-undeclared struct. Every C-family
+ * backend (OpenCL/CUDA/HIP/Metal) then failed at compile time with
+ * `unknown type name '<Inner>'`, and GLSL/WGSL with a parse error at the
+ * field line. The values-carrying backends (Interpreter, Native) never see a
+ * struct declaration and were unaffected.
+ *
+ * Three shapes are exercised, all of them beyond the trivial one-level pair:
+ *   1. one-level nesting     — [outer { tag; mid : triple }]
+ *   2. a THREE-level chain   — [chain_top { s : chain_mid { r : chain_leaf } }]
+ *   3. two INDEPENDENT       — [twin { left : triple; right : chain_leaf }]
+ *      nested types            (the sort must order both, deterministically)
+ *
+ * Each kernel is READ-ONLY on the nested field (`dst.(tid) <- src.(tid).f.g`).
+ * That is deliberate: the defect is in the type-declaration emission, not in
+ * the field-store path, so a read-only kernel is enough to reproduce it and
+ * keeps this test independent of nested-field-store support.
+ *
+ * Every available device must PASS. There is no per-backend tolerance here:
+ * a device that fails makes the process exit non-zero.
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module Device = Spoc_core.Device
+module Transfer = Spoc_core.Transfer
+
+[@@@warning "-32"]
+
+let () =
+  Sarek_native.Native_plugin.init () ;
+  Sarek_interpreter.Interpreter_plugin.init () ;
+  Sarek_cuda.Cuda_plugin.init () ;
+  Sarek_opencl.Opencl_plugin.init () ;
+  Sarek_vulkan.Vulkan_plugin.init ()
+
+type float32 = float
+
+(* --- Shape 1: one-level nesting ----------------------------------------- *)
+type triple = {a : float32; b : float32; c : float32} [@@sarek.type]
+
+type outer = {tag : float32; mid : triple} [@@sarek.type]
+
+(* --- Shape 2: a three-level chain --------------------------------------- *)
+type chain_leaf = {p : float32} [@@sarek.type]
+
+type chain_mid = {r : chain_leaf} [@@sarek.type]
+
+type chain_top = {s : chain_mid} [@@sarek.type]
+
+(* --- Shape 3: two independent nested types in one record ---------------- *)
+type twin = {left : triple; right : chain_leaf} [@@sarek.type]
+
+(* Read `.mid.b` out of a nested record — no field store anywhere. *)
+let k_outer =
+  snd
+    [%kernel
+      fun (src : outer vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x in
+        if tid < n then dst.(tid) <- src.(tid).mid.b]
+
+(* Read through a three-level chain. *)
+let k_chain =
+  snd
+    [%kernel
+      fun (src : chain_top vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x in
+        if tid < n then dst.(tid) <- src.(tid).s.r.p]
+
+(* Read both independent nested fields and combine them. *)
+let k_twin =
+  snd
+    [%kernel
+      fun (src : twin vector) (dst : float32 vector) (n : int32) ->
+        let tid = thread_idx_x in
+        if tid < n then dst.(tid) <- src.(tid).left.a +. src.(tid).right.p]
+
+let n = 64
+
+let devices () =
+  Device.init
+    ~frameworks:["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"; "Metal"]
+    ()
+
+let ir_of name kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith (name ^ ": kernel has no IR")
+
+(* Run one kernel on one device and verify the float32 output vector. *)
+let run_case ~dev ~name ~kirc ~make_src ~expected =
+  Printf.printf "  [%s] %s / %s: %!" dev.Device.framework dev.Device.name name ;
+  try
+    let src = make_src () in
+    let dst = Vector.create Vector.float32 n in
+    for i = 0 to n - 1 do
+      Vector.set dst i 0.0
+    done ;
+    let threads = min 64 n in
+    let grid_x = (n + threads - 1) / threads in
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~block:(Sarek.Execute.dims1d threads)
+      ~grid:(Sarek.Execute.dims1d grid_x)
+      ~ir:(ir_of name kirc)
+      ~args:
+        [
+          Sarek.Execute.Vec src;
+          Sarek.Execute.Vec dst;
+          Sarek.Execute.Int32 (Int32.of_int n);
+        ]
+      () ;
+    Transfer.flush dev ;
+    let ok = ref true in
+    for i = 0 to n - 1 do
+      let got = Vector.get dst i in
+      let want = expected i in
+      if abs_float (got -. want) > 1e-3 then begin
+        if !ok then
+          Printf.printf
+            "\n    mismatch at %d: got %.3f expected %.3f%!"
+            i
+            got
+            want ;
+        ok := false
+      end
+    done ;
+    if !ok then print_endline "PASSED" else print_endline "FAILED" ;
+    !ok
+  with e ->
+    Printf.printf "FAILED (%s)\n%!" (Printexc.to_string e) ;
+    false
+
+let make_outer () =
+  let v = Vector.create_custom outer_custom n in
+  for i = 0 to n - 1 do
+    let f = float_of_int i in
+    Vector.set v i {tag = f; mid = {a = f; b = f +. 0.5; c = f +. 1.0}}
+  done ;
+  v
+
+let make_chain () =
+  let v = Vector.create_custom chain_top_custom n in
+  for i = 0 to n - 1 do
+    Vector.set v i {s = {r = {p = float_of_int i *. 2.0}}}
+  done ;
+  v
+
+let make_twin () =
+  let v = Vector.create_custom twin_custom n in
+  for i = 0 to n - 1 do
+    let f = float_of_int i in
+    Vector.set v i {left = {a = f; b = 0.0; c = 0.0}; right = {p = f *. 10.0}}
+  done ;
+  v
+
+let () =
+  print_endline "=== nested-record struct declaration order (backlog-203) ===" ;
+  let devs = devices () in
+  if Array.length devs = 0 then begin
+    print_endline "No devices found - nothing to verify" ;
+    exit 0
+  end ;
+  let any_failure = ref false in
+  Array.iter
+    (fun dev ->
+      (* Each case has its own element type, so the three runs are spelled out
+         rather than folded over a list (no existential to hide the type). *)
+      let check b = if not b then any_failure := true in
+      check
+        (run_case
+           ~dev
+           ~name:"one-level (outer.mid.b)"
+           ~kirc:k_outer
+           ~make_src:make_outer
+           ~expected:(fun i -> float_of_int i +. 0.5)) ;
+      check
+        (run_case
+           ~dev
+           ~name:"three-level (top.s.r.p)"
+           ~kirc:k_chain
+           ~make_src:make_chain
+           ~expected:(fun i -> float_of_int i *. 2.0)) ;
+      check
+        (run_case
+           ~dev
+           ~name:"two independent (left.a + right.p)"
+           ~kirc:k_twin
+           ~make_src:make_twin
+           ~expected:(fun i -> float_of_int i +. (float_of_int i *. 10.0))))
+    devs ;
+  if !any_failure then begin
+    print_endline "FAILED: at least one device/case did not verify" ;
+    exit 1
+  end ;
+  print_endline "ALL PASSED"

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -691,27 +691,37 @@ exception Record_type_cycle of string list
 
 (** Mangled names of every record type mentioned anywhere inside [ty]'s type
     tree, including through arrays, vectors, variant payloads and the fields of
-    a nested record. [seen] stops a cyclic {!Sarek_ir_types.elttype} value from
-    looping — the walk is over a graph, not a guaranteed-finite tree. *)
+    a nested record. The walk is over a graph, not a guaranteed-finite tree, so
+    it terminates on a cyclic {!Sarek_ir_types.elttype} value.
+
+    [seen] is keyed on PHYSICAL IDENTITY of the node, not on a record name. A
+    name-keyed guard only closes cycles that pass through a [TRecord], and a
+    cyclic value need not: [let rec t = TVec t] and
+    [let rec t = TVariant ("c", [("C", [t])])] are both accepted by OCaml's
+    recursive-value rule and both close without a [TRecord] on the cycle. Keyed
+    on names, those two shapes looped forever. Skipping a physically re-visited
+    node cannot lose a name — [acc] already holds everything reachable from it —
+    so the general guard does not narrow the result. *)
 let referenced_record_names (ty : Sarek_ir_types.elttype) : string list =
   let open Sarek_ir_types in
   let acc = ref [] in
-  let rec go seen ty =
-    match ty with
-    | TRecord (name, fields) ->
-        let mangled = mangle_name name in
-        if not (List.mem mangled seen) then begin
-          acc := mangled :: !acc ;
-          List.iter (fun (_, fty) -> go (mangled :: seen) fty) fields
-        end
-    | TVariant (_, constrs) ->
-        List.iter (fun (_, args) -> List.iter (go seen) args) constrs
-    | TArray (elt, _) | TVec elt -> go seen elt
-    | TInt32 | TInt64 | TFloat16 | TFloat32 | TFloat64 | TUint8 | TBool | TUnit
-      ->
-        ()
+  let seen = ref [] in
+  let rec go ty =
+    if not (List.exists (fun s -> s == ty) !seen) then begin
+      seen := ty :: !seen ;
+      match ty with
+      | TRecord (name, fields) ->
+          acc := mangle_name name :: !acc ;
+          List.iter (fun (_, fty) -> go fty) fields
+      | TVariant (_, constrs) ->
+          List.iter (fun (_, args) -> List.iter go args) constrs
+      | TArray (elt, _) | TVec elt -> go elt
+      | TInt32 | TInt64 | TFloat16 | TFloat32 | TFloat64 | TUint8 | TBool
+      | TUnit ->
+          ()
+    end
   in
-  go [] ty ;
+  go ty ;
   List.sort_uniq String.compare !acc
 
 (** Order record declarations so that a struct is emitted only after every
@@ -777,8 +787,19 @@ let sort_record_types_by_dependency
 
 (** Emit C-family record type declarations: one [typedef struct { ... } name;]
     per record, one field per line. Shared by CUDA/OpenCL/Metal; only
-    [type_of_elttype] differs. Declarations are emitted in dependency order (see
-    {!sort_record_types_by_dependency}). *)
+    [type_of_elttype] differs. Records are emitted in dependency order among
+    THEMSELVES (see {!sort_record_types_by_dependency}).
+
+    Records only, and that boundary is not yet where it should be. The C-family
+    callers run {!gen_variant_def} BEFORE this function, so a variant with a
+    record payload emits [<Record> <C>_v;] ahead of that record's typedef and
+    the kernel still fails to compile — measured on OpenCL (radeonsi):
+    [error: unknown type name 'Probe_pt'], reachable from ordinary
+    [[@@sarek.type]] source. GLSL/WGSL emit records BEFORE variants and so have
+    the mirror half of the same gap: a record with a variant-typed field. Both
+    halves are the same defect class as backlog-203 and neither is fixed here;
+    ordering records against variants needs one interleaved loop per backend
+    family. *)
 let gen_record_typedefs ~type_of_elttype buf types =
   List.iter
     (fun (name, fields) ->

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -687,9 +687,98 @@ let gen_param ~param_type ~gen_array_param ~invalid buf decl =
       emit_length v.var_name
   | DLocal _ | DShared _ -> invalid ()
 
+exception Record_type_cycle of string list
+
+(** Mangled names of every record type mentioned anywhere inside [ty]'s type
+    tree, including through arrays, vectors, variant payloads and the fields of
+    a nested record. [seen] stops a cyclic {!Sarek_ir_types.elttype} value from
+    looping — the walk is over a graph, not a guaranteed-finite tree. *)
+let referenced_record_names (ty : Sarek_ir_types.elttype) : string list =
+  let open Sarek_ir_types in
+  let acc = ref [] in
+  let rec go seen ty =
+    match ty with
+    | TRecord (name, fields) ->
+        let mangled = mangle_name name in
+        if not (List.mem mangled seen) then begin
+          acc := mangled :: !acc ;
+          List.iter (fun (_, fty) -> go (mangled :: seen) fty) fields
+        end
+    | TVariant (_, constrs) ->
+        List.iter (fun (_, args) -> List.iter (go seen) args) constrs
+    | TArray (elt, _) | TVec elt -> go seen elt
+    | TInt32 | TInt64 | TFloat16 | TFloat32 | TFloat64 | TUint8 | TBool | TUnit
+      ->
+        ()
+  in
+  go [] ty ;
+  List.sort_uniq String.compare !acc
+
+(** Order record declarations so that a struct is emitted only after every
+    struct its field types reference.
+
+    The emission loops used to walk [kern_types] in list order, and that order
+    is not a dependency order: the PPX prepends the types reachable through the
+    registry to the ones declared in the kernel's own payload, so a record with
+    a record-typed field could be emitted ahead of the struct it names. Every
+    C-family backend then failed to compile the kernel
+    ([unknown type name '<Inner>']) and GLSL/WGSL failed to parse the field
+    line. This is that missing sort (backlog-203).
+
+    {b Stability.} Two records with no dependency between them keep their
+    relative position in the input list — ties break on the incoming index, not
+    on the name — so adding this sort leaves the emission of an
+    already-correctly-ordered type list byte-identical and committed goldens do
+    not churn.
+
+    {b Cycles.} A record cycle has no valid emission order, so it raises
+    {!Record_type_cycle} with the names still unplaced rather than falling back
+    to input order — a silently wrong order is the very defect this function
+    exists to remove. Note the check is a backstop, not a live guard: the PPX
+    resolves a record field's alignment from a registry populated when the
+    field's own type declaration was processed, so a record whose field type is
+    itself or a later type is refused there first ("unknown alignment for field
+    type '...'"), and no cycle can reach codegen through the PPX front end. It
+    is kept for the IR-constructed-by-hand path (fusion, tests, a future front
+    end), where nothing else would notice. *)
+let sort_record_types_by_dependency
+    (types : (string * (string * Sarek_ir_types.elttype) list) list) :
+    (string * (string * Sarek_ir_types.elttype) list) list =
+  let declared = List.map (fun (name, _) -> mangle_name name) types in
+  let indexed = List.mapi (fun i entry -> (i, entry)) types in
+  (* Dependencies of one entry: the declared records its fields reference,
+     minus itself (a self-reference cannot be satisfied by ordering, and
+     dropping it keeps the diagnostic about real cycles). *)
+  let deps (_, (name, fields)) =
+    let self = mangle_name name in
+    List.concat_map (fun (_, fty) -> referenced_record_names fty) fields
+    |> List.filter (fun d -> d <> self && List.mem d declared)
+  in
+  let remaining = ref indexed and placed = ref [] and out = ref [] in
+  let rec loop () =
+    if !remaining <> [] then
+      match
+        List.find_opt
+          (fun e -> List.for_all (fun d -> List.mem d !placed) (deps e))
+          !remaining
+      with
+      | Some ((i, (name, _)) as entry) ->
+          out := snd entry :: !out ;
+          placed := mangle_name name :: !placed ;
+          remaining := List.filter (fun (j, _) -> j <> i) !remaining ;
+          loop ()
+      | None ->
+          raise
+            (Record_type_cycle
+               (List.map (fun (_, (name, _)) -> name) !remaining))
+  in
+  loop () ;
+  List.rev !out
+
 (** Emit C-family record type declarations: one [typedef struct { ... } name;]
     per record, one field per line. Shared by CUDA/OpenCL/Metal; only
-    [type_of_elttype] differs. *)
+    [type_of_elttype] differs. Declarations are emitted in dependency order (see
+    {!sort_record_types_by_dependency}). *)
 let gen_record_typedefs ~type_of_elttype buf types =
   List.iter
     (fun (name, fields) ->
@@ -705,7 +794,7 @@ let gen_record_typedefs ~type_of_elttype buf types =
       Buffer.add_string buf "} " ;
       Buffer.add_string buf (mangle_name name) ;
       Buffer.add_string buf ";\n\n")
-    types
+    (sort_record_types_by_dependency types)
 
 (** Emit a GLSL variant type. GLSL lacks enum/typedef/union, so tags are
     const-int declarations, the type is a bare struct with flat payload fields,

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -796,10 +796,13 @@ let sort_record_types_by_dependency
     the kernel still fails to compile — measured on OpenCL (radeonsi):
     [error: unknown type name 'Probe_pt'], reachable from ordinary
     [[@@sarek.type]] source. GLSL/WGSL emit records BEFORE variants and so have
-    the mirror half of the same gap: a record with a variant-typed field. Both
-    halves are the same defect class as backlog-203 and neither is fixed here;
-    ordering records against variants needs one interleaved loop per backend
-    family. *)
+    the mirror half: a record with a variant-typed field, measured red on Vulkan
+    (RADV, both devices) as [syntax error, unexpected IDENTIFIER] at the field
+    line while the SAME kernel passes on OpenCL. Each half is reachable from the
+    PPX and each is green on exactly the family the other one fails on, which is
+    why neither showed up in the backlog-203 reproducer. Both are the same
+    defect class and neither is fixed here; ordering records against variants
+    needs one interleaved loop per backend family. *)
 let gen_record_typedefs ~type_of_elttype buf types =
   List.iter
     (fun (name, fields) ->

--- a/spoc/ir/Sarek_ir_codegen.mli
+++ b/spoc/ir/Sarek_ir_codegen.mli
@@ -266,9 +266,35 @@ val gen_param :
   Sarek_ir_types.decl ->
   unit
 
+(** Raised by {!sort_record_types_by_dependency} when the record declarations
+    form a cycle, carrying the unplaced type names. A cycle has no valid
+    emission order, so it is refused rather than emitted in input order. *)
+exception Record_type_cycle of string list
+
+(** Mangled names of every record type reachable from a field type, through
+    arrays, vectors, variant payloads and nested record fields. Sorted and
+    deduplicated; safe on a cyclic [elttype] value. *)
+val referenced_record_names : Sarek_ir_types.elttype -> string list
+
+(** Order record declarations so a struct comes after every struct its field
+    types reference (backlog-203: list order is not dependency order, because
+    the PPX prepends registry-reachable types to the payload's own).
+
+    Stable: records with no dependency between them keep their relative input
+    position, so an already-correctly-ordered list is returned unchanged and
+    committed goldens do not churn.
+
+    @raise Record_type_cycle
+      if the declarations form a cycle. Unreachable through the PPX — it refuses
+      a self- or forward-referencing record field at alignment-resolution time —
+      but load-bearing for hand-built IR. *)
+val sort_record_types_by_dependency :
+  (string * (string * Sarek_ir_types.elttype) list) list ->
+  (string * (string * Sarek_ir_types.elttype) list) list
+
 (** Emit C-family record type declarations: one [typedef struct { ... } name;]
     per record, one field per line. Only [type_of_elttype] differs per backend.
-*)
+    Declarations are emitted in {!sort_record_types_by_dependency} order. *)
 val gen_record_typedefs :
   type_of_elttype:(Sarek_ir_types.elttype -> string) ->
   Buffer.t ->

--- a/spoc/ir/Sarek_ir_codegen.mli
+++ b/spoc/ir/Sarek_ir_codegen.mli
@@ -267,13 +267,19 @@ val gen_param :
   unit
 
 (** Raised by {!sort_record_types_by_dependency} when the record declarations
-    form a cycle, carrying the unplaced type names. A cycle has no valid
-    emission order, so it is refused rather than emitted in input order. *)
+    form a cycle between DISTINCT declarations, carrying the unplaced type
+    names. Such a cycle has no valid emission order, so it is refused rather
+    than emitted in input order. A record whose own field type is itself is NOT
+    reported here: the self-edge is dropped so the diagnostic stays about cycles
+    between declarations, and the backend's field-type emission is what reports
+    it. *)
 exception Record_type_cycle of string list
 
 (** Mangled names of every record type reachable from a field type, through
     arrays, vectors, variant payloads and nested record fields. Sorted and
-    deduplicated; safe on a cyclic [elttype] value. *)
+    deduplicated. Terminates on a cyclic [elttype] value whatever closes the
+    cycle — the visited set is keyed on physical node identity, not on a record
+    name, so a cycle through [TVec]/[TArray]/[TVariant] alone is caught too. *)
 val referenced_record_names : Sarek_ir_types.elttype -> string list
 
 (** Order record declarations so a struct comes after every struct its field
@@ -284,17 +290,29 @@ val referenced_record_names : Sarek_ir_types.elttype -> string list
     position, so an already-correctly-ordered list is returned unchanged and
     committed goldens do not churn.
 
+    Records only. Variant declarations are emitted by a separate loop, and the
+    two loops disagree on order across backends, so this does not order a record
+    against a variant either way (see {!gen_record_typedefs}).
+
     @raise Record_type_cycle
-      if the declarations form a cycle. Unreachable through the PPX — it refuses
-      a self- or forward-referencing record field at alignment-resolution time —
-      but load-bearing for hand-built IR. *)
+      if the declarations form a cycle between distinct declarations; a
+      self-referencing field is dropped, not reported. No current caller can
+      reach it: the PPX refuses a self- or forward-referencing record field at
+      alignment-resolution time, and fusion only concatenates two PPX-produced
+      (hence acyclic) type lists. It is a backstop for hand-built IR — tests
+      today, a future front end — where nothing else would notice, not a guard
+      anything presently depends on. *)
 val sort_record_types_by_dependency :
   (string * (string * Sarek_ir_types.elttype) list) list ->
   (string * (string * Sarek_ir_types.elttype) list) list
 
 (** Emit C-family record type declarations: one [typedef struct { ... } name;]
     per record, one field per line. Only [type_of_elttype] differs per backend.
-    Declarations are emitted in {!sort_record_types_by_dependency} order. *)
+    Records are emitted in {!sort_record_types_by_dependency} order among
+    themselves — NOT against variants: the C-family callers emit variants first,
+    so a variant with a record payload still names a struct declared later and
+    still fails to compile. See the implementation comment for the measured
+    OpenCL error and the mirror GLSL/WGSL half. *)
 val gen_record_typedefs :
   type_of_elttype:(Sarek_ir_types.elttype -> string) ->
   Buffer.t ->

--- a/spoc/ir/test/dune
+++ b/spoc/ir/test/dune
@@ -7,4 +7,4 @@
   test_sarek_coopmat
   test_sarek_pure_registry
   test_sarek_ir_codegen_record_order)
- (libraries sarek_ir alcotest str))
+ (libraries sarek_ir alcotest str unix))

--- a/spoc/ir/test/dune
+++ b/spoc/ir/test/dune
@@ -5,5 +5,6 @@
   test_sarek_ir_analysis
   test_sarek_capability
   test_sarek_coopmat
-  test_sarek_pure_registry)
+  test_sarek_pure_registry
+  test_sarek_ir_codegen_record_order)
  (libraries sarek_ir alcotest str))

--- a/spoc/ir/test/test_sarek_ir_codegen_record_order.ml
+++ b/spoc/ir/test/test_sarek_ir_codegen_record_order.ml
@@ -33,6 +33,41 @@ let check_order what expected got =
          (String.concat "; " expected)
          (String.concat "; " got))
 
+exception Timed_out
+
+(* Run [f] under a hard deadline and FAIL if it does not return.
+   [referenced_record_names] walks a graph, so its regression mode is a
+   non-terminating tail-recursive loop, not a wrong answer. Left to itself that
+   reads as a hung test rather than a failing one, and `dune runtest` imposes no
+   timeout of its own — the only thing that would eventually notice is a CI job
+   limit, with no message naming the cause. SIGALRM turns the hang into a named
+   assertion: the walk allocates on every step (it conses onto the visited set),
+   so there is a poll point for the signal to be delivered at. *)
+let within_deadline ~seconds ~what f =
+  let prev =
+    Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> raise Timed_out))
+  in
+  let restore () =
+    ignore (Unix.alarm 0) ;
+    Sys.set_signal Sys.sigalrm prev
+  in
+  ignore (Unix.alarm seconds) ;
+  match f () with
+  | v ->
+      restore () ;
+      v
+  | exception Timed_out ->
+      restore () ;
+      failwith
+        (Printf.sprintf
+           "%s: did not terminate within %ds — the cyclic-value guard no \
+            longer closes this shape"
+           what
+           seconds)
+  | exception e ->
+      restore () ;
+      raise e
+
 let triple_fields = [("a", TFloat32); ("b", TFloat32); ("c", TFloat32)]
 
 let triple = TRecord ("triple", triple_fields)
@@ -221,37 +256,34 @@ let test_c_family_emission_order () =
    cycles below have no [TRecord] on the cycle at all and looped forever (they
    are tail-recursive, so they hang rather than overflow — a test that only
    covered the record shape reported a general "safe on a cyclic value" it had
-   never exercised). A hang has no failure message, so these cases pin
-   termination by returning at all: if the guard regresses, the test process
-   never finishes and dune's timeout is the red. *)
+   never exercised). Each case runs under {!within_deadline} so a regression is a
+   named failure, not a hung process. *)
 let test_referenced_names_terminates_on_cyclic_value () =
+  let check what expected ty =
+    let got =
+      within_deadline ~seconds:10 ~what (fun () ->
+          Sarek_ir_codegen.referenced_record_names ty)
+    in
+    if got <> expected then
+      failwith
+        (Printf.sprintf
+           "%s: expected [%s] got [%s]"
+           what
+           (String.concat "; " expected)
+           (String.concat "; " got))
+  in
   (* Shape 1: the cycle passes through a TRecord. *)
   let rec node = TRecord ("node", [("self", node)]) in
-  let got = Sarek_ir_codegen.referenced_record_names node in
-  if got <> ["node"] then
-    failwith
-      (Printf.sprintf
-         "referenced_record_names: expected [node] got [%s]"
-         (String.concat "; " got)) ;
+  check "referenced_record_names on a TRecord cycle" ["node"] node ;
   (* Shape 2: the cycle is closed by TVec alone — no TRecord on it. *)
   let rec vec_cycle = TVec vec_cycle in
-  let got = Sarek_ir_codegen.referenced_record_names vec_cycle in
-  if got <> [] then
-    failwith
-      (Printf.sprintf
-         "referenced_record_names on a TVec cycle: expected [] got [%s]"
-         (String.concat "; " got)) ;
+  check "referenced_record_names on a TVec cycle" [] vec_cycle ;
   (* Shape 3: the cycle is closed by a TVariant payload — no TRecord on it, but
      a record hangs off the same variant and must still be reported. *)
   let rec var_cycle =
     TVariant ("loop", [("Stop", [leaf]); ("Go", [TArray (var_cycle, Global)])])
   in
-  let got = Sarek_ir_codegen.referenced_record_names var_cycle in
-  if got <> ["leaf"] then
-    failwith
-      (Printf.sprintf
-         "referenced_record_names on a TVariant cycle: expected [leaf] got [%s]"
-         (String.concat "; " got)) ;
+  check "referenced_record_names on a TVariant cycle" ["leaf"] var_cycle ;
   print_endline
     "  referenced_record_names terminates on record/vec/variant cycles: OK"
 

--- a/spoc/ir/test/test_sarek_ir_codegen_record_order.ml
+++ b/spoc/ir/test/test_sarek_ir_codegen_record_order.ml
@@ -213,9 +213,19 @@ let test_c_family_emission_order () =
   print_endline "  gen_record_typedefs declares the inner struct first: OK"
 
 (* [referenced_record_names] must terminate on a cyclic elttype VALUE, not just
-   on a finite tree — the sort calls it on IR nobody promised is acyclic. *)
+   on a finite tree — the sort calls it on IR nobody promised is acyclic.
+
+   All THREE cycle shapes OCaml's recursive-value rule admits are pinned, not
+   just the record one. The first version of the guard was keyed on the record
+   NAME, which closes a cycle only if a [TRecord] sits on it; the vec and variant
+   cycles below have no [TRecord] on the cycle at all and looped forever (they
+   are tail-recursive, so they hang rather than overflow — a test that only
+   covered the record shape reported a general "safe on a cyclic value" it had
+   never exercised). A hang has no failure message, so these cases pin
+   termination by returning at all: if the guard regresses, the test process
+   never finishes and dune's timeout is the red. *)
 let test_referenced_names_terminates_on_cyclic_value () =
-  (* A genuinely cyclic value: [node]'s only field type IS [node]. *)
+  (* Shape 1: the cycle passes through a TRecord. *)
   let rec node = TRecord ("node", [("self", node)]) in
   let got = Sarek_ir_codegen.referenced_record_names node in
   if got <> ["node"] then
@@ -223,7 +233,27 @@ let test_referenced_names_terminates_on_cyclic_value () =
       (Printf.sprintf
          "referenced_record_names: expected [node] got [%s]"
          (String.concat "; " got)) ;
-  print_endline "  referenced_record_names terminates and dedups: OK"
+  (* Shape 2: the cycle is closed by TVec alone — no TRecord on it. *)
+  let rec vec_cycle = TVec vec_cycle in
+  let got = Sarek_ir_codegen.referenced_record_names vec_cycle in
+  if got <> [] then
+    failwith
+      (Printf.sprintf
+         "referenced_record_names on a TVec cycle: expected [] got [%s]"
+         (String.concat "; " got)) ;
+  (* Shape 3: the cycle is closed by a TVariant payload — no TRecord on it, but
+     a record hangs off the same variant and must still be reported. *)
+  let rec var_cycle =
+    TVariant ("loop", [("Stop", [leaf]); ("Go", [TArray (var_cycle, Global)])])
+  in
+  let got = Sarek_ir_codegen.referenced_record_names var_cycle in
+  if got <> ["leaf"] then
+    failwith
+      (Printf.sprintf
+         "referenced_record_names on a TVariant cycle: expected [leaf] got [%s]"
+         (String.concat "; " got)) ;
+  print_endline
+    "  referenced_record_names terminates on record/vec/variant cycles: OK"
 
 let () =
   print_endline "=== record declaration dependency order (backlog-203) ===" ;

--- a/spoc/ir/test/test_sarek_ir_codegen_record_order.ml
+++ b/spoc/ir/test/test_sarek_ir_codegen_record_order.ml
@@ -1,0 +1,240 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * Unit tests for record-declaration dependency ordering (backlog-203).
+ *
+ * [kern_types] list order is NOT dependency order — the PPX prepends the types
+ * reachable through the registry to the ones the kernel payload declares — so a
+ * record with a record-typed field could have its struct emitted AFTER the
+ * struct that uses it. Every C-family backend then failed to compile
+ * (`unknown type name '<Inner>'`) and GLSL/WGSL failed to parse the field line.
+ *
+ * These tests pin the sort at the level the device e2e test cannot reach:
+ *   - the emission ORDER for the C family, including Metal and HIP, for which
+ *     this host has no hardware (the e2e test can only prove OpenCL/Vulkan);
+ *   - STABILITY, which no device can observe: two independent records must keep
+ *     their input order, or every committed golden churns on unrelated edits;
+ *   - the CYCLE refusal, which the PPX front end cannot produce at all.
+ ******************************************************************************)
+
+open Sarek_ir_types
+
+let names types = List.map fst types
+
+let check_order what expected got =
+  if expected <> got then
+    failwith
+      (Printf.sprintf
+         "%s: expected [%s] got [%s]"
+         what
+         (String.concat "; " expected)
+         (String.concat "; " got))
+
+let triple_fields = [("a", TFloat32); ("b", TFloat32); ("c", TFloat32)]
+
+let triple = TRecord ("triple", triple_fields)
+
+let leaf_fields = [("p", TFloat32)]
+
+let leaf = TRecord ("leaf", leaf_fields)
+
+let mid_fields = [("r", leaf)]
+
+let mid = TRecord ("mid", mid_fields)
+
+(* A dependent record placed BEFORE its dependency in the input list — the
+   shape the PPX actually produced. *)
+let test_one_level () =
+  let input =
+    [("outer", [("tag", TFloat32); ("mid", triple)]); ("triple", triple_fields)]
+  in
+  check_order
+    "one-level nesting"
+    ["triple"; "outer"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  print_endline "  one-level: inner struct first: OK"
+
+(* Three levels, worst-case input order: each entry depends on the next. *)
+let test_three_level_chain () =
+  let input =
+    [("top", [("s", mid)]); ("mid", mid_fields); ("leaf", leaf_fields)]
+  in
+  check_order
+    "three-level chain"
+    ["leaf"; "mid"; "top"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  print_endline "  three-level chain: leaf, mid, top: OK"
+
+(* Two independent nested types in one record: both dependencies must precede
+   the user, and the two independent ones must keep their INPUT order. The
+   names here are deliberately not in alphabetical order, so a name-keyed sort
+   would produce ["leaf"; "triple"; ...] and fail this test. *)
+let test_two_independent_nested () =
+  let input =
+    [
+      ("twin", [("left", triple); ("right", leaf)]);
+      ("triple", triple_fields);
+      ("leaf", leaf_fields);
+    ]
+  in
+  check_order
+    "two independent nested types"
+    ["triple"; "leaf"; "twin"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  print_endline "  two independent nested types: both before the user: OK"
+
+(* Stability, stated as its own property: an input with no dependencies at all
+   comes back byte-identical, in a name order no comparison function would
+   produce. This is what keeps committed goldens from churning. *)
+let test_stable_on_independent_records () =
+  let input =
+    [
+      ("zeta", leaf_fields);
+      ("alpha", leaf_fields);
+      ("mu", leaf_fields);
+      ("beta", leaf_fields);
+    ]
+  in
+  check_order
+    "stability"
+    ["zeta"; "alpha"; "mu"; "beta"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  print_endline "  independent records keep their input order: OK"
+
+(* An already dependency-ordered list is returned unchanged — the sort is a
+   no-op on every type list that compiled before this change. *)
+let test_noop_on_sorted_input () =
+  let input =
+    [("leaf", leaf_fields); ("mid", mid_fields); ("top", [("s", mid)])]
+  in
+  check_order
+    "already sorted"
+    ["leaf"; "mid"; "top"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  print_endline "  already-ordered input is unchanged: OK"
+
+(* A record referenced through an array or a variant payload is still a
+   dependency: the struct has to exist before the type that names it. *)
+let test_dependency_through_array_and_variant () =
+  let input =
+    [("holder", [("xs", TArray (triple, Global))]); ("triple", triple_fields)]
+  in
+  check_order
+    "dependency through an array field"
+    ["triple"; "holder"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  let input =
+    [
+      ("wrapper", [("v", TVariant ("opt", [("None", []); ("Some", [leaf])]))]);
+      ("leaf", leaf_fields);
+    ]
+  in
+  check_order
+    "dependency through a variant payload"
+    ["leaf"; "wrapper"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  print_endline "  array and variant-payload field types count as deps: OK"
+
+(* A cycle has no valid emission order. It must be refused, not emitted in
+   input order — a silently wrong order is the defect this sort removes.
+   Unreachable from the PPX (it resolves a field's alignment from a registry
+   populated by the field type's own earlier declaration, so a self- or
+   forward-referencing field is refused there), so this is the only place the
+   refusal can be exercised. *)
+let test_cycle_is_refused () =
+  let rec_a = TRecord ("a", [("to_b", TRecord ("b", []))]) in
+  let input =
+    [("a", [("to_b", TRecord ("b", []))]); ("b", [("to_a", rec_a)])]
+  in
+  match Sarek_ir_codegen.sort_record_types_by_dependency input with
+  | order ->
+      failwith
+        (Printf.sprintf
+           "cycle: expected Record_type_cycle, got [%s]"
+           (String.concat "; " (names order)))
+  | exception Sarek_ir_codegen.Record_type_cycle unplaced ->
+      if List.sort String.compare unplaced <> ["a"; "b"] then
+        failwith
+          (Printf.sprintf
+             "cycle: expected both names unplaced, got [%s]"
+             (String.concat "; " unplaced)) ;
+      print_endline "  a record cycle raises Record_type_cycle: OK"
+
+(* A record field of the record's OWN type is not orderable either, but it is
+   not a cycle between distinct declarations: the self-edge is dropped so the
+   diagnostic stays about real cycles, and the C backend's own field-type
+   emission is what reports it. Pinned so the drop is deliberate, not
+   incidental. *)
+let test_self_reference_does_not_raise () =
+  let input = [("selfy", [("me", TRecord ("selfy", []))])] in
+  check_order
+    "self reference"
+    ["selfy"]
+    (names (Sarek_ir_codegen.sort_record_types_by_dependency input)) ;
+  print_endline "  a self-referencing field is not reported as a cycle: OK"
+
+(* The C-family emitter itself, not just the sort: this is the only coverage
+   Metal and HIP get on a host with neither. *)
+let test_c_family_emission_order () =
+  let type_of_elttype = function
+    | TFloat32 -> "float"
+    | TRecord (n, _) -> Sarek_ir_codegen.mangle_name n
+    | _ -> "int"
+  in
+  let buf = Buffer.create 256 in
+  Sarek_ir_codegen.gen_record_typedefs
+    ~type_of_elttype
+    buf
+    [("outer", [("mid", triple)]); ("triple", triple_fields)] ;
+  let src = Buffer.contents buf in
+  let idx needle =
+    let nl = String.length needle and hl = String.length src in
+    let rec go i =
+      if i + nl > hl then -1
+      else if String.sub src i nl = needle then i
+      else go (i + 1)
+    in
+    go 0
+  in
+  let decl_triple = idx "} triple;" and use_triple = idx "  triple mid;" in
+  if decl_triple < 0 || use_triple < 0 then
+    failwith (Printf.sprintf "C-family emission: unexpected source:\n%s" src) ;
+  if decl_triple > use_triple then
+    failwith
+      (Printf.sprintf
+         "C-family emission: `triple` used at %d before its declaration at %d:\n\
+          %s"
+         use_triple
+         decl_triple
+         src) ;
+  print_endline "  gen_record_typedefs declares the inner struct first: OK"
+
+(* [referenced_record_names] must terminate on a cyclic elttype VALUE, not just
+   on a finite tree — the sort calls it on IR nobody promised is acyclic. *)
+let test_referenced_names_terminates_on_cyclic_value () =
+  (* A genuinely cyclic value: [node]'s only field type IS [node]. *)
+  let rec node = TRecord ("node", [("self", node)]) in
+  let got = Sarek_ir_codegen.referenced_record_names node in
+  if got <> ["node"] then
+    failwith
+      (Printf.sprintf
+         "referenced_record_names: expected [node] got [%s]"
+         (String.concat "; " got)) ;
+  print_endline "  referenced_record_names terminates and dedups: OK"
+
+let () =
+  print_endline "=== record declaration dependency order (backlog-203) ===" ;
+  test_one_level () ;
+  test_three_level_chain () ;
+  test_two_independent_nested () ;
+  test_stable_on_independent_records () ;
+  test_noop_on_sorted_input () ;
+  test_dependency_through_array_and_variant () ;
+  test_cycle_is_refused () ;
+  test_self_reference_does_not_raise () ;
+  test_c_family_emission_order () ;
+  test_referenced_names_terminates_on_cyclic_value () ;
+  print_endline "All record-order tests passed!"


### PR DESCRIPTION
## What was wrong

A `[@@sarek.type]` record with a **record-typed field** had its inner struct emitted **after** the struct that referenced it, so no kernel touching a nested record compiled on any shader backend.

Both declaration-emission loops walked `kern_types` in list order:

- `spoc/ir/Sarek_ir_codegen.ml` → `gen_record_typedefs` (C family: OpenCL, CUDA-C, HIP, Metal)
- `sarek/codegen/Sarek_ir_glsl.ml` → the `gen_record_def` loop (GLSL / Vulkan)
- `sarek/codegen/Sarek_ir_wgsl.ml` → the `gen_record_def` loop (WGSL — same shape, not previously measured)

List order is not dependency order: the PPX prepends the types reachable through the registry to the ones the kernel payload declares, so the struct that *uses* a record type can land ahead of the struct it names.

This is **not** a missing-emission bug and **not** a field-store bug. The reproducer here is a **read-only** nested access — `dst.(tid) <- src.(tid).mid.b`, no field store anywhere — and it fails identically. Interpreter and Native were never affected: they carry values, not struct declarations.

## Measured, on this host (RX 7900 XTX + Raphael iGPU)

Nested-record case, per device — the CUDA rows are **ZLUDA on AMD**, there is no NVIDIA, Metal or HIP hardware here.

| Device | Framework | Before | After |
|---|---|---|---|
| CPU Interpreter (Sequential) | Interpreter | PASS ×3 | PASS ×3 |
| CPU Interpreter (Parallel, 32 cores) | Interpreter | PASS ×3 | PASS ×3 |
| CPU Native (Parallel, 32 cores) | Native | PASS ×3 | PASS ×3 |
| RX 7900 XTX | CUDA/PTX — **ZLUDA-on-AMD** | PASS ×3 | PASS ×3 |
| Ryzen 9 7950X | CUDA/PTX — **ZLUDA-on-AMD** | PASS ×3 | PASS ×3 |
| RX 7900 XTX (radeonsi, navi31) | OpenCL | **FAIL ×3** | PASS ×3 |
| Ryzen 9 7950X (radeonsi, raphael_mendocino) | OpenCL | **FAIL ×3** | PASS ×3 |
| RX 7900 XTX (RADV NAVI31) | Vulkan | **FAIL ×3** | PASS ×3 |
| Ryzen 9 7950X (RADV RAPHAEL_MENDOCINO) | Vulkan | **FAIL ×3** | PASS ×3 |

`×3` = the three nesting shapes (one-level, three-level chain, two independent nested types). 27 device/case rows, all green after the fix; 12 red before.

Before, OpenCL:

```
input.cl:3:3: error: unknown type name 'Test_record_nested_struct_order_triple'
    3 |   Test_record_nested_struct_order_triple mid;
```

Before, Vulkan (glslang never names the identifier):

```
ERROR: /tmp/sarek_0d77e5.comp:8: '' :  syntax error, unexpected IDENTIFIER, expecting RIGHT_BRACE
```

The CUDA/PTX rows pass in both columns because the direct PTX emitter flattens aggregates and emits no struct declarations. The CUDA **C** path shares `gen_record_typedefs` with OpenCL, so it is fixed by the same change — but it is not exercised on this host, and neither are Metal or HIP. Their coverage here is source-level only (see below).

## The fix

`Sarek_ir_codegen.sort_record_types_by_dependency` places a declaration only after every declaration its field types reference. Dependencies are collected from the whole field type tree — through `TArray`, `TVec`, variant payloads, and the fields of a nested record — by `referenced_record_names`, which is guarded against a cyclic `elttype` *value* rather than assuming a finite tree. Comparison is on mangled names, which is what the emitted identifier actually is.

All three loci now call it. `gen_record_typedefs` calls it internally, so CUDA-C, HIP and Metal are fixed without touching their files.

**Ties break on the incoming list position, never on the name.** The algorithm repeatedly takes the earliest still-unplaced entry whose dependencies are all placed, so two independent records keep their relative input order and an already-correctly-ordered list comes back unchanged. That is what makes this safe for the goldens: `dune runtest --force` regenerated **zero** committed golden files, with and without ZLUDA. `git status --porcelain` was empty after both runs. There was no golden diff to explain.

**A cycle is refused, loudly** — `Record_type_cycle` carrying the unplaced names, rather than a fall-back to input order, since a silently wrong order is the exact defect being removed.

And the honest part about that refusal: **it cannot fire through the PPX.** The PPX resolves a record field's alignment from a registry populated when the field type's *own* declaration was processed, so a cycle is refused there first. Measured, both spellings:

```
type selfy = {v : float32; me : selfy} [@@sarek.type]
  → sarek: unknown alignment for field type 'selfy' - register it with [%ktype] before ...

type a = {to_b : b} [@@sarek.type] and b = {to_a : a} [@@sarek.type]
  → sarek: unknown alignment for field type 'b' - register it with [%ktype] before ...
```

The comment on the function says this rather than claiming a load-bearing guard. The check is kept for the hand-built-IR path (fusion, tests, a future front end), where nothing else would notice, and the unit test is the only place it can be exercised.

A *self*-referencing field is deliberately not reported as a cycle — the self-edge is dropped, so the diagnostic stays about cycles between distinct declarations — and that drop is pinned by a test so it reads as a decision, not an accident.

## Tests

- `sarek/tests/e2e/test_record_nested_struct_order.ml` (new) — the three nesting shapes on **every** available device, with no per-backend tolerance; a device failure exits non-zero.
- `spoc/ir/test/test_sarek_ir_codegen_record_order.ml` (new) — 10 cases pinning what no device here can observe: the C-family emission order (the **only** coverage Metal and HIP get on a host with neither), stability on independent records, no-op on already-sorted input, dependency edges through arrays and variant payloads, the cycle refusal, the self-reference non-refusal, and termination of `referenced_record_names` on a genuinely cyclic value.

## Prove-red

Both polarities, with the mutation asserted to have landed before either was trusted.

**1. Whole fix reverted** (`git checkout 93b865f5 -- <4 files>`; `grep -c sort_record_types_by_dependency` = 0 in all four). E2E exit 1, original errors back: `unknown type name 'Test_record_nested_struct_order_triple'` on OpenCL ×2, `syntax error, unexpected IDENTIFIER` on Vulkan ×2, all three shapes. The unit test cannot even build at this polarity (`Unbound value ... sort_record_types_by_dependency`) — a build-level red, which is weaker than an assertion, hence polarity 2.

**2. Call sites unwired, function kept** (`perl -0pi` on the three loci; asserted 0 remaining call sites *and* the definition still present, `grep -c "^let sort_record_types_by_dependency"` = 1). The unit test now fails on an assertion, not a link error:

```
Fatal error: exception Failure("C-family emission: `triple` used at 17 before its declaration at 91:
typedef struct {
  triple mid;
} outer;

typedef struct {
  float a;
  float b;
  float c;
} triple;
")
```

and the e2e test goes red on 12 of 27 rows with the same device errors. Restored from `HEAD` afterwards; tree clean, both green again.

`git stash` was not used at any point — `git checkout <ref> -- <path>` only.

## Gates

| Gate | Exit |
|---|---|
| `dune build` | 0 |
| `dune runtest --force` (with ZLUDA) | 0 — 5419 lines of output, not a cached no-op |
| `dune runtest --force` (without ZLUDA) | 0 — 5157 lines |
| `dune build @fmt` | 0 (after `dune promote`) |
| `scripts/check-license-headers.sh` | 0 |
| `scripts/check-kb-properties.sh` | 0 |
| `scripts/prove-red.sh` | 0 — 6 subjects, 30 mutations |
| `scripts/check-opam-clean.sh` | 0 |
| `scripts/check-test-alias-coverage.sh` | 0 |
| `scripts/check-dune-dir-visibility.sh` | 0 |
| `test_record_nested_struct_order.exe` with ZLUDA | 0 |
| `test_record_nested_struct_order.exe` without ZLUDA | 0 |
| `test_sarek_ir_codegen_record_order.exe` | 0 |

No `kb/properties.md` or `.github/workflows/ci.yml` change, so no shared-file contention with the sibling branches.

## Two things a reviewer needs to know

**1. The known-gap tolerances are not in this PR, because they are not on `main`.** The task asked for `is_backlog203_struct_gap` to be deleted from `sarek/tests/e2e/test_record_field_store.ml` and for the sibling tolerance in `test_record_local_alias_agreement.ml` to go with it. Neither file exists on `main` — both are introduced by **#376** (`fix/interp-record-field-store`), which is currently `CONFLICTING`/`DIRTY`, and its test files depend on that PR's interpreter/native changes, so they cannot be lifted onto `main` on their own. Basing this fix on #376 would have stacked a `main`-facing codegen fix behind an unmergeable branch, so it is based on `main` as instructed and the deletion is left as a required follow-up: **#376 must drop `is_backlog203_struct_gap` (4 references) and the backlog-203 tolerance in `test_record_local_alias_agreement.ml` before it lands**, or it merges a tolerance for a gap that no longer exists. Flagged on that PR.

**2. An adjacent ordering gap this PR deliberately does not touch — and it has TWO halves, not one.** GLSL and WGSL emit records *before* variants; OpenCL/CUDA/Metal emit variants *before* records. Records and variants are each sorted within their own loop, so neither ordering fixes an edge that crosses between them, and the asymmetry means **each family is red on exactly the shape the other family is green on**:

- a record with a **variant**-typed field is emitted ahead of its variant struct on **GLSL/WGSL**;
- a variant with a **record** payload is emitted ahead of that record across the whole **C family**.

An earlier revision of this section named only the first half and asserted the C family was clear. That was a claim wider than the code. The review pass measured both halves from ordinary `[@@sarek.type]` source: the C-family half is **T3-reachable**, `error: unknown type name 'Probe_pt'` on both OpenCL devices while Vulkan compiles the same kernel, and the GLSL/WGSL half is red on both Vulkan devices while both OpenCL devices pass. Either half read on its own reproduces as "ordering is fixed", which is how it stayed invisible.

Neither half is fixed here — the fix is an interleaved emission loop per backend family, which is a different change from this one. Both are now documented with their measured errors at `gen_record_typedefs`, in the `.mli`, and in `CHANGES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

