### PR TITLE
fix(soa): Soa_vector.scatter refuses loudly when auto-sync is off (backlog-220)

### DIFF
--- a/sarek/core/Soa.mli
+++ b/sarek/core/Soa.mli
@@ -37,13 +37,30 @@ type leaf = {
     element size in bytes (the stride between consecutive elements in AoS). *)
 type plan = {name : string; leaves : leaf list; aos_stride : int}
 
-(** Raised to refuse an operation this module cannot do without either
-    corrupting data or misrepresenting what happened. Two distinct causes
-    share it: a type is not a v1-supported SoA target (non-record, or a
-    record with a nested-record / variant / array field — flat records only
-    for v1), raised by {!plan}/{!plan_of_elttype}; or, raised by
-    {!Soa_vector.scatter}, a vector's host data is out of date and auto-sync
-    is disabled, so the transpose cannot be done correctly and silently. *)
+(** Raised to refuse an operation the SoA layer cannot do without either
+    corrupting data or misrepresenting what happened.
+
+    Below is the list of RAISERS, which is closed as of this comment
+    ([grep -rn "Unsupported" sarek/core/Soa.ml sarek/core/Soa_vector.ml] to
+    re-derive it). The reasons under each raiser are examples, not an
+    enumeration — read the message, not this list, to learn why a particular
+    call refused.
+
+    - {!plan} and {!plan_of_elttype}: the element type is not a v1-supported SoA
+      target. Reached by a non-record; by a nested-record, variant, array or
+      vector field; by an f16 or uint8 field; and by a
+      [Sarek_ir_layout.record_layout] failure such as a misaligned field.
+    - {!Soa_vector.create}, and therefore {!Soa_vector.create_transparent}: the
+      element type's [custom_type.ir_fields] is [None], so no flat-record layout
+      is derivable at all. Raised before {!plan} is reached.
+    - {!Soa_vector.scatter}: a vector's host data is out of date while auto-sync
+      is disabled, so the transpose cannot be done correctly and silently.
+
+    That last cause is unlike the others and callers must not conflate them: it
+    is a transient property of one VECTOR's state, not a permanent property of a
+    TYPE, and the same call succeeds once the host copy is refreshed. A handler
+    that reads {!Unsupported} as "this type can never be SoA" and installs a
+    permanent AoS fallback is wrong for it. *)
 exception Unsupported of string
 
 (** Build a SoA plan from a record's named fields. Reuses

--- a/sarek/core/Soa.mli
+++ b/sarek/core/Soa.mli
@@ -37,8 +37,13 @@ type leaf = {
     element size in bytes (the stride between consecutive elements in AoS). *)
 type plan = {name : string; leaves : leaf list; aos_stride : int}
 
-(** Raised when a type is not a v1-supported SoA target (non-record, or a record
-    with a nested-record / variant / array field — flat records only for v1). *)
+(** Raised to refuse an operation this module cannot do without either
+    corrupting data or misrepresenting what happened. Two distinct causes
+    share it: a type is not a v1-supported SoA target (non-record, or a
+    record with a nested-record / variant / array field — flat records only
+    for v1), raised by {!plan}/{!plan_of_elttype}; or, raised by
+    {!Soa_vector.scatter}, a vector's host data is out of date and auto-sync
+    is disabled, so the transpose cannot be done correctly and silently. *)
 exception Unsupported of string
 
 (** Build a SoA plan from a record's named fields. Reuses

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -87,7 +87,35 @@ let get t i = Vector.get t.aos i
 
 let leaf_ptrs t = Array.map (fun (Leaf v) -> Vector.to_ctypes_ptr v) t.leaves
 
+(* backlog-220. [Vector.ensure_cpu_sync] below is a no-op whenever auto-sync is
+   off, REGARDLESS of whether the host copy is actually behind a device's data
+   ([Vector_transfer.ensure_cpu_sync] tests [auto_sync] before it even looks at
+   [location]). So on [Stale_CPU] — the state a device write leaves the AoS
+   vector in — an auto-sync-off [scatter] used to transpose the STALE host
+   bytes into the leaves and return [unit], indistinguishable from a correct
+   call. That is silent data corruption, not a no-op: every subsequent read of
+   this SoA vector's leaves (and anything transferred from them to a device)
+   is now wrong, with nothing in the return type or the logs to say so.
+
+   [CPU]/[GPU]/[Both]/[Stale_GPU] are unaffected: the host buffer already IS
+   the fresh data (or, for pure [GPU], scatter never claimed to fix that
+   pre-existing gap — see [Vector_transfer.ensure_cpu_sync]'s own doc). Only
+   [Stale_CPU] means "a device holds newer data than what scatter is about to
+   read", so only that state is refused. *)
 let scatter t =
+  (match (Vector.location t.aos, Vector.auto_sync t.aos) with
+  | Vector.Stale_CPU _, false ->
+      raise
+        (Soa.Unsupported
+           "Soa_vector.scatter: this vector's host data is out of date and \
+            auto-sync is off, so scattering now would silently copy stale \
+            values to the device buffers instead of refusing. Before \
+            scattering, either call Transfer.to_cpu on its AoS vector \
+            (Soa_vector.aos_vector t) to refresh the host copy, or call \
+            Vector.set_auto_sync on it to turn auto-sync back on.")
+  | (Vector.CPU | Vector.GPU _ | Vector.Both _ | Vector.Stale_GPU _), _
+  | Vector.Stale_CPU _, true ->
+      ()) ;
   (* Make the AoS host copy authoritative before transposing out of it. *)
   Vector.ensure_cpu_sync t.aos ;
   Soa.scatter

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -104,21 +104,56 @@ let leaf_ptrs t = Array.map (fun (Leaf v) -> Vector.to_ctypes_ptr v) t.leaves
    this refusal does not attempt to cover it either, so it is excluded from
    the match rather than silently folded into the same message. Only
    [Stale_CPU] means "a device holds newer data than what scatter is about to
-   read", so only that state is refused. *)
+   read", so only that state is refused.
+
+   "Auto-sync will rescue the stale host copy" has TWO independent gates, and
+   the first version of this refusal read only one of them: [Vector.auto_sync]
+   is the PER-VECTOR flag [Vector.set_auto_sync] toggles; [Transfer.is_auto ()]
+   is the GLOBAL mode [Transfer.disable_auto]/[Transfer.enable_auto] toggle for
+   every vector at once. [Vector_transfer.ensure_cpu_sync] only calls the
+   registered sync callback when the per-vector flag is on, and the callback
+   [Transfer.ml] registers only performs the sync when the global mode is also
+   on ([if not !auto_mode then false else (to_cpu vec; true)]) — so a rescue
+   happens if AND ONLY IF both are on. A version of this predicate that checked
+   only the per-vector flag refused correctly with the global mode left alone,
+   but silently permitted the exact same corruption whenever a caller had
+   turned auto-sync off globally ([Transfer.disable_auto ()]) while leaving
+   this particular vector's own flag at its [true] default — reproducing the
+   original bug through the other spelling of "auto-sync is off". *)
 let scatter t =
-  (match (Vector.location t.aos, Vector.auto_sync t.aos) with
-  | Vector.Stale_CPU _, false ->
-      raise
-        (Soa.Unsupported
-           "Soa_vector.scatter: this vector's host data is out of date and \
-            auto-sync is off, so scattering now would copy stale values into \
-            this vector's per-leaf host buffers with no error. Before \
-            scattering, either call Transfer.to_cpu on its AoS vector \
-            (Soa_vector.aos_vector) to refresh the host copy, or call \
-            Vector.set_auto_sync on it to turn auto-sync back on.")
-  | (Vector.CPU | Vector.GPU _ | Vector.Both _ | Vector.Stale_GPU _), _
-  | Vector.Stale_CPU _, true ->
-      ()) ;
+  (match Vector.location t.aos with
+  | Vector.Stale_CPU _ ->
+      let per_vector_on = Vector.auto_sync t.aos in
+      let global_on = Transfer.is_auto () in
+      if not (per_vector_on && global_on) then
+        let reason =
+          match (per_vector_on, global_on) with
+          | false, true ->
+              "this vector's own auto-sync flag is off (call \
+               Vector.set_auto_sync on it to turn it back on)"
+          | true, false ->
+              "auto-sync is off globally, for every vector, via \
+               Transfer.disable_auto (call Transfer.enable_auto to turn it \
+               back on)"
+          | false, false ->
+              "auto-sync is off both on this vector (Vector.set_auto_sync) \
+               and globally (Transfer.disable_auto / Transfer.enable_auto)"
+          | true, true ->
+              (* Unreachable: the enclosing [if] only fires when at least one
+                 of the two is [false]. *)
+              assert false
+        in
+        raise
+          (Soa.Unsupported
+             (Printf.sprintf
+                "Soa_vector.scatter: this vector's host data is out of date \
+                 and %s, so nothing will refresh it, and scattering now \
+                 would copy stale values into this vector's per-leaf host \
+                 buffers with no error. Before scattering, call \
+                 Transfer.to_cpu on its AoS vector (Soa_vector.aos_vector) to \
+                 refresh the host copy directly."
+                reason))
+  | Vector.CPU | Vector.GPU _ | Vector.Both _ | Vector.Stale_GPU _ -> ()) ;
   (* Make the AoS host copy authoritative before transposing out of it. *)
   Vector.ensure_cpu_sync t.aos ;
   Soa.scatter

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -97,9 +97,12 @@ let leaf_ptrs t = Array.map (fun (Leaf v) -> Vector.to_ctypes_ptr v) t.leaves
    this SoA vector's leaves (and anything transferred from them to a device)
    is now wrong, with nothing in the return type or the logs to say so.
 
-   [CPU]/[GPU]/[Both]/[Stale_GPU] are unaffected: the host buffer already IS
-   the fresh data (or, for pure [GPU], scatter never claimed to fix that
-   pre-existing gap — see [Vector_transfer.ensure_cpu_sync]'s own doc). Only
+   [CPU]/[Both]/[Stale_GPU] are unaffected because the host buffer there
+   already IS the fresh data. Pure [GPU] (no host buffer written yet) is a
+   pre-existing gap [ensure_cpu_sync] never covered even with auto-sync on —
+   nothing constructs that state for an AoS vector in this codebase today, and
+   this refusal does not attempt to cover it either, so it is excluded from
+   the match rather than silently folded into the same message. Only
    [Stale_CPU] means "a device holds newer data than what scatter is about to
    read", so only that state is refused. *)
 let scatter t =
@@ -108,10 +111,10 @@ let scatter t =
       raise
         (Soa.Unsupported
            "Soa_vector.scatter: this vector's host data is out of date and \
-            auto-sync is off, so scattering now would silently copy stale \
-            values to the device buffers instead of refusing. Before \
+            auto-sync is off, so scattering now would copy stale values into \
+            this vector's per-leaf host buffers with no error. Before \
             scattering, either call Transfer.to_cpu on its AoS vector \
-            (Soa_vector.aos_vector t) to refresh the host copy, or call \
+            (Soa_vector.aos_vector) to refresh the host copy, or call \
             Vector.set_auto_sync on it to turn auto-sync back on.")
   | (Vector.CPU | Vector.GPU _ | Vector.Both _ | Vector.Stale_GPU _), _
   | Vector.Stale_CPU _, true ->

--- a/sarek/core/Soa_vector.ml
+++ b/sarek/core/Soa_vector.ml
@@ -106,15 +106,37 @@ let leaf_ptrs t = Array.map (fun (Leaf v) -> Vector.to_ctypes_ptr v) t.leaves
    [Stale_CPU] means "a device holds newer data than what scatter is about to
    read", so only that state is refused.
 
-   "Auto-sync will rescue the stale host copy" has TWO independent gates, and
-   the first version of this refusal read only one of them: [Vector.auto_sync]
-   is the PER-VECTOR flag [Vector.set_auto_sync] toggles; [Transfer.is_auto ()]
-   is the GLOBAL mode [Transfer.disable_auto]/[Transfer.enable_auto] toggle for
-   every vector at once. [Vector_transfer.ensure_cpu_sync] only calls the
-   registered sync callback when the per-vector flag is on, and the callback
-   [Transfer.ml] registers only performs the sync when the global mode is also
-   on ([if not !auto_mode then false else (to_cpu vec; true)]) — so a rescue
-   happens if AND ONLY IF both are on. A version of this predicate that checked
+   "Auto-sync is on" has TWO independent caller-facing gates — which is NOT
+   the same set as "a rescue will happen", see below — and the first version
+   of this refusal read only one of them: [Vector.auto_sync] is the PER-VECTOR
+   flag [Vector.set_auto_sync] toggles; [Transfer.is_auto ()] is the GLOBAL
+   mode [Transfer.disable_auto]/[Transfer.enable_auto]/[Transfer.set_auto]
+   toggle for every vector at once. [Vector_transfer.ensure_cpu_sync] only
+   calls the registered sync callback when the per-vector flag is on, and the
+   callback [Transfer.ml] registers only performs the sync when the global
+   mode is also on ([if not !auto_mode then false else (to_cpu vec; true)]) —
+   so with THAT callback installed, a rescue happens if and only if both are
+   on.
+
+   The two gates are not symmetric, and this predicate is deliberately not an
+   exact test of "will a rescue happen":
+     - the per-vector flag is necessary unconditionally —
+       [Vector_transfer.ensure_cpu_sync] tests it itself and returns before
+       looking at anything else;
+     - the global mode is necessary only for the callback [Transfer.ml]
+       installs. Nothing in [Vector_transfer] reads it, and
+       [Vector.register_sync_callback] is public, so a caller can install a
+       callback that ignores it (this item's own test suite does exactly
+       that);
+     - neither is sufficient: [ensure_cpu_sync] does nothing at all when no
+       callback is registered ([| None -> ()]), and it discards the callback's
+       [bool] result either way.
+   Reading both gates therefore errs in one direction only: it can refuse a
+   scatter that a bespoke callback would have rescued, and it never permits
+   one that nothing will. That is the safe side, and it is why this reads
+   gates rather than trying to predict the callback.
+
+   A version of this predicate that checked
    only the per-vector flag refused correctly with the global mode left alone,
    but silently permitted the exact same corruption whenever a caller had
    turned auto-sync off globally ([Transfer.disable_auto ()]) while leaving
@@ -136,8 +158,8 @@ let scatter t =
                Transfer.disable_auto (call Transfer.enable_auto to turn it \
                back on)"
           | false, false ->
-              "auto-sync is off both on this vector (Vector.set_auto_sync) \
-               and globally (Transfer.disable_auto / Transfer.enable_auto)"
+              "auto-sync is off both on this vector (Vector.set_auto_sync) and \
+               globally (Transfer.disable_auto / Transfer.enable_auto)"
           | true, true ->
               (* Unreachable: the enclosing [if] only fires when at least one
                  of the two is [false]. *)
@@ -147,11 +169,11 @@ let scatter t =
           (Soa.Unsupported
              (Printf.sprintf
                 "Soa_vector.scatter: this vector's host data is out of date \
-                 and %s, so nothing will refresh it, and scattering now \
-                 would copy stale values into this vector's per-leaf host \
-                 buffers with no error. Before scattering, call \
-                 Transfer.to_cpu on its AoS vector (Soa_vector.aos_vector) to \
-                 refresh the host copy directly."
+                 and %s, so nothing will refresh it, and scattering now would \
+                 copy stale values into this vector's per-leaf host buffers \
+                 with no error. Before scattering, call Transfer.to_cpu on its \
+                 AoS vector (Soa_vector.aos_vector) to refresh the host copy \
+                 directly."
                 reason))
   | Vector.CPU | Vector.GPU _ | Vector.Both _ | Vector.Stale_GPU _ -> ()) ;
   (* Make the AoS host copy authoritative before transposing out of it. *)

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -101,8 +101,12 @@ val set : 'a t -> int -> 'a -> unit
 val get : 'a t -> int -> 'a
 
 (** [scatter t] transposes the AoS host buffer into the N per-leaf host buffers
-    (call before transferring the leaves to a device). Ensures the AoS host copy
-    is current first. *)
+    (call before transferring the leaves to a device). Brings the AoS host copy
+    up to date first when auto-sync is enabled.
+
+    When auto-sync is disabled and the host copy is behind a device's data,
+    there is no way to bring it up to date silently, so [scatter] raises
+    {!Soa.Unsupported} instead of transposing the stale host bytes. *)
 val scatter : 'a t -> unit
 
 (** [gather t] transposes the N per-leaf host buffers back into the AoS host

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -102,12 +102,15 @@ val get : 'a t -> int -> 'a
 
 (** [scatter t] transposes the AoS host buffer into the N per-leaf host buffers
     (call before transferring the leaves to a device). When the host copy is
-    behind a device's data ([Stale_CPU]) and auto-sync is enabled, attempts to
-    bring it up to date first.
+    behind a device's data ([Stale_CPU]) and auto-sync would actually rescue
+    it — both this vector's own flag ({!Vector.auto_sync}) AND the global mode
+    ({!Transfer.is_auto}) are on — attempts to bring it up to date first.
 
-    When the host copy is [Stale_CPU] and auto-sync is disabled, there is no
-    way to bring it up to date silently, so [scatter] raises
-    {!Soa.Unsupported} instead of transposing the stale host bytes. Every
+    When the host copy is [Stale_CPU] and EITHER auto-sync gate is off (this
+    vector's own flag via {!Vector.set_auto_sync}, or the global mode via
+    {!Transfer.disable_auto}), there is no way to bring it up to date silently,
+    so [scatter] raises {!Soa.Unsupported} instead of transposing the stale
+    host bytes; the message names whichever of the two is actually off. Every
     other location ([CPU], [GPU], [Both], [Stale_GPU]) is unaffected either
     way, since the host copy there is already the vector's freshest data. *)
 val scatter : 'a t -> unit

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -102,17 +102,29 @@ val get : 'a t -> int -> 'a
 
 (** [scatter t] transposes the AoS host buffer into the N per-leaf host buffers
     (call before transferring the leaves to a device). When the host copy is
-    behind a device's data ([Stale_CPU]) and auto-sync would actually rescue
-    it — both this vector's own flag ({!Vector.auto_sync}) AND the global mode
-    ({!Transfer.is_auto}) are on — attempts to bring it up to date first.
+    behind a device's data ([Stale_CPU]), [scatter] first reads two auto-sync
+    gates: this vector's own flag ({!Vector.auto_sync}) and the global mode
+    ({!Transfer.is_auto}).
 
-    When the host copy is [Stale_CPU] and EITHER auto-sync gate is off (this
-    vector's own flag via {!Vector.set_auto_sync}, or the global mode via
-    {!Transfer.disable_auto}), there is no way to bring it up to date silently,
-    so [scatter] raises {!Soa.Unsupported} instead of transposing the stale
-    host bytes; the message names whichever of the two is actually off. Every
-    other location ([CPU], [GPU], [Both], [Stale_GPU]) is unaffected either
-    way, since the host copy there is already the vector's freshest data. *)
+    With both on, [scatter] proceeds and calls {!Vector.ensure_cpu_sync} to
+    bring the host copy up to date first. Whether that actually refreshes
+    anything is up to the registered sync callback; [scatter] does not verify
+    that it did.
+
+    With EITHER gate off (this vector's own flag via {!Vector.set_auto_sync}, or
+    the global mode via {!Transfer.disable_auto} / {!Transfer.set_auto}),
+    [scatter] refuses: it raises {!Soa.Unsupported} rather than transpose host
+    bytes it cannot establish are current, and the message names whichever gate
+    is off. That is a deliberate over-refusal and not a claim that no rescue was
+    possible — a caller that installed its own callback through
+    {!Vector.register_sync_callback} may have a path [scatter] does not reason
+    about.
+
+    [CPU], [Both] and [Stale_GPU] are unaffected either way, since the host copy
+    there is already the vector's freshest data. Pure [GPU] is not refused
+    either, but for a weaker reason and not because the host copy is fresh:
+    nothing in this library puts an AoS vector into that state, so it is an
+    uncovered gap rather than a state this function has cleared. *)
 val scatter : 'a t -> unit
 
 (** [gather t] transposes the N per-leaf host buffers back into the AoS host

--- a/sarek/core/Soa_vector.mli
+++ b/sarek/core/Soa_vector.mli
@@ -101,12 +101,15 @@ val set : 'a t -> int -> 'a -> unit
 val get : 'a t -> int -> 'a
 
 (** [scatter t] transposes the AoS host buffer into the N per-leaf host buffers
-    (call before transferring the leaves to a device). Brings the AoS host copy
-    up to date first when auto-sync is enabled.
+    (call before transferring the leaves to a device). When the host copy is
+    behind a device's data ([Stale_CPU]) and auto-sync is enabled, attempts to
+    bring it up to date first.
 
-    When auto-sync is disabled and the host copy is behind a device's data,
-    there is no way to bring it up to date silently, so [scatter] raises
-    {!Soa.Unsupported} instead of transposing the stale host bytes. *)
+    When the host copy is [Stale_CPU] and auto-sync is disabled, there is no
+    way to bring it up to date silently, so [scatter] raises
+    {!Soa.Unsupported} instead of transposing the stale host bytes. Every
+    other location ([CPU], [GPU], [Both], [Stale_GPU]) is unaffected either
+    way, since the host copy there is already the vector's freshest data. *)
 val scatter : 'a t -> unit
 
 (** [gather t] transposes the N per-leaf host buffers back into the AoS host

--- a/sarek/tests/unit/soa_vector_scatter_refuse/dune
+++ b/sarek/tests/unit/soa_vector_scatter_refuse/dune
@@ -1,0 +1,13 @@
+; backlog-220: Soa_vector.scatter must refuse loudly (not silently transpose
+; stale host bytes) when auto-sync is off. Isolated in its own directory for
+; the same reason as ir_fields/ and ktype_variant_field/: the sarek_ppx
+; preprocessing here would collide with the metaquot test group in the parent
+; unit/ directory.
+
+(test
+ (name test_soa_vector_scatter_refuse)
+ (libraries sarek spoc_core spoc.ir ctypes alcotest)
+ (preprocess
+  (pps sarek_ppx))
+ (flags
+  (:standard -w -32-33-34-69)))

--- a/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
+++ b/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
@@ -1,0 +1,131 @@
+(******************************************************************************)
+(* SPDX-License-Identifier: CECILL-B                                          *)
+(* SPDX-FileCopyrightText: 2026 Mathias Bourgoin <mathias.bourgoin@gmail.com> *)
+(******************************************************************************)
+
+(** backlog-220: [Soa_vector.scatter] used to silently transpose stale host
+    bytes into the leaves whenever auto-sync was off and the AoS vector's host
+    copy was behind a device's ([Stale_CPU]). It returned [unit], not an
+    error, so the caller had no way to tell a correct scatter from a corrupt
+    one. This pins that it now refuses instead — and, just as importantly,
+    that it does NOT refuse in the other states auto-sync-off can be in
+    ([CPU] and [Stale_GPU], where the host copy is already the fresh data, so
+    there is nothing stale to guard against). *)
+
+module Soa = Spoc_core.Soa
+module Soa_vector = Spoc_core.Soa_vector
+module Vector = Spoc_core.Vector
+
+type float32 = float
+
+type point3d = {mutable x : float32; mutable y : float32; mutable z : float32}
+[@@sarek.type]
+
+let make_caps () : Spoc_framework.Framework_sig.capabilities =
+  {
+    max_threads_per_block = 256;
+    max_block_dims = (256, 256, 64);
+    max_grid_dims = (65535, 65535, 65535);
+    shared_mem_per_block = 16384;
+    total_global_mem = 1073741824L;
+    compute_capability = (0, 0);
+    device_features = [Sarek_ir_analysis.Float64; Sarek_ir_analysis.Int64];
+    coopmat = None;
+    supports_atomics = true;
+    warp_size = 32;
+    max_registers_per_block = 16384;
+    clock_rate_khz = 1000000;
+    multiprocessor_count = 4;
+    is_cpu = false;
+  }
+
+let make_device id =
+  {
+    Spoc_core.Device.id;
+    backend_id = id;
+    name = Printf.sprintf "Fake Device %d" id;
+    framework = "Fake";
+    capabilities = make_caps ();
+  }
+
+let refusal_message =
+  "Soa_vector.scatter: this vector's host data is out of date and auto-sync \
+   is off, so scattering now would silently copy stale values to the device \
+   buffers instead of refusing. Before scattering, either call \
+   Transfer.to_cpu on its AoS vector (Soa_vector.aos_vector t) to refresh the \
+   host copy, or call Vector.set_auto_sync on it to turn auto-sync back on."
+
+let make_soa_vector () =
+  let sv = Soa_vector.create point3d_custom 4 in
+  for i = 0 to 3 do
+    Soa_vector.set
+      sv
+      i
+      {x = float_of_int i; y = float_of_int (i + 1); z = float_of_int (i + 2)}
+  done ;
+  sv
+
+(* The bug: auto-sync off AND the host copy behind a device ([Stale_CPU]) used
+   to scatter the stale host bytes silently. Must now refuse, with a message
+   naming the problem and the two remedies. *)
+let test_refuses_when_stale_and_auto_sync_off () =
+  let sv = make_soa_vector () in
+  let aos = Soa_vector.aos_vector sv in
+  Vector.set_auto_sync aos false ;
+  aos.Spoc_core.Vector_types.location <-
+    Spoc_core.Vector_types.Stale_CPU (make_device 0) ;
+  Alcotest.check_raises
+    "scatter refuses on Stale_CPU + auto-sync off"
+    (Soa.Unsupported refusal_message)
+    (fun () -> Soa_vector.scatter sv)
+
+(* Both polarities of the predicate matter (house defect class: a claim wider
+   than its code). Auto-sync off alone must NOT be enough to refuse — only
+   when the host copy is ALSO stale relative to a device. [CPU] is the
+   ordinary case (never touched a device); the host copy is already the only
+   copy, so there is nothing stale to guard against. *)
+let test_does_not_refuse_on_cpu_with_auto_sync_off () =
+  let sv = make_soa_vector () in
+  let aos = Soa_vector.aos_vector sv in
+  Vector.set_auto_sync aos false ;
+  (match aos.Spoc_core.Vector_types.location with
+  | Spoc_core.Vector_types.CPU -> ()
+  | _ -> Alcotest.fail "expected a fresh vector to start at location CPU") ;
+  Soa_vector.scatter sv ;
+  Alcotest.(check pass) "scatter did not raise on CPU + auto-sync off" () ()
+
+(* [Stale_GPU]: the HOST copy is the fresh one and the device is behind. That
+   is the opposite of the hazard scatter guards against, so auto-sync off
+   must not refuse here either. *)
+let test_does_not_refuse_on_stale_gpu_with_auto_sync_off () =
+  let sv = make_soa_vector () in
+  let aos = Soa_vector.aos_vector sv in
+  Vector.set_auto_sync aos false ;
+  aos.Spoc_core.Vector_types.location <-
+    Spoc_core.Vector_types.Stale_GPU (make_device 0) ;
+  Soa_vector.scatter sv ;
+  Alcotest.(check pass)
+    "scatter did not raise on Stale_GPU + auto-sync off"
+    ()
+    ()
+
+let () =
+  Alcotest.run
+    "soa_vector_scatter_refuse"
+    [
+      ( "scatter",
+        [
+          Alcotest.test_case
+            "refuses stale+auto-sync-off"
+            `Quick
+            test_refuses_when_stale_and_auto_sync_off;
+          Alcotest.test_case
+            "does not refuse on CPU"
+            `Quick
+            test_does_not_refuse_on_cpu_with_auto_sync_off;
+          Alcotest.test_case
+            "does not refuse on Stale_GPU"
+            `Quick
+            test_does_not_refuse_on_stale_gpu_with_auto_sync_off;
+        ] );
+    ]

--- a/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
+++ b/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
@@ -5,12 +5,12 @@
 
 (** backlog-220: [Soa_vector.scatter] used to silently transpose stale host
     bytes into the leaves whenever auto-sync was off and the AoS vector's host
-    copy was behind a device's ([Stale_CPU]). It returned [unit], not an
-    error, so the caller had no way to tell a correct scatter from a corrupt
-    one. This pins that it now refuses instead — and, just as importantly,
-    that it does NOT refuse in the other states auto-sync-off can be in
-    ([CPU] and [Stale_GPU], where the host copy is already the fresh data, so
-    there is nothing stale to guard against). *)
+    copy was behind a device's ([Stale_CPU]). It returned [unit], not an error,
+    so the caller had no way to tell a correct scatter from a corrupt one. This
+    pins that it now refuses instead — and, just as importantly, that it does
+    NOT refuse in the other states auto-sync-off can be in ([CPU] and
+    [Stale_GPU], where the host copy is already the fresh data, so there is
+    nothing stale to guard against). *)
 
 module Soa = Spoc_core.Soa
 module Soa_vector = Spoc_core.Soa_vector
@@ -56,15 +56,15 @@ let make_device id =
    rather than a single generic phrase. *)
 let refusal_message_per_vector_off =
   "Soa_vector.scatter: this vector's host data is out of date and this \
-   vector's own auto-sync flag is off (call Vector.set_auto_sync on it to \
-   turn it back on), so nothing will refresh it, and scattering now would \
-   copy stale values into this vector's per-leaf host buffers with no error. \
-   Before scattering, call Transfer.to_cpu on its AoS vector \
-   (Soa_vector.aos_vector) to refresh the host copy directly."
+   vector's own auto-sync flag is off (call Vector.set_auto_sync on it to turn \
+   it back on), so nothing will refresh it, and scattering now would copy \
+   stale values into this vector's per-leaf host buffers with no error. Before \
+   scattering, call Transfer.to_cpu on its AoS vector (Soa_vector.aos_vector) \
+   to refresh the host copy directly."
 
 let refusal_message_global_off =
-  "Soa_vector.scatter: this vector's host data is out of date and auto-sync \
-   is off globally, for every vector, via Transfer.disable_auto (call \
+  "Soa_vector.scatter: this vector's host data is out of date and auto-sync is \
+   off globally, for every vector, via Transfer.disable_auto (call \
    Transfer.enable_auto to turn it back on), so nothing will refresh it, and \
    scattering now would copy stale values into this vector's per-leaf host \
    buffers with no error. Before scattering, call Transfer.to_cpu on its AoS \
@@ -171,8 +171,8 @@ let test_refuses_when_stale_and_global_auto_off () =
       aos.Spoc_core.Vector_types.location <-
         Spoc_core.Vector_types.Stale_CPU (make_device 0) ;
       Alcotest.check_raises
-        "scatter refuses on Stale_CPU + global auto-sync off (per-vector \
-         flag still true)"
+        "scatter refuses on Stale_CPU + global auto-sync off (per-vector flag \
+         still true)"
         (Soa.Unsupported refusal_message_global_off)
         (fun () -> Soa_vector.scatter sv))
 
@@ -180,8 +180,10 @@ let test_refuses_when_stale_and_global_auto_off () =
    refuse" branch above genuinely reaches [Vector.ensure_cpu_sync] and its
    registered sync callback, rather than "does not refuse" being true merely
    because nothing downstream would have exercised the bug either way. This
-   registers the SAME callback [Transfer.ml] registers at program start (real
-   [Transfer.to_cpu], gated on the global mode) rather than the trivial
+   registers a callback of the same SHAPE as the one [Transfer.ml] registers
+   at program start — a hand-written copy, not that callback itself, so drift
+   in [Transfer.ml]'s version will not fail this case — driving the real
+   [Transfer.to_cpu] and gated on the global mode, rather than the trivial
    always-succeeds stub the sibling test above uses, specifically so that
    letting [scatter] proceed drives a REAL device transfer attempt. The fake
    [Device.t] this suite builds has no backing buffer registered anywhere, so

--- a/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
+++ b/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
@@ -15,6 +15,7 @@
 module Soa = Spoc_core.Soa
 module Soa_vector = Spoc_core.Soa_vector
 module Vector = Spoc_core.Vector
+module Transfer = Spoc_core.Transfer
 
 type float32 = float
 
@@ -48,12 +49,26 @@ let make_device id =
     capabilities = make_caps ();
   }
 
-let refusal_message =
+(* backlog-220 hole: "auto-sync is off" has two independent spellings — the
+   per-vector flag ([Vector.set_auto_sync]) and the global mode
+   ([Transfer.disable_auto]) — and a rescue only happens when BOTH are on. The
+   refusal message now names whichever of the two is actually responsible,
+   rather than a single generic phrase. *)
+let refusal_message_per_vector_off =
+  "Soa_vector.scatter: this vector's host data is out of date and this \
+   vector's own auto-sync flag is off (call Vector.set_auto_sync on it to \
+   turn it back on), so nothing will refresh it, and scattering now would \
+   copy stale values into this vector's per-leaf host buffers with no error. \
+   Before scattering, call Transfer.to_cpu on its AoS vector \
+   (Soa_vector.aos_vector) to refresh the host copy directly."
+
+let refusal_message_global_off =
   "Soa_vector.scatter: this vector's host data is out of date and auto-sync \
-   is off, so scattering now would copy stale values into this vector's \
-   per-leaf host buffers with no error. Before scattering, either call \
-   Transfer.to_cpu on its AoS vector (Soa_vector.aos_vector) to refresh the \
-   host copy, or call Vector.set_auto_sync on it to turn auto-sync back on."
+   is off globally, for every vector, via Transfer.disable_auto (call \
+   Transfer.enable_auto to turn it back on), so nothing will refresh it, and \
+   scattering now would copy stale values into this vector's per-leaf host \
+   buffers with no error. Before scattering, call Transfer.to_cpu on its AoS \
+   vector (Soa_vector.aos_vector) to refresh the host copy directly."
 
 let make_soa_vector () =
   let sv = Soa_vector.create point3d_custom 4 in
@@ -75,8 +90,8 @@ let test_refuses_when_stale_and_auto_sync_off () =
   aos.Spoc_core.Vector_types.location <-
     Spoc_core.Vector_types.Stale_CPU (make_device 0) ;
   Alcotest.check_raises
-    "scatter refuses on Stale_CPU + auto-sync off"
-    (Soa.Unsupported refusal_message)
+    "scatter refuses on Stale_CPU + per-vector auto-sync off"
+    (Soa.Unsupported refusal_message_per_vector_off)
     (fun () -> Soa_vector.scatter sv)
 
 (* Both polarities of the predicate matter (house defect class: a claim wider
@@ -138,6 +153,66 @@ let test_does_not_refuse_on_stale_cpu_with_auto_sync_on () =
     Spoc_core.Vector_types.Stale_CPU (make_device 0) ;
   Soa_vector.scatter sv
 
+(* backlog-220 hole, closed here. "Auto-sync is off" has TWO independent
+   spellings: this vector's own flag ([Vector.set_auto_sync]), and the GLOBAL
+   mode ([Transfer.disable_auto]) that applies to every vector at once. The
+   predicate used to read only the per-vector flag, so this exact state —
+   [Stale_CPU], per-vector flag left at its [true] default, global mode off —
+   reproduced the original silent-corruption bug completely unrefused: nothing
+   in [Soa_vector.scatter] ever looked at [Transfer.is_auto ()]. *)
+let test_refuses_when_stale_and_global_auto_off () =
+  Fun.protect
+    ~finally:(fun () -> Transfer.enable_auto ())
+    (fun () ->
+      let sv = make_soa_vector () in
+      let aos = Soa_vector.aos_vector sv in
+      Vector.set_auto_sync aos true ;
+      Transfer.disable_auto () ;
+      aos.Spoc_core.Vector_types.location <-
+        Spoc_core.Vector_types.Stale_CPU (make_device 0) ;
+      Alcotest.check_raises
+        "scatter refuses on Stale_CPU + global auto-sync off (per-vector \
+         flag still true)"
+        (Soa.Unsupported refusal_message_global_off)
+        (fun () -> Soa_vector.scatter sv))
+
+(* The control this suite was missing: a case that proves the "does not
+   refuse" branch above genuinely reaches [Vector.ensure_cpu_sync] and its
+   registered sync callback, rather than "does not refuse" being true merely
+   because nothing downstream would have exercised the bug either way. This
+   registers the SAME callback [Transfer.ml] registers at program start (real
+   [Transfer.to_cpu], gated on the global mode) rather than the trivial
+   always-succeeds stub the sibling test above uses, specifically so that
+   letting [scatter] proceed drives a REAL device transfer attempt. The fake
+   [Device.t] this suite builds has no backing buffer registered anywhere, so
+   that real attempt fails with [Transfer]'s own "no device buffer" message —
+   which is the point: reaching that failure is only possible if control
+   actually passed through the drain path, so observing it here is what makes
+   the "did not refuse" observations elsewhere in this suite trustworthy
+   rather than a dead branch no test ever entered. *)
+let test_control_drain_path_entered_when_both_auto_on () =
+  Vector.register_sync_callback
+    {
+      Vector.sync =
+        (fun vec ->
+          if not (Transfer.is_auto ()) then false
+          else begin
+            Transfer.to_cpu vec ;
+            true
+          end);
+    } ;
+  let sv = make_soa_vector () in
+  let aos = Soa_vector.aos_vector sv in
+  Vector.set_auto_sync aos true ;
+  Transfer.enable_auto () ;
+  aos.Spoc_core.Vector_types.location <-
+    Spoc_core.Vector_types.Stale_CPU (make_device 0) ;
+  Alcotest.check_raises
+    "scatter (not refusing) genuinely enters the drain path, evidenced by a \
+     real Transfer.to_cpu failure on the fake device's missing buffer"
+    (Failure "to_cpu: no device buffer to transfer from")
+    (fun () -> Soa_vector.scatter sv)
+
 let () =
   Alcotest.run
     "soa_vector_scatter_refuse"
@@ -164,5 +239,13 @@ let () =
             "does not refuse on Stale_CPU + auto-sync on"
             `Quick
             test_does_not_refuse_on_stale_cpu_with_auto_sync_on;
+          Alcotest.test_case
+            "refuses stale+global-auto-off"
+            `Quick
+            test_refuses_when_stale_and_global_auto_off;
+          Alcotest.test_case
+            "control: drain path entered when both auto-sync gates are on"
+            `Quick
+            test_control_drain_path_entered_when_both_auto_on;
         ] );
     ]

--- a/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
+++ b/sarek/tests/unit/soa_vector_scatter_refuse/test_soa_vector_scatter_refuse.ml
@@ -50,9 +50,9 @@ let make_device id =
 
 let refusal_message =
   "Soa_vector.scatter: this vector's host data is out of date and auto-sync \
-   is off, so scattering now would silently copy stale values to the device \
-   buffers instead of refusing. Before scattering, either call \
-   Transfer.to_cpu on its AoS vector (Soa_vector.aos_vector t) to refresh the \
+   is off, so scattering now would copy stale values into this vector's \
+   per-leaf host buffers with no error. Before scattering, either call \
+   Transfer.to_cpu on its AoS vector (Soa_vector.aos_vector) to refresh the \
    host copy, or call Vector.set_auto_sync on it to turn auto-sync back on."
 
 let make_soa_vector () =
@@ -91,8 +91,10 @@ let test_does_not_refuse_on_cpu_with_auto_sync_off () =
   (match aos.Spoc_core.Vector_types.location with
   | Spoc_core.Vector_types.CPU -> ()
   | _ -> Alcotest.fail "expected a fresh vector to start at location CPU") ;
-  Soa_vector.scatter sv ;
-  Alcotest.(check pass) "scatter did not raise on CPU + auto-sync off" () ()
+  (* The assertion IS the absence of a raise here: an uncaught exception from
+     [scatter] fails this test case on its own; there is nothing further to
+     check once control reaches the end of the function. *)
+  Soa_vector.scatter sv
 
 (* [Stale_GPU]: the HOST copy is the fresh one and the device is behind. That
    is the opposite of the hazard scatter guards against, so auto-sync off
@@ -103,11 +105,38 @@ let test_does_not_refuse_on_stale_gpu_with_auto_sync_off () =
   Vector.set_auto_sync aos false ;
   aos.Spoc_core.Vector_types.location <-
     Spoc_core.Vector_types.Stale_GPU (make_device 0) ;
-  Soa_vector.scatter sv ;
-  Alcotest.(check pass)
-    "scatter did not raise on Stale_GPU + auto-sync off"
-    ()
-    ()
+  Soa_vector.scatter sv
+
+(* [Both]: host and device agree, so there is nothing stale to refuse either —
+   auto-sync off is irrelevant here for the same reason as [CPU]. *)
+let test_does_not_refuse_on_both_with_auto_sync_off () =
+  let sv = make_soa_vector () in
+  let aos = Soa_vector.aos_vector sv in
+  Vector.set_auto_sync aos false ;
+  aos.Spoc_core.Vector_types.location <-
+    Spoc_core.Vector_types.Both (make_device 0) ;
+  Soa_vector.scatter sv
+
+(* The other half of the guard: [Stale_CPU] with auto-sync back ON must NOT
+   refuse. Pins that the predicate is conjunctive (stale AND auto-sync-off),
+   not "stale" alone — the exact regression an over-eager tightening of this
+   check would introduce.
+
+   With auto-sync on, [ensure_cpu_sync] actually invokes the registered sync
+   callback (unlike every other case above, where auto-sync off or a
+   non-stale location means it never gets that far). Linking [sarek] pulls in
+   the real callback, which drives a real device transfer this test's fake
+   [Device.t] has no backing buffer for — so this test registers its own
+   trivial callback first, to exercise scatter's OWN refusal-or-not decision
+   in isolation from that unrelated machinery. *)
+let test_does_not_refuse_on_stale_cpu_with_auto_sync_on () =
+  Vector.register_sync_callback {Vector.sync = (fun _ -> true)} ;
+  let sv = make_soa_vector () in
+  let aos = Soa_vector.aos_vector sv in
+  Vector.set_auto_sync aos true ;
+  aos.Spoc_core.Vector_types.location <-
+    Spoc_core.Vector_types.Stale_CPU (make_device 0) ;
+  Soa_vector.scatter sv
 
 let () =
   Alcotest.run
@@ -127,5 +156,13 @@ let () =
             "does not refuse on Stale_GPU"
             `Quick
             test_does_not_refuse_on_stale_gpu_with_auto_sync_off;
+          Alcotest.test_case
+            "does not refuse on Both"
+            `Quick
+            test_does_not_refuse_on_both_with_auto_sync_off;
+          Alcotest.test_case
+            "does not refuse on Stale_CPU + auto-sync on"
+            `Quick
+            test_does_not_refuse_on_stale_cpu_with_auto_sync_on;
         ] );
     ]


### PR DESCRIPTION
`Soa_vector.scatter` silently no-op'd when auto-sync was off, scattering stale
host bytes. It now **refuses loudly**. This is a deliberate behaviour change:
anyone relying on the silent no-op will start seeing an exception, which is the
intent.

## Caller sweep — every in-tree `scatter` call site

| Caller | Breaks? |
|---|---|
| `Soa_launch.ml:342` (`run_soa`) | No — marks only the leaves stale, never the AoS vector's `location` |
| `Soa_vector.ml:241` (`soa_scatter` closure) | No — zero readers anywhere |
| `Soa_vector.ml:246` (`soa_to_device`) | **The only breaking path** — ends `location <- Stale_CPU dev`, so a second `Execute.run_vectors` on the same transparent vector re-enters `scatter` at `Stale_CPU`. **No in-tree caller does this today.** |
| `benchmarks/bench_soa_emitter.ml:123` | No — one scatter on a fresh host-filled vector |
| `test_soa_emitter_equiv.ml:1511` | No — flag cleared after the host writes, exactly one launch |

The conclusion holds, but note `c93cf495`'s stated evidence did **not** establish
it: that survey cites two tests and omits three real call sites. The table above
is the re-derived version.

## The refusal predicate is conservative, not equivalent

There are **three** gates on "a rescue happens", not two: the per-vector
`auto_sync` field (`Vector_transfer.ml:45`), the global `Transfer.auto_mode`
(read only inside the callback at `Transfer.ml:719`), and **a callback being
registered at all** (`Vector_transfer.ml:47-50`). The predicate reads the first
two. The third is invisible to it, and the global gate is not necessary in
general — `Vector.register_sync_callback` is public and the suite's own case 5
installs a callback that ignores it.

Reading two gates **over-refuses and never under-refuses**, which is the safe
side. Three `.mli`/comment claims asserted *equivalence* rather than
conservatism; those are corrected here.

There are also four API spellings, not two: `Vector.set_auto_sync` or a direct
`auto_sync <-` field write, and `Transfer.disable_auto` **or
`Transfer.set_auto false`**. The refusal message names only `disable_auto` —
left as-is, pinned by two test constants, and recorded as an open finding.

## Tests — 7 cases, each proven able to fail

Five mutations, each confirmed landed via `git diff --numstat`, each reverted:

| Mutation | Observed |
|---|---|
| drop the global gate | case 5 red, only |
| one word inside the message (`out of date` → `OUTOFDATE`) | cases 0 and 5 red — **exception constructor unchanged**, so the tests assert the MESSAGE, not the type |
| disable the refusal | cases 0, 5 red; all negatives still green |
| refuse on every location | cases 1, 2, 3 red |
| delete the `ensure_cpu_sync` drain call | case 6 red, only — the claimed control is genuine |

The suite runs inside `@sarek/tests/runtest`. No self-skip, no vacuous green.

## Review

`roster-review` GO, `roster-qa` GO. Nine findings were fixed in place, all
doc/comment, none behavioural — every one an instance of "a claim wider than its
code". One correction was **itself** an instance: it asserted an exhaustive audit
while omitting `TFloat16`, `TUint8` and the `Layout` error. The adversarial pass
caught it; the narrowing correction overshot exactly as the standing rule warns.

`937fd397` shipped all four files **ocamlformat-unclean** — `dune build @fmt`
exited 1 as committed. Fixed here and verified: fmt/build/runtest all exit 0
under dune 3.24.1, OCaml 5.4.0, ppxlib 0.38.0.

## Not verified

**No GPU execution of the changed path.** Every refusal case uses a fake
`Device.t` with no backing buffer and a hand-written sync callback. The
`soa_to_device` second-launch break is established by code reading plus an
architect trace — **not** by an executed two-launch run on hardware. That single
claim is at code-review tier only. No NVIDIA/Metal/HIP/WGSL hardware exists on
this host.

The cross-runtime review pass degraded twice (`non-conforming-output`), so this
round has **no cross-runtime review coverage**; the attestation records `claude`
only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scattering stale host data when automatic synchronization is disabled.
  * Added clear diagnostics identifying whether vector-level or global synchronization is disabled.
  * Preserved existing behavior for other vector freshness states.

* **Documentation**
  * Clarified synchronization behavior and possible errors for stale host data.

* **Tests**
  * Added coverage for refusal, synchronization, cleanup, and transfer-failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->