### PR TITLE
docs+test(execute): scope the SoA arity-shift claims to their actual cases (backlog-219)

### DIFF
--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -266,10 +266,21 @@ let get_device_buffer (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
    pointers plus one shared length. The two generated-JIT sites pass [true]
    explicitly and everything else defaults to [false], because the dangerous
    direction is an EXTERNAL kernel: [run_source] hands the backend a source
-   string Sarek did not emit, whose parameter block is the packed [(ptr, len)]
-   pair, and binding N leaf pointers to it is not a crash but silently wrong
-   data. A default of [true] would make that the behaviour any new caller
-   inherits by omission. *)
+   string Sarek did not emit, whose parameter block at the vector's position is
+   the packed [(ptr, len)] pair the kernel author wrote there, not the
+   N-pointer layout this module can produce. [run_source] does not expose
+   [~soa_abi] and always calls this with the default, so that mismatch cannot
+   occur through it today. The design point is what a future caller passing
+   [~soa_abi:true] for an externally-authored kernel would hit: [soa_dispatch]
+   only ever answers [Some] on CUDA/PTX, which binds through the same bare
+   pointer array as CUDA/C and HIP, with nothing checking the bound arguments
+   against the compiled signature — so the outcome is the same
+   shape-dependent shift {!Backend_error.reject_soa_params} analyses in detail,
+   where a trap is among the possibilities but so is silent corruption (a
+   record's Nth leaf landing in a valid pointer slot of the wrong buffer) or no
+   visible effect at all (the vector declared last), never uniformly "a crash"
+   or uniformly "silently wrong data." A default of [true] would make that
+   hazard the behaviour any new caller inherits by omission. *)
 let soa_dispatch (type a b) ~(soa_abi : bool) (v : (a, b) Vector.t)
     (dev : Device.t) : Vector.soa_binding option =
   match v.Vector.soa with
@@ -930,16 +941,27 @@ let run ~(device : Device.t) ~(name : string)
                  predicate the transfer and expansion use (backlog-54). The
                  emitted signature and the bound argument list are then two
                  consequences of one decision rather than two decisions that
-                 could disagree — a disagreement here is not a crash but N
-                 pointers bound to a packed-AoS param block, i.e. silently wrong
-                 data. Empty list on every non-CUDA/PTX backend, because
-                 soa_dispatch is what decides — and since backlog-214 the
-                 source-generating ones among them REFUSE a non-empty list
-                 rather than ignore it, so this gate is the fast path and no
-                 longer the only guarantee. Native, Interpreter and WebGPU
-                 return None unconditionally and carry no refusal; WebGPU is
-                 the one to watch, being a JIT backend whose WGSL codegen is
-                 not yet wired. *)
+                 could disagree — and because both derive from [soa_dispatch]
+                 applied to the same [args]/[device], they structurally cannot
+                 disagree today. This list is only ever non-empty on CUDA/PTX
+                 (the one framework [soa_dispatch] answers [Some] for), which
+                 binds through the same bare pointer array as CUDA/C and HIP,
+                 with nothing checking the bound arguments against the
+                 compiled signature. So WERE the emitted signature and the
+                 bound arguments to disagree here, the outcome would be the
+                 same shape-dependent shift {!Backend_error.reject_soa_params}
+                 analyses for the external-kernel case: a trap is among the
+                 possible outcomes, but so is silent corruption or no visible
+                 effect at all depending on where the SoA vector sits in the
+                 parameter list — never uniformly "a crash" or uniformly
+                 "silently wrong data." Empty list on every non-CUDA/PTX
+                 backend, because soa_dispatch is what decides — and since
+                 backlog-214 the source-generating ones among them REFUSE a
+                 non-empty list rather than ignore it, so this gate is the
+                 fast path and no longer the only guarantee. Native,
+                 Interpreter and WebGPU return None unconditionally and carry
+                 no refusal; WebGPU is the one to watch, being a JIT backend
+                 whose WGSL codegen is not yet wired. *)
               let soa_params = soa_param_names ir args device in
               match B.generate_source ~block ~soa_params ir with
               | None ->

