### PR TITLE
fix(interp,native,ppx,ptx): a shared array of a record aliased every slot on one backend, refused on another, and did not compile on two more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -132,8 +132,9 @@
   `assignment target of .a (got unit)`; Native accepted the store and wrote
   EVERY slot (`7 7 7 7`, want `7 0 0 0`); CUDA/PTX ×2 raised
   `unsupported construct: btype of custom type`, naming neither the array nor
-  the type; and OpenCL ×2 and Vulkan ×2 failed inside the DEVICE compiler with
-  `unknown type name`. Three separate causes. (1) Native's
+  the type; and OpenCL ×2 and Vulkan ×2 failed inside the DEVICE compiler,
+  OpenCL with `unknown type name 'Test_..._tri'` and Vulkan with a glslang
+  syntax error at the shared declaration. Three separate causes. (1) Native's
   `alloc_shared_with_key` filled the array with `Array.make size default`, so
   every slot of a boxed element type was the same allocation — it now takes a
   per-slot thunk and calls `Array.init`, and the identical `Array.make` in the
@@ -141,8 +142,14 @@
   record element type to `VUnit`, so there was nothing to store into — it now
   builds a zeroed `VRecord` — or, for a variant with at least one
   constructor, a constructor-0 `VVariant` — per slot in
-  `Sarek_ir_interp_value.alloc_kernel_array`, which replaces four copies of the
-  old init table. (3) OpenCL and Vulkan had no shared-memory gap at all:
+  `Sarek_ir_interp_value.alloc_kernel_array`. That replaces three identical
+  copies of the old init table in `Sarek_ir_interp_eval` plus a fourth, NARROWER
+  one on `Sarek_ir_interp`'s `DShared` kernel-parameter path, which mapped only
+  `TInt32` and `TFloat32` and everything else to `VUnit`. Unifying them
+  therefore also widens that path: `TInt64`, `TFloat64`, `TBool`, `TFloat16` and
+  `TUint8` go from `VUnit` to their typed zeros there. That is a fix, but it is
+  a behaviour change outside backlog-206's shape and it is stated rather than
+  folded into the word "copies". (3) OpenCL and Vulkan had no shared-memory gap at all:
   `register_types_from_typ` ran over PARAMETER types only, so a record named
   nowhere but the shared declaration was never emitted as a `struct`; it is now
   top-level and runs at both kernel-array declaration sites. The tell was that

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,36 @@
 
 ### Fixed
 
+- A shared-memory array of a record type behaved four different ways across
+  nine devices, none of them right. `let%shared (s : tri) = 4l` followed by
+  `s.(i).a <- e`, measured on this host: the Interpreter ×2 raised
+  `assignment target of .a (got unit)`; Native accepted the store and wrote
+  EVERY slot (`7 7 7 7`, want `7 0 0 0`); CUDA/PTX ×2 raised
+  `unsupported construct: btype of custom type`, naming neither the array nor
+  the type; and OpenCL ×2 and Vulkan ×2 failed inside the DEVICE compiler with
+  `unknown type name`. Three separate causes. (1) Native's
+  `alloc_shared_with_key` filled the array with `Array.make size default`, so
+  every slot of a boxed element type was the same allocation — it now takes a
+  per-slot thunk and calls `Array.init`, and the identical `Array.make` in the
+  `create_array n Local` path is fixed with it. (2) The interpreter mapped a
+  record element type to `VUnit`, so there was nothing to store into — it now
+  builds a zeroed `VRecord` (or a constructor-0 `VVariant`) per slot in
+  `Sarek_ir_interp_value.alloc_kernel_array`, which replaces four copies of the
+  old init table. (3) OpenCL and Vulkan had no shared-memory gap at all:
+  `register_types_from_typ` ran over PARAMETER types only, so a record named
+  nowhere but the shared declaration was never emitted as a `struct`; it is now
+  top-level and runs at both kernel-array declaration sites. The tell was that
+  the same kernel written with a whole-slot store (`s.(tid) <- {...}`) compiled
+  and ran correctly on all seven non-PTX devices throughout, because the record
+  literal registered the type — so a whole-slot-store test would have been green
+  the whole time, and `test_shared_record_slots.ml` exercises both shapes.
+  CUDA/PTX still refuses, and the test asserts the refusal rather than
+  tolerating it: PTX has no struct type and
+  `Sarek_ir_ptx_mem.emit_agg_elem_addr` refuses state-space aggregates on
+  purpose. What changed there is that the message names the array, the element
+  type and the state space. Metal, HIP and WGSL were not measured — no such
+  device on this machine — and nothing is claimed about them.
+
 - A `[@@sarek.type]` record with a record-typed field had its inner struct
   emitted AFTER the struct that referenced it, so no kernel touching a nested
   record compiled on any shader backend. Both declaration-emission loops walked

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,7 +139,8 @@
   per-slot thunk and calls `Array.init`, and the identical `Array.make` in the
   `create_array n Local` path is fixed with it. (2) The interpreter mapped a
   record element type to `VUnit`, so there was nothing to store into — it now
-  builds a zeroed `VRecord` (or a constructor-0 `VVariant`) per slot in
+  builds a zeroed `VRecord` — or, for a variant with at least one
+  constructor, a constructor-0 `VVariant` — per slot in
   `Sarek_ir_interp_value.alloc_kernel_array`, which replaces four copies of the
   old init table. (3) OpenCL and Vulkan had no shared-memory gap at all:
   `register_types_from_typ` ran over PARAMETER types only, so a record named

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,9 +140,16 @@
   per-slot thunk and calls `Array.init`, and the identical `Array.make` in the
   `create_array n Local` path is fixed with it. (2) The interpreter mapped a
   record element type to `VUnit`, so there was nothing to store into — it now
-  builds a zeroed `VRecord` — or, for a variant with at least one
-  constructor, a constructor-0 `VVariant` — per slot in
-  `Sarek_ir_interp_value.alloc_kernel_array`. That replaces three identical
+  builds a zeroed `VRecord` — or, for a variant, a `VVariant` carrying the
+  first NULLARY constructor (the first constructor with zeroed payloads if
+  there is no nullary one), which is the same constructor Native's
+  `default_value_for_type` puts in that slot — per slot in
+  `Sarek_ir_interp_value.alloc_kernel_array`. The tag is
+  `Hashtbl.hash ctor mod 256`, the encoding `EVariant` and the two matchers
+  already use and which is now the single `variant_tag_of_ctor`; a positional
+  index there produced a `VVariant` no arm could match, so reading a default
+  variant slot raised `Pattern match failure in SMatch` on the Interpreter
+  while Native answered the nullary constructor. That replaces three identical
   copies of the old init table in `Sarek_ir_interp_eval` plus a fourth, NARROWER
   one on `Sarek_ir_interp`'s `DShared` kernel-parameter path, which mapped only
   `TInt32` and `TFloat32` and everything else to `VUnit`. Unifying them

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,9 +141,10 @@
   `create_array n Local` path is fixed with it. (2) The interpreter mapped a
   record element type to `VUnit`, so there was nothing to store into — it now
   builds a zeroed `VRecord` — or, for a variant, a `VVariant` carrying the
-  first NULLARY constructor (the first constructor with zeroed payloads if
-  there is no nullary one), which is the same constructor Native's
-  `default_value_for_type` puts in that slot — per slot in
+  first NULLARY constructor, the same one Native's `default_value_for_type`
+  picks, falling back to the first constructor with zeroed payloads where
+  there is no nullary one (a case in which Native has no default at all and
+  raises, so the interpreter is more defined there rather than agreeing) — per slot in
   `Sarek_ir_interp_value.alloc_kernel_array`. The tag is
   `Hashtbl.hash ctor mod 256`, the encoding `EVariant` and the two matchers
   already use and which is now the single `variant_tag_of_ctor`; a positional

--- a/kb/research/obj-usage/README.md
+++ b/kb/research/obj-usage/README.md
@@ -34,7 +34,7 @@ No active `Obj.field`, `Obj.set_field`, `Obj.tag`, `Obj.size`, or related low-le
 - `sarek/plugins/interpreter/Interpreter_plugin.ml:93`: `Obj.magic` from `EXEC_VECTOR` to `Kernel_arg.Vec`.
 - `sarek/plugins/native/Native_plugin.ml:264-269`: `Obj.obj`, `Obj.repr`, and `Obj.obj` for custom vector access.
 - `sarek/sarek/Kirc_kernel.ml:251-256`: same custom vector access bridge.
-- `sarek/sarek/Sarek_cpu_runtime_types.ml:126` (`alloc_shared_with_key`): former `Obj.obj (Obj.repr arr)` in generic shared-memory custom arrays — now typed via `Type_id.Refl` (resolved; module split out of `Sarek_cpu_runtime.ml`).
+- `sarek/sarek/Sarek_cpu_runtime_types.ml:151` (`alloc_shared_with_key`): former `Obj.obj (Obj.repr arr)` in generic shared-memory custom arrays — now typed via `Type_id.Refl` (resolved; module split out of `Sarek_cpu_runtime.ml`).
 - `sarek/sarek/Sarek_type_helpers.ml:65-66`: `Obj.obj (Obj.repr ...)` in untyped helper dispatch.
 - `sarek/sarek/Sarek_ir_interp.ml:239` (`vector_to_array`), `274` (`array_to_vector`): former fallback vector element casts — no `Obj` present now (interpreter module split; bridge stayed in main).
 - `sarek/plugins/native/Native_plugin.ml:384-385`: legacy `Obj.t array` direct execution type.

--- a/kb/research/obj-usage/shared-memory-type-ids.md
+++ b/kb/research/obj-usage/shared-memory-type-ids.md
@@ -9,9 +9,9 @@ repointed to current locations and retained for history.
 
 ## Obj Sites (former)
 
-- `sarek/sarek/Sarek_cpu_runtime_types.ml:126` (`alloc_shared_with_key`): the former
+- `sarek/sarek/Sarek_cpu_runtime_types.ml:151` (`alloc_shared_with_key`): the former
   `Obj.obj (Obj.repr arr)` cast is gone — now a typed `Type_id.equal`/`Refl` match.
-- `sarek/sarek/Sarek_cpu_runtime.mli:84`: now documents typed custom allocation (no
+- `sarek/sarek/Sarek_cpu_runtime.mli:101`: now documents typed custom allocation (no
   `Obj.t`).
 
 ## Assumed Invariant

--- a/sarek/codegen/Sarek_ir_ptx_stmt.ml
+++ b/sarek/codegen/Sarek_ir_ptx_stmt.ml
@@ -42,12 +42,10 @@ let refuse_aggregate_state_space_array ~what ~(name : string) (elt : elttype) :
             PTX has no struct type and this backend addresses aggregates only \
             in global vectors, so an aggregate %s array cannot be declared. \
             Pass the data as a vector parameter, or declare one scalar %s \
-            array per field. (The same kernel runs on the Interpreter, Native, \
-            OpenCL and Vulkan backends, which do have an aggregate %s array.)"
+            array per field."
            what
            name
            tyname
-           what
            what
            what)
   | TInt32 | TInt64 | TFloat16 | TFloat32 | TFloat64 | TUint8 | TBool | TUnit

--- a/sarek/codegen/Sarek_ir_ptx_stmt.ml
+++ b/sarek/codegen/Sarek_ir_ptx_stmt.ml
@@ -13,6 +13,47 @@ open Sarek_ir_ptx_types
 open Sarek_ir_ptx_mem
 open Sarek_ir_ptx_expr
 
+(** Refuse a [.shared]/[.local] array whose element type is a record or a
+    variant, BY NAME (backlog-206).
+
+    The refusal itself is not new and is not being lifted here: PTX has no
+    struct type, so an aggregate element would need byte-offset addressing in
+    the state space, which {!Sarek_ir_ptx_mem.emit_agg_elem_addr} refuses on
+    purpose ("aggregate elements are supported in global vectors only"). What
+    was wrong is what the user saw. The declaration path reached
+    [ptx_btype_of_elttype], whose refusal read "PTX codegen: unsupported
+    construct: btype of custom type" — no array, no type, no mention of shared
+    memory, and identical for the two unrelated call sites that reach it.
+    Measured verbatim on two ZLUDA devices for [let%shared (s : tri) = 4l].
+    Since the same program COMPILES AND RUNS on the Interpreter, Native, OpenCL
+    and Vulkan after this branch's fixes, "PTX cannot do this one" is the single
+    thing the message has to convey, and it did not.
+
+    [what] is the state-space word used in the message ("shared" / "local") and
+    must match the declaration being emitted; it is passed rather than derived
+    so the two call sites below cannot both say "shared". *)
+let refuse_aggregate_state_space_array ~what ~(name : string) (elt : elttype) :
+    unit =
+  match elt with
+  | TRecord (tyname, _) | TVariant (tyname, _) ->
+      unsupported
+        (Printf.sprintf
+           "%s-memory array '%s' has element type '%s', a record or variant. \
+            PTX has no struct type and this backend addresses aggregates only \
+            in global vectors, so an aggregate %s array cannot be declared. \
+            Pass the data as a vector parameter, or declare one scalar %s \
+            array per field. (The same kernel runs on the Interpreter, Native, \
+            OpenCL and Vulkan backends, which do have an aggregate %s array.)"
+           what
+           name
+           tyname
+           what
+           what
+           what)
+  | TInt32 | TInt64 | TFloat16 | TFloat32 | TFloat64 | TUint8 | TBool | TUnit
+  | TArray _ | TVec _ ->
+      ()
+
 (** {1 Statement emitter} *)
 
 let rec emit_stmt buf alloc (env : env) (stmt : stmt) : unit =
@@ -22,6 +63,7 @@ let rec emit_stmt buf alloc (env : env) (stmt : stmt) : unit =
   | SLet (v, EArrayCreate (elt, size_e, Shared), body) ->
       (* let%shared lowers to this shape (the PPX never emits DShared decls).
          Declare the array in .shared space and bind its base address. *)
+      refuse_aggregate_state_space_array ~what:"shared" ~name:v.var_name elt ;
       let n =
         match size_e with
         | EConst (CInt32 n) when Int32.compare n 0l > 0 -> Int32.to_int n
@@ -62,6 +104,7 @@ let rec emit_stmt buf alloc (env : env) (stmt : stmt) : unit =
          Small constant-indexed arrays would be faster fully promoted to
          registers; that optimization pass is future work — this is the
          baseline. *)
+      refuse_aggregate_state_space_array ~what:"local" ~name:v.var_name elt ;
       let n =
         match size_e with
         | EConst (CInt32 n) when Int32.compare n 0l > 0 -> Int32.to_int n

--- a/sarek/interp/Sarek_ir_interp.ml
+++ b/sarek/interp/Sarek_ir_interp.ml
@@ -275,13 +275,10 @@ let run_kernel (k : kernel) ~block:(bx, by, bz) ~grid:(gx, gy, gz)
             }
           in
           let size = to_int (eval_expr dummy_state env size_expr) in
-          let init =
-            match ty with
-            | TInt32 -> VInt32 0l
-            | TFloat32 -> VFloat32 0.0
-            | _ -> VUnit
-          in
-          Hashtbl.add env.shared name (Array.make size init)
+          Hashtbl.add
+            env.shared
+            name
+            (Sarek_ir_interp_value.alloc_kernel_array ty size)
       | _ -> ())
     k.kern_params
     args ;

