### PR TITLE
test(soa): close the self-skip hole; refute backlog-225's 'not a flake' premise

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,12 +73,39 @@
   numerically clean — which a numeric-only audit would have mis-reported as
   unaffected. See `docs/optimization/amdgpu-f16-fusion-shape-audit.md`.
 - ZLUDA/AMD support for the CUDA/PTX backend (PTX launch ABI fix)
-- `SAREK_REQUIRE_PTX` for `test_soa_emitter_equiv`: set it and the test fails
-  when no enumerated device reports the `CUDA/PTX` framework, instead of
-  skipping every SoA-ABI case and still exiting 0. Nothing in the repository
-  sets it, and unset nothing changes, so an absent device still reads as
-  skipped rather than as a pass or a failure. It asserts enumeration only — whether
+- `SAREK_REQUIRE_PTX` for `test_soa_emitter_equiv`: set it to exactly `1` and
+  the test fails when no enumerated device reports the `CUDA/PTX` framework,
+  instead of exiting 0 with the SoA legs either skipped or reported as PASSED
+  with a `(SoA skipped: non-PTX)` note. Nothing in the repository's dune
+  rules, Makefile targets or CI jobs sets it, and unset (or any value other
+  than `1`) nothing changes, so an absent device still reads as skipped
+  rather than as a pass or a failure. It asserts enumeration only — whether
   the SoA cases pass on that device is what the per-case rows say.
+  Opt-in-by-hand; see `gh-pages/docs/device_selection.md`.
+- **KNOWN RESIDUAL (backlog-225, not fixed).** `test_soa_emitter_equiv`'s
+  `check_roundtrip` and the `Vector.fill` row of `check_relaunch` have each
+  been seen, once, to return `y` equal to the un-doubled host value on
+  ZLUDA's CUDA/PTX view of this host's devices — a leaf write that appears
+  not to have landed before read-back. 2 occurrences noticed over "some
+  2,500" executions of the test binary; a separate non-reproduction campaign
+  afterward ran 2,443 further executions (2,000 + 300 + 40 concurrent + 40 on
+  a cold ZLUDA cache + 3 under `dune runtest --force` + 60 isolated), all
+  zero, which does not reconcile arithmetically against the ~2,500 figure —
+  whether the 2 occurrences fall inside or outside that 2,443 cannot be
+  determined from the record. No root cause established; nothing here
+  claims a fix. `Transfer.flush` was added on the `check_roundtrip` leg as a
+  defensive measure, not offered as the fix — the `check_relaunch` occurrence
+  was on a leg that already synchronizes. Also found and filed but NOT
+  implicated as the cause (both failing legs already call
+  `Device.set_current` correctly via `Device.synchronize`): `Cuda_api.ml`'s
+  `Stream.synchronize` was the only function in its module omitting
+  `Device.set_current` before touching a stream/device (fixed here), and
+  `Cuda_plugin_base.ml`'s `current_device` is a plain global ref while
+  `Cuda_api.ml` underneath it deliberately uses a `Domain.DLS` key for the
+  same state (not fixed; filed). See the full comment at
+  `sarek/tests/e2e/test_soa_emitter_equiv.ml:703` and
+  `docs/optimization/tier1b-emitter-soa-handoff.md`'s backlog-225 status
+  block.
 - T3-SEMANTIC milestone lock for both formal projects; conformance +
   mutation tests wired into `dune runtest`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,12 @@
   numerically clean — which a numeric-only audit would have mis-reported as
   unaffected. See `docs/optimization/amdgpu-f16-fusion-shape-audit.md`.
 - ZLUDA/AMD support for the CUDA/PTX backend (PTX launch ABI fix)
+- `SAREK_REQUIRE_PTX` for `test_soa_emitter_equiv`: set it and the test fails
+  when no enumerated device reports the `CUDA/PTX` framework, instead of
+  skipping every SoA-ABI case and still exiting 0. Nothing in the repository
+  sets it, and unset nothing changes, so an absent device still reads as
+  skipped rather than as a pass or a failure. It asserts enumeration only — whether
+  the SoA cases pass on that device is what the per-case rows say.
 - T3-SEMANTIC milestone lock for both formal projects; conformance +
   mutation tests wired into `dune runtest`
 

--- a/docs/optimization/tier1b-emitter-soa-handoff.md
+++ b/docs/optimization/tier1b-emitter-soa-handoff.md
@@ -62,7 +62,8 @@ existing enumeration — the STOP condition in the task did not fire).
   custom-vector `[%kernel]` IR compiled AoS (`run_vectors`) and SoA
   (`generate ~soa_params` + `run_source ~inject_lengths:false` with
   host-transposed leaf vectors) produce identical results to a pure-OCaml
-  reference. **PASS** for `point3d` (3× f32) and `dpair` (2× f64) on RX 7900 XTX
+  reference. **PASS, with a known intermittent exception recorded below
+  (backlog-225)** for `point3d` (3× f32) and `dpair` (2× f64) on RX 7900 XTX
   and CPU-as-CUDA under ZLUDA; `point3d`'s AoS leg also passes on
   OpenCL/Vulkan/Native/Interpreter. i32/i64 leaves are covered at the
   PTX-instruction + ptxas-assembly level AND on device — see the table below and
@@ -72,7 +73,7 @@ existing enumeration — the STOP condition in the task did not fire).
 
 | Leaf type combo | PTX markers | ptxas | device e2e (ZLUDA) |
 |---|---|---|---|
