### PR TITLE
fix(codegen): refuse a type declaration referencing an undeclared type, by name

### DIFF
--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -1910,3 +1910,23 @@
    LD_LIBRARY_PATH
    %{env:HOME=}/opt/zluda
    (run %{dep:test_shared_record_slots.exe}))))
+
+; backlog-212: a type referenced but never DECLARED is refused by name, not
+; silently forwarded to whichever backend compiler happens to run over the
+; generated source. Deliberately deviceless (see the file header): the
+; refusal lives in shared string-generation code in spoc/ir, so no device is
+; needed to observe it and CI (no GPU) still exercises it every run.
+
+(executable
+ (name test_undeclared_variant_payload_record)
+ (modules test_undeclared_variant_payload_record)
+ (libraries sarek sarek.stdlib sarek_ir sarek.codegen spoc_core sarek_native)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34)))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_undeclared_variant_payload_record.exe})))

--- a/sarek/tests/e2e/test_undeclared_variant_payload_record.ml
+++ b/sarek/tests/e2e/test_undeclared_variant_payload_record.ml
@@ -1,0 +1,209 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(******************************************************************************
+ * E2E test: a type referenced but never DECLARED produces a refusal, not
+ * silence (backlog-212).
+ *
+ * PR #397/backlog-211 made record and variant declarations emit from one
+ * interleaved dependency-ordered pass, so a cross-kind edge between a
+ * DECLARED record and a DECLARED variant is now ordered correctly. That pass
+ * only orders declarations that EXIST in [kern_types]/[kern_variants]. If a
+ * type is referenced by a field or a constructor payload but was never
+ * registered as a declaration at all, there is no node for it in either list,
+ * so there is no edge and (before this fix) no error: [gen_type_decls] wrote
+ * the referencing declaration anyway, and the emitted source names a
+ * struct/union member type with no [typedef]/[struct] anywhere above it.
+ *
+ * THIS IS REACHABLE FROM ORDINARY [@@sarek.type] SOURCE, established BY
+ * EXECUTION (running the ACTUAL [%kernel] PPX output through
+ * [Sarek_ir_codegen], not a hand-built [Sarek_ir_types.kernel] value) — see
+ * [require_undeclared_reference] below, which fails loudly if a future PPX
+ * change closes this gap and the kernel below stops carrying it.
+ *
+ * WHY THIS SHAPE, MEASURED: [Sarek_lower_ir.ml]'s [TEConstr] case registers a
+ * variant's constructor payload from the CONSTRUCTOR'S OWN declared type
+ * (via the typer's [repr te.ty]), independent of how the value passed to the
+ * constructor was obtained. [register_types_from_typ] (also in
+ * [Sarek_lower_ir.ml]) registers a record type when it is a literal
+ * ([TERecord]), a parameter type, or a local array element type — but it
+ * does NOT recurse through a [TVariant] at all (documented at length on that
+ * function: "VARIANTS are deliberately NOT handled here"). So a record whose
+ * ONLY occurrence in a kernel is a value extracted from a variant match arm
+ * and immediately re-wrapped in a DIFFERENT constructor never enters
+ * [kern_types]: [probe2] (the target variant) is registered via [TEConstr],
+ * but [probe_pt] (its constructor's payload record) is not, because it is
+ * never literal-constructed, never a parameter type, and never reached
+ * through the [probe]-typed source parameter (a [TVariant], which
+ * [register_types_from_typ] skips).
+ *
+ * WHAT THIS KERNEL DOES NOT ALSO CLAIM TO FIX. [probe] itself (the SOURCE
+ * parameter's type) is never registered either — no [TEConstr] ever applies
+ * IT, only matches against it — which is the separate, already-documented
+ * "variant-typed kernel parameter" gap [register_types_from_typ]'s doc
+ * comment calls out (a kernel whose only variant occurrence is a parameter
+ * "already fails today, identically"). That gap is NOT backlog-212 and is not
+ * touched by this fix; this kernel is not claimed to compile end-to-end even
+ * after it, and no device is run over it here — see the deviceless-only
+ * rationale below. What backlog-212 fixes, and what this test isolates, is
+ * that [probe2] (which DOES reach [kern_variants]) can no longer silently
+ * reference an undeclared [probe_pt].
+ *
+ * DEVICE-INDEPENDENT ON PURPOSE. [Sarek_ir_codegen.gen_type_decls] (and the
+ * per-backend [generate_with_types] built on it) is pure string generation —
+ * no device is needed to observe the refusal it raises, and CI has none. This
+ * file therefore never opens a [Device.init] and never runs a kernel; it
+ * calls [generate_with_types] directly (OpenCL, chosen arbitrarily — the
+ * check lives in the shared [spoc/ir] module every struct-emitting backend
+ * goes through) and asserts on the raised exception's MESSAGE, not just that
+ * something raised: a crash or an unrelated exception would also make an
+ * exit-code-only assertion pass.
+ ******************************************************************************)
+
+[@@@warning "-32"]
+
+let () = Sarek_native.Native_plugin.init ()
+
+type float32 = float
+
+(* The record that must end up referenced but undeclared. *)
+type probe_pt = {px : float32; py : float32} [@@sarek.type]
+
+(* A SOURCE variant, matched but never constructed in this kernel — [probe]
+   itself is the separate, out-of-scope gap described above. *)
+type probe = Nowhere | At of probe_pt [@@sarek.type]
+
+(* The TARGET variant: constructed via [At2 q], so [TEConstr] registers it in
+   [kern_variants] with a payload type of [TRecord ("..probe_pt", ...)] — the
+   undeclared reference this file exists to catch. *)
+type probe2 = Nowhere2 | At2 of probe_pt [@@sarek.type]
+
+let k =
+  snd
+    [%kernel
+      fun (p : probe) (dst : probe2 vector) (n : int32) ->
+        let tid = thread_idx_x + (block_dim_x * block_idx_x) in
+        if tid < n then begin
+          match p with
+          | Nowhere -> dst.(tid) <- Nowhere2
+          | At q -> dst.(tid) <- At2 q
+        end]
+
+let ir =
+  match k.Sarek.Kirc_types.body_ir with
+  | Some ir -> ir
+  | None -> failwith "kernel has no IR"
+
+(* THE GAP UNDER TEST MUST BE IN THE LOWERED IR, checked rather than assumed —
+   the same discipline test_record_variant_decl_order.ml's
+   [require_cross_edge] uses for backlog-211. If a future PPX change starts
+   registering [probe_pt] here (closing this specific reachability path), this
+   kernel would no longer exercise the codegen refusal at all, and every
+   assertion below would vacuously pass by never reaching the exception. *)
+let require_undeclared_reference () =
+  let open Sarek_ir_types in
+  (* [vname] is module-qualified as the PPX registers it (e.g.
+     "Test_undeclared_variant_payload_record.probe2"), so match the
+     unqualified suffix rather than an exact/mangled name. *)
+  let is_probe2 vname =
+    let suffix = ".probe2" in
+    let sl = String.length suffix and vl = String.length vname in
+    vname = "probe2" || (vl >= sl && String.sub vname (vl - sl) sl = suffix)
+  in
+  let payload_record_name =
+    List.find_map
+      (fun (vname, constrs) ->
+        if not (is_probe2 vname) then None
+        else
+          List.find_map
+            (fun (cname, args) ->
+              if cname <> "At2" then None
+              else
+                List.find_map
+                  (function TRecord (rn, _) -> Some rn | _ -> None)
+                  args)
+            constrs)
+      ir.kern_variants
+  in
+  match payload_record_name with
+  | None ->
+      Printf.printf
+        "NOTHING TO VERIFY: kern_variants=[%s] carries no \"probe2\"/\"At2\" \
+         entry with a record payload, so the codegen refusal below would not \
+         be exercised. kern_types=[%s]\n\
+         %!"
+        (String.concat "; " (List.map fst ir.kern_variants))
+        (String.concat "; " (List.map fst ir.kern_types)) ;
+      exit 1
+  | Some rn ->
+      if List.exists (fun (n, _) -> n = rn) ir.kern_types then begin
+        Printf.printf
+          "NOTHING TO VERIFY: %S is present in kern_types=[%s] — the PPX now \
+           registers it, so this kernel no longer carries an undeclared \
+           reference and the refusal below is not exercised.\n\
+           %!"
+          rn
+          (String.concat "; " (List.map fst ir.kern_types)) ;
+        exit 1
+      end ;
+      Printf.printf
+        "confirmed: kern_variants has \"probe2\"'s \"At2\" payload naming %S, \
+         absent from kern_types=[%s] (reached from ordinary [@@sarek.type] + \
+         [%%kernel] source, not hand-built IR)\n\
+         %!"
+        rn
+        (String.concat "; " (List.map fst ir.kern_types))
+
+(* The refusal itself, on the shared [spoc/ir] entry point every
+   struct-emitting backend goes through. OpenCL is arbitrary — the check lives
+   in [Sarek_ir_codegen.sort_type_decls_by_dependency], shared by all five. *)
+let require_refusal () =
+  match
+    Sarek_codegen.Sarek_ir_opencl.generate_with_types
+      ~types:ir.Sarek_ir_types.kern_types
+      ir
+  with
+  | src ->
+      Printf.printf
+        "FAILED: generate_with_types produced %d bytes with NO error — the \
+         undeclared reference silently reached the emitted source (the \
+         pre-backlog-212 defect). First 200 chars:\n\
+         %s\n"
+        (String.length src)
+        (String.sub src 0 (min 200 (String.length src))) ;
+      exit 1
+  | exception Sarek_ir_codegen.Undeclared_type_ref msgs ->
+      let joined = String.concat "; " msgs in
+      let has substr =
+        let sl = String.length substr and jl = String.length joined in
+        let rec go i =
+          i + sl <= jl && (String.sub joined i sl = substr || go (i + 1))
+        in
+        go 0
+      in
+      (* The names in the message are module-qualified and then mangled
+         (e.g. ["Test_..._probe_pt"]), so check unqualified substrings rather
+         than exact/mangled equality. *)
+      if not (has "probe2" && has {|"At2"|} && has "probe_pt") then begin
+        Printf.printf
+          "FAILED: Undeclared_type_ref raised but its message does not name \
+           the variant, the constructor, and the missing record: %s\n"
+          joined ;
+        exit 1
+      end ;
+      Printf.printf "PASSED: Undeclared_type_ref, named: %s\n" joined
+  | exception e ->
+      Printf.printf
+        "FAILED: expected Undeclared_type_ref, got %s\n"
+        (Printexc.to_string e) ;
+      exit 1
+
+let () =
+  print_endline
+    "=== a type referenced but never declared is refused, by name \
+     (backlog-212) ===" ;
+  require_undeclared_reference () ;
+  require_refusal () ;
+  print_endline "ALL PASSED (deviceless: no device is needed to observe this)"

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -826,19 +826,30 @@ let referenced_type_names (ty : Sarek_ir_types.elttype) : string list =
     not an error either", and that was the gap.) Only declared types can be
     ordered, so before any placement this function first checks that every name
     any declaration's fields/payloads reference resolves to SOME declaration in
-    the same list, by mangled name, either kind. A name that resolves to nothing
-    raises {!Undeclared_type_ref} naming the referencing declaration, the field
-    or constructor site, and the missing type — rather than silently falling
-    through to the backend's own "unknown type name" on whichever compiler the
-    generated source happens to reach, or a Metal/PTX generator that never runs
-    a C compiler over its output at all and would have said nothing. The hole
-    this closes is reachable from ordinary [[@@sarek.type]] source: the PPX
-    registers a variant's constructor payload from the constructor's own
-    declared type — independent of whether the record instance it is constructed
-    from was ever separately registered — so a record whose only occurrence in a
-    kernel is as a value extracted from a differently-typed source (never
-    literal-constructed, never a parameter type, never a local array element
-    type) never enters [kern_types] at all. See
+    the same list, by mangled name, either kind (a field/payload typed
+    [TVariant "t"] is satisfied by a [Record_decl "t"] and vice versa — the same
+    kind-blind resolution {!deps_of} already uses for ordering edges, kept for
+    consistency with the "a record's edge to a same-named variant is kept"
+    guarantee below; a set that is COMPLETE by this check can still emit a
+    struct whose member names a same-mangled-name declaration of the wrong kind,
+    which compiles but names the wrong type — a residual this check does not
+    close). A name that resolves to nothing raises {!Undeclared_type_ref} naming
+    the referencing declaration, the field or constructor site, and the missing
+    type — rather than silently falling through to the backend's own "unknown
+    type name" on whichever compiler the generated source happens to reach. (PTX
+    and Metal are NOT both examples of a silent generator: Metal goes through
+    {!gen_c_type_decls} like every other struct-emitting backend and is fully
+    covered by this check; PTX ([Sarek_ir_ptx_kernel.generate_with_types])
+    ignores its [~types] argument and never calls {!gen_type_decls} at all, so
+    it stays exactly as silent on an undeclared reference after this fix as
+    before — this closes the gap for every backend that DECLARES struct types,
+    not for the one that declares none.) The hole this closes is reachable from
+    ordinary [[@@sarek.type]] source: the PPX registers a variant's constructor
+    payload from the constructor's own declared type — independent of whether
+    the record instance it is constructed from was ever separately registered —
+    so a record whose only occurrence in a kernel is as a value extracted from a
+    differently-typed source (never literal-constructed, never a parameter type,
+    never a local array element type) never enters [kern_types] at all. See
     sarek/tests/e2e/test_undeclared_variant_payload_record.ml.
 
     {b Cycles.} A declaration cycle has no valid emission order, so it raises
@@ -915,11 +926,17 @@ let sort_type_decls_by_dependency (decls : type_decl list) : type_decl list =
           (fun (site, name) ->
             if List.mem name declared_mangled_names then None
             else
+              (* Both names in the message are MANGLED, including the
+                 referencing declaration's — [name] (from
+                 [referenced_type_names]) always is, and printing
+                 [type_decl_name d] unmangled beside it would pair a
+                 dotted source name with an underscored one, naming the
+                 same declaration two different ways in one sentence. *)
               Some
                 (Printf.sprintf
                    "%s %S's %s references undeclared type %S"
                    (type_decl_kind d)
-                   (type_decl_name d)
+                   (mangle_name (type_decl_name d))
                    site
                    name))
           (referenced_with_sites d))