--- a/sarek/execute/Execute.ml
+++ b/sarek/execute/Execute.ml
@@ -263,24 +263,29 @@ let get_device_buffer (type a b) (v : (a, b) Vector.t) (dev : Device.t) :
 
    [soa_abi] is the caller's statement that the kernel about to run was emitted
    by Sarek with [~soa_params] — i.e. that its signature really is N leaf
-   pointers plus one shared length. The two generated-JIT sites pass [true]
-   explicitly and everything else defaults to [false], because the dangerous
-   direction is an EXTERNAL kernel: [run_source] hands the backend a source
-   string Sarek did not emit, whose parameter block at the vector's position is
-   the packed [(ptr, len)] pair the kernel author wrote there, not the
-   N-pointer layout this module can produce. [run_source] does not expose
-   [~soa_abi] and always calls this with the default, so that mismatch cannot
-   occur through it today. The design point is what a future caller passing
-   [~soa_abi:true] for an externally-authored kernel would hit: [soa_dispatch]
-   only ever answers [Some] on CUDA/PTX, which binds through the same bare
-   pointer array as CUDA/C and HIP, with nothing checking the bound arguments
-   against the compiled signature — so the outcome is the same
-   shape-dependent shift {!Backend_error.reject_soa_params} analyses in detail,
-   where a trap is among the possibilities but so is silent corruption (a
-   record's Nth leaf landing in a valid pointer slot of the wrong buffer) or no
-   visible effect at all (the vector declared last), never uniformly "a crash"
-   or uniformly "silently wrong data." A default of [true] would make that
-   hazard the behaviour any new caller inherits by omission. *)
+   pointers plus one shared length. [run]'s [expand_to_run_source_args] and
+   [run_vectors]'s [transfer_vectors_to_device] pass [true] explicitly (and
+   [soa_param_names] hardcodes it, per its own comment); everything else
+   defaults to [false], because the dangerous direction is an EXTERNAL kernel:
+   [run_source] hands the backend a source string Sarek did not emit, whose
+   parameter block at the vector's position is, under [run_source]'s
+   [~inject_lengths] default, the packed [(ptr, len)] pair the kernel author
+   wrote there (a [~inject_lengths:false] caller declares a bare pointer
+   instead), not the N-pointer layout this module can produce. [run_source]
+   does not expose [~soa_abi] and always calls this with the default, so that
+   mismatch cannot occur through it today. The design point is what a future
+   caller passing [~soa_abi:true] for an externally-authored kernel would hit:
+   [soa_dispatch] only ever answers [Some] on CUDA/PTX, which binds through
+   the same bare pointer array as CUDA/C and HIP, with nothing checking the
+   bound arguments against the compiled signature — so the outcome is the
+   same shape-dependent shift {!Backend_error.reject_soa_params} analyses in
+   detail, where a trap is among the possibilities but so is silent
+   corruption (a record's Nth leaf landing in a valid pointer slot of the
+   wrong buffer) or, with the vector declared last, no shift into any
+   FOLLOWING pointer slot at all — though the vector's own (ptr, len) slots
+   still receive leaf pointers — never uniformly "a crash" or uniformly
+   "silently wrong data." A default of [true] would make that hazard the
+   behaviour any new caller inherits by omission. *)
 let soa_dispatch (type a b) ~(soa_abi : bool) (v : (a, b) Vector.t)
     (dev : Device.t) : Vector.soa_binding option =
   match v.Vector.soa with
@@ -951,9 +956,11 @@ let run ~(device : Device.t) ~(name : string)
                  bound arguments to disagree here, the outcome would be the
                  same shape-dependent shift {!Backend_error.reject_soa_params}
                  analyses for the external-kernel case: a trap is among the