--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -173,7 +173,7 @@ and eval_composite_expr state env = function
         )
   | EVariant (ty, ctor, args) ->
       VVariant
-        (ty, Hashtbl.hash ctor mod 256, List.map (eval_expr state env) args)
+        (ty, variant_tag_of_ctor ctor, List.map (eval_expr state env) args)
   | _ ->
       Interp_error.raise_error
         (Pattern_match_failure
@@ -197,7 +197,7 @@ and eval_control_flow state env = function
             Interp_error.raise_error
               (Pattern_match_failure {context = "EMatch"})
         | (PConstr (name, vars), body) :: rest ->
-            if Hashtbl.hash name mod 256 = tag then begin
+            if variant_tag_of_ctor name = tag then begin
               (* Bind the constructor's payload variables positionally, exactly
                  as SMatch does, so an expression-position match on a variant
                  (e.g. [let s = match c.kind with Shade f -> f]) can use the
@@ -383,7 +383,7 @@ and exec_stmt state env stmt =
             Interp_error.raise_error
               (Pattern_match_failure {context = "SMatch"})
         | (PConstr (name, vars), body) :: rest ->
-            if Hashtbl.hash name mod 256 = tag then begin
+            if variant_tag_of_ctor name = tag then begin
               (* Bind pattern variables by name *)
               (match v with
               | VVariant (_, _, args) ->

--- a/sarek/interp/Sarek_ir_interp_eval.ml
+++ b/sarek/interp/Sarek_ir_interp_eval.ml
@@ -98,16 +98,7 @@ and eval_array_expr state env = function
       VInt32 (Int32.of_int (Array.length a))
   | EArrayCreate (ty, size_expr, _memspace) ->
       let size = to_int (eval_expr state env size_expr) in
-      let init =
-        match ty with
-        | TInt32 -> VInt32 0l
-        | TInt64 -> VInt64 0L
-        | TFloat32 -> VFloat32 0.0
-        | TFloat64 -> VFloat64 0.0
-        | TBool -> VBool false
-        | _ -> VUnit
-      in
-      VArray (Array.make size init)
+      VArray (alloc_kernel_array ty size)
   | _ ->
       Interp_error.raise_error
         (Pattern_match_failure
@@ -424,16 +415,7 @@ and exec_stmt state env stmt =
           | Some arr -> bind_var env v (VArray arr)
           | None ->
               let size = to_int (eval_expr state env size_expr) in
-              let init =
-                match ty with
-                | TInt32 -> VInt32 0l
-                | TInt64 -> VInt64 0L
-                | TFloat32 -> VFloat32 0.0
-                | TFloat64 -> VFloat64 0.0
-                | TBool -> VBool false
-                | _ -> VUnit
-              in
-              let arr = Array.make size init in
+              let arr = alloc_kernel_array ty size in
               Hashtbl.add env.shared name arr ;
               bind_var env v (VArray arr)) ;
           exec_stmt state env body
@@ -841,16 +823,7 @@ and exec_stmt_for_return state env stmt =
           | Some arr -> bind_var env v (VArray arr)
           | None ->
               let size = to_int (eval_expr state env size_expr) in
-              let init =
-                match ty with
-                | TInt32 -> VInt32 0l
-                | TInt64 -> VInt64 0L
-                | TFloat32 -> VFloat32 0.0
-                | TFloat64 -> VFloat64 0.0
-                | TBool -> VBool false
-                | _ -> VUnit
-              in
-              let arr = Array.make size init in
+              let arr = alloc_kernel_array ty size in
               Hashtbl.add env.shared name arr ;
               bind_var env v (VArray arr)) ;
           exec_stmt_for_return state env body

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -356,6 +356,16 @@ let detach_record (v : value) : value =
     what the device does. It is not a promise that reading an unwritten slot is
     defined.
 
+    [TUint8] gets [VInt32 0l], and that is a GUESS rather than a convention:
+    [TUint8] appears nowhere else in this interpreter, so unlike [TFloat16] —
+    whose [VFloat32] carrier is established by [Sarek_ir_interp_eval] and
+    [Sarek_ir_interp] — nothing here fixes its representation. It exists only as
+    a cooperative-matrix operand element type, which does not reach a kernel
+    array declaration, so the arm is unreachable in practice; it is written this
+    way so that the match is exhaustive rather than because a zero of that type
+    has been agreed. If [TUint8] ever becomes a real element type, decide its
+    carrier before trusting this.
+
     [TArray] and [TVec] elements stay [VUnit]: an array of arrays is not
     expressible as a kernel array element type on any backend, and inventing a
     nested [VArray] of an unknown length here would be a guess.

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -332,6 +332,65 @@ let detach_record (v : value) : value =
   in
   go 0 v
 
+(** {1 Array allocation — backlog-206}
+
+    Zero value of an element type, used to fill a freshly declared kernel array
+    ([EArrayCreate] / [DShared]).
+
+    Records and variants used to fall through to [VUnit] here, which is why
+    [let%shared (s : tri) = 4l] followed by [s.(i).a <- e] raised "assignment
+    target of .a (got unit)" on the Interpreter while Native accepted the same
+    store — the divergence backlog-206 is about. A record element type now gets
+    a [VRecord] whose fields are themselves zeroed, and a variant gets its FIRST
+    constructor with zeroed payloads.
+
+    Choosing constructor 0 is a choice, not a neutral default: an uninitialised
+    slot of a variant array reads back as that constructor rather than as
+    "nothing". No device backend offers anything better — [__local]/[shared]
+    memory is uninitialised storage on all of them, so ANY value read before a
+    write is arbitrary — and constructor 0 is what the tag byte of zeroed
+    storage decodes to, so it is the closest the interpreter can get to what the
+    device does. It is not a promise that reading an unwritten slot is defined.
+
+    [TArray] and [TVec] elements stay [VUnit]: an array of arrays is not
+    expressible as a kernel array element type on any backend, and inventing a
+    nested [VArray] of an unknown length here would be a guess.
+
+    Plain recursion, no depth guard, unlike {!detach_record}. The argument is
+    different in kind: this walks an [elttype], a finite tree the PPX builds
+    bottom-up, where {!detach_record} walks a [value], which the interpreter's
+    in-place field store can shape at run time. *)
+let rec default_value_of_elttype (ty : elttype) : value =
+  match ty with
+  | TInt32 -> VInt32 0l
+  | TInt64 -> VInt64 0L
+  | TFloat16 | TFloat32 -> VFloat32 0.0
+  | TFloat64 -> VFloat64 0.0
+  | TUint8 -> VInt32 0l
+  | TBool -> VBool false
+  | TUnit -> VUnit
+  | TRecord (name, fields) ->
+      VRecord
+        ( name,
+          Array.of_list
+            (List.map (fun (_, fty) -> default_value_of_elttype fty) fields) )
+  | TVariant (name, constrs) -> (
+      match constrs with
+      | (_, payload) :: _ ->
+          VVariant (name, 0, List.map default_value_of_elttype payload)
+      | [] -> VUnit)
+  | TArray _ | TVec _ -> VUnit
+
+(** Allocate a kernel array of [size] elements of type [ty].
+
+    [Array.init], never [Array.make]: for a boxed element type (a record, or a
+    variant with a payload) [Array.make] stores ONE value in every slot, so
+    [s.(0).f <- e] is visible through every index. That is exactly the Native
+    half of backlog-206, whose CPU-runtime allocator had the same
+    [Array.make size default] shape. Slots must be independent allocations. *)
+let alloc_kernel_array (ty : elttype) (size : int) : value array =
+  Array.init size (fun _ -> default_value_of_elttype ty)
+
 (** Bind a variable in the environment (both by id and name).
 
     Records are detached on the way in (see {!detach_record}): binding is what

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -334,11 +334,20 @@ let detach_record (v : value) : value =
 
 (** The interpreter's variant tag for a constructor NAME.
 
-    THE definition, and the only one: {!Sarek_ir_interp_eval}'s [EVariant] arm
-    and both of its matchers ([EMatch], [SMatch]) call this rather than
-    repeating [Hashtbl.hash _ mod 256], so a value built here and an arm
-    selected there cannot drift apart. They were three separate copies of the
-    expression, which is how a fourth copy — a literal [0] — went unnoticed.
+    The definition for everything INSIDE the interpreter, and the whole of it:
+    {!Sarek_ir_interp_eval}'s [EVariant] arm and both of its matchers ([EMatch],
+    [SMatch]) call this rather than repeating [Hashtbl.hash _ mod 256], so a
+    value built here and an arm selected there cannot drift apart. They were
+    three separate copies of the expression, which is how a fourth copy — a
+    literal [0] — went unnoticed.
+
+    ONE copy is left outside: [Sarek_ppx]'s [Ptype_variant] helper emits
+    [Hashtbl.hash "C" mod 256] as a RUNTIME expression into generated user code,
+    so a [@@sarek.type] variant round-trips to the same tag. It could be routed
+    here — the generated code already reaches [Sarek.Sarek_value] by a
+    forwarding alias — and is not, so it is a duplication rather than a
+    boundary. If the encoding here changes, that emitter is the second place to
+    change, and it says so at its own site.
 
     [mod 256] means the encoding is NOT injective: two constructors of the same
     type whose names collide modulo 256 select each other's arms. That is a
@@ -377,12 +386,24 @@ let variant_tag_of_ctor (ctor : string) : int = Hashtbl.hash ctor mod 256
     slot decodes to the constructor this function chose.
 
     The constructor is the first NULLARY one if there is one, else the first
-    constructor with zeroed payloads. That is not an aesthetic preference: it is
-    what the Native backend's {!Sarek_native_gen_expr} default does
-    ([Sarek_native_helpers.default_value_for_type] searches for a nullary
-    constructor first), and a CPU-backend disagreement about the contents of a
-    freshly declared shared array is the exact shape of divergence backlog-206
-    was filed as. The two CPU backends now agree.
+    constructor with zeroed payloads. The nullary preference is not an aesthetic
+    choice: it is what [Sarek_native_helpers.default_value_for_type] does
+    ([List.find_opt] over the constructors for one with no argument), so for a
+    variant that HAS a nullary constructor the two CPU backends put the same
+    constructor in the slot — and a CPU-backend disagreement about the contents
+    of a freshly declared shared array is the exact shape of divergence
+    backlog-206 was filed as. Measured for [type c2 = A of float32 | B]:
+    Interpreter x2 and Native all answer [B].
+
+    The FALLBACK is where they stop agreeing, and it is one-sided rather than
+    divergent. With no nullary constructor Native takes the first one and
+    recurses on its argument type, which has no arm for a TUPLE argument — so
+    [C of float32 * float32] as the only shape reaches
+    [failwith "Cannot create default value for this type"] and the kernel does
+    not initialise at all on Native, where this function zeroes each payload
+    component and carries on. The interpreter is strictly more defined there;
+    that is not two answers to one question, and it is NOT asserted as
+    agreement. Nothing here changes the Native side.
 
     None of this is a promise that reading an unwritten slot is DEFINED.
     [__local]/[shared] memory is uninitialised storage on every device, so any

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -332,6 +332,21 @@ let detach_record (v : value) : value =
   in
   go 0 v
 
+(** The interpreter's variant tag for a constructor NAME.
+
+    THE definition, and the only one: {!Sarek_ir_interp_eval}'s [EVariant] arm
+    and both of its matchers ([EMatch], [SMatch]) call this rather than
+    repeating [Hashtbl.hash _ mod 256], so a value built here and an arm
+    selected there cannot drift apart. They were three separate copies of the
+    expression, which is how a fourth copy — a literal [0] — went unnoticed.
+
+    [mod 256] means the encoding is NOT injective: two constructors of the same
+    type whose names collide modulo 256 select each other's arms. That is a
+    pre-existing property of the interpreter's variant representation, not
+    something introduced here, and it is left alone; naming the function at
+    least gives it one place to be fixed. *)
+let variant_tag_of_ctor (ctor : string) : int = Hashtbl.hash ctor mod 256
+
 (** {1 Array allocation — backlog-206}
 
     Zero value of an element type, used to fill a freshly declared kernel array
@@ -342,19 +357,38 @@ let detach_record (v : value) : value =
     target of .a (got unit)" on the Interpreter while Native accepted the same
     store — the divergence backlog-206 is about. A record element type now gets
     a [VRecord] whose fields are themselves zeroed, and a variant with at least
-    one constructor gets its FIRST constructor with zeroed payloads. A
-    [TVariant] carrying an EMPTY constructor list still gives [VUnit]: there is
-    no first constructor to pick, the PPX produces no such type, and inventing a
-    tag for it would be worse than the [VUnit].
+    one constructor gets a real constructor with zeroed payloads. A [TVariant]
+    carrying an EMPTY constructor list still gives [VUnit]: there is no
+    constructor to pick, the PPX produces no such type, and inventing a tag for
+    it would be worse than the [VUnit].
 
-    Choosing constructor 0 is a choice, not a neutral default: an uninitialised
-    slot of a variant array reads back as that constructor rather than as
-    "nothing". No device backend offers anything better — [__local]/[shared]
-    memory is uninitialised storage on all of them, so ANY value read before a
-    write is arbitrary — and constructor 0 is what the zeroed tag field of
-    zeroed storage decodes to, so it is the closest the interpreter can get to
-    what the device does. It is not a promise that reading an unwritten slot is
-    defined.
+    WHICH constructor, and WHAT TAG, are both load-bearing, and the first
+    version of this got the tag wrong.
+
+    The tag is {b not} a positional index in this interpreter. [EVariant]
+    encodes [Hashtbl.hash ctor_name mod 256] ({!Sarek_ir_interp_eval}), and
+    [EMatch]/[SMatch] select an arm with exactly that predicate. A literal [0]
+    therefore matches the first constructor only if its name happens to hash to
+    zero — so a default slot matched NO arm and the interpreter raised "Pattern
+    match failure in SMatch". Measured on a registered
+    [type c2 = A of float32 | B] whose unwritten shared slot was read:
+    Interpreter x2 RAISED where Native answered [B]. The tag now goes through
+    {!variant_tag_of_ctor}, the same encoding the evaluator uses, so a default
+    slot decodes to the constructor this function chose.
+
+    The constructor is the first NULLARY one if there is one, else the first
+    constructor with zeroed payloads. That is not an aesthetic preference: it is
+    what the Native backend's {!Sarek_native_gen_expr} default does
+    ([Sarek_native_helpers.default_value_for_type] searches for a nullary
+    constructor first), and a CPU-backend disagreement about the contents of a
+    freshly declared shared array is the exact shape of divergence backlog-206
+    was filed as. The two CPU backends now agree.
+
+    None of this is a promise that reading an unwritten slot is DEFINED.
+    [__local]/[shared] memory is uninitialised storage on every device, so any
+    value read before a write is arbitrary there; what these two paragraphs buy
+    is that the two backends which do have to put something in the slot put the
+    same thing, and that the something is a value the interpreter can match.
 
     [TUint8] gets [VInt32 0l], and that is a GUESS rather than a convention:
     [TUint8] appears nowhere else in this interpreter, so unlike [TFloat16] —
@@ -389,10 +423,15 @@ let rec default_value_of_elttype (ty : elttype) : value =
           Array.of_list
             (List.map (fun (_, fty) -> default_value_of_elttype fty) fields) )
   | TVariant (name, constrs) -> (
-      match constrs with
-      | (_, payload) :: _ ->
-          VVariant (name, 0, List.map default_value_of_elttype payload)
-      | [] -> VUnit)
+      let nullary = List.find_opt (fun (_, payload) -> payload = []) constrs in
+      match (nullary, constrs) with
+      | Some (ctor, _), _ -> VVariant (name, variant_tag_of_ctor ctor, [])
+      | None, (ctor, payload) :: _ ->
+          VVariant
+            ( name,
+              variant_tag_of_ctor ctor,
+              List.map default_value_of_elttype payload )
+      | None, [] -> VUnit)
   | TArray _ | TVec _ -> VUnit
 
 (** Allocate a kernel array of [size] elements of type [ty].

--- a/sarek/interp/Sarek_ir_interp_value.ml
+++ b/sarek/interp/Sarek_ir_interp_value.ml
@@ -341,16 +341,20 @@ let detach_record (v : value) : value =
     [let%shared (s : tri) = 4l] followed by [s.(i).a <- e] raised "assignment
     target of .a (got unit)" on the Interpreter while Native accepted the same
     store — the divergence backlog-206 is about. A record element type now gets
-    a [VRecord] whose fields are themselves zeroed, and a variant gets its FIRST
-    constructor with zeroed payloads.
+    a [VRecord] whose fields are themselves zeroed, and a variant with at least
+    one constructor gets its FIRST constructor with zeroed payloads. A
+    [TVariant] carrying an EMPTY constructor list still gives [VUnit]: there is
+    no first constructor to pick, the PPX produces no such type, and inventing a
+    tag for it would be worse than the [VUnit].
 
     Choosing constructor 0 is a choice, not a neutral default: an uninitialised
     slot of a variant array reads back as that constructor rather than as
     "nothing". No device backend offers anything better — [__local]/[shared]
     memory is uninitialised storage on all of them, so ANY value read before a
-    write is arbitrary — and constructor 0 is what the tag byte of zeroed
-    storage decodes to, so it is the closest the interpreter can get to what the
-    device does. It is not a promise that reading an unwritten slot is defined.
+    write is arbitrary — and constructor 0 is what the zeroed tag field of
+    zeroed storage decodes to, so it is the closest the interpreter can get to
+    what the device does. It is not a promise that reading an unwritten slot is
+    defined.
 
     [TArray] and [TVec] elements stay [VUnit]: an array of arrays is not
     expressible as a kernel array element type on any backend, and inventing a

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -580,12 +580,40 @@ let register_tuple_type (state : state) (ty : typ) : unit =
     over a variant-element vector parameter, contains no [TEConstr], and the
     [TVec] arm below bottoms out at [| _ -> ()] for [TVariant] — so on the
     struct-emitting backends that is the same undeclared-type-name failure this
-    function fixes for records, still open for variants. It is NOT fixed here
-    because adding a [TVariant] arm changes what gets emitted for ordinary
-    variant PARAMETERS too, and this change has no measurement for that; the
-    shape above was reasoned about, not executed. The interpreter and PTX halves
-    of backlog-206 DO handle [TVariant], so the treatment is deliberately uneven
-    and this is where it is uneven. *)
+    function fixes for records, still open for variants.
+
+    Now MEASURED rather than reasoned, and the measurement moves the seam. The
+    shared array is not what makes that shape fail. A kernel whose ONLY variant
+    occurrence is a [color vector] PARAMETER, with no shared array anywhere and
+    no [TEConstr] —
+
+    {[
+      fun (v : color vector) (out : float32 vector) ->
+        match v.(tid) with Red -> out.(tid) <- 0.0 | Value x -> out.(tid) <- x
+    ]}
+
+    — already fails today, identically: [kern_types = []], OpenCL ×2 "unknown
+    type name 'M_color'" on the PARAMETER declaration, Vulkan ×2 a glslang
+    syntax error. So the gap is variant registration in general, not a
+    shared-memory seam; the shared-array shape above is one instance of it, and
+    it is one this function's records fix does not reach.
+
+    It is still NOT fixed here, but not for the reason first written. "Adding a
+    [TVariant] arm would change what gets emitted for ordinary variant
+    parameters, unmeasured" is wrong where it matters: for a parameter-only
+    variant there is nothing working to regress — that kernel does not compile.
+    The real obstacle is that this function writes [state.types], the RECORD
+    table, and a variant belongs in [state.variants]; a [TVariant] arm here
+    would declare a variant as a record struct. And registration alone is not
+    even sufficient: with the type unregistered the emitter also drops the
+    match-arm payload binder and emits [out[tid] = x;] with no [x] declared
+    (measured on the same kernel — the binder comes from [kern_variants], which
+    [TEConstr] fills and this traversal does not touch). Fixing variants means
+    routing to [state.variants], which is a change with its own evidence to
+    gather, not a one-line arm here.
+
+    The interpreter and PTX halves of backlog-206 DO handle [TVariant], so the
+    treatment is deliberately uneven and this is where it is uneven. *)
 let rec register_types_from_typ (state : state) (ty : typ) : unit =
   match repr ty with
   | TRecord (name, fields) ->

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -544,6 +544,56 @@ let register_tuple_type (state : state) (ty : typ) : unit =
         Hashtbl.add state.types name fields
   | _ -> ()
 
+(** Register every record type reachable from [ty] in the codegen types table,
+    so the struct-emitting backends write out its [struct] definition.
+
+    Hoisted out of {!lower_kernel}, which applied it to PARAMETER types only.
+    That was the whole reason a shared array of a record failed to COMPILE on
+    OpenCL and Vulkan (backlog-206): in
+
+    {[
+      let%shared (s : tri) = 4l in
+      if tid = 0l then s.(tid).a <- 7.0
+    ]}
+
+    [tri] appears nowhere but the shared declaration — no parameter carries it,
+    and there is no record literal to route through [TERecord]'s registration —
+    so nothing put it in [state.types] and the emitted kernel said
+    [__local Test_tri s[4];] with no [Test_tri] anywhere above it. Measured:
+    OpenCL "error: unknown type name 'Test_shared_record_slots_tri'", Vulkan a
+    glslang syntax error at the declaration. The SAME kernel with a whole-slot
+    store ([s.(tid) <- {a = ...}]) compiled and ran, because the literal
+    registered the type — which is what made this look like a shared-memory gap
+    rather than the type-collection gap it is.
+
+    VARIANTS are deliberately NOT handled here. A shared array of a variant is
+    only useful if some constructor application appears in the kernel, and
+    [TEConstr] registers the type; a read-only variant array over never-written
+    shared memory has no defined contents on any backend. Adding a [TVariant]
+    arm would also change what gets emitted for ordinary variant PARAMETERS,
+    which this change has no measurement for. *)
+let rec register_types_from_typ (state : state) (ty : typ) : unit =
+  match repr ty with
+  | TRecord (name, fields) ->
+      if not (Hashtbl.mem state.types name) then begin
+        let field_types =
+          List.map (fun (n, t) -> (n, elttype_of_typ t)) fields
+        in
+        Hashtbl.add state.types name field_types
+      end ;
+      List.iter (fun (_, t) -> register_types_from_typ state t) fields
+  | TVec elem_ty -> register_types_from_typ state elem_ty
+  | TArr (elem_ty, _) -> register_types_from_typ state elem_ty
+  | TTuple tys ->
+      (* L13: register the synthesized record for a tuple aggregate so the
+         codegen types table knows its field layout, mirroring records.
+         Primitivity is checked on the SOURCE types (prim_component_elttype),
+         never via elttype_of_typ, whose TTuple/TFun placeholder would let a
+         nested tuple register as an int32 field. *)
+      register_tuple_type state ty ;
+      List.iter (register_types_from_typ state) tys
+  | _ -> ()
+
 (** Convert Sarek_ast.binop to Sarek_ir_ppx.binop *)
 let ir_binop (op : binop) (_ty : typ) : Ir.binop =
   match op with
@@ -1215,6 +1265,11 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
       (* Special case: create_array - need proper array declaration *)
       | TECreateArray (size, elem_ty, mem) ->
           let size_ir = lower_expr state size in
+          (* Same registration point as [TELetShared] below: the element type
+             may appear NOWHERE else in the kernel, and an unregistered record
+             element emits a declaration naming a struct that was never
+             defined. *)
+          register_types_from_typ state elem_ty ;
           let v = make_var name id (TArr (elem_ty, mem)) false in
           let body_ir = lower_stmt state body in
           Ir.SLet
@@ -1349,6 +1404,11 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
             ~loc:(Sarek_ast.loc_to_ppxlib te.te_loc)
             "Function-typed shared-memory arrays are not supported."
       | _ -> ()) ;