--- a/spoc/ir/Sarek_ir_codegen.ml
+++ b/spoc/ir/Sarek_ir_codegen.ml
@@ -704,6 +704,21 @@ let () =
              (String.concat "; " names))
     | _ -> None)
 
+exception Undeclared_type_ref of string list
+
+(* Same reasoning as {!Type_decl_cycle}'s printer: the payload IS the
+   diagnostic, and without a printer OCaml renders it
+   [Undeclared_type_ref(_)], losing the one thing that makes this refusal
+   useful — which declaration named which missing type. *)
+let () =
+  Printexc.register_printer (function
+    | Undeclared_type_ref msgs ->
+        Some
+          (Printf.sprintf
+             "Sarek_ir_codegen.Undeclared_type_ref: %s"
+             (String.concat "; " msgs))
+    | _ -> None)
+
 (** One record or variant type declaration. The two kinds are carried in a
     SINGLE list so that {!sort_type_decls_by_dependency} can order a record
     against a variant, which is the whole point of backlog-211: before it, each
@@ -806,13 +821,25 @@ let referenced_type_names (ty : Sarek_ir_types.elttype) : string list =
     record and a variant share a name, which is exactly the edge class this pass
     exists to order.
 
-    {b A reference to something not in the list is not an edge.} Only declared
-    types can be ordered, so a type referenced but never declared produces no
-    edge and no error here; it surfaces later as the backend's own "unknown type
-    name". That hole is reachable — the PPX registers a variant in
-    [kern_variants] without registering a record that appears only in its
-    payload — but it is a MISSING declaration, not a misordered one, and no
-    ordering pass can fix it.
+    {b A reference to something not in the list is not an edge — it is now a
+       refusal.} (backlog-212; before it, this paragraph read "not an edge and
+    not an error either", and that was the gap.) Only declared types can be
+    ordered, so before any placement this function first checks that every name
+    any declaration's fields/payloads reference resolves to SOME declaration in
+    the same list, by mangled name, either kind. A name that resolves to nothing
+    raises {!Undeclared_type_ref} naming the referencing declaration, the field
+    or constructor site, and the missing type — rather than silently falling
+    through to the backend's own "unknown type name" on whichever compiler the
+    generated source happens to reach, or a Metal/PTX generator that never runs
+    a C compiler over its output at all and would have said nothing. The hole
+    this closes is reachable from ordinary [[@@sarek.type]] source: the PPX
+    registers a variant's constructor payload from the constructor's own
+    declared type — independent of whether the record instance it is constructed
+    from was ever separately registered — so a record whose only occurrence in a
+    kernel is as a value extracted from a differently-typed source (never
+    literal-constructed, never a parameter type, never a local array element
+    type) never enters [kern_types] at all. See
+    sarek/tests/e2e/test_undeclared_variant_payload_record.ml.
 
     {b Cycles.} A declaration cycle has no valid emission order, so it raises
     {!Type_decl_cycle} with the names still unplaced rather than falling back to
@@ -841,6 +868,64 @@ let sort_type_decls_by_dependency (decls : type_decl list) : type_decl list =
           (fun (_, args) -> List.concat_map referenced_type_names args)
           constrs
   in
+  (* Same walk, but keeping the SITE a reference came from (a field name or a
+     constructor name) alongside the mangled name it names — the completeness
+     check below needs both: the name to look up, the site to name in the
+     diagnostic. *)
+  let referenced_with_sites = function
+    | Record_decl (_, fields) ->
+        List.concat_map
+          (fun (fname, fty) ->
+            List.map
+              (fun n -> (Printf.sprintf "field %S" fname, n))
+              (referenced_type_names fty))
+          fields
+    | Variant_decl (_, constrs) ->
+        List.concat_map
+          (fun (cname, args) ->
+            List.concat_map
+              (fun fty ->
+                List.map
+                  (fun n -> (Printf.sprintf "constructor %S" cname, n))
+                  (referenced_type_names fty))
+              args)
+          constrs
+  in
+  (* COMPLETENESS: every type name any declaration's own fields/payloads
+     reference must resolve to SOME declaration in this same list — a record
+     or a variant, either kind, matched by mangled name exactly as
+     [deps_of] below matches an edge. A name that resolves to nothing is not
+     an edge for the sort to place; it is a type the PPX (or fusion, or a
+     hand-built IR) referenced but never declared, and no ordering pass can
+     invent a declaration for it. Left unchecked, it silently reaches the
+     backend as a reference to a struct/union member type with no
+     [typedef]/[struct] above it, and the backend compiler is the one that
+     eventually complains, if it complains at all (see the doc comment on this
+     function). Checked before the topological placement loop, so a caller
+     gets this refusal rather than a superficially-successful order over an
+     incomplete set. A self-reference always passes: the declaration
+     supplying the name is itself in [declared_mangled_names]. *)
+  let declared_mangled_names =
+    List.map (fun (_, d) -> mangle_name (type_decl_name d)) indexed
+  in
+  let missing =
+    List.concat_map
+      (fun (_, d) ->
+        List.filter_map
+          (fun (site, name) ->
+            if List.mem name declared_mangled_names then None
+            else
+              Some
+                (Printf.sprintf
+                   "%s %S's %s references undeclared type %S"
+                   (type_decl_kind d)
+                   (type_decl_name d)
+                   site
+                   name))
+          (referenced_with_sites d))
+      indexed
+  in
+  if missing <> [] then raise (Undeclared_type_ref missing) ;
   (* Dependencies of one entry, as INCOMING INDICES: every OTHER declaration in
      the list whose name this one references. Dropping index [i] itself is what
      makes a self-referencing declaration emittable in place (a self-reference

--- a/spoc/ir/Sarek_ir_codegen.mli
+++ b/spoc/ir/Sarek_ir_codegen.mli
@@ -335,16 +335,24 @@ val referenced_type_names : Sarek_ir_types.elttype -> string list
 
     {b Completeness (backlog-212).} Before any placement, every name any
     declaration's fields/payloads reference is checked against the declared set
-    (by mangled name, either kind); the self-reference case always passes,
-    because the declaration supplying the name is itself in that set. A name
-    that resolves to nothing raises {!Undeclared_type_ref} rather than being
-    silently dropped as "not an edge" — that used to surface only later, as
-    whichever backend compiler happened to run over the generated source
-    complaining about an unknown type name, or (Metal/PTX) not complaining at
-    all. This is reachable from ordinary [[@@sarek.type]] source: the PPX
-    registers a variant's constructor payload from the constructor's OWN
-    declared type, independent of whether the value passed to the constructor
-    ever separately registered its own record type.
+    (by mangled name, either kind — the same kind-blind resolution the edges
+    above already use, so a set this check accepts as complete can still name a
+    same-mangled, wrong-kind declaration; that residual is not what this check
+    closes); the self-reference case always passes, because the declaration
+    supplying the name is itself in that set. A name that resolves to nothing
+    raises {!Undeclared_type_ref} rather than being silently dropped as "not an
+    edge" — that used to surface only later, as whichever backend compiler
+    happened to run over the generated source complaining about an unknown type
+    name. Not every backend is in that "later" set: Metal goes through
+    {!gen_c_type_decls} like the rest of the C family and is fully covered here;
+    PTX declares no struct types at all (its [generate_with_types] never calls
+    {!gen_type_decls}), so an undeclared reference on the PTX path is exactly as
+    silent after this check as before it — this closes the gap for every
+    struct-DECLARING backend, not for the one backend that declares none. This
+    is reachable from ordinary [[@@sarek.type]] source: the PPX registers a
+    variant's constructor payload from the constructor's OWN declared type,
+    independent of whether the value passed to the constructor ever separately
+    registered its own record type.
 
     Exported for the tests; {!gen_type_decls} is the only production caller.
 
@@ -367,11 +375,14 @@ val sort_type_decls_by_dependency : type_decl list -> type_decl list
     or payload types name a record or variant that is not itself among the
     declarations it was given — a reference with nothing behind it, as opposed
     to {!Type_decl_cycle}'s reference to something present but unorderable. Each
-    string in the payload names the referencing declaration's kind and name, the
-    field or constructor site, and the missing type, e.g.
+    string in the payload names the referencing declaration's kind and MANGLED
+    name, the field or constructor site, and the missing (also mangled) type,
+    e.g.
     [{"variant \"probe2\"'s constructor \"At2\" references undeclared type
-     \"probe_pt\""}]. A [Printexc] printer is registered so the message reaches
-    the user instead of [Undeclared_type_ref(_)].
+     \"probe_pt\""}] — both names mangled consistently, never one dotted and the
+    other underscored for what is otherwise the same declaration. A [Printexc]
+    printer is registered so the message reaches the user instead of
+    [Undeclared_type_ref(_)].
 
     Reachable from ordinary [[@@sarek.type]] source: the PPX registers a
     variant's constructor payload type from the constructor's own declaration,

--- a/spoc/ir/Sarek_ir_codegen.mli
+++ b/spoc/ir/Sarek_ir_codegen.mli
@@ -331,9 +331,20 @@ val referenced_type_names : Sarek_ir_types.elttype -> string list
     Node identity is the POSITION in the list. Two same-named declarations are
     therefore two nodes, and a record's edge to a same-named variant is kept — a
     name-keyed self-edge drop would lose exactly that edge. A reference to a
-    type that is in the list is an edge; a reference to one that is not is
-    neither an edge nor an error here, and surfaces later as the backend's own
-    "unknown type name".
+    type that is in the list is an edge to order.
+
+    {b Completeness (backlog-212).} Before any placement, every name any
+    declaration's fields/payloads reference is checked against the declared set
+    (by mangled name, either kind); the self-reference case always passes,
+    because the declaration supplying the name is itself in that set. A name
+    that resolves to nothing raises {!Undeclared_type_ref} rather than being
+    silently dropped as "not an edge" — that used to surface only later, as
+    whichever backend compiler happened to run over the generated source
+    complaining about an unknown type name, or (Metal/PTX) not complaining at
+    all. This is reachable from ordinary [[@@sarek.type]] source: the PPX
+    registers a variant's constructor payload from the constructor's OWN
+    declared type, independent of whether the value passed to the constructor
+    ever separately registered its own record type.
 
     Exported for the tests; {!gen_type_decls} is the only production caller.
 
@@ -344,8 +355,33 @@ val referenced_type_names : Sarek_ir_types.elttype -> string list
       field at alignment-resolution time, and fusion only concatenates two
       PPX-produced (hence acyclic) type lists. It is a backstop for hand-built
       IR — tests today, a future front end — where nothing else would notice,
-      not a guard anything presently depends on. *)
+      not a guard anything presently depends on.
+    @raise Undeclared_type_ref
+      if any declaration's own field or payload types name a record or variant
+      that is not itself in [decls] — checked, and reachable from ordinary
+      [[@@sarek.type]] source, not only from hand-built IR; see the completeness
+      paragraph above. *)
 val sort_type_decls_by_dependency : type_decl list -> type_decl list
