### PR TITLE
backlog-214: five emitters accepted an SoA request and answered with AoS source

### DIFF
--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -201,8 +201,13 @@ codegen-level `~soa_params` knob:
 > in exactly one place: the caller-side predicate. The five source-generating
 > backends without an SoA lowering (CUDA/C, HIP, OpenCL, Vulkan, Metal) bound
 > `?soa_params:_` away, so a caller that reached them with a non-empty list got
-> AoS source for an SoA argument list — silently wrong data, not a crash. They
-> now raise `Backend_error.reject_soa_params` instead. The `"CUDA/PTX"` gate is
+> AoS source for an SoA argument list — an ABI mismatch no compiler catches,
+> whose consequence is per backend: rejected at bind or launch on OpenCL
+> (`clSetKernelArg` / `CL_INVALID_ARG_INDEX`) and Vulkan
+> (`validate_buffer_indices`, count read from the GLSL `binding = N`
+> declarations), silently misinterpreted data on CUDA/C and HIP, which bind
+> positionally into an unchecked argument array. They now raise
+> `Backend_error.reject_soa_params` instead. The `"CUDA/PTX"` gate is
 > unchanged and is still the thing that keeps the refusal unreached; what
 > changed is that it is no longer the only thing. Extending SoA to a further
 > backend remains separate work (backlog-215): each such backend removes its own

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -205,8 +205,11 @@ codegen-level `~soa_params` knob:
 > whose consequence is per backend: rejected at bind or launch on OpenCL
 > (`clSetKernelArg` / `CL_INVALID_ARG_INDEX`) and Vulkan
 > (`validate_buffer_indices`, count read from the GLSL `binding = N`
-> declarations), silently misinterpreted data on CUDA/C and HIP, which bind
-> positionally into an unchecked argument array. They now raise
+> declarations); on CUDA/C, HIP and Metal, which all bind positionally with no
+> arity check against the compiled kernel, the shift can misinterpret data or
+> trap on an illegal address — `Backend_error.reject_soa_params` carries the
+> per-backend detail, and none of the three is described by "silently wrong
+> data" alone. They now raise
 > `Backend_error.reject_soa_params` instead. The `"CUDA/PTX"` gate is
 > unchanged and is still the thing that keeps the refusal unreached; what
 > changed is that it is no longer the only thing. Extending SoA to a further

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -205,11 +205,11 @@ codegen-level `~soa_params` knob:
 > whose consequence is per backend: rejected at bind or launch on OpenCL
 > (`clSetKernelArg` / `CL_INVALID_ARG_INDEX`) and Vulkan
 > (`validate_buffer_indices`, count read from the GLSL `binding = N`
-> declarations); on CUDA/C, HIP and Metal, which all bind positionally with no
-> arity check against the compiled kernel, the shift can misinterpret data or
-> trap on an illegal address — `Backend_error.reject_soa_params` carries the
-> per-backend detail, and none of the three is described by "silently wrong
-> data" alone. They now raise
+> declarations); on CUDA/C, HIP and Metal, which all bind positionally with
+> nothing comparing the expanded list against the compiled kernel, the shift goes
+> unchecked and every declared slot from the vector onward is fed a value of the
+> wrong kind — `Backend_error.reject_soa_params` carries the per-backend detail,
+> and none of the three is described by "silently wrong data" alone. They now raise
 > `Backend_error.reject_soa_params` instead. The `"CUDA/PTX"` gate is
 > unchanged and is still the thing that keeps the refusal unreached; what
 > changed is that it is no longer the only thing. Extending SoA to a further

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -197,6 +197,17 @@ codegen-level `~soa_params` knob:
   documented fallback that guarantees "never wrong data". `of_ctypes_ptr` /
   `sub_vector` stay AoS-only.
 
+> **Update (backlog-214).** The sentence above described a guarantee that lived
+> in exactly one place: the caller-side predicate. The five source-generating
+> backends without an SoA lowering (CUDA/C, HIP, OpenCL, Vulkan, Metal) bound
+> `?soa_params:_` away, so a caller that reached them with a non-empty list got
+> AoS source for an SoA argument list — silently wrong data, not a crash. They
+> now raise `Backend_error.reject_soa_params` instead. The `"CUDA/PTX"` gate is
+> unchanged and is still the thing that keeps the refusal unreached; what
+> changed is that it is no longer the only thing. Extending SoA to a further
+> backend remains separate work (backlog-215): each such backend removes its own
+> refusal when its emitter gains the lowering.
+
 This is pure plumbing (no new coalescing) — the roadmap (§1.2c/e) rates it the
 bulk of the SoA cost; it was descoped here so the emitter could ship complete
 and proven. When it lands, extend `test_soa_emitter_equiv` to drive SoA through

--- a/sarek-cuda/Cuda_c_plugin.ml
+++ b/sarek-cuda/Cuda_c_plugin.ml
@@ -33,8 +33,13 @@ module Backend : Framework_sig.BACKEND = struct
      node. That error is allowed to PROPAGATE so callers surface the name rather
      than the opaque "generate_source returned None" — catching it here and
      returning [None] hid it identically to the Vulkan swallow (PR #259). *)
-  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+  let generate_source ?block:_ ?(soa_params = []) (ir : Sarek_ir_types.kernel) :
       string option =
+    (* Refused rather than bound away: this emitter has no SoA lowering, and
+       [name] is passed so the message says CUDA/C — the sibling CUDA/PTX
+       backend does honour it, and [Cuda_error]'s own backend string is "CUDA"
+       for both, which would not distinguish them (backlog-214). *)
+    Sarek_backend_error.Backend_error.reject_soa_params ~backend:name soa_params ;
     Some (Sarek_ir_cuda.generate_with_types ~types:ir.kern_types ir)
 
   let execute_direct ~native_fn:_ ~ir:_ ~block:_ ~grid:_ _args =

--- a/sarek-cuda/test/dune
+++ b/sarek-cuda/test/dune
@@ -102,3 +102,22 @@
  (libraries sarek_cuda sarek.codegen spoc.ir alcotest str unix)
  (instrumentation
   (backend bisect_ppx)))
+
+; backlog-214 - the CUDA/C plugin refuses a non-empty ~soa_params instead of
+; answering an SoA argument list with AoS source. Pure codegen, no device.
+
+(test
+ (name test_cuda_c_soa_refusal)
+ (modules test_cuda_c_soa_refusal)
+ (libraries sarek_cuda sarek_ir sarek_backend_error alcotest)
+ (instrumentation
+  (backend bisect_ppx)))
+
+; backlog-214, other polarity - CUDA/PTX must NOT have acquired that refusal.
+
+(test
+ (name test_ptx_soa_not_refused)
+ (modules test_ptx_soa_not_refused)
+ (libraries sarek_cuda sarek_ir sarek.codegen sarek_backend_error alcotest)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/sarek-cuda/test/test_cuda_c_soa_refusal.ml
+++ b/sarek-cuda/test/test_cuda_c_soa_refusal.ml
@@ -11,15 +11,18 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. On this backend nothing checks the arity either: the argument
- * array reaches [cuLaunchKernel] positionally and unchecked, so at two or more
- * leaves the list is LONGER than the AoS signature and every parameter after
- * the vector shifts. The declared length slot then reads a pointer value and
- * the next declared POINTER parameter reads its 8 bytes out of the 4-byte
- * length cell - which can misinterpret data and can equally trap on an illegal
- * device address. Neither "a crash" nor "silently wrong data" describes it on
- * its own; see [Backend_error.reject_soa_params] and
- * [Execute.expand_to_run_source_args].
+ * compile error. Nothing then compares the list against the compiled kernel's
+ * signature: the array reaches [cuLaunchKernel] positionally, and
+ * [Execute.check_launch_args] checks arity against the CALLER's vector list
+ * before expansion, so it cannot see this. At two or more leaves the expanded
+ * list is LONGER than the AoS signature and every declared slot from the vector
+ * onward is fed a value of the wrong kind. WHICH wrong kind depends on the
+ * parameter list: a length slot reading a pointer yields a garbage length, and
+ * where a pointer parameter follows the vector it reads 8 bytes out of a 4-byte
+ * length cell. So the general claim is only that the mapping is wrong from the
+ * vector onward and that this can misinterpret data and can trap - neither "a
+ * crash" nor "silently wrong data" describes it on its own. See
+ * [Backend_error.reject_soa_params] and [Execute.expand_to_run_source_args].
  *
  * [Sarek_ir_cuda] has no SoA lowering to select, so it is refused. (A
  * single-leaf record would in fact bind correctly, N = 1 making the two

--- a/sarek-cuda/test/test_cuda_c_soa_refusal.ml
+++ b/sarek-cuda/test/test_cuda_c_soa_refusal.ml
@@ -11,16 +11,24 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. On this backend it is not reliably a crash either: the
- * argument array reaches [cuLaunchKernel] unchecked, so N pointers land in a
- * packed parameter block - silently wrong data.
+ * compile error. On this backend nothing checks the arity either: the argument
+ * array reaches [cuLaunchKernel] positionally and unchecked, so at two or more
+ * leaves the list is LONGER than the AoS signature and every parameter after
+ * the vector shifts. The declared length slot then reads a pointer value and
+ * the next declared POINTER parameter reads its 8 bytes out of the 4-byte
+ * length cell - which can misinterpret data and can equally trap on an illegal
+ * device address. Neither "a crash" nor "silently wrong data" describes it on
+ * its own; see [Backend_error.reject_soa_params] and
+ * [Execute.expand_to_run_source_args].
  *
  * [Sarek_ir_cuda] has no SoA lowering to select, so it is refused. (A
  * single-leaf record would in fact bind correctly, N = 1 making the two
  * argument lists the same shape - it is refused anyway, because that is a
  * coincidence of the leaf count and not a property of the emitter. See
- * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
- * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * [Backend_error.reject_soa_params].)
+ *
+ * Both polarities are pinned here, because the refusal has its own failure
+ * mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *

--- a/sarek-cuda/test/test_cuda_c_soa_refusal.ml
+++ b/sarek-cuda/test/test_cuda_c_soa_refusal.ml
@@ -10,14 +10,15 @@
  * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
- * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
- * compile error and not reliably a crash - it is N pointers bound to a packed
- * parameter block, i.e. silently wrong data.
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
+ * compile error. On this backend it is not reliably a crash either: the
+ * argument array reaches [cuLaunchKernel] unchecked, so N pointers land in a
+ * packed parameter block - silently wrong data.
  *
  * [Sarek_ir_cuda] has no SoA lowering, so the request cannot be honoured and is
  * refused. Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
- * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
@@ -68,13 +69,11 @@ let test_cuda_c_refuses_nonempty_soa_params () =
   match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
   | Some src ->
       Alcotest.failf
-        "expected a refusal; generate_source answered an SoA request with \
-         %d          bytes of AoS source"
+        "expected a refusal, got %d bytes of AoS source"
         (String.length src)
   | None ->
       Alcotest.fail
-        "expected a refusal; generate_source returned None (the request \
-         was          swallowed, not refused)"
+        "expected a refusal, got None (request swallowed, not refused)"
   | exception
       Backend_error.Backend_error
         (Backend_error.Plugin
@@ -124,9 +123,7 @@ let test_cuda_c_empty_soa_params_still_generates () =
         omitted
         explicit_empty
   | None, _ | _, None ->
-      Alcotest.fail
-        "generate_source returned None for an AoS kernel - the empty-list \
-         fast          path regressed"
+      Alcotest.fail "None for an AoS kernel: the empty-list fast path regressed"
 
 let () =
   Alcotest.run

--- a/sarek-cuda/test/test_cuda_c_soa_refusal.ml
+++ b/sarek-cuda/test/test_cuda_c_soa_refusal.ml
@@ -15,14 +15,19 @@
  * argument array reaches [cuLaunchKernel] unchecked, so N pointers land in a
  * packed parameter block - silently wrong data.
  *
- * [Sarek_ir_cuda] has no SoA lowering, so the request cannot be honoured and is
- * refused. Both polarities are pinned here, because the refusal has its own
+ * [Sarek_ir_cuda] has no SoA lowering to select, so it is refused. (A
+ * single-leaf record would in fact bind correctly, N = 1 making the two
+ * argument lists the same shape - it is refused anyway, because that is a
+ * coincidence of the leaf count and not a property of the emitter. See
+ * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
- *      parameter that was requested;
+ *      parameter that was requested - checked for a scalar-element vector AND
+ *      for a flat two-leaf record, the shape a real SoA launch names, so a
+ *      refusal conditional on eligibility could not pass for a refusal;
  *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
  *      byte-identical to each other.
  ******************************************************************************)
@@ -106,6 +111,53 @@ let test_cuda_c_refusal_renders_the_framework () =
         true
         (string_contains ~haystack:msg ~needle:"CUDA/C")
 
+(* The scalar-element probe above is a name the PTX emitter would itself reject
+   as SoA-ineligible, so on its own it cannot distinguish "refuses any non-empty
+   list" from "refuses only ineligible names while still ignoring the eligible
+   ones" - and the second is the pre-fix behaviour with a coat of paint. This
+   case is the shape a real SoA launch actually names: a flat two-leaf record,
+   which [Soa.plan] accepts and the PTX emitter does lower. It must be refused
+   here too, and by the SoA refusal rather than by anything the emitter has to
+   say about record vectors. *)
+let test_cuda_c_refuses_a_record_vector () =
+  let pt = TRecord ("pt2", [("x", TFloat32); ("y", TFloat32)]) in
+  let pts = make_var "pts" (TVec pt) in
+  let out = make_var "out" (TVec TFloat32) in
+  let k =
+    {
+      default_kernel with
+      kern_name = "soa_refusal_record_probe";
+      kern_params =
+        [
+          DParam (pts, Some {arr_elttype = pt; arr_memspace = Global});
+          DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_body =
+        SAssign
+          ( LArrayElem ("out", EConst (CInt32 0l)),
+            ERecordField (EArrayRead ("pts", EConst (CInt32 0l)), "x") );
+    }
+  in
+  match Backend.generate_source ~soa_params:["pts"] k with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal for a record vector, got %d bytes of AoS source"
+        (String.length src)
+  | None -> Alcotest.fail "expected a refusal for a record vector, got None"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {backend; error = Backend_error.Feature_not_supported {feature; _}})
+    ->
+      Alcotest.(check string)
+        "the refusal names this framework"
+        "CUDA/C"
+        backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'pts'")
+
 (* --- polarity 2: the empty list is the untouched fast path --- *)
 
 let test_cuda_c_empty_soa_params_still_generates () =
@@ -139,6 +191,10 @@ let () =
             "rendered refusal names the framework"
             `Quick
             test_cuda_c_refusal_renders_the_framework;
+          Alcotest.test_case
+            "a record vector - the realistic shape - is refused too"
+            `Quick
+            test_cuda_c_refuses_a_record_vector;
           Alcotest.test_case
             "empty list still generates AoS source"
             `Quick

--- a/sarek-cuda/test/test_cuda_c_soa_refusal.ml
+++ b/sarek-cuda/test/test_cuda_c_soa_refusal.ml
@@ -11,18 +11,20 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. Nothing then compares the list against the compiled kernel's
- * signature: the array reaches [cuLaunchKernel] positionally, and
- * [Execute.check_launch_args] checks arity against the CALLER's vector list
- * before expansion, so it cannot see this. At two or more leaves the expanded
- * list is LONGER than the AoS signature and every declared slot from the vector
- * onward is fed a value of the wrong kind. WHICH wrong kind depends on the
- * parameter list: a length slot reading a pointer yields a garbage length, and
- * where a pointer parameter follows the vector it reads 8 bytes out of a 4-byte
- * length cell. So the general claim is only that the mapping is wrong from the
- * vector onward and that this can misinterpret data and can trap - neither "a
- * crash" nor "silently wrong data" describes it on its own. See
- * [Backend_error.reject_soa_params] and [Execute.expand_to_run_source_args].
+ * compile error. The general consequence, and the only part that holds for
+ * every kernel shape, is that every parameter declared AFTER the vector
+ * receives the wrong entry. Nothing here catches that: [cuLaunchKernel] takes
+ * the array positionally, and [Execute.check_launch_args] checks arity against
+ * the CALLER's vector list before expansion, so it cannot see it. What the
+ * shift MEANS is a property of the parameter list and not of SoA - at N = 2
+ * with a pointer parameter following the vector (this file's probe shape) a
+ * length slot receives a pointer and the pointer slot reads 8 bytes out of a
+ * 4-byte cell; at N = 3 the third leaf lands in that pointer slot instead, a
+ * VALID pointer to the wrong buffer with nothing to trap on; with the vector
+ * declared last, nothing after it shifts into a pointer slot at all. Because
+ * this backend passes a bare pointer array, a caller-supplied value can reach
+ * the device as an address, so a trap is among the outcomes - but only among
+ * them. See [Backend_error.reject_soa_params] for the full enumeration.
  *
  * [Sarek_ir_cuda] has no SoA lowering to select, so it is refused. (A
  * single-leaf record would in fact bind correctly, N = 1 making the two

--- a/sarek-cuda/test/test_cuda_c_soa_refusal.ml
+++ b/sarek-cuda/test/test_cuda_c_soa_refusal.ml
@@ -1,0 +1,150 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-214 - the CUDA/C backend REFUSES a non-empty [~soa_params].
+ *
+ * [Framework_sig.generate_source] offers [?soa_params] to every backend. This
+ * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
+ * source: one pointer plus one length per vector parameter. The launch side
+ * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
+ * compile error and not reliably a crash - it is N pointers bound to a packed
+ * parameter block, i.e. silently wrong data.
+ *
+ * [Sarek_ir_cuda] has no SoA lowering, so the request cannot be honoured and is
+ * refused. Both polarities are pinned here, because the refusal has its own
+ * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * single launch:
+ *
+ *   1. a non-empty list raises, and the message names this framework and the
+ *      parameter that was requested;
+ *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
+ *      byte-identical to each other.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend = Sarek_cuda.Cuda_c_plugin.Backend
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* Minimal kernel: c.[0] <- a.[0]. No intrinsic, so codegen is not what decides
+   the outcome of either case below. *)
+let probe_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  {
+    default_kernel with
+    kern_name = "soa_refusal_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_body =
+      SAssign
+        ( LArrayElem ("c", EConst (CInt32 0l)),
+          EArrayRead ("a", EConst (CInt32 0l)) );
+  }
+
+(* Dependency-light substring check (mirror of the codegen_golden helper). *)
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+(* --- polarity 1: a non-empty list is refused, by name --- *)
+
+let test_cuda_c_refuses_nonempty_soa_params () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal; generate_source answered an SoA request with \
+         %d          bytes of AoS source"
+        (String.length src)
+  | None ->
+      Alcotest.fail
+        "expected a refusal; generate_source returned None (the request \
+         was          swallowed, not refused)"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {
+             backend;
+             error = Backend_error.Feature_not_supported {feature; backend = _};
+           }) ->
+      Alcotest.(check string)
+        "the refusal names this framework"
+        "CUDA/C"
+        backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'a'") ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S says what was refused" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"Structure-of-Arrays")
+
+(* The rendered message is what a user sees, and the framework name reaches it
+   only through the [backend] field checked above - so render it and look. *)
+let test_cuda_c_refusal_renders_the_framework () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | _ -> Alcotest.fail "expected a refusal, generate_source did not raise"
+  | exception Backend_error.Backend_error err ->
+      let msg = Backend_error.to_string err in
+      Alcotest.(check bool)
+        (Printf.sprintf "rendered message %S names CUDA/C" msg)
+        true
+        (string_contains ~haystack:msg ~needle:"CUDA/C")
+
+(* --- polarity 2: the empty list is the untouched fast path --- *)
+
+let test_cuda_c_empty_soa_params_still_generates () =
+  let k = probe_kernel () in
+  match
+    (Backend.generate_source k, Backend.generate_source ~soa_params:[] k)
+  with
+  | Some omitted, Some explicit_empty ->
+      Alcotest.(check bool)
+        "AoS source is non-empty"
+        true
+        (String.length omitted > 0) ;
+      Alcotest.(check string)
+        "~soa_params:[] is byte-identical to omitting the argument"
+        omitted
+        explicit_empty
+  | None, _ | _, None ->
+      Alcotest.fail
+        "generate_source returned None for an AoS kernel - the empty-list \
+         fast          path regressed"
+
+let () =
+  Alcotest.run
+    "CUDA/C SoA refusal (backlog-214)"
+    [
+      ( "soa_params",
+        [
+          Alcotest.test_case
+            "non-empty list is refused, naming framework and parameter"
+            `Quick
+            test_cuda_c_refuses_nonempty_soa_params;
+          Alcotest.test_case
+            "rendered refusal names the framework"
+            `Quick
+            test_cuda_c_refusal_renders_the_framework;
+          Alcotest.test_case
+            "empty list still generates AoS source"
+            `Quick
+            test_cuda_c_empty_soa_params_still_generates;
+        ] );
+    ]