+      (* backlog-206. A record element type reaches the struct-emitting backends
+         ONLY if it is in [state.types]; the shared declaration is the one place
+         a type can appear with nothing else to register it. See
+         {!register_types_from_typ}. *)
+      register_types_from_typ state elem_ty ;
       let elem_ir = elttype_of_typ elem_ty in
       (* Use EArrayCreate with Shared memspace - codegen will emit proper declaration *)
       Ir.SLet
@@ -1525,44 +1585,13 @@ let lower_kernel (kernel : tkernel) : Ir.kernel =
     all_mod_items ;
   let state = create_state fun_map in
 
-  (* Register record types from parameter types (especially vector element types) *)
-  let rec register_types_from_typ ty =
-    match repr ty with
-    | TRecord (name, fields) ->
-        if not (Hashtbl.mem state.types name) then begin
-          let field_types =
-            List.map (fun (n, t) -> (n, elttype_of_typ t)) fields
-          in
-          Hashtbl.add state.types name field_types
-        end ;
-        List.iter (fun (_, t) -> register_types_from_typ t) fields
-    | TVec elem_ty -> register_types_from_typ elem_ty
-    | TArr (elem_ty, _) -> register_types_from_typ elem_ty
-    | TTuple tys ->
-        (* L13: register the synthesized record for a tuple aggregate so the
-           codegen types table knows its field layout, mirroring records.
-           Primitivity is checked on the SOURCE types (prim_component_elttype),
-           never via elttype_of_typ, whose TTuple/TFun placeholder would let a
-           nested tuple register as an int32 field. *)
-        (match
-           List.map prim_component_elttype tys |> fun opts ->
-           if List.for_all Option.is_some opts then
-             Some (List.map Option.get opts)
-           else None
-         with
-        | Some comps ->
-            let name = tuple_record_name comps in
-            if not (Hashtbl.mem state.types name) then
-              Hashtbl.add
-                state.types
-                name
-                (List.mapi (fun i e -> (tuple_field_name i, e)) comps)
-        | None -> ()) ;
-        List.iter register_types_from_typ tys
-    | _ -> ()
-  in
+  (* Register record types from parameter types (especially vector element
+     types). The traversal itself is top-level ({!register_types_from_typ}) so
+     that the kernel-array declaration sites can reach it too — see the note
+     there on the shared-array-of-record compile failure that came of it being
+     applied to parameters only. *)
   List.iter
-    (fun (p : tparam) -> register_types_from_typ p.tparam_type)
+    (fun (p : tparam) -> register_types_from_typ state p.tparam_type)
     kernel.tkern_params ;
 
   (* Lower module-level constants *)

--- a/sarek/ppx/Sarek_lower_ir.ml
+++ b/sarek/ppx/Sarek_lower_ir.ml
@@ -566,12 +566,26 @@ let register_tuple_type (state : state) (ty : typ) : unit =
     registered the type — which is what made this look like a shared-memory gap
     rather than the type-collection gap it is.
 
-    VARIANTS are deliberately NOT handled here. A shared array of a variant is
-    only useful if some constructor application appears in the kernel, and
-    [TEConstr] registers the type; a read-only variant array over never-written
-    shared memory has no defined contents on any backend. Adding a [TVariant]
-    arm would also change what gets emitted for ordinary variant PARAMETERS,
-    which this change has no measurement for. *)
+    VARIANTS are deliberately NOT handled here, and the reason is narrower than
+    it first looks. The common shape — a kernel that puts constructor
+    applications into the array — is covered, because [TEConstr] registers the
+    type into [state.variants]. What is NOT covered, stated rather than left to
+    be discovered: copying a variant in from elsewhere, e.g.
+
+    {[
+      let%shared (s : color) = 4l in
+      s.(tid) <- v.(tid)
+    ]}
+
+    over a variant-element vector parameter, contains no [TEConstr], and the
+    [TVec] arm below bottoms out at [| _ -> ()] for [TVariant] — so on the
+    struct-emitting backends that is the same undeclared-type-name failure this
+    function fixes for records, still open for variants. It is NOT fixed here
+    because adding a [TVariant] arm changes what gets emitted for ordinary
+    variant PARAMETERS too, and this change has no measurement for that; the
+    shape above was reasoned about, not executed. The interpreter and PTX halves
+    of backlog-206 DO handle [TVariant], so the treatment is deliberately uneven
+    and this is where it is uneven. *)
 let rec register_types_from_typ (state : state) (ty : typ) : unit =
   match repr ty with
   | TRecord (name, fields) ->
@@ -1265,10 +1279,18 @@ and lower_stmt (state : state) (te : texpr) : Ir.stmt =
       (* Special case: create_array - need proper array declaration *)
       | TECreateArray (size, elem_ty, mem) ->
           let size_ir = lower_expr state size in
-          (* Same registration point as [TELetShared] below: the element type
-             may appear NOWHERE else in the kernel, and an unregistered record
-             element emits a declaration naming a struct that was never
-             defined. *)
+          (* Same REASON as [TELetShared] below — the element type may appear
+             NOWHERE else in the kernel, and an unregistered record element
+             emits a declaration naming a struct that was never defined — but
+             NOT the same position in its arm, and the difference is worth
+             stating. [TELetShared] registers AFTER its tuple/function refusals;
+             this site has no refusals, so a [create_array n Local] with a
+             primitive-component TUPLE element type now also registers the
+             synthesized [_tup_*] record, where the declaration itself still
+             collapses to [TInt32] through [elttype_of_typ]. The emitted kernel
+             gains an unreferenced struct typedef it did not have before. That
+             is inert output, not a behaviour change a program can observe, and
+             it is recorded here rather than special-cased. *)
           register_types_from_typ state elem_ty ;
           let v = make_var name id (TArr (elem_ty, mem)) false in
           let body_ir = lower_stmt state body in

--- a/sarek/ppx/Sarek_native_gen_expr.ml
+++ b/sarek/ppx/Sarek_native_gen_expr.ml
@@ -271,25 +271,24 @@ let gen_memory_access ~loc ~ctx ~gen_expr (te : texpr) : expression =
              vector base above needed the rebuild.
 
              This arm ALSO catches a shared-memory array element
-             ([let%shared (s : tri) = 4l] then [s.(i).a <- e]), and there the
-             setfield is emitted onto a record that is NOT this thread's own.
-             Measured, 4 threads, [if tid = 0l then s.(tid).a <- 7.0]:
+             ([let%shared (s : tri) = 4l] then [s.(i).a <- e]). That used to be
+             a silent wrong answer — measured, 4 threads,
+             [if tid = 0l then s.(tid).a <- 7.0]:
 
                Native      7 7 7 7   (want 7 0 0 0)
                Interpreter raises "assignment target of .a (got unit)"
 