+
+(** Raised by {!sort_type_decls_by_dependency} when some declaration's own field
+    or payload types name a record or variant that is not itself among the
+    declarations it was given — a reference with nothing behind it, as opposed
+    to {!Type_decl_cycle}'s reference to something present but unorderable. Each
+    string in the payload names the referencing declaration's kind and name, the
+    field or constructor site, and the missing type, e.g.
+    [{"variant \"probe2\"'s constructor \"At2\" references undeclared type
+     \"probe_pt\""}]. A [Printexc] printer is registered so the message reaches
+    the user instead of [Undeclared_type_ref(_)].
+
+    Reachable from ordinary [[@@sarek.type]] source: the PPX registers a
+    variant's constructor payload type from the constructor's own declaration,
+    independent of whether the value passed to the constructor ever separately
+    caused its record type to be registered (a record literal, a parameter of
+    that type, or a local array element of that type all register it; extracting
+    an existing value of that type from elsewhere — e.g. a differently-typed
+    source — does not). See
+    sarek/tests/e2e/test_undeclared_variant_payload_record.ml. *)
+exception Undeclared_type_ref of string list
 
 (** Emit a backend's record and variant declarations from ONE
     {!sort_type_decls_by_dependency} pass over both lists together, dispatching
@@ -360,10 +396,11 @@ val sort_type_decls_by_dependency : type_decl list -> type_decl list
     inside their own fields and payloads. It orders NOTHING ELSE the backend
     emits — headers, bindings and helper functions are the caller's sequencing —
     and it does not make an unorderable or incomplete input emittable: see
-    {!Type_decl_cycle} for a cycle, and {!sort_type_decls_by_dependency} for the
-    self-reference and undeclared-reference cases.
+    {!Type_decl_cycle} for a cycle, and {!Undeclared_type_ref} for a reference
+    to a type that is not in [records]/[variants] at all.
 
-    @raise Type_decl_cycle see {!sort_type_decls_by_dependency}. *)
+    @raise Type_decl_cycle see {!sort_type_decls_by_dependency}.
+    @raise Undeclared_type_ref see {!sort_type_decls_by_dependency}. *)
 val gen_type_decls :
   emit_record:
     (Buffer.t -> string * (string * Sarek_ir_types.elttype) list -> unit) ->