--- a/sarek-cuda/test/test_ptx_soa_not_refused.ml
+++ b/sarek-cuda/test/test_ptx_soa_not_refused.ml
@@ -103,7 +103,7 @@ let must_contain ptx needle =
     true
     (string_contains ~haystack:ptx ~needle)
 
-(* --- 1. direct: a record vector named in ~soa_params yields the SoA block --- *)
+(* --- 1. direct: a record vector in ~soa_params yields the SoA block --- *)
 
 let test_ptx_record_soa_params_lowers_to_leaves () =
   match

--- a/sarek-cuda/test/test_ptx_soa_not_refused.ml
+++ b/sarek-cuda/test/test_ptx_soa_not_refused.ml
@@ -13,17 +13,29 @@
  * added there would delete working functionality, which is the overshoot a
  * narrowing correction invites.
  *
- * The check has to be indirect. Naming a SCALAR-element vector in
- * [~soa_params] is rejected by the PTX emitter itself (SoA v1 is flat records
- * only), so this kernel does raise - but it must raise
- * [Ptx_codegen_error], the emitter's OWN rejection, which is only reachable if
- * the plugin threaded [~soa_params] into codegen. If the plugin had grown the
- * backlog-214 refusal, the exception would be [Backend_error] and codegen
- * would never have been entered. Distinguishing those two exceptions is
- * therefore exactly the question "did the refusal land here too".
+ * Checked two ways, positively first, because a purely negative "did not
+ * raise the wrong exception" is satisfied by a plugin that does nothing at all:
  *
- * The record-typed SoA path itself is covered, positively and by execution, in
- * sarek/tests/unit/test_ptx_snapshot.ml; this file is not that test.
+ *   1. DIRECT. A record-typed ([point3d]) vector named in [~soa_params] must
+ *      come back as PTX carrying the SoA parameter block - three per-leaf base
+ *      pointers plus one shared length - and NOT the single packed AoS pointer.
+ *      No plugin-level refusal can satisfy that assertion.
+ *   2. INDIRECT, kept as a second belt. Naming a SCALAR-element vector is
+ *      rejected by the PTX emitter itself (SoA v1 is flat records only), so
+ *      that call does raise - but it must raise [Ptx_codegen_error], the
+ *      emitter's OWN rejection, reachable only if the plugin threaded
+ *      [~soa_params] into codegen. Had the plugin grown the backlog-214
+ *      refusal, the exception would be [Backend_error] and codegen would never
+ *      have been entered.
+ *
+ * Case 2's hook is the flat-records-only restriction, which is scheduled to be
+ * lifted; case 1 is why that does not leave this file's subject uncovered.
+ *
+ * The SoA lowering itself is covered far more thoroughly elsewhere, and this
+ * file is not that test: at PTX-text and ptxas-assembly level in
+ * sarek/tests/unit/test_ptx_snapshot.ml (declared CPU-only, no device, and the
+ * ptxas half skips when ptxas is off PATH), and by execution on a CUDA/PTX
+ * device in sarek/tests/e2e/test_soa_emitter_equiv.ml.
  ******************************************************************************)
 
 open Sarek_ir_types
@@ -49,6 +61,71 @@ let probe_kernel () =
         ( LArrayElem ("c", EConst (CInt32 0l)),
           EArrayRead ("a", EConst (CInt32 0l)) );
   }