-             The cause is upstream of this file and predates it:
-             [Sarek_cpu_runtime_types.alloc_shared_with_key] allocates with
-             [Array.make size default], so every slot of a shared array of a
-             boxed record type holds the SAME record, and a setfield through any
-             index is visible through all of them. Emitting a functional update
-             here would not fix it either — the slots would still alias.
+             The cause was never in this file, which is why the setfield here is
+             unchanged: [Sarek_cpu_runtime_types.alloc_shared_with_key]
+             allocated with [Array.make size default], so every slot of a shared
+             array of a boxed record held the SAME record. A functional update
+             here would not have fixed it — the slots would still have aliased.
 
-             Not fixed here: the fix is a per-slot allocation in the CPU shared
-             allocator, plus the Interpreter's own shared-array-of-record gap
-             (its [SLet]/[EArrayCreate Shared] arm initialises custom element
-             types to [VUnit]), and neither is a record-field-store change.
-             Tracked as backlog-206. *)
+             Fixed in backlog-206 at the two allocation sites instead: that
+             allocator now takes a per-slot THUNK and calls [Array.init], and the
+             Interpreter builds a real zeroed [VRecord] per slot instead of the
+             [VUnit] its [SLet]/[EArrayCreate Shared] arm used to store. The
+             setfield below is correct once the slots are distinct. *)
           let rec_e = gen_expr ~loc record in
           match field_access_of ~loc ~ctx record.ty field_name with
           | Field_lid lid ->
@@ -521,7 +520,14 @@ let gen_data_structure ~loc ~ctx ~gen_expr (te : texpr) : expression =
          OCaml int, so convert like the for-loop bounds do (see :196-208). *)
       let size_e = gen_expr ~loc size in
       let default_e = default_value_for_type ~loc elem_ty in
-      [%expr Array.make (Int32.to_int [%e size_e]) [%e default_e]]
+      (* [Array.init], not [Array.make]: the same per-slot-aliasing point as the
+         shared allocator (backlog-206, see
+         [Sarek_cpu_runtime_types.alloc_shared_with_key]). [Array.make] with a
+         boxed default puts ONE record in every slot of a
+         [create_array n Local] array too, so [a.(0).f <- e] would be visible
+         through every index. Covered by the local-array case of
+         sarek/tests/e2e/test_shared_record_slots.ml. *)
+      [%expr Array.init (Int32.to_int [%e size_e]) (fun _ -> [%e default_e])]
   | _ -> failwith "gen_data_structure: not a data structure expression"
 
 (** Generate special expressions (return, global ref, native, pragma, open) *)
@@ -614,7 +620,7 @@ let gen_parallel_construct ?current_module ?inline_types ~loc ~gen_expr
                 Spoc_core.Vector.char_type_id
                 [%e name_e]
                 [%e size_e]
-                '\000']
+                (fun () -> '\000')]
         | _ ->
             (* For custom types, generate proper default value *)
             let default_val = default_value_for_type ~loc elem_ty in
@@ -629,13 +635,17 @@ let gen_parallel_construct ?current_module ?inline_types ~loc ~gen_expr
                         .Spoc_core.Vector.type_id]
               | _ -> [%expr failwith "unsupported shared memory type identity"]
             in
+            (* A THUNK, so [alloc_shared_with_key] builds one record PER SLOT.
+               Passing [default_val] itself is what backlog-206 was: every slot
+               of a shared array of a boxed record held the same allocation, and
+               [s.(i).f <- e] wrote through all of them. *)
             [%expr
               Sarek.Sarek_cpu_runtime.alloc_shared_with_key
                 [%e shared]
                 [%e key_expr]
                 [%e name_e]
                 [%e size_e]
-                [%e default_val]]
+                (fun () -> [%e default_val])]
       in
       [%expr
         let [%p pat] = [%e alloc_expr] in

--- a/sarek/ppx/Sarek_ppx.ml
+++ b/sarek/ppx/Sarek_ppx.ml
@@ -1518,10 +1518,20 @@ let generate_interp_helpers ~loc (td : type_declaration) : structure_item list =
   | Ptype_variant constrs ->
       (* Interpreter value-model helper for a variant type: convert the native
          OCaml constructor to/from a [VVariant]. The interpreter tags a variant
-         by [Hashtbl.hash ctor mod 256] (Sarek_ir_interp_eval EVariant/EMatch/
-         SMatch), NOT by the declaration index the byte path uses; the tag is
-         emitted as a runtime [Hashtbl.hash "C" mod 256] expression so it
-         matches that convention byte-for-byte regardless of compile vs runtime.
+         by [Hashtbl.hash ctor mod 256] — [Sarek_ir_interp_value]'s
+         [variant_tag_of_ctor], which Sarek_ir_interp_eval's EVariant, EMatch
+         and SMatch all call — NOT by the declaration index the byte path uses;
+         the tag is emitted as a runtime [Hashtbl.hash "C" mod 256] expression
+         so it matches that convention byte-for-byte regardless of compile vs
+         runtime.
+
+         THIS IS THE ONE COPY OF THE ENCODING OUTSIDE THE INTERPRETER. It is a
+         duplication, not an impossibility: the generated code already reaches
+         [Sarek.Sarek_value] through a forwarding alias, so the same route could
+         expose [variant_tag_of_ctor] and make this a call. Left duplicated
+         because that widens [sarek]'s public surface for one expression, which
+         is a change with its own argument to make. Until then: if
+         [variant_tag_of_ctor] changes, change this line with it.
 
          This makes a variant field of a [@@sarek.type] record round-trip on the
          Interpreter/Native value path (the record helper delegates the field to

--- a/sarek/sarek/Sarek_cpu_runtime.mli
+++ b/sarek/sarek/Sarek_cpu_runtime.mli
@@ -89,10 +89,19 @@ val alloc_shared_int64 : shared_mem -> string -> int -> int64 -> int64 array
 
 (** {2 Generic Allocator}
 
-    For custom types not covered by typed allocators. *)
+    For custom types not covered by typed allocators.
+
+    The last argument is a THUNK run once PER SLOT, not a value copied into
+    every slot (backlog-206). For a boxed element type the value form aliased
+    all slots, so a store through one index was visible through all of them. *)
 
 val alloc_shared_with_key :
-  shared_mem -> 'a Sarek_ir_types.Type_id.t -> string -> int -> 'a -> 'a array
+  shared_mem ->
+  'a Sarek_ir_types.Type_id.t ->
+  string ->
+  int ->
+  (unit -> 'a) ->
+  'a array
 
 (** {1 Execution Modes} *)
 

--- a/sarek/sarek/Sarek_cpu_runtime.mli
+++ b/sarek/sarek/Sarek_cpu_runtime.mli
@@ -91,9 +91,12 @@ val alloc_shared_int64 : shared_mem -> string -> int -> int64 -> int64 array
 
     For custom types not covered by typed allocators.
 
-    The last argument is a THUNK run once PER SLOT, not a value copied into
-    every slot (backlog-206). For a boxed element type the value form aliased
-    all slots, so a store through one index was visible through all of them. *)
+    The last argument is a THUNK, run once per slot ON THE ALLOCATING CALL, not
+    a value copied into every slot (backlog-206). For a boxed element type the
+    value form aliased all slots, so a store through one index was visible
+    through all of them. A call that finds [name] already allocated returns the
+    existing array and does NOT run the thunk at all — that is the reuse this
+    function exists for, and it is why the thunk must not carry side effects. *)
 
 val alloc_shared_with_key :
   shared_mem ->

--- a/sarek/sarek/Sarek_cpu_runtime_types.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_types.ml
@@ -124,16 +124,34 @@ let alloc_shared_int64 (shared : shared_mem) name size (default : int64) :
       arr
 
 (** Generic allocator for custom types. The caller must ensure they use
-    consistent types for each name. *)
+    consistent types for each name.
+
+    [mk] is a THUNK, not a value, and that is the whole of backlog-206's Native
+    half. This used to take an [a] and call [Array.make size default]; for a
+    boxed element type — every record, and every variant with a payload —
+    [Array.make] puts the SAME allocation in every slot, so
+    [let%shared (s : tri) = 4l] followed by [s.(0).a <- 7.0] was visible through
+    every index. Measured on 4 threads before the change: Native read back
+    [7; 7; 7; 7] where the wanted answer is [7; 0; 0; 0].
+
+    [Array.init] calls [mk] once per slot, so the slots are independent
+    allocations. A thunk rather than a value because nothing here can copy an
+    ['a]: the caller (the PPX, {!Sarek_native_gen_expr.gen_parallel_construct})
+    is the only place that knows how to build one, and passing a value would put
+    the aliasing back no matter what this function did with it.
+
+    Unchanged for immediate element types ([char], and the four typed allocators
+    above): they cannot alias, so this costs them one extra closure call per
+    slot at allocation and nothing else. *)
 let alloc_shared_with_key (type a) (shared : shared_mem)
-    (key : a Sarek_ir_types.Type_id.t) name size (default : a) : a array =
+    (key : a Sarek_ir_types.Type_id.t) name size (mk : unit -> a) : a array =
   match Hashtbl.find_opt shared.custom_arrays name with
   | Some (AnyArray (stored_key, arr)) -> (
       match Sarek_ir_types.Type_id.equal key stored_key with
       | Some Sarek_ir_types.Type_id.Refl -> arr
       | None -> invalid_arg ("alloc_shared: type mismatch for " ^ name))
   | None ->
-      let arr = Array.make size default in
+      let arr = Array.init size (fun _ -> mk ()) in
       Hashtbl.add shared.custom_arrays name (AnyArray (key, arr)) ;
       arr
 

--- a/sarek/sarek/Sarek_cpu_runtime_types.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_types.ml
@@ -143,9 +143,11 @@ let alloc_shared_int64 (shared : shared_mem) name size (default : int64) :
     knows how to build one, and passing a value would put the aliasing back no
     matter what this function did with it.
 
-    Unchanged for immediate element types ([char], and the four typed allocators
-    above): they cannot alias, so this costs them one extra closure call per
-    slot at allocation and nothing else. *)
+    Unchanged for the one immediate element type routed through here — [char],
+    from {!Sarek_native_gen_expr.gen_parallel_construct} — which cannot alias
+    and pays one extra closure call per slot at allocation and nothing else. The
+    four typed allocators above do NOT go through this function; they call
+    [Array.make] directly, are untouched, and pay nothing. *)
 let alloc_shared_with_key (type a) (shared : shared_mem)
     (key : a Sarek_ir_types.Type_id.t) name size (mk : unit -> a) : a array =
   match Hashtbl.find_opt shared.custom_arrays name with

--- a/sarek/sarek/Sarek_cpu_runtime_types.ml
+++ b/sarek/sarek/Sarek_cpu_runtime_types.ml
@@ -135,10 +135,13 @@ let alloc_shared_int64 (shared : shared_mem) name size (default : int64) :
     [7; 7; 7; 7] where the wanted answer is [7; 0; 0; 0].
 
     [Array.init] calls [mk] once per slot, so the slots are independent
-    allocations. A thunk rather than a value because nothing here can copy an
-    ['a]: the caller (the PPX, {!Sarek_native_gen_expr.gen_parallel_construct})
-    is the only place that knows how to build one, and passing a value would put
-    the aliasing back no matter what this function did with it.
+    allocations — on the ALLOCATING call. A call that finds [name] already
+    allocated returns the stored array and never runs [mk], which is the reuse
+    the [Hashtbl] lookup below is for. A thunk rather than a value because
+    nothing here can copy an ['a]: the caller (the PPX,
+    {!Sarek_native_gen_expr.gen_parallel_construct}) is the only place that
+    knows how to build one, and passing a value would put the aliasing back no
+    matter what this function did with it.
 
     Unchanged for immediate element types ([char], and the four typed allocators
     above): they cannot alias, so this costs them one extra closure call per

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1873,3 +1873,40 @@
    LD_LIBRARY_PATH
    %{env:HOME=}/opt/zluda
    (run %{dep:test_record_variant_decl_order.exe}))))
+
+; backlog-206: shared/local array of a record type, across every enumerable
+; device. LD_LIBRARY_PATH is set for the same reason as the
+; test_record_field_store rule above: this file makes a measured claim ABOUT
+; CUDA/PTX (that the aggregate shared array is refused with a message naming
+; the array and its type), and without ZLUDA on the loader path no CUDA/PTX
+; device enumerates, so the claim goes unreproduced. The test prints a named
+; NOT-MEASURED-HERE line where the device is genuinely absent.
+
+(executable
+ (name test_shared_record_slots)
+ (modules test_shared_record_slots)
+ (libraries
+  sarek
+  spoc_framework_registry
+  sarek.stdlib
+  sarek_ir
+  sarek.codegen
+  spoc_core
+  sarek_native
+  sarek_interpreter
+  sarek_cuda
+  sarek_opencl
+  sarek_vulkan
+  sarek_backend_error)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))
+
+(rule
+ (alias runtest)
+ (action
+  (setenv
+   LD_LIBRARY_PATH
+   %{env:HOME=}/opt/zluda
+   (run %{dep:test_shared_record_slots.exe}))))

--- a/sarek/tests/e2e/test_shared_record_slots.ml
+++ b/sarek/tests/e2e/test_shared_record_slots.ml
@@ -225,9 +225,21 @@ let failf fmt =
    [Device.framework] reports ("CUDA/PTX"), never the family name "CUDA" that
    [Device.init ~frameworks] accepts -- a predicate written against the wrong
    vocabulary is silently always-false, which is the same defect as an assertion
-   that cannot fail. Asserted below rather than trusted: if no enumerated device
-   reports a framework starting with "CUDA", the CUDA leg simply did not run
-   here and says so. *)
+   that cannot fail.
+
+   NOT asserted anywhere in the device loop, and the earlier wording here said
+   it was. What the run does is REPORT: the NOT-MEASURED-HERE list near the
+   bottom prints a named line when no device reports exactly "CUDA/PTX", and
+   that list is explicitly not a failure. The exactness cuts both ways — a host
+   running the "CUDA/C" backend (sarek-cuda/Cuda_c_plugin.ml, not linked by this
+   file) would get the printed line rather than an assertion about a device that
+   did run.
+
+   The thing that IS asserted, with no device at all, is [check_deviceless]
+   below: the PTX generator is invoked directly on this kernel's IR and its
+   refusal message is checked. So the PTX half of backlog-206 has a gate on
+   every host, and this predicate only decides how an enumerated device is
+   scored. *)
 let expects_refusal (dev : Device.t) = dev.Device.framework = "CUDA/PTX"
 
 let run_field_case (dev : Device.t) =
@@ -416,7 +428,146 @@ let run_local_case (dev : Device.t) =
         if !bad then Printf.printf "\n%!" else Printf.printf "OK\n%!"
       end
 