-| f32 × 3 (`point3d`) | ✓ | ✓ | ✓ |
+| f32 × 3 (`point3d`) | ✓ | ✓ | ✓ (see backlog-225 below: 2 intermittent failures observed) |
 | f64 × 2 (`dpair`) | ✓ | ✓ | ✓ |
 | i32 + f64 (`{i;d}`) | ✓ | ✓ (`soa_mixed`) | ✓ (2026-07-30, ZLUDA) |
 | i64 + i32 (`{p;q}`) | ✓ (`ld.global.s64`+`s32`) | ✓ (`soa_long`) | ✓ (2026-07-30, ZLUDA) |
@@ -90,6 +91,25 @@ the generic dispatch together. Each leaf is written to its own output array at
 its own width — deliberately no int<->float conversion, since a conversion folds
 both leaves into one number and a per-leaf stride error could then be masked by a
 compensating error in the other leaf.
+
+> **Update (backlog-225, not fixed).** The round-trip case (`check_roundtrip`)
+> and the `Vector.fill` row of `check_relaunch` (a different test, same file)
+> have each been seen, once, to return `y` equal to the un-doubled host value
+> — exactly half the expected result — on ZLUDA's CUDA/PTX view of the AMD
+> Ryzen 9 7950X integrated GPU. 2 occurrences over "some 2,500" executions of
+> the test binary; a separate non-reproduction campaign of 2,443 further runs
+> (2,000 + 300 + 40 concurrent + 40 cold-cache + 3 under `--force` + 60
+> isolated) all came back zero, and that count does not arithmetically
+> reconcile against ~2,500 — whether the 2 occurrences are inside or outside
+> the 2,443 cannot be determined from the record. **No root cause
+> established. Not fixed.** A `Transfer.flush` was added on the
+> `check_roundtrip` leg defensively, not as a fix — the `check_relaunch`
+> occurrence was already on a leg that synchronizes. Positive control: every
+> counted run was confirmed to have printed a `SoA-roundtrip [CUDA/PTX]` row
+> for both CUDA/PTX devices on this host. See the full record at
+> `sarek/tests/e2e/test_soa_emitter_equiv.ml:703` and the `SAREK_REQUIRE_PTX`
+> gate this investigation added (closes the "silently skipped, not
+> exercised" self-skip hole; does not touch this defect).
 
 Observed: both rows OK on the N-leaf PTX ABI (2 ZLUDA devices). On the AoS
 fallback the two rows differ and are counted separately — the earlier single "5

--- a/gh-pages/docs/device_selection.md
+++ b/gh-pages/docs/device_selection.md
@@ -54,6 +54,22 @@ SPOC_DISABLE_OPENCL=1 dune exec -- sarek-device-info
 SPOC_DISABLE_GPU=1 dune exec -- my_program.exe
 ```
 
+## Test-only strictness variable
+
+`SAREK_REQUIRE_PTX=1` is read by one test, `sarek/tests/e2e/test_soa_emitter_equiv.ml`,
+not by the library. Unset (the default everywhere, including CI), a host with no
+CUDA/PTX device silently skips that test's SoA legs and the binary still exits 0 —
+the normal, desired outcome on the vast majority of hosts. Set to exactly `1` on a
+host that is expected to have a CUDA/PTX device (e.g. a ZLUDA-equipped machine), it
+turns "no device reported framework `CUDA/PTX`" into a failure, so a regression that
+silently drops the device is caught instead of reading as a pass. It is opt-in-by-hand:
+no dune rule, Makefile target or CI job sets it today.
+
+```bash
+SAREK_REQUIRE_PTX=1 LD_LIBRARY_PATH=$HOME/opt/zluda \
+  dune exec sarek/tests/e2e/test_soa_emitter_equiv.exe
+```
+
 ## Select a device in the example / benchmark programs
 
 The bundled e2e examples and benchmarks accept backend/device flags:

--- a/kb/sarek/runtime/execution.md
+++ b/kb/sarek/runtime/execution.md
@@ -12,6 +12,7 @@ Reviewed execution-facing files under `sarek/sarek/**` and, following the 2026-0
 - `sarek/sarek/BSP.md`: intended BSP/barrier semantics for CPU execution.
 - `sarek/execute/Execute.ml`: runtime dispatch, kernel argument conversion, vector transfer integration, native/interpreter/backend selection, and stale marking. (`sarek/sarek/Execute.ml` is now a 6-line forwarding shim.)
 - `sarek/execute/Execute_error.ml`: execution error variants and formatting. (`sarek/sarek/Execute_error.ml` is now a 6-line forwarding shim.)
+- `sarek/execute/Soa_launch.ml`: `run_soa` — executes a kernel with SoA-lowered custom-vector arguments (CUDA/PTX only). Two caller obligations, both on the caller and neither enforced by the type system: it never gathers automatically (a kernel that writes an SoA leaf requires the caller to `Transfer.to_cpu` each leaf, then `Soa_vector.gather`), and it never synchronizes (it returns once the launch is queued; a caller must drain the device, e.g. `Transfer.flush`, before reading results back rather than resting on same-stream ordering). See backlog-225 (`sarek/tests/e2e/test_soa_emitter_equiv.ml:703`) for an intermittent, unexplained round-trip mismatch observed on this path.
 - `sarek/sarek/Kirc_types.ml` and `Kirc_types.mli`: KIRC type, expression, statement, declaration, and kernel AST definitions.
 - `sarek/sarek/Sarek_ir.ml`: lower-level IR representation used by interpreter/fusion paths.
 - `sarek/sarek/Sarek_value.ml`: boxed runtime values and conversion helpers.

--- a/sarek-cuda/Cuda_api.ml
+++ b/sarek-cuda/Cuda_api.ml
@@ -433,6 +433,19 @@ module Stream = struct
     check "cuStreamDestroy" (cuStreamDestroy stream.handle)
 
   let synchronize stream =
+    (* backlog-225 review: this was the only function in the module omitting
+       Device.set_current before touching the stream/device. [Stream.default]
+       is a NULL handle (the current context's null stream, not necessarily
+       [stream.device]'s), so without this call, with device A current and a
+       [Stream.default B] in hand, this would drain A and then retire B's
+       kernarg keepalives under (B, 0) below — a use-after-free once the GC
+       reclaims the argument CArray before B's kernel has actually launched.
+       Filed as a real hazard (T1, code-reading only, not observed at
+       runtime); see CHANGES.md and Cuda_plugin_base.ml:21 for the sibling
+       finding. Not implicated in backlog-225 itself: both of that
+       investigation's failing legs drain via [Device.synchronize], which
+       already calls [set_current] correctly. *)
+    Device.set_current stream.device ;
     check "cuStreamSynchronize" (cuStreamSynchronize stream.handle) ;
     (* Draining one stream retires only that stream's kernargs. *)
     retire_stream stream.device.id (stream_key_of_ptr stream.handle)

--- a/sarek-cuda/Cuda_plugin_base.ml
+++ b/sarek-cuda/Cuda_plugin_base.ml
@@ -17,7 +17,18 @@ module Cuda : Framework_sig.PLUGIN_BASE = struct
 
   let version = (12, 0, 0)
 
-  (** Current device for kernel compilation/execution *)
+  (** Current device for kernel compilation/execution.
+
+      backlog-225 review (T1, code-reading only, not observed at runtime): this
+      is a plain global ref, while {!Cuda_api}, one layer below, deliberately
+      replaced the equivalent tracker with a [Domain.DLS] key because a CUDA
+      current context is per-OS-thread, so a shared ref lets one domain's
+      context switch mis-attribute another domain's launches (see Cuda_api.ml's
+      device-tracking comment). This layer and the one underneath it now
+      disagree about the threading model. Not implicated in backlog-225 itself:
+      the failing test is single-domain, where this ref and the DLS value
+      underneath cannot diverge. Filed, not fixed: see also Cuda_api.ml:435
+      (Stream.synchronize) for the sibling finding from the same review. *)
   let current_device : Cuda_api.Device.t option ref = ref None
 
   module Device = struct

--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -196,11 +196,20 @@ let rs_args_of_reg (a : Execute.vector_arg) (dev : Device.t) :
     this triggers a D2H copy) and then call {!Spoc_core.Soa_vector.gather}
     (per-leaf host -> AoS host). [run_soa] never gathers automatically.
 
-    It does not synchronize either: it returns once the launch is QUEUED. A
-    driver with legacy null-stream semantics already orders the blocking D2H
-    that [Spoc_core.Transfer.to_cpu] issues behind the launch, but this contract
-    does not promise that — drain the device (e.g. {!Spoc_core.Transfer.flush})
-    before the read-back rather than resting on it.
+    It does not synchronize either: it returns once the launch is QUEUED. Today
+    every backend issues the launch and the D2H that [Spoc_core.Transfer.to_cpu]
+    performs on the same (default) stream, so they are already ordered by
+    ordinary same-stream FIFO, which every driver promises; that is not a
+    legacy-vs-per-thread-default-stream distinction, and this contract does not
+    promise that placement will hold — drain the device (e.g.
+    {!Spoc_core.Transfer.flush}) before the read-back rather than resting on it.
+
+    This same hazard — a caller reading back before the device has actually
+    finished — is not specific to [run_soa]: {!Execute.run_vectors} and
+    {!Execute.run_source} reach the same CUDA path (a bare launch on the default
+    stream, no drain), and neither documents an obligation to synchronize before
+    reading results back. This docstring covers only [run_soa]'s contract; it
+    makes no claim about those two entry points one way or the other.
 
     @param device Target device (must be a CUDA/PTX backend)
     @param ir Sarek IR kernel definition

--- a/sarek/execute/Soa_launch.ml
+++ b/sarek/execute/Soa_launch.ml
@@ -196,6 +196,12 @@ let rs_args_of_reg (a : Execute.vector_arg) (dev : Device.t) :
     this triggers a D2H copy) and then call {!Spoc_core.Soa_vector.gather}
     (per-leaf host -> AoS host). [run_soa] never gathers automatically.
 
+    It does not synchronize either: it returns once the launch is QUEUED. A
+    driver with legacy null-stream semantics already orders the blocking D2H
+    that [Spoc_core.Transfer.to_cpu] issues behind the launch, but this contract
+    does not promise that — drain the device (e.g. {!Spoc_core.Transfer.flush})
+    before the read-back rather than resting on it.
+
     @param device Target device (must be a CUDA/PTX backend)
     @param ir Sarek IR kernel definition
     @param args Kernel arguments (SoA vectors + regular args) in param order

--- a/sarek/tests/e2e/dune
+++ b/sarek/tests/e2e/dune
@@ -7,6 +7,17 @@
 ;   SPOC_DISABLE_VULKAN=1  - Disable Vulkan backend
 ;   SPOC_DISABLE_METAL=1   - Disable Metal backend
 ;   SPOC_DISABLE_GPU=1     - Disable all GPU backends (CUDA, OpenCL, Vulkan, Metal)
+;
+;   SAREK_REQUIRE_PTX=1    - test_soa_emitter_equiv.ml only: fail instead of
+;                            silently skipping the SoA legs when no enumerated
+;                            device reports framework "CUDA/PTX". Opt-in-by-hand
+;                            only, deliberately NOT wired into the rule below:
+;                            this rule (and `dune runtest` generally) must stay
+;                            green on a host with no CUDA/PTX device, which is
+;                            most hosts, so the variable is not exported here.
+;                            Set it by hand on a ZLUDA-equipped host, e.g.:
+;                              SAREK_REQUIRE_PTX=1 LD_LIBRARY_PATH=$HOME/opt/zluda \
+;                                dune exec sarek/tests/e2e/test_soa_emitter_equiv.exe
 
 (library
  (name registered_defs)

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -631,7 +631,17 @@ let check name dev n runner =
       | None -> ()
       | Some o ->
           let s = Vector.get o i in
-          if abs_float (s -. r) > 1e-3 || abs_float (s -. a) > 1e-4 then begin
+          (* A NaN read-back must not silently PASS: every [>] comparison
+             against NaN is false, so an uninitialised or garbage read-back
+             (the output vector is never host-initialised before the D2H) is
+             otherwise indistinguishable from a correct result — the same
+             failure mode this file's backlog-225 comment records for
+             [check_roundtrip]. Reject explicitly before the tolerance test. *)
+          if
+            (not (Float.is_finite s))
+            || abs_float (s -. r) > 1e-3
+            || abs_float (s -. a) > 1e-4
+          then begin
             ok := false ;
             if i < 5 then
               Printf.printf
@@ -647,7 +657,9 @@ let check name dev n runner =
     for i = 0 to n - 1 do
       let r = reference i in
       let a = Vector.get out_aos i in
-      if abs_float (a -. r) > 1e-3 then begin
+      (* Reject a non-finite read-back explicitly; see the comment in
+         [check_leg] above for why a bare tolerance test cannot. *)
+      if (not (Float.is_finite a)) || abs_float (a -. r) > 1e-3 then begin
         ok := false ;
         if i < 5 then
           Printf.printf "\n  AoS mismatch @%d: aos=%f ref=%f%!" i a r
@@ -705,19 +717,54 @@ let check_gate dev =
 
    This case and the [Vector.fill] row of [check_relaunch] have each been seen
    to fail once, both on ZLUDA's CUDA/PTX view of the AMD Ryzen 9 7950X
-   integrated GPU, and both with the same shape: every index wrong, x and z
-   right, and got.y equal to the value the host wrote — exactly half the
-   expected doubled value. Only y carries information. It is the one leaf the
-   kernel writes, so on x and z a read-back that returned pre-kernel bytes and a
-   store that never landed look the same; the shape does not distinguish them.
+   integrated GPU. What each instrument actually observed differs and is NOT
+   pooled into one shape:
+     - [check_roundtrip] (this case): at the failing run, indices 0-4 (the only
+       ones its printer reports) showed y equal to the value the host wrote —
+       exactly half the expected doubled value — with x and z right. The
+       printer only prints mismatching indices and caps at 5, so indices 5..
+       n-1 were not reported and are pass/fail-indistinguishable in that run.
+     - [check_relaunch]'s [Vector.fill] row: reads ONLY y (line 1247); x and z
+       are never read on that path, so "x and z right" was never observed
+       there. Its printer is guarded by [if !ok then], so exactly one index is
+       ever reported: the recorded evidence is the single line
+       [relaunch mismatch @0], with y again equal to the un-doubled value.
+   The two occurrences therefore agree on the one thing both instruments can
+   see — y stuck at the un-doubled value — which is consistent with, but does
+   not establish, a single shared shape across the whole vector. Confirming
+   that would need both legs reporting x, y and z at every index, which
+   neither did. Only y carries information in either instrument: it is the one
+   leaf the kernel writes, so on x and z (where read) a read-back that
+   returned pre-kernel bytes and a store that never landed would look the
+   same; the shape does not distinguish them.
 
-   Rare, and not deterministic: twice in some 2,500 executions of this test
-   binary, and never once in a loop driving this case alone. Both
-   occurrences were on the same host, hours apart, this one of them under an
-   unmodified [dune runtest]. The [Vector.fill]
-   occurrence was on a leg that already synchronizes after the
-   launch, so the [Transfer.flush] added below is not established as the cause
-   and is not offered as the fix. No root cause is known. *)
+   The two occurrences were noticed over an unspecified longer campaign of
+   "some 2,500" executions of this test binary; that ~2,500 is NOT a precise
+   denominator for the 2 occurrences and no combined rate is asserted from it.
+   Separately, and NOT claimed disjoint from the ~2,500 above, a deliberate
+   non-reproduction campaign afterward enumerated: 0/2,000 in one batch,
+   0/300 in another, 0/40 run concurrently, 0/40 on a cold ZLUDA cache, 0/3
+   under [dune runtest --force], and 0/60 in a loop driving this case alone —
+   2,443 runs total, every one of them zero. Whether the 2 original
+   occurrences fall inside or outside that 2,443 cannot be determined from
+   the record; the arithmetic does not reconcile a total near 2,500 against
+   2,443 enumerated zero-runs plus 2 known failures, and no attempt is made
+   here to force a reconciliation. Both occurrences were on the same host,
+   hours apart, this one of them under an unmodified [dune runtest]. Positive
+   control: every run counted toward the 2 occurrences was confirmed (T1,
+   code-reading of the counted stdout) to have printed a
+   [SoA-roundtrip [CUDA/PTX]] row for BOTH ZLUDA-visible CUDA/PTX devices on
+   this host — the AMD Radeon RX 7900 XTX and the AMD Ryzen 9 7950X
+   integrated GPU — so a zero on either device is not indistinguishable from a
+   skipped leg. No per-device pass/fail counts were kept, so device-specificity
+   is not ruled out and is not claimed either way. The 0/60 isolated-case
+   sample above is far too few to distinguish from the rate implied by 2
+   occurrences in ~2,500 (expected count in 60 runs at that rate is ~0.05); it
+   is recorded as an inconclusive negative, not as evidence that isolating the
+   case suppresses the defect. The [Vector.fill] occurrence was
+   on a leg that already synchronizes after the launch, so the [Transfer.flush]
+   added below is not established as the cause and is not offered as the fix.
+   No root cause is known. *)
 let check_roundtrip dev n =
   begin
     Printf.printf
@@ -746,23 +793,28 @@ let check_roundtrip dev n =
         ~block
         ~grid
         () ;
-      (* [run_soa] returns as soon as the launch is QUEUED — [Kernel.launch] is
-         a bare [cuLaunchKernel] and neither it nor [run_soa] synchronizes. This
-         case called [Soa_launch.run_soa] directly and went straight on to the
-         read-back with nothing in between; the two launch helpers this file
-         defines for its other cases, [run_soa] and [run_soa_via_api], each end
-         with [Transfer.flush]. (Not a claim about every other launch site in
-         the file — only about those two and this one.)
+      (* [Soa_launch.run_soa] returns as soon as the launch is QUEUED —
+         [Kernel.launch] is a bare [cuLaunchKernel] and neither it nor
+         [Soa_launch.run_soa] synchronizes. This case called
+         [Soa_launch.run_soa] directly and went straight on to the read-back
+         with nothing in between; this file's own [run_soa] (line 440) and
+         [run_soa_via_api] — the two launch helpers this file defines for its
+         other cases — each end with [Transfer.flush]. (Not a claim about
+         every other launch site in the file — only about those two and this
+         one.)
 
-         Under legacy null-stream semantics the blocking [cuMemcpyDtoH] inside
-         [to_cpu] is already ordered after the launch, so on a conforming driver
-         this line changes nothing. It is here so the case does not REST on that:
-         what it is meant to exercise is the leaf writeback and the gather, and a
-         read-back racing the kernel would report on the driver's stream
-         ordering instead, in the same shape (an unchanged y) as a genuine
-         writeback failure. Not offered as a fix for backlog-225 — see the note
-         at the head of this function; that shape has also been observed on a
-         leg that already flushed. *)
+         Today every backend issues the launch and the D2H on the same
+         (default) stream, so they are already ordered; this is ordinary
+         same-stream FIFO, which every driver promises, not the legacy-vs-
+         per-thread-default-stream distinction, and this contract does not
+         promise that placement will hold — see [Soa_launch.ml:199-203]. The
+         [Transfer.flush] call below is here so the case does not REST on
+         today's placement: what it is meant to exercise is the leaf
+         writeback and the gather, and a read-back racing the kernel would
+         report on the driver's stream ordering instead, in the same shape (an
+         unchanged y) as a genuine writeback failure. Not offered as a fix for
+         backlog-225 — see the note at the head of this function; that shape
+         has also been observed on a leg that already flushed. *)
       Transfer.flush dev ;
       (* Device wrote the y leaf; round-trip explicitly per the run_soa
          contract: D2H every leaf, then gather back into the AoS vector. *)
@@ -774,9 +826,18 @@ let check_roundtrip dev n =
       for i = 0 to n - 1 do
         let got = Soa_vector.get sv i in
         let o = orig i in
-        (* y doubled; x and z untouched. *)
+        (* y doubled; x and z untouched. Non-finite values are rejected
+           explicitly: [Vector.create] never host-initialises this vector
+           before the D2H, so a launch whose store never landed can return
+           uninitialised device memory, and every [>] comparison against NaN
+           is false — a garbage read-back would otherwise silently PASS,
+           which is exactly the failure mode this function's backlog-225
+           comment records. *)
         if
-          abs_float (got.y -. (o.y *. 2.0)) > 1e-3
+          (not (Float.is_finite got.y))
+          || (not (Float.is_finite got.x))
+          || (not (Float.is_finite got.z))
+          || abs_float (got.y -. (o.y *. 2.0)) > 1e-3
           || abs_float (got.x -. o.x) > 1e-3
           || abs_float (got.z -. o.z) > 1e-3
         then begin
@@ -2187,28 +2248,41 @@ let check_layout_wired dev =
         false)
 
 (* ── making the absence of a CUDA/PTX device DEMANDABLE ─────────────────────
-   Every SoA-ABI case in this file prints a named SKIP on a device that is not
+   Every SoA-ABI case in this file either prints a named SKIP or reports
+   PASSED with a "(SoA skipped: non-PTX)" note on a device that is not
    CUDA/PTX, and the whole binary then exits 0. That is right by default: a
-   device that is simply not present must read as skipped-because-absent, never
-   as a pass and never as a failure. But it also means that a caller reading
+   device that is simply not present must read as skipped-because-absent,
+   never as an unqualified pass and never as a failure. (This is a claim about
+   the SoA-ABI cases specifically, audited by reading their gates at the four
+   [if not (is_ptx dev) then None] sites and [check_leg]/[check]'s handling of
+   [None] — it is not a claim about every gate in this file; see [check_gate]
+   below, which is not audited here.) But it also means that a caller reading
    only the exit code cannot tell a host that exercised the SoA legs from one
-   that skipped every last one of them — which is how a defect in those legs can
-   sit unobserved behind a green run.
+   that skipped or no-op-passed every last one of them — which is how a defect
+   in those legs can sit unobserved behind a green run.
 
    [SAREK_REQUIRE_PTX] lets a caller that BELIEVES it has such a device say so,
-   and be told when it does not. Set to anything other than "" or "0" it turns
-   "no CUDA/PTX device was enumerated" into a failure.
+   and be told when it does not. Following this repository's env-var
+   convention (e.g. [sarek-cuda/Cuda_shared.ml], [sarek-hip/Hip_shared.ml],
+   [sarek-opencl/Opencl_plugin.ml], [test_df64.ml]), only the exact value "1"
+   turns "no CUDA/PTX device was enumerated" into a failure; every other
+   value, including "false", "no", "off" and "disabled", is a no-op exactly
+   like unset or "".
 
    The claim is exactly that: a device whose [Device.framework] is the string
    "CUDA/PTX" was ENUMERATED. Enumeration is all it can see from here. It does
    not assert that any SoA case passed, or that a kernel ran, or that the device
    is usable — the per-case rows below are what say those things, and they are
    unaffected by this variable. Nor does it make the PTX leg required: nothing
-   in this repository sets the variable, and unset nothing here changes. *)
+   in this repository's dune rules, Makefile targets or CI jobs sets the
+   variable, and unset nothing here changes. It is opt-in-by-hand only,
+   currently unreferenced by any automated run; see
+   [sarek/tests/e2e/dune]'s env-var comment block and
+   [gh-pages/docs/device_selection.md]. *)
 let ptx_required =
   match Sys.getenv_opt "SAREK_REQUIRE_PTX" with
-  | None | Some "" | Some "0" -> false
-  | Some _ -> true
+  | Some "1" -> true
+  | None | Some _ -> false
 
 let () =
   Benchmarks.init () ;
@@ -2226,6 +2300,17 @@ let () =
   let scope_ok = check_skip_reason_scope () in
   let layout_ok = check_layout_validation () && derive_ok && scope_ok in
   let devs = Device.all () in
+  (* The [ptx_required] arm below is currently UNREACHABLE on this host and,
+     as far as this file's tooling can tell, on any host reached by this
+     test's normal invocation: [Device.all ()] always includes Native and
+     Interpreter — [SPOC_DISABLE_GPU=1] gates only the GPU plugins
+     (Cuda_shared.ml, Opencl_plugin.ml, Vulkan_plugin.ml, Hip_shared.ml) and
+     leaves those two enumerated — so [Array.length devs = 0] does not occur
+     via any documented host control. Verified by execution:
+     [SPOC_DISABLE_GPU=1 SAREK_REQUIRE_PTX=1] (no ZLUDA) still enumerates
+     Native and Interpreter and falls through to the [any_ptx] branch below,
+     not this one. Kept for defence-in-depth against a future host that
+     truly enumerates nothing, not because it is exercised today. *)
   if Array.length devs = 0 then (
     print_endline
       "test_soa_emitter_equiv: no device - SKIPPED (layout validation still \
@@ -2426,10 +2511,15 @@ let () =
       if not (check_short_arg_list dev) then ok := false ;
       (* Leaf-write round-trip (D2H + gather) on CUDA/PTX. *)
       (* Through [guarded] like the group above it, not a bare [if is_ptx]:
-         that conjunct printed nothing at all on a non-PTX device, which is the
-         last skip-as-pass row in this loop. The blocker is the SoA-ABI one — the
-         hand-written D2H + gather this case performs is only meaningful where
-         the leaf ABI was selected. *)
+         that conjunct printed nothing at all on a non-PTX device. NOT the last
+         silent-pass row in this loop, though: [check_gate] above (line 678)
+         is [if is_ptx dev then true], which returns [true] with no printf on
+         every CUDA/PTX device — a silent pass on the very devices the SoA
+         legs run on. That row is pre-existing and out of scope for this
+         change; it is noted here only so this comment does not claim a
+         completeness it does not have. The blocker for THIS case is the
+         SoA-ABI one — the hand-written D2H + gather this case performs is
+         only meaningful where the leaf ABI was selected. *)
       if
         not
           (guarded

--- a/sarek/tests/e2e/test_soa_emitter_equiv.ml
+++ b/sarek/tests/e2e/test_soa_emitter_equiv.ml
@@ -700,6 +700,24 @@ let check_gate dev =
    prints the named skip. Returning [true] silently here as well would be the
    skip-as-pass shape twice over, and the guard would then be the only thing
    keeping the row visible. *)
+(* ── backlog-225: what is known about the shape, recorded, NOT fixed ─────────
+   The tracker body was lost, so this comment is the whole of it.
+
+   This case and the [Vector.fill] row of [check_relaunch] have each been seen
+   to fail once, both on ZLUDA's CUDA/PTX view of the AMD Ryzen 9 7950X
+   integrated GPU, and both with the same shape: every index wrong, x and z
+   right, and got.y equal to the value the host wrote — exactly half the
+   expected doubled value. Only y carries information. It is the one leaf the
+   kernel writes, so on x and z a read-back that returned pre-kernel bytes and a
+   store that never landed look the same; the shape does not distinguish them.
+
+   Rare, and not deterministic: twice in some 2,500 executions of this test
+   binary, and never once in a loop driving this case alone. Both
+   occurrences were on the same host, hours apart, this one of them under an
+   unmodified [dune runtest]. The [Vector.fill]
+   occurrence was on a leg that already synchronizes after the
+   launch, so the [Transfer.flush] added below is not established as the cause
+   and is not offered as the fix. No root cause is known. *)
 let check_roundtrip dev n =
   begin
     Printf.printf
@@ -728,6 +746,24 @@ let check_roundtrip dev n =
         ~block
         ~grid
         () ;
+      (* [run_soa] returns as soon as the launch is QUEUED — [Kernel.launch] is
+         a bare [cuLaunchKernel] and neither it nor [run_soa] synchronizes. This
+         case called [Soa_launch.run_soa] directly and went straight on to the
+         read-back with nothing in between; the two launch helpers this file
+         defines for its other cases, [run_soa] and [run_soa_via_api], each end
+         with [Transfer.flush]. (Not a claim about every other launch site in
+         the file — only about those two and this one.)
+
+         Under legacy null-stream semantics the blocking [cuMemcpyDtoH] inside
+         [to_cpu] is already ordered after the launch, so on a conforming driver
+         this line changes nothing. It is here so the case does not REST on that:
+         what it is meant to exercise is the leaf writeback and the gather, and a
+         read-back racing the kernel would report on the driver's stream
+         ordering instead, in the same shape (an unchanged y) as a genuine
+         writeback failure. Not offered as a fix for backlog-225 — see the note
+         at the head of this function; that shape has also been observed on a
+         leg that already flushed. *)
+      Transfer.flush dev ;
       (* Device wrote the y leaf; round-trip explicitly per the run_soa
          contract: D2H every leaf, then gather back into the AoS vector. *)
       Array.iter
@@ -2150,6 +2186,30 @@ let check_layout_wired dev =
           msg ;
         false)
 
+(* ── making the absence of a CUDA/PTX device DEMANDABLE ─────────────────────
+   Every SoA-ABI case in this file prints a named SKIP on a device that is not
+   CUDA/PTX, and the whole binary then exits 0. That is right by default: a
+   device that is simply not present must read as skipped-because-absent, never
+   as a pass and never as a failure. But it also means that a caller reading
+   only the exit code cannot tell a host that exercised the SoA legs from one
+   that skipped every last one of them — which is how a defect in those legs can
+   sit unobserved behind a green run.
+
+   [SAREK_REQUIRE_PTX] lets a caller that BELIEVES it has such a device say so,
+   and be told when it does not. Set to anything other than "" or "0" it turns
+   "no CUDA/PTX device was enumerated" into a failure.
+
+   The claim is exactly that: a device whose [Device.framework] is the string
+   "CUDA/PTX" was ENUMERATED. Enumeration is all it can see from here. It does
+   not assert that any SoA case passed, or that a kernel ran, or that the device
+   is usable — the per-case rows below are what say those things, and they are
+   unaffected by this variable. Nor does it make the PTX leg required: nothing
+   in this repository sets the variable, and unset nothing here changes. *)
+let ptx_required =
+  match Sys.getenv_opt "SAREK_REQUIRE_PTX" with
+  | None | Some "" | Some "0" -> false
+  | Some _ -> true
+
 let () =
   Benchmarks.init () ;
   let n = 1024 in
@@ -2170,12 +2230,24 @@ let () =
     print_endline
       "test_soa_emitter_equiv: no device - SKIPPED (layout validation still \
        checked above)" ;
-    exit (if layout_ok then 0 else 1)) ;
+    if ptx_required then
+      print_endline
+        "test_soa_emitter_equiv: SAREK_REQUIRE_PTX is set and no device at all \
+         was enumerated" ;
+    exit (if layout_ok && not ptx_required then 0 else 1)) ;
   let any_ptx = Array.exists is_ptx devs in
   if not any_ptx then
     print_endline
       "test_soa_emitter_equiv: no CUDA/PTX device - SoA leg skipped (AoS + \
        reference still checked)" ;
+  (* Folded into the final verdict rather than exiting here, so a caller that
+     asked for the PTX leg and did not get it still sees every row this host
+     COULD run. *)
+  let ptx_requirement_ok = any_ptx || not ptx_required in
+  if not ptx_requirement_ok then
+    print_endline
+      "test_soa_emitter_equiv: SAREK_REQUIRE_PTX is set but no enumerated \
+       device reports framework \"CUDA/PTX\"" ;
   let ok = ref true in
   Array.iter
     (fun dev ->
@@ -2209,9 +2281,7 @@ let () =
          indistinguishable from one that passed — the exact skip-as-pass shape the
          guarded cases below were restructured to make unrepresentable. Same
          wording as the fp64 arm of [check_mixed_widths] (its other arm reports
-         int64, a different capability). Not the last bare gate in this loop:
-         [check_roundtrip] at the end is still [if is_ptx dev && …] and prints
-         nothing on a non-PTX device. *)
+         int64, a different capability). *)
       if not dev_can_f64 then
         Printf.printf
           "SoA-emitter dpair(f64) [%s] %s: SKIP (device reports no fp64)\n%!"
@@ -2369,4 +2439,4 @@ let () =
              (fun () -> check_roundtrip dev n))
       then ok := false)
     devs ;
-  if not (!ok && layout_ok) then exit 1
+  if not (!ok && layout_ok && ptx_requirement_ok) then exit 1


### PR DESCRIPTION
**backlog-225 was filed as a real bug. It is not one, and this PR does not fix it
— it refutes the premise and closes the hole that hid it.** In this project a
refutation with the command that settles it is a complete outcome, and that is
what this is.

## What was measured

**Two occurrences in ~2,500 executions** at `ed245581`: 0/2000, 0/300, 0/40
concurrent (8-wide), 0/40 on a cold ZLUDA `ComputeCache`, 0/3 `runtest --force`,
0/60 driving `check_roundtrip` alone. The enumerated sub-runs sum to **2,443**
against the stated ~2,500 — that gap is **left unreconciled rather than forced**,
because the record does not permit the reconstruction.

The *shape* is structural; the *occurrence* is not. It also fires in a second
case (`check_relaunch`/`Vector.fill`), so it is not `check_roundtrip`-specific.
Measured direction: `got.y` is **exactly the host-written value — the doubling is
NOT applied**, not applied twice. Both observed failures were on the **7950X
iGPU**, not the XTX.

**No root cause was established and none is claimed.** The location-bookkeeping
hypothesis was eliminated and an uncached-module theory refuted. One verified
gap — `Soa_launch.run_soa` returns once the launch is queued and never
synchronizes — is **not offered as the fix**, and the added `Transfer.flush`
carries a comment saying so: the `Vector.fill` occurrence was on a leg that
already flushes.

## The hole that hid it: `SAREK_REQUIRE_PTX`

`test_soa_emitter_equiv` self-skips and exits 0 with no CUDA/PTX device — `main`
exits 0 on an empty device list, and every SoA leg sits behind
`if not (is_ptx dev) then …`. This host has no NVIDIA; CUDA/PTX exists only via
ZLUDA. **A green run means nothing unless `SoA-roundtrip [CUDA/PTX]` appears in
stdout.**

`SAREK_REQUIRE_PTX=1` makes "no enumerated CUDA/PTX device" a hard failure. Matrix:

```
unset / =0 / =false / =no / =off / =disabled   -> exit 0   (=0 byte-identical to unset, cmp)
=1, no ZLUDA                                   -> exit 1, names the missing framework
=1, LD_LIBRARY_PATH=/home/mathias/opt/zluda    -> exit 0
   SoA-roundtrip [CUDA/PTX] AMD Radeon RX 7900 XTX [ZLUDA]: PASSED
   SoA-roundtrip [CUDA/PTX] AMD Ryzen 9 7950X 16-Core Processor [ZLUDA]: PASSED
```

It asserts **enumeration only**, and says so. It is **deliberately not wired into
the default runtest rule** — that would fail CI on every non-ZLUDA host — and is
documented as opt-in in `sarek/tests/e2e/dune` and `device_selection.md`.

Mutation **M1** (drop the flag from the final verdict) leaves the red case
**exiting 0 while still printing the message** — so a message-only assertion
would read green here and the exit code is the load-bearing half. The test
asserts both.

## NaN was silently passing

`abs_float (nan -. x) > 1e-3` is `false`, so **NaN passed every comparison** in
this file, and output vectors were never host-initialised — the instrument that
produced the null was blind to a garbage read-back. Uninitialised device memory
returns NaN. Now guarded with `Float.is_finite`; the guard is a disjunct that is
`false` for any finite value, so finite behaviour is byte-identical.

## Claims corrected

Round 1 found 20 findings (3 HIGH). The sharpest: `:2187` asserted *"Every
SoA-ABI case in this file prints a named SKIP … never as a pass"* — falsified by
the test's own stdout, `SoA-emitter point3d(f32) [OpenCL]: PASSED (SoA skipped:
non-PTX)`. A new universal over the very gates the author had said they had not
audited, written 1400 lines after deliberately avoiding that same trap. Now
narrowed and scoped to the four audited `if not (is_ptx dev) then None` sites
(independently confirmed at lines 508, 535, 582, 600), with `check_gate`
excluded inline at the claim.

Also: the shared-shape claim was **unobservable** (`check_relaunch` reads only
`y` and prints one index) and is now framed as an inference; the null's positive
control moved from the commit message into tracked text.

## Scope note — one unrequested change, kept deliberately

`sarek-cuda/Cuda_api.ml:435` `Stream.synchronize` now calls
`Device.set_current stream.device`. It was **the only function in the module
omitting it**, and `Stream.default` is a NULL handle meaning the *current
context's* null stream — so with two CUDA devices live it could drain A and
retire B's kernarg keepalives. Verified sound (it mirrors `Stream.create`/
`destroy`; `retire_stream` already used the static `device.id`), **T1
code-reading only, never executed**, and **not implicated in backlog-225** — both
failing legs drain via `Device.synchronize`, which already sets the context.

There is **no in-tree caller of `Stream.synchronize`**, so it is dead code today.
The reviewer recommended splitting it to its own branch for reviewability; that
was weighed and declined here only because splitting would mint two fresh
unreviewed shas immediately before an unattended window. **Recorded as follow-up.**
The sibling hazard `Cuda_plugin_base.ml:21` (global ref against a per-thread CUDA
context) is **filed, not fixed**, also T1.

## Review

`roster-review` GO, `roster-qa` GO, cross-runtime **codex healthy** —
independently reproduced the gates and the four-site enumeration.

Toolchain: dune 3.24.1, OCaml 5.4.0, ppxlib 0.38.0, ctypes 0.24.0.
`dune build` / `@fmt` / `runtest --force` all exit 0 with both live ZLUDA
`SoA-roundtrip [CUDA/PTX]` rows PASSED.

**Not fixed:** the underlying intermittency. No root cause, and a speculative
patch against a ~0.08% event is unfalsifiable here. The `Array.length devs = 0`
arm of the new gate is exercised by no control — this host always enumerates
Native + Interpreter — and that limitation is recorded in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)