+
+(* A flat record vector - the shape a real SoA launch actually names. *)
+let point3d_ty =
+  TRecord ("point3d", [("x", TFloat32); ("y", TFloat32); ("z", TFloat32)])
+
+let soa_field_sum_kernel () =
+  let pts = make_var "pts" (TVec point3d_ty) in
+  let out = make_var "out" (TVec TFloat32) in
+  let tid = make_var "tid" TInt32 in
+  let fld f = ERecordField (EArrayRead ("pts", EVar tid), f) in
+  {
+    default_kernel with
+    kern_name = "p3sum";
+    kern_params =
+      [
+        DParam (pts, Some {arr_elttype = point3d_ty; arr_memspace = Global});
+        DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_body =
+      SLet
+        ( tid,
+          EIntrinsic ([], "global_thread_id", []),
+          SAssign
+            ( LArrayElem ("out", EVar tid),
+              EBinop (Add, EBinop (Add, fld "x", fld "y"), fld "z") ) );
+  }
+
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+let must_contain ptx needle =
+  Alcotest.(check bool)
+    (Printf.sprintf "generated PTX contains %S" needle)
+    true
+    (string_contains ~haystack:ptx ~needle)
+
+(* --- 1. direct: a record vector named in ~soa_params yields the SoA block --- *)
+
+let test_ptx_record_soa_params_lowers_to_leaves () =
+  match
+    Backend.generate_source ~soa_params:["pts"] (soa_field_sum_kernel ())
+  with
+  | None -> Alcotest.fail "generate_source returned None for an SoA request"
+  | Some ptx ->
+      must_contain ptx ".param .u64 param_sarek_soa_pts_x" ;
+      must_contain ptx ".param .u64 param_sarek_soa_pts_y" ;
+      must_contain ptx ".param .u64 param_sarek_soa_pts_z" ;
+      must_contain ptx ".param .u32 param_sarek_pts_length" ;
+      Alcotest.(check bool)
+        "the single packed AoS base pointer is gone"
+        false
+        (string_contains ~haystack:ptx ~needle:".param .u64 param_pts,")
+  | exception Backend_error.Backend_error err ->
+      Alcotest.failf
+        "CUDA/PTX raised a plugin-level refusal (%s) for a record vector it is \
+         supposed to lower"
+        (Backend_error.to_string err)
+
+(* --- 2. indirect: the emitter's own rejection, not the plugin's --- *)
 
 let test_ptx_soa_params_reaches_the_emitter () =
   match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
@@ -86,6 +163,10 @@ let () =
     [
       ( "soa_params",
         [
+          Alcotest.test_case
+            "a record vector still lowers to per-leaf pointers plus a length"
+            `Quick
+            test_ptx_record_soa_params_lowers_to_leaves;
           Alcotest.test_case
             "~soa_params reaches the PTX emitter, unrefused by the plugin"
             `Quick

--- a/sarek-cuda/test/test_ptx_soa_not_refused.ml
+++ b/sarek-cuda/test/test_ptx_soa_not_refused.ml
@@ -1,0 +1,98 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-214, the other polarity of the change: the CUDA/PTX backend must NOT
+ * acquire the refusal its five siblings just did.
+ *
+ * CUDA/PTX is the one backend whose emitter lowers a named vector parameter to
+ * N per-leaf base pointers plus one shared length, so [~soa_params] is not a
+ * request it cannot serve - it is the reason the parameter exists. A refusal
+ * added there would delete working functionality, which is the overshoot a
+ * narrowing correction invites.
+ *
+ * The check has to be indirect. Naming a SCALAR-element vector in
+ * [~soa_params] is rejected by the PTX emitter itself (SoA v1 is flat records
+ * only), so this kernel does raise - but it must raise
+ * [Ptx_codegen_error], the emitter's OWN rejection, which is only reachable if
+ * the plugin threaded [~soa_params] into codegen. If the plugin had grown the
+ * backlog-214 refusal, the exception would be [Backend_error] and codegen
+ * would never have been entered. Distinguishing those two exceptions is
+ * therefore exactly the question "did the refusal land here too".
+ *
+ * The record-typed SoA path itself is covered, positively and by execution, in
+ * sarek/tests/unit/test_ptx_snapshot.ml; this file is not that test.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend = Sarek_cuda.Cuda_ptx_plugin.Backend
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+let probe_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  {
+    default_kernel with
+    kern_name = "soa_refusal_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_body =
+      SAssign
+        ( LArrayElem ("c", EConst (CInt32 0l)),
+          EArrayRead ("a", EConst (CInt32 0l)) );
+  }
+
+let test_ptx_soa_params_reaches_the_emitter () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | _ ->
+      Alcotest.fail
+        "expected the PTX emitter's own rejection of a scalar-element SoA \
+         parameter; generate_source did not raise"
+  | exception Sarek_codegen.Sarek_ir_ptx_types.Ptx_codegen_error _ -> ()
+  | exception Backend_error.Backend_error err ->
+      Alcotest.failf
+        "CUDA/PTX raised a plugin-level refusal (%s) - ~soa_params no longer \
+         reaches the emitter that implements it"
+        (Backend_error.to_string err)
+
+let test_ptx_empty_soa_params_still_generates () =
+  let k = probe_kernel () in
+  match
+    (Backend.generate_source k, Backend.generate_source ~soa_params:[] k)
+  with
+  | Some omitted, Some explicit_empty ->
+      Alcotest.(check bool)
+        "PTX source is non-empty"
+        true
+        (String.length omitted > 0) ;
+      Alcotest.(check string)
+        "~soa_params:[] is byte-identical to omitting the argument"
+        omitted
+        explicit_empty
+  | None, _ | _, None ->
+      Alcotest.fail "generate_source returned None for an AoS kernel"
+
+let () =
+  Alcotest.run
+    "CUDA/PTX keeps SoA (backlog-214)"
+    [
+      ( "soa_params",
+        [
+          Alcotest.test_case
+            "~soa_params reaches the PTX emitter, unrefused by the plugin"
+            `Quick
+            test_ptx_soa_params_reaches_the_emitter;
+          Alcotest.test_case
+            "empty list still generates PTX"
+            `Quick
+            test_ptx_empty_soa_params_still_generates;
+        ] );
+    ]

--- a/sarek-hip/Hip_plugin.ml
+++ b/sarek-hip/Hip_plugin.ml
@@ -30,8 +30,12 @@ module Backend : Framework_sig.BACKEND = struct
   (* Codegen is reused verbatim from the CUDA-C generator. A located
      Backend_error (Codegen ...) is allowed to PROPAGATE rather than being
      swallowed as [None] (matches the CUDA/C backend, PR #259). *)
-  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+  let generate_source ?block:_ ?(soa_params = []) (ir : Sarek_ir_types.kernel) :
       string option =
+    (* Refused rather than bound away (backlog-214). HIP reuses the CUDA-C
+       generator, which has no SoA lowering — so this backend inherits the AoS
+       signature and must not accept a request for the other ABI. *)
+    Sarek_backend_error.Backend_error.reject_soa_params ~backend:name soa_params ;
     Some
       (Sarek_codegen.Sarek_ir_cuda.generate_with_types ~types:ir.kern_types ir)
 

--- a/sarek-hip/test/dune
+++ b/sarek-hip/test/dune
@@ -129,3 +129,13 @@
  (alias e2e-hip)
  (action
   (run %{dep:test_hip_f16_shapes.exe})))
+
+; backlog-214 - the HIP plugin refuses a non-empty ~soa_params instead of
+; answering an SoA argument list with AoS source. Pure codegen: no HIP device
+; and no ROCm runtime, so unlike everything else in this directory it is a
+; (test) under the default runtest alias rather than an e2e-hip executable.
+
+(test
+ (name test_hip_soa_refusal)
+ (modules test_hip_soa_refusal)
+ (libraries sarek_hip sarek_ir sarek_backend_error alcotest))

--- a/sarek-hip/test/test_hip_soa_refusal.ml
+++ b/sarek-hip/test/test_hip_soa_refusal.ml
@@ -11,18 +11,20 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. Nothing then compares the list against the compiled kernel's
- * signature: the array reaches [hipModuleLaunchKernel] positionally, and
- * [Execute.check_launch_args] checks arity against the CALLER's vector list
- * before expansion, so it cannot see this. At two or more leaves the expanded
- * list is LONGER than the AoS signature and every declared slot from the vector
- * onward is fed a value of the wrong kind. WHICH wrong kind depends on the
- * parameter list: a length slot reading a pointer yields a garbage length, and
- * where a pointer parameter follows the vector it reads 8 bytes out of a 4-byte
- * length cell. So the general claim is only that the mapping is wrong from the
- * vector onward and that this can misinterpret data and can trap - neither "a
- * crash" nor "silently wrong data" describes it on its own. See
- * [Backend_error.reject_soa_params] and [Execute.expand_to_run_source_args].
+ * compile error. The general consequence, and the only part that holds for
+ * every kernel shape, is that every parameter declared AFTER the vector
+ * receives the wrong entry. Nothing here catches that: [hipModuleLaunchKernel]
+ * takes the array positionally, and [Execute.check_launch_args] checks arity
+ * against the CALLER's vector list before expansion, so it cannot see it. What
+ * the shift MEANS is a property of the parameter list and not of SoA - at N =
+ * 2 with a pointer parameter following the vector (this file's probe shape) a
+ * length slot receives a pointer and the pointer slot reads 8 bytes out of a
+ * 4-byte cell; at N = 3 the third leaf lands in that pointer slot instead, a
+ * VALID pointer to the wrong buffer with nothing to trap on; with the vector
+ * declared last, nothing after it shifts into a pointer slot at all. Because
+ * this backend passes a bare pointer array, a caller-supplied value can reach
+ * the device as an address, so a trap is among the outcomes - but only among
+ * them. See [Backend_error.reject_soa_params] for the full enumeration.
  *
  * HIP reuses the CUDA-C generator verbatim ([Sarek_ir_cuda]), which has no SoA
  * lowering to select, so it is refused (single-leaf records included - see

--- a/sarek-hip/test/test_hip_soa_refusal.ml
+++ b/sarek-hip/test/test_hip_soa_refusal.ml
@@ -16,7 +16,9 @@
  * in a packed parameter block - silently wrong data.
  *
  * HIP reuses the CUDA-C generator verbatim ([Sarek_ir_cuda]), which has no SoA
- * lowering, so the request cannot be honoured and is refused. One lowering
+ * lowering to select, so it is refused (single-leaf records included - see
+ * [Backend_error.reject_soa_params] for why the degenerate case is not carved
+ * out). One lowering
  * would therefore retire two of the five refusals - noted for backlog-215.
  * Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
@@ -24,7 +26,9 @@
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
- *      parameter that was requested;
+ *      parameter that was requested - checked for a scalar-element vector AND
+ *      for a flat two-leaf record, the shape a real SoA launch names, so a
+ *      refusal conditional on eligibility could not pass for a refusal;
  *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
  *      byte-identical to each other.
  ******************************************************************************)
@@ -105,6 +109,50 @@ let test_hip_refusal_renders_the_framework () =
         true
         (string_contains ~haystack:msg ~needle:"HIP")
 
+(* The scalar-element probe above is a name the PTX emitter would itself reject
+   as SoA-ineligible, so on its own it cannot distinguish "refuses any non-empty
+   list" from "refuses only ineligible names while still ignoring the eligible
+   ones" - and the second is the pre-fix behaviour with a coat of paint. This
+   case is the shape a real SoA launch actually names: a flat two-leaf record,
+   which [Soa.plan] accepts and the PTX emitter does lower. It must be refused
+   here too, and by the SoA refusal rather than by anything the emitter has to
+   say about record vectors. *)
+let test_hip_refuses_a_record_vector () =
+  let pt = TRecord ("pt2", [("x", TFloat32); ("y", TFloat32)]) in
+  let pts = make_var "pts" (TVec pt) in
+  let out = make_var "out" (TVec TFloat32) in
+  let k =
+    {
+      default_kernel with
+      kern_name = "soa_refusal_record_probe";
+      kern_params =
+        [
+          DParam (pts, Some {arr_elttype = pt; arr_memspace = Global});
+          DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_body =
+        SAssign
+          ( LArrayElem ("out", EConst (CInt32 0l)),
+            ERecordField (EArrayRead ("pts", EConst (CInt32 0l)), "x") );
+    }
+  in
+  match Backend.generate_source ~soa_params:["pts"] k with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal for a record vector, got %d bytes of AoS source"
+        (String.length src)
+  | None -> Alcotest.fail "expected a refusal for a record vector, got None"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {backend; error = Backend_error.Feature_not_supported {feature; _}})
+    ->
+      Alcotest.(check string) "the refusal names this framework" "HIP" backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'pts'")
+
 (* --- polarity 2: the empty list is the untouched fast path --- *)
 
 let test_hip_empty_soa_params_still_generates () =
@@ -138,6 +186,10 @@ let () =
             "rendered refusal names the framework"
             `Quick
             test_hip_refusal_renders_the_framework;
+          Alcotest.test_case
+            "a record vector - the realistic shape - is refused too"
+            `Quick
+            test_hip_refuses_a_record_vector;
           Alcotest.test_case
             "empty list still generates AoS source"
             `Quick

--- a/sarek-hip/test/test_hip_soa_refusal.ml
+++ b/sarek-hip/test/test_hip_soa_refusal.ml
@@ -11,17 +11,24 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. On this backend it is not reliably a crash either: the
- * argument array reaches [hipModuleLaunchKernel] unchecked, so N pointers land
- * in a packed parameter block - silently wrong data.
+ * compile error. On this backend nothing checks the arity either: the argument
+ * array reaches [hipModuleLaunchKernel] positionally and unchecked, so at two
+ * or more leaves the list is LONGER than the AoS signature and every parameter
+ * after the vector shifts. The declared length slot then reads a pointer value
+ * and the next declared POINTER parameter reads its 8 bytes out of the 4-byte
+ * length cell - which can misinterpret data and can equally trap on an illegal
+ * device address. Neither "a crash" nor "silently wrong data" describes it on
+ * its own; see [Backend_error.reject_soa_params] and
+ * [Execute.expand_to_run_source_args].
  *
  * HIP reuses the CUDA-C generator verbatim ([Sarek_ir_cuda]), which has no SoA
  * lowering to select, so it is refused (single-leaf records included - see
  * [Backend_error.reject_soa_params] for why the degenerate case is not carved
- * out). One lowering
- * would therefore retire two of the five refusals - noted for backlog-215.
- * Both polarities are pinned here, because the refusal has its own
- * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * out). One lowering would therefore retire two of the five refusals - noted
+ * for backlog-215.
+ *
+ * Both polarities are pinned here, because the refusal has its own failure
+ * mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *

--- a/sarek-hip/test/test_hip_soa_refusal.ml
+++ b/sarek-hip/test/test_hip_soa_refusal.ml
@@ -1,0 +1,147 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-214 - the HIP backend REFUSES a non-empty [~soa_params].
+ *
+ * [Framework_sig.generate_source] offers [?soa_params] to every backend. This
+ * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
+ * source: one pointer plus one length per vector parameter. The launch side
+ * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
+ * compile error and not reliably a crash - it is N pointers bound to a packed
+ * parameter block, i.e. silently wrong data.
+ *
+ * The CUDA-C generator HIP reuses has no SoA lowering, so the request cannot be honoured and is
+ * refused. Both polarities are pinned here, because the refusal has its own
+ * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * single launch:
+ *
+ *   1. a non-empty list raises, and the message names this framework and the
+ *      parameter that was requested;
+ *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
+ *      byte-identical to each other.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend = Sarek_hip.Hip_plugin.Backend
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* Minimal kernel: c.[0] <- a.[0]. No intrinsic, so codegen is not what decides
+   the outcome of either case below. *)
+let probe_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  {
+    default_kernel with
+    kern_name = "soa_refusal_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_body =
+      SAssign
+        ( LArrayElem ("c", EConst (CInt32 0l)),
+          EArrayRead ("a", EConst (CInt32 0l)) );
+  }
+
+(* Dependency-light substring check (mirror of the codegen_golden helper). *)
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+(* --- polarity 1: a non-empty list is refused, by name --- *)
+
+let test_hip_refuses_nonempty_soa_params () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal; generate_source answered an SoA request with \
+         %d          bytes of AoS source"
+        (String.length src)
+  | None ->
+      Alcotest.fail
+        "expected a refusal; generate_source returned None (the request \
+         was          swallowed, not refused)"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {
+             backend;
+             error = Backend_error.Feature_not_supported {feature; backend = _};
+           }) ->
+      Alcotest.(check string) "the refusal names this framework" "HIP" backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'a'") ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S says what was refused" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"Structure-of-Arrays")
+
+(* The rendered message is what a user sees, and the framework name reaches it
+   only through the [backend] field checked above - so render it and look. *)
+let test_hip_refusal_renders_the_framework () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | _ -> Alcotest.fail "expected a refusal, generate_source did not raise"
+  | exception Backend_error.Backend_error err ->
+      let msg = Backend_error.to_string err in
+      Alcotest.(check bool)
+        (Printf.sprintf "rendered message %S names HIP" msg)
+        true
+        (string_contains ~haystack:msg ~needle:"HIP")
+
+(* --- polarity 2: the empty list is the untouched fast path --- *)
+
+let test_hip_empty_soa_params_still_generates () =
+  let k = probe_kernel () in
+  match
+    (Backend.generate_source k, Backend.generate_source ~soa_params:[] k)
+  with
+  | Some omitted, Some explicit_empty ->
+      Alcotest.(check bool)
+        "AoS source is non-empty"
+        true
+        (String.length omitted > 0) ;
+      Alcotest.(check string)
+        "~soa_params:[] is byte-identical to omitting the argument"
+        omitted
+        explicit_empty
+  | None, _ | _, None ->
+      Alcotest.fail
+        "generate_source returned None for an AoS kernel - the empty-list \
+         fast          path regressed"
+
+let () =
+  Alcotest.run
+    "HIP SoA refusal (backlog-214)"
+    [
+      ( "soa_params",
+        [
+          Alcotest.test_case
+            "non-empty list is refused, naming framework and parameter"
+            `Quick
+            test_hip_refuses_nonempty_soa_params;
+          Alcotest.test_case
+            "rendered refusal names the framework"
+            `Quick
+            test_hip_refusal_renders_the_framework;
+          Alcotest.test_case
+            "empty list still generates AoS source"
+            `Quick
+            test_hip_empty_soa_params_still_generates;
+        ] );
+    ]

--- a/sarek-hip/test/test_hip_soa_refusal.ml
+++ b/sarek-hip/test/test_hip_soa_refusal.ml
@@ -11,15 +11,18 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. On this backend nothing checks the arity either: the argument
- * array reaches [hipModuleLaunchKernel] positionally and unchecked, so at two
- * or more leaves the list is LONGER than the AoS signature and every parameter
- * after the vector shifts. The declared length slot then reads a pointer value
- * and the next declared POINTER parameter reads its 8 bytes out of the 4-byte
- * length cell - which can misinterpret data and can equally trap on an illegal
- * device address. Neither "a crash" nor "silently wrong data" describes it on
- * its own; see [Backend_error.reject_soa_params] and
- * [Execute.expand_to_run_source_args].
+ * compile error. Nothing then compares the list against the compiled kernel's
+ * signature: the array reaches [hipModuleLaunchKernel] positionally, and
+ * [Execute.check_launch_args] checks arity against the CALLER's vector list
+ * before expansion, so it cannot see this. At two or more leaves the expanded
+ * list is LONGER than the AoS signature and every declared slot from the vector
+ * onward is fed a value of the wrong kind. WHICH wrong kind depends on the
+ * parameter list: a length slot reading a pointer yields a garbage length, and
+ * where a pointer parameter follows the vector it reads 8 bytes out of a 4-byte
+ * length cell. So the general claim is only that the mapping is wrong from the
+ * vector onward and that this can misinterpret data and can trap - neither "a
+ * crash" nor "silently wrong data" describes it on its own. See
+ * [Backend_error.reject_soa_params] and [Execute.expand_to_run_source_args].
  *
  * HIP reuses the CUDA-C generator verbatim ([Sarek_ir_cuda]), which has no SoA
  * lowering to select, so it is refused (single-leaf records included - see

--- a/sarek-hip/test/test_hip_soa_refusal.ml
+++ b/sarek-hip/test/test_hip_soa_refusal.ml
@@ -10,14 +10,17 @@
  * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
- * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
- * compile error and not reliably a crash - it is N pointers bound to a packed
- * parameter block, i.e. silently wrong data.
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
+ * compile error. On this backend it is not reliably a crash either: the
+ * argument array reaches [hipModuleLaunchKernel] unchecked, so N pointers land
+ * in a packed parameter block - silently wrong data.
  *
- * The CUDA-C generator HIP reuses has no SoA lowering, so the request cannot be honoured and is
- * refused. Both polarities are pinned here, because the refusal has its own
+ * HIP reuses the CUDA-C generator verbatim ([Sarek_ir_cuda]), which has no SoA
+ * lowering, so the request cannot be honoured and is refused. One lowering
+ * would therefore retire two of the five refusals - noted for backlog-215.
+ * Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
- * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
@@ -68,13 +71,11 @@ let test_hip_refuses_nonempty_soa_params () =
   match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
   | Some src ->
       Alcotest.failf
-        "expected a refusal; generate_source answered an SoA request with \
-         %d          bytes of AoS source"
+        "expected a refusal, got %d bytes of AoS source"
         (String.length src)
   | None ->
       Alcotest.fail
-        "expected a refusal; generate_source returned None (the request \
-         was          swallowed, not refused)"
+        "expected a refusal, got None (request swallowed, not refused)"
   | exception
       Backend_error.Backend_error
         (Backend_error.Plugin
@@ -121,9 +122,7 @@ let test_hip_empty_soa_params_still_generates () =
         omitted
         explicit_empty
   | None, _ | _, None ->
-      Alcotest.fail
-        "generate_source returned None for an AoS kernel - the empty-list \
-         fast          path regressed"
+      Alcotest.fail "None for an AoS kernel: the empty-list fast path regressed"
 
 let () =
   Alcotest.run

--- a/sarek-metal/Metal_plugin.ml
+++ b/sarek-metal/Metal_plugin.ml
@@ -180,8 +180,12 @@ module Backend : Framework_sig.BACKEND = struct
       None" (PR #259 review); a blanket [try ... with _ -> None] previously
       swallowed it. Codegen never legitimately declines a kernel by returning
       [None]. *)
-  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+  let generate_source ?block:_ ?(soa_params = []) (ir : Sarek_ir_types.kernel) :
       string option =
+    (* Refused rather than bound away (backlog-214): [Sarek_ir_metal] emits the
+       packed AoS signature for every vector parameter and has no SoA lowering
+       to select. *)
+    Sarek_backend_error.Backend_error.reject_soa_params ~backend:name soa_params ;
     let source = Sarek_ir_metal.generate_with_types ~types:ir.kern_types ir in
     Spoc_core.Log.debug Kernel ("Metal source:\n" ^ source) ;
     Some source

--- a/sarek-metal/test/dune
+++ b/sarek-metal/test/dune
@@ -14,3 +14,11 @@
  (name test_metal_compile_options)
  (modules test_metal_compile_options)
  (libraries sarek_metal alcotest))
+
+; backlog-214 - the Metal plugin refuses a non-empty ~soa_params instead of
+; answering an SoA argument list with AoS source. Pure codegen, no device.
+
+(test
+ (name test_metal_soa_refusal)
+ (modules test_metal_soa_refusal)
+ (libraries sarek_metal sarek_ir sarek_backend_error alcotest))

--- a/sarek-metal/test/test_metal_soa_refusal.ml
+++ b/sarek-metal/test/test_metal_soa_refusal.ml
@@ -10,14 +10,18 @@
  * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
- * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
- * compile error and not reliably a crash - it is N pointers bound to a packed
- * parameter block, i.e. silently wrong data.
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
+ * compile error. How badly it then fails is a property of this
+ * backend's binding layer, not of codegen: [Metal_plugin_base] derives its
+ * expected argument count from the indices the caller bound
+ * ([Kernel_args.count]), so it has no independent count to disagree with. This
+ * test does not claim which symptom follows - it claims the emitter should not
+ * have accepted the request.
  *
  * [Sarek_ir_metal] has no SoA lowering, so the request cannot be honoured and is
  * refused. Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
- * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
@@ -68,13 +72,11 @@ let test_metal_refuses_nonempty_soa_params () =
   match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
   | Some src ->
       Alcotest.failf
-        "expected a refusal; generate_source answered an SoA request with \
-         %d          bytes of AoS source"
+        "expected a refusal, got %d bytes of AoS source"
         (String.length src)
   | None ->
       Alcotest.fail
-        "expected a refusal; generate_source returned None (the request \
-         was          swallowed, not refused)"
+        "expected a refusal, got None (request swallowed, not refused)"
   | exception
       Backend_error.Backend_error
         (Backend_error.Plugin
@@ -121,9 +123,7 @@ let test_metal_empty_soa_params_still_generates () =
         omitted
         explicit_empty
   | None, _ | _, None ->
-      Alcotest.fail
-        "generate_source returned None for an AoS kernel - the empty-list \
-         fast          path regressed"
+      Alcotest.fail "None for an AoS kernel: the empty-list fast path regressed"
 
 let () =
   Alcotest.run

--- a/sarek-metal/test/test_metal_soa_refusal.ml
+++ b/sarek-metal/test/test_metal_soa_refusal.ml
@@ -11,17 +11,22 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. Nothing on this backend checks the arity:
- * [Metal_plugin_base]'s preflight count comes from the indices the caller bound
- * ([Kernel_args.count]), and the args are then bound BY LIST POSITION
- * ([atIndex:]) with nothing compared against the compiled function. So Metal
- * sits with CUDA/C and HIP rather than with OpenCL and Vulkan: the shift is
- * unchecked, and every declared slot from the vector onward is fed a value of
- * the wrong kind. What the Metal runtime then does with a buffer bound where
- * the function declares bytes, or the reverse, is NOT something this tree
- * establishes - unlike OpenCL, where the rejecting call is in this repository
- * ([Opencl_api.Kernel.set_arg_mem]) - so no symptom is claimed for Metal beyond
- * the mapping being wrong. See [Backend_error.reject_soa_params].
+ * compile error. Nothing here checks the arity either: [Metal_plugin_base]'s
+ * preflight count comes from the indices the caller bound
+ * ([Kernel_args.count]) and the args are then bound BY LIST POSITION
+ * ([atIndex:]) with nothing compared against the compiled function, so every
+ * parameter declared after the vector receives the wrong entry. Metal does NOT
+ * inherit the trap half of that, though, and this is where folding it in with
+ * CUDA/C and HIP would overclaim: no caller-supplied ADDRESS ever crosses.
+ * Buffers go through [setBuffer] as MTLBuffer objects and scalars through
+ * [setBytes] as a driver-allocated inline copy ([Metal_api]), against
+ * parameters declared [device T* x [[buffer(k)]], constant int &sarek_x_length
+ * [[buffer(k+1)]]] ([Sarek_ir_metal.gen_buffer_param]). So a length index
+ * receives a buffer whose first 4 bytes are read as the length, and a pointer
+ * index receives inline [setBytes] data indexed out of bounds or another
+ * buffer - wrong data and out-of-bounds reads within valid allocations, or an
+ * encode Metal's own API validation rejects. See
+ * [Backend_error.reject_soa_params].
  *
  * [Sarek_ir_metal] has no SoA lowering to select, so it is refused. (A
  * single-leaf record would in fact bind correctly, N = 1 making the two

--- a/sarek-metal/test/test_metal_soa_refusal.ml
+++ b/sarek-metal/test/test_metal_soa_refusal.ml
@@ -11,18 +11,22 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. How badly it then fails is a property of this
- * backend's binding layer, not of codegen: [Metal_plugin_base]'s preflight count
- * comes from the indices the caller bound ([Kernel_args.count]), so that check
- * has no source-derived count to disagree with. This test does not claim which
- * symptom follows - it claims the emitter should not have accepted the request.
+ * compile error. Nothing on this backend checks the arity:
+ * [Metal_plugin_base]'s preflight count comes from the indices the caller bound
+ * ([Kernel_args.count]), and the args are then bound BY LIST POSITION
+ * ([atIndex:]) with nothing compared against the compiled function. So Metal
+ * sits with CUDA/C and HIP rather than with OpenCL and Vulkan: the shift can
+ * misinterpret data and can equally trap. See
+ * [Backend_error.reject_soa_params].
  *
  * [Sarek_ir_metal] has no SoA lowering to select, so it is refused. (A
  * single-leaf record would in fact bind correctly, N = 1 making the two
  * argument lists the same shape - it is refused anyway, because that is a
  * coincidence of the leaf count and not a property of the emitter. See
- * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
- * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * [Backend_error.reject_soa_params].)
+ *
+ * Both polarities are pinned here, because the refusal has its own failure
+ * mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *

--- a/sarek-metal/test/test_metal_soa_refusal.ml
+++ b/sarek-metal/test/test_metal_soa_refusal.ml
@@ -1,0 +1,147 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-214 - the Metal backend REFUSES a non-empty [~soa_params].
+ *
+ * [Framework_sig.generate_source] offers [?soa_params] to every backend. This
+ * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
+ * source: one pointer plus one length per vector parameter. The launch side
+ * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
+ * compile error and not reliably a crash - it is N pointers bound to a packed
+ * parameter block, i.e. silently wrong data.
+ *
+ * [Sarek_ir_metal] has no SoA lowering, so the request cannot be honoured and is
+ * refused. Both polarities are pinned here, because the refusal has its own
+ * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * single launch:
+ *
+ *   1. a non-empty list raises, and the message names this framework and the
+ *      parameter that was requested;
+ *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
+ *      byte-identical to each other.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend = Sarek_metal.Metal_plugin.Backend
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* Minimal kernel: c.[0] <- a.[0]. No intrinsic, so codegen is not what decides
+   the outcome of either case below. *)
+let probe_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  {
+    default_kernel with
+    kern_name = "soa_refusal_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_body =
+      SAssign
+        ( LArrayElem ("c", EConst (CInt32 0l)),
+          EArrayRead ("a", EConst (CInt32 0l)) );
+  }
+
+(* Dependency-light substring check (mirror of the codegen_golden helper). *)
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+(* --- polarity 1: a non-empty list is refused, by name --- *)
+
+let test_metal_refuses_nonempty_soa_params () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal; generate_source answered an SoA request with \
+         %d          bytes of AoS source"
+        (String.length src)
+  | None ->
+      Alcotest.fail
+        "expected a refusal; generate_source returned None (the request \
+         was          swallowed, not refused)"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {
+             backend;
+             error = Backend_error.Feature_not_supported {feature; backend = _};
+           }) ->
+      Alcotest.(check string) "the refusal names this framework" "Metal" backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'a'") ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S says what was refused" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"Structure-of-Arrays")
+
+(* The rendered message is what a user sees, and the framework name reaches it
+   only through the [backend] field checked above - so render it and look. *)
+let test_metal_refusal_renders_the_framework () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | _ -> Alcotest.fail "expected a refusal, generate_source did not raise"
+  | exception Backend_error.Backend_error err ->
+      let msg = Backend_error.to_string err in
+      Alcotest.(check bool)
+        (Printf.sprintf "rendered message %S names Metal" msg)
+        true
+        (string_contains ~haystack:msg ~needle:"Metal")
+
+(* --- polarity 2: the empty list is the untouched fast path --- *)
+
+let test_metal_empty_soa_params_still_generates () =
+  let k = probe_kernel () in
+  match
+    (Backend.generate_source k, Backend.generate_source ~soa_params:[] k)
+  with
+  | Some omitted, Some explicit_empty ->
+      Alcotest.(check bool)
+        "AoS source is non-empty"
+        true
+        (String.length omitted > 0) ;
+      Alcotest.(check string)
+        "~soa_params:[] is byte-identical to omitting the argument"
+        omitted
+        explicit_empty
+  | None, _ | _, None ->
+      Alcotest.fail
+        "generate_source returned None for an AoS kernel - the empty-list \
+         fast          path regressed"
+
+let () =
+  Alcotest.run
+    "Metal SoA refusal (backlog-214)"
+    [
+      ( "soa_params",
+        [
+          Alcotest.test_case
+            "non-empty list is refused, naming framework and parameter"
+            `Quick
+            test_metal_refuses_nonempty_soa_params;
+          Alcotest.test_case
+            "rendered refusal names the framework"
+            `Quick
+            test_metal_refusal_renders_the_framework;
+          Alcotest.test_case
+            "empty list still generates AoS source"
+            `Quick
+            test_metal_empty_soa_params_still_generates;
+        ] );
+    ]

--- a/sarek-metal/test/test_metal_soa_refusal.ml
+++ b/sarek-metal/test/test_metal_soa_refusal.ml
@@ -12,20 +12,24 @@
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
  * compile error. How badly it then fails is a property of this
- * backend's binding layer, not of codegen: [Metal_plugin_base] derives its
- * expected argument count from the indices the caller bound
- * ([Kernel_args.count]), so it has no independent count to disagree with. This
- * test does not claim which symptom follows - it claims the emitter should not
- * have accepted the request.
+ * backend's binding layer, not of codegen: [Metal_plugin_base]'s preflight count
+ * comes from the indices the caller bound ([Kernel_args.count]), so that check
+ * has no source-derived count to disagree with. This test does not claim which
+ * symptom follows - it claims the emitter should not have accepted the request.
  *
- * [Sarek_ir_metal] has no SoA lowering, so the request cannot be honoured and is
- * refused. Both polarities are pinned here, because the refusal has its own
+ * [Sarek_ir_metal] has no SoA lowering to select, so it is refused. (A
+ * single-leaf record would in fact bind correctly, N = 1 making the two
+ * argument lists the same shape - it is refused anyway, because that is a
+ * coincidence of the leaf count and not a property of the emitter. See
+ * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
- *      parameter that was requested;
+ *      parameter that was requested - checked for a scalar-element vector AND
+ *      for a flat two-leaf record, the shape a real SoA launch names, so a
+ *      refusal conditional on eligibility could not pass for a refusal;
  *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
  *      byte-identical to each other.
  ******************************************************************************)
@@ -106,6 +110,50 @@ let test_metal_refusal_renders_the_framework () =
         true
         (string_contains ~haystack:msg ~needle:"Metal")
 
+(* The scalar-element probe above is a name the PTX emitter would itself reject
+   as SoA-ineligible, so on its own it cannot distinguish "refuses any non-empty
+   list" from "refuses only ineligible names while still ignoring the eligible
+   ones" - and the second is the pre-fix behaviour with a coat of paint. This
+   case is the shape a real SoA launch actually names: a flat two-leaf record,
+   which [Soa.plan] accepts and the PTX emitter does lower. It must be refused
+   here too, and by the SoA refusal rather than by anything the emitter has to
+   say about record vectors. *)
+let test_metal_refuses_a_record_vector () =
+  let pt = TRecord ("pt2", [("x", TFloat32); ("y", TFloat32)]) in
+  let pts = make_var "pts" (TVec pt) in
+  let out = make_var "out" (TVec TFloat32) in
+  let k =
+    {
+      default_kernel with
+      kern_name = "soa_refusal_record_probe";
+      kern_params =
+        [
+          DParam (pts, Some {arr_elttype = pt; arr_memspace = Global});
+          DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_body =
+        SAssign
+          ( LArrayElem ("out", EConst (CInt32 0l)),
+            ERecordField (EArrayRead ("pts", EConst (CInt32 0l)), "x") );
+    }
+  in
+  match Backend.generate_source ~soa_params:["pts"] k with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal for a record vector, got %d bytes of AoS source"
+        (String.length src)
+  | None -> Alcotest.fail "expected a refusal for a record vector, got None"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {backend; error = Backend_error.Feature_not_supported {feature; _}})
+    ->
+      Alcotest.(check string) "the refusal names this framework" "Metal" backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'pts'")
+
 (* --- polarity 2: the empty list is the untouched fast path --- *)
 
 let test_metal_empty_soa_params_still_generates () =
@@ -139,6 +187,10 @@ let () =
             "rendered refusal names the framework"
             `Quick
             test_metal_refusal_renders_the_framework;
+          Alcotest.test_case
+            "a record vector - the realistic shape - is refused too"
+            `Quick
+            test_metal_refuses_a_record_vector;
           Alcotest.test_case
             "empty list still generates AoS source"
             `Quick

--- a/sarek-metal/test/test_metal_soa_refusal.ml
+++ b/sarek-metal/test/test_metal_soa_refusal.ml
@@ -15,9 +15,13 @@
  * [Metal_plugin_base]'s preflight count comes from the indices the caller bound
  * ([Kernel_args.count]), and the args are then bound BY LIST POSITION
  * ([atIndex:]) with nothing compared against the compiled function. So Metal
- * sits with CUDA/C and HIP rather than with OpenCL and Vulkan: the shift can
- * misinterpret data and can equally trap. See
- * [Backend_error.reject_soa_params].
+ * sits with CUDA/C and HIP rather than with OpenCL and Vulkan: the shift is
+ * unchecked, and every declared slot from the vector onward is fed a value of
+ * the wrong kind. What the Metal runtime then does with a buffer bound where
+ * the function declares bytes, or the reverse, is NOT something this tree
+ * establishes - unlike OpenCL, where the rejecting call is in this repository
+ * ([Opencl_api.Kernel.set_arg_mem]) - so no symptom is claimed for Metal beyond
+ * the mapping being wrong. See [Backend_error.reject_soa_params].
  *
  * [Sarek_ir_metal] has no SoA lowering to select, so it is refused. (A
  * single-leaf record would in fact bind correctly, N = 1 making the two

--- a/sarek-opencl/Opencl_plugin.ml
+++ b/sarek-opencl/Opencl_plugin.ml
@@ -187,8 +187,12 @@ module Backend : Framework_sig.BACKEND = struct
       returned None" (PR #259 review); a blanket [try ... with _ -> None]
       previously swallowed it. Codegen never legitimately declines a kernel by
       returning [None]. *)
-  let generate_source ?block:_ ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+  let generate_source ?block:_ ?(soa_params = []) (ir : Sarek_ir_types.kernel) :
       string option =
+    (* Refused rather than bound away (backlog-214): [Sarek_ir_opencl] emits the
+       packed AoS signature for every vector parameter and has no SoA lowering
+       to select. *)
+    Sarek_backend_error.Backend_error.reject_soa_params ~backend:name soa_params ;
     let source = Sarek_ir_opencl.generate_with_types ~types:ir.kern_types ir in
     (* Add FP64 pragma if kernel uses double precision *)
     let source =

--- a/sarek-opencl/test/dune
+++ b/sarek-opencl/test/dune
@@ -5,7 +5,8 @@
   test_opencl_cache_two_kernels
   test_opencl_ffi_check_funnel
   test_opencl_f16_tripwire
-  test_opencl_fp_conformance)
- (libraries sarek_opencl sarek_backend_error alcotest str)
+  test_opencl_fp_conformance
+  test_opencl_soa_refusal)
+ (libraries sarek_opencl sarek_ir sarek_backend_error alcotest str)
  (instrumentation
   (backend bisect_ppx)))

--- a/sarek-opencl/test/test_opencl_soa_refusal.ml
+++ b/sarek-opencl/test/test_opencl_soa_refusal.ml
@@ -11,11 +11,11 @@
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
- * compile error. How badly it then fails is a property of this
- * backend's binding layer, not of codegen: [Opencl_plugin_base]'s PREFLIGHT count
- * comes from the indices the caller bound ([Kernel_args.count]), so that check
- * has no source-derived count to disagree with - but binding itself goes through
- * the checked [clSetKernelArg] funnel ([Opencl_api.Kernel.set_arg_mem]), which
+ * compile error. How badly it then fails is a property of this backend's
+ * binding layer, not of codegen: [Opencl_plugin_base]'s PREFLIGHT count comes
+ * from the indices the caller bound ([Kernel_args.count]), so that check has no
+ * source-derived count to disagree with - but binding itself goes through the
+ * checked [clSetKernelArg] funnel ([Opencl_api.Kernel.set_arg_mem]), which
  * raises on [CL_INVALID_ARG_INDEX] once the index runs past the compiled
  * kernel's argument list. This test does not claim which symptom follows - it
  * claims the emitter should not have accepted the request.
@@ -24,8 +24,10 @@
  * single-leaf record would in fact bind correctly, N = 1 making the two
  * argument lists the same shape - it is refused anyway, because that is a
  * coincidence of the leaf count and not a property of the emitter. See
- * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
- * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * [Backend_error.reject_soa_params].)
+ *
+ * Both polarities are pinned here, because the refusal has its own failure
+ * mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *

--- a/sarek-opencl/test/test_opencl_soa_refusal.ml
+++ b/sarek-opencl/test/test_opencl_soa_refusal.ml
@@ -10,14 +10,18 @@
  * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
  * source: one pointer plus one length per vector parameter. The launch side
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
- * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
- * compile error and not reliably a crash - it is N pointers bound to a packed
- * parameter block, i.e. silently wrong data.
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
+ * compile error. How badly it then fails is a property of this
+ * backend's binding layer, not of codegen: [Opencl_plugin_base] derives its
+ * expected argument count from the indices the caller bound
+ * ([Kernel_args.count]), so it has no independent count to disagree with. This
+ * test does not claim which symptom follows - it claims the emitter should not
+ * have accepted the request.
  *
  * [Sarek_ir_opencl] has no SoA lowering, so the request cannot be honoured and is
  * refused. Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
- * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
@@ -68,13 +72,11 @@ let test_opencl_refuses_nonempty_soa_params () =
   match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
   | Some src ->
       Alcotest.failf
-        "expected a refusal; generate_source answered an SoA request with \
-         %d          bytes of AoS source"
+        "expected a refusal, got %d bytes of AoS source"
         (String.length src)
   | None ->
       Alcotest.fail
-        "expected a refusal; generate_source returned None (the request \
-         was          swallowed, not refused)"
+        "expected a refusal, got None (request swallowed, not refused)"
   | exception
       Backend_error.Backend_error
         (Backend_error.Plugin
@@ -124,9 +126,7 @@ let test_opencl_empty_soa_params_still_generates () =
         omitted
         explicit_empty
   | None, _ | _, None ->
-      Alcotest.fail
-        "generate_source returned None for an AoS kernel - the empty-list \
-         fast          path regressed"
+      Alcotest.fail "None for an AoS kernel: the empty-list fast path regressed"
 
 let () =
   Alcotest.run

--- a/sarek-opencl/test/test_opencl_soa_refusal.ml
+++ b/sarek-opencl/test/test_opencl_soa_refusal.ml
@@ -1,0 +1,150 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-214 - the OpenCL backend REFUSES a non-empty [~soa_params].
+ *
+ * [Framework_sig.generate_source] offers [?soa_params] to every backend. This
+ * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
+ * source: one pointer plus one length per vector parameter. The launch side
+ * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
+ * compile error and not reliably a crash - it is N pointers bound to a packed
+ * parameter block, i.e. silently wrong data.
+ *
+ * [Sarek_ir_opencl] has no SoA lowering, so the request cannot be honoured and is
+ * refused. Both polarities are pinned here, because the refusal has its own
+ * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * single launch:
+ *
+ *   1. a non-empty list raises, and the message names this framework and the
+ *      parameter that was requested;
+ *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
+ *      byte-identical to each other.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend = Sarek_opencl.Opencl_plugin.Backend
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* Minimal kernel: c.[0] <- a.[0]. No intrinsic, so codegen is not what decides
+   the outcome of either case below. *)
+let probe_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  {
+    default_kernel with
+    kern_name = "soa_refusal_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_body =
+      SAssign
+        ( LArrayElem ("c", EConst (CInt32 0l)),
+          EArrayRead ("a", EConst (CInt32 0l)) );
+  }
+
+(* Dependency-light substring check (mirror of the codegen_golden helper). *)
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+(* --- polarity 1: a non-empty list is refused, by name --- *)
+
+let test_opencl_refuses_nonempty_soa_params () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal; generate_source answered an SoA request with \
+         %d          bytes of AoS source"
+        (String.length src)
+  | None ->
+      Alcotest.fail
+        "expected a refusal; generate_source returned None (the request \
+         was          swallowed, not refused)"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {
+             backend;
+             error = Backend_error.Feature_not_supported {feature; backend = _};
+           }) ->
+      Alcotest.(check string)
+        "the refusal names this framework"
+        "OpenCL"
+        backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'a'") ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S says what was refused" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"Structure-of-Arrays")
+
+(* The rendered message is what a user sees, and the framework name reaches it
+   only through the [backend] field checked above - so render it and look. *)
+let test_opencl_refusal_renders_the_framework () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | _ -> Alcotest.fail "expected a refusal, generate_source did not raise"
+  | exception Backend_error.Backend_error err ->
+      let msg = Backend_error.to_string err in
+      Alcotest.(check bool)
+        (Printf.sprintf "rendered message %S names OpenCL" msg)
+        true
+        (string_contains ~haystack:msg ~needle:"OpenCL")
+
+(* --- polarity 2: the empty list is the untouched fast path --- *)
+
+let test_opencl_empty_soa_params_still_generates () =
+  let k = probe_kernel () in
+  match
+    (Backend.generate_source k, Backend.generate_source ~soa_params:[] k)
+  with
+  | Some omitted, Some explicit_empty ->
+      Alcotest.(check bool)
+        "AoS source is non-empty"
+        true
+        (String.length omitted > 0) ;
+      Alcotest.(check string)
+        "~soa_params:[] is byte-identical to omitting the argument"
+        omitted
+        explicit_empty
+  | None, _ | _, None ->
+      Alcotest.fail
+        "generate_source returned None for an AoS kernel - the empty-list \
+         fast          path regressed"
+
+let () =
+  Alcotest.run
+    "OpenCL SoA refusal (backlog-214)"
+    [
+      ( "soa_params",
+        [
+          Alcotest.test_case
+            "non-empty list is refused, naming framework and parameter"
+            `Quick
+            test_opencl_refuses_nonempty_soa_params;
+          Alcotest.test_case
+            "rendered refusal names the framework"
+            `Quick
+            test_opencl_refusal_renders_the_framework;
+          Alcotest.test_case
+            "empty list still generates AoS source"
+            `Quick
+            test_opencl_empty_soa_params_still_generates;
+        ] );
+    ]

--- a/sarek-opencl/test/test_opencl_soa_refusal.ml
+++ b/sarek-opencl/test/test_opencl_soa_refusal.ml
@@ -12,20 +12,27 @@
  * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
  * [RSA_Vector_Length], so AoS source under an SoA argument list is never a
  * compile error. How badly it then fails is a property of this
- * backend's binding layer, not of codegen: [Opencl_plugin_base] derives its
- * expected argument count from the indices the caller bound
- * ([Kernel_args.count]), so it has no independent count to disagree with. This
- * test does not claim which symptom follows - it claims the emitter should not
- * have accepted the request.
+ * backend's binding layer, not of codegen: [Opencl_plugin_base]'s PREFLIGHT count
+ * comes from the indices the caller bound ([Kernel_args.count]), so that check
+ * has no source-derived count to disagree with - but binding itself goes through
+ * the checked [clSetKernelArg] funnel ([Opencl_api.Kernel.set_arg_mem]), which
+ * raises on [CL_INVALID_ARG_INDEX] once the index runs past the compiled
+ * kernel's argument list. This test does not claim which symptom follows - it
+ * claims the emitter should not have accepted the request.
  *
- * [Sarek_ir_opencl] has no SoA lowering, so the request cannot be honoured and is
- * refused. Both polarities are pinned here, because the refusal has its own
+ * [Sarek_ir_opencl] has no SoA lowering to select, so it is refused. (A
+ * single-leaf record would in fact bind correctly, N = 1 making the two
+ * argument lists the same shape - it is refused anyway, because that is a
+ * coincidence of the leaf count and not a property of the emitter. See
+ * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
- *      parameter that was requested;
+ *      parameter that was requested - checked for a scalar-element vector AND
+ *      for a flat two-leaf record, the shape a real SoA launch names, so a
+ *      refusal conditional on eligibility could not pass for a refusal;
  *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
  *      byte-identical to each other.
  ******************************************************************************)
@@ -109,6 +116,53 @@ let test_opencl_refusal_renders_the_framework () =
         true
         (string_contains ~haystack:msg ~needle:"OpenCL")
 
+(* The scalar-element probe above is a name the PTX emitter would itself reject
+   as SoA-ineligible, so on its own it cannot distinguish "refuses any non-empty
+   list" from "refuses only ineligible names while still ignoring the eligible
+   ones" - and the second is the pre-fix behaviour with a coat of paint. This
+   case is the shape a real SoA launch actually names: a flat two-leaf record,
+   which [Soa.plan] accepts and the PTX emitter does lower. It must be refused
+   here too, and by the SoA refusal rather than by anything the emitter has to
+   say about record vectors. *)
+let test_opencl_refuses_a_record_vector () =
+  let pt = TRecord ("pt2", [("x", TFloat32); ("y", TFloat32)]) in
+  let pts = make_var "pts" (TVec pt) in
+  let out = make_var "out" (TVec TFloat32) in
+  let k =
+    {
+      default_kernel with
+      kern_name = "soa_refusal_record_probe";
+      kern_params =
+        [
+          DParam (pts, Some {arr_elttype = pt; arr_memspace = Global});
+          DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_body =
+        SAssign
+          ( LArrayElem ("out", EConst (CInt32 0l)),
+            ERecordField (EArrayRead ("pts", EConst (CInt32 0l)), "x") );
+    }
+  in
+  match Backend.generate_source ~soa_params:["pts"] k with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal for a record vector, got %d bytes of AoS source"
+        (String.length src)
+  | None -> Alcotest.fail "expected a refusal for a record vector, got None"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {backend; error = Backend_error.Feature_not_supported {feature; _}})
+    ->
+      Alcotest.(check string)
+        "the refusal names this framework"
+        "OpenCL"
+        backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'pts'")
+
 (* --- polarity 2: the empty list is the untouched fast path --- *)
 
 let test_opencl_empty_soa_params_still_generates () =
@@ -142,6 +196,10 @@ let () =
             "rendered refusal names the framework"
             `Quick
             test_opencl_refusal_renders_the_framework;
+          Alcotest.test_case
+            "a record vector - the realistic shape - is refused too"
+            `Quick
+            test_opencl_refuses_a_record_vector;
           Alcotest.test_case
             "empty list still generates AoS source"
             `Quick

--- a/sarek-vulkan/Vulkan_plugin.ml
+++ b/sarek-vulkan/Vulkan_plugin.ml
@@ -187,8 +187,12 @@ module Backend : Framework_sig.BACKEND = struct
       it, and Execute then raised the opaque "generate_source returned None"
       with the name lost (PR #259 review). This function therefore always
       returns [Some _] on success. *)
-  let generate_source ?block ?soa_params:_ (ir : Sarek_ir_types.kernel) :
+  let generate_source ?block ?(soa_params = []) (ir : Sarek_ir_types.kernel) :
       string option =
+    (* Refused rather than bound away (backlog-214): [Sarek_ir_glsl] emits the
+       packed AoS binding for every vector parameter and has no SoA lowering to
+       select. *)
+    Sarek_backend_error.Backend_error.reject_soa_params ~backend:name soa_params ;
     let block_tuple =
       match block with
       | Some b -> Some (b.Framework_sig.x, b.Framework_sig.y, b.Framework_sig.z)

--- a/sarek-vulkan/test/dune
+++ b/sarek-vulkan/test/dune
@@ -50,3 +50,11 @@
  (name test_vulkan_coopmat_integer)
  (modules test_vulkan_coopmat_integer)
  (libraries sarek_vulkan spoc_framework sarek_ir alcotest astring))
+
+; backlog-214 - the Vulkan plugin refuses a non-empty ~soa_params instead of
+; answering an SoA argument list with AoS source. Pure codegen, no device.
+
+(test
+ (name test_vulkan_soa_refusal)
+ (modules test_vulkan_soa_refusal)
+ (libraries sarek_vulkan sarek_ir sarek_backend_error alcotest))

--- a/sarek-vulkan/test/test_vulkan_soa_refusal.ml
+++ b/sarek-vulkan/test/test_vulkan_soa_refusal.ml
@@ -19,19 +19,23 @@
  * What it IS on Vulkan specifically, stated rather than assumed: this backend
  * carries a second, source-derived count -
  * [Vulkan_api_kernel.validate_buffer_indices], whose [expected_count] is read
- * from the GLSL [binding = N] declarations - so N leaf buffers against
- * 1-binding AoS GLSL is caught late as "expected 1 buffer argument but got N",
- * a named rejection that says nothing about SoA. That is better than the
- * silently-wrong-data outcome CUDA/C and HIP would have, and it is still the
- * wrong diagnostic at the wrong layer. Refusing in the emitter makes it early
- * and named.
+ * from the GLSL [binding = N] declarations - so an SoA argument list against
+ * AoS GLSL is caught late, as a buffer-count rejection naming the count the
+ * shader declares and the count that arrived (the exact numbers depend on how
+ * many vector parameters the kernel has, so they are not quoted here). It is a
+ * named rejection that says nothing about SoA. That is a better outcome than
+ * CUDA/C, HIP and Metal have, where nothing checks the arity at all, and it is
+ * still the wrong diagnostic at the wrong layer. Refusing in the emitter makes
+ * it early and named.
  *
  * [Sarek_ir_glsl] has no SoA lowering to select, so it is refused. (A
  * single-leaf record would in fact bind correctly, N = 1 making the two
  * argument lists the same shape - it is refused anyway, because that is a
  * coincidence of the leaf count and not a property of the emitter. See
- * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
- * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * [Backend_error.reject_soa_params].)
+ *
+ * Both polarities are pinned here, because the refusal has its own failure
+ * mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
@@ -122,15 +126,16 @@ let test_vulkan_refusal_renders_the_framework () =
         true
         (string_contains ~haystack:msg ~needle:"Vulkan")
 
-(* The refusal must precede codegen, not follow it. In all five backends that is
-   structural - it is the first statement of [generate_source] - but structure is
-   not evidence, so it is executed once, here, on the backend that already has a
-   known-unsupported intrinsic pinned by test_vulkan_error_observability.ml.
-   [warp_shuffle] has no GLSL lowering, so codegen on this kernel raises
-   [Codegen (Unknown_intrinsic _)]; getting the SoA refusal instead is what
-   proves nothing was generated before the request was rejected. Reachable only
-   here: the other four backends' unsupported-intrinsic sets are their own, and
-   duplicating this case five times would assert the same one ordering. *)
+(* The refusal must precede codegen, not follow it. In all five backends that
+   is structural - it is the first statement of [generate_source] - but
+   structure is not evidence, so it is executed once, here, on the backend that
+   already has a known-unsupported intrinsic pinned by
+   test_vulkan_error_observability.ml. [warp_shuffle] has no GLSL lowering, so
+   codegen on this kernel raises [Codegen (Unknown_intrinsic _)]; getting the
+   SoA refusal instead is what proves nothing was generated before the request
+   was rejected. Reachable only here: the other four backends'
+   unsupported-intrinsic sets are their own, and duplicating this case five
+   times would assert the same one ordering. *)
 let test_vulkan_refusal_precedes_codegen () =
   let a = make_var "a" (TVec TFloat32) in
   let c = make_var "c" (TVec TFloat32) in

--- a/sarek-vulkan/test/test_vulkan_soa_refusal.ml
+++ b/sarek-vulkan/test/test_vulkan_soa_refusal.ml
@@ -8,16 +8,28 @@
  *
  * [Framework_sig.generate_source] offers [?soa_params] to every backend. This
  * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
- * source: one pointer plus one length per vector parameter. The launch side
- * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
- * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
- * compile error and not reliably a crash - it is N pointers bound to a packed
- * parameter block, i.e. silently wrong data.
+ * source. A GLSL compute entry point has no parameter list at all, so "packed
+ * AoS" here means one SSBO binding per vector with its length in the
+ * push-constant block ([Sarek_ir_glsl.gen_push_constants],
+ * [glsl_array_length_name]) - NOT the pointer-plus-length parameter shape the
+ * C-family backends emit. The launch side expands an SoA-dispatched vector into
+ * N [RSA_Buffer]s plus one [RSA_Vector_Length], so AoS source under an SoA
+ * argument list is never a compile error.
+ *
+ * What it IS on Vulkan specifically, stated rather than assumed: this backend
+ * carries a second, source-derived count -
+ * [Vulkan_api_kernel.validate_buffer_indices], whose [expected_count] is read
+ * from the GLSL [binding = N] declarations - so N leaf buffers against
+ * 1-binding AoS GLSL is caught late as "expected 1 buffer argument but got N",
+ * a named rejection that says nothing about SoA. That is better than the
+ * silently-wrong-data outcome CUDA/C and HIP would have, and it is still the
+ * wrong diagnostic at the wrong layer. Refusing in the emitter makes it early
+ * and named.
  *
  * [Sarek_ir_glsl] has no SoA lowering, so the request cannot be honoured and is
  * refused. Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
- * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
@@ -68,13 +80,11 @@ let test_vulkan_refuses_nonempty_soa_params () =
   match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
   | Some src ->
       Alcotest.failf
-        "expected a refusal; generate_source answered an SoA request with \
-         %d          bytes of AoS source"
+        "expected a refusal, got %d bytes of AoS source"
         (String.length src)
   | None ->
       Alcotest.fail
-        "expected a refusal; generate_source returned None (the request \
-         was          swallowed, not refused)"
+        "expected a refusal, got None (request swallowed, not refused)"
   | exception
       Backend_error.Backend_error
         (Backend_error.Plugin
@@ -107,6 +117,57 @@ let test_vulkan_refusal_renders_the_framework () =
         true
         (string_contains ~haystack:msg ~needle:"Vulkan")
 
+(* The refusal must precede codegen, not follow it. In all five backends that is
+   structural - it is the first statement of [generate_source] - but structure is
+   not evidence, so it is executed once, here, on the backend that already has a
+   known-unsupported intrinsic pinned by test_vulkan_error_observability.ml.
+   [warp_shuffle] has no GLSL lowering, so codegen on this kernel raises
+   [Codegen (Unknown_intrinsic _)]; getting the SoA refusal instead is what
+   proves nothing was generated before the request was rejected. Reachable only
+   here: the other four backends' unsupported-intrinsic sets are their own, and
+   duplicating this case five times would assert the same one ordering. *)
+let test_vulkan_refusal_precedes_codegen () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  let arg = EArrayRead ("a", EConst (CInt32 0l)) in
+  let uncompilable =
+    {
+      default_kernel with
+      kern_name = "soa_refusal_order_probe";
+      kern_params =
+        [
+          DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+          DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_body =
+        SAssign
+          ( LArrayElem ("c", EConst (CInt32 0l)),
+            EIntrinsic ([], "warp_shuffle", [arg; arg]) );
+    }
+  in
+  (* Control: without the SoA request this kernel really is uncompilable, so the
+     case below cannot pass by the intrinsic having quietly become supported. *)
+  (match Backend.generate_source uncompilable with
+  | _ ->
+      Alcotest.fail
+        "control failed: warp_shuffle now compiles to GLSL, so this kernel no \
+         longer distinguishes refusal-before-codegen from refusal-after"
+  | exception Backend_error.Backend_error (Backend_error.Codegen {error = _; _})
+    ->
+      ()) ;
+  match Backend.generate_source ~soa_params:["a"] uncompilable with
+  | _ -> Alcotest.fail "expected a refusal, generate_source did not raise"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin {error = Backend_error.Feature_not_supported _; _})
+    ->
+      ()
+  | exception Backend_error.Backend_error (Backend_error.Codegen {error = _; _})
+    ->
+      Alcotest.fail
+        "codegen ran before the SoA request was refused - the refusal is not \
+         the first thing generate_source does"
+
 (* --- polarity 2: the empty list is the untouched fast path --- *)
 
 let test_vulkan_empty_soa_params_still_generates () =
@@ -124,9 +185,7 @@ let test_vulkan_empty_soa_params_still_generates () =
         omitted
         explicit_empty
   | None, _ | _, None ->
-      Alcotest.fail
-        "generate_source returned None for an AoS kernel - the empty-list \
-         fast          path regressed"
+      Alcotest.fail "None for an AoS kernel: the empty-list fast path regressed"
 
 let () =
   Alcotest.run
@@ -142,6 +201,10 @@ let () =
             "rendered refusal names the framework"
             `Quick
             test_vulkan_refusal_renders_the_framework;
+          Alcotest.test_case
+            "the refusal precedes codegen"
+            `Quick
+            test_vulkan_refusal_precedes_codegen;
           Alcotest.test_case
             "empty list still generates AoS source"
             `Quick

--- a/sarek-vulkan/test/test_vulkan_soa_refusal.ml
+++ b/sarek-vulkan/test/test_vulkan_soa_refusal.ml
@@ -26,14 +26,19 @@
  * wrong diagnostic at the wrong layer. Refusing in the emitter makes it early
  * and named.
  *
- * [Sarek_ir_glsl] has no SoA lowering, so the request cannot be honoured and is
- * refused. Both polarities are pinned here, because the refusal has its own
+ * [Sarek_ir_glsl] has no SoA lowering to select, so it is refused. (A
+ * single-leaf record would in fact bind correctly, N = 1 making the two
+ * argument lists the same shape - it is refused anyway, because that is a
+ * coincidence of the leaf count and not a property of the emitter. See
+ * [Backend_error.reject_soa_params].) Both polarities are pinned here, because the refusal has its own
  * failure mode - refusing the EMPTY list would break every ordinary launch,
  * and the ["CUDA/PTX"] caller-side gate passes [[]] on this backend on every
  * single launch:
  *
  *   1. a non-empty list raises, and the message names this framework and the
- *      parameter that was requested;
+ *      parameter that was requested - checked for a scalar-element vector AND
+ *      for a flat two-leaf record, the shape a real SoA launch names, so a
+ *      refusal conditional on eligibility could not pass for a refusal;
  *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
  *      byte-identical to each other.
  ******************************************************************************)
@@ -168,6 +173,53 @@ let test_vulkan_refusal_precedes_codegen () =
         "codegen ran before the SoA request was refused - the refusal is not \
          the first thing generate_source does"
 
+(* The scalar-element probe above is a name the PTX emitter would itself reject
+   as SoA-ineligible, so on its own it cannot distinguish "refuses any non-empty
+   list" from "refuses only ineligible names while still ignoring the eligible
+   ones" - and the second is the pre-fix behaviour with a coat of paint. This
+   case is the shape a real SoA launch actually names: a flat two-leaf record,
+   which [Soa.plan] accepts and the PTX emitter does lower. It must be refused
+   here too, and by the SoA refusal rather than by anything the emitter has to
+   say about record vectors. *)
+let test_vulkan_refuses_a_record_vector () =
+  let pt = TRecord ("pt2", [("x", TFloat32); ("y", TFloat32)]) in
+  let pts = make_var "pts" (TVec pt) in
+  let out = make_var "out" (TVec TFloat32) in
+  let k =
+    {
+      default_kernel with
+      kern_name = "soa_refusal_record_probe";
+      kern_params =
+        [
+          DParam (pts, Some {arr_elttype = pt; arr_memspace = Global});
+          DParam (out, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        ];
+      kern_body =
+        SAssign
+          ( LArrayElem ("out", EConst (CInt32 0l)),
+            ERecordField (EArrayRead ("pts", EConst (CInt32 0l)), "x") );
+    }
+  in
+  match Backend.generate_source ~soa_params:["pts"] k with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal for a record vector, got %d bytes of AoS source"
+        (String.length src)
+  | None -> Alcotest.fail "expected a refusal for a record vector, got None"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {backend; error = Backend_error.Feature_not_supported {feature; _}})
+    ->
+      Alcotest.(check string)
+        "the refusal names this framework"
+        "Vulkan"
+        backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'pts'")
+
 (* --- polarity 2: the empty list is the untouched fast path --- *)
 
 let test_vulkan_empty_soa_params_still_generates () =
@@ -205,6 +257,10 @@ let () =
             "the refusal precedes codegen"
             `Quick
             test_vulkan_refusal_precedes_codegen;
+          Alcotest.test_case
+            "a record vector - the realistic shape - is refused too"
+            `Quick
+            test_vulkan_refuses_a_record_vector;
           Alcotest.test_case
             "empty list still generates AoS source"
             `Quick

--- a/sarek-vulkan/test/test_vulkan_soa_refusal.ml
+++ b/sarek-vulkan/test/test_vulkan_soa_refusal.ml
@@ -1,0 +1,150 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * backlog-214 - the Vulkan backend REFUSES a non-empty [~soa_params].
+ *
+ * [Framework_sig.generate_source] offers [?soa_params] to every backend. This
+ * one bound it away as [?soa_params:_] and returned its ordinary packed-AoS
+ * source: one pointer plus one length per vector parameter. The launch side
+ * expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
+ * [RSA_Vector_Length], so AoS source under an SoA argument list is not a
+ * compile error and not reliably a crash - it is N pointers bound to a packed
+ * parameter block, i.e. silently wrong data.
+ *
+ * [Sarek_ir_glsl] has no SoA lowering, so the request cannot be honoured and is
+ * refused. Both polarities are pinned here, because the refusal has its own
+ * failure mode - refusing the EMPTY list would break every ordinary launch,
+ * and the [`"CUDA/PTX"`] caller-side gate passes [[]] on this backend on every
+ * single launch:
+ *
+ *   1. a non-empty list raises, and the message names this framework and the
+ *      parameter that was requested;
+ *   2. [~soa_params:[]] and an omitted [?soa_params] both still produce source,
+ *      byte-identical to each other.
+ ******************************************************************************)
+
+open Sarek_ir_types
+module Backend = Sarek_vulkan.Vulkan_plugin.Backend
+module Backend_error = Sarek_backend_error.Backend_error
+
+let make_var name ty =
+  {var_name = name; var_id = 0; var_type = ty; var_mutable = false}
+
+(* Minimal kernel: c.[0] <- a.[0]. No intrinsic, so codegen is not what decides
+   the outcome of either case below. *)
+let probe_kernel () =
+  let a = make_var "a" (TVec TFloat32) in
+  let c = make_var "c" (TVec TFloat32) in
+  {
+    default_kernel with
+    kern_name = "soa_refusal_probe";
+    kern_params =
+      [
+        DParam (a, Some {arr_elttype = TFloat32; arr_memspace = Global});
+        DParam (c, Some {arr_elttype = TFloat32; arr_memspace = Global});
+      ];
+    kern_body =
+      SAssign
+        ( LArrayElem ("c", EConst (CInt32 0l)),
+          EArrayRead ("a", EConst (CInt32 0l)) );
+  }
+
+(* Dependency-light substring check (mirror of the codegen_golden helper). *)
+let string_contains ~haystack ~needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+(* --- polarity 1: a non-empty list is refused, by name --- *)
+
+let test_vulkan_refuses_nonempty_soa_params () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | Some src ->
+      Alcotest.failf
+        "expected a refusal; generate_source answered an SoA request with \
+         %d          bytes of AoS source"
+        (String.length src)
+  | None ->
+      Alcotest.fail
+        "expected a refusal; generate_source returned None (the request \
+         was          swallowed, not refused)"
+  | exception
+      Backend_error.Backend_error
+        (Backend_error.Plugin
+           {
+             backend;
+             error = Backend_error.Feature_not_supported {feature; backend = _};
+           }) ->
+      Alcotest.(check string)
+        "the refusal names this framework"
+        "Vulkan"
+        backend ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S names the requested parameter" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"'a'") ;
+      Alcotest.(check bool)
+        (Printf.sprintf "refusal %S says what was refused" feature)
+        true
+        (string_contains ~haystack:feature ~needle:"Structure-of-Arrays")
+
+(* The rendered message is what a user sees, and the framework name reaches it
+   only through the [backend] field checked above - so render it and look. *)
+let test_vulkan_refusal_renders_the_framework () =
+  match Backend.generate_source ~soa_params:["a"] (probe_kernel ()) with
+  | _ -> Alcotest.fail "expected a refusal, generate_source did not raise"
+  | exception Backend_error.Backend_error err ->
+      let msg = Backend_error.to_string err in
+      Alcotest.(check bool)
+        (Printf.sprintf "rendered message %S names Vulkan" msg)
+        true
+        (string_contains ~haystack:msg ~needle:"Vulkan")
+
+(* --- polarity 2: the empty list is the untouched fast path --- *)
+
+let test_vulkan_empty_soa_params_still_generates () =
+  let k = probe_kernel () in
+  match
+    (Backend.generate_source k, Backend.generate_source ~soa_params:[] k)
+  with
+  | Some omitted, Some explicit_empty ->
+      Alcotest.(check bool)
+        "AoS source is non-empty"
+        true
+        (String.length omitted > 0) ;
+      Alcotest.(check string)
+        "~soa_params:[] is byte-identical to omitting the argument"
+        omitted
+        explicit_empty
+  | None, _ | _, None ->
+      Alcotest.fail
+        "generate_source returned None for an AoS kernel - the empty-list \
+         fast          path regressed"
+
+let () =
+  Alcotest.run
+    "Vulkan SoA refusal (backlog-214)"
+    [
+      ( "soa_params",
+        [
+          Alcotest.test_case
+            "non-empty list is refused, naming framework and parameter"
+            `Quick
+            test_vulkan_refuses_nonempty_soa_params;
+          Alcotest.test_case
+            "rendered refusal names the framework"
+            `Quick
+            test_vulkan_refusal_renders_the_framework;
+          Alcotest.test_case
+            "empty list still generates AoS source"
+            `Quick
+            test_vulkan_empty_soa_params_still_generates;
+        ] );
+    ]

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -933,9 +933,13 @@ let run ~(device : Device.t) ~(name : string)
                  could disagree — a disagreement here is not a crash but N
                  pointers bound to a packed-AoS param block, i.e. silently wrong
                  data. Empty list on every non-CUDA/PTX backend, because
-                 soa_dispatch is what decides — and since backlog-214 those
-                 backends REFUSE a non-empty list rather than ignore it, so
-                 this gate is the fast path and no longer the only guarantee. *)
+                 soa_dispatch is what decides — and since backlog-214 the
+                 source-generating ones among them REFUSE a non-empty list
+                 rather than ignore it, so this gate is the fast path and no
+                 longer the only guarantee. Native, Interpreter and WebGPU
+                 return None unconditionally and carry no refusal; WebGPU is
+                 the one to watch, being a JIT backend whose WGSL codegen is
+                 not yet wired. *)
               let soa_params = soa_param_names ir args device in
               match B.generate_source ~block ~soa_params ir with
               | None ->

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -932,8 +932,10 @@ let run ~(device : Device.t) ~(name : string)
                  consequences of one decision rather than two decisions that
                  could disagree — a disagreement here is not a crash but N
                  pointers bound to a packed-AoS param block, i.e. silently wrong
-                 data. Empty list on every non-CUDA/PTX backend, where
-                 generate_source ignores it anyway. *)
+                 data. Empty list on every non-CUDA/PTX backend, because
+                 soa_dispatch is what decides — and since backlog-214 those
+                 backends REFUSE a non-empty list rather than ignore it, so
+                 this gate is the fast path and no longer the only guarantee. *)
               let soa_params = soa_param_names ir args device in
               match B.generate_source ~block ~soa_params ir with
               | None ->

--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -318,7 +318,11 @@ let run_soa ~(device : Device.t) ~(ir : Sarek_ir_types.kernel)
           param_names
       in
       (* Generate SoA-lowered source through the backend (keeps Execute
-         codegen-free; only the CUDA/PTX backend honours ~soa_params). *)
+         codegen-free; only the CUDA/PTX backend honours ~soa_params, and since
+         backlog-214 the source-generating backends that do not honour it raise
+         rather than answer with AoS source — so the gate above is a fast path
+         with a clearer message, not the only thing standing between an SoA
+         launch and a mismatched signature). *)
       let source =
         match B.generate_source ~block ~soa_params ir with
         | Some s -> s

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -352,9 +352,15 @@ module type BACKEND = sig
         Names of custom (record) vector parameters to lower as
         Structure-of-Arrays: each expands to N per-leaf base pointers + one
         shared length instead of a single packed AoS pointer (the #260 PTX
-        emitter ABI). Honoured only by the CUDA/PTX backend; every other backend
-        ignores it and emits its ordinary AoS code. Defaults to [[]] (all AoS),
-        so existing callers are byte-identical. *)
+        emitter ABI). Honoured only by the CUDA/PTX backend. A backend that
+        cannot honour it must REFUSE a non-empty list rather than ignore it —
+        see {!Sarek_backend_error.Backend_error.reject_soa_params}, which the
+        five source-generating backends without an SoA lowering (CUDA/C, HIP,
+        OpenCL, Vulkan, Metal) call — because emitting AoS source for an SoA
+        argument list is silently wrong data, not a crash (backlog-214). The
+        backends that return [None] unconditionally (Native, Interpreter,
+        WebGPU) generate no source at all and so do not carry that refusal.
+        Defaults to [[]] (all AoS), so existing callers are byte-identical. *)
   val generate_source :
     ?block:dims ->
     ?soa_params:string list ->

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -359,10 +359,13 @@ module type BACKEND = sig
         OpenCL, Vulkan, Metal) call — because emitting AoS source for an SoA
         argument list is an ABI mismatch that no compiler catches, and what
         happens next is per backend: rejected at bind or launch on OpenCL and
-        Vulkan, silently misinterpreted data on CUDA/C and HIP (backlog-214).
-        The backends that return [None] unconditionally (Native, Interpreter,
-        WebGPU) generate no source at all and so do not carry that refusal.
-        Defaults to [[]] (all AoS), so existing callers are byte-identical. *)
+        Vulkan; on CUDA/C, HIP and Metal nothing checks the arity, so the
+        positional shift can misinterpret data or trap on an illegal address
+        (backlog-214; {!Sarek_backend_error.Backend_error.reject_soa_params}
+        carries the per-backend detail). The backends that return [None]
+        unconditionally (Native, Interpreter, WebGPU) generate no source at all
+        and so do not carry that refusal. Defaults to [[]] (all AoS), so
+        existing callers are byte-identical. *)
   val generate_source :
     ?block:dims ->
     ?soa_params:string list ->

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -357,8 +357,10 @@ module type BACKEND = sig
         see {!Sarek_backend_error.Backend_error.reject_soa_params}, which the
         five source-generating backends without an SoA lowering (CUDA/C, HIP,
         OpenCL, Vulkan, Metal) call — because emitting AoS source for an SoA
-        argument list is silently wrong data, not a crash (backlog-214). The
-        backends that return [None] unconditionally (Native, Interpreter,
+        argument list is an ABI mismatch that no compiler catches, and what
+        happens next is per backend: rejected at bind or launch on OpenCL and
+        Vulkan, silently misinterpreted data on CUDA/C and HIP (backlog-214).
+        The backends that return [None] unconditionally (Native, Interpreter,
         WebGPU) generate no source at all and so do not carry that refusal.
         Defaults to [[]] (all AoS), so existing callers are byte-identical. *)
   val generate_source :

--- a/spoc/framework/Framework_sig.ml
+++ b/spoc/framework/Framework_sig.ml
@@ -359,8 +359,8 @@ module type BACKEND = sig
         OpenCL, Vulkan, Metal) call — because emitting AoS source for an SoA
         argument list is an ABI mismatch that no compiler catches, and what
         happens next is per backend: rejected at bind or launch on OpenCL and
-        Vulkan; on CUDA/C, HIP and Metal nothing checks the arity, so the
-        positional shift can misinterpret data or trap on an illegal address
+        Vulkan; on CUDA/C, HIP and Metal nothing compares the expanded list
+        against the compiled kernel, so the positional shift goes unchecked
         (backlog-214; {!Sarek_backend_error.Backend_error.reject_soa_params}
         carries the per-backend detail). The backends that return [None]
         unconditionally (Native, Interpreter, WebGPU) generate no source at all

--- a/spoc/framework_error/Backend_error.ml
+++ b/spoc/framework_error/Backend_error.ml
@@ -296,23 +296,46 @@ let raise_error err = raise (Backend_error err)
     it fails is per backend rather than uniform, which is why the refusal is
     stated here in terms of the mismatch and not of its symptom:
 
-    - CUDA/C, HIP and Metal bind POSITIONALLY with nothing comparing the list
-      against the compiled kernel's signature ([Cuda_shared.bind_args],
-      [Hip_shared.bind_args] into the bare pointer array
-      [cuLaunchKernel]/[hipModuleLaunchKernel] take; [Metal_plugin_base] by list
-      position via [atIndex:], its [expected_count] being [Kernel_args.count]
-      and so caller-derived). [Execute.check_launch_args] does check arity, but
-      against the CALLER's vector list before expansion, so it cannot see this.
-      At two or more leaves the expanded list is LONGER than the AoS signature,
-      so every declared slot from the vector onward is fed a value of the wrong
-      kind — exactly the shift [Execute.expand_to_run_source_args] warns about
-      for a leaf-count disagreement. WHICH wrong kind depends on the parameter
-      list and is not fixed: a length slot reading a pointer value yields a
-      garbage length; where a pointer parameter follows the vector, it reads its
-      8 bytes out of a 4-byte length cell. The general statement is only that
-      the mapping is wrong from the vector onward, and that this can
-      misinterpret data and can trap. "Not a crash" and "silently wrong data"
-      are each too narrow;
+    THE GENERAL FORM, and the only part that holds for every kernel shape: every
+    parameter declared AFTER the vector receives the wrong entry. Nothing
+    catches it on three of the five: [Execute.check_launch_args] checks arity,
+    but against the CALLER's vector list before expansion, so it cannot see
+    this, and it is the shift [Execute.expand_to_run_source_args] warns about
+    for a leaf-count disagreement. What that shift then MEANS is a property of
+    the parameter list, not of SoA, and the three cases below are examples
+    rather than the consequence:
+
+    - at N = 2 with a pointer parameter declared after the vector (the shape the
+      probe kernels in this repository's five refusal tests happen to have), a
+      length slot receives a pointer value and the pointer slot reads its 8
+      bytes out of a 4-byte length cell;
+    - at N = 3, the third leaf lands in the following pointer slot — a VALID
+      device pointer to the wrong buffer. Silent corruption, nothing to trap on;
+    - with the SoA vector declared LAST, nothing after it shifts into a pointer
+      slot at all.
+
+    So "not a crash" and "silently wrong data" are each too narrow, and so is
+    any single mechanism.
+
+    - CUDA/C and HIP bind into the bare pointer array
+      [cuLaunchKernel]/[hipModuleLaunchKernel] take ([Cuda_shared.bind_args],
+      [Hip_shared.bind_args]) with nothing comparing it against the compiled
+      kernel's signature, so a caller-supplied value can reach the device as an
+      address and a trap IS among the outcomes;
+    - Metal binds positionally too ([Metal_plugin_base] by list position via
+      [atIndex:], its [expected_count] being [Kernel_args.count] and so
+      caller-derived), but no caller-supplied ADDRESS ever crosses: buffers go
+      through [setBuffer] as MTLBuffer objects and scalars through [setBytes] as
+      a driver-allocated inline copy ([Metal_api], the [Buffer]/[Int32] arms),
+      against parameters declared
+      [device T* x [[buffer(k)]], constant int &sarek_x_length [[buffer(k+1)]]]
+      ([Sarek_ir_metal.gen_buffer_param]). Under the shift a length index
+      receives a buffer whose first 4 bytes are read as the length, and a
+      pointer index receives inline [setBytes] data (a valid 4-byte allocation
+      indexed out of bounds) or another buffer (valid address, wrong buffer).
+      Wrong data, out-of-bounds reads within valid allocations, or an encode
+      Metal's own API validation rejects — but nothing that traps in the CUDA
+      sense, so this backend does NOT inherit that half of the claim;
     - OpenCL shares that caller-derived preflight count, but has a late check it
       did not put there: binding goes through the checked [clSetKernelArg]
       funnel ([Opencl_api.Kernel.set_arg_mem]), which raises on

--- a/spoc/framework_error/Backend_error.ml
+++ b/spoc/framework_error/Backend_error.ml
@@ -288,26 +288,42 @@ let raise_error err = raise (Backend_error err)
 
     [Framework_sig.generate_source] offers [?soa_params] to every backend, but
     only an emitter that actually lowers a named vector parameter to N per-leaf
-    base pointers plus one shared length can honour it. A backend without that
+    bindings plus one shared length can honour it. A backend without that
     lowering used to bind the argument away as [?soa_params:_] and return its
-    ordinary packed-AoS source — a signature taking ONE pointer per vector,
-    while the launch side expands an SoA-dispatched vector into N [RSA_Buffer]s
-    plus one [RSA_Vector_Length]. That mismatch is not a compile error and not
-    reliably a crash: it is N pointers bound to a packed parameter block, i.e.
-    silently wrong data.
+    ordinary packed-AoS source — ONE binding per vector — while the launch side
+    expands an SoA-dispatched vector into N [RSA_Buffer]s plus one
+    [RSA_Vector_Length]. That mismatch is never a compile error, and how badly
+    it fails is per backend rather than uniform, which is why the refusal is
+    stated here in terms of the mismatch and not of its symptom:
 
-    Today no such call is made — [Execute.soa_dispatch] restricts SoA to the
-    CUDA/PTX device and [Soa_launch] gates on [PTX] being in the backend's
-    [supported_source_langs] — so this is a boundary, not a live bug fix. What
-    it changes is where the guarantee lives: it was one caller-side predicate
-    and nothing else, and a backend that cannot honour the request now says so
-    instead of answering with the wrong ABI.
+    - CUDA/C and HIP bind positionally into an unchecked argument array
+      ([Cuda_shared.bind_args], [Hip_shared.bind_args]) handed to
+      [cuLaunchKernel]/[hipModuleLaunchKernel], so N pointers land in a packed
+      parameter block — not a crash, silently wrong data;
+    - Metal and OpenCL derive their expected argument count from the indices the
+      caller bound ([Kernel_args.count]), so they have no independent count to
+      disagree with either;
+    - Vulkan does have a second, source-derived count
+      ([Vulkan_api_kernel.validate_buffer_indices], whose [expected_count] is
+      read from the GLSL [binding = N] declarations), so there the mismatch
+      surfaces late as "expected 1 buffer argument but got N" — a named
+      rejection that says nothing about SoA.
+
+    As of backlog-214 no caller in this tree reaches any of that:
+    [Execute.soa_dispatch] restricts SoA to the CUDA/PTX device and [Soa_launch]
+    gates on [PTX] being in the backend's [supported_source_langs]. So this is a
+    boundary, not a live bug fix. What it changes is where the guarantee lives:
+    it was one caller-side predicate and nothing else, and a backend that cannot
+    honour the request now says so instead of answering with the wrong ABI.
 
     Scope of what this raises, stated narrowly on purpose: it says what THIS
     backend does with vector parameters. It deliberately does not name which
     other backend does support SoA — that set is expected to grow (backlog-215),
     and a message enumerating it would go stale in a file that is not edited
-    when it does.
+    when it does. It is also not re-exported through {!Make}: [Make] closes over
+    one backend string per error module, and [Cuda_error]'s is "CUDA" for both
+    the CUDA/PTX backend that implements SoA and the CUDA/C backend that refuses
+    it, so a [Make]-based version could not tell the caller which one answered.
 
     [[]] returns [()], so every existing caller and the caller-side fast path
     are byte-for-byte unaffected. *)
@@ -321,8 +337,8 @@ let reject_soa_params ~backend (soa_params : string list) : unit =
            (Printf.sprintf
               "Structure-of-Arrays parameter lowering, requested for %s. This \
                backend's emitter gives every vector parameter the packed \
-               Array-of-Structures signature (one pointer plus one length), so \
-               the N-leaf-pointer argument list an SoA launch binds would not \
+               Array-of-Structures form (one binding plus one length), so the \
+               N-leaf-binding argument list an SoA launch produces would not \
                match the source it generates. Pass the vector through the \
                ordinary AoS launch path on this backend."
               (String.concat ", " (List.map (Printf.sprintf "'%s'") names))))

--- a/spoc/framework_error/Backend_error.ml
+++ b/spoc/framework_error/Backend_error.ml
@@ -296,18 +296,23 @@ let raise_error err = raise (Backend_error err)
     it fails is per backend rather than uniform, which is why the refusal is
     stated here in terms of the mismatch and not of its symptom:
 
-    - CUDA/C, HIP and Metal bind POSITIONALLY with no arity check against the
-      compiled kernel ([Cuda_shared.bind_args], [Hip_shared.bind_args] into the
-      bare pointer array [cuLaunchKernel]/[hipModuleLaunchKernel] take;
-      [Metal_plugin_base] by list position via [atIndex:], its [expected_count]
-      being [Kernel_args.count] and so caller-derived). At two or more leaves
-      the list is LONGER than the AoS signature, which shifts every parameter
-      after the vector — exactly what [Execute.expand_to_run_source_args] warns
-      about for a leaf-count disagreement. So the declared length slot reads a
-      pointer value and the next declared POINTER parameter reads its 8 bytes
-      out of the 4-byte length cell: this can misinterpret data, and it can
-      equally trap on an illegal device address. Not a crash and silently wrong
-      data are both too narrow a description of it;
+    - CUDA/C, HIP and Metal bind POSITIONALLY with nothing comparing the list
+      against the compiled kernel's signature ([Cuda_shared.bind_args],
+      [Hip_shared.bind_args] into the bare pointer array
+      [cuLaunchKernel]/[hipModuleLaunchKernel] take; [Metal_plugin_base] by list
+      position via [atIndex:], its [expected_count] being [Kernel_args.count]
+      and so caller-derived). [Execute.check_launch_args] does check arity, but
+      against the CALLER's vector list before expansion, so it cannot see this.
+      At two or more leaves the expanded list is LONGER than the AoS signature,
+      so every declared slot from the vector onward is fed a value of the wrong
+      kind — exactly the shift [Execute.expand_to_run_source_args] warns about
+      for a leaf-count disagreement. WHICH wrong kind depends on the parameter
+      list and is not fixed: a length slot reading a pointer value yields a
+      garbage length; where a pointer parameter follows the vector, it reads its
+      8 bytes out of a 4-byte length cell. The general statement is only that
+      the mapping is wrong from the vector onward, and that this can
+      misinterpret data and can trap. "Not a crash" and "silently wrong data"
+      are each too narrow;
     - OpenCL shares that caller-derived preflight count, but has a late check it
       did not put there: binding goes through the checked [clSetKernelArg]
       funnel ([Opencl_api.Kernel.set_arg_mem]), which raises on

--- a/spoc/framework_error/Backend_error.ml
+++ b/spoc/framework_error/Backend_error.ml
@@ -300,9 +300,12 @@ let raise_error err = raise (Backend_error err)
       ([Cuda_shared.bind_args], [Hip_shared.bind_args]) handed to
       [cuLaunchKernel]/[hipModuleLaunchKernel], so N pointers land in a packed
       parameter block — not a crash, silently wrong data;
-    - Metal and OpenCL derive their expected argument count from the indices the
-      caller bound ([Kernel_args.count]), so they have no independent count to
-      disagree with either;
+    - Metal and OpenCL derive their PREFLIGHT count from the indices the caller
+      bound ([Kernel_args.count]), so that check has no source-derived count to
+      disagree with. OpenCL still has a late one it did not put there: binding
+      goes through the checked [clSetKernelArg] funnel
+      ([Opencl_api.Kernel.set_arg_mem]), which raises on [CL_INVALID_ARG_INDEX]
+      once the index runs past the compiled kernel's argument list;
     - Vulkan does have a second, source-derived count
       ([Vulkan_api_kernel.validate_buffer_indices], whose [expected_count] is
       read from the GLSL [binding = N] declarations), so there the mismatch
@@ -325,8 +328,19 @@ let raise_error err = raise (Backend_error err)
     the CUDA/PTX backend that implements SoA and the CUDA/C backend that refuses
     it, so a [Make]-based version could not tell the caller which one answered.
 
-    [[]] returns [()], so every existing caller and the caller-side fast path
-    are byte-for-byte unaffected. *)
+    One case is deliberately refused although it would happen to work: a record
+    with a SINGLE leaf. [Soa.plan] permits it, and at N = 1 the SoA argument
+    list (one leaf buffer plus one length) has the same shape as the AoS one, so
+    the AoS source would bind correctly. It is refused anyway, because that
+    correctness is a coincidence of the leaf count rather than a property of the
+    emitter: the same call means something different the moment the record gains
+    a second field, and a carve-out that silently changes meaning under an
+    unrelated edit is worse than a refusal.
+
+    [[]] returns [()], so every in-tree caller — all of which pass an omitted or
+    empty list — and the caller-side fast path are byte-for-byte unaffected. An
+    out-of-tree caller already passing a non-empty list to one of these five now
+    raises; that is the intended change. *)
 let reject_soa_params ~backend (soa_params : string list) : unit =
   match soa_params with
   | [] -> ()
@@ -336,11 +350,11 @@ let reject_soa_params ~backend (soa_params : string list) : unit =
            ~backend
            (Printf.sprintf
               "Structure-of-Arrays parameter lowering, requested for %s. This \
-               backend's emitter gives every vector parameter the packed \
-               Array-of-Structures form (one binding plus one length), so the \
-               N-leaf-binding argument list an SoA launch produces would not \
-               match the source it generates. Pass the vector through the \
-               ordinary AoS launch path on this backend."
+               backend's emitter has no SoA lowering to select: every vector \
+               parameter gets the packed Array-of-Structures form, one binding \
+               plus one length, which coincides with the N-leaf argument list \
+               an SoA launch produces only for a single-leaf record. Pass the \
+               vector through the ordinary AoS launch path on this backend."
               (String.concat ", " (List.map (Printf.sprintf "'%s'") names))))
 
 (** Print error to stderr *)

--- a/spoc/framework_error/Backend_error.ml
+++ b/spoc/framework_error/Backend_error.ml
@@ -296,21 +296,28 @@ let raise_error err = raise (Backend_error err)
     it fails is per backend rather than uniform, which is why the refusal is
     stated here in terms of the mismatch and not of its symptom:
 
-    - CUDA/C and HIP bind positionally into an unchecked argument array
-      ([Cuda_shared.bind_args], [Hip_shared.bind_args]) handed to
-      [cuLaunchKernel]/[hipModuleLaunchKernel], so N pointers land in a packed
-      parameter block — not a crash, silently wrong data;
-    - Metal and OpenCL derive their PREFLIGHT count from the indices the caller
-      bound ([Kernel_args.count]), so that check has no source-derived count to
-      disagree with. OpenCL still has a late one it did not put there: binding
-      goes through the checked [clSetKernelArg] funnel
-      ([Opencl_api.Kernel.set_arg_mem]), which raises on [CL_INVALID_ARG_INDEX]
-      once the index runs past the compiled kernel's argument list;
-    - Vulkan does have a second, source-derived count
+    - CUDA/C, HIP and Metal bind POSITIONALLY with no arity check against the
+      compiled kernel ([Cuda_shared.bind_args], [Hip_shared.bind_args] into the
+      bare pointer array [cuLaunchKernel]/[hipModuleLaunchKernel] take;
+      [Metal_plugin_base] by list position via [atIndex:], its [expected_count]
+      being [Kernel_args.count] and so caller-derived). At two or more leaves
+      the list is LONGER than the AoS signature, which shifts every parameter
+      after the vector — exactly what [Execute.expand_to_run_source_args] warns
+      about for a leaf-count disagreement. So the declared length slot reads a
+      pointer value and the next declared POINTER parameter reads its 8 bytes
+      out of the 4-byte length cell: this can misinterpret data, and it can
+      equally trap on an illegal device address. Not a crash and silently wrong
+      data are both too narrow a description of it;
+    - OpenCL shares that caller-derived preflight count, but has a late check it
+      did not put there: binding goes through the checked [clSetKernelArg]
+      funnel ([Opencl_api.Kernel.set_arg_mem]), which raises on
+      [CL_INVALID_ARG_INDEX] once the index runs past the compiled kernel's
+      argument list;
+    - Vulkan has a second, source-derived count
       ([Vulkan_api_kernel.validate_buffer_indices], whose [expected_count] is
       read from the GLSL [binding = N] declarations), so there the mismatch
-      surfaces late as "expected 1 buffer argument but got N" — a named
-      rejection that says nothing about SoA.
+      surfaces late as a buffer-count rejection naming the two numbers — and
+      saying nothing about SoA.
 
     As of backlog-214 no caller in this tree reaches any of that:
     [Execute.soa_dispatch] restricts SoA to the CUDA/PTX device and [Soa_launch]

--- a/spoc/framework_error/Backend_error.ml
+++ b/spoc/framework_error/Backend_error.ml
@@ -281,6 +281,52 @@ let () =
 (** Raise backend error as exception *)
 let raise_error err = raise (Backend_error err)
 
+(** {1 Shared refusals} *)
+
+(** Refuse a non-empty [~soa_params] on a backend whose emitter has no
+    Structure-of-Arrays lowering (backlog-214).
+
+    [Framework_sig.generate_source] offers [?soa_params] to every backend, but
+    only an emitter that actually lowers a named vector parameter to N per-leaf
+    base pointers plus one shared length can honour it. A backend without that
+    lowering used to bind the argument away as [?soa_params:_] and return its
+    ordinary packed-AoS source — a signature taking ONE pointer per vector,
+    while the launch side expands an SoA-dispatched vector into N [RSA_Buffer]s
+    plus one [RSA_Vector_Length]. That mismatch is not a compile error and not
+    reliably a crash: it is N pointers bound to a packed parameter block, i.e.
+    silently wrong data.
+
+    Today no such call is made — [Execute.soa_dispatch] restricts SoA to the
+    CUDA/PTX device and [Soa_launch] gates on [PTX] being in the backend's
+    [supported_source_langs] — so this is a boundary, not a live bug fix. What
+    it changes is where the guarantee lives: it was one caller-side predicate
+    and nothing else, and a backend that cannot honour the request now says so
+    instead of answering with the wrong ABI.
+
+    Scope of what this raises, stated narrowly on purpose: it says what THIS
+    backend does with vector parameters. It deliberately does not name which
+    other backend does support SoA — that set is expected to grow (backlog-215),
+    and a message enumerating it would go stale in a file that is not edited
+    when it does.
+
+    [[]] returns [()], so every existing caller and the caller-side fast path
+    are byte-for-byte unaffected. *)
+let reject_soa_params ~backend (soa_params : string list) : unit =
+  match soa_params with
+  | [] -> ()
+  | names ->
+      raise_error
+        (feature_not_supported
+           ~backend
+           (Printf.sprintf
+              "Structure-of-Arrays parameter lowering, requested for %s. This \
+               backend's emitter gives every vector parameter the packed \
+               Array-of-Structures signature (one pointer plus one length), so \
+               the N-leaf-pointer argument list an SoA launch binds would not \
+               match the source it generates. Pass the vector through the \
+               ordinary AoS launch path on this backend."
+              (String.concat ", " (List.map (Printf.sprintf "'%s'") names))))
+
 (** Print error to stderr *)
 let print_error err = Printf.eprintf "%s\n%!" (to_string err)
 


### PR DESCRIPTION
## backlog-214 — five emitters accepted an SoA request and answered with AoS source

`Framework_sig.generate_source` offers `?soa_params:string list` to every backend. Only the CUDA/PTX emitter lowers a named vector parameter to N per-leaf base pointers plus one shared length. Five source-generating backends bound the parameter away and returned their ordinary packed-AoS source:

| plugin | before | after |
| --- | --- | --- |
| `sarek-cuda/Cuda_ptx_plugin.ml` | `?(soa_params = [])` → emitter | unchanged — this is the one that implements it |
| `sarek-cuda/Cuda_c_plugin.ml` | `?soa_params:_` | refuses a non-empty list |
| `sarek-hip/Hip_plugin.ml` | `?soa_params:_` | refuses |
| `sarek-opencl/Opencl_plugin.ml` | `?soa_params:_` | refuses |
| `sarek-vulkan/Vulkan_plugin.ml` | `?soa_params:_` | refuses |
| `sarek-metal/Metal_plugin.ml` | `?soa_params:_` | refuses |

The launch side expands an SoA-dispatched vector into N `RSA_Buffer`s plus one `RSA_Vector_Length`, so AoS source under an SoA argument list is an ABI mismatch no compiler catches.

**The defect is not that this happens — it cannot happen today. It is that the guarantee lived in exactly one place, on the caller side, and the emitters accepted the parameter without complaint.** `Execute.soa_dispatch` restricts SoA to a `"CUDA/PTX"` device and `Soa_launch` gates on `PTX` being in the backend's `supported_source_langs`. Those two predicates were the whole thing standing between an SoA launch and a mismatched signature. `?soa_params:_` is a silent filter where a refusal belongs — the same class as backlog-192, closed for the parser in #398.

Each of the five now calls the shared `Backend_error.reject_soa_params ~backend`, which raises `Plugin (Feature_not_supported _)` naming the framework and the requested parameter, and returns `()` for `[]` so the caller-side fast path is byte-for-byte unchanged. `~backend` is the plugin's own `name`, not its `*_error` module's: `Cuda_error` says `"CUDA"` for both CUDA plugins, and CUDA/PTX is precisely the one that does support SoA.

### What I verified before building, since three of four items filed that day were mis-filed

- **The ignoring is real, and the filed line numbers were exact** — `Cuda_ptx_plugin.ml:37`, `Opencl_plugin.ml:190`, `Vulkan_plugin.ml:190`, `Metal_plugin.ml:183`, `Cuda_c_plugin.ml:36`, `Hip_plugin.ml:33`, all unmoved by #375.
- **No backend could honour it instead.** None of `Sarek_ir_cuda`, `Sarek_ir_opencl`, `Sarek_ir_metal` or `Sarek_ir_glsl` contains any SoA lowering; `soa_params` appears in the PTX emitter and nowhere else. Refusing is not an overshoot here. (HIP reuses the CUDA-C generator verbatim, so one lowering would retire two of the five refusals — noted for backlog-215.)
- **No caller can bypass `Execute`'s gate.** Three call sites: `Execute.ml:944` (gated), `Soa_launch.ml:327` (gated, by a different predicate that happens to select the same single backend — only `Cuda_ptx_plugin` advertises `PTX`), and `Kirc_kernel.source_for_backend`, which omits the argument entirely. **`run_source` never calls `generate_source` at all** — it takes a source string. On CodeRabbit's adjacent #375 point: `run_source`'s transfer and expansion both default to `~soa_abi:false`, so its two halves agree on the packed ABI. **This change is therefore prophylactic, and the PR does not claim otherwise.**

### Scope

Emitter-side refusal only. The caller-side gate is untouched and extending SoA to another backend stays backlog-215.

Native, Interpreter and WebGPU return `None` unconditionally, generate no source, and carry no refusal. **WebGPU is the one to watch** — it is a JIT backend whose WGSL codegen is not yet wired, and when it is wired it inherits the original defect. Flagged in `Execute.ml` and `Framework_sig.ml` rather than pre-emptively patched.

**Nothing in this PR makes a future backend refuse by construction.** A new plugin that omits the call still silently emits AoS for an SoA launch. `Framework_sig`'s doc now states the obligation, and that is a comment, not a gate. A source-level gate over the plugin directories would close it; it is not here, because it is a new gate needing its own `kb/properties.md` row, red path and carrier.

### Evidence

Six Alcotest binaries, 24 cases, no GPU, all under the default `runtest` alias so CI runs them. `sarek-hip/test` gets its first `(test)` stanza — everything else there is an `e2e-hip` executable — because this check needs neither a device nor ROCm.

Both polarities per backend, and each separation was proved by **mutating the code and requiring the expected MESSAGE**, with `git diff --numstat` asserted non-empty first so a pattern that failed to match could not read as separation holding:

| mutation | expected | observed |
| --- | --- | --- |
| revert each of the five to `?soa_params:_` | that backend's refusal case red | 5/5 red on `expected a refusal, got N bytes of AoS source` |
| add the refusal to CUDA/PTX | no-overshoot case red | red on `CUDA/PTX raised a plugin-level refusal` |
| break the PTX leaf-pointer naming | the direct record case red | red on `a record vector still lowers to per-leaf pointers` |
| make the refusal fire on `[]` too | the fast-path case red | 5/5 red on `empty list still generates AoS source` |
| refuse only names that are *not* the record param | the record case red, scalar case green | 5/5 red on the record case only |
| move the Vulkan refusal below codegen | the ordering case red | red on `the refusal precedes codegen` |

The last two exist because of review. The refusal tests originally probed only with a scalar-element vector — a name the PTX emitter would itself reject as ineligible — so the pair could not distinguish "refuses any non-empty list" from "refuses only ineligible names while still ignoring the eligible ones", and the second is the pre-fix behaviour with a coat of paint. Each test now also names a flat two-leaf record, the shape a real SoA launch names.

`test_ptx_soa_not_refused.ml` is the other direction of the change: CUDA/PTX must **not** acquire the refusal. It asserts directly that a `point3d` vector still comes back as PTX carrying `param_sarek_soa_pts_{x,y,z}` + `param_sarek_pts_length` and not the packed `param_pts`.

### One thing deliberately refused although it would work

A record with a **single leaf**. `Soa.plan` permits it, and at N = 1 both ABIs are one binding plus one length, so the AoS source would bind correctly — codex proposed carving it out. It is refused anyway, and the reason is recorded next to the code: that correctness is a coincidence of the leaf count, not a property of the emitter. The same call means something different the moment the record gains a second field, and a carve-out that silently changes meaning under an unrelated edit is worse than a refusal. No in-tree caller can reach it either.

### Five review rounds, every finding one class

Every finding across all five rounds was **a claim wider than its code**. Not one was a wrong algorithm. Three of the five rounds found instances introduced by the *previous* round's correction, which is the part worth reading:

1. The refusal message described a "packed parameter signature (one pointer plus one length)". A GLSL compute entry point has no parameter list — SSBO bindings plus a push-constant length. And "silently wrong data, not a crash" was asserted uniformly and is wrong for Vulkan, which carries a second source-derived count (`validate_buffer_indices`, read from the GLSL `binding = N` declarations) that catches the mismatch late as a buffer-count rejection.
2. The five refusal tests probed only with a scalar-element vector — a name the PTX emitter would itself reject as ineligible — so they could not distinguish "refuses any non-empty list" from "refuses only ineligible names while still ignoring the eligible ones", and the second is the pre-fix behaviour with a coat of paint. Each now also names a flat two-leaf record. Also: the refusal deliberately covers a **single-leaf record**, which would in fact bind correctly (see above).
3. Narrowing (1) for OpenCL and Vulkan **left CUDA/C and HIP stated absolutely**, including in the `Framework_sig` doc comment that is the public contract for `?soa_params` — and dropped **Metal** from an enumeration that reads exhaustive, five backends named and four accounted for.
4. Round 3's replacement was then over-specific in the other direction, and its Metal fold carried a claim about Metal that Metal cannot produce. I found both myself, by asking the two questions a fix of that shape invites.
5. A fresh read found sharper versions of both and I took those. The mechanism sentence — "the length slot reads a pointer and the next pointer parameter reads 8 bytes out of a 4-byte cell" — holds only at N = 2 with a pointer parameter declared after the vector, which is exactly the probe kernels' shape. At **N = 3** the third leaf lands in the following pointer slot: a *valid* device pointer to the wrong buffer, silent corruption, nothing to trap on. With the vector declared **last**, nothing after it shifts into a pointer slot at all. So the claim is now the general form — every parameter declared after the vector receives the wrong entry — with the three shapes as conditioned examples under it.

   And the trap half is **false on Metal**, not merely unestablished: Metal never receives a caller-supplied address. Buffers go through `setBuffer` as MTLBuffer objects, scalars through `setBytes` as a driver-allocated inline copy, against `device T* x [[buffer(k)]], constant int &sarek_x_length [[buffer(k+1)]]`. Under the shift a length index reads a buffer's first 4 bytes as the length and a pointer index gets inline `setBytes` data indexed out of bounds, or another buffer — wrong data and out-of-bounds reads inside valid allocations, or an encode Metal's own API validation rejects. Nothing that traps in the CUDA sense.

Also worth recording: I first *refuted* a reviewer's report of literal space runs in the failure messages, using the pre-ocamlformat literal. Re-checked against the rendered output of the compiled binary, the reviewer was right and I was wrong. The messages now read `expected a refusal, got 155 bytes of AoS source`.

The commit bodies of the first two commits overstate the CUDA/C and HIP symptom in the way (3) describes. Left in place and corrected in the later bodies, so the sequence of corrections stays legible rather than looking as though it never happened.

### Known pre-existing inconsistency, deliberately not fixed here

`Backend_error.reject_soa_params` now cites `Execute.expand_to_run_source_args` as its authority for the shift. **`Execute.ml:270` and `Execute.ml:933` still describe that same shift as "not a crash but silently wrong data"** — the exact claim rounds 3 and 5 established is too narrow. Both predate this branch (`9d0ac351`, `5178b553`) and neither is touched by it, so following the citation currently lands on text that contradicts the citing text. Flagged so the next reader does not conclude the new text is the wrong half; being filed as its own item.

### Gates

Project switch `/home/mathias/dev/SPOC/_opam` — dune **3.24.1**, OCaml **5.4.0**, ppxlib **0.38.0**. Each exit code captured directly.

| gate | exit |
| --- | --- |
| `dune build` | 0 |
| `dune runtest --force` | 0 (see the flake note below) |
| `dune build @fmt` | 0 |
| `make test_negative` | 0 |
| `scripts/prove-red.sh` (8 subjects / 53 mutations) | 0 |
| `scripts/check-kb-properties.sh` / `.test.sh` | 0 / 0 |
| `scripts/check-ppx-construct-names.sh` / `.test.sh` | 0 / 0 |
| `scripts/check-license-headers.sh` | 0 |
| `scripts/check-cited-paths-exist.sh` / `.test.sh` | 0 / 0 |
| `scripts/check-opam-clean.sh` | **0** |
| `scripts/check-test-alias-coverage.sh` | 0 |
| `scripts/check-alcotest-registration.js` | 0 |
| `scripts/check-dune-dir-visibility.sh` | 0 |
| backlog-214 prove-red rounds a / b / c | 0 / 0 / 0 |

`check-opam-clean.sh` exits **0**, not the 1 tracked as backlog-213 — #399 landed while this branch was parked and fixed the dune-3.24.1 `"dune" {>= "3.15" & >= "3.15"}` duplication. The working tree is clean after every gate, so no regenerated `.opam` is committed.

**One `dune runtest --force` run went red and I am reporting it rather than only the green one.** The failure was `test_record_variant_decl_order` (backlog-211, untouched by this branch) on `[CUDA/PTX] AMD Ryzen 9 7950X [ZLUDA]` — the ZLUDA-on-CPU device — with the other ZLUDA device passing the same case. Measured rather than argued: standalone on this branch 3/3 exit 0; standalone on `origin/main` built in a throwaway worktree, exit 0; full `dune runtest --force` re-run on this branch, exit 0. So it is a pre-existing flake under parallel device contention on this machine, which has ZLUDA and two Vulkan/OpenCL devices. CI has no such device and never runs that arm.

**Not verified:** nothing here runs on a GPU. The refusals and the PTX text assertions are host-side codegen, which is the whole point — but the per-backend *symptom* descriptions (illegal-address trap on CUDA/C and HIP, `CL_INVALID_ARG_INDEX` on OpenCL, the Vulkan buffer-count rejection) are read from the binding code and were never executed, because reaching them requires defeating the caller-side gate this PR deliberately leaves alone. They are stated as what the code does, not as observed behaviour. Ambient dune 3.23.0 / ppxlib 0.35.0 cannot build this tree at all (`Ptyp_open` needs ppxlib ≥ 0.37), so no row was measured there.

Rebased onto `9a3a8f79`. No file on this branch is touched by any of the five PRs that merged while it was parked, so the clean rebase cannot have hidden a rerere-applied resolution — verified by intersecting the two name lists, which is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