+(* DEVICE-INDEPENDENT SECTION, and it runs FIRST.
+
+   Everything below this point needs a device. CI has no GPU, so on CI the
+   device loop exercises the Interpreter and Native and then PRINTS a
+   NOT-MEASURED-HERE line for OpenCL, Vulkan and CUDA/PTX without failing. That
+   is honest about what ran, but it means the two halves of this fix that
+   affect only those backends — the record-type registration that made OpenCL
+   and Vulkan compile at all, which is 4 of the 9 devices, and the named PTX
+   refusal — have no gate on a GPU-less host: revert either and CI stays green.
+
+   Both are checkable with no device, because both are properties of GENERATED
+   SOURCE. The record type is either in [kern_types] or it is not; the OpenCL
+   and GLSL text either declares the struct before the shared array that names
+   it or it does not; the PTX generator either raises a message naming the array
+   and the type or it does not. Asserted here on the same [k] the device loop
+   runs, so the two cannot drift apart.
+
+   Failures here [exit 1] immediately rather than accumulating: they mean the
+   generated source is wrong, so every device row after them would be reporting
+   on a kernel this file already knows is broken. *)
+let contains (hay : string) (needle : string) : bool =
+  let n = String.length needle and m = String.length hay in
+  let rec go i = i + n <= m && (String.sub hay i n = needle || go (i + 1)) in
+  n = 0 || go 0
+
+(* Index of the first occurrence, [-1] if absent. Used to check DECLARATION
+   ORDER, which a mere "both substrings are present" check cannot see — the
+   struct being emitted after the array that names it is precisely how
+   backlog-203 failed, and it would satisfy a presence-only assertion. *)
+let index_of (hay : string) (needle : string) : int =
+  let n = String.length needle and m = String.length hay in
+  let rec go i =
+    if i + n > m then -1
+    else if String.sub hay i n = needle then i
+    else go (i + 1)
+  in
+  go 0
+
+let deviceless_failures = ref 0
+
+let dfail fmt =
+  Printf.ksprintf
+    (fun s ->
+      incr deviceless_failures ;
+      Printf.printf "DEVICELESS FAILED: %s\n%!" s)
+    fmt
+
+let record_type_name = "Test_shared_record_slots.tri"
+
+let check_deviceless () =
+  let ir = ir_of k in
+  (* 1. The lowerer registered the record type from the shared declaration
+        alone. [tri] appears in no parameter and in no record literal in [k], so
+        before the fix this list did not contain it. *)
+  let names = List.map fst ir.Sarek_ir_types.kern_types in
+  Printf.printf "deviceless: kern_types = [%s]\n%!" (String.concat "; " names) ;
+  if not (List.mem record_type_name names) then
+    dfail
+      "the record type %S is not in kern_types, so no struct-emitting backend \
+       can declare it. This is the OpenCL/Vulkan half of backlog-206."
+      record_type_name ;
+  (* 2. OpenCL and GLSL declare the struct BEFORE the shared array names it.
+        The struct tag is the type name with dots replaced; rather than
+        reimplementing that mangling, look for the array declaration and require
+        SOME earlier occurrence of the mangled name. *)
+  let mangled =
+    String.map (fun c -> if c = '.' then '_' else c) record_type_name
+  in
+  (* STRICTLY BEFORE THE DECLARATION LINE, not merely before the array name.
+
+     The first version of this check compared the first occurrence of the
+     mangled type name against the offset of "s[4]" — and it could not fail.
+     The array declaration is `__local Test_..._tri s[4];`, so the type name
+     occurs ON THAT LINE, a few characters before "s[4]", whether or not any
+     struct was ever defined. Measured: with the registration reverted, the
+     kern_types assertion went red and this one stayed green on both dialects.
+
+     So the anchor is the START OF THE LINE that declares the array, and the
+     requirement is an occurrence of the type name before it. Deliberately not a
+     dialect-specific anchor ("typedef struct" in OpenCL, "struct X {" in GLSL):
+     two spellings would be two things to keep in step with two emitters, and
+     the property — the name is introduced before the line that uses it — is the
+     same in both. *)
+  List.iter
+    (fun (label, src) ->
+      let arr = index_of src "s[4]" in
+      if arr < 0 then
+        dfail "%s source has no shared array declaration for [s]:\n%s" label src
+      else begin
+        let line_start =
+          match String.rindex_from_opt src arr '\n' with
+          | Some i -> i + 1
+          | None -> 0
+        in
+        let before = String.sub src 0 line_start in
+        let decl = index_of before mangled in
+        if decl < 0 then
+          dfail
+            "%s uses the type %S on the shared-array declaration line but \
+             nothing above that line introduces it — the struct definition is \
+             missing, which is the OpenCL/Vulkan half of backlog-206:\n\
+             %s"
+            label
+            mangled
+            src
+      end)
+    [
+      ("OpenCL", Sarek_codegen.Sarek_ir_opencl.generate ir);
+      ("GLSL", Sarek_codegen.Sarek_ir_glsl.generate ir);
+    ] ;
+  (* 3. PTX refuses, and the refusal names the array, the state space and the
+        type. Same predicate the device rows use, so the two cannot disagree
+        about what "named" means. *)
+  (match Sarek_codegen.Sarek_ir_ptx.generate ir with
+  | exception e ->
+      let msg = Printexc.to_string e in
+      if ptx_refusal_is_named ~what:"shared" ~arr:"s" msg then
+        Printf.printf "deviceless: PTX refused, named\n%!"
+      else
+        dfail
+          "PTX refused but the message names neither the shared array nor its \
+           record type: %s"
+          msg
+  | _src ->
+      dfail
+        "PTX generated code for an aggregate shared array. If the PTX backend \
+         gained aggregate state-space addressing, delete this expectation and \
+         assert the emitted code instead.") ;
+  if !deviceless_failures > 0 then begin
+    Printf.printf
+      "%d deviceless failure(s) — not running the device cases on a kernel \
+       whose generated source is already wrong\n\
+       %!"
+      !deviceless_failures ;
+    exit 1
+  end ;
+  Printf.printf "deviceless: OK (no device needed for any of the above)\n%!"
+
 let () =
+  check_deviceless () ;
   let devs =
     Device.init
       ~frameworks:

--- a/sarek/tests/e2e/test_shared_record_slots.ml
+++ b/sarek/tests/e2e/test_shared_record_slots.ml
@@ -1,0 +1,430 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-206. A shared-memory array of a record type: `let%shared (s : tri)`
+ * then a FIELD store through one slot, `s.(i).a <- e`.
+ *
+ * MEASURED BEFORE, on this host, 9 devices, the 4-thread kernel below
+ * (`if tid = 0l then s.(tid).a <- 7.0`, want 7 0 0 0):
+ *
+ *   Interpreter x2  RAISED  "assignment target of .a (got unit)"
+ *   Native          7 7 7 7 -- accepted the store and wrote EVERY slot
+ *   CUDA/PTX x2     RAISED  "PTX codegen: unsupported construct: btype of
+ *                            custom type"
+ *   OpenCL x2       device compiler: "unknown type name
+ *                            'Test_shared_record_slots_tri'"
+ *   Vulkan x2       glslang: syntax error at the shared declaration
+ *
+ * Nine devices, four different answers, none of them right. Three separate
+ * causes, and only the first two are the ones the backlog item named:
+ *
+ *  1. Native. [Sarek_cpu_runtime_types.alloc_shared_with_key] filled the array
+ *     with [Array.make size default] -- ONE record in every slot -- so a field
+ *     store through any index was visible through all of them. It now takes a
+ *     per-slot thunk and calls [Array.init].
+ *
+ *  2. Interpreter. Its [EArrayCreate]/[DShared] arms mapped a record element
+ *     type to [VUnit], so the store had nothing to write into. It now builds a
+ *     zeroed [VRecord] per slot ([Sarek_ir_interp_value.alloc_kernel_array]).
+ *
+ *  3. OpenCL and Vulkan. NOT a shared-memory gap at all: the record type was
+ *     never registered in the codegen types table, so the kernel declared
+ *     `__local Test_..._tri s[4];` with no such struct defined above it.
+ *     [Sarek_lower_ir.register_types_from_typ] ran over PARAMETER types only,
+ *     and in this kernel [tri] appears nowhere but the shared declaration. The
+ *     tell is that the SAME kernel with a whole-slot store (`s.(tid) <- {...}`)
+ *     compiled and ran correctly on both, all along -- the record literal
+ *     registered the type. That is why this file exercises BOTH shapes: a
+ *     whole-slot-store-only test would have been green throughout the defect.
+ *
+ * CUDA/PTX still refuses, deliberately, and this file asserts the refusal
+ * rather than tolerating it. PTX has no struct type, and this backend addresses
+ * aggregates only in global vectors ([Sarek_ir_ptx_mem.emit_agg_elem_addr]
+ * refuses shared/local aggregates on purpose). What changed there is the
+ * message: it now names the array, the element type and the state space
+ * instead of "unsupported construct: btype of custom type". The check below is
+ * on the message content, so deleting the refusal, or replacing it with the old
+ * anonymous one, fails.
+ *
+ * WHAT THIS FILE DOES NOT COVER, stated rather than left to be found:
+ *   - Metal, HIP and WGSL. There is no such device on this machine, nothing was
+ *     measured on them, and nothing is claimed. A failure on any of them is a
+ *     failure -- they are on the [Device.init] list and are not tolerated.
+ *   - Reading a shared slot that no thread wrote. Shared/__local/threadgroup
+ *     memory is UNINITIALISED on every device, so an unwritten slot has no
+ *     defined value. An earlier draft of this test asserted 0 for the untouched
+ *     slots and read back, on real hardware, [7; 0.973611; 1210; 1] (OpenCL,
+ *     RX 7900 XTX) -- correct behaviour failing a wrong assertion. Every slot
+ *     this file reads is written first, by the thread that reads it or by its
+ *     neighbour across a barrier. The Interpreter and Native DO zero their
+ *     slots (an [Array.init] has to put something there); that is an
+ *     implementation detail of the CPU backends and deliberately not asserted.
+ *
+ * A THIRD case covers [create_array n Local] with the same record element type.
+ * That is per-thread private memory, not shared memory, so it is not the
+ * backlog-206 defect -- but the Native generator built it with the same
+ * [Array.make size default] one line away, so it had the same all-slots-alias
+ * bug, and it is fixed and covered here rather than left for the next report.
+ *
+ * Every device failure makes the process exit non-zero.
+ ******************************************************************************)
+
+module Vector = Spoc_core.Vector
+module Device = Spoc_core.Device
+module Transfer = Spoc_core.Transfer
+
+(* Explicit registration: linking a plugin does not enumerate its devices. *)
+let () =
+  Sarek_native.Native_plugin.init () ;
+  Sarek_interpreter.Interpreter_plugin.init () ;
+  Sarek_cuda.Cuda_plugin.init () ;
+  Sarek_opencl.Opencl_plugin.init () ;
+  Sarek_vulkan.Vulkan_plugin.init ()
+
+type float32 = float
+
+type ('a, 'b) vector = ('a, 'b) Vector.t
+
+(* MUTABLE fields, and it is load-bearing: the Native code generator emits a
+   [setfield] for a store into a record held in a local or a shared slot, so
+   with immutable fields the pre-fix build failed with "The record field a is
+   not mutable" -- loud, but a build failure, not the silent all-slots write
+   this file is about. This is the same split [test_record_field_store.ml] pins
+   at depth 1 with [triple]/[mtriple]. The immutable half is NOT reproduced here
+   because it cannot be observed in the same build as the silent half, and the
+   silent half is the dangerous one. *)
+type tri = {mutable a : float32; mutable b : float32; mutable c : float32}
+[@@sarek.type]
+
+let n = 4
+
+(* FIELD stores only, no record literal anywhere: that is what makes this kernel
+   the one that broke, and it is also what left [tri] unregistered for the
+   struct-emitting backends.
+
+   Every thread writes its OWN slot and then, after a barrier, reads its
+   NEIGHBOUR's. So the values are defined without relying on any initial content
+   of shared memory, and the read proves two things at once: the slots are
+   distinct (each carries its own writer's value) and they really are shared
+   across the block (a thread sees another thread's write).
+
+   Under the pre-fix Native aliasing all four threads wrote the SAME record, so
+   after the barrier every thread read the same value and the four outputs were
+   equal. They cannot be equal and also be the four distinct expected values, so
+   the separation is deterministic rather than a race between writers. *)
+let k =
+  snd
+    [%kernel
+      fun (src : float32 vector)
+          (out_own : float32 vector)
+          (out_nb : float32 vector) ->
+        let%shared (s : tri) = 4l in
+        let tid = thread_idx_x in
+        s.(tid).a <- src.(tid) ;
+        s.(tid).b <- src.(tid) +. 100.0 ;
+        block_barrier () ;
+        let nb = (tid + 1l) mod 4l in
+        out_own.(tid) <- s.(tid).a ;
+        out_nb.(tid) <- s.(nb).b]
+
+(* The whole-slot shape, which worked on 7 of 9 devices throughout the defect.
+   It is here as a REGRESSION guard, not as evidence of the fix: the thunked
+   allocator and the interpreter's new per-slot record both sit on this path
+   too, and a wrong per-slot default would show up here first. *)
+let k_slot =
+  snd
+    [%kernel
+      fun (src : float32 vector) (out : float32 vector) ->
+        let%shared (s : tri) = 4l in
+        let tid = thread_idx_x in
+        s.(tid) <- {a = src.(tid); b = 0.0; c = 0.0} ;
+        block_barrier () ;
+        let nb = (tid + 1l) mod 4l in
+        out.(tid) <- s.(nb).a]
+
+(* PER-THREAD local array of the same record type, [create_array n Local]. It
+   is not shared memory, so it is not the backlog-206 defect, but the Native
+   generator built it with the same [Array.make size default] and therefore had
+   the same all-slots-alias bug one line away. Thread 0's slots are the ones
+   asserted; every slot read is field-stored first, for the same
+   uninitialised-storage reason as above. *)
+let k_local =
+  snd
+    [%kernel
+      fun (src : float32 vector)
+          (out0 : float32 vector)
+          (out1 : float32 vector) ->
+        let open Sarek_stdlib.Std in
+        let tid = thread_idx_x in
+        let arr = create_array 4l Local in
+        (* Slot 2 is written whole and never read again. Its only job is to give
+           the element type, which a field store does not infer
+           ("Expected a record type, got 't16[0]"). It does NOT break the
+           aliasing this case is looking for: [Array.make] put one record in all
+           four slots, and replacing slot 2's pointer leaves 0, 1 and 3 sharing
+           the original. *)
+        arr.(2l) <- {a = 0.0; b = 0.0; c = 0.0} ;
+        arr.(0l).a <- src.(tid) ;
+        arr.(1l).a <- src.(tid) +. 10.0 ;
+        out0.(tid) <- arr.(0l).a ;
+        out1.(tid) <- arr.(1l).a]
+
+let ir_of kirc =
+  match kirc.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+(* The PTX refusal, asserted on CONTENT. Three independent substrings, because a
+   message that merely mentions PTX would also be produced by a dozen unrelated
+   failures, and because the point of the backlog-206 change to it is precisely
+   that it names the array and the type. *)
+let ptx_refusal_is_named (msg : string) : bool =
+  let has sub =
+    let n = String.length sub and m = String.length msg in
+    let rec go i = i + n <= m && (String.sub msg i n = sub || go (i + 1)) in
+    n = 0 || go 0
+  in
+  has "shared-memory array" && has "'s'" && has "tri"
+
+let fail_count = ref 0
+
+let failf fmt =
+  Printf.ksprintf
+    (fun s ->
+      incr fail_count ;
+      Printf.printf "  FAILED: %s\n%!" s)
+    fmt
+
+(* CUDA/PTX must refuse, everything else must run. Keyed on the BACKEND name
+   [Device.framework] reports ("CUDA/PTX"), never the family name "CUDA" that
+   [Device.init ~frameworks] accepts -- a predicate written against the wrong
+   vocabulary is silently always-false, which is the same defect as an assertion
+   that cannot fail. Asserted below rather than trusted: if no enumerated device
+   reports a framework starting with "CUDA", the CUDA leg simply did not run
+   here and says so. *)
+let expects_refusal (dev : Device.t) = dev.Device.framework = "CUDA/PTX"
+
+let run_field_case (dev : Device.t) =
+  Printf.printf
+    "shared-record field-store [%s] %s: %!"
+    dev.Device.framework
+    dev.Device.name ;
+  let src = Vector.create Vector.float32 n in
+  let out_own = Vector.create Vector.float32 n in
+  let out_nb = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set src i (float_of_int i) ;
+    Vector.set out_own i (-1.0) ;
+    Vector.set out_nb i (-1.0)
+  done ;
+  match
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of k)
+      ~args:[Vec src; Vec out_own; Vec out_nb]
+      ~block:(Sarek.Execute.dims1d n)
+      ~grid:(Sarek.Execute.dims1d 1)
+      ()
+  with
+  | exception e ->
+      let msg = Printexc.to_string e in
+      if expects_refusal dev then
+        if ptx_refusal_is_named msg then
+          Printf.printf "refused, named (expected)\n%!"
+        else begin
+          Printf.printf "refused\n%!" ;
+          failf
+            "CUDA/PTX refused, as expected, but the message does not name the \
+             shared array and its record type. Got: %s"
+            msg
+        end
+      else begin
+        Printf.printf "RAISED\n%!" ;
+        failf "%s raised: %s" dev.Device.framework msg
+      end
+  | () ->
+      Transfer.flush dev ;
+      if expects_refusal dev then begin
+        Printf.printf "ran\n%!" ;
+        failf
+          "CUDA/PTX accepted an aggregate shared array. If the PTX backend \
+           gained aggregate state-space addressing, delete this expectation \
+           and assert the values instead."
+      end
+      else begin
+        let bad = ref false in
+        for i = 0 to n - 1 do
+          let got_own = Vector.get out_own i in
+          let want_own = float_of_int i in
+          let got_nb = Vector.get out_nb i in
+          let want_nb = float_of_int ((i + 1) mod n) +. 100.0 in
+          if Float.abs (got_own -. want_own) > 1e-4 then begin
+            bad := true ;
+            failf "@%d own slot .a: got %g want %g" i got_own want_own
+          end ;
+          if Float.abs (got_nb -. want_nb) > 1e-4 then begin
+            bad := true ;
+            failf "@%d neighbour slot .b: got %g want %g" i got_nb want_nb
+          end
+        done ;
+        if !bad then Printf.printf "\n%!" else Printf.printf "OK\n%!"
+      end
+
+let run_slot_case (dev : Device.t) =
+  Printf.printf
+    "shared-record slot-store  [%s] %s: %!"
+    dev.Device.framework
+    dev.Device.name ;
+  let src = Vector.create Vector.float32 n in
+  let out = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set src i (float_of_int i) ;
+    Vector.set out i (-1.0)
+  done ;
+  match
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of k_slot)
+      ~args:[Vec src; Vec out]
+      ~block:(Sarek.Execute.dims1d n)
+      ~grid:(Sarek.Execute.dims1d 1)
+      ()
+  with
+  | exception e ->
+      let msg = Printexc.to_string e in
+      if expects_refusal dev then Printf.printf "refused (expected)\n%!"
+      else begin
+        Printf.printf "RAISED\n%!" ;
+        failf "%s raised: %s" dev.Device.framework msg
+      end
+  | () ->
+      Transfer.flush dev ;
+      if expects_refusal dev then begin
+        Printf.printf "ran\n%!" ;
+        failf "CUDA/PTX accepted an aggregate shared array (slot-store shape)."
+      end
+      else begin
+        let bad = ref false in
+        for i = 0 to n - 1 do
+          let got = Vector.get out i in
+          let want = float_of_int ((i + 1) mod n) in
+          if Float.abs (got -. want) > 1e-4 then begin
+            bad := true ;
+            failf "@%d neighbour slot .a: got %g want %g" i got want
+          end
+        done ;
+        if !bad then Printf.printf "\n%!" else Printf.printf "OK\n%!"
+      end
+
+let run_local_case (dev : Device.t) =
+  Printf.printf
+    "local-array field  [%s] %s: %!"
+    dev.Device.framework
+    dev.Device.name ;
+  let src = Vector.create Vector.float32 n in
+  let out0 = Vector.create Vector.float32 n in
+  let out1 = Vector.create Vector.float32 n in
+  for i = 0 to n - 1 do
+    Vector.set src i (float_of_int i) ;
+    Vector.set out0 i (-1.0) ;
+    Vector.set out1 i (-1.0)
+  done ;
+  match
+    Sarek.Execute.run_vectors
+      ~device:dev
+      ~ir:(ir_of k_local)
+      ~args:[Vec src; Vec out0; Vec out1]
+      ~block:(Sarek.Execute.dims1d n)
+      ~grid:(Sarek.Execute.dims1d 1)
+      ()
+  with
+  | exception e ->
+      let msg = Printexc.to_string e in
+      if expects_refusal dev then Printf.printf "refused (expected)\n%!"
+      else begin
+        Printf.printf "RAISED\n%!" ;
+        failf "%s raised: %s" dev.Device.framework msg
+      end
+  | () ->
+      Transfer.flush dev ;
+      if expects_refusal dev then begin
+        Printf.printf "ran\n%!" ;
+        failf "CUDA/PTX accepted an aggregate local array."
+      end
+      else begin
+        let bad = ref false in
+        for i = 0 to n - 1 do
+          let g0 = Vector.get out0 i and g1 = Vector.get out1 i in
+          let w0 = float_of_int i and w1 = float_of_int i +. 10.0 in
+          if Float.abs (g0 -. w0) > 1e-4 then begin
+            bad := true ;
+            failf "@%d local slot 0 .a: got %g want %g" i g0 w0
+          end ;
+          if Float.abs (g1 -. w1) > 1e-4 then begin
+            bad := true ;
+            failf "@%d local slot 1 .a: got %g want %g" i g1 w1
+          end
+        done ;
+        if !bad then Printf.printf "\n%!" else Printf.printf "OK\n%!"
+      end
+
+let () =
+  let devs =
+    Device.init
+      ~frameworks:
+        ["Interpreter"; "Native"; "CUDA"; "OpenCL"; "Vulkan"; "Metal"; "HIP"]
+      ()
+  in
+  if Array.length devs = 0 then begin
+    print_endline "No devices found — nothing asserted, and that is a gap" ;
+    exit 1
+  end ;
+  Array.iter run_field_case devs ;
+  Array.iter run_slot_case devs ;
+  Array.iter run_local_case devs ;
+  let frameworks_seen =
+    Array.to_list devs |> List.map (fun (d : Device.t) -> d.Device.framework)
+  in
+  (* The claims this header makes that a deviceless (or driver-less) run cannot
+     reproduce, named one by one. Absence of a line means a device of that
+     framework was enumerated and every case above asserted on it. Nothing here
+     is a failure: a host with no CUDA driver legitimately has no CUDA/PTX
+     device, and failing there would make the suite unrunnable rather than
+     honest. Keys are BACKEND names, matching [Device.framework]. *)
+  List.iter
+    (fun (fw, claim) ->
+      if not (List.mem fw frameworks_seen) then
+        Printf.printf
+          "NOT MEASURED HERE: no %s device was enumerated, so the header's %s \
+           claim (%s) is NOT reproduced by this run.\n\
+           %!"
+          fw
+          fw
+          claim)
+    [
+      ( "Interpreter",
+        "the field store lands per-slot, the pre-fix \"assignment target of .a \
+         (got unit)\" refusal being gone" );
+      ("Native", "the field store lands in ONE slot rather than all of them");
+      ( "CUDA/PTX",
+        "the aggregate shared array is refused with a message naming the array \
+         and its record type — put ZLUDA on LD_LIBRARY_PATH, or run on a CUDA \
+         host, to exercise it" );
+      ( "OpenCL",
+        "the kernel COMPILES (the record type is now registered from the \
+         shared declaration) and the field store lands per-slot" );
+      ( "Vulkan",
+        "the kernel COMPILES (the record type is now registered from the \
+         shared declaration) and the field store lands per-slot" );
+    ] ;
+  Printf.printf
+    "%d device(s) exercised (frameworks: %s)\n%!"
+    (Array.length devs)
+    (String.concat ", " (List.sort_uniq String.compare frameworks_seen)) ;
+  if !fail_count > 0 then begin
+    Printf.printf "%d failure(s)\n%!" !fail_count ;
+    exit 1
+  end