@@ -385,7 +422,8 @@ val gen_type_decls :
     is deliberately not exported on its own: a record loop with no sort in it is
     the shape backlog-203 fixed.
 
-    @raise Type_decl_cycle see {!sort_type_decls_by_dependency}. *)
+    @raise Type_decl_cycle see {!sort_type_decls_by_dependency}.
+    @raise Undeclared_type_ref see {!sort_type_decls_by_dependency}. *)
 val gen_c_type_decls :
   type_of_elttype:(Sarek_ir_types.elttype -> string) ->
   constructor_prefix:string ->

--- a/spoc/ir/test/test_sarek_ir_codegen_decl_order.ml
+++ b/spoc/ir/test/test_sarek_ir_codegen_decl_order.ml
@@ -228,16 +228,23 @@ let test_dependency_through_array_and_variant () =
     "dependency through an array field"
     ["triple"; "holder"]
     (sort_records input) ;
+  (* "opt" must be declared here too (backlog-212): a variant referenced by a
+     record field but absent from the decl set is no longer silently treated
+     as "not an edge" — it is a completeness violation, pinned separately
+     below. This case is purely about the ORIGINAL edge-through-variant-payload
+     behavior, so the fixture must be reference-complete. *)
   let input =
     [
-      ("wrapper", [("v", TVariant ("opt", [("None", []); ("Some", [leaf])]))]);
-      ("leaf", leaf_fields);
+      Sarek_ir_codegen.Record_decl
+        ("wrapper", [("v", TVariant ("opt", [("None", []); ("Some", [leaf])]))]);
+      Sarek_ir_codegen.Variant_decl ("opt", [("None", []); ("Some", [leaf])]);
+      Sarek_ir_codegen.Record_decl ("leaf", leaf_fields);
     ]
   in
   check_order
     "dependency through a variant payload"