-                 possible outcomes, but so is silent corruption or no visible
-                 effect at all depending on where the SoA vector sits in the
-                 parameter list — never uniformly "a crash" or uniformly
+                 possible outcomes, but so is silent corruption or, when the
+                 vector is declared last, no shift into any following
+                 pointer slot — the vector's own slots still mis-bind —
+                 depending on where the SoA vector sits in the parameter
+                 list — never uniformly "a crash" or uniformly
                  "silently wrong data." Empty list on every non-CUDA/PTX
                  backend, because soa_dispatch is what decides — and since
                  backlog-214 the source-generating ones among them REFUSE a

--- a/sarek/tests/unit/test_execute.ml
+++ b/sarek/tests/unit/test_execute.ml
@@ -425,8 +425,10 @@ let test_interp_feature_gate_can_refuse () =
 
 (** {1 SoA arity-shift structural pinning (backlog-219)}
 
-    Backend_error.reject_soa_params's per-shape analysis (N=2 pointer-after, N=3
-    valid-pointer-into-the-wrong-buffer, vector-declared-last) is unreachable
+    Three of the shapes Backend_error.reject_soa_params gives as EXAMPLES of the
+    general shift (N=2 pointer-after, N=3 valid-pointer-into-the-wrong-buffer,
+    vector-declared-last — it states the general form separately: every
+    parameter after the vector receives the wrong entry) are unreachable
     end-to-end in this sandbox: [Execute.soa_dispatch] only ever answers [Some]
     for a real CUDA/PTX device, and there is no GPU here to launch one, so
     nothing below claims to have observed a trap. What these tests DO pin
@@ -507,44 +509,62 @@ let bind_all (args : Framework_sig.run_source_arg list) : unit =
       | _ -> ())
     args
 
-(* Case 1: N=2, a scalar param declared right after the SoA vector. The AoS
-   ABI would bind it at index 2 (buf, len, THIS); the SoA ABI shifts it to
-   index 3, because the vector now occupies 3 slots (2 leaves + length), not
-   2 — the shift a CUDA/C or HIP launch would bind straight into a bare
-   pointer array with no compiled-signature check. *)
+(* Case 1: N=2, a POINTER param (a second vector) declared right after the SoA
+   vector — the only shape Backend_error identifies as trap-capable, and the
+   only one that needs a pointer successor rather than a scalar. A compiled
+   AoS-ABI kernel expects (ptr0, len0, ptr1, len1) at indices 0-3; the SoA ABI
+   expands the first vector into 2 leaves + 1 shared length (3 slots, not
+   AoS's 2), shifting everything after it right by one. So index 1 (len0, a
+   length slot) receives leafB — a real device pointer — and index 2 (ptr1, a
+   pointer slot the kernel will read 8 bytes from) receives the shared
+   length — a 4-byte int32. That is Backend_error's trap, verbatim: "a length
+   slot receives a pointer value and the pointer slot reads its 8 bytes out of
+   a 4-byte length cell." Reuses case 2's out_v/fake_leaf_buffer pattern for
+   the pointer successor, rather than inventing a new fixture idiom. *)
 let test_soa_shift_n2_pointer_after () =
   let calls = ref [] in
   let v = soa_vector_with ["leafA"; "leafB"] calls in
+  let out_v = Vector.create_custom point_custom 4 in
+  Hashtbl.replace
+    out_v.Vector.device_buffers
+    cuda_ptx_device.Device.id
+    (fake_leaf_buffer "out_buffer" calls) ;
   let result =
-    expand_to_run_source_args ~soa_abi:true [Vec v; Int32 99l] cuda_ptx_device
+    expand_to_run_source_args ~soa_abi:true [Vec v; Vec out_v] cuda_ptx_device
   in
   check
     int
-    "2 leaves + shared length + the shifted scalar = 4 args"
-    4
+    "2 leaves + shared length + the out vector's own (buf, len) = 5 args"
+    5
     (List.length result) ;
   bind_all result ;
   check
     (list (pair int string))