--- a/sarek/tests/e2e/test_shared_record_slots.ml
+++ b/sarek/tests/e2e/test_shared_record_slots.ml
@@ -50,9 +50,15 @@
  * anonymous one, fails.
  *
  * WHAT THIS FILE DOES NOT COVER, stated rather than left to be found:
- *   - Metal, HIP and WGSL. There is no such device on this machine, nothing was
- *     measured on them, and nothing is claimed. A failure on any of them is a
- *     failure -- they are on the [Device.init] list and are not tolerated.
+ *   - Metal, HIP and WGSL. Nothing is measured and nothing is claimed, and the
+ *     reason is stronger than "no such hardware here": this file initialises
+ *     the Native, Interpreter, CUDA, OpenCL and Vulkan plugins ONLY, and WGSL
+ *     is not even on the [Device.init] list. So no Metal, HIP or WGSL device
+ *     can enumerate here on ANY host, and saying "a failure on those is a
+ *     failure" would be a promise about legs this file cannot run. Naming them
+ *     in [Device.init] is forward compatibility, not coverage. Covering them
+ *     means linking their plugins and initialising them, which is a change to
+ *     make when such hardware exists to check the result against.
  *   - Reading a shared slot that no thread wrote. Shared/__local/threadgroup
  *     memory is UNINITIALISED on every device, so an unwritten slot has no
  *     defined value. An earlier draft of this test asserted 0 for the untouched
@@ -177,17 +183,34 @@ let ir_of kirc =
   | Some ir -> ir
   | None -> failwith "kernel has no IR"
 
-(* The PTX refusal, asserted on CONTENT. Three independent substrings, because a
-   message that merely mentions PTX would also be produced by a dozen unrelated
+(* The PTX refusal, asserted on CONTENT. Three independent substrings — the
+   state space, the array name and the element type name — because a message
+   that merely mentions PTX would also be produced by a dozen unrelated
    failures, and because the point of the backlog-206 change to it is precisely
-   that it names the array and the type. *)
-let ptx_refusal_is_named (msg : string) : bool =
+   that it names those three things.
+
+   PARAMETERISED over the state space and the array name rather than fixed on
+   the shared case. The first version was fixed, and the local-array case
+   therefore accepted ANY CUDA/PTX exception: the named local-state-space
+   refusal could have regressed to the old anonymous "btype of custom type", or
+   to something unrelated, and the test would have stayed green. A refusal
+   expectation that accepts any exception is a check that cannot fail. *)
+let ptx_refusal_is_named ~(what : string) ~(arr : string) (msg : string) : bool
+    =
   let has sub =
     let n = String.length sub and m = String.length msg in
     let rec go i = i + n <= m && (String.sub msg i n = sub || go (i + 1)) in
     n = 0 || go 0
   in
-  has "shared-memory array" && has "'s'" && has "tri"
+  has (what ^ "-memory array") && has ("'" ^ arr ^ "'") && has "tri"
+
+(* [Float.abs (got -. want) > 1e-4] is FALSE when [got] is NaN, so a tolerance
+   comparison on its own accepts NaN — and NaN is exactly what a read of
+   uninitialised device memory can hand back, which is the failure mode this
+   file exists to catch. Every value check goes through here, so the guard
+   cannot be present at some call sites and missing at others. *)
+let close_enough ~(got : float) ~(want : float) : bool =
+  Float.is_finite got && Float.abs (got -. want) <= 1e-4
 
 let fail_count = ref 0
 
@@ -232,7 +255,7 @@ let run_field_case (dev : Device.t) =
   | exception e ->
       let msg = Printexc.to_string e in
       if expects_refusal dev then
-        if ptx_refusal_is_named msg then
+        if ptx_refusal_is_named ~what:"shared" ~arr:"s" msg then
           Printf.printf "refused, named (expected)\n%!"
         else begin
           Printf.printf "refused\n%!" ;
@@ -261,11 +284,11 @@ let run_field_case (dev : Device.t) =
           let want_own = float_of_int i in
           let got_nb = Vector.get out_nb i in
           let want_nb = float_of_int ((i + 1) mod n) +. 100.0 in
-          if Float.abs (got_own -. want_own) > 1e-4 then begin
+          if not (close_enough ~got:got_own ~want:want_own) then begin
             bad := true ;
             failf "@%d own slot .a: got %g want %g" i got_own want_own
           end ;
-          if Float.abs (got_nb -. want_nb) > 1e-4 then begin
+          if not (close_enough ~got:got_nb ~want:want_nb) then begin
             bad := true ;
             failf "@%d neighbour slot .b: got %g want %g" i got_nb want_nb
           end
@@ -295,7 +318,17 @@ let run_slot_case (dev : Device.t) =
   with
   | exception e ->
       let msg = Printexc.to_string e in
-      if expects_refusal dev then Printf.printf "refused (expected)\n%!"
+      if expects_refusal dev then
+        if ptx_refusal_is_named ~what:"shared" ~arr:"s" msg then
+          Printf.printf "refused, named (expected)\n%!"
+        else begin
+          Printf.printf "refused\n%!" ;
+          failf
+            "CUDA/PTX refused the slot-store shape, as expected, but the \
+             message does not name the shared array and its record type. Got: \
+             %s"
+            msg
+        end
       else begin
         Printf.printf "RAISED\n%!" ;
         failf "%s raised: %s" dev.Device.framework msg
@@ -311,7 +344,7 @@ let run_slot_case (dev : Device.t) =
         for i = 0 to n - 1 do
           let got = Vector.get out i in
           let want = float_of_int ((i + 1) mod n) in
-          if Float.abs (got -. want) > 1e-4 then begin
+          if not (close_enough ~got ~want) then begin
             bad := true ;
             failf "@%d neighbour slot .a: got %g want %g" i got want
           end
@@ -343,7 +376,19 @@ let run_local_case (dev : Device.t) =
   with
   | exception e ->
       let msg = Printexc.to_string e in
-      if expects_refusal dev then Printf.printf "refused (expected)\n%!"
+      if expects_refusal dev then
+        (* "local", not "shared": the local declaration site passes its own
+           state-space word, and a predicate that asked for "shared" here would
+           be a check that can never pass on a correct refusal. *)
+        if ptx_refusal_is_named ~what:"local" ~arr:"arr" msg then
+          Printf.printf "refused, named (expected)\n%!"
+        else begin
+          Printf.printf "refused\n%!" ;
+          failf
+            "CUDA/PTX refused the local array, as expected, but the message \
+             does not name the local array and its record type. Got: %s"
+            msg
+        end
       else begin
         Printf.printf "RAISED\n%!" ;
         failf "%s raised: %s" dev.Device.framework msg