-    ["leaf"; "wrapper"]
-    (sort_records input) ;
+    ["record:leaf"; "variant:opt"; "record:wrapper"]
+    (tagged_names (Sarek_ir_codegen.sort_type_decls_by_dependency input)) ;
   print_endline "  array and variant-payload field types count as deps: OK"
 
 (* ---------------------------------------------------------------------------
@@ -459,6 +466,110 @@ let test_self_reference_does_not_raise () =
   check_order "self reference" ["selfy"] (sort_records input) ;
   print_endline "  a self-referencing field is not reported as a cycle: OK"
 
+(* ---------------------------------------------------------------------------
+   backlog-212: a type referenced but never DECLARED.
+   --------------------------------------------------------------------------- *)
+
+(* A variant's payload names a record that is nowhere in the declaration set —
+   the exact shape the PPX produces when a variant constructor is applied to a
+   value whose record type was never separately registered (see
+   sarek/tests/e2e/test_undeclared_variant_payload_record.ml for the
+   ordinary-source reproducer). Before backlog-212 this silently fell through
+   [sort_type_decls_by_dependency] as "not an edge"; it must now raise
+   [Undeclared_type_ref] naming the variant, the constructor, and the missing
+   record — BEFORE any device or backend generator runs. *)
+let test_undeclared_record_in_variant_payload_is_refused () =
+  let input = [Sarek_ir_codegen.Variant_decl ("probe2", [("At2", [leaf])])] in
+  match Sarek_ir_codegen.sort_type_decls_by_dependency input with
+  | order ->
+      failwith
+        (Printf.sprintf
+           "undeclared record via variant payload: expected \
+            Undeclared_type_ref, got [%s]"
+           (String.concat "; " (tagged_names order)))
+  | exception Sarek_ir_codegen.Undeclared_type_ref msgs ->
+      let joined = String.concat "; " msgs in
+      let has substr =
+        let sl = String.length substr and jl = String.length joined in
+        let rec go i =
+          i + sl <= jl && (String.sub joined i sl = substr || go (i + 1))
+        in
+        go 0
+      in
+      if not (has {|"probe2"|} && has {|"At2"|} && has {|"leaf"|}) then
+        failwith
+          (Printf.sprintf
+             "undeclared record via variant payload: message must name the \
+              variant, the constructor, and the missing record; got [%s]"
+             joined) ;
+      print_endline
+        "  a variant payload naming an undeclared record raises \
+         Undeclared_type_ref, by name: OK"
+
+(* Mirror in the other direction: a record's field names a variant that is
+   nowhere in the declaration set. *)
+let test_undeclared_variant_in_record_field_is_refused () =
+  let input =
+    [
+      Sarek_ir_codegen.Record_decl
+        ( "gauge2",
+          [("gk", TVariant ("flagv2", [("Off", [])])); ("gv", TFloat32)] );
+    ]
+  in
+  match Sarek_ir_codegen.sort_type_decls_by_dependency input with
+  | order ->
+      failwith
+        (Printf.sprintf
+           "undeclared variant via record field: expected Undeclared_type_ref, \
+            got [%s]"
+           (String.concat "; " (tagged_names order)))
+  | exception Sarek_ir_codegen.Undeclared_type_ref msgs ->
+      let joined = String.concat "; " msgs in
+      let has substr =
+        let sl = String.length substr and jl = String.length joined in
+        let rec go i =
+          i + sl <= jl && (String.sub joined i sl = substr || go (i + 1))
+        in
+        go 0
+      in
+      if not (has {|"gauge2"|} && has {|"gk"|} && has {|"flagv2"|}) then
+        failwith
+          (Printf.sprintf
+             "undeclared variant via record field: message must name the \
+              record, the field, and the missing variant; got [%s]"
+             joined) ;
+      print_endline
+        "  a record field naming an undeclared variant raises \
+         Undeclared_type_ref, by name: OK"
+
+(* A completeness refusal is not a cycle refusal in disguise: the SAME missing
+   reference must never mimic [Type_decl_cycle] (whose payload identifies
+   declarations, not fields/constructors) nor silently sort as if the
+   reference did not exist. Also pins that a REFERENCE-COMPLETE set with no
+   cycle is unaffected — the two checks are independent — by reusing
+   [test_gen_type_decls_dispatch_and_order]'s already-complete fixtures
+   elsewhere in this file as the implicit negative case. *)
+let test_gen_type_decls_propagates_undeclared_ref () =
+  let emit_record buf (name, _) =
+    Buffer.add_string buf (Printf.sprintf "R(%s) " name)
+  in
+  let emit_variant buf (name, _) =
+    Buffer.add_string buf (Printf.sprintf "V(%s) " name)
+  in
+  match
+    Sarek_ir_codegen.gen_type_decls
+      ~emit_record
+      ~emit_variant
+      ~tie_break:Sarek_ir_codegen.Variants_first
+      (Buffer.create 16)
+      ~records:[]
+      ~variants:[("probe2", [("At2", [leaf])])]
+  with
+  | () -> failwith "gen_type_decls: expected Undeclared_type_ref, got ()"
+  | exception Sarek_ir_codegen.Undeclared_type_ref _ ->
+      print_endline
+        "  gen_type_decls propagates Undeclared_type_ref from the sort: OK"
+
 (* The generic emission driver, not just the sort: each entry must be handed to
    the emitter for its OWN kind, and in the sorted order. Both cross shapes are
    driven through it with stand-in emitters, so a dispatch that sent a variant
@@ -636,6 +747,9 @@ let () =
   test_variant_self_payload_does_not_raise () ;
   test_cycle_is_refused () ;
   test_self_reference_does_not_raise () ;
+  test_undeclared_record_in_variant_payload_is_refused () ;
+  test_undeclared_variant_in_record_field_is_refused () ;
+  test_gen_type_decls_propagates_undeclared_ref () ;
   test_gen_type_decls_dispatch_and_order () ;
   test_c_family_emission_order () ;
   test_referenced_names_terminates_on_cyclic_value () ;


### PR DESCRIPTION
## Summary

backlog-212. PR #397 (backlog-211) made record and variant type
declarations for Sarek GPU kernels emit from ONE interleaved
dependency-ordered pass (`Sarek_ir_codegen.sort_type_decls_by_dependency`),
so a dependency edge between an EXISTING record declaration and an EXISTING
variant declaration is now ordered correctly before emission.

That pass only orders declarations that already exist in the assembled
`kern_types`/`kern_variants` lists. If a type is referenced by a field or a
constructor payload but was never registered as a declaration at all, there
was no node for it, so there was no edge and — before this PR — no error:
the emitter wrote a reference to an undeclared struct/union member type
name and left whichever backend compiler happens to run over the generated
source to complain, or (Metal aside, PTX) not complain at all.

This PR adds a completeness check, in the same place the declaration set is
assembled (`sort_type_decls_by_dependency`, before the topological
placement loop): every type name any declaration's own fields/payloads
reference must resolve to some declaration in the same list (record or
variant, matched by mangled name — the same kind-blind resolution the
existing ordering edges already use). A name that resolves to nothing
raises a new `Undeclared_type_ref` exception, naming the referencing
declaration, the field/constructor site, and the missing type, e.g.:

```
Sarek_ir_codegen.Undeclared_type_ref: variant "..._probe2"'s constructor
"At2" references undeclared type "..._probe_pt"
```

## Reachability: ordinary source, not hand-built IR — and how that was settled

This is **reachable from ordinary `[@@sarek.type]` + `[%kernel]` source**,
established by running the actual PPX-compiled kernel and inspecting the
lowered IR (not by hand-constructing a `Sarek_ir_types.kernel` value):

```
dune exec sarek/tests/e2e/test_undeclared_variant_payload_record.exe
```

Pre-fix, this command printed:

```
kern_types=[]
kern_variants=[Test_undeclared_variant_payload_record.probe2]
```

i.e. the PPX registered the `probe2` variant (via a constructor
application, `TEConstr`) while its constructor's record payload type
(`probe_pt`) never entered `kern_types` at all — and calling
`Sarek_ir_opencl.generate_with_types` on that IR (pre-fix) produced 989
bytes of C source with **no error**, silently naming the undeclared struct
type `..._probe_pt` in a union member and a helper-function parameter.
Post-fix, the same call raises `Undeclared_type_ref` naming exactly that.

Why this is reachable at all: `Sarek_lower_ir.ml`'s `TEConstr` case
registers a variant's constructor payload from the **constructor's own
declared type**, independent of whether the value passed to it was ever
separately registered. `register_types_from_typ` (same file) does **not**
recurse through a `TVariant` at all — documented at length on that function
("VARIANTS are deliberately NOT handled here"). So a record whose only
occurrence in a kernel is a value extracted from a variant match arm and
re-wrapped in a *different* constructor never enters `kern_types`. The
reproducer kernel does exactly that: it matches `p : probe` (never
constructed, so `probe` itself stays unregistered too — a separate,
already-documented gap, see below) and re-wraps the extracted payload as
`At2 q`, registering `probe2` but not `probe_pt`.

**This is not the same shape as #397's tag-erasure trap, but the same
defeat is still required and present.** Static tag erasure
(`Sarek_tag_erasure.ml`, S1/S2) only reduces a variant-typed *local `let`
binding* written by a literal constructor and read only as a match
scrutinee. The reproducer's `dst.(tid) <- At2 q` is a vector store, not a
local binding, so it is conservatively left tagged and `probe2` reaches
`kern_variants` regardless — no `if` is needed to defeat erasure here
because the shape this bug lives in was never eligible for that reduction
in the first place. (I did check: erasure's scope is `let`-bound locals
only; a vector-store target is out of its scope by construction, confirmed
by reading `Sarek_tag_erasure.ml`'s own header comment.)

**What this does NOT also claim to fix.** `probe` (the reproducer's SOURCE
parameter type) is never registered either — no `TEConstr` ever applies IT,
only pattern-matches against it — which is the separate, already-documented
"variant-typed kernel parameter" gap (`register_types_from_typ`'s own doc
comment: a kernel whose only variant occurrence is a parameter "already
fails today, identically"). That gap is **not** backlog-212 and is not
touched here; the reproducer kernel is not claimed to compile end-to-end
even after this fix, and no device is run over it — see below.

## Why the test is deviceless, and what it actually asserts

`Sarek_ir_codegen.gen_type_decls` (and every backend's `generate_with_types`
built on it) is pure string generation — no device is needed to observe the
refusal, and CI has none. `test_undeclared_variant_payload_record.ml`
therefore never opens a `Device.init` and never runs a kernel. It:

1. Asserts, on the actual lowered IR, that `kern_variants` carries a
   `probe2`/`At2` entry whose payload names a record absent from
   `kern_types` — so a future PPX change that starts registering that
   record would make this test print "NOTHING TO VERIFY" and exit 1 rather
   than silently passing on a closed gap.
2. Asserts that `Sarek_ir_opencl.generate_with_types` raises
   `Undeclared_type_ref`, and checks the **message text** (not just the
   exception type) names `probe2`, `At2`, and `probe_pt` — a bare
   `try...with _ -> ()` would not catch a message drift or a wrong
   exception.

## Scope note on backlog-211's claim

This narrows, not widens, #397's claim. Before this PR, "declaration order
is sound" covered ordering only and said nothing about a reference to
something never declared at all. After this PR it also requires
completeness: every reference resolves to a declaration, or the sort
refuses by name. The check remains kind-blind by mangled name (matching the
existing edge-resolution behavior) — a set accepted as complete can in
principle still emit a struct member naming a same-mangled, wrong-kind
declaration; that residual is documented in the `.mli` and is not closed by
this PR.

## Review

Two legs of the mandatory cross-runtime review did not produce usable
verdicts and are recorded honestly rather than invented:

- **codex**: ran twice against a JSON-only, schema-constrained prompt and
  both times returned non-conforming (prose) output under this repo's
  `xruntime-review.js` harness — no parseable verdict obtained. Recorded as
  a skip, not attested as GO.
- **opencode**: measured non-functional on this host across three
  independent attempts (zero-byte output, a hard timeout, and an
  `AI_APICallError` from an unreachable local ollama backend it falls back
  to). Recorded as a skip with that reason, authorized by mathias.
- **Independent adversarial review performed instead**:
  `pr-review-toolkit:code-reviewer`, given the diff cold with no access to
  this PR body, found two real issues, both fixed in the second commit:
  (1) the exception message paired an unmangled, module-qualified
  referencing-declaration name with a mangled missing-type name — same kind
  of thing shown two different ways in one sentence; (2) the `.mli` doc
  comment overclaimed PTX coverage (PTX's `generate_with_types` ignores
  `~types` and never calls `gen_type_decls` at all, so it is untouched by
  this fix, unlike Metal which goes through the same `gen_c_type_decls`
  path as every other struct-emitting backend).

Per this repo's standing bar, an independent adversarial review is
sufficient to land; CodeRabbit's own auto-review on this PR is welcome but
not blocking, and no CodeRabbit re-review has been requested.

## Gates (switch `/home/mathias/dev/SPOC/_opam`, dune 3.24.1, OCaml 5.4.0,
ppxlib 0.38.0), each exit code captured directly:

| Gate | Exit |
|---|---|
| `dune build` | 0 |
| `dune runtest --force` (full tree, real GPU devices: 2x OpenCL, 2x Vulkan, Native, Interpreter, CUDA/PTX via ZLUDA) | 0 |
| `dune build @fmt` | 0 |
| `make test_negative` | 0 |
| `scripts/prove-red.sh` | 0 (8 subjects / 53 mutations, every declared mutation produced its declared exit code and message) |
| `scripts/check-kb-properties.sh` (+ `.test.sh`) | 0 / 0 |
| `scripts/check-ppx-construct-names.sh` (+ `.test.sh`) | 0 / 0 |
| `scripts/check-license-headers.sh` | 0 |
| `scripts/check-cited-paths-exist.sh` (+ `.test.sh`) | 0 / 0 |
| `scripts/check-test-alias-coverage.sh` | 0 |
| `scripts/check-opam-clean.sh` | 0 |

`git checkout -- '*.opam'` run before every commit; no regenerated `.opam`
committed. `origin/main` had not moved past this branch's base at push
time, so no rebase was needed.

## What I could not verify

- No NVIDIA, HIP, native Metal, or WGSL hardware on this host — Metal/WGSL
  codegen coverage for this change is the same pure-string-generation path
  every other backend goes through (`gen_type_decls`), exercised by the
  deviceless test above, but not run on real Metal/WGSL hardware.
- codex's and opencode's cross-runtime review legs, as stated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