-    "leaves bound at 0,1 in declaration order"
-    [(0, "leafA"); (1, "leafB")]
+    "leaves bound at 0,1; the out vector's buffer displaced to index 3, not \
+     the AoS-ABI index 2"
+    [(0, "leafA"); (1, "leafB"); (3, "out_buffer")]
     (List.rev !calls) ;
+  (* index 2 is the trap Backend_error names: a compiled AoS-ABI kernel's
+     second pointer parameter expects a device pointer at what it thinks is
+     index 2 — instead it is this shared length, a 4-byte int32 the kernel's
+     pointer slot would read 8 bytes from. *)
   (match List.nth result 2 with
   | Framework_sig.RSA_Vector_Length n -> check int32 "shared length" 4l n
   | _ -> fail "expected the shared SoA length at index 2") ;
-  match List.nth result 3 with
-  | Framework_sig.RSA_Int32 n ->
+  match List.nth result 4 with
+  | Framework_sig.RSA_Vector_Length n ->
       check
         int32
-        "the following param is unmodified but now at index 3, not the AoS-ABI \
-         index 2"
-        99l
+        "the out vector's own length, unshifted in kind but now at index 4, \
+         not the AoS-ABI index 3"
+        4l
         n
-  | _ -> fail "expected the following param, unshifted VALUE, at index 3"
+  | _ -> fail "expected the out vector's own length at index 4"
 