@@ -359,11 +404,11 @@ let run_local_case (dev : Device.t) =
         for i = 0 to n - 1 do
           let g0 = Vector.get out0 i and g1 = Vector.get out1 i in
           let w0 = float_of_int i and w1 = float_of_int i +. 10.0 in
-          if Float.abs (g0 -. w0) > 1e-4 then begin
+          if not (close_enough ~got:g0 ~want:w0) then begin
             bad := true ;
             failf "@%d local slot 0 .a: got %g want %g" i g0 w0
           end ;
-          if Float.abs (g1 -. w1) > 1e-4 then begin
+          if not (close_enough ~got:g1 ~want:w1) then begin
             bad := true ;
             failf "@%d local slot 1 .a: got %g want %g" i g1 w1
           end

--- a/sarek/tests/unit/dune
+++ b/sarek/tests/unit/dune
@@ -106,6 +106,14 @@
  (modules test_interp_field_store_resolution)
  (libraries sarek.interp sarek_ir alcotest))
 
+; backlog-206: the interpreter's kernel-array allocator, with no device and no
+; PPX. The e2e evidence enumerates devices; this holds on a CI host too.
+
+(test
+ (name test_interp_shared_array_slots)
+ (modules test_interp_shared_array_slots)
+ (libraries sarek.interp sarek_ir alcotest))
+
 ; Fusion tests use sarek library directly (no ppx needed).
 ;
 ; sarek.codegen and str are for the backlog-153 cases: the defect there was

--- a/sarek/tests/unit/test_cpu_runtime.ml
+++ b/sarek/tests/unit/test_cpu_runtime.ml
@@ -320,7 +320,7 @@ let other_record_key : other_record Sarek_ir_types.Type_id.t =
 
 let test_alloc_shared_custom () =
   let shared = create_shared () in
-  let default = {x = 0; y = 0.0} in
+  let default () = {x = 0; y = 0.0} in
   let arr = alloc_shared_with_key shared custom_record_key "custom" 4 default in
   check int "array length" 4 (Array.length arr) ;
   check int "default x" 0 arr.(0).x ;
@@ -330,7 +330,7 @@ let test_alloc_shared_custom () =
 
 let test_alloc_shared_custom_reuse () =
   let shared = create_shared () in
-  let default = {x = 0; y = 0.0} in
+  let default () = {x = 0; y = 0.0} in
   let arr1 =
     alloc_shared_with_key shared custom_record_key "custom" 4 default
   in
@@ -344,13 +344,60 @@ let test_alloc_shared_custom_reuse () =
 let test_alloc_shared_custom_type_mismatch () =
   let shared = create_shared () in
   let _ =
-    alloc_shared_with_key shared custom_record_key "custom" 4 {x = 0; y = 0.0}
+    alloc_shared_with_key shared custom_record_key "custom" 4 (fun () ->
+        {x = 0; y = 0.0})
   in
   check_raises
     "same shared name with different custom type"
     (Invalid_argument "alloc_shared: type mismatch for custom")
     (fun () ->
-      ignore (alloc_shared_with_key shared other_record_key "custom" 4 {z = 0l}))
+      ignore
+        (alloc_shared_with_key shared other_record_key "custom" 4 (fun () ->
+             {z = 0l})))
+
+(* backlog-206: the slots of a shared array of a BOXED element type must be
+   independent allocations.
+
+   [alloc_shared_with_key] used to take a VALUE and call [Array.make size v],
+   which stores the same allocation in every slot — so a store through one index
+   was visible through all of them, which is what [let%shared (s : tri) = 4l]
+   followed by [s.(0).a <- 7.0] did on Native (read back 7 7 7 7, want 7 0 0 0).
+
+   The record below is MUTABLE on purpose. The aliasing is only observable
+   through an in-place field store; a whole-slot replacement ([arr.(i) <- r])
+   writes a new pointer into that slot and looks correct either way, which is
+   exactly why [test_alloc_shared_custom] above — which does only that — passed
+   throughout the defect and cannot be the check.
+
+   Physical inequality of the slots is asserted TOO, and separately: it is the
+   direct statement of the property, where the value check is the consequence
+   users see. Either alone would pass under a plausible wrong fix — a deep-copy
+   on read would give distinct values with shared slots, and distinct slots
+   holding a shared sub-record would give [!=] with aliased writes. *)
+type mutable_record = {mutable mx : int} [@@warning "-69"]
+
+let mutable_record_key : mutable_record Sarek_ir_types.Type_id.t =
+  Sarek_ir_types.Type_id.create ()
+
+let test_alloc_shared_custom_slots_are_independent () =
+  let shared = create_shared () in
+  let arr =
+    alloc_shared_with_key shared mutable_record_key "slots" 4 (fun () ->
+        {mx = 0})
+  in
+  check int "array length" 4 (Array.length arr) ;
+  arr.(0).mx <- 7 ;
+  check int "slot 0 written" 7 arr.(0).mx ;
+  check int "slot 1 untouched" 0 arr.(1).mx ;
+  check int "slot 2 untouched" 0 arr.(2).mx ;
+  check int "slot 3 untouched" 0 arr.(3).mx ;
+  for i = 1 to 3 do
+    check
+      bool
+      (Printf.sprintf "slot 0 and slot %d are distinct allocations" i)
+      true
+      (arr.(0) != arr.(i))
+  done
 
 (** Test shared memory isolation between blocks *)
 let test_shared_memory_isolation () =
@@ -608,6 +655,9 @@ let shared_memory_tests =
     ("custom type", `Quick, test_alloc_shared_custom);
     ("custom reuse", `Quick, test_alloc_shared_custom_reuse);
     ("custom mismatch", `Quick, test_alloc_shared_custom_type_mismatch);
+    ( "custom slots are independent",
+      `Quick,
+      test_alloc_shared_custom_slots_are_independent );
     ("isolation", `Quick, test_shared_memory_isolation);
   ]
 

--- a/sarek/tests/unit/test_interp_shared_array_slots.ml
+++ b/sarek/tests/unit/test_interp_shared_array_slots.ml
@@ -1,0 +1,129 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** backlog-206, Interpreter half, WITHOUT a device.
+
+    The end-to-end evidence for this fix lives in
+    [sarek/tests/e2e/test_shared_record_slots.ml], which enumerates devices — so
+    on CI, which has no GPU, it exercises the Interpreter and Native only, and
+    on a host where the CPU plugins somehow did not register it would assert
+    nothing at all. This file checks the interpreter's array allocator directly:
+    it needs no device, no PPX and no kernel, so it holds wherever the test
+    suite runs.
+
+    Two properties, and they are not the same property.
+
+    1. A record element type produces a [VRecord] with zeroed fields. Before the
+    fix it produced [VUnit], which is why [s.(i).a <- e] raised "Expected
+    record, got: assignment target of .a (got unit)" on the Interpreter while
+    Native accepted the same store.
+
+    2. The slots are DISTINCT allocations. [VRecord] carries a MUTABLE
+    [value array], so [Array.make size (default_value ...)] would put one array
+    in every slot and a field store through one index would be visible through
+    all of them — exactly the Native defect, reproduced in the interpreter. Only
+    [Array.init] avoids it, and only a mutation-then-read check can tell the two
+    apart: both spellings give a structurally equal array. *)
+
+open Alcotest
+open Sarek_ir_types
+open Sarek_interp.Sarek_ir_interp_value
+
+let tri : elttype =
+  TRecord ("tri", [("a", TFloat32); ("b", TFloat32); ("c", TInt32)])
+
+let field_f32 v i =
+  match v with
+  | VRecord (_, fields) -> (
+      match fields.(i) with
+      | VFloat32 f -> f
+      | _ -> failf "field %d is not a VFloat32" i)
+  | _ -> failf "not a VRecord"
+
+let test_default_record_is_zeroed () =
+  match default_value_of_elttype tri with
+  | VRecord (name, fields) -> (
+      check string "record name" "tri" name ;
+      check int "field count" 3 (Array.length fields) ;
+      check (float 0.0) "a" 0.0 (field_f32 (VRecord (name, fields)) 0) ;
+      check (float 0.0) "b" 0.0 (field_f32 (VRecord (name, fields)) 1) ;
+      match fields.(2) with
+      | VInt32 n -> check int32 "c" 0l n
+      | _ -> fail "field c is not a VInt32")
+  | v ->
+      failf
+        "a record element type must produce a VRecord, got %s"
+        (match v with
+        | VUnit -> "VUnit (the pre-fix behaviour)"
+        | _ -> "some other value")
+
+let test_default_variant_is_first_constructor () =
+  match
+    default_value_of_elttype (TVariant ("choice", [("Zero", []); ("One", [])]))
+  with
+  | VVariant (name, tag, args) ->
+      check string "variant name" "choice" name ;
+      check int "tag" 0 tag ;
+      check int "no payload" 0 (List.length args)
+  | _ -> fail "a variant element type must produce a VVariant"
+
+(* THE property. Mutate slot 0 in place and require the other slots to be
+   unchanged AND physically distinct. The value check is what a user sees; the
+   [!=] check is the direct statement, and each would pass under a different
+   plausible wrong fix, so both are asserted. *)
+let test_slots_are_independent () =
+  let arr = alloc_kernel_array tri 4 in
+  check int "length" 4 (Array.length arr) ;
+  (match arr.(0) with
+  | VRecord (_, fields) -> fields.(0) <- VFloat32 7.0
+  | _ -> fail "slot 0 is not a VRecord") ;
+  check (float 0.0) "slot 0 was written" 7.0 (field_f32 arr.(0) 0) ;
+  for i = 1 to 3 do
+    check
+      (float 0.0)
+      (Printf.sprintf "slot %d untouched" i)
+      0.0
+      (field_f32 arr.(i) 0) ;
+    check
+      bool
+      (Printf.sprintf "slot 0 and slot %d are distinct allocations" i)
+      true
+      (arr.(0) != arr.(i))
+  done
+
+let test_scalar_slots_still_zeroed () =
+  let arr = alloc_kernel_array TInt32 3 in
+  check int "length" 3 (Array.length arr) ;
+  Array.iteri
+    (fun i v ->
+      match v with
+      | VInt32 n -> check int32 (Printf.sprintf "slot %d" i) 0l n
+      | _ -> failf "slot %d is not a VInt32" i)
+    arr
+
+let () =
+  run
+    "interp shared array slots"
+    [
+      ( "backlog-206",
+        [
+          test_case
+            "record default is zeroed"
+            `Quick
+            test_default_record_is_zeroed;
+          test_case
+            "variant default is constructor 0"
+            `Quick
+            test_default_variant_is_first_constructor;
+          test_case
+            "slots are independent allocations"
+            `Quick
+            test_slots_are_independent;
+          test_case
+            "scalar slots still zeroed"
+            `Quick
+            test_scalar_slots_still_zeroed;
+        ] );
+    ]

--- a/sarek/tests/unit/test_interp_shared_array_slots.ml
+++ b/sarek/tests/unit/test_interp_shared_array_slots.ml
@@ -13,7 +13,7 @@
     it needs no device, no PPX and no kernel, so it holds wherever the test
     suite runs.
 
-    Two properties, and they are not the same property.
+    Three properties, and they are not the same property.
 
     1. A record element type produces a [VRecord] with zeroed fields. Before the
     fix it produced [VUnit], which is why [s.(i).a <- e] raised "Expected
@@ -25,7 +25,14 @@
     in every slot and a field store through one index would be visible through
     all of them — exactly the Native defect, reproduced in the interpreter. Only
     [Array.init] avoids it, and only a mutation-then-read check can tell the two
-    apart: both spellings give a structurally equal array. *)
+    apart: both spellings give a structurally equal array.
+
+    3. A VARIANT element type produces a value the interpreter's own matcher can
+    select an arm for, carrying the same constructor Native puts there. The tag
+    is [Hashtbl.hash ctor mod 256], not a positional index, and the first
+    version of the fix stored a literal [0] — structurally a fine [VVariant],
+    and unmatchable. Pinned against [variant_tag_of_ctor] rather than a
+    hard-coded number. *)
 
 open Alcotest
 open Sarek_ir_types
@@ -59,14 +66,62 @@ let test_default_record_is_zeroed () =
         | VUnit -> "VUnit (the pre-fix behaviour)"
         | _ -> "some other value")
 
-let test_default_variant_is_first_constructor () =
+(* The tag a default variant slot carries must be the tag the interpreter's own
+   matcher looks for, NOT a positional index. [EMatch]/[SMatch] select an arm
+   with [variant_tag_of_ctor name = tag]; the first version of this default
+   stored a literal [0], which matches the chosen constructor only if its name
+   happens to hash to zero, so reading a default slot raised "Pattern match
+   failure in SMatch" (measured: Interpreter x2 raised where Native answered the
+   nullary constructor). Asserted as the MATCHER'S PREDICATE rather than as a
+   hard-coded number, so the two cannot drift apart. *)
+let test_default_variant_is_matchable () =
   match
     default_value_of_elttype (TVariant ("choice", [("Zero", []); ("One", [])]))
   with
   | VVariant (name, tag, args) ->
       check string "variant name" "choice" name ;
-      check int "tag" 0 tag ;
+      check
+        bool
+        "the matcher selects the chosen constructor's arm"
+        true
+        (variant_tag_of_ctor "Zero" = tag) ;
+      check
+        bool
+        "and does NOT select the other constructor's arm"
+        false
+        (variant_tag_of_ctor "One" = tag) ;
       check int "no payload" 0 (List.length args)
+  | _ -> fail "a variant element type must produce a VVariant"
+
+(* Which constructor: the first NULLARY one, matching what the Native backend's
+   [Sarek_native_helpers.default_value_for_type] puts in the same slot. A
+   CPU-backend disagreement about a freshly declared shared array is the shape
+   of divergence backlog-206 was filed as, so the agreement is pinned. *)
+let test_default_variant_prefers_nullary () =
+  match
+    default_value_of_elttype (TVariant ("c2", [("A", [TFloat32]); ("B", [])]))
+  with
+  | VVariant (_, tag, args) ->
+      check
+        bool
+        "B, the nullary constructor, not A which comes first"
+        true
+        (variant_tag_of_ctor "B" = tag) ;
+      check int "no payload" 0 (List.length args)
+  | _ -> fail "a variant element type must produce a VVariant"
+
+(* No nullary constructor anywhere: fall back to the first one, payload zeroed.
+   Native does the same. *)
+let test_default_variant_without_nullary () =
+  match
+    default_value_of_elttype
+      (TVariant ("pair", [("L", [TInt32]); ("R", [TFloat32])]))
+  with
+  | VVariant (_, tag, args) -> (
+      check bool "L, the first constructor" true (variant_tag_of_ctor "L" = tag) ;
+      match args with
+      | [VInt32 n] -> check int32 "payload zeroed" 0l n
+      | _ -> fail "payload is not a single zeroed VInt32")
   | _ -> fail "a variant element type must produce a VVariant"
 
 (* THE property. Mutate slot 0 in place and require the other slots to be
@@ -114,9 +169,17 @@ let () =
             `Quick
             test_default_record_is_zeroed;
           test_case
-            "variant default is constructor 0"
+            "variant default is matchable by the interpreter"
             `Quick
-            test_default_variant_is_first_constructor;
+            test_default_variant_is_matchable;
+          test_case
+            "variant default prefers the nullary constructor"
+            `Quick
+            test_default_variant_prefers_nullary;
+          test_case
+            "variant default without a nullary constructor"
+            `Quick
+            test_default_variant_without_nullary;
           test_case
             "slots are independent allocations"
             `Quick

--- a/sarek/tests/unit/test_interp_shared_array_slots.ml
+++ b/sarek/tests/unit/test_interp_shared_array_slots.ml
@@ -32,7 +32,7 @@
     is [Hashtbl.hash ctor mod 256], not a positional index, and the first
     version of the fix stored a literal [0] — structurally a fine [VVariant],
     and unmatchable. Pinned against [variant_tag_of_ctor] rather than a
-    hard-coded number. *)
+    hard-coded number, with the limits of that stated at the case itself. *)
 
 open Alcotest
 open Sarek_ir_types