-(* Case 2: N=3. Backend_error calls this "the case with literally no crash
-   signal": the third leaf is a valid device pointer, so wherever it lands it
-   faults nothing. Here that slot is a second vector's own buffer, declared
+(* Case 2: N=3. Backend_error calls this "Silent corruption, nothing to trap
+   on" (Backend_error.ml:313): the third leaf is a valid device pointer, so
+   wherever it lands it faults nothing. Here that slot is a second vector's
+   own buffer, declared
    right after — so this pins that the second vector's buffer binder is
    invoked two slots later than an AoS-unaware reader would expect (index 4,
    not index 2), and that index 2 — where such a reader would look for its

--- a/sarek/tests/unit/test_execute.ml
+++ b/sarek/tests/unit/test_execute.ml
@@ -423,6 +423,191 @@ let test_interp_feature_gate_can_refuse () =
       fail "device_verdict permitted a feature absent from the provided list"
   | _ -> ()
 
+(** {1 SoA arity-shift structural pinning (backlog-219)}
+
+    Backend_error.reject_soa_params's per-shape analysis (N=2 pointer-after, N=3
+    valid-pointer-into-the-wrong-buffer, vector-declared-last) is unreachable
+    end-to-end in this sandbox: [Execute.soa_dispatch] only ever answers [Some]
+    for a real CUDA/PTX device, and there is no GPU here to launch one, so
+    nothing below claims to have observed a trap. What these tests DO pin
+    without a device: the positional shift itself, in
+    [expand_to_run_source_args]'s output list, given a synthetic
+    [Vector.soa_binding]. That output is exactly what a real CUDA/PTX launch
+    would hand [Cuda_shared.bind_args] — so this is the shape Backend_error's
+    per-backend claims are ABOUT, even though none of those backends run here.
+    Case 2 (the 3-leaf shape) is the one Backend_error calls out as having no
+    crash signal to catch drift with, which is exactly why it gets a structural
+    pin here instead of nothing. *)
+
+let cuda_ptx_device : Device.t =
+  {
+    id = 0;
+    backend_id = 0;
+    name = "Fake CUDA/PTX Device";
+    framework = "CUDA/PTX";
+    capabilities = caps_with [];
+  }
+
+(* Stands in for a real device pointer: records the (index, tag) pair it was
+   bound at instead of touching any GPU. *)
+let fake_leaf_buffer (tag : string) (calls : (int * string) list ref) :
+    (module Vector.DEVICE_BUFFER) =
+  (module struct
+    let device = cuda_ptx_device
+
+    let size = 1
+
+    let elem_size = 4
+
+    let device_ptr = 0n
+
+    let host_ptr_to_device (_ : unit Ctypes.ptr) ~byte_size:(_ : int) : unit =
+      ()
+
+    let device_to_host_ptr (_ : unit Ctypes.ptr) ~byte_size:(_ : int) : unit =
+      ()
+
+    let bind_to_kargs (_ : Framework_sig.kargs) (idx : int) : unit =
+      calls := (idx, tag) :: !calls
+
+    let free () : unit = ()
+  end : Vector.DEVICE_BUFFER)
+
+(* A [point] vector whose [.soa] is a synthetic binding with [tags] leaves, in
+   declaration order — the same shape [Soa_vector.create_transparent] would
+   produce, built directly so the test needs neither Soa_vector's Ctypes
+   plumbing nor a real device. *)
+let soa_vector_with (tags : string list) (calls : (int * string) list ref) :
+    (point, unit) Vector.t =
+  let v = Vector.create_custom point_custom 4 in
+  v.Vector.soa <-
+    Some
+      {
+        Vector.soa_num_leaves = List.length tags;
+        soa_aos_stride = 8 * List.length tags;
+        soa_scatter = (fun () -> ());
+        soa_gather = (fun () -> ());
+        soa_to_device = (fun (_ : Device.t) -> ());
+        soa_leaf_bufs =
+          (fun (_ : Device.t) ->
+            List.map (fun t -> fake_leaf_buffer t calls) tags);
+        soa_from_device = (fun (_ : Device.t) -> ());
+        soa_free_leaves = (fun (_ : Device.t option) -> ());
+        soa_leaves_live = ref false;
+      } ;
+  v
+
+(* Mirrors the real bind_args pattern (Cuda_shared/Hip_shared): iterate the
+   run_source_arg list, invoke every buffer's binder at ITS position. *)
+let bind_all (args : Framework_sig.run_source_arg list) : unit =
+  List.iteri
+    (fun i arg ->
+      match arg with
+      | Framework_sig.RSA_Buffer {binder; _} -> binder Framework_sig.No_kargs i
+      | _ -> ())
+    args
+
+(* Case 1: N=2, a scalar param declared right after the SoA vector. The AoS
+   ABI would bind it at index 2 (buf, len, THIS); the SoA ABI shifts it to
+   index 3, because the vector now occupies 3 slots (2 leaves + length), not
+   2 — the shift a CUDA/C or HIP launch would bind straight into a bare
+   pointer array with no compiled-signature check. *)
+let test_soa_shift_n2_pointer_after () =
+  let calls = ref [] in
+  let v = soa_vector_with ["leafA"; "leafB"] calls in
+  let result =
+    expand_to_run_source_args ~soa_abi:true [Vec v; Int32 99l] cuda_ptx_device
+  in
+  check
+    int
+    "2 leaves + shared length + the shifted scalar = 4 args"
+    4
+    (List.length result) ;
+  bind_all result ;
+  check
+    (list (pair int string))
+    "leaves bound at 0,1 in declaration order"
+    [(0, "leafA"); (1, "leafB")]
+    (List.rev !calls) ;
+  (match List.nth result 2 with
+  | Framework_sig.RSA_Vector_Length n -> check int32 "shared length" 4l n
+  | _ -> fail "expected the shared SoA length at index 2") ;
+  match List.nth result 3 with
+  | Framework_sig.RSA_Int32 n ->
+      check
+        int32
+        "the following param is unmodified but now at index 3, not the AoS-ABI \
+         index 2"
+        99l
+        n
+  | _ -> fail "expected the following param, unshifted VALUE, at index 3"
+
+(* Case 2: N=3. Backend_error calls this "the case with literally no crash
+   signal": the third leaf is a valid device pointer, so wherever it lands it
+   faults nothing. Here that slot is a second vector's own buffer, declared
+   right after — so this pins that the second vector's buffer binder is
+   invoked two slots later than an AoS-unaware reader would expect (index 4,
+   not index 2), and that index 2 — where such a reader would look for its
+   own out-buffer pointer — holds the SoA vector's third leaf instead. *)
+let test_soa_shift_n3_valid_pointer_wrong_buffer () =
+  let calls = ref [] in
+  let v = soa_vector_with ["leafA"; "leafB"; "leafC"] calls in
+  let out_v = Vector.create_custom point_custom 4 in
+  Hashtbl.replace
+    out_v.Vector.device_buffers
+    cuda_ptx_device.Device.id
+    (fake_leaf_buffer "out_buffer" calls) ;
+  let result =
+    expand_to_run_source_args ~soa_abi:true [Vec v; Vec out_v] cuda_ptx_device
+  in
+  check
+    int
+    "3 leaves + shared length + the out vector's own (buf, len) = 6 args"
+    6
+    (List.length result) ;
+  bind_all result ;
+  check
+    (list (pair int string))
+    "3 leaves at 0,1,2; the out buffer displaced to index 4, not index 2"
+    [(0, "leafA"); (1, "leafB"); (2, "leafC"); (4, "out_buffer")]
+    (List.rev !calls) ;
+  match List.nth result 2 with
+  | Framework_sig.RSA_Buffer _ -> ()
+  | _ ->
+      fail
+        "backlog-219 case 2: index 2 must hold a real (leaf) buffer pointer — \
+         if this ever turns into a scalar, the leaf count silently changed and \
+         the case this test exists for (a valid pointer landing in the wrong \
+         buffer's slot, with no crash to catch it) can no longer happen this \
+         way"
+
+(* Case 3: the SoA vector declared LAST. Nothing follows it, so nothing can
+   shift into a pointer slot — the leading scalar param stays exactly where
+   an AoS ABI would have put it. *)
+let test_soa_shift_vector_last_nothing_shifts () =
+  let calls = ref [] in
+  let v = soa_vector_with ["leafA"; "leafB"] calls in
+  let result =
+    expand_to_run_source_args ~soa_abi:true [Int32 7l; Vec v] cuda_ptx_device
+  in
+  check
+    int
+    "leading scalar + 2 leaves + shared length = 4 args"
+    4
+    (List.length result) ;
+  (match List.nth result 0 with
+  | Framework_sig.RSA_Int32 n -> check int32 "leading scalar unshifted" 7l n
+  | _ -> fail "expected the leading scalar, unshifted, at index 0") ;
+  bind_all result ;
+  check
+    (list (pair int string))
+    "leaves bound at 1,2, after the untouched leading scalar"
+    [(1, "leafA"); (2, "leafB")]
+    (List.rev !calls) ;
+  match List.nth result 3 with
+  | Framework_sig.RSA_Vector_Length n -> check int32 "shared length" 4l n
+  | _ -> fail "expected the shared SoA length at index 3"
+
 (** {1 Test suite} *)
 
 let () =
@@ -501,5 +686,20 @@ let () =
             "custom_exec_vector_get_set"
             `Quick
             test_custom_exec_vector_get_set;
+        ] );
+      ( "soa_arity_shift",
+        [
+          test_case
+            "N=2 pointer-after param shifted"
+            `Quick
+            test_soa_shift_n2_pointer_after;
+          test_case
+            "N=3 leaf lands in wrong buffer's slot"
+            `Quick
+            test_soa_shift_n3_valid_pointer_wrong_buffer;
+          test_case
+            "vector last: nothing shifts"
+            `Quick
+            test_soa_shift_vector_last_nothing_shifts;
         ] );
     ]


### PR DESCRIPTION
`Execute.ml:270` and `:933` called the SoA arity shift *"silently wrong data"*
while `Backend_error.ml` described a **trap**. Both were true, of different
cases. This scopes each claim to the case it actually holds for, and pins the
mechanism with tests.

## The cases

1. **N=2 with a pointer parameter after the vector** — can trap: a length slot
   receives a pointer value **and** the pointer slot reads its 8 bytes out of a
   4-byte length cell.
2. **3-leaf record** — `leaf3` lands in an `out` slot: valid pointer, wrong
   buffer, **no trap**.
3. **Vector declared last** — nothing *after* it shifts into a pointer slot.
4. **Metal** — cannot trap at all; `setBuffer`/`setBytes` never pass a
   caller-supplied address.

Case 4 is handled by **omission, correctly**: `soa_dispatch` gates on CUDA/PTX,
so Metal is unreachable from these sites. No Metal claim appears anywhere in the
new prose — deliberately, since there is no Metal hardware on this host and any
such claim would be argument, not measurement.

## The item's own first attempt reintroduced the defect it exists to fix

Two HIGH findings, both caught in review:

- **The test did not test what it was named for.** `test_soa_shift_n2_pointer_after`
  used `[Vec v; Int32 99l]` — a **scalar** successor. Case 1's trap needs a
  **pointer** successor, and the shapes differ even in arity (a following `Vec`
  expands to `(buf, len)` → 5 args, not 4). **Case 1, the only trap-capable
  shape, was entirely unpinned** while the commit claimed all three were covered.
  Now `[Vec v; Vec out_v]`, arity 5, asserting the shared length at index 2 and
  the out-vector's own length at index 4.