@@ -72,8 +72,19 @@ let test_default_record_is_zeroed () =
    stored a literal [0], which matches the chosen constructor only if its name
    happens to hash to zero, so reading a default slot raised "Pattern match
    failure in SMatch" (measured: Interpreter x2 raised where Native answered the
-   nullary constructor). Asserted as the MATCHER'S PREDICATE rather than as a
-   hard-coded number, so the two cannot drift apart. *)
+   nullary constructor).
+
+   WHAT THIS DOES AND DOES NOT PIN. It asserts the tag through
+   [variant_tag_of_ctor] rather than a hard-coded number, and it asserts the
+   NEGATIVE side too — the tag must not also select the other constructor's arm,
+   which a literal 0 or a constant function would satisfy. It does NOT execute
+   [EMatch]/[SMatch]: no kernel runs here, by design (this file exists to hold
+   on a host with no device and no PPX). The arms and this value are kept in
+   step by CONSTRUCTION instead — both call [variant_tag_of_ctor] — so a matcher
+   that stopped calling it would leave this green. The executed evidence is a
+   whole-kernel read of an unwritten shared slot on the Interpreter and Native,
+   which is not committed because it reads storage this project treats as
+   undefined on a device. *)
 let test_default_variant_is_matchable () =
   match
     default_value_of_elttype (TVariant ("choice", [("Zero", []); ("One", [])]))
@@ -93,10 +104,12 @@ let test_default_variant_is_matchable () =
       check int "no payload" 0 (List.length args)
   | _ -> fail "a variant element type must produce a VVariant"
 
-(* Which constructor: the first NULLARY one, matching what the Native backend's
-   [Sarek_native_helpers.default_value_for_type] puts in the same slot. A
-   CPU-backend disagreement about a freshly declared shared array is the shape
-   of divergence backlog-206 was filed as, so the agreement is pinned. *)
+(* Which constructor: the first NULLARY one, which is also what the Native
+   backend's [Sarek_native_helpers.default_value_for_type] picks. Only the
+   INTERPRETER side is pinned here — Native's choice is a PPX-time expression
+   with no unit test that inspects it, so the agreement is read off the two
+   implementations and measured end-to-end once, not gated. If Native's
+   preference changes, this test stays green. *)
 let test_default_variant_prefers_nullary () =
   match
     default_value_of_elttype (TVariant ("c2", [("A", [TFloat32]); ("B", [])]))
@@ -111,7 +124,10 @@ let test_default_variant_prefers_nullary () =
   | _ -> fail "a variant element type must produce a VVariant"
 
 (* No nullary constructor anywhere: fall back to the first one, payload zeroed.
-   Native does the same. *)
+   NOT "Native does the same" — Native recurses on the argument type and has no
+   arm for a tuple, so a single multi-component constructor reaches
+   [failwith "Cannot create default value for this type"] there. This path is
+   the interpreter being strictly more defined, not the two agreeing. *)
 let test_default_variant_without_nullary () =
   match
     default_value_of_elttype


### PR DESCRIPTION
backlog-206. `let%shared (s : tri) = 4l` then `s.(i).a <- e`. The item filed it as a Native/Interpreter divergence. Measured on 9 devices before touching anything, it was four answers, none of them right, from three unrelated causes — and one of those causes is not a shared-memory bug at all.

## Measured before

4 threads, `if tid = 0l then s.(tid).a <- 7.0`, want `7 0 0 0`:

| Backend | Before |
|---|---|
| Interpreter ×2 | **raised** `Expected record, got: assignment target of .a (got unit)` |
| Native | `7 7 7 7` — accepted the store and wrote **every** slot |
| CUDA/PTX ×2 (ZLUDA) | **raised** `PTX codegen: unsupported construct: btype of custom type` — names no array, no type, no state space |
| OpenCL ×2 | device compiler: `error: unknown type name 'Test_shared_record_slots_tri'` |
| Vulkan ×2 | glslang: syntax error at the shared declaration |

## Make it work, not refuse it — and the evidence that decides it

The brief's fork was make-it-work versus a loud located refusal. The measurement that settles it is one the item does not mention: **the same kernel written with a whole-slot store (`s.(tid) <- {a = ...}`) compiled and ran correctly on 7 of the 9 devices throughout the defect.** A shared array of a record is a working, exercised feature; only the *field-store* shape was broken. A blanket refusal at the `let%shared` boundary would have deleted working functionality on seven devices — the narrowing correction overshooting, which is how this repo's dominant defect recurs.

That whole-slot result is also the tell for cause (3). The record literal is what registered the type; without it nothing did.

CUDA/PTX keeps its refusal, because that one is a real emitter constraint rather than unimplemented work: PTX has no struct type, and `Sarek_ir_ptx_mem.emit_agg_elem_addr` already refuses state-space aggregates on purpose ("aggregate elements are supported in global vectors only"). What changed there is that the message now names the array, the element type and the state space, and the test asserts the refusal on content instead of tolerating any exception.

## The three causes

**1. Native — the aliasing the item described.** `alloc_shared_with_key` filled the array with `Array.make size default`, so every slot of a boxed element type was the same allocation. It now takes a per-slot **thunk** and calls `Array.init`. A thunk rather than a value because nothing in the runtime can copy an `'a` — the PPX is the only place that knows how to build one, and passing a value puts the aliasing back whatever the allocator does with it. The identical `Array.make` sits one line away in the `create_array n Local` path and is fixed with it.

**2. Interpreter — no record to store into.** `EArrayCreate` / `DShared` mapped a record element type to `VUnit`. `Sarek_ir_interp_value.alloc_kernel_array` now builds a zeroed `VRecord` (or a constructor-0 `VVariant`) per slot. That replaces three identical copies of the old init table plus a fourth, narrower one on `Sarek_ir_interp`'s `DShared` path, which mapped only `TInt32`/`TFloat32`; unifying them also widens that path's `TInt64`/`TFloat64`/`TBool`/`TFloat16`/`TUint8` from `VUnit` to typed zeros. That is a fix, but it is outside this shape, so it is stated in CHANGES rather than folded into the word "copies".

**3. OpenCL and Vulkan — a type-collection gap, not a shared-memory gap.** `register_types_from_typ` ran over PARAMETER types only. In a kernel whose record appears nowhere but the shared declaration, nothing put it in `state.types`, so the emitted source said `__local Test_..._tri s[4];` with no such struct above it. The traversal is now top-level and runs at both kernel-array declaration sites.

Variants are deliberately **not** covered by (3), and the code says where the seam is: `TEConstr` registers the type, so the common shape works, but copying a variant in from a vector parameter registers nothing and would still fail on the struct-emitting backends. That shape was reasoned about, not executed, and it is left open rather than fixed blind — a `TVariant` arm also changes what is emitted for ordinary variant parameters, which nothing here measures.

## After — 27 device rows, plus 3 with no device at all

`sarek/tests/e2e/test_shared_record_slots.ml`, 9 devices × 3 shapes (field store, whole-slot store, `create_array n Local`), exit 0:

```
deviceless: kern_types = [Test_shared_record_slots.tri]
deviceless: PTX refused, named
deviceless: OK (no device needed for any of the above)
shared-record field-store [Interpreter] ×2: OK
shared-record field-store [Native]: OK
shared-record field-store [CUDA/PTX] ×2 (ZLUDA): refused, named (expected)
shared-record field-store [OpenCL] ×2: OK
shared-record field-store [Vulkan] ×2: OK
... slot-store ×9, local-array ×9 ...
9 device(s) exercised (frameworks: CUDA/PTX, Interpreter, Native, OpenCL, Vulkan)
```

**A slot is never read unless something wrote it.** An earlier draft asserted `0` for the untouched slots and read back `[7; 0.973611; 1210; 1]` on an RX 7900 XTX under OpenCL — correct hardware behaviour failing a wrong assertion. `__local`/`shared`/`threadgroup` memory is uninitialised on every device. The CPU backends do zero their slots; that is an implementation detail and is deliberately not asserted.

**CI has no GPU, so the two backend-only halves are also checked with no device**, first thing, on the same kernel the device loop runs: `kern_types` contains the record type, the OpenCL and GLSL text introduce the struct above the line that declares the array, and the PTX generator raises a message naming the array and the type. Without this, reverting either half left CI green.

## Prove-red — 10 mutations, each asserted to have landed

Committed first, then mutated; `git diff --numstat` checked non-empty every time (one restore silently reverted uncommitted work, which is why the counts are checked rather than assumed). Each mutation keeps the function and breaks the wiring or one arm, so nothing reads red because it failed to link.

| # | Mutation | Went red as |
|---|---|---|
| 1 | `Array.init` → `Array.make` in `alloc_shared_with_key` | `test_cpu_runtime` exit 1, `FAIL slot 1 untouched: Expected 0, Received 7`; e2e Native `@0 own slot .a: got 3 want 0` (all four outputs equal) |
| 2 | `Array.init` → `Array.make` in `alloc_kernel_array` | interp unit exit 1, `slots are independent allocations`; e2e Interpreter ×2 `got 3 want 0` |
| 3 | record default back to `VUnit` | `a record element type must produce a VRecord, got VUnit (the pre-fix behaviour)`; e2e `Expected record, got: assignment target of .a (got unit)` |
| 4 | unwire `register_types_from_typ` at the `let%shared` site | OpenCL ×2 + Vulkan ×2 `unknown type name 'Test_shared_record_slots_tri'` |
| 5 | unwire the PTX named refusal | `refused, but the message does not name the shared array and its record type. Got: ... btype of custom type` |
| 6 | `Array.init` → `Array.make` in `create_array n Local` | Native `@0 local slot 0 .a: got 10 want 0` — slots 0 and 1 aliased |
| 7 | PTX local site passes `~what:"shared"` | `refused the local array ... does not name the local array and its record type` — proves the predicate distinguishes the two state spaces rather than accepting either |
| 8 | (4) again, **with no GPU on the path** | deviceless `kern_types = []` |
| 9 | (8) after fixing the ordering check | deviceless, 3 failures: `kern_types`, OpenCL and GLSL |
| 10 | (5) **with no GPU on the path** | deviceless `PTX refused but the message names neither the shared array nor its record type` |

Mutation 8 is why 9 exists. The first version of the source-ordering check **could not fail**: it compared the first occurrence of the type name against the offset of `s[4]`, and the declaration line is `__local Test_..._tri s[4];`, so the name is on that line whether or not a struct was ever defined. Measured — with the registration reverted the `kern_types` assertion went red and the ordering one stayed green on both dialects. The anchor is now the start of the declaration line.

## Two review passes, 15 findings, all this repo's dominant class

A cross-runtime pass (codex) and an unscoped fresh read. Every finding was a claim wider than its code; the fixes are commits 3 and 4. The substantive ones:

- The tolerance comparisons **accepted NaN** — `Float.abs (got -. want) > 1e-4` is false for NaN, and NaN is exactly what a read of uninitialised device memory returns, which is the failure mode this file exists to catch. One `close_enough` with an `is_finite` guard now carries all five sites.
- The local-array and slot-store cases **accepted any CUDA/PTX exception**, so the named refusal could regress to the old anonymous one and stay green.
- The header said a Metal/HIP/WGSL failure "is not tolerated". It cannot be: this file initialises five plugins and WGSL is not on the `Device.init` list, so no such device can enumerate here on any host.
- `expects_refusal` was described as "asserted below" against a framework "starting with CUDA". Neither: the list prints, and the match is exact equality on `"CUDA/PTX"`.
- The `.mli` said the thunk runs "once per slot"; a cache hit returns the stored array and never runs it.
- The PTX message claimed the same kernel runs on four other backends, which is not guaranteed for the unregistered-variant shape above.
- `TUint8 -> VInt32 0l` is a guess, not a convention — `TUint8` occurs nowhere else in the interpreter — and the docstring's silence read as "nothing to say".
- CHANGES gave Vulkan OpenCL's error message, and two `kb/research` line references drifted when the allocator moved.

## Gates

Project switch `/home/mathias/dev/SPOC/_opam`, dune 3.24.1, OCaml 5.4.0, ppxlib 0.38.0. Exit codes captured directly, never a prose PASS.

| Gate | Exit |
|---|---|
| `dune build` | 0 |
| `dune runtest --force` | 0 |
| `dune build @fmt` | 0 |
| `make test_negative` | 0 |
| `scripts/prove-red.sh` | 0 |
| `scripts/check-kb-properties.sh` (+ `.test.sh`) | 0 / 0 |
| `scripts/check-ppx-construct-names.sh` (+ `.test.sh`) | 0 / 0 |
| `scripts/check-license-headers.sh` | 0 |
| `scripts/check-cited-paths-exist.sh` (+ `.test.sh`) | 0 / 0 |
| `scripts/check-negative-case-coverage.sh` | 0 |
| `scripts/check-opam-clean.sh` | **1** |

`check-opam-clean` is **pre-existing and unchanged by this branch**, verified rather than assumed: a detached worktree at `origin/main` (97a062a2) gives the identical **1** under the project switch (`FAIL: sarek.opam differs from the tracked version after 'make opam'`) and **2** under ambient dune 3.23.0, where the tree no longer builds at all (`Ptyp_open` / ppxlib 0.35 — the floor #398 raised). No `.opam` is committed here.

No new gate script, so no new `kb/properties.md` `gate-red-path` row is required.

## Not verified

- **Metal, HIP, WGSL, and NVIDIA hardware.** None exist on this host. WGSL is not even on this file's `Device.init` list and the Metal/HIP plugins are not initialised by it, so those legs cannot run here on any host — the header says so rather than promising non-tolerance. They get source-level coverage only: `Sarek_ir_metal` and `Sarek_ir_wgsl` were read, not executed.
- **The unregistered-variant shape** (`s.(tid) <- v.(tid)` from a variant-element vector parameter). Reasoned about from the code, not executed. Left open and documented at the seam.
- **opencode.** On this host it is on `PATH` but non-functional: the review invocation produced zero bytes in 25 minutes, and a 120-second smoke test with a one-line prompt also timed out with no output. The cross-runtime pass was codex only, plus an unscoped fresh read. Recorded as `GO codex,claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shared record-array allocation and initialization to prevent element aliasing across slots.
  * Improved field-store handling for record types in arrays.
  * Fixed vector record-field stores and record detachment issues.

* **New Features**
  * PTX backend now provides contextual error messages for unsupported aggregate shared-memory accesses, naming the memory space, array, and element type.

* **Tests**
  * Added comprehensive end-to-end tests for shared and local record arrays across backends.
  * Added unit tests validating shared array allocation and initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->