- **`Execute.ml:280` claimed more than its cited source.** *"no visible effect at
  all (the vector declared last)"* — but `Backend_error.ml:314-315` scopes that
  to *following* parameters. With the vector last at N=2, slot 0 reads leaf A's
  array as the packed AoS base and slot 1 takes leafB's 64-bit pointer as a
  4-byte length: wrong data plus an out-of-range length. Now scoped, with a
  clause that also blocks the inverse overshoot (implying harmlessness). Same
  correction applied at the second site, `:954`.

Also fixed: a quote attributed to `Backend_error` that **a grep over all tracked
`.ml`/`.mli`/`.md` found nowhere but that comment** (the real text at `:313` is
*"Silent corruption, nothing to trap on"*); a **closed** list presented as "the
per-shape analysis" where the source calls them *"examples rather than the
consequence"* — reopened, since closing an open list is the same defect in
reverse; and "the two generated-JIT sites", which are **three**, one of which
(`run_vectors`) is not the JIT path.

## The tests are not redundant, and they assert messages

A full mutation matrix gave distinct red signatures — T1={A,Q}, T2={A,H},
T3={A,L,Q} — so no test is subsumed by another. Assertions are on **messages**
(`Expected: [(0,"leafA");(1,"leafB")] / Received: …`), not exit codes. No skip
predicate exists; the tests build a literal `Device.t` with
`framework = "CUDA/PTX"`, the correct **backend** name for the comparison at
`Execute.ml:287` — no family/backend conflation, no vacuous green.

`Backend_error.ml` needed no change and is byte-identical to base — it carries no
line citation to `Execute.ml`, names three *functions* rather than trap
authority, and already rebuts both old phrasings at `:317`.

## Gates

dune 3.24.1, OCaml 5.4.0, ppxlib 0.38.0, ctypes 0.24.0. `dune build @all` 0;
`test_execute` **28/28** including all three SoA-shift tests; `dune build @fmt` 0.
A single mutation (expected out-buffer index 3 → the old AoS index 2) failed on
the assertion message and was restored by inverse edit.

## Not verified

Nothing on real hardware — no CUDA/PTX, Metal, HIP or WGSL device was used; every
backend claim is code-reading plus the mutation harness, **tier T1/T2, never T3**.
**Cross-runtime was not run** and is recorded as not-run rather than passed over;
the attestation records `claude` